### PR TITLE
Replace usage of VK_ICD_FILENAMES with VK_DRIVER_FILES

### DIFF
--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -172,12 +172,12 @@ def RunVVLTests(args):
         raise Exception(f'VK_LAYER_PATH directory "{layer_path}" does not exist')
     lvt_env['VK_LAYER_PATH'] = layer_path
 
-    icd_filenames = os.path.join(EXTERNAL_DIR, 'Vulkan-Tools', BUILD_DIR_NAME, 'icd')
-    if IsWindows(): icd_filenames = os.path.join(icd_filenames, args.configuration.capitalize())
-    icd_filenames = os.path.join(icd_filenames, 'VkICD_mock_icd.json')
-    if not os.path.isfile(icd_filenames):
-        raise Exception(f'VK_ICD_FILENAMES "{icd_filenames}" does not exist')
-    lvt_env['VK_ICD_FILENAMES'] = icd_filenames
+    vk_driver_files = os.path.join(EXTERNAL_DIR, 'Vulkan-Tools', BUILD_DIR_NAME, 'icd')
+    if IsWindows(): vk_driver_files = os.path.join(vk_driver_files, args.configuration.capitalize())
+    vk_driver_files = os.path.join(vk_driver_files, 'VkICD_mock_icd.json')
+    if not os.path.isfile(vk_driver_files):
+        raise Exception(f'VK_DRIVER_FILES "{vk_driver_files}" does not exist')
+    lvt_env['VK_DRIVER_FILES'] = vk_driver_files
 
     RunShellCmd(lvt_cmd, env=lvt_env)
     print("Re-Running multithreaded tests with VK_LAYER_FINE_GRAINED_LOCKING=1:")

--- a/tests/README.md
+++ b/tests/README.md
@@ -91,7 +91,7 @@ Clone and build the [MoltenVK](https://github.com/KhronosGroup/MoltenVK) reposit
 You will have to direct the loader from Vulkan-Loader to the MoltenVK ICD:
 
 ```bash
-export VK_ICD_FILENAMES=<path to MoltenVK repository>/Package/Latest/MoltenVK/macOS/MoltenVK_icd.json
+export VK_DRIVER_FILES=<path to MoltenVK repository>/Package/Latest/MoltenVK/macOS/MoltenVK_icd.json
 ```
 
 ## Running Tests on MockICD and Profiles layer
@@ -118,7 +118,7 @@ export VK_LAYER_PATH=$VK_LAYER_PATH:$VULKAN_SDK/etc/vulkan/explicit_layer.d/
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$VULKAN_SDK/lib/
 
 # Set MockICD to be driver
-export VK_ICD_FILENAMES=/path/to/Vulkan-Tools/build/icd/VkICD_mock_icd.json
+export VK_DRIVER_FILES=/path/to/Vulkan-Tools/build/icd/VkICD_mock_icd.json
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/Vulkan-Tools/build/icd/
 
 # Set Layers, the order here is VERY IMPORTANT otherwise the test will see the


### PR DESCRIPTION
VK_ICD_FILENAMES is listed as a deprecated environment variable:
https://github.com/KhronosGroup/Vulkan-Loader/blob/master/docs/LoaderInterfaceArchitecture.md#deprecated-environment-variables
