### PR TITLE
state: Simplify CMD_BUFFER_STATE object tracking

### DIFF
--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -250,7 +250,6 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     uint32_t active_render_pass_device_mask;
     uint32_t activeSubpass;
     std::shared_ptr<FRAMEBUFFER_STATE> activeFramebuffer;
-    layer_data::unordered_set<std::shared_ptr<FRAMEBUFFER_STATE>> framebuffers;
     // Unified data structs to track objects bound to this command buffer as well as object
     //  dependencies that have been broken : either destroyed objects, or updated descriptor sets
     layer_data::unordered_set<std::shared_ptr<BASE_NODE>> object_bindings;


### PR DESCRIPTION
Remove the `framebuffers` map since it is redundant with `object_bindings`.

Work around a possible race condition in NotifyInvalidate. Due to interactions between the `BASE_NODE::tree_lock_` and `CMD_BUFFER_STATE::lock` it was possible for a (not really) 'bad' binding to get added to `broken_bindings`. Try to fix this by only adding a node to `broken_bindings` if it was still found in `object_bindings`.