### PR TITLE
Breakup ValidatePipeline function

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1824,19 +1824,19 @@ bool CoreChecks::ValidateCmdRayQueryState(const CMD_BUFFER_STATE &cb_state, CMD_
     return skip;
 }
 
-bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE &pPipeline) const {
+bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE &pipeline) const {
     bool skip = false;
-    const auto *color_blend_state = pPipeline.ColorBlendState();
-    const auto &rp_state = pPipeline.RenderPassState();
+    const auto *color_blend_state = pipeline.ColorBlendState();
+    const auto &rp_state = pipeline.RenderPassState();
     if (rp_state && color_blend_state) {
-        const auto subpass = pPipeline.Subpass();
+        const auto subpass = pipeline.Subpass();
         const auto *subpass_desc = &rp_state->createInfo.pSubpasses[subpass];
 
         uint32_t numberColorAttachments = rp_state->UsesDynamicRendering()
                                               ? rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount
                                               : subpass_desc->colorAttachmentCount;
 
-        for (uint32_t i = 0; i < pPipeline.Attachments().size() && i < numberColorAttachments; ++i) {
+        for (uint32_t i = 0; i < pipeline.Attachments().size() && i < numberColorAttachments; ++i) {
             VkFormatFeatureFlags2KHR format_features;
 
             if (rp_state->UsesDynamicRendering()) {
@@ -1844,7 +1844,7 @@ bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE &pPipe
                     skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06055",
                                      "Pipeline %s: VkPipelineRenderingCreateInfoKHR::colorAttachmentCount (%" PRIu32
                                      ") must equal pColorBlendState->attachmentCount (%" PRIu32 ")",
-                                     report_data->FormatHandle(pPipeline.pipeline()).c_str(), numberColorAttachments,
+                                     report_data->FormatHandle(pipeline.pipeline()).c_str(), numberColorAttachments,
                                      color_blend_state->attachmentCount);
                 }
             } else {
@@ -1854,8 +1854,8 @@ bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE &pPipe
                 const auto attachment_desc = rp_state->createInfo.pAttachments[attachment];
                 format_features = GetPotentialFormatFeatures(attachment_desc.format);
 
-                const auto *raster_state = pPipeline.RasterizationState();
-                if (raster_state && !raster_state->rasterizerDiscardEnable && pPipeline.Attachments()[i].blendEnable &&
+                const auto *raster_state = pipeline.RasterizationState();
+                if (raster_state && !raster_state->rasterizerDiscardEnable && pipeline.Attachments()[i].blendEnable &&
                     !(format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR)) {
                     skip |= LogError(
                         device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06041",

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -634,6 +634,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelinePreRasterState(const PIPELINE_STATE& pipeline, const uint32_t pipe_index) const;
     bool ValidateGraphicsPipelineColorBlendState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
                                                  const uint32_t pipe_index) const;
+    bool ValidateGraphicsPipelineRasterizationState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
+                                                    const uint32_t pipe_index) const;
     bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline) const;
     uint32_t CalcShaderStageCount(const PIPELINE_STATE& pipeline, VkShaderStageFlagBits stageBit) const;
     bool GroupHasValidIndex(const PIPELINE_STATE& pipeline, uint32_t group, uint32_t stage) const;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -631,6 +631,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineShaderDynamicState(const PIPELINE_STATE& pipeline, const CMD_BUFFER_STATE& cb_state,
                                                     const char* caller, const DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE& pPipeline) const;
+    bool ValidateGraphicsPipelineColorBlendState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
+                                                 const uint32_t pipe_index) const;
     bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline) const;
     uint32_t CalcShaderStageCount(const PIPELINE_STATE& pipeline, VkShaderStageFlagBits stageBit) const;
     bool GroupHasValidIndex(const PIPELINE_STATE& pipeline, uint32_t group, uint32_t stage) const;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -630,7 +630,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineShaderState(const PIPELINE_STATE& pipeline) const;
     bool ValidateGraphicsPipelineShaderDynamicState(const PIPELINE_STATE& pipeline, const CMD_BUFFER_STATE& cb_state,
                                                     const char* caller, const DrawDispatchVuid& vuid) const;
-    bool ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE& pPipeline) const;
+    bool ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE& pipeline) const;
     bool ValidateGraphicsPipelineColorBlendState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
                                                  const uint32_t pipe_index) const;
     bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline) const;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -631,6 +631,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineShaderDynamicState(const PIPELINE_STATE& pipeline, const CMD_BUFFER_STATE& cb_state,
                                                     const char* caller, const DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE& pipeline) const;
+    bool ValidateGraphicsPipelinePreRasterState(const PIPELINE_STATE& pipeline, const uint32_t pipe_index) const;
     bool ValidateGraphicsPipelineColorBlendState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
                                                  const uint32_t pipe_index) const;
     bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline) const;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -636,6 +636,8 @@ class CoreChecks : public ValidationStateTracker {
                                                  const uint32_t pipe_index) const;
     bool ValidateGraphicsPipelineRasterizationState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
                                                     const uint32_t pipe_index) const;
+    bool ValidateGraphicsPipelineMultisampleState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
+                                                  const uint32_t pipe_index) const;
     bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline) const;
     uint32_t CalcShaderStageCount(const PIPELINE_STATE& pipeline, VkShaderStageFlagBits stageBit) const;
     bool GroupHasValidIndex(const PIPELINE_STATE& pipeline, uint32_t group, uint32_t stage) const;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -638,6 +638,7 @@ class CoreChecks : public ValidationStateTracker {
                                                     const uint32_t pipe_index) const;
     bool ValidateGraphicsPipelineMultisampleState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
                                                   const uint32_t pipe_index) const;
+    bool ValidateGraphicsPipelineDynamicState(const PIPELINE_STATE& pipeline, const uint32_t pipe_index) const;
     bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline) const;
     uint32_t CalcShaderStageCount(const PIPELINE_STATE& pipeline, VkShaderStageFlagBits stageBit) const;
     bool GroupHasValidIndex(const PIPELINE_STATE& pipeline, uint32_t group, uint32_t stage) const;


### PR DESCRIPTION
The function was hitting over 2000 lines and hard to maintain and some redundant work being done. Broke the function into some helper functions, makes it easier to make improvements in the future for this change

Made a per-commit change because moving the Dynamic and Multisample state code seems to trip up `git` and does a **bad** job showing the simple move diff