### PR TITLE
layers: Remove GetImageSubresourceLayout2 tiling VU

### DIFF
--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -7709,13 +7709,13 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkIma
     if (IsExtEnabled(device_extensions.vk_ext_image_drm_format_modifier)) {
         if ((image_entry->createInfo.tiling != VK_IMAGE_TILING_LINEAR) &&
             (image_entry->createInfo.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT)) {
-            skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-image-02270",
+            skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-image-07790",
                              "vkGetImageSubresourceLayout(): Image must have tiling of VK_IMAGE_TILING_LINEAR or "
                              "VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT.");
         }
     } else {
         if (image_entry->createInfo.tiling != VK_IMAGE_TILING_LINEAR) {
-            skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-image-00996",
+            skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-image-07789",
                              "vkGetImageSubresourceLayout(): Image must have tiling of VK_IMAGE_TILING_LINEAR.");
         }
     }

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -21925,26 +21925,9 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout2EXT(VkDevice device, V
 
     if (imageState) {
         const VkImageAspectFlags aspectMask = pSubresource->imageSubresource.aspectMask;
-        const VkImageTiling imageTiling = imageState->createInfo.tiling;
         const VkFormat imageFormat = imageState->createInfo.format;
         const uint32_t imageMipLevels = imageState->createInfo.mipLevels;
         const uint32_t imageArrayLayers = imageState->createInfo.arrayLayers;
-
-        if (IsExtEnabled(device_extensions.vk_ext_image_drm_format_modifier)) {
-            if (imageTiling != VK_IMAGE_TILING_LINEAR && imageTiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
-                skip |= LogError(image, "VUID-vkGetImageSubresourceLayout-image-02270",
-                                 "vkGetImageSubresourceLayout2EXT: Image tiling is required to be VK_IMAGE_TILING_LINEAR or "
-                                 "VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT but image tiling is %s",
-                                 string_VkImageTiling(imageTiling));
-            }
-        } else {
-            if (imageTiling != VK_IMAGE_TILING_LINEAR) {
-                skip |= LogError(image, "VUID-vkGetImageSubresourceLayout2EXT-image-00996",
-                                 "vkGetImageSubresourceLayout2EXT: Image tiling is required to be VK_IMAGE_TILING_LINEAR but image "
-                                 "tiling is image tiling is %s",
-                                 string_VkImageTiling(imageTiling));
-            }
-        }
 
         if (aspectMask == 0 || (aspectMask & (aspectMask - 1))) {  // 0 or Multiple bit set
             skip |= LogError(image, "VUID-vkGetImageSubresourceLayout2EXT-aspectMask-00997",

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -8142,7 +8142,7 @@ TEST_F(VkLayerTest, ExerciseGetImageSubresourceLayout) {
         subres.mipLevel = 0;
         subres.arrayLayer = 0;
 
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout-image-00996");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout-image-07789");
         vk::GetImageSubresourceLayout(m_device->device(), img.image(), &subres, &subres_layout);
         m_errorMonitor->VerifyFound();
     }
@@ -16047,22 +16047,6 @@ TEST_F(VkLayerTest, InvalidImageCompressionControl) {
 
         return supported;
     };
-
-    // Image Tiling Mode
-    {
-        VkImageObj image(m_device);
-        if (create_compressed_image(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL, image)) {
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2EXT-image-00996");
-            VkImageSubresource2EXT subresource = LvlInitStruct<VkImageSubresource2EXT>();
-            subresource.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0};
-
-            VkImageCompressionPropertiesEXT compressionProperties = LvlInitStruct<VkImageCompressionPropertiesEXT>();
-            VkSubresourceLayout2EXT layout = LvlInitStruct<VkSubresourceLayout2EXT>(&compressionProperties);
-
-            vkGetImageSubresourceLayout2EXT(m_device->handle(), image.handle(), &subresource, &layout);
-            m_errorMonitor->VerifyFound();
-        }
-    }
 
     // Exceed MipmapLevel
     {

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -598,7 +598,7 @@ TEST_F(VkLayerTest, InvalidPushConstants) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
     // Check for invalid stage flag
-    // Note that VU 00996 isn't reached due to parameter validation
+    // Note that VU 07789 isn't reached due to parameter validation
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdPushConstants-stageFlags-requiredbitmask");
     vk::CmdPushConstants(m_commandBuffer->handle(), pipeline_layout_obj.handle(), 0, 0, 16, dummy_values);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
the 1.3.238 headers removed the tiling check for `GetImageSubresourceLayout2`

This both removes the VU and relabels the `GetImageSubresourceLayout` VUIDs