### PR TITLE
Add draw time Unknown format texel count

### DIFF
--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -190,9 +190,10 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     std::shared_ptr<const CMD_BUFFER_STATE> shared_from_this() const { return SharedFromThisImpl(this); }
     std::shared_ptr<CMD_BUFFER_STATE> shared_from_this() { return SharedFromThisImpl(this); }
 
+    using DescriptorBindingInfo = std::pair<const uint32_t, DescriptorRequirement>;
     struct CmdDrawDispatchInfo {
         CMD_TYPE cmd_type;
-        std::vector<std::pair<const uint32_t, DescriptorRequirement>> binding_infos;
+        std::vector<DescriptorBindingInfo> binding_infos;
         VkFramebuffer framebuffer;
         std::shared_ptr<std::vector<SUBPASS_INFO>> subpasses;
         std::shared_ptr<std::vector<IMAGE_VIEW_STATE *>> attachments;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -114,6 +114,8 @@ struct DrawDispatchVuid {
     const char* storage_image_write_without_format = kVUIDUndefined;
     const char* storage_texel_buffer_read_without_format = kVUIDUndefined;
     const char* storage_texel_buffer_write_without_format = kVUIDUndefined;
+    const char* storage_image_write_texel_count = kVUIDUndefined;
+    const char* storage_texel_buffer_write_texel_count = kVUIDUndefined;
     const char* depth_compare_sample = kVUIDUndefined;
     const char* depth_read_only = kVUIDUndefined;
     const char* stencil_read_only = kVUIDUndefined;
@@ -595,9 +597,8 @@ class CoreChecks : public ValidationStateTracker {
 
     // helper for the common parts of ImageSamplerDescriptor and SamplerDescriptor validation
     bool ValidateSamplerDescriptor(const char* caller, const DrawDispatchVuid& vuids, const CMD_BUFFER_STATE* cb_node,
-                                   const cvdescriptorset::DescriptorSet* descriptor_set,
-                                   const std::pair<const uint32_t, DescriptorRequirement>& binding_info, uint32_t index,
-                                   VkSampler sampler, bool is_immutable, const SAMPLER_STATE* sampler_state) const;
+                                   const cvdescriptorset::DescriptorSet* descriptor_set, const DescriptorBindingInfo& binding_info,
+                                   uint32_t index, VkSampler sampler, bool is_immutable, const SAMPLER_STATE* sampler_state) const;
 
     // Validate contents of a CopyUpdate
     using DescriptorSet = cvdescriptorset::DescriptorSet;

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -112,6 +112,8 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDraw-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDraw-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDraw-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDraw-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDraw-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDraw-None-06479";
         depth_read_only                    = "VUID-vkCmdDraw-None-06886";
         stencil_read_only                  = "VUID-vkCmdDraw-None-06887";
@@ -225,6 +227,8 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawMultiEXT-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawMultiEXT-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawMultiEXT-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawMultiEXT-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawMultiEXT-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawMultiEXT-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawMultiEXT-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawMultiEXT-None-06887";
@@ -339,6 +343,8 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawIndexed-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawIndexed-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawIndexed-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawIndexed-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawIndexed-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawIndexed-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawIndexed-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawIndexed-None-06887";
@@ -453,6 +459,8 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawMultiIndexedEXT-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawMultiIndexedEXT-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawMultiIndexedEXT-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawMultiIndexedEXT-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawMultiIndexedEXT-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawMultiIndexedEXT-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawMultiIndexedEXT-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawMultiIndexedEXT-None-06887";
@@ -568,6 +576,8 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawIndirect-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawIndirect-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawIndirect-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawIndirect-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawIndirect-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawIndirect-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawIndirect-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawIndirect-None-06887";
@@ -684,6 +694,8 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawIndexedIndirect-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawIndexedIndirect-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawIndexedIndirect-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawIndexedIndirect-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawIndexedIndirect-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawIndexedIndirect-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawIndexedIndirect-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawIndexedIndirect-None-06887";
@@ -753,6 +765,8 @@ struct DispatchVuidsCmdDispatch : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDispatch-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDispatch-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDispatch-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDispatch-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDispatch-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDispatch-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdDispatch-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDispatch-None-08115";
@@ -787,6 +801,8 @@ struct DispatchVuidsCmdDispatchIndirect : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDispatchIndirect-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDispatchIndirect-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDispatchIndirect-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDispatchIndirect-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDispatchIndirect-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDispatchIndirect-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdDispatchIndirect-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDispatchIndirect-None-08115";
@@ -868,6 +884,8 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawIndirectCount-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawIndirectCount-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawIndirectCount-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawIndirectCount-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawIndirectCount-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawIndirectCount-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawIndirectCount-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawIndirectCount-None-06887";
@@ -987,6 +1005,8 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawIndexedIndirectCount-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawIndexedIndirectCount-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawIndexedIndirectCount-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawIndexedIndirectCount-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawIndexedIndirectCount-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawIndexedIndirectCount-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawIndexedIndirectCount-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawIndexedIndirectCount-None-06887";
@@ -1056,6 +1076,8 @@ struct DispatchVuidsCmdTraceRaysNV: DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdTraceRaysNV-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdTraceRaysNV-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdTraceRaysNV-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdTraceRaysNV-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdTraceRaysNV-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdTraceRaysNV-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdTraceRaysNV-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdTraceRaysNV-None-08115";
@@ -1088,6 +1110,8 @@ struct DispatchVuidsCmdTraceRaysKHR: DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdTraceRaysKHR-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdTraceRaysKHR-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdTraceRaysKHR-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdTraceRaysKHR-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdTraceRaysKHR-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdTraceRaysKHR-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdTraceRaysKHR-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdTraceRaysKHR-None-08115";
@@ -1122,6 +1146,8 @@ struct DispatchVuidsCmdTraceRaysIndirectKHR: DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdTraceRaysIndirectKHR-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdTraceRaysIndirectKHR-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdTraceRaysIndirectKHR-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdTraceRaysIndirectKHR-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdTraceRaysIndirectKHR-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdTraceRaysIndirectKHR-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdTraceRaysIndirectKHR-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdTraceRaysIndirectKHR-None-08115";
@@ -1156,6 +1182,8 @@ struct DispatchVuidsCmdTraceRaysIndirect2KHR: DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdTraceRaysIndirect2KHR-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdTraceRaysIndirect2KHR-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdTraceRaysIndirect2KHR-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdTraceRaysIndirect2KHR-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdTraceRaysIndirect2KHR-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdTraceRaysIndirect2KHR-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdTraceRaysIndirect2KHR-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdTraceRaysIndirect2KHR-None-08115";
@@ -1223,6 +1251,8 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawMeshTasksNV-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawMeshTasksNV-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawMeshTasksNV-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawMeshTasksNV-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawMeshTasksNV-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawMeshTasksNV-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawMeshTasksNV-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawMeshTasksNV-None-06887";
@@ -1331,6 +1361,8 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawMeshTasksIndirectNV-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawMeshTasksIndirectNV-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawMeshTasksIndirectNV-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawMeshTasksIndirectNV-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawMeshTasksIndirectNV-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawMeshTasksIndirectNV-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawMeshTasksIndirectNV-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawMeshTasksIndirectNV-None-06887";
@@ -1442,6 +1474,8 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawMeshTasksIndirectCountNV-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawMeshTasksIndirectCountNV-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawMeshTasksIndirectCountNV-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawMeshTasksIndirectCountNV-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-06887";
@@ -1590,6 +1624,8 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDrawIndirectByteCountEXT-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDrawIndirectByteCountEXT-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDrawIndirectByteCountEXT-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDrawIndirectByteCountEXT-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDrawIndirectByteCountEXT-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDrawIndirectByteCountEXT-None-06479";
         depth_read_only                    = "VUID-vkCmdDrawIndirectByteCountEXT-None-06886";
         stencil_read_only                  = "VUID-vkCmdDrawIndirectByteCountEXT-None-06887";
@@ -1659,6 +1695,8 @@ struct DispatchVuidsCmdDispatchBase: DrawDispatchVuid {
         storage_image_write_without_format = "VUID-vkCmdDispatchBase-OpTypeImage-07027";
         storage_texel_buffer_read_without_format  = "VUID-vkCmdDispatchBase-OpTypeImage-07030";
         storage_texel_buffer_write_without_format = "VUID-vkCmdDispatchBase-OpTypeImage-07029";
+        storage_image_write_texel_count           = "VUID-vkCmdDispatchBase-None-04115";
+        storage_texel_buffer_write_texel_count    = "VUID-vkCmdDispatchBase-OpImageWrite-04469";
         depth_compare_sample               = "VUID-vkCmdDispatchBase-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdDispatchBase-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDispatchBase-None-08115";

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -187,6 +187,7 @@ PIPELINE_STATE::ActiveSlotMap PIPELINE_STATE::GetActiveSlots(const StageStateVec
                     ++image_index;
                 }
             }
+            entry.write_without_formats_component_count_list = use.second.write_without_formats_component_count_list;
         }
     }
     return active_slots;

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -89,6 +89,8 @@ struct DescriptorRequirement {
     bool is_writable;
     // Copy from StageState.InterfaceVariable. It combines from plural shader stages. The index of array is index of image.
     std::vector<layer_data::unordered_set<SamplerUsedByImage>> samplers_used_by_image;
+    // For storage images - list of < OpImageWrite : Texel component length >
+    std::vector<std::pair<Instruction, uint32_t>> write_without_formats_component_count_list;
     DescriptorRequirement() : reqs(0), is_writable(false) {}
 };
 
