### PR TITLE
layers: Fix intermittent VUID 03047 false positives

### DIFF
--- a/layers/cmd_buffer_state.cpp
+++ b/layers/cmd_buffer_state.cpp
@@ -300,6 +300,7 @@ void CMD_BUFFER_STATE::NotifyInvalidate(const BASE_NODE::NodeList &invalid_nodes
             // being tracked by the command buffer. This is to try to avoid race conditions
             // caused by separate CMD_BUFFER_STATE and BASE_NODE::parent_nodes locking.
             if (object_bindings.erase(obj)) {
+                obj->RemoveParent(this);
                 found_invalid = true;
             }
             switch (obj->Type()) {


### PR DESCRIPTION
Make sure to remove the parent node if we're cleaning up an object_bindings entry in CMD_BUFFER_STATE::NotifyInvalidate(). Without this, child objects could have a stale parent and think they are in use when they're not.

Fixes #4981