### PR TITLE
More cleaning up of ValidatePipeline

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3185,6 +3185,138 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicState(const PIPELINE_STATE &pipe
     return skip;
 }
 
+bool CoreChecks::ValidateGraphicsPipelineFragmentShadingRateState(const PIPELINE_STATE &pipeline, const uint32_t pipe_index) const {
+    bool skip = false;
+    const VkPipelineFragmentShadingRateStateCreateInfoKHR *fragment_shading_rate_state =
+        LvlFindInChain<VkPipelineFragmentShadingRateStateCreateInfoKHR>(pipeline.PNext());
+    if (fragment_shading_rate_state && !pipeline.IsDynamic(VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR)) {
+        const char *struct_name = "VkPipelineFragmentShadingRateStateCreateInfoKHR";
+
+        if (fragment_shading_rate_state->fragmentSize.width == 0) {
+            skip |=
+                LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04494",
+                         "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32 "]: Fragment width of %u has been specified in %s.",
+                         pipe_index, fragment_shading_rate_state->fragmentSize.width, struct_name);
+        }
+
+        if (fragment_shading_rate_state->fragmentSize.height == 0) {
+            skip |=
+                LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04495",
+                         "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32 "]: Fragment height of %u has been specified in %s.",
+                         pipe_index, fragment_shading_rate_state->fragmentSize.height, struct_name);
+        }
+
+        if (fragment_shading_rate_state->fragmentSize.width != 0 &&
+            !IsPowerOfTwo(fragment_shading_rate_state->fragmentSize.width)) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04496",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: Non-power-of-two fragment width of %u has been specified in %s.",
+                             pipe_index, fragment_shading_rate_state->fragmentSize.width, struct_name);
+        }
+
+        if (fragment_shading_rate_state->fragmentSize.height != 0 &&
+            !IsPowerOfTwo(fragment_shading_rate_state->fragmentSize.height)) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04497",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: Non-power-of-two fragment height of %u has been specified in %s.",
+                             pipe_index, fragment_shading_rate_state->fragmentSize.height, struct_name);
+        }
+
+        if (fragment_shading_rate_state->fragmentSize.width > 4) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04498",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: Fragment width of %u specified in %s is too large.",
+                             pipe_index, fragment_shading_rate_state->fragmentSize.width, struct_name);
+        }
+
+        if (fragment_shading_rate_state->fragmentSize.height > 4) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04499",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: Fragment height of %u specified in %s is too large",
+                             pipe_index, fragment_shading_rate_state->fragmentSize.height, struct_name);
+        }
+
+        if (!enabled_features.fragment_shading_rate_features.pipelineFragmentShadingRate &&
+            fragment_shading_rate_state->fragmentSize.width != 1) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04500",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: Pipeline fragment width of %u has been specified in %s, but "
+                             "pipelineFragmentShadingRate is not enabled",
+                             pipe_index, fragment_shading_rate_state->fragmentSize.width, struct_name);
+        }
+
+        if (!enabled_features.fragment_shading_rate_features.pipelineFragmentShadingRate &&
+            fragment_shading_rate_state->fragmentSize.height != 1) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04500",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: Pipeline fragment height of %u has been specified in %s, but "
+                             "pipelineFragmentShadingRate is not enabled",
+                             pipe_index, fragment_shading_rate_state->fragmentSize.height, struct_name);
+        }
+
+        if (!enabled_features.fragment_shading_rate_features.primitiveFragmentShadingRate &&
+            fragment_shading_rate_state->combinerOps[0] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04501",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: First combiner operation of %s has been specified in %s, but "
+                             "primitiveFragmentShadingRate is not enabled",
+                             pipe_index, string_VkFragmentShadingRateCombinerOpKHR(fragment_shading_rate_state->combinerOps[0]),
+                             struct_name);
+        }
+
+        if (!enabled_features.fragment_shading_rate_features.attachmentFragmentShadingRate &&
+            fragment_shading_rate_state->combinerOps[1] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04502",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: Second combiner operation of %s has been specified in %s, but "
+                             "attachmentFragmentShadingRate is not enabled",
+                             pipe_index, string_VkFragmentShadingRateCombinerOpKHR(fragment_shading_rate_state->combinerOps[1]),
+                             struct_name);
+        }
+
+        if (!phys_dev_ext_props.fragment_shading_rate_props.fragmentShadingRateNonTrivialCombinerOps &&
+            (fragment_shading_rate_state->combinerOps[0] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR &&
+             fragment_shading_rate_state->combinerOps[0] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_REPLACE_KHR)) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-fragmentShadingRateNonTrivialCombinerOps-04506",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: First combiner operation of %s has been specified in %s, but "
+                             "fragmentShadingRateNonTrivialCombinerOps is not supported",
+                             pipe_index, string_VkFragmentShadingRateCombinerOpKHR(fragment_shading_rate_state->combinerOps[0]),
+                             struct_name);
+        }
+
+        if (!phys_dev_ext_props.fragment_shading_rate_props.fragmentShadingRateNonTrivialCombinerOps &&
+            (fragment_shading_rate_state->combinerOps[1] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR &&
+             fragment_shading_rate_state->combinerOps[1] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_REPLACE_KHR)) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-fragmentShadingRateNonTrivialCombinerOps-04506",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: Second combiner operation of %s has been specified in %s, but "
+                             "fragmentShadingRateNonTrivialCombinerOps is not supported",
+                             pipe_index, string_VkFragmentShadingRateCombinerOpKHR(fragment_shading_rate_state->combinerOps[1]),
+                             struct_name);
+        }
+
+        const auto combiner_ops = fragment_shading_rate_state->combinerOps;
+        if (pipeline.pre_raster_state || pipeline.fragment_shader_state) {
+            if (std::find(AllVkFragmentShadingRateCombinerOpKHREnums.begin(), AllVkFragmentShadingRateCombinerOpKHREnums.end(),
+                          combiner_ops[0]) == AllVkFragmentShadingRateCombinerOpKHREnums.end()) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-06567",
+                                 "vkCreateGraphicsPipelines(): in pCreateInfos[%" PRIu32
+                                 "], combinerOp[0] (%s) is not a valid VkFragmentShadingRateCombinerOpKHR value.",
+                                 pipe_index, string_VkFragmentShadingRateCombinerOpKHR(combiner_ops[0]));
+            }
+            if (std::find(AllVkFragmentShadingRateCombinerOpKHREnums.begin(), AllVkFragmentShadingRateCombinerOpKHREnums.end(),
+                          combiner_ops[1]) == AllVkFragmentShadingRateCombinerOpKHREnums.end()) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-06568",
+                                 "vkCreateGraphicsPipelines(): in pCreateInfos[%" PRIu32
+                                 "], combinerOp[1] (%s) is not a valid VkFragmentShadingRateCombinerOpKHR value.",
+                                 pipe_index, string_VkFragmentShadingRateCombinerOpKHR(combiner_ops[1]));
+            }
+        }
+    }
+    return skip;
+}
+
 bool CoreChecks::ValidatePipelineLibraryFlags(const VkGraphicsPipelineLibraryFlagsEXT lib_flags,
                                               const VkPipelineLibraryCreateInfoKHR &link_info,
                                               const VkPipelineRenderingCreateInfo *rendering_struct, uint32_t pipe_index,
@@ -3411,6 +3543,7 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
     skip |= ValidateGraphicsPipelineRasterizationState(pipeline, subpass_desc, pipe_index);
     skip |= ValidateGraphicsPipelineMultisampleState(pipeline, subpass_desc, pipe_index);
     skip |= ValidateGraphicsPipelineDynamicState(pipeline, pipe_index);
+    skip |= ValidateGraphicsPipelineFragmentShadingRateState(pipeline, pipe_index);
     skip |= ValidateGraphicsPipelineShaderState(pipeline);
     skip |= ValidateGraphicsPipelineBlendEnable(pipeline);
 
@@ -3475,135 +3608,6 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
     skip |= ValidatePipelineCacheControlFlags(pipeline.GetPipelineCreateFlags(), pipe_index, "vkCreateGraphicsPipelines",
                                               "VUID-VkGraphicsPipelineCreateInfo-pipelineCreationCacheControl-02878");
     skip |= ValidatePipelineProtectedAccessFlags(pipeline.GetPipelineCreateFlags(), pipe_index);
-
-    const VkPipelineFragmentShadingRateStateCreateInfoKHR *fragment_shading_rate_state =
-        LvlFindInChain<VkPipelineFragmentShadingRateStateCreateInfoKHR>(pipeline.PNext());
-
-    if (fragment_shading_rate_state && !pipeline.IsDynamic(VK_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR)) {
-        const char *struct_name = "VkPipelineFragmentShadingRateStateCreateInfoKHR";
-
-        if (fragment_shading_rate_state->fragmentSize.width == 0) {
-            skip |=
-                LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04494",
-                         "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32 "]: Fragment width of %u has been specified in %s.",
-                         pipe_index, fragment_shading_rate_state->fragmentSize.width, struct_name);
-        }
-
-        if (fragment_shading_rate_state->fragmentSize.height == 0) {
-            skip |=
-                LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04495",
-                         "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32 "]: Fragment height of %u has been specified in %s.",
-                         pipe_index, fragment_shading_rate_state->fragmentSize.height, struct_name);
-        }
-
-        if (fragment_shading_rate_state->fragmentSize.width != 0 &&
-            !IsPowerOfTwo(fragment_shading_rate_state->fragmentSize.width)) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04496",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: Non-power-of-two fragment width of %u has been specified in %s.",
-                             pipe_index, fragment_shading_rate_state->fragmentSize.width, struct_name);
-        }
-
-        if (fragment_shading_rate_state->fragmentSize.height != 0 &&
-            !IsPowerOfTwo(fragment_shading_rate_state->fragmentSize.height)) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04497",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: Non-power-of-two fragment height of %u has been specified in %s.",
-                             pipe_index, fragment_shading_rate_state->fragmentSize.height, struct_name);
-        }
-
-        if (fragment_shading_rate_state->fragmentSize.width > 4) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04498",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: Fragment width of %u specified in %s is too large.",
-                             pipe_index, fragment_shading_rate_state->fragmentSize.width, struct_name);
-        }
-
-        if (fragment_shading_rate_state->fragmentSize.height > 4) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04499",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: Fragment height of %u specified in %s is too large",
-                             pipe_index, fragment_shading_rate_state->fragmentSize.height, struct_name);
-        }
-
-        if (!enabled_features.fragment_shading_rate_features.pipelineFragmentShadingRate &&
-            fragment_shading_rate_state->fragmentSize.width != 1) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04500",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: Pipeline fragment width of %u has been specified in %s, but "
-                             "pipelineFragmentShadingRate is not enabled",
-                             pipe_index, fragment_shading_rate_state->fragmentSize.width, struct_name);
-        }
-
-        if (!enabled_features.fragment_shading_rate_features.pipelineFragmentShadingRate &&
-            fragment_shading_rate_state->fragmentSize.height != 1) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04500",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: Pipeline fragment height of %u has been specified in %s, but "
-                             "pipelineFragmentShadingRate is not enabled",
-                             pipe_index, fragment_shading_rate_state->fragmentSize.height, struct_name);
-        }
-
-        if (!enabled_features.fragment_shading_rate_features.primitiveFragmentShadingRate &&
-            fragment_shading_rate_state->combinerOps[0] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04501",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: First combiner operation of %s has been specified in %s, but "
-                             "primitiveFragmentShadingRate is not enabled",
-                             pipe_index, string_VkFragmentShadingRateCombinerOpKHR(fragment_shading_rate_state->combinerOps[0]),
-                             struct_name);
-        }
-
-        if (!enabled_features.fragment_shading_rate_features.attachmentFragmentShadingRate &&
-            fragment_shading_rate_state->combinerOps[1] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-04502",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: Second combiner operation of %s has been specified in %s, but "
-                             "attachmentFragmentShadingRate is not enabled",
-                             pipe_index, string_VkFragmentShadingRateCombinerOpKHR(fragment_shading_rate_state->combinerOps[1]),
-                             struct_name);
-        }
-
-        if (!phys_dev_ext_props.fragment_shading_rate_props.fragmentShadingRateNonTrivialCombinerOps &&
-            (fragment_shading_rate_state->combinerOps[0] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR &&
-             fragment_shading_rate_state->combinerOps[0] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_REPLACE_KHR)) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-fragmentShadingRateNonTrivialCombinerOps-04506",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: First combiner operation of %s has been specified in %s, but "
-                             "fragmentShadingRateNonTrivialCombinerOps is not supported",
-                             pipe_index, string_VkFragmentShadingRateCombinerOpKHR(fragment_shading_rate_state->combinerOps[0]),
-                             struct_name);
-        }
-
-        if (!phys_dev_ext_props.fragment_shading_rate_props.fragmentShadingRateNonTrivialCombinerOps &&
-            (fragment_shading_rate_state->combinerOps[1] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR &&
-             fragment_shading_rate_state->combinerOps[1] != VK_FRAGMENT_SHADING_RATE_COMBINER_OP_REPLACE_KHR)) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-fragmentShadingRateNonTrivialCombinerOps-04506",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: Second combiner operation of %s has been specified in %s, but "
-                             "fragmentShadingRateNonTrivialCombinerOps is not supported",
-                             pipe_index, string_VkFragmentShadingRateCombinerOpKHR(fragment_shading_rate_state->combinerOps[1]),
-                             struct_name);
-        }
-
-        const auto combiner_ops = fragment_shading_rate_state->combinerOps;
-        if (pipeline.pre_raster_state || pipeline.fragment_shader_state) {
-            if (std::find(AllVkFragmentShadingRateCombinerOpKHREnums.begin(), AllVkFragmentShadingRateCombinerOpKHREnums.end(),
-                          combiner_ops[0]) == AllVkFragmentShadingRateCombinerOpKHREnums.end()) {
-                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-06567",
-                                 "vkCreateGraphicsPipelines(): in pCreateInfos[%" PRIu32
-                                 "], combinerOp[0] (%s) is not a valid VkFragmentShadingRateCombinerOpKHR value.",
-                                 pipe_index, string_VkFragmentShadingRateCombinerOpKHR(combiner_ops[0]));
-            }
-            if (std::find(AllVkFragmentShadingRateCombinerOpKHREnums.begin(), AllVkFragmentShadingRateCombinerOpKHREnums.end(),
-                          combiner_ops[1]) == AllVkFragmentShadingRateCombinerOpKHREnums.end()) {
-                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-06568",
-                                 "vkCreateGraphicsPipelines(): in pCreateInfos[%" PRIu32
-                                 "], combinerOp[1] (%s) is not a valid VkFragmentShadingRateCombinerOpKHR value.",
-                                 pipe_index, string_VkFragmentShadingRateCombinerOpKHR(combiner_ops[1]));
-            }
-        }
-    }
 
     const auto *discard_rectangle_state = LvlFindInChain<VkPipelineDiscardRectangleStateCreateInfoEXT>(pipeline.PNext());
     if (discard_rectangle_state) {

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -3317,6 +3317,169 @@ bool CoreChecks::ValidateGraphicsPipelineFragmentShadingRateState(const PIPELINE
     return skip;
 }
 
+bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE &pipeline, const uint32_t pipe_index) const {
+    bool skip = false;
+    const auto rendering_struct = LvlFindInChain<VkPipelineRenderingCreateInfo>(pipeline.PNext());
+    if (rendering_struct) {
+        const auto color_blend_state = pipeline.ColorBlendState();
+        const auto raster_state = pipeline.RasterizationState();
+        const bool has_rasterization = raster_state && (raster_state->rasterizerDiscardEnable == VK_FALSE);
+        if (has_rasterization) {
+            if (((rendering_struct->depthAttachmentFormat != VK_FORMAT_UNDEFINED) ||
+                 (rendering_struct->stencilAttachmentFormat != VK_FORMAT_UNDEFINED)) &&
+                !pipeline.DepthStencilState()) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06053",
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "]: has fragment state and a depth format (%s) or stencil format (%s) and an invalid "
+                                 "pDepthStencilState structure",
+                                 pipe_index, string_VkFormat(rendering_struct->depthAttachmentFormat),
+                                 string_VkFormat(rendering_struct->stencilAttachmentFormat));
+            }
+
+            if ((rendering_struct->colorAttachmentCount != 0) && !color_blend_state &&
+                pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass == VK_NULL_HANDLE) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06054",
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "] has VkPipelineRenderingCreateInfoKHR::colorAttachmentCount (%" PRIu32
+                                 ") and an invalid pColorBlendState structure",
+                                 pipe_index, rendering_struct->colorAttachmentCount);
+            }
+        }
+
+        if (rendering_struct->viewMask != 0) {
+            const uint32_t active_shaders = pipeline.active_shaders;
+            if (!enabled_features.core11.multiviewTessellationShader &&
+                (active_shaders & VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
+                 active_shaders & VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06057",
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "] has VkPipelineRenderingCreateInfoKHR->viewMask(%" PRIu32
+                                 ") and "
+                                 "multiviewTessellationShader is not enabled, contains tesselation shaders",
+                                 pipe_index, rendering_struct->viewMask);
+            }
+
+            if (!enabled_features.core11.multiviewGeometryShader && (active_shaders & VK_SHADER_STAGE_GEOMETRY_BIT)) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06058",
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "] has VkPipelineRenderingCreateInfoKHR->viewMask(%" PRIu32
+                                 ") and "
+                                 "multiviewGeometryShader is not enabled, contains geometry shader",
+                                 pipe_index, rendering_struct->viewMask);
+            }
+
+            if (!enabled_features.mesh_shader_features.multiviewMeshShader && (active_shaders & VK_SHADER_STAGE_MESH_BIT_EXT)) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-07064",
+                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                 "] has VkPipelineRenderingCreateInfoKHR->viewMask(%" PRIu32
+                                 ") and "
+                                 "multiviewMeshShader is not enabled, contains mesh shader",
+                                 pipe_index, rendering_struct->viewMask);
+            }
+
+            if (pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass == VK_NULL_HANDLE && raster_state) {
+                for (const auto &stage : pipeline.stage_state) {
+                    if (stage.writes_to_gl_layer) {
+                        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06059",
+                                         "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                         "] is being created with fragment shader state and renderPass != VK_NULL_HANDLE, but "
+                                         "pMultisampleState is NULL.",
+                                         pipe_index);
+                    }
+                }
+            }
+        }
+
+        for (uint32_t color_index = 0; color_index < rendering_struct->colorAttachmentCount; color_index++) {
+            const VkFormat color_format = rendering_struct->pColorAttachmentFormats[color_index];
+            if (color_format != VK_FORMAT_UNDEFINED) {
+                VkFormatFeatureFlags2KHR format_features = GetPotentialFormatFeatures(color_format);
+                if (((format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) == 0) &&
+                    (color_blend_state && (color_index < color_blend_state->attachmentCount) &&
+                     (color_blend_state->pAttachments[color_index].blendEnable != VK_FALSE))) {
+                    skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06062",
+                                     "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                     "]: pColorBlendState->blendEnable must be false ",
+                                     pipe_index);
+                }
+
+                if (!IsExtEnabled(device_extensions.vk_nv_linear_color_attachment)) {
+                    if ((format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT) == 0) {
+                        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06581",
+                                         "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                                         "]: color_format (%s) must be a format with potential format features that include "
+                                         "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
+                                         pipe_index, string_VkFormat(color_format));
+                    }
+                } else {
+                    if ((format_features &
+                         (VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT | VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV)) == 0) {
+                        skip |=
+                            LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06582",
+                                     "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                                     "]: color_format (%s) must be a format with potential format features that include "
+                                     "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT or VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
+                                     pipe_index, string_VkFormat(color_format));
+                    }
+                }
+            }
+        }
+
+        if (rendering_struct->depthAttachmentFormat != VK_FORMAT_UNDEFINED) {
+            VkFormatFeatureFlags2 format_features = GetPotentialFormatFeatures(rendering_struct->depthAttachmentFormat);
+            if ((format_features & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06585",
+                                 "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                                 "]: depthAttachmentFormat (%s) must be a format with potential format features that include "
+                                 "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                                 pipe_index, string_VkFormat(rendering_struct->depthAttachmentFormat));
+            }
+        }
+
+        if (rendering_struct->stencilAttachmentFormat != VK_FORMAT_UNDEFINED) {
+            VkFormatFeatureFlags2 format_features = GetPotentialFormatFeatures(rendering_struct->stencilAttachmentFormat);
+            if ((format_features & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06586",
+                                 "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                                 "]: stencilAttachmentFormat (%s) must be a format with potential format features that include "
+                                 "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                                 pipe_index, string_VkFormat(rendering_struct->stencilAttachmentFormat));
+            }
+        }
+
+        if ((rendering_struct->depthAttachmentFormat != VK_FORMAT_UNDEFINED) &&
+            (rendering_struct->stencilAttachmentFormat != VK_FORMAT_UNDEFINED) &&
+            (rendering_struct->depthAttachmentFormat != rendering_struct->stencilAttachmentFormat)) {
+            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06589",
+                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                             "]: depthAttachmentFormat is not VK_FORMAT_UNDEFINED and stencilAttachmentFormat is not "
+                             "VK_FORMAT_UNDEFINED, but depthAttachmentFormat (%s) does not equal stencilAttachmentFormat (%s)",
+                             pipe_index, string_VkFormat(rendering_struct->depthAttachmentFormat),
+                             string_VkFormat(rendering_struct->stencilAttachmentFormat));
+        }
+
+        if (pipeline.IsRenderPassStateRequired()) {
+            if ((enabled_features.core11.multiview == VK_FALSE) && (rendering_struct->viewMask != 0)) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-multiview-06577",
+                                 "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                                 "]: multiview is not enabled but viewMask is (%u).",
+                                 pipe_index, rendering_struct->viewMask);
+            }
+
+            if (MostSignificantBit(rendering_struct->viewMask) >=
+                static_cast<int32_t>(phys_dev_props_core11.maxMultiviewViewCount)) {
+                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06578",
+                                 "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
+                                 "]: Most significant bit in "
+                                 "VkPipelineRenderingCreateInfo->viewMask(%u) must be less maxMultiviewViewCount(%u)",
+                                 pipe_index, rendering_struct->viewMask, phys_dev_props_core11.maxMultiviewViewCount);
+            }
+        }
+    }
+
+    return skip;
+}
+
 bool CoreChecks::ValidatePipelineLibraryFlags(const VkGraphicsPipelineLibraryFlagsEXT lib_flags,
                                               const VkPipelineLibraryCreateInfoKHR &link_info,
                                               const VkPipelineRenderingCreateInfo *rendering_struct, uint32_t pipe_index,
@@ -3466,9 +3629,7 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
     }
 
     const auto &rp_state = pipeline.RenderPassState();
