### PR TITLE
Add support for VK_EXT_surface_maintenance1 and VK_EXT_swapchain_maintenance1

### DIFF
--- a/layers/core_validation.h
+++ b/layers/core_validation.h
@@ -470,6 +470,13 @@ class CoreChecks : public ValidationStateTracker {
     template <typename BufBarrier>
     bool ValidateBarrierQueueFamilies(const Location& loc, const CMD_BUFFER_STATE* cb_state, const BufBarrier& barrier,
                                       const BUFFER_STATE* state_data) const;
+    bool ValidateSwapchainPresentModesCreateInfo(VkPresentModeKHR present_mode, const char* func_name,
+                                                 VkSwapchainCreateInfoKHR const* create_info,
+                                                 const SURFACE_STATE* surface_state) const;
+    bool ValidateSwapchainPresentScalingCreateInfo(VkPresentModeKHR present_mode, const char* func_name,
+                                                   VkSurfaceCapabilitiesKHR* capabilities,
+                                                   VkSwapchainCreateInfoKHR const* create_info,
+                                                   const SURFACE_STATE* surface_state) const;
     bool ValidateCreateSwapchain(const char* func_name, VkSwapchainCreateInfoKHR const* pCreateInfo,
                                  const SURFACE_STATE* surface_state, const SWAPCHAIN_NODE* old_swapchain_state) const;
     bool ValidateGraphicsPipelineBindPoint(const CMD_BUFFER_STATE* cb_state, const PIPELINE_STATE& pipeline) const;
@@ -1752,6 +1759,7 @@ class CoreChecks : public ValidationStateTracker {
     void PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
                                              VkImage* pSwapchainImages, VkResult result) override;
     bool PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) const override;
+    bool PreCallValidateReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo) const override;
     bool PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
                                                   const VkSwapchainCreateInfoKHR* pCreateInfos,
                                                   const VkAllocationCallbacks* pAllocator,

--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -664,6 +664,7 @@ VkResult DispatchQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresent
                     local_pPresentInfo->pSwapchains[index1] = layer_data->Unwrap(pPresentInfo->pSwapchains[index1]);
                 }
             }
+            WrapPnextChainHandles(layer_data, local_pPresentInfo->pNext);
         }
     }
     VkResult result = layer_data->device_dispatch_table.QueuePresentKHR(queue, local_pPresentInfo->ptr());

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -373,7 +373,7 @@ class SURFACE_STATE : public BASE_NODE {
     void SetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi, bool supported);
     bool GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) const;
 
-    void SetPresentModes(VkPhysicalDevice phys_dev, std::vector<VkPresentModeKHR> &&modes);
+    void SetPresentModes(VkPhysicalDevice phys_dev, layer_data::span<const VkPresentModeKHR> modes);
     std::vector<VkPresentModeKHR> GetPresentModes(VkPhysicalDevice phys_dev) const;
 
     void SetFormats(VkPhysicalDevice phys_dev, std::vector<VkSurfaceFormatKHR> &&fmts);
@@ -383,9 +383,8 @@ class SURFACE_STATE : public BASE_NODE {
     VkSurfaceCapabilitiesKHR GetCapabilities(VkPhysicalDevice phys_dev) const;
 
     void SetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
-                            std::vector<VkPresentModeKHR> &&compatible_modes);
+                            layer_data::span<const VkPresentModeKHR> compatible_modes);
     std::vector<VkPresentModeKHR> GetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode) const;
-
     void SetPresentModeCapabilities(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
                                     const VkSurfaceCapabilitiesKHR &caps, const VkSurfacePresentScalingCapabilitiesEXT &scaling_caps);
     VkSurfaceCapabilitiesKHR GetPresentModeSurfaceCapabilities(VkPhysicalDevice phys_dev,
@@ -401,5 +400,6 @@ class SURFACE_STATE : public BASE_NODE {
     mutable layer_data::unordered_map<VkPhysicalDevice, std::vector<VkSurfaceFormatKHR>> formats_;
     mutable layer_data::unordered_map<VkPhysicalDevice, VkSurfaceCapabilitiesKHR> capabilities_;
     mutable layer_data::unordered_map<VkPhysicalDevice,
-        layer_data::unordered_map<VkPresentModeKHR, std::optional<std::shared_ptr<PresentModeState>>>> present_modes_data_;
+                                      layer_data::unordered_map<VkPresentModeKHR, std::optional<std::shared_ptr<PresentModeState>>>>
+        present_modes_data_;
 };

--- a/layers/image_state.h
+++ b/layers/image_state.h
@@ -400,8 +400,6 @@ class SURFACE_STATE : public BASE_NODE {
     mutable layer_data::unordered_map<GpuQueue, bool> gpu_queue_support_;
     mutable layer_data::unordered_map<VkPhysicalDevice, std::vector<VkSurfaceFormatKHR>> formats_;
     mutable layer_data::unordered_map<VkPhysicalDevice, VkSurfaceCapabilitiesKHR> capabilities_;
-    mutable layer_data::unordered_map<VkPhysicalDevice, std::vector<VkPresentModeKHR>> present_modes_;
     mutable layer_data::unordered_map<VkPhysicalDevice,
-        layer_data::unordered_map<VkPresentModeKHR, std::shared_ptr<PresentModeState>>> maint1_present_modes_;
-
+        layer_data::unordered_map<VkPresentModeKHR, std::optional<std::shared_ptr<PresentModeState>>>> present_modes_data_;
 };

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -9294,6 +9294,49 @@ bool StatelessValidation::manual_PreCallValidateGetPhysicalDeviceSurfaceCapabili
         }
     }
 #endif
