### PR TITLE
layers: Do not allow binding empty DS

### DIFF
--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -165,8 +165,14 @@ bool CoreChecks::VerifySetLayoutCompatibility(const cvdescriptorset::DescriptorS
     }
     if (descriptor_set.IsPushDescriptor()) return true;
     const auto *layout_node = pipeline_layout.set_layouts[layoutIndex].get();
-    if (layout_node && (descriptor_set.GetBindingCount() > 0) && (layout_node->GetBindingCount() > 0)) {
-        return VerifySetLayoutCompatibility(*layout_node, *descriptor_set.GetLayout(), errorMsg);
+    if (layout_node) {
+        if ((descriptor_set.GetBindingCount() > 0) && (layout_node->GetBindingCount() > 0)) {
+            return VerifySetLayoutCompatibility(*layout_node, *descriptor_set.GetLayout(), errorMsg);
+        } else {
+            // Only a null DSL can be used to "skip" a descriptor set a bind time, not an empty one.
+            errorMsg = "Descriptor set " + report_data->FormatHandle(descriptor_set.Handle()) + " is empty (has no bindings). Use VK_NULL_HANDLE to indicate this set is unused if using VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT.";
+            return false;
+        }
     } else {
         // It's possible the DSL is null when creating a graphics pipeline library, in which case we can't verify compatibility
         // here.


### PR DESCRIPTION
This effectively reverts https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/c82d75fe22da9a1115e3a5b5f98cd220fc8653bb, which allowed binding empty
descriptor sets.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4768.