@@ -96,6 +98,7 @@ inline bool operator==(const DescriptorRequirement &a, const DescriptorRequireme
 
 inline bool operator<(const DescriptorRequirement &a, const DescriptorRequirement &b) noexcept { return a.reqs < b.reqs; }
 
+// < binding index (of descriptor set) : meta data >
 typedef std::map<uint32_t, DescriptorRequirement> BindingReqMap;
 
 struct PipelineStageState {

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -2796,9 +2796,7 @@ bool CoreChecks::ValidateImageWrite(const SHADER_MODULE_STATE &module_state, con
             const VkFormat compatible_format = CompatibleSpirvImageFormat(image_format);
             if (compatible_format != VK_FORMAT_UNDEFINED) {
                 const uint32_t format_component_count = FormatComponentCount(compatible_format);
-                const Instruction *texel_def = module_state.FindDef(insn.Word(3));
-                const Instruction *texel_type = module_state.FindDef(texel_def->Word(1));
-                const uint32_t texel_component_count = (texel_type->Opcode() == spv::OpTypeVector) ? texel_type->Word(3) : 1;
+                const uint32_t texel_component_count = module_state.GetTexelComponentCount(insn);
                 if (texel_component_count < format_component_count) {
                     skip |= LogError(device, "VUID-RuntimeSpirv-OpImageWrite-07112",
                                      "%s: OpImageWrite Texel operand only contains %" PRIu32

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -2953,7 +2953,7 @@ TEST_F(VkPositiveLayerTest, StorageImageWriteMoreComponent) {
 
     const VkFormat format = VK_FORMAT_R32G32_UINT;  // Rg32ui
     if (!ImageFormatAndFeaturesSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
-        GTEST_SKIP() << "Format doesn't support stroage image";
+        GTEST_SKIP() << "Format doesn't support storage image";
     }
 
     VkImageObj image(m_device);
@@ -3049,7 +3049,7 @@ TEST_F(VkPositiveLayerTest, StorageImageUnknownWriteMoreComponent) {
 
     const VkFormat format = VK_FORMAT_R32G32_UINT;
     if (!ImageFormatAndFeaturesSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
-        GTEST_SKIP() << "Format doesn't support stroage image";
+        GTEST_SKIP() << "Format doesn't support storage image";
     }
 
     VkImageObj image(m_device);
@@ -3144,7 +3144,7 @@ TEST_F(VkPositiveLayerTest, StorageImageWriteSpecConstantMoreComponent) {
 
     const VkFormat format = VK_FORMAT_R32G32_UINT;  // Rg32ui
     if (!ImageFormatAndFeaturesSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
-        GTEST_SKIP() << "Format doesn't support stroage image";
+        GTEST_SKIP() << "Format doesn't support storage image";
     }
 
     VkImageObj image(m_device);
@@ -3247,7 +3247,7 @@ TEST_F(VkPositiveLayerTest, StorageTexelBufferWriteMoreComponent) {
 
     const VkFormat format = VK_FORMAT_R32G32_UINT;  // Rg32ui
     if (!BufferFormatAndFeaturesSupported(gpu(), format, VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
-        GTEST_SKIP() << "Format doesn't support stroage texel buffer";
+        GTEST_SKIP() << "Format doesn't support storage texel buffer";
     }
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();


### PR DESCRIPTION
Adds `VUID-vkCmdDispatch-None-04115` and `VUID-vkCmdDispatch-OpImageWrite-04469`

These are the draw time version of `VUID-RuntimeSpirv-OpImageWrite-07112`

It maps the `OpImageWrite` -> `OpLoad`/`OpAccessChain` -> Descriptor `OpVariable` . From there the descriptor can see all the `OpImageWrite` used on it.

------

I think there is improvement in how we are having to copy the data from `InterfaceVariable` to `DescriptorRequirement`, but realize that becomes messy due to `UPDATE_AFTER_BIND` descriptors being a thing. I decided to defer that to a follow-up PR