### PR TITLE
layers: Fix 06887 to check stencil write mask

### DIFF
--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -235,6 +235,9 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     bool usedDynamicViewportCount;
     bool usedDynamicScissorCount;
 
+    uint32_t write_mask_front;
+    uint32_t write_mask_back;
+
     uint32_t initial_device_mask;
     VkPrimitiveTopology primitiveTopology;
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3018,6 +3018,17 @@ void ValidationStateTracker::PreCallRecordCmdSetStencilWriteMask(VkCommandBuffer
     cb_state->RecordStateCmd(CMD_SETSTENCILWRITEMASK, CB_DYNAMIC_STENCIL_WRITE_MASK_SET);
 }
 
+void ValidationStateTracker::PostCallRecordCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
+                                                                  uint32_t writeMask) {
+    auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
+    if (faceMask == VK_STENCIL_FACE_FRONT_BIT || faceMask == VK_STENCIL_FACE_FRONT_AND_BACK) {
+        cb_state->write_mask_front = writeMask;
+    }
+    if (faceMask == VK_STENCIL_FACE_BACK_BIT || faceMask == VK_STENCIL_FACE_FRONT_AND_BACK) {
+        cb_state->write_mask_back = writeMask;
+    }
+}
+
 void ValidationStateTracker::PreCallRecordCmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                                  uint32_t reference) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);

--- a/layers/state_tracker.h
+++ b/layers/state_tracker.h
@@ -1076,6 +1076,8 @@ class ValidationStateTracker : public ValidationObject {
                                              uint32_t reference) override;
     void PreCallRecordCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                              uint32_t writeMask) override;
+    void PostCallRecordCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
+                                              uint32_t writeMask) override;
     void PreCallRecordCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                      const VkViewport* pViewports) override;
     void PreCallRecordCmdSetViewportShadingRatePaletteNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4921

The spec was updated in 1.3.237 to have the VU check the `writeMask` (static or dynamic)