+
+    if (IsExtEnabled(device_extensions.vk_ext_surface_maintenance1)) {
+        const auto *surface_present_mode_compatibility =
+            LvlFindInChain<VkSurfacePresentModeCompatibilityEXT>(pSurfaceCapabilities->pNext);
+        const auto *surface_present_scaling_compatibilities =
+            LvlFindInChain<VkSurfacePresentScalingCapabilitiesEXT>(pSurfaceCapabilities->pNext);
+
+        if (!(LvlFindInChain<VkSurfacePresentModeEXT>(pSurfaceInfo->pNext))) {
+            if (surface_present_mode_compatibility) {
+                skip |= LogError(device, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-07776",
+                                 "vkGetPhysicalDeviceSurfaceCapabilities2KHR(): VK_EXT_surface_maintenance1 is enabled and "
+                                 "pSurfaceCapabilities->pNext contains VkSurfacePresentModeCompatibilityEXT, but "
+                                 "pSurfaceInfo->pNext does not contain a VkSurfacePresentModeEXT structure.");
+            }
+
+            if (surface_present_scaling_compatibilities) {
+                skip |= LogError(device, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-07777",
+                                 "vkGetPhysicalDeviceSurfaceCapabilities2KHR(): VK_EXT_surface_maintenance1 is enabled and "
+                                 "pSurfaceCapabilities->pNext contains VkSurfacePresentScalingCapabilitiesEXT, but "
+                                 "pSurfaceInfo->pNext does not contain a VkSurfacePresentModeEXT structure.");
+            }
+        }
+
+        if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
+            if (pSurfaceInfo->surface == VK_NULL_HANDLE) {
+                if (surface_present_mode_compatibility) {
+                    skip |=
+                        LogError(physicalDevice, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-07778",
+                                 "vkGetPhysicalDeviceSurfaceCapabilities2KHR: VK_EXT_surface_maintenance1 and "
+                                 "VK_GOOGLE_surfaceless_query are enabled and pSurfaceCapabilities->pNext contains a "
+                                 "VkSurfacePresentModeCompatibilityEXT structure, but pSurfaceInfo->surface is VK_NULL_HANDLE.");
+                }
+
+                if (surface_present_scaling_compatibilities) {
+                    skip |=
+                        LogError(physicalDevice, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-07779",
+                                 "vkGetPhysicalDeviceSurfaceCapabilities2KHR: VK_EXT_surface_maintenance1 and "
+                                 "VK_GOOGLE_surfaceless_query are enabled and pSurfaceCapabilities->pNext contains a "
+                                 "VkSurfacePresentScalingCapabilitiesEXT structure, but pSurfaceInfo->surface is VK_NULL_HANDLE.");
+                }
+            }
+        }
+    }
     return skip;
 }
 

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4213,7 +4213,6 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
                 LvlFindInChain<VkSurfacePresentModeCompatibilityEXT>(pSurfaceCapabilities->pNext);
         
             if (compatible_modes && compatible_modes->pPresentModes) {
-                
                 surface_state->SetCompatibleModes(
                     physicalDevice, surface_present_mode->presentMode,
                     std::vector<VkPresentModeKHR>(compatible_modes->pPresentModes,

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -4211,12 +4211,12 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
                 LvlFindInChain<VkSurfacePresentScalingCapabilitiesEXT>(pSurfaceCapabilities->pNext);
             const VkSurfacePresentModeCompatibilityEXT *compatible_modes =
                 LvlFindInChain<VkSurfacePresentModeCompatibilityEXT>(pSurfaceCapabilities->pNext);
-        
+
             if (compatible_modes && compatible_modes->pPresentModes) {
                 surface_state->SetCompatibleModes(
                     physicalDevice, surface_present_mode->presentMode,
-                    std::vector<VkPresentModeKHR>(compatible_modes->pPresentModes,
-                                                  compatible_modes->pPresentModes + compatible_modes->presentModeCount));
+                    layer_data::span<const VkPresentModeKHR>(compatible_modes->pPresentModes,
+                                                             compatible_modes->presentModeCount));
             }
             if (present_scaling_caps) {
                 surface_state->SetPresentModeCapabilities(physicalDevice, surface_present_mode->presentMode,
@@ -4265,7 +4265,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfacePresentModesK
         if (surface) {
             auto surface_state = Get<SURFACE_STATE>(surface);
             surface_state->SetPresentModes(physicalDevice,
-                                           std::vector<VkPresentModeKHR>(pPresentModes, pPresentModes + *pPresentModeCount));
+                                           layer_data::span<const VkPresentModeKHR>(pPresentModes, *pPresentModeCount));
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
             assert(pd_state);

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -513,6 +513,7 @@ VkResult DispatchQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresent
                     local_pPresentInfo->pSwapchains[index1] = layer_data->Unwrap(pPresentInfo->pSwapchains[index1]);
                 }
             }
+            WrapPnextChainHandles(layer_data, local_pPresentInfo->pNext);
         }
     }
     VkResult result = layer_data->device_dispatch_table.QueuePresentKHR(queue, local_pPresentInfo->ptr());


### PR DESCRIPTION
Most if not all of the existing review feedback has been addressed. Should be in fully reviewable form -- see the top two commits for the newer, more questionable changes.

replaces `VUID-vkAcquireNextImage2KHR-swapchain-01803` and `VUID-vkAcquireNextImageKHR-swapchain-01802` for `VUID-vkAcquireNextImage2KHR-surface-07784` and `VUID-vkAcquireNextImageKHR-surface-07783`

Fixes #4985.

When final, update tracking issue [here](https://github.com/KhronosGroup/Vulkan-Docs/issues/2006).