### PR TITLE
VK_EXT_descriptor_buffer: Fix problems with VUIDS 08903, 08125 and 08116

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1628,16 +1628,6 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE *cb_node, CMD_TY
                                "VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT", function);
     }
 
-    if (pipe->descriptor_buffer_mode) {
-        if (!cb_node->descriptor_buffer_bindings.empty()) {
-            // TODO Issue 4832 - VUID 08116 Descriptors in bound descriptor buffers, specified via vkCmdSetDescriptorBufferOffsetsEXT, must be valid
-            // if they are statically used by the VkPipeline bound to the pipeline bind point used by this command and the bound
-            // VkPipeline was created with VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT
-            // result |= LogError(pipe->pipeline(), vuid.descriptor_buffer_set_offset_dynamic,
-            //                    "TODO: Layers need to have access to content of buffers. GPU AV assistance needed.");
-        }
-    }
-
     if (VK_PIPELINE_BIND_POINT_GRAPHICS == bind_point) {
         result |= ValidateDrawDynamicState(cb_node, pipe, cmd_type);
         result |= ValidatePipelineDrawtimeState(last_bound, cb_node, cmd_type, pipe);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -156,7 +156,6 @@ struct DrawDispatchVuid {
     const char* missing_mesh_shader_stages = kVUIDUndefined;
     const char* descriptor_buffer_bit_set = kVUIDUndefined;
     const char* descriptor_buffer_bit_not_set = kVUIDUndefined;
-    const char* descriptor_buffer_set_offset_dynamic = kVUIDUndefined;
     const char* descriptor_buffer_set_offset_missing = kVUIDUndefined;
 };
 

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -3925,7 +3925,7 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureOpaqueCaptureDescriptorD
         }
 
         if (pInfo->accelerationStructureNV != VK_NULL_HANDLE) {
-            LogError(device, "VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-accelerationStructureNV-08093",
+            LogError(device, "VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-accelerationStructure-08093",
                      "VkAccelerationStructureCaptureDescriptorDataInfoEXT(): If accelerationStructure is not VK_NULL_HANDLE, "
                      "accelerationStructureNV must be VK_NULL_HANDLE. ");
         }
@@ -4296,7 +4296,7 @@ bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescri
                              "determined by the value in slink:VkPhysicalDeviceDescriptorBufferPropertiesEXT",
                              dataSize, size);
         } else {
-            skip |= LogError(device, "VUID-vkGetDescriptorEXT-pDescriptorInfo-08125",
+            skip |= LogError(device, "VUID-vkGetDescriptorEXT-dataSize-08125",
                              "vkGetDescriptorEXT(): dataSize (%zu) must equal the size of a descriptor (%zu) of type VkDescriptorGetInfoEXT::type "
                              "determined by the value in VkPhysicalDeviceDescriptorBufferPropertiesEXT, or "
                              "VkPhysicalDeviceDescriptorBufferDensityMapPropertiesEXT::combinedImageSamplerDensityMapDescriptorSize if "

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -152,7 +152,6 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         invalid_mesh_shader_stages         = "VUID-vkCmdDraw-stage-06481";
         descriptor_buffer_bit_set          = "VUID-vkCmdDraw-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDraw-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDraw-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDraw-None-08117";
     }
 };
@@ -266,7 +265,6 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         invalid_mesh_shader_stages         = "VUID-vkCmdDrawMultiEXT-stage-06481";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawMultiEXT-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawMultiEXT-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawMultiEXT-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMultiEXT-None-08117";
     }
 };
@@ -381,7 +379,6 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         invalid_mesh_shader_stages         = "VUID-vkCmdDrawIndexed-stage-06481";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawIndexed-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawIndexed-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawIndexed-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndexed-None-08117";
     }
 };
@@ -496,7 +493,6 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         invalid_mesh_shader_stages         = "VUID-vkCmdDrawMultiIndexedEXT-stage-06481";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawMultiIndexedEXT-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawMultiIndexedEXT-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawMultiIndexedEXT-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMultiIndexedEXT-None-08117";
     }
 };
@@ -612,7 +608,6 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         invalid_mesh_shader_stages         = "VUID-vkCmdDrawIndirect-stage-06481";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawIndirect-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawIndirect-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawIndirect-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndirect-None-08117";
     }
 };
@@ -729,7 +724,6 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         invalid_mesh_shader_stages         = "VUID-vkCmdDrawIndexedIndirect-stage-06481";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawIndexedIndirect-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawIndexedIndirect-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawIndexedIndirect-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndexedIndirect-None-08117";
     }
 };
@@ -762,7 +756,6 @@ struct DispatchVuidsCmdDispatch : DrawDispatchVuid {
         depth_compare_sample               = "VUID-vkCmdDispatch-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdDispatch-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDispatch-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDispatch-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDispatch-None-08117";
     }
 };
@@ -797,7 +790,6 @@ struct DispatchVuidsCmdDispatchIndirect : DrawDispatchVuid {
         depth_compare_sample               = "VUID-vkCmdDispatchIndirect-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdDispatchIndirect-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDispatchIndirect-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDispatchIndirect-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDispatchIndirect-None-08117";
     }
 };
@@ -916,7 +908,6 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         invalid_mesh_shader_stages         = "VUID-vkCmdDrawIndirectCount-stage-06481";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawIndirectCount-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawIndirectCount-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawIndirectCount-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndirectCount-None-08117";
     }
 };
@@ -1036,7 +1027,6 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         invalid_mesh_shader_stages         = "VUID-vkCmdDrawIndexedIndirectCount-stage-06481";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawIndexedIndirectCount-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawIndexedIndirectCount-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawIndexedIndirectCount-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndexedIndirectCount-None-08117";
     }
 };
@@ -1069,7 +1059,6 @@ struct DispatchVuidsCmdTraceRaysNV: DrawDispatchVuid {
         depth_compare_sample               = "VUID-vkCmdTraceRaysNV-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdTraceRaysNV-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdTraceRaysNV-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdTraceRaysNV-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdTraceRaysNV-None-08117";
     }
 };
@@ -1102,7 +1091,6 @@ struct DispatchVuidsCmdTraceRaysKHR: DrawDispatchVuid {
         depth_compare_sample               = "VUID-vkCmdTraceRaysKHR-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdTraceRaysKHR-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdTraceRaysKHR-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdTraceRaysKHR-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdTraceRaysKHR-None-08117";
     }
 };
@@ -1137,7 +1125,6 @@ struct DispatchVuidsCmdTraceRaysIndirectKHR: DrawDispatchVuid {
         depth_compare_sample               = "VUID-vkCmdTraceRaysIndirectKHR-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdTraceRaysIndirectKHR-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdTraceRaysIndirectKHR-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdTraceRaysIndirectKHR-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdTraceRaysIndirectKHR-None-08117";
     }
 };
@@ -1172,7 +1159,6 @@ struct DispatchVuidsCmdTraceRaysIndirect2KHR: DrawDispatchVuid {
         depth_compare_sample               = "VUID-vkCmdTraceRaysIndirect2KHR-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdTraceRaysIndirect2KHR-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdTraceRaysIndirect2KHR-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdTraceRaysIndirect2KHR-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdTraceRaysIndirect2KHR-None-08117";
     }
 };
@@ -1278,7 +1264,6 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         missing_mesh_shader_stages         = "VUID-vkCmdDrawMeshTasksNV-MeshNV-07080";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawMeshTasksNV-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawMeshTasksNV-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawMeshTasksNV-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMeshTasksNV-None-08117";
     }
 };
@@ -1387,7 +1372,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         missing_mesh_shader_stages         = "VUID-vkCmdDrawMeshTasksIndirectNV-MeshNV-07081";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08117";
     }
 };
@@ -1499,7 +1483,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         missing_mesh_shader_stages         = "VUID-vkCmdDrawMeshTasksIndirectCountNV-MeshNV-07082";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08117";
     }
 };
@@ -1510,7 +1493,6 @@ struct DispatchVuidsCmdDrawMeshTasksEXT: DrawDispatchVuid {
         missing_mesh_shader_stages         = "VUID-vkCmdDrawMeshTasksEXT-MeshEXT-07087";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawMeshTasksEXT-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawMeshTasksEXT-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawMeshTasksEXT-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMeshTasksEXT-None-08117";
     }
 };
@@ -1521,7 +1503,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectEXT: DrawDispatchVuid {
         missing_mesh_shader_stages         = "VUID-vkCmdDrawMeshTasksIndirectEXT-MeshEXT-07091";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08117";
     }
 };
@@ -1534,7 +1515,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountEXT : DrawDispatchVuid {
         indirect_count_buffer_bit          = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-02715";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08117";
     }
 };
@@ -1650,7 +1630,6 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         invalid_mesh_shader_stages         = "VUID-vkCmdDrawIndirectByteCountEXT-stage-06481";
         descriptor_buffer_bit_set          = "VUID-vkCmdDrawIndirectByteCountEXT-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDrawIndirectByteCountEXT-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDrawIndirectByteCountEXT-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndirectByteCountEXT-None-08117";
     }
 };
@@ -1683,7 +1662,6 @@ struct DispatchVuidsCmdDispatchBase: DrawDispatchVuid {
         depth_compare_sample               = "VUID-vkCmdDispatchBase-None-06479";
         descriptor_buffer_bit_set          = "VUID-vkCmdDispatchBase-None-08114";
         descriptor_buffer_bit_not_set      = "VUID-vkCmdDispatchBase-None-08115";
-        descriptor_buffer_set_offset_dynamic = "VUID-vkCmdDispatchBase-None-08116";
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDispatchBase-None-08117";
     }
 };


### PR DESCRIPTION
08903 and 08125 had typos in their VUID strings.

08116 isn't implemented but VUID strings were in the code so vk_validation_stats.py got confused.

Unimplemented VUIDs for this extension are tracked in #4832 