### PR TITLE
tests: Use vk_testing:: objects in descriptor tests

### DIFF
--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -678,6 +678,12 @@ void Buffer::bind_memory(const Device &dev, VkMemoryPropertyFlags mem_props, VkD
     bind_memory(internal_mem_, mem_offset);
 }
 
+VkDeviceAddress Buffer::address() const {
+    auto bdai = LvlInitStruct<VkBufferDeviceAddressInfo>();
+    bdai.buffer = handle();
+    return vk::GetBufferDeviceAddress(device(), &bdai);
+}
+
 NON_DISPATCHABLE_HANDLE_DTOR(BufferView, vk::DestroyBufferView)
 
 void BufferView::init(const Device &dev, const VkBufferViewCreateInfo &info) {

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -437,6 +437,12 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
     explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
         init(dev, info, mem_props, alloc_info_pnext);
     }
+    explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props,
+                    VkMemoryAllocateFlags alloc_flags) {
+        auto memflagsinfo = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+        memflagsinfo.flags = alloc_flags;
+        init(dev, info, mem_props, &memflagsinfo);
+    }
     explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, NoMemT) { init_no_mem(dev, info); }
     explicit Buffer(const Device &dev, VkDeviceSize size) { init(dev, size); }
 
@@ -525,6 +531,8 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
         }
         return barrier;
     }
