### PR TITLE
layers: Fix descriptor buffer VUIDs 08115 and 08117

### DIFF
--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -313,11 +313,6 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     uint32_t conditional_rendering_subpass{0};
     uint32_t dynamicColorWriteEnableAttachmentCount{0};
     std::vector<VkDescriptorBufferBindingInfoEXT> descriptor_buffer_binding_info;
-    struct DescriptorBufferBinding {
-        uint32_t index;
-        VkDeviceSize offset;
-    };
-    std::vector<DescriptorBufferBinding> descriptor_buffer_bindings;
 
     mutable std::shared_mutex lock;
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock); }
@@ -421,12 +416,16 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
 
     void ExecuteCommands(uint32_t commandBuffersCount, const VkCommandBuffer *pCommandBuffers);
 
-    void UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_bind_point, const PIPELINE_LAYOUT_STATE *pipeline_layout,
+    void UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_bind_point, const PIPELINE_LAYOUT_STATE &pipeline_layout,
                                        uint32_t first_set, uint32_t set_count, const VkDescriptorSet *pDescriptorSets,
                                        std::shared_ptr<cvdescriptorset::DescriptorSet> &push_descriptor_set,
                                        uint32_t dynamic_offset_count, const uint32_t *p_dynamic_offsets);
 
-    void PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint, PIPELINE_LAYOUT_STATE *pipeline_layout, uint32_t set,
+    void UpdateLastBoundDescriptorBuffers(VkPipelineBindPoint pipeline_bind_point, const PIPELINE_LAYOUT_STATE &pipeline_layout,
+                                          uint32_t first_set, uint32_t set_count, const uint32_t *buffer_indicies,
+                                          const VkDeviceSize *buffer_offsets);
+
+    void PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint, const PIPELINE_LAYOUT_STATE &pipeline_layout, uint32_t set,
                                 uint32_t descriptorWriteCount, const VkWriteDescriptorSet *pDescriptorWrites);
 
     void UpdateDrawCmd(CMD_TYPE cmd_type);

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -3735,39 +3735,6 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(
     return skip;
 }
 
