### PR TITLE
build, docs: try to remove repo-specific incantations

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -24,14 +24,13 @@ The following will be enough for most people, for platform-specific instructions
 git clone https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
 cd Vulkan-ValidationLayers
 
-mkdir build
-cd build
-
 # Linux
-python3 ../scripts/update_deps.py --dir ../external --arch x64 --config debug
-cmake -G Ninja -C ../external/helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug -DUPDATE_DEPS=TRUE
+ninja -C build
 
 # Windows
+mkdir build
+cd build
 python3 ..\scripts\update_deps.py --dir ..\external --arch x64 --config debug
 cmake -A x64 -C ..\external\helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -20,22 +20,38 @@
 
 The following will be enough for most people, for platform-specific instructions, see below.
 
+### Linux
+
 ```bash
 git clone https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
 cd Vulkan-ValidationLayers
-
-# Linux
-cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug -DUPDATE_DEPS=TRUE
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug
 ninja -C build
+```
 
-# Windows
+### Windows & Visual Studio
+
+```bash
+git clone https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
+cd Vulkan-ValidationLayers
 mkdir build
 cd build
 python3 ..\scripts\update_deps.py --dir ..\external --arch x64 --config debug
 cmake -A x64 -C ..\external\helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
-
 cmake --build . --config Debug
 ```
+
+### Windows & Ninja
+
+```bash
+# Load MSBUILD x64 devenv
+C:\"Program Files (x86)"\"Microsoft Visual Studio"\2019\Professional\VC\Auxiliary\Build\vcvars64.bat
+git clone https://github.com/KhronosGroup/Vulkan-ValidationLayers.git
+cd Vulkan-ValidationLayers
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug
+ninja -C build
+```
+
 ### CCACHE
 
 There are 2 methods to enable CCACHE:
@@ -457,6 +473,7 @@ This repository uses CMake to generate build or project files that are then
 used to build the repository. The CMake generators explicitly supported in
 this repository are:
 
+- Ninja
 - Unix Makefiles
 - Xcode
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ project(VVL LANGUAGES CXX C)
 option(VVL_ENABLE_ASAN "Use address sanitization (specifically -fsanitize=address)" OFF)
 
 option(BUILD_TESTS "Build the tests" OFF)
+option(UPDATE_DEPS "Clone & build dependencies" ON)
 
 add_definitions(-DVK_ENABLE_BETA_EXTENSIONS) # Enable beta Vulkan extensions
 


### PR DESCRIPTION
This project uses cmake, and maybe it would be useful to remove friction? -> run cmake, it works.

By setting the UPDATE_DEPS as a enabled-by-default option, we can remove the manual call to update deps script.
Updated the doc to reflect that. Added Ninja as supported code generator since the default build instruction were already using Ninja.

Kept the windows part mostly unchanged, as Windows is a bit more specific, just added the VS env call in the short ones as ninja/cmake/msbuild might not be available on the default cmd by default.