### PR TITLE
Add Dynaimc state Discard Rectangle VU

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -430,6 +430,7 @@ bool CoreChecks::ValidateDrawDynamicState(const CMD_BUFFER_STATE &cb_state, cons
     skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_PRIMITIVE_RESTART_ENABLE_SET, cmd_type, vuid.primitive_restart_enable);
     skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_VERTEX_INPUT_BINDING_STRIDE_SET, cmd_type, vuid.vertex_input_binding_stride);
     skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_VERTEX_INPUT_EXT_SET, cmd_type, vuid.vertex_input);
+    skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_DISCARD_RECTANGLE_EXT_SET, cmd_type, vuid.dynamic_discard_rectangle);
     skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_COLOR_WRITE_ENABLE_EXT_SET, cmd_type, vuid.dynamic_color_write_enable);
     skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_TESSELLATION_DOMAIN_ORIGIN_EXT_SET, cmd_type,
                                     vuid.dynamic_tessellation_domain_origin);

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -91,6 +91,7 @@ struct DrawDispatchVuid {
     const char* vertex_input_binding_stride = kVUIDUndefined;
     const char* vertex_input = kVUIDUndefined;
     const char* blend_enable = kVUIDUndefined;
+    const char* dynamic_discard_rectangle = kVUIDUndefined;
     const char* dynamic_color_write_enable = kVUIDUndefined;
     const char* dynamic_color_write_enable_count = kVUIDUndefined;
     const char* dynamic_rendering_view_mask = kVUIDUndefined;

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -89,6 +89,7 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         vertex_input_binding_stride        = "VUID-vkCmdDraw-pStrides-04884";
         vertex_input                       = "VUID-vkCmdDraw-None-04914";
         blend_enable                       = "VUID-vkCmdDraw-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDraw-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDraw-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDraw-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDraw-viewMask-06178";
@@ -204,6 +205,7 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         vertex_input_binding_stride        = "VUID-vkCmdDrawMultiEXT-pStrides-04884";
         vertex_input                       = "VUID-vkCmdDrawMultiEXT-None-04914";
         blend_enable                       = "VUID-vkCmdDrawMultiEXT-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawMultiEXT-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawMultiEXT-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawMultiEXT-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawMultiEXT-viewMask-06178";
@@ -320,6 +322,7 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndexed-pStrides-04884";
         vertex_input                       = "VUID-vkCmdDrawIndexed-None-04914";
         blend_enable                       = "VUID-vkCmdDrawIndexed-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawIndexed-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawIndexed-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawIndexed-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawIndexed-viewMask-06178";
@@ -436,6 +439,7 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         vertex_input_binding_stride        = "VUID-vkCmdDrawMultiIndexedEXT-pStrides-04884";
         vertex_input                       = "VUID-vkCmdDrawMultiIndexedEXT-None-04914";
         blend_enable                       = "VUID-vkCmdDrawMultiIndexedEXT-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawMultiIndexedEXT-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawMultiIndexedEXT-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawMultiIndexedEXT-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawMultiIndexedEXT-viewMask-06178";
@@ -553,6 +557,7 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndirect-pStrides-04884";
         vertex_input                       = "VUID-vkCmdDrawIndirect-None-04914";
         blend_enable                       = "VUID-vkCmdDrawIndirect-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawIndirect-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawIndirect-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawIndirect-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawIndirect-viewMask-06178";
@@ -671,6 +676,7 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndexedIndirect-pStrides-04884";
         vertex_input                       = "VUID-vkCmdDrawIndexedIndirect-None-04914";
         blend_enable                       = "VUID-vkCmdDrawIndexedIndirect-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawIndexedIndirect-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawIndexedIndirect-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawIndexedIndirect-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawIndexedIndirect-viewMask-06178";
@@ -861,6 +867,7 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndirectCount-pStrides-04884";
         vertex_input                       = "VUID-vkCmdDrawIndirectCount-None-04914";
         blend_enable                       = "VUID-vkCmdDrawIndirectCount-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawIndirectCount-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawIndirectCount-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawIndirectCount-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawIndirectCount-viewMask-06178";
@@ -982,6 +989,7 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndexedIndirectCount-pStrides-04884";
         vertex_input                       = "VUID-vkCmdDrawIndexedIndirectCount-None-04914";
         blend_enable                       = "VUID-vkCmdDrawIndexedIndirectCount-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawIndexedIndirectCount-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawIndexedIndirectCount-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawIndexedIndirectCount-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawIndexedIndirectCount-viewMask-06178";
@@ -1228,6 +1236,7 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         depth_bias_enable                  = "VUID-vkCmdDrawMeshTasksNV-None-04877";
         logic_op                           = "VUID-vkCmdDrawMeshTasksNV-logicOp-04878";
         blend_enable                       = "VUID-vkCmdDrawMeshTasksNV-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawMeshTasksNV-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawMeshTasksNV-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawMeshTasksNV-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawMeshTasksNV-viewMask-06178";
@@ -1338,6 +1347,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         depth_bias_enable                  = "VUID-vkCmdDrawMeshTasksIndirectNV-None-04877";
         logic_op                           = "VUID-vkCmdDrawMeshTasksIndirectNV-logicOp-04878";
         blend_enable                       = "VUID-vkCmdDrawMeshTasksIndirectNV-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawMeshTasksIndirectNV-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawMeshTasksIndirectNV-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawMeshTasksIndirectNV-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawMeshTasksIndirectNV-viewMask-06178";
@@ -1451,6 +1461,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         depth_bias_enable                  = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-04877";
         logic_op                           = "VUID-vkCmdDrawMeshTasksIndirectCountNV-logicOp-04878";
         blend_enable                       = "VUID-vkCmdDrawMeshTasksIndirectCountNV-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawMeshTasksIndirectCountNV-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawMeshTasksIndirectCountNV-viewMask-06178";
@@ -1601,6 +1612,7 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         vertex_input_binding_stride        = "VUID-vkCmdDrawIndirectByteCountEXT-pStrides-04884";
         vertex_input                       = "VUID-vkCmdDrawIndirectByteCountEXT-None-04914";
         blend_enable                       = "VUID-vkCmdDrawIndirectByteCountEXT-blendEnable-04727";
+        dynamic_discard_rectangle          = "VUID-vkCmdDrawIndirectByteCountEXT-None-07751";
         dynamic_color_write_enable         = "VUID-vkCmdDrawIndirectByteCountEXT-None-07749";
         dynamic_color_write_enable_count   = "VUID-vkCmdDrawIndirectByteCountEXT-attachmentCount-07750";
         dynamic_rendering_view_mask        = "VUID-vkCmdDrawIndirectByteCountEXT-viewMask-06178";


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3417 and https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3505

adds new `VUID-vkCmdDraw-None-07751` from 1.3.236