-void ValidationStateTracker::PostCallRecordGetDescriptorSetLayoutSizeEXT(VkDevice device, VkDescriptorSetLayout layout,
-    VkDeviceSize* pLayoutSizeInBytes) {
-    auto descriptor_set_layout = Get<cvdescriptorset::DescriptorSetLayout>(layout);
-
-    descriptor_set_layout->SetLayoutSizeInBytes(pLayoutSizeInBytes);
-}
-
-void ValidationStateTracker::PreCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
-                                                          const VkDescriptorBufferBindingInfoEXT *pBindingInfos) {
-    auto cb_state = Get<CMD_BUFFER_STATE>(commandBuffer);
-
-    cb_state->descriptor_buffer_binding_info.clear();
-    cb_state->descriptor_buffer_binding_info.reserve(bufferCount);
-
-    for (uint32_t i = 0; i < bufferCount; i++) {
-        cb_state->descriptor_buffer_binding_info.push_back(pBindingInfos[i]);
-    }
-}
-
-void ValidationStateTracker::PreCallRecordCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer,
-                                                                           VkPipelineBindPoint pipelineBindPoint,
-                                                               VkPipelineLayout layout, uint32_t firstSet, uint32_t setCount,
-                                                               const uint32_t *pBufferIndices, const VkDeviceSize *pOffsets) {
-    auto cb_state = Get<CMD_BUFFER_STATE>(commandBuffer);
-
-    cb_state->descriptor_buffer_bindings.resize(setCount);
-
-    for (uint32_t i = 0; i < setCount; i++) {
-        cb_state->descriptor_buffer_bindings[i].index = pBufferIndices[i];
-        cb_state->descriptor_buffer_bindings[i].offset = pOffsets[i];
-    }
-}
-
 bool CoreChecks::PreCallValidateGetDescriptorSetLayoutSizeEXT(VkDevice device, VkDescriptorSetLayout layout,
                                                               VkDeviceSize *pLayoutSizeInBytes) const {
     bool skip = false;

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -2492,6 +2492,13 @@ void ValidationStateTracker::PostCallRecordCreateDescriptorSetLayout(VkDevice de
     Add(std::make_shared<cvdescriptorset::DescriptorSetLayout>(pCreateInfo, *pSetLayout));
 }
 
+void ValidationStateTracker::PostCallRecordGetDescriptorSetLayoutSizeEXT(VkDevice device, VkDescriptorSetLayout layout,
+                                                                         VkDeviceSize *pLayoutSizeInBytes) {
+    auto descriptor_set_layout = Get<cvdescriptorset::DescriptorSetLayout>(layout);
+
+    descriptor_set_layout->SetLayoutSizeInBytes(pLayoutSizeInBytes);
+}
+
 void ValidationStateTracker::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
                                                                 const VkAllocationCallbacks *pAllocator,
                                                                 VkPipelineLayout *pPipelineLayout, VkResult result) {
@@ -3024,12 +3031,16 @@ void ValidationStateTracker::PreCallRecordCmdBindDescriptorSets(VkCommandBuffer 
                                                                 const VkDescriptorSet *pDescriptorSets, uint32_t dynamicOffsetCount,
                                                                 const uint32_t *pDynamicOffsets) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
-    cb_state->RecordCmd(CMD_BINDDESCRIPTORSETS);
     auto pipeline_layout = Get<PIPELINE_LAYOUT_STATE>(layout);
+    if (!cb_state || !pipeline_layout) {
+        return;
+    }
+    cb_state->RecordCmd(CMD_BINDDESCRIPTORSETS);
+
     std::shared_ptr<cvdescriptorset::DescriptorSet> no_push_desc;
 
-    cb_state->UpdateLastBoundDescriptorSets(pipelineBindPoint, pipeline_layout.get(), firstSet, setCount, pDescriptorSets,
-                                            no_push_desc, dynamicOffsetCount, pDynamicOffsets);
+    cb_state->UpdateLastBoundDescriptorSets(pipelineBindPoint, *pipeline_layout, firstSet, setCount, pDescriptorSets, no_push_desc,
+                                            dynamicOffsetCount, pDynamicOffsets);
 }
 
 void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer,
@@ -3038,7 +3049,27 @@ void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetKHR(VkCommandBuffe
                                                                   const VkWriteDescriptorSet *pDescriptorWrites) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     auto pipeline_layout = Get<PIPELINE_LAYOUT_STATE>(layout);
-    cb_state->PushDescriptorSetState(pipelineBindPoint, pipeline_layout.get(), set, descriptorWriteCount, pDescriptorWrites);
+    cb_state->PushDescriptorSetState(pipelineBindPoint, *pipeline_layout, set, descriptorWriteCount, pDescriptorWrites);
+}
+
+void ValidationStateTracker::PreCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
+                                                                      const VkDescriptorBufferBindingInfoEXT *pBindingInfos) {
+    auto cb_state = Get<CMD_BUFFER_STATE>(commandBuffer);
+
+    cb_state->descriptor_buffer_binding_info.resize(bufferCount);
+
+    std::copy(pBindingInfos, pBindingInfos + bufferCount, cb_state->descriptor_buffer_binding_info.data());
+}
+
+void ValidationStateTracker::PreCallRecordCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer,
+                                                                           VkPipelineBindPoint pipelineBindPoint,
+                                                                           VkPipelineLayout layout, uint32_t firstSet,
+                                                                           uint32_t setCount, const uint32_t *pBufferIndices,
+                                                                           const VkDeviceSize *pOffsets) {
+    auto cb_state = Get<CMD_BUFFER_STATE>(commandBuffer);
+    auto pipeline_layout = Get<PIPELINE_LAYOUT_STATE>(layout);
+
+    cb_state->UpdateLastBoundDescriptorBuffers(pipelineBindPoint, *pipeline_layout, firstSet, setCount, pBufferIndices, pOffsets);
 }
 
 void ValidationStateTracker::PostCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
