### PR TITLE
layers: Use stage from pipleline library

### DIFF
--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -3461,7 +3461,7 @@ bool CoreChecks::GroupHasValidIndex(const PIPELINE_STATE &pipeline, uint32_t gro
             const auto lib_stages = library_pipeline->GetShaderStages();
             const uint32_t stage_count = static_cast<uint32_t>(lib_stages.size());
             if (group < stage_count) {
-                return (stages[group].stage & stage) != 0;
+                return (lib_stages[group].stage & stage) != 0;
             }
             group -= stage_count;
         }


### PR DESCRIPTION
Should fix https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3672
