### PR TITLE
Add best practices VU for useless secondary command buffer

### DIFF
--- a/layers/best_practices_error_enums.h
+++ b/layers/best_practices_error_enums.h
@@ -91,6 +91,8 @@
     "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateCommandPool_CommandBufferReset =
     "UNASSIGNED-BestPractices-vkCreateCommandPool-command-buffer-reset";
+[[maybe_unused]] static const char *kVUID_BestPractices_AllocateCommandBuffers_UnusableSecondary =
+    "UNASSIGNED-BestPractices-vkAllocateCommandBuffers-unusable-secondary";
 [[maybe_unused]] static const char *kVUID_BestPractices_BeginCommandBuffer_SimultaneousUse =
     "UNASSIGNED-BestPractices-vkBeginCommandBuffer-simultaneous-use";
 [[maybe_unused]] static const char *kVUID_BestPractices_AllocateMemory_SmallAllocation =

--- a/layers/best_practices_validation.h
+++ b/layers/best_practices_validation.h
@@ -441,6 +441,8 @@ class BestPractices : public ValidationStateTracker {
     void PreCallRecordSetDeviceMemoryPriorityEXT(VkDevice device, VkDeviceMemory memory, float priority) override;
     bool PreCallValidateCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
                                           const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool) const override;
+    bool PreCallValidateAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                               VkCommandBuffer* pCommandBuffers) const override;
     void PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator) override;
     bool PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator) const override;
     bool ValidateMultisampledBlendingArm(uint32_t createInfoCount, const VkGraphicsPipelineCreateInfo* pCreateInfos) const;


### PR DESCRIPTION
This change adds a new VU to the best practices layer that detects `vkAllocateCommandBuffers` calls trying to allocate secondary command buffers for queue families that do not support the `vkCmdExecuteCommands` command (queues that do not support graphics, compute, or transfer) and reports a warning about the allocated command buffer not being submittable.