@@ -4231,20 +4262,21 @@ void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetWithTemplateKHR(Vk
                                                                               VkPipelineLayout layout, uint32_t set,
                                                                               const void *pData) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
+    auto template_state = Get<UPDATE_TEMPLATE_STATE>(descriptorUpdateTemplate);
+    auto layout_data = Get<PIPELINE_LAYOUT_STATE>(layout);
+    if (!cb_state || !template_state || !layout_data) {
+        return;
+    }
 
     cb_state->RecordCmd(CMD_PUSHDESCRIPTORSETWITHTEMPLATEKHR);
-    auto template_state = Get<UPDATE_TEMPLATE_STATE>(descriptorUpdateTemplate);
-    if (template_state) {
-        auto layout_data = Get<PIPELINE_LAYOUT_STATE>(layout);
-        auto dsl = layout_data ? layout_data->GetDsl(set) : nullptr;
-        const auto &template_ci = template_state->create_info;
-        // Decode the template into a set of write updates
-        cvdescriptorset::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state.get(), pData,
-                                                                dsl->GetDescriptorSetLayout());
-        cb_state->PushDescriptorSetState(template_ci.pipelineBindPoint, layout_data.get(), set,
-                                         static_cast<uint32_t>(decoded_template.desc_writes.size()),
-                                         decoded_template.desc_writes.data());
-    }
+    auto dsl = layout_data->GetDsl(set);
+    const auto &template_ci = template_state->create_info;
+    // Decode the template into a set of write updates
+    cvdescriptorset::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state.get(), pData,
+                                                            dsl->GetDescriptorSetLayout());
+    cb_state->PushDescriptorSetState(template_ci.pipelineBindPoint, *layout_data, set,
+                                     static_cast<uint32_t>(decoded_template.desc_writes.size()),
+                                     decoded_template.desc_writes.data());
 }
 
 void ValidationStateTracker::RecordGetPhysicalDeviceDisplayPlanePropertiesState(VkPhysicalDevice physicalDevice,

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -952,6 +952,10 @@ void PipelineLayout::init(const Device &dev, VkPipelineLayoutCreateInfo &info,
     info.setLayoutCount = layout_handles.size();
     info.pSetLayouts = layout_handles.data();
 
+    init(dev, info);
+}
+
+void PipelineLayout::init(const Device &dev, VkPipelineLayoutCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreatePipelineLayout, dev, &info);
 }
 

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -758,8 +758,11 @@ class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
   public:
     PipelineLayout() noexcept : NonDispHandle() {}
     PipelineLayout(const Device &dev, VkPipelineLayoutCreateInfo &info,
-                   const std::vector<const DescriptorSetLayout *> &layouts = {}) {
+                   const std::vector<const DescriptorSetLayout *> &layouts) {
         init(dev, info, layouts);
+    }
+    PipelineLayout(const Device &dev, VkPipelineLayoutCreateInfo &info) {
+        init(dev, info);
     }
     ~PipelineLayout() noexcept;
 
@@ -774,6 +777,7 @@ class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
 
     // vCreatePipelineLayout()
     void init(const Device &dev, VkPipelineLayoutCreateInfo &info, const std::vector<const DescriptorSetLayout *> &layouts);
+    void init(const Device &dev, VkPipelineLayoutCreateInfo &info);
 };
 
 class Sampler : public internal::NonDispHandle<VkSampler> {


### PR DESCRIPTION
These 2 VUIDs are about which pipelines are compatible with vkCmdBindDescriptorSets() or vkCmdSetDescriptorBufferOffsetsEXT(). The old code was looking at state set by vkCmdBindDescriptorBuffersEXT(). It should be valid to have descriptor buffers bound but not used to allow switching back and forth between pipelines that use descriptor sets and descriptor buffers.

Fixes #4913