### PR TITLE
cmake: Fix MINGW build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,11 +210,13 @@ elseif(MSVC)
 
     # Allow usage of unsafe CRT functions and minimize what Windows.h leaks
     add_definitions(-D_CRT_SECURE_NO_WARNINGS -DNOMINMAX -DWIN32_LEAN_AND_MEAN)
-    if(MINGW)
-        add_definitions(-D_WIN32_WINNT=0x0600) # Must be declared before including Windows.h
-    endif()
 
     add_compile_options($<$<BOOL:${MSVC_IDE}>:/MP>) # Speed up Visual Studio builds
+endif()
+
+if(MINGW)
+    add_definitions(-D_WIN32_WINNT=0x0600) # Must be declared before including Windows.h
+    add_compile_options("-Wa,-mbig-obj")
 endif()
 
 option(INSTALL_TESTS "Install tests" OFF)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -71,9 +71,6 @@ if(MSVC)
     # that constructor initializers are now fixed to clear the struct members.
     add_compile_options("$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19>>:/wd4351>")
 else()
-    if(MINGW)
-        add_compile_options("-Wa,-mbig-obj")
-    endif()
     add_compile_options(-Wpointer-arith -Wno-unused-function -Wno-sign-compare)
 endif()
 


### PR DESCRIPTION
Currently MINGW call is nested under a check for MSVC. MINGW doesn't  use MSVC.