+
+    [[nodiscard]] VkDeviceAddress address() const;
 
   private:
     VkBufferCreateInfo create_info_;

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -193,6 +193,7 @@ class Device : public internal::Handle<VkDevice> {
   public:
     explicit Device(VkPhysicalDevice phy) : phy_(phy) {}
     ~Device() noexcept;
+    void destroy() noexcept;
 
     // vkCreateDevice()
     void init(const VkDeviceCreateInfo &info);
@@ -309,6 +310,7 @@ class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
     DeviceMemory() = default;
     DeviceMemory(const Device &dev, const VkMemoryAllocateInfo &info) { init(dev, info); }
     ~DeviceMemory() noexcept;
+    void destroy() noexcept;
 
     // vkAllocateMemory()
     void init(const Device &dev, const VkMemoryAllocateInfo &info);
@@ -338,6 +340,7 @@ class Fence : public internal::NonDispHandle<VkFence> {
     Fence() = default;
     Fence(const Device &dev, const VkFenceCreateInfo &info) { init(dev, info); }
     ~Fence() noexcept;
+    void destroy() noexcept;
 
     // vkCreateFence()
     void init(const Device &dev, const VkFenceCreateInfo &info);
@@ -367,6 +370,7 @@ class Semaphore : public internal::NonDispHandle<VkSemaphore> {
     Semaphore(const Device &dev) { init(dev, LvlInitStruct<VkSemaphoreCreateInfo>()); }
     Semaphore(const Device &dev, const VkSemaphoreCreateInfo &info) { init(dev, info); }
     ~Semaphore() noexcept;
+    void destroy() noexcept;
 
     // vkCreateSemaphore()
     void init(const Device &dev, const VkSemaphoreCreateInfo &info);
@@ -384,6 +388,7 @@ class Event : public internal::NonDispHandle<VkEvent> {
     Event(const Device &dev) { init(dev, LvlInitStruct<VkEventCreateInfo>()); }
     Event(const Device &dev, const VkEventCreateInfo &info) { init(dev, info); }
     ~Event() noexcept;
+    void destroy() noexcept;
 
     // vkCreateEvent()
     void init(const Device &dev, const VkEventCreateInfo &info);
@@ -408,6 +413,7 @@ class QueryPool : public internal::NonDispHandle<VkQueryPool> {
     QueryPool() = default;
     QueryPool(const Device &dev, const VkQueryPoolCreateInfo &info) { init(dev, info); }
     ~QueryPool() noexcept;
+    void destroy() noexcept;
 
     // vkCreateQueryPool()
     void init(const Device &dev, const VkQueryPoolCreateInfo &info);
@@ -435,6 +441,7 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
     explicit Buffer(const Device &dev, VkDeviceSize size) { init(dev, size); }
 
     ~Buffer() noexcept;
+    void destroy() noexcept;
 
     // vkCreateBuffer()
     void init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext = nullptr);
@@ -530,6 +537,7 @@ class BufferView : public internal::NonDispHandle<VkBufferView> {
     BufferView() = default;
     BufferView(const Device &dev, const VkBufferViewCreateInfo &info) { init(dev, info); }
     ~BufferView() noexcept;
+    void destroy() noexcept;
 
     // vkCreateBufferView()
     void init(const Device &dev, const VkBufferViewCreateInfo &info);
@@ -554,6 +562,7 @@ class Image : public internal::NonDispHandle<VkImage> {
     explicit Image(const Device &dev, const VkImageCreateInfo &info, NoMemT) : format_features_(0) { init_no_mem(dev, info); }
 
     ~Image() noexcept;
+    void destroy() noexcept;
 
     // vkCreateImage()
     void init(const Device &dev, const VkImageCreateInfo &info, VkMemoryPropertyFlags mem_props);
@@ -658,6 +667,7 @@ class ImageView : public internal::NonDispHandle<VkImageView> {
     explicit ImageView() = default;
     explicit ImageView(const Device &dev, const VkImageViewCreateInfo &info) { init(dev, info); }
     ~ImageView() noexcept;
+    void destroy() noexcept;
 
     // vkCreateImageView()
     void init(const Device &dev, const VkImageViewCreateInfo &info);
@@ -668,7 +678,8 @@ class AccelerationStructure : public internal::NonDispHandle<VkAccelerationStruc
     explicit AccelerationStructure(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory = true) {
         init(dev, info, init_memory);
     }
-    ~AccelerationStructure();
+    ~AccelerationStructure() noexcept;
+    void destroy() noexcept;
 
     // vkCreateAccelerationStructureNV
     void init(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory = true);
@@ -697,7 +708,9 @@ class AccelerationStructureKHR : public internal::NonDispHandle<VkAccelerationSt
                                       bool init_memory = true) {
         init(dev, info, init_memory);
     }
-    ~AccelerationStructureKHR();
+    ~AccelerationStructureKHR() noexcept;
+    void destroy() noexcept;
+
     // vkCreateAccelerationStructureNV
     void init(const Device &dev, const VkAccelerationStructureCreateInfoKHR &info, bool init_memory = true);
     uint64_t opaque_handle() const { return opaque_handle_; }
@@ -718,6 +731,7 @@ class AccelerationStructureKHR : public internal::NonDispHandle<VkAccelerationSt
 class ShaderModule : public internal::NonDispHandle<VkShaderModule> {
   public:
     ~ShaderModule() noexcept;
+    void destroy() noexcept;
 
     // vkCreateShaderModule()
     void init(const Device &dev, const VkShaderModuleCreateInfo &info);
@@ -735,6 +749,7 @@ class Pipeline : public internal::NonDispHandle<VkPipeline> {
     }
     Pipeline(const Device &dev, const VkComputePipelineCreateInfo &info) { init(dev, info); }
     ~Pipeline() noexcept;
+    void destroy() noexcept;
 
     // vkCreateGraphicsPipeline()
     void init(const Device &dev, const VkGraphicsPipelineCreateInfo &info);
@@ -765,6 +780,7 @@ class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
         init(dev, info);
     }
     ~PipelineLayout() noexcept;
+    void destroy() noexcept;
 
     // Move constructor for Visual Studio 2013
     PipelineLayout(PipelineLayout &&src) noexcept : NonDispHandle(std::move(src)){};
@@ -785,6 +801,7 @@ class Sampler : public internal::NonDispHandle<VkSampler> {
     Sampler() = default;
     Sampler(const Device &dev, const VkSamplerCreateInfo &info) { init(dev, info); }
     ~Sampler() noexcept;
+    void destroy() noexcept;
 
     // vkCreateSampler()
     void init(const Device &dev, const VkSamplerCreateInfo &info);
@@ -795,6 +812,7 @@ class DescriptorSetLayout : public internal::NonDispHandle<VkDescriptorSetLayout
     DescriptorSetLayout() noexcept : NonDispHandle(){};
     DescriptorSetLayout(const Device &dev, const VkDescriptorSetLayoutCreateInfo &info) { init(dev, info); }
     ~DescriptorSetLayout() noexcept;
+    void destroy() noexcept;
 
     // Move constructor for Visual Studio 2013
     DescriptorSetLayout(DescriptorSetLayout &&src) noexcept : NonDispHandle(std::move(src)){};
@@ -814,6 +832,7 @@ class DescriptorPool : public internal::NonDispHandle<VkDescriptorPool> {
     DescriptorPool() = default;
     DescriptorPool(const Device &dev, const VkDescriptorPoolCreateInfo &info) { init(dev, info); }
     ~DescriptorPool() noexcept;
+    void destroy() noexcept;
 
     // Descriptor sets allocated from this pool will need access to the original
     // object
@@ -859,6 +878,7 @@ inline VkDescriptorPoolCreateInfo DescriptorPool::create_info(VkDescriptorPoolCr
 class DescriptorSet : public internal::NonDispHandle<VkDescriptorSet> {
   public:
     ~DescriptorSet() noexcept;
+    void destroy() noexcept;
 
     explicit DescriptorSet() : NonDispHandle() {}
     explicit DescriptorSet(const Device &dev, DescriptorPool *pool, VkDescriptorSet set) : NonDispHandle(dev.handle(), set) {
@@ -872,6 +892,7 @@ class DescriptorSet : public internal::NonDispHandle<VkDescriptorSet> {
 class CommandPool : public internal::NonDispHandle<VkCommandPool> {
   public:
     ~CommandPool() noexcept;
+    void destroy() noexcept;
 
     explicit CommandPool() : NonDispHandle() {}
     explicit CommandPool(const Device &dev, const VkCommandPoolCreateInfo &info) { init(dev, info); }
@@ -891,6 +912,7 @@ inline VkCommandPoolCreateInfo CommandPool::create_info(uint32_t queue_family_in
 class CommandBuffer : public internal::Handle<VkCommandBuffer> {
   public:
     ~CommandBuffer() noexcept;
+    void destroy() noexcept;
 
     explicit CommandBuffer() : Handle() {}
     explicit CommandBuffer(const Device &dev, const VkCommandBufferAllocateInfo &info) { init(dev, info); }
@@ -921,6 +943,7 @@ class RenderPass : public internal::NonDispHandle<VkRenderPass> {
     RenderPass(const Device &dev, const VkRenderPassCreateInfo &info) { init(dev, info); }
     RenderPass(const Device &dev, const VkRenderPassCreateInfo2 &info, bool khr = false) { init(dev, info, khr); }
     ~RenderPass() noexcept;
+    void destroy() noexcept;
 
     // vkCreateRenderPass()
     void init(const Device &dev, const VkRenderPassCreateInfo &info);
@@ -934,6 +957,7 @@ class Framebuffer : public internal::NonDispHandle<VkFramebuffer> {
     Framebuffer() = default;
     Framebuffer(const Device &dev, const VkFramebufferCreateInfo &info) { init(dev, info); }
     ~Framebuffer() noexcept;
+    void destroy() noexcept;
 
     // vkCreateFramebuffer()
     void init(const Device &dev, const VkFramebufferCreateInfo &info);
@@ -949,6 +973,7 @@ class SamplerYcbcrConversion : public internal::NonDispHandle<VkSamplerYcbcrConv
         init(dev, info, khr);
     }
     ~SamplerYcbcrConversion() noexcept;
+    void destroy() noexcept;
 
     void init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info, bool khr);
     VkSamplerYcbcrConversionInfo ConversionInfo();


### PR DESCRIPTION
Add some stuff to make the vk_testing:: objects easier to use:

- vk_testing::*::destroy() methods 
- vk_testing::Buffer::address() and another constructor that makes it easy to set VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT

Then convert a bunch of descriptor tests to use these objects instead of raw vulkan handles.