### PR TITLE
layers: Fix 00736 trigger

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1983,7 +1983,9 @@ bool CoreChecks::ValidateGraphicsPipelinePreRasterState(const PIPELINE_STATE &pi
 
         // VK_PRIMITIVE_TOPOLOGY_PATCH_LIST primitive topology is only valid for tessellation pipelines.
         // Mismatching primitive topology and tessellation fails graphics pipeline creation.
-        if (has_control && has_eval && (!ia_state || ia_state->topology != VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)) {
+        // NOTE: For GPL, vertex input state must be present to test this
+        if (has_control && has_eval && pipeline.vertex_input_state && pipeline.pre_raster_state &&
+            (!ia_state || ia_state->topology != VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)) {
             skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pStages-00736",
                              "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
                              "] State: VK_PRIMITIVE_TOPOLOGY_PATCH_LIST must be set as IA topology for "


### PR DESCRIPTION
00736 should only be triggered when vertex input state (not just
pre-raster state) is present.