### PR TITLE
layers: Track input assembly state at pre_raster_state

### DIFF
--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -393,6 +393,8 @@ class PIPELINE_STATE : public BASE_NODE {
     const safe_VkPipelineInputAssemblyStateCreateInfo *InputAssemblyState() const {
         if (vertex_input_state) {
             return vertex_input_state->input_assembly_state;
+        } else if (pre_raster_state) {
+            return pre_raster_state->input_assembly_state;
         }
         return nullptr;
     }

--- a/layers/pipeline_sub_state.cpp
+++ b/layers/pipeline_sub_state.cpp
@@ -63,6 +63,7 @@ PreRasterState::PreRasterState(const PIPELINE_STATE &p, const ValidationStateTra
 
     rp_state = dev_data.Get<RENDER_PASS_STATE>(create_info.renderPass);
 
+    input_assembly_state = create_info.pInputAssemblyState;
     raster_state = create_info.pRasterizationState;
 
     tess_create_info = create_info.pTessellationState;

--- a/layers/pipeline_sub_state.h
+++ b/layers/pipeline_sub_state.h
@@ -72,8 +72,8 @@ struct PreRasterState {
     const PIPELINE_STATE &parent;
 
     std::shared_ptr<const PIPELINE_LAYOUT_STATE> pipeline_layout;
+    safe_VkPipelineInputAssemblyStateCreateInfo *input_assembly_state = nullptr;
     safe_VkPipelineViewportStateCreateInfo *viewport_state = nullptr;
-
     safe_VkPipelineRasterizationStateCreateInfo *raster_state = nullptr;
 
     std::shared_ptr<const RENDER_PASS_STATE> rp_state;


### PR DESCRIPTION
Currently the validation layer can't judge if 00736 is being kept correctly because pre_raster_state doesn't have the input assembly state.