-
-    const bool rp_state_required = pipeline.pre_raster_state || pipeline.fragment_shader_state || pipeline.fragment_output_state;
-    if (rp_state_required) {
+    if (pipeline.IsRenderPassStateRequired()) {
         if (!rp_state) {
             const char *vuid = nullptr;
             if (!IsExtEnabled(device_extensions.vk_khr_dynamic_rendering)) {
@@ -3544,6 +3705,7 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
     skip |= ValidateGraphicsPipelineMultisampleState(pipeline, subpass_desc, pipe_index);
     skip |= ValidateGraphicsPipelineDynamicState(pipeline, pipe_index);
     skip |= ValidateGraphicsPipelineFragmentShadingRateState(pipeline, pipe_index);
+    skip |= ValidateGraphicsPipelineDynamicRendering(pipeline, pipe_index);
     skip |= ValidateGraphicsPipelineShaderState(pipeline);
     skip |= ValidateGraphicsPipelineBlendEnable(pipeline);
 
@@ -3619,149 +3781,6 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
                 "] is not less than VkPhysicalDeviceDiscardRectanglePropertiesEXT::maxDiscardRectangles (%" PRIu32 ".",
                 discard_rectangle_state->discardRectangleCount, pipe_index,
                 phys_dev_ext_props.discard_rectangle_props.maxDiscardRectangles);
-        }
-    }
-
-    const auto color_blend_state = pipeline.ColorBlendState();
-    const auto rendering_struct = LvlFindInChain<VkPipelineRenderingCreateInfo>(pipeline.PNext());
-    if (rendering_struct) {
-        const auto raster_state = pipeline.RasterizationState();
-        const bool has_rasterization = raster_state && (raster_state->rasterizerDiscardEnable == VK_FALSE);
-        if (has_rasterization &&
-            ((rendering_struct->depthAttachmentFormat != VK_FORMAT_UNDEFINED) ||
-             (rendering_struct->stencilAttachmentFormat != VK_FORMAT_UNDEFINED)) &&
-            !pipeline.DepthStencilState()) {
-            skip |= LogError(
-                device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06053",
-                "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-                "]: has fragment state and a depth format (%s) or stencil format (%s) and an invalid pDepthStencilState structure",
-                pipe_index, string_VkFormat(rendering_struct->depthAttachmentFormat),
-                string_VkFormat(rendering_struct->stencilAttachmentFormat));
-        }
-
-        if (has_rasterization && (rendering_struct->colorAttachmentCount != 0) && !color_blend_state &&
-            pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass == VK_NULL_HANDLE) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06054",
-                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-                             "] has VkPipelineRenderingCreateInfoKHR::colorAttachmentCount (%" PRIu32
-                             ") and an invalid pColorBlendState structure",
-                             pipe_index, rendering_struct->colorAttachmentCount);
-        }
-
-        if ((rendering_struct->viewMask != 0) && !enabled_features.core11.multiviewTessellationShader &&
-            (active_shaders & VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
-             active_shaders & VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06057",
-                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-                             "] has VkPipelineRenderingCreateInfoKHR->viewMask(%" PRIu32
-                             ") and "
-                             "multiviewTessellationShader is not enabled, contains tesselation shaders",
-                             pipe_index, rendering_struct->viewMask);
-        }
-
-        if ((rendering_struct->viewMask != 0) && !enabled_features.core11.multiviewGeometryShader &&
-            (active_shaders & VK_SHADER_STAGE_GEOMETRY_BIT)) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06058",
-                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-                             "] has VkPipelineRenderingCreateInfoKHR->viewMask(%" PRIu32
-                             ") and "
-                             "multiviewGeometryShader is not enabled, contains geometry shader",
-                             pipe_index, rendering_struct->viewMask);
-        }
-
-        if ((rendering_struct->viewMask != 0) && !enabled_features.mesh_shader_features.multiviewMeshShader &&
-            (active_shaders & VK_SHADER_STAGE_MESH_BIT_EXT)) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-07064",
-                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-                             "] has VkPipelineRenderingCreateInfoKHR->viewMask(%" PRIu32
-                             ") and "
-                             "multiviewMeshShader is not enabled, contains mesh shader",
-                             pipe_index, rendering_struct->viewMask);
-        }
-
-        for (uint32_t color_index = 0; color_index < rendering_struct->colorAttachmentCount; color_index++) {
-            const VkFormat color_format = rendering_struct->pColorAttachmentFormats[color_index];
-            if (color_format != VK_FORMAT_UNDEFINED) {
-                VkFormatFeatureFlags2KHR format_features = GetPotentialFormatFeatures(color_format);
-                if (((format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) == 0) &&
-                    (color_blend_state && (color_index < color_blend_state->attachmentCount) &&
-                     (color_blend_state->pAttachments[color_index].blendEnable != VK_FALSE))) {
-                    skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06062",
-                                     "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-                                     "]: pColorBlendState->blendEnable must be false ",
-                                     pipe_index);
-                }
-
-                if (!IsExtEnabled(device_extensions.vk_nv_linear_color_attachment)) {
-                    if ((format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT) == 0) {
-                        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06581",
-                                         "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                                         "]: color_format (%s) must be a format with potential format features that include "
-                                         "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT",
-                                         pipe_index, string_VkFormat(color_format));
-                    }
-                } else {
-                    if ((format_features &
-                         (VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT | VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV)) == 0) {
-                        skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06582",
-                                         "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                                         "]: color_format (%s) must be a format with potential format features that include "
-                                         "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT or VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV",
-                                         pipe_index, string_VkFormat(color_format));
-                    }
-                }
-            }
-        }
-
-        if (rendering_struct->depthAttachmentFormat != VK_FORMAT_UNDEFINED) {
-            VkFormatFeatureFlags2 format_features = GetPotentialFormatFeatures(rendering_struct->depthAttachmentFormat);
-            if ((format_features & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
-                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06585",
-                                 "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                                 "]: depthAttachmentFormat (%s) must be a format with potential format features that include "
-                                 "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
-                                 pipe_index, string_VkFormat(rendering_struct->depthAttachmentFormat));
-            }
-        }
-
-        if (rendering_struct->stencilAttachmentFormat != VK_FORMAT_UNDEFINED) {
-            VkFormatFeatureFlags2 format_features = GetPotentialFormatFeatures(rendering_struct->stencilAttachmentFormat);
-            if ((format_features & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
-                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06586",
-                                 "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                                 "]: stencilAttachmentFormat (%s) must be a format with potential format features that include "
-                                 "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT",
-                                 pipe_index, string_VkFormat(rendering_struct->stencilAttachmentFormat));
-            }
-        }
-
-        if ((rendering_struct->depthAttachmentFormat != VK_FORMAT_UNDEFINED) &&
-            (rendering_struct->stencilAttachmentFormat != VK_FORMAT_UNDEFINED) &&
-            (rendering_struct->depthAttachmentFormat != rendering_struct->stencilAttachmentFormat)) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06589",
-                             "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                             "]: depthAttachmentFormat is not VK_FORMAT_UNDEFINED and stencilAttachmentFormat is not "
-                             "VK_FORMAT_UNDEFINED, but depthAttachmentFormat (%s) does not equal stencilAttachmentFormat (%s)",
-                             pipe_index, string_VkFormat(rendering_struct->depthAttachmentFormat),
-                             string_VkFormat(rendering_struct->stencilAttachmentFormat));
-        }
-
-        if (rp_state_required) {
-            if ((enabled_features.core11.multiview == VK_FALSE) && (rendering_struct->viewMask != 0)) {
-                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-multiview-06577",
-                                 "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                                 "]: multiview is not enabled but viewMask is (%u).",
-                                 pipe_index, rendering_struct->viewMask);
-            }
-
-            if (MostSignificantBit(rendering_struct->viewMask) >=
-                static_cast<int32_t>(phys_dev_props_core11.maxMultiviewViewCount)) {
-                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06578",
-                                 "vkCreateGraphicsPipelines() pCreateInfos[%" PRIu32
-                                 "]: Most significant bit in "
-                                 "VkPipelineRenderingCreateInfo->viewMask(%u) must be less maxMultiviewViewCount(%u)",
-                                 pipe_index, rendering_struct->viewMask, phys_dev_props_core11.maxMultiviewViewCount);
-            }
         }
     }
 
@@ -3980,6 +3999,7 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
             }
         }
 
+        const auto rendering_struct = LvlFindInChain<VkPipelineRenderingCreateInfo>(pipeline.PNext());
         if (gpl_info && link_info && pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass == VK_NULL_HANDLE) {
             const uint32_t flags_count =
                 GetBitSetCount(gpl_info->flags & (VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT |
@@ -4211,19 +4231,6 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
                              "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
                              "] is being created with fragment shader that uses samples, but pMultisampleState is not set.",
                              pipe_index);
-        }
-    }
-
-    if (pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass == VK_NULL_HANDLE && pipeline.RasterizationState() &&
-        rendering_struct && rendering_struct->viewMask != 0) {
-        for (const auto &stage : pipeline.stage_state) {
-            if (stage.writes_to_gl_layer) {
-                skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06059",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-                                 "] is being created with fragment shader state and renderPass != VK_NULL_HANDLE, but "
-                                 "pMultisampleState is NULL.",
-                                 pipe_index);
-            }
         }
     }
 

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -640,6 +640,7 @@ class CoreChecks : public ValidationStateTracker {
                                                   const uint32_t pipe_index) const;
     bool ValidateGraphicsPipelineDynamicState(const PIPELINE_STATE& pipeline, const uint32_t pipe_index) const;
     bool ValidateGraphicsPipelineFragmentShadingRateState(const PIPELINE_STATE& pipeline, const uint32_t pipe_index) const;
+    bool ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE& pipeline, const uint32_t pipe_index) const;
     bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline) const;
     uint32_t CalcShaderStageCount(const PIPELINE_STATE& pipeline, VkShaderStageFlagBits stageBit) const;
     bool GroupHasValidIndex(const PIPELINE_STATE& pipeline, uint32_t group, uint32_t stage) const;

--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -639,6 +639,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineMultisampleState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
                                                   const uint32_t pipe_index) const;
     bool ValidateGraphicsPipelineDynamicState(const PIPELINE_STATE& pipeline, const uint32_t pipe_index) const;
+    bool ValidateGraphicsPipelineFragmentShadingRateState(const PIPELINE_STATE& pipeline, const uint32_t pipe_index) const;
     bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline) const;
     uint32_t CalcShaderStageCount(const PIPELINE_STATE& pipeline, VkShaderStageFlagBits stageBit) const;
     bool GroupHasValidIndex(const PIPELINE_STATE& pipeline, uint32_t group, uint32_t stage) const;

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -311,6 +311,8 @@ class PIPELINE_STATE : public BASE_NODE {
         return rp_state;
     }
 
+    bool IsRenderPassStateRequired() const { return pre_raster_state || fragment_shader_state || fragment_output_state; }
+
     const std::shared_ptr<const PIPELINE_LAYOUT_STATE> PipelineLayoutState() const {
         // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
         if (merged_graphics_layout) {


### PR DESCRIPTION
Trying to reduce the `CoreChecks::ValidatePipeline` more, moved the Fragment Shading Rate and Dynamic Rendering create info logic to its own function