### PR TITLE
tests: Use new GetProcAddr helper

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -998,9 +998,8 @@ VkPhysicalDeviceFeatures2 VkLayerTest::GetPhysicalDeviceFeatures2(VkPhysicalDevi
     if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
         vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
     } else {
-        auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
-            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
-        assert(vkGetPhysicalDeviceFeatures2KHR);
+        auto vkGetPhysicalDeviceFeatures2KHR =
+            GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFeatures2KHR>("vkGetPhysicalDeviceFeatures2KHR");
         vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
     }
     return features2;
@@ -1011,9 +1010,8 @@ VkPhysicalDeviceProperties2 VkLayerTest::GetPhysicalDeviceProperties2(VkPhysical
     if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
         vk::GetPhysicalDeviceProperties2(gpu(), &props2);
     } else {
-        auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
-            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
-        assert(vkGetPhysicalDeviceProperties2KHR);
+        auto vkGetPhysicalDeviceProperties2KHR =
+            GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
         vkGetPhysicalDeviceProperties2KHR(gpu(), &props2);
     }
     return props2;
@@ -1040,9 +1038,10 @@ bool VkLayerTest::LoadDeviceProfileLayer(
 
     // Load required functions
     fpvkSetPhysicalDeviceFormatPropertiesEXT =
-        (PFN_vkSetPhysicalDeviceFormatPropertiesEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFormatPropertiesEXT");
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT = (PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT)vk::GetInstanceProcAddr(
-        instance(), "vkGetOriginalPhysicalDeviceFormatPropertiesEXT");
+        GetInstanceProcAddr<PFN_vkSetPhysicalDeviceFormatPropertiesEXT, false>("vkSetPhysicalDeviceFormatPropertiesEXT");
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT =
+        GetInstanceProcAddr<PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT, false>(
+            "vkGetOriginalPhysicalDeviceFormatPropertiesEXT");
 
     if (!(fpvkSetPhysicalDeviceFormatPropertiesEXT) || !(fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT)) {
         printf(
@@ -1064,10 +1063,10 @@ bool VkLayerTest::LoadDeviceProfileLayer(
 
     // Load required functions
     fpvkSetPhysicalDeviceFormatProperties2EXT =
-        (PFN_vkSetPhysicalDeviceFormatProperties2EXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFormatProperties2EXT");
+        GetInstanceProcAddr<PFN_vkSetPhysicalDeviceFormatProperties2EXT, false>("vkSetPhysicalDeviceFormatProperties2EXT");
     fpvkGetOriginalPhysicalDeviceFormatProperties2EXT =
-        (PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT)vk::GetInstanceProcAddr(
-            instance(), "vkGetOriginalPhysicalDeviceFormatProperties2EXT");
+        GetInstanceProcAddr<PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT, false>(
+            "vkGetOriginalPhysicalDeviceFormatProperties2EXT");
 
     if (!(fpvkSetPhysicalDeviceFormatProperties2EXT) || !(fpvkGetOriginalPhysicalDeviceFormatProperties2EXT)) {
         printf(
@@ -1087,10 +1086,9 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceLimitsEXT &fpvkS
     }
 
     // Load required functions
-    fpvkSetPhysicalDeviceLimitsEXT =
-        (PFN_vkSetPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT");
+    fpvkSetPhysicalDeviceLimitsEXT = GetInstanceProcAddr<PFN_vkSetPhysicalDeviceLimitsEXT, false>("vkSetPhysicalDeviceLimitsEXT");
     fpvkGetOriginalPhysicalDeviceLimitsEXT =
-        (PFN_vkGetOriginalPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceLimitsEXT");
+        GetInstanceProcAddr<PFN_vkGetOriginalPhysicalDeviceLimitsEXT, false>("vkGetOriginalPhysicalDeviceLimitsEXT");
 
     if (!(fpvkSetPhysicalDeviceLimitsEXT) || !(fpvkGetOriginalPhysicalDeviceLimitsEXT)) {
         printf(
@@ -1111,9 +1109,9 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceFeaturesEXT &fpv
 
     // Load required functions
     fpvkSetPhysicalDeviceFeaturesEXT =
-        (PFN_vkSetPhysicalDeviceFeaturesEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceFeaturesEXT");
+        GetInstanceProcAddr<PFN_vkSetPhysicalDeviceFeaturesEXT, false>("vkSetPhysicalDeviceFeaturesEXT");
     fpvkGetOriginalPhysicalDeviceFeaturesEXT =
-        (PFN_vkGetOriginalPhysicalDeviceFeaturesEXT)vk::GetInstanceProcAddr(instance(), "vkGetOriginalPhysicalDeviceFeaturesEXT");
+        GetInstanceProcAddr<PFN_vkGetOriginalPhysicalDeviceFeaturesEXT, false>("vkGetOriginalPhysicalDeviceFeaturesEXT");
 
     if (!(fpvkSetPhysicalDeviceFeaturesEXT) || !(fpvkGetOriginalPhysicalDeviceFeaturesEXT)) {
         printf(
@@ -1133,7 +1131,7 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_VkSetPhysicalDeviceProperties2EXT &
 
     // Load required functions
     fpvkSetPhysicalDeviceProperties2EXT =
-        (PFN_VkSetPhysicalDeviceProperties2EXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceProperties2EXT");
+        GetInstanceProcAddr<PFN_VkSetPhysicalDeviceProperties2EXT, false>("vkSetPhysicalDeviceProperties2EXT");
 
     if (!fpvkSetPhysicalDeviceProperties2EXT) {
         printf(
@@ -2546,8 +2544,7 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
 
     PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     auto ray_tracing_properties = LvlInitStruct<VkPhysicalDeviceRayTracingPropertiesNV>();
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&ray_tracing_properties);

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -542,12 +542,9 @@ TEST_F(VkPositiveLayerTest, DrawIndirectCountWithoutFeature) {
         GTEST_SKIP() << "Tests requires Vulkan 1.1 exactly";
     }
 
-    auto vkCmdDrawIndirectCountKHR =
-        reinterpret_cast<PFN_vkCmdDrawIndirectCountKHR>(vk::GetDeviceProcAddr(device(), "vkCmdDrawIndirectCountKHR"));
-    ASSERT_TRUE(vkCmdDrawIndirectCountKHR != nullptr);
+    auto vkCmdDrawIndirectCountKHR = GetDeviceProcAddr<PFN_vkCmdDrawIndirectCountKHR>("vkCmdDrawIndirectCountKHR");
     auto vkCmdDrawIndexedIndirectCountKHR =
-        reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCountKHR>(vk::GetDeviceProcAddr(device(), "vkCmdDrawIndexedIndirectCountKHR"));
-    ASSERT_TRUE(vkCmdDrawIndexedIndirectCountKHR != nullptr);
+        GetDeviceProcAddr<PFN_vkCmdDrawIndexedIndirectCountKHR>("vkCmdDrawIndexedIndirectCountKHR");
 
     VkBufferObj indirect_buffer;
     indirect_buffer.init(*m_device, sizeof(VkDrawIndirectCommand), VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
@@ -1206,8 +1203,7 @@ TEST_F(VkPositiveLayerTest, WriteTimestampNoneAndAll) {
         GTEST_SKIP() << "Device graphic queue has timestampValidBits of 0, skipping.\n";
     }
 
-    auto vkCmdWriteTimestamp2KHR =
-        reinterpret_cast<PFN_vkCmdWriteTimestamp2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdWriteTimestamp2KHR"));
+    auto vkCmdWriteTimestamp2KHR = GetDeviceProcAddr<PFN_vkCmdWriteTimestamp2KHR>("vkCmdWriteTimestamp2KHR");
 
     vk_testing::QueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_ci = LvlInitStruct<VkQueryPoolCreateInfo>();

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -369,9 +369,7 @@ TEST_F(VkPositiveLayerTest, PushDescriptorNullDstSetTest) {
     descriptor_write.dstSet = 0;  // Should not cause a validation error
 
     // Find address of extension call and make the call
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
-    assert(vkCmdPushDescriptorSetKHR != nullptr);
+    auto vkCmdPushDescriptorSetKHR = GetDeviceProcAddr<PFN_vkCmdPushDescriptorSetKHR>("vkCmdPushDescriptorSetKHR");
 
     m_commandBuffer->begin();
 
@@ -444,9 +442,7 @@ TEST_F(VkPositiveLayerTest, PushDescriptorUnboundSetTest) {
     descriptor_set.WriteDescriptorBufferInfo(2, buffer.handle(), 0, sizeof(bo_data));
     descriptor_set.UpdateDescriptorSets();
 
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
-    assert(vkCmdPushDescriptorSetKHR != nullptr);
+    auto vkCmdPushDescriptorSetKHR = GetDeviceProcAddr<PFN_vkCmdPushDescriptorSetKHR>("vkCmdPushDescriptorSetKHR");
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
@@ -602,9 +598,7 @@ TEST_F(VkPositiveLayerTest, PushDescriptorSetUpdatingSetNumber) {
 
     VkDescriptorBufferInfo buffer_info = {buffer_obj.handle(), 0, VK_WHOLE_SIZE};
 
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
-    ASSERT_TRUE(vkCmdPushDescriptorSetKHR != nullptr);
+    auto vkCmdPushDescriptorSetKHR = GetDeviceProcAddr<PFN_vkCmdPushDescriptorSetKHR>("vkCmdPushDescriptorSetKHR");
 
     const VkDescriptorSetLayoutBinding ds_binding_0 = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT,
                                                        nullptr};
@@ -873,8 +867,7 @@ TEST_F(VkPositiveLayerTest, PushingDescriptorSetWithImmutableSampler) {
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
+    auto vkCmdPushDescriptorSetKHR = GetDeviceProcAddr<PFN_vkCmdPushDescriptorSetKHR>("vkCmdPushDescriptorSetKHR");
 
     std::vector<VkDescriptorSetLayoutBinding> ds_bindings = {
         {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, &sampler_handle}};
@@ -921,9 +914,7 @@ TEST_F(VkPositiveLayerTest, BindVertexBuffers2EXTNullDescriptors) {
         GTEST_SKIP() << "nullDescriptor feature not supported";
     }
 
-    PFN_vkCmdBindVertexBuffers2EXT vkCmdBindVertexBuffers2EXT =
-        (PFN_vkCmdBindVertexBuffers2EXT)vk::GetInstanceProcAddr(instance(), "vkCmdBindVertexBuffers2EXT");
-    ASSERT_TRUE(vkCmdBindVertexBuffers2EXT != nullptr);
+    auto vkCmdBindVertexBuffers2EXT = GetInstanceProcAddr<PFN_vkCmdBindVertexBuffers2EXT>("vkCmdBindVertexBuffers2EXT");
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -235,12 +235,8 @@ TEST_F(VkPositiveLayerTest, TestBeginQueryInDynamicRendering) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkCmdBeginRendering vkCmdBeginRendering =
-        reinterpret_cast<PFN_vkCmdBeginRendering>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginRendering"));
-    assert(vkCmdBeginRendering != nullptr);
-    PFN_vkCmdEndRendering vkCmdEndRendering =
-        reinterpret_cast<PFN_vkCmdEndRendering>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndRendering"));
-    assert(vkCmdEndRendering != nullptr);
+    auto vkCmdBeginRendering = GetDeviceProcAddr<PFN_vkCmdBeginRendering>("vkCmdBeginRendering");
+    auto vkCmdEndRendering = GetDeviceProcAddr<PFN_vkCmdEndRendering>("vkCmdEndRendering");
 
     VkRenderingInfoKHR begin_rendering_info = LvlInitStruct<VkRenderingInfoKHR>();
     begin_rendering_info.layerCount = 1;

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -965,9 +965,7 @@ TEST_F(VkPositiveLayerTest, ExternalMemory) {
                                                  VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, handle_type};
     VkExternalBufferPropertiesKHR ebp = {VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR, nullptr, {0, 0, 0}};
     auto vkGetPhysicalDeviceExternalBufferPropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceExternalBufferPropertiesKHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceExternalBufferPropertiesKHR != nullptr);
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR>("vkGetPhysicalDeviceExternalBufferPropertiesKHR");
     vkGetPhysicalDeviceExternalBufferPropertiesKHR(gpu(), &ebi, &ebp);
     if (!(ebp.externalMemoryProperties.compatibleHandleTypes & handle_type) ||
         !(ebp.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1032,9 +1030,7 @@ TEST_F(VkPositiveLayerTest, ExternalMemory) {
 
 #ifdef _WIN32
     // Export memory to handle
-    auto vkGetMemoryWin32HandleKHR =
-        (PFN_vkGetMemoryWin32HandleKHR)vk::GetInstanceProcAddr(instance(), "vkGetMemoryWin32HandleKHR");
-    ASSERT_TRUE(vkGetMemoryWin32HandleKHR != nullptr);
+    auto vkGetMemoryWin32HandleKHR = GetInstanceProcAddr<PFN_vkGetMemoryWin32HandleKHR>("vkGetMemoryWin32HandleKHR");
     VkMemoryGetWin32HandleInfoKHR mghi = {VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, nullptr, memory_export.handle(),
                                           handle_type};
     HANDLE handle;
@@ -1044,8 +1040,7 @@ TEST_F(VkPositiveLayerTest, ExternalMemory) {
                                                     handle};
 #else
     // Export memory to fd
-    auto vkGetMemoryFdKHR = (PFN_vkGetMemoryFdKHR)vk::GetInstanceProcAddr(instance(), "vkGetMemoryFdKHR");
-    ASSERT_TRUE(vkGetMemoryFdKHR != nullptr);
+    auto vkGetMemoryFdKHR = GetInstanceProcAddr<PFN_vkGetMemoryFdKHR>("vkGetMemoryFdKHR");
     VkMemoryGetFdInfoKHR mgfi = {VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR, nullptr, memory_export.handle(), handle_type};
     int fd;
     ASSERT_VK_SUCCESS(vkGetMemoryFdKHR(m_device->device(), &mgfi, &fd));

--- a/tests/positive/instance.cpp
+++ b/tests/positive/instance.cpp
@@ -76,7 +76,7 @@ TEST_F(VkPositiveLayerTest, NullFunctionPointer) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     auto fpGetBufferMemoryRequirements =
-        (PFN_vkGetBufferMemoryRequirements2)vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferMemoryRequirements2");
+        GetDeviceProcAddr<PFN_vkGetBufferMemoryRequirements2, false>("vkGetBufferMemoryRequirements2");
     if (fpGetBufferMemoryRequirements) {
         m_errorMonitor->SetError("Null was expected!");
     }

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -375,14 +375,14 @@ TEST_F(VkPositiveLayerTest, HostQueryResetSuccess) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto vkResetQueryPoolEXT = GetDeviceProcAddr<PFN_vkResetQueryPoolEXT>("vkResetQueryPoolEXT");
 
     VkQueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
     vk::CreateQueryPool(m_device->device(), &query_pool_create_info, nullptr, &query_pool);
-    fpvkResetQueryPoolEXT(m_device->device(), query_pool, 0, 1);
+    vkResetQueryPoolEXT(m_device->device(), query_pool, 0, 1);
     vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
 }
 

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -2927,9 +2927,8 @@ TEST_F(VkPositiveLayerTest, ShaderFloatControl) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     auto shader_float_control = LvlInitStruct<VkPhysicalDeviceFloatControlsProperties>();
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&shader_float_control);

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -1098,9 +1098,7 @@ TEST_F(VkPositiveLayerTest, BeginRenderPassWithViewMask) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_write.dstSet = 0;  // Should not cause a validation error
 
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
-    assert(vkCmdPushDescriptorSetKHR != nullptr);
+    auto vkCmdPushDescriptorSetKHR = GetDeviceProcAddr<PFN_vkCmdPushDescriptorSetKHR>("vkCmdPushDescriptorSetKHR");
 
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_);

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -95,8 +95,7 @@ TEST_F(VkPositiveLayerTest, ShaderUboStd430Layout) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
-        (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2 = GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFeatures2>("vkGetPhysicalDeviceFeatures2");
 
     auto uniform_buffer_standard_layout_features = LvlInitStruct<VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR>(NULL);
     uniform_buffer_standard_layout_features.uniformBufferStandardLayout = VK_TRUE;
@@ -153,8 +152,7 @@ TEST_F(VkPositiveLayerTest, ShaderScalarBlockLayout) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2 vkGetPhysicalDeviceFeatures2 =
-        (PFN_vkGetPhysicalDeviceFeatures2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2 = GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFeatures2>("vkGetPhysicalDeviceFeatures2");
 
     auto scalar_block_features = LvlInitStruct<VkPhysicalDeviceScalarBlockLayoutFeaturesEXT>(NULL);
     auto query_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&scalar_block_features);
@@ -2744,7 +2742,7 @@ TEST_F(VkPositiveLayerTest, PositiveShaderModuleIdentifier) {
     auto sm_id_create_info = LvlInitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto vkGetShaderModuleIdentifierEXT = (PFN_vkGetShaderModuleIdentifierEXT)vk::GetDeviceProcAddr(m_device->device(), "vkGetShaderModuleIdentifierEXT");
+    auto vkGetShaderModuleIdentifierEXT = GetDeviceProcAddr<PFN_vkGetShaderModuleIdentifierEXT>("vkGetShaderModuleIdentifierEXT");
     auto get_identifier = LvlInitStruct<VkShaderModuleIdentifierEXT>();
     vkGetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -53,12 +53,9 @@ TEST_F(VkPositiveLayerTest, ThreadSafetyDisplayObjects) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetPhysicalDeviceDisplayPropertiesKHR vkGetPhysicalDeviceDisplayPropertiesKHR =
-        (PFN_vkGetPhysicalDeviceDisplayPropertiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceDisplayPropertiesKHR");
-    PFN_vkGetDisplayModePropertiesKHR vkGetDisplayModePropertiesKHR =
-        (PFN_vkGetDisplayModePropertiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayModePropertiesKHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceDisplayPropertiesKHR != nullptr);
-    ASSERT_TRUE(vkGetDisplayModePropertiesKHR != nullptr);
+    auto vkGetPhysicalDeviceDisplayPropertiesKHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceDisplayPropertiesKHR>("vkGetPhysicalDeviceDisplayPropertiesKHR");
+    auto vkGetDisplayModePropertiesKHR = GetInstanceProcAddr<PFN_vkGetDisplayModePropertiesKHR>("vkGetDisplayModePropertiesKHR");
 
     uint32_t prop_count = 0;
     vkGetPhysicalDeviceDisplayPropertiesKHR(gpu(), &prop_count, nullptr);
@@ -83,13 +80,9 @@ TEST_F(VkPositiveLayerTest, ThreadSafetyDisplayPlaneObjects) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR vkGetPhysicalDeviceDisplayPlanePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR)vk::GetInstanceProcAddr(instance(),
-                                                                                  "vkGetPhysicalDeviceDisplayPlanePropertiesKHR");
-    PFN_vkGetDisplayModePropertiesKHR vkGetDisplayModePropertiesKHR =
-        (PFN_vkGetDisplayModePropertiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayModePropertiesKHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceDisplayPlanePropertiesKHR != nullptr);
-    ASSERT_TRUE(vkGetDisplayModePropertiesKHR != nullptr);
+    auto vkGetPhysicalDeviceDisplayPlanePropertiesKHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>("vkGetPhysicalDeviceDisplayPlanePropertiesKHR");
+    auto vkGetDisplayModePropertiesKHR = GetInstanceProcAddr<PFN_vkGetDisplayModePropertiesKHR>("vkGetDisplayModePropertiesKHR");
 
     uint32_t prop_count = 0;
     vkGetPhysicalDeviceDisplayPlanePropertiesKHR(gpu(), &prop_count, nullptr);
@@ -1398,8 +1391,8 @@ TEST_F(VkPositiveLayerTest, ExternalSemaphore) {
                                                     handle_type};
     VkExternalSemaphorePropertiesKHR esp = {VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES_KHR, nullptr};
     auto vkGetPhysicalDeviceExternalSemaphorePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>(
+            "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
     vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1493,16 +1486,15 @@ TEST_F(VkPositiveLayerTest, ExternalTimelineSemaphore) {
     auto esp = LvlInitStruct<VkExternalSemaphorePropertiesKHR>();
 
     auto vkGetPhysicalDeviceExternalSemaphorePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>(
+            "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
     vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR)) {
         GTEST_SKIP() << "External semaphore does not support importing and exporting, skipping test";
     }
-    auto fpGetSemaphoreCounterValue = reinterpret_cast<PFN_vkGetSemaphoreCounterValueKHR>(
-        vk::GetDeviceProcAddr(m_device->handle(), "vkGetSemaphoreCounterValueKHR"));
+    auto vkGetSemaphoreCounterValueKHR = GetDeviceProcAddr<PFN_vkGetSemaphoreCounterValueKHR>("vkGetSemaphoreCounterValueKHR");
 
     VkResult err;
 
@@ -1554,11 +1546,11 @@ TEST_F(VkPositiveLayerTest, ExternalTimelineSemaphore) {
 
     uint64_t import_value{0}, export_value{0};
 
-    err = fpGetSemaphoreCounterValue(m_device->handle(), export_semaphore.handle(), &export_value);
+    err = vkGetSemaphoreCounterValueKHR(m_device->handle(), export_semaphore.handle(), &export_value);
     ASSERT_VK_SUCCESS(err);
     ASSERT_EQ(export_value, signal_value);
 
-    err = fpGetSemaphoreCounterValue(m_device->handle(), import_semaphore.handle(), &import_value);
+    err = vkGetSemaphoreCounterValueKHR(m_device->handle(), import_semaphore.handle(), &import_value);
     ASSERT_VK_SUCCESS(err);
     ASSERT_EQ(import_value, signal_value);
 }
@@ -1585,8 +1577,8 @@ TEST_F(VkPositiveLayerTest, ExternalFence) {
     auto efi = LvlInitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
     efi.handleType = handle_type;
     auto efp = LvlInitStruct<VkExternalFencePropertiesKHR>();
-    auto vkGetPhysicalDeviceExternalFencePropertiesKHR = (PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR)vk::GetInstanceProcAddr(
-        instance(), "vkGetPhysicalDeviceExternalFencePropertiesKHR");
+    auto vkGetPhysicalDeviceExternalFencePropertiesKHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR>("vkGetPhysicalDeviceExternalFencePropertiesKHR");
     vkGetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1651,8 +1643,8 @@ TEST_F(VkPositiveLayerTest, ExternalFenceSyncFdLoop) {
     auto efi = LvlInitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
     efi.handleType = handle_type;
     auto efp = LvlInitStruct<VkExternalFencePropertiesKHR>();
-    auto vkGetPhysicalDeviceExternalFencePropertiesKHR = (PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR)vk::GetInstanceProcAddr(
-        instance(), "vkGetPhysicalDeviceExternalFencePropertiesKHR");
+    auto vkGetPhysicalDeviceExternalFencePropertiesKHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR>("vkGetPhysicalDeviceExternalFencePropertiesKHR");
     vkGetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1835,10 +1827,8 @@ TEST_F(VkPositiveLayerTest, QueueSubmitTimelineSemaphore2Queue) {
     if (!CheckTimelineSemaphoreSupportAndInitState(this)) {
         GTEST_SKIP() << "Timeline semaphore not supported";
     }
-    auto fpWaitSemaphores =
-        reinterpret_cast<PFN_vkWaitSemaphoresKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkWaitSemaphoresKHR"));
-    auto fpSignalSemaphore =
-        reinterpret_cast<PFN_vkSignalSemaphoreKHR>(vk::GetDeviceProcAddr(m_device->device(), "vkSignalSemaphoreKHR"));
+    auto vkWaitSemaphoresKHR = GetDeviceProcAddr<PFN_vkWaitSemaphoresKHR>("vkWaitSemaphoresKHR");
+    auto vkSignalSemaphoreKHR = GetDeviceProcAddr<PFN_vkSignalSemaphoreKHR>("vkSignalSemaphoreKHR");
 
     vk_testing::Queue *q0 = m_device->graphics_queues()[0];
     vk_testing::Queue *q1 = nullptr;
@@ -1934,7 +1924,7 @@ TEST_F(VkPositiveLayerTest, QueueSubmitTimelineSemaphore2Queue) {
     auto signal_info = LvlInitStruct<VkSemaphoreSignalInfo>();
     signal_info.semaphore = semaphore.handle();
     signal_info.value = kQ0Begin;
-    fpSignalSemaphore(m_device->device(), &signal_info);
+    vkSignalSemaphoreKHR(m_device->device(), &signal_info);
 
     // buffer_a is only used by the q0 commands
     uint64_t wait_info_value = kQ0End;
@@ -1942,16 +1932,16 @@ TEST_F(VkPositiveLayerTest, QueueSubmitTimelineSemaphore2Queue) {
     wait_info.semaphoreCount = 1;
     wait_info.pSemaphores = &semaphore.handle();
     wait_info.pValues = &wait_info_value;
-    fpWaitSemaphores(m_device->device(), &wait_info, 1000000000);
+    vkWaitSemaphoresKHR(m_device->device(), &wait_info, 1000000000);
     buffer_a.reset();
 
     // signal semaphore to 3 to allow q1 to proceed
     signal_info.value = kQ1Begin;
-    fpSignalSemaphore(m_device->device(), &signal_info);
+    vkSignalSemaphoreKHR(m_device->device(), &signal_info);
 
     // buffer_b is used by both q0 and q1, buffer_c is used by q1
     wait_info_value = kQ1End;
-    fpWaitSemaphores(m_device->device(), &wait_info, 1000000000);
+    vkWaitSemaphoresKHR(m_device->device(), &wait_info, 1000000000);
     buffer_b.reset();
     buffer_c.reset();
 
@@ -2048,14 +2038,15 @@ struct FenceSemRaceData {
 
 void WaitTimelineSem(FenceSemRaceData *data) {
     uint64_t wait_value = data->wait_value;
-    auto fpWaitSemaphores = reinterpret_cast<PFN_vkWaitSemaphoresKHR>(vk::GetDeviceProcAddr(data->device, "vkWaitSemaphoresKHR"));
+    auto vkWaitSemaphoresKHR =
+        reinterpret_cast<PFN_vkWaitSemaphoresKHR>(vk::GetDeviceProcAddr(data->device, "vkWaitSemaphoresKHR"));
     auto wait_info = LvlInitStruct<VkSemaphoreWaitInfo>();
     wait_info.semaphoreCount = 1;
     wait_info.pSemaphores = &data->sem;
     wait_info.pValues = &wait_value;
 
     for (uint32_t i = 0; i < data->iterations; i++, wait_value++) {
-        fpWaitSemaphores(data->device, &wait_info, data->timeout);
+        vkWaitSemaphoresKHR(data->device, &wait_info, data->timeout);
         if (*data->bailout) {
             break;
         }

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1188,9 +1188,9 @@ TEST_F(VkBestPracticesLayerTest, ExpectedQueryDetails) {
     vk::GetPhysicalDeviceQueueFamilyProperties2(phys_device_obj.handle(), &queue_count, queue_family_props2.data());
 
     // And for GetPhysicalDeviceQueueFamilyProperties2KHR
-    PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR vkGetPhysicalDeviceQueueFamilyProperties2KHR =
-        reinterpret_cast<PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR>(
-            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceQueueFamilyProperties2KHR"));
+    auto vkGetPhysicalDeviceQueueFamilyProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceQueueFamilyProperties2KHR, false>(
+            "vkGetPhysicalDeviceQueueFamilyProperties2KHR");
     if (vkGetPhysicalDeviceQueueFamilyProperties2KHR) {
         vkGetPhysicalDeviceQueueFamilyProperties2KHR(phys_device_obj.handle(), &queue_count, nullptr);
 

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -5484,8 +5484,8 @@ TEST_F(VkLayerTest, InvalidBarriers) {
     const bool feedback_loop_layout = IsExtensionsEnabled(VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_EXTENSION_NAME);
 
     // Set separate depth stencil feature bit
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFeatures2KHR>("vkGetPhysicalDeviceFeatures2KHR");
     auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR>();
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&separate_depth_stencil_layouts_features);
     if (vkGetPhysicalDeviceFeatures2KHR) {
@@ -10333,10 +10333,8 @@ TEST_F(VkLayerTest, ImageStencilCreate) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(&device_features));
 
-    PFN_vkGetPhysicalDeviceImageFormatProperties2KHR vkGetPhysicalDeviceImageFormatProperties2KHR =
-        (PFN_vkGetPhysicalDeviceImageFormatProperties2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                  "vkGetPhysicalDeviceImageFormatProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceImageFormatProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceImageFormatProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceImageFormatProperties2KHR>("vkGetPhysicalDeviceImageFormatProperties2KHR");
 
     VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.flags = 0;
@@ -11621,9 +11619,8 @@ TEST_F(VkLayerTest, FragmentDensityMapEnabled) {
         GTEST_SKIP() << "fragmentDensityMapDynamic not supported";
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     VkPhysicalDeviceFragmentDensityMap2PropertiesEXT density_map2_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentDensityMap2PropertiesEXT>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&density_map2_properties);
@@ -11948,9 +11945,8 @@ TEST_F(VkLayerTest, CustomBorderColor) {
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     VkPhysicalDeviceCustomBorderColorPropertiesEXT custom_properties =
         LvlInitStruct<VkPhysicalDeviceCustomBorderColorPropertiesEXT>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&custom_properties);
@@ -13841,9 +13837,8 @@ TEST_F(VkLayerTest, ImageFormatInfoDrmFormatModifier) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto vkGetPhysicalDeviceImageFormatProperties2KHR = (PFN_vkGetPhysicalDeviceImageFormatProperties2KHR)vk::GetInstanceProcAddr(
-        instance(), "vkGetPhysicalDeviceImageFormatProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceImageFormatProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceImageFormatProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceImageFormatProperties2KHR>("vkGetPhysicalDeviceImageFormatProperties2KHR");
 
     VkPhysicalDeviceImageDrmFormatModifierInfoEXT image_drm_format_modifier =
         LvlInitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
@@ -15004,8 +14999,7 @@ TEST_F(VkLayerTest, DeviceImageMemoryRequirementsSwapchain) {
     }
 
     PFN_vkGetDeviceImageMemoryRequirementsKHR vkGetDeviceImageMemoryRequirementsKHR =
-        reinterpret_cast<PFN_vkGetDeviceImageMemoryRequirementsKHR>(vk::GetInstanceProcAddr(instance(), "vkGetDeviceImageMemoryRequirementsKHR"));
-    assert(vkGetDeviceImageMemoryRequirementsKHR != nullptr);
+        GetDeviceProcAddr<PFN_vkGetDeviceImageMemoryRequirementsKHR>("vkGetDeviceImageMemoryRequirementsKHR");
 
     auto image_swapchain_create_info = LvlInitStruct<VkImageSwapchainCreateInfoKHR>();
     image_swapchain_create_info.swapchain = m_swapchain;
@@ -15046,9 +15040,7 @@ TEST_F(VkLayerTest, DeviceImageMemoryRequirementsDrmFormatModifier) {
     }
 
     PFN_vkGetDeviceImageMemoryRequirementsKHR vkGetDeviceImageMemoryRequirementsKHR =
-        reinterpret_cast<PFN_vkGetDeviceImageMemoryRequirementsKHR>(
-            vk::GetInstanceProcAddr(instance(), "vkGetDeviceImageMemoryRequirementsKHR"));
-    assert(vkGetDeviceImageMemoryRequirementsKHR != nullptr);
+        GetDeviceProcAddr<PFN_vkGetDeviceImageMemoryRequirementsKHR>("vkGetDeviceImageMemoryRequirementsKHR");
 
     VkSubresourceLayout planeLayout = {0, 0, 0, 0, 0};
     auto drm_format_modifier_create_info = LvlInitStruct<VkImageDrmFormatModifierExplicitCreateInfoEXT>();
@@ -15097,9 +15089,7 @@ TEST_F(VkLayerTest, DeviceImageMemoryRequirementsDisjoint) {
     }
 
     PFN_vkGetDeviceImageMemoryRequirementsKHR vkGetDeviceImageMemoryRequirementsKHR =
-        reinterpret_cast<PFN_vkGetDeviceImageMemoryRequirementsKHR>(
-            vk::GetInstanceProcAddr(instance(), "vkGetDeviceImageMemoryRequirementsKHR"));
-    assert(vkGetDeviceImageMemoryRequirementsKHR != nullptr);
+        GetDeviceProcAddr<PFN_vkGetDeviceImageMemoryRequirementsKHR>("vkGetDeviceImageMemoryRequirementsKHR");
 
     auto image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -15992,8 +15982,7 @@ TEST_F(VkLayerTest, InvalidImageCompressionControl) {
     }
 
     auto vkGetImageSubresourceLayout2EXT =
-        reinterpret_cast<PFN_vkGetImageSubresourceLayout2EXT>(vk::GetInstanceProcAddr(instance(), "vkGetImageSubresourceLayout2EXT"));
-    ASSERT_TRUE(vkGetImageSubresourceLayout2EXT != nullptr);
+        GetDeviceProcAddr<PFN_vkGetImageSubresourceLayout2EXT>("vkGetImageSubresourceLayout2EXT");
 
     // A bit set flag bit
     ASSERT_NO_FATAL_FAILURE(InitState());

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -6342,7 +6342,7 @@ TEST_F(VkLayerTest, MeshShaderNV) {
     }
 
     PFN_vkCmdDrawMeshTasksIndirectNV vkCmdDrawMeshTasksIndirectNV =
-        (PFN_vkCmdDrawMeshTasksIndirectNV)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksIndirectNV");
+        GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksIndirectNV>("vkCmdDrawMeshTasksIndirectNV");
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = sizeof(uint32_t);
@@ -7296,9 +7296,8 @@ TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     auto protected_memory_features = LvlInitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
     auto features2 = GetPhysicalDeviceFeatures2(protected_memory_features);
@@ -8225,9 +8224,8 @@ TEST_F(VkLayerTest, VerifyMaxMultiviewInstanceIndex) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     auto multiview_props = LvlInitStruct<VkPhysicalDeviceMultiviewProperties>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&multiview_props);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
@@ -8449,9 +8447,8 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsLimit) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fsr_properties);
@@ -8858,7 +8855,7 @@ TEST_F(VkLayerTest, TestEndCommandBufferWithConditionalRendering) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     PFN_vkCmdBeginConditionalRenderingEXT vkCmdBeginConditionalRenderingEXT =
-        (PFN_vkCmdBeginConditionalRenderingEXT)vk::GetInstanceProcAddr(instance(), "vkCmdBeginConditionalRenderingEXT");
+        GetDeviceProcAddr<PFN_vkCmdBeginConditionalRenderingEXT>("vkCmdBeginConditionalRenderingEXT");
 
     auto buffer_ci =
         vk_testing::Buffer::create_info(32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT);
@@ -10505,12 +10502,11 @@ TEST_F(VkLayerTest, MeshShaderEXTDrawCmds) {
     VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = LvlInitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
-    PFN_vkCmdDrawMeshTasksEXT vkCmdDrawMeshTasksEXT =
-        (PFN_vkCmdDrawMeshTasksEXT)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksEXT");
+    PFN_vkCmdDrawMeshTasksEXT vkCmdDrawMeshTasksEXT = GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksEXT>("vkCmdDrawMeshTasksEXT");
     PFN_vkCmdDrawMeshTasksIndirectEXT vkCmdDrawMeshTasksIndirectEXT =
-        (PFN_vkCmdDrawMeshTasksIndirectEXT)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksIndirectEXT");
+        GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksIndirectEXT>("vkCmdDrawMeshTasksIndirectEXT");
     PFN_vkCmdDrawMeshTasksIndirectCountEXT vkCmdDrawMeshTasksIndirectCountEXT =
-        (PFN_vkCmdDrawMeshTasksIndirectCountEXT)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksIndirectCountEXT");
+        GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksIndirectCountEXT>("vkCmdDrawMeshTasksIndirectCountEXT");
 
     // #version 450
     // #extension GL_EXT_mesh_shader : enable
@@ -10674,9 +10670,9 @@ TEST_F(VkLayerTest, MeshShaderEXTMultiDrawIndirect) {
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
     PFN_vkCmdDrawMeshTasksIndirectEXT vkCmdDrawMeshTasksIndirectEXT =
-        (PFN_vkCmdDrawMeshTasksIndirectEXT)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksIndirectEXT");
+        GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksIndirectEXT>("vkCmdDrawMeshTasksIndirectEXT");
     PFN_vkCmdDrawMeshTasksIndirectCountEXT vkCmdDrawMeshTasksIndirectCountEXT =
-        (PFN_vkCmdDrawMeshTasksIndirectCountEXT)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksIndirectCountEXT");
+        GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksIndirectCountEXT>("vkCmdDrawMeshTasksIndirectCountEXT");
 
     // #version 450
     // #extension GL_EXT_mesh_shader : require
@@ -10816,12 +10812,11 @@ TEST_F(VkLayerTest, MeshShaderNVDrawCmds) {
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkCmdDrawMeshTasksNV vkCmdDrawMeshTasksNV =
-        (PFN_vkCmdDrawMeshTasksNV)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksNV");
+    PFN_vkCmdDrawMeshTasksNV vkCmdDrawMeshTasksNV = GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksNV>("vkCmdDrawMeshTasksNV");
     PFN_vkCmdDrawMeshTasksIndirectNV vkCmdDrawMeshTasksIndirectNV =
-        (PFN_vkCmdDrawMeshTasksIndirectNV)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksIndirectNV");
+        GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksIndirectNV>("vkCmdDrawMeshTasksIndirectNV");
     PFN_vkCmdDrawMeshTasksIndirectCountNV vkCmdDrawMeshTasksIndirectCountNV =
-        (PFN_vkCmdDrawMeshTasksIndirectCountNV)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksIndirectCountNV");
+        GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksIndirectCountNV>("vkCmdDrawMeshTasksIndirectCountNV");
 
     static const char mesh_src[] = R"glsl(
         #version 450

--- a/tests/vklayertests_debug_printf.cpp
+++ b/tests/vklayertests_debug_printf.cpp
@@ -407,9 +407,7 @@ TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
     VkResult err = pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass());
     ASSERT_VK_SUCCESS(err);
 
-    PFN_vkCmdDrawMeshTasksNV vkCmdDrawMeshTasksNV =
-        (PFN_vkCmdDrawMeshTasksNV)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksNV");
-    ASSERT_TRUE(vkCmdDrawMeshTasksNV != nullptr);
+    PFN_vkCmdDrawMeshTasksNV vkCmdDrawMeshTasksNV = GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksNV>("vkCmdDrawMeshTasksNV");
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -2235,9 +2235,8 @@ TEST_F(VkLayerTest, RenderPassBeginSampleLocationsInvalidIndicesEXT) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     auto sample_locations_props = LvlInitStruct<VkPhysicalDeviceSampleLocationsPropertiesEXT>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&sample_locations_props);
@@ -2324,16 +2323,11 @@ TEST_F(VkLayerTest, InvalidSampleLocations) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
-    PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT vkGetPhysicalDeviceMultisamplePropertiesEXT =
-        (PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT)vk::GetInstanceProcAddr(instance(),
-                                                                                 "vkGetPhysicalDeviceMultisamplePropertiesEXT");
-    assert(vkGetPhysicalDeviceMultisamplePropertiesEXT != nullptr);
-    PFN_vkCmdSetSampleLocationsEXT vkCmdSetSampleLocationsEXT =
-        (PFN_vkCmdSetSampleLocationsEXT)vk::GetInstanceProcAddr(instance(), "vkCmdSetSampleLocationsEXT");
-    assert(vkCmdSetSampleLocationsEXT != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
+    auto vkGetPhysicalDeviceMultisamplePropertiesEXT =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT>("vkGetPhysicalDeviceMultisamplePropertiesEXT");
+    auto vkCmdSetSampleLocationsEXT = GetDeviceProcAddr<PFN_vkCmdSetSampleLocationsEXT>("vkCmdSetSampleLocationsEXT");
 
     auto sample_locations_props = LvlInitStruct<VkPhysicalDeviceSampleLocationsPropertiesEXT>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&sample_locations_props);
@@ -2883,9 +2877,8 @@ TEST_F(VkLayerTest, InvalidRenderPassEndFragmentDensityMapOffsetQCOM) {
         offsetting.pFragmentDensityOffsets = m_vOffsets;
         offsetting.fragmentDensityOffsetCount = 2;
 
-        PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-            (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-        ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+        auto vkGetPhysicalDeviceProperties2KHR =
+            GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
         auto fdm_offset_properties = LvlInitStruct<VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM>();
         auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fdm_offset_properties);
         vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
@@ -7667,9 +7660,8 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     auto inline_uniform_block_features = LvlInitStruct<VkPhysicalDeviceInlineUniformBlockFeaturesEXT>(pNext);
     auto features2 = GetPhysicalDeviceFeatures2(inline_uniform_block_features);
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     // Get the inline uniform block limits
     auto inline_uniform_props = LvlInitStruct<VkPhysicalDeviceInlineUniformBlockPropertiesEXT>();
@@ -8748,9 +8740,8 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     auto fsr_properties = LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fsr_properties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
@@ -8989,12 +8980,9 @@ TEST_F(VkLayerTest, DepthStencilResolveMode) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    assert(vkGetPhysicalDeviceProperties2KHR != nullptr);
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkCreateRenderPass2KHR");
-    assert(vkCreateRenderPass2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
+    auto vkCreateRenderPass2KHR = GetDeviceProcAddr<PFN_vkCreateRenderPass2KHR>("vkCreateRenderPass2KHR");
 
     VkFormat depthFormat = FindSupportedDepthOnlyFormat(gpu());
     VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -1174,8 +1174,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     ASSERT_VK_SUCCESS(err);
 
     if (mesh_shader_supported) {
-        PFN_vkCmdDrawMeshTasksNV vkCmdDrawMeshTasksNV =
-            (PFN_vkCmdDrawMeshTasksNV)vk::GetInstanceProcAddr(instance(), "vkCmdDrawMeshTasksNV");
+        PFN_vkCmdDrawMeshTasksNV vkCmdDrawMeshTasksNV = GetDeviceProcAddr<PFN_vkCmdDrawMeshTasksNV>("vkCmdDrawMeshTasksNV");
         const unsigned push_constant_range_count = 1;
         VkPushConstantRange push_constant_ranges[push_constant_range_count] = {};
         push_constant_ranges[0].stageFlags = VK_SHADER_STAGE_MESH_BIT_NV;

--- a/tests/vklayertests_nvidia_best_practices.cpp
+++ b/tests/vklayertests_nvidia_best_practices.cpp
@@ -313,9 +313,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
     vk_testing::Buffer acceleration_structure_buffer(test_device, acceleration_structure_buffer_ci);
     vk_testing::Buffer scratch_buffer(test_device, scratch_buffer_ci);
 
-    auto vkGetBufferDeviceAddressKHR =
-        (PFN_vkGetBufferDeviceAddress)vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferDeviceAddressKHR");
-    ASSERT_TRUE(vkGetBufferDeviceAddressKHR != nullptr);
+    auto vkGetBufferDeviceAddressKHR = GetDeviceProcAddr<PFN_vkGetBufferDeviceAddress>("vkGetBufferDeviceAddressKHR");
 
     VkBufferDeviceAddressInfo scratch_buffer_device_address_info = LvlInitStruct<VkBufferDeviceAddressInfo>();
     scratch_buffer_device_address_info.buffer = scratch_buffer.handle();
@@ -363,9 +361,8 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
 
     VkAccelerationStructureBuildRangeInfoKHR *p_build_range_info = &build_range_info;
 
-    auto vkCmdBuildAccelerationStructuresKHR = reinterpret_cast<PFN_vkCmdBuildAccelerationStructuresKHR>(
-        vk::GetDeviceProcAddr(test_device.handle(), "vkCmdBuildAccelerationStructuresKHR"));
-    ASSERT_NE(vkCmdBuildAccelerationStructuresKHR, nullptr);
+    auto vkCmdBuildAccelerationStructuresKHR =
+        GetDeviceProcAddr<PFN_vkCmdBuildAccelerationStructuresKHR>("vkCmdBuildAccelerationStructuresKHR");
 
     for (uint32_t queue_family_index : queue_family_indices) {
         VkCommandPoolCreateInfo command_pool_ci = LvlInitStruct<VkCommandPoolCreateInfo>();
@@ -529,8 +526,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_NoPriority) {
         m_errorMonitor->VerifyFound();
     }
 
-    auto vkSetDeviceMemoryPriorityEXT = reinterpret_cast<PFN_vkSetDeviceMemoryPriorityEXT>(
-        vk::GetDeviceProcAddr(test_device.handle(), "vkSetDeviceMemoryPriorityEXT"));
+    auto vkSetDeviceMemoryPriorityEXT = GetDeviceProcAddr<PFN_vkSetDeviceMemoryPriorityEXT>("vkSetDeviceMemoryPriorityEXT");
     vkSetDeviceMemoryPriorityEXT(test_device.handle(), memory.handle(), 0.5f);
 
     {

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -108,9 +108,8 @@ TEST_F(VkLayerTest, VersionCheckPromotedAPIs) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    PFN_vkGetPhysicalDeviceProperties2 vkGetPhysicalDeviceProperties2 =
-        (PFN_vkGetPhysicalDeviceProperties2)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2");
-    assert(vkGetPhysicalDeviceProperties2);
+    auto vkGetPhysicalDeviceProperties2 =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     VkPhysicalDeviceProperties2 phys_dev_props_2{};
 
@@ -359,9 +358,8 @@ TEST_F(VkLayerTest, DuplicateMessageLimit) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     // Create an invalid pNext structure to trigger the stateless validation warning
     VkBaseOutStructure bogus_struct{};
@@ -795,7 +793,7 @@ TEST_F(VkLayerTest, DebugMarkerNameTest) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     PFN_vkDebugMarkerSetObjectNameEXT fpvkDebugMarkerSetObjectNameEXT =
-        (PFN_vkDebugMarkerSetObjectNameEXT)vk::GetInstanceProcAddr(instance(), "vkDebugMarkerSetObjectNameEXT");
+        GetInstanceProcAddr<PFN_vkDebugMarkerSetObjectNameEXT, false>("vkDebugMarkerSetObjectNameEXT");
     if (!(fpvkDebugMarkerSetObjectNameEXT)) {
         GTEST_SKIP() << "Can't find fpvkDebugMarkerSetObjectNameEXT; skipped";
     }
@@ -897,18 +895,11 @@ TEST_F(VkLayerTest, DebugUtilsNameTest) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkSetDebugUtilsObjectNameEXT vkSetDebugUtilsObjectNameEXT =
-        (PFN_vkSetDebugUtilsObjectNameEXT)vk::GetInstanceProcAddr(instance(), "vkSetDebugUtilsObjectNameEXT");
-    ASSERT_TRUE(vkSetDebugUtilsObjectNameEXT);  // Must be extant if extension is enabled
-    PFN_vkCreateDebugUtilsMessengerEXT vkCreateDebugUtilsMessengerEXT =
-        (PFN_vkCreateDebugUtilsMessengerEXT)vk::GetInstanceProcAddr(instance(), "vkCreateDebugUtilsMessengerEXT");
-    ASSERT_TRUE(vkCreateDebugUtilsMessengerEXT);  // Must be extant if extension is enabled
-    PFN_vkDestroyDebugUtilsMessengerEXT vkDestroyDebugUtilsMessengerEXT =
-        (PFN_vkDestroyDebugUtilsMessengerEXT)vk::GetInstanceProcAddr(instance(), "vkDestroyDebugUtilsMessengerEXT");
-    ASSERT_TRUE(vkDestroyDebugUtilsMessengerEXT);  // Must be extant if extension is enabled
-    PFN_vkCmdInsertDebugUtilsLabelEXT vkCmdInsertDebugUtilsLabelEXT =
-        (PFN_vkCmdInsertDebugUtilsLabelEXT)vk::GetInstanceProcAddr(instance(), "vkCmdInsertDebugUtilsLabelEXT");
-    ASSERT_TRUE(vkCmdInsertDebugUtilsLabelEXT);  // Must be extant if extension is enabled
+    auto vkSetDebugUtilsObjectNameEXT = GetInstanceProcAddr<PFN_vkSetDebugUtilsObjectNameEXT>("vkSetDebugUtilsObjectNameEXT");
+    auto vkCreateDebugUtilsMessengerEXT = GetInstanceProcAddr<PFN_vkCreateDebugUtilsMessengerEXT>("vkCreateDebugUtilsMessengerEXT");
+    auto vkDestroyDebugUtilsMessengerEXT =
+        GetInstanceProcAddr<PFN_vkDestroyDebugUtilsMessengerEXT>("vkDestroyDebugUtilsMessengerEXT");
+    auto vkCmdInsertDebugUtilsLabelEXT = GetInstanceProcAddr<PFN_vkCmdInsertDebugUtilsLabelEXT>("vkCmdInsertDebugUtilsLabelEXT");
 
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "Skipping object naming test with MockICD.";
@@ -1089,9 +1080,8 @@ TEST_F(VkLayerTest, InvalidStructPNext) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     m_errorMonitor->SetDesiredFailureMsg((kErrorBit | kWarningBit), "VUID-VkCommandPoolCreateInfo-pNext-pNext");
     // Set VkCommandPoolCreateInfo::pNext to a non-NULL value, when pNext must be NULL.
@@ -1430,8 +1420,8 @@ TEST_F(VkLayerTest, TemporaryExternalSemaphore) {
     auto esp = LvlInitStruct<VkExternalSemaphorePropertiesKHR>();
 
     auto vkGetPhysicalDeviceExternalSemaphorePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>(
+            "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
     vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1532,8 +1522,8 @@ TEST_F(VkLayerTest, ExternalTimelineSemaphore) {
         auto esp = LvlInitStruct<VkExternalSemaphorePropertiesKHR>();
 
         auto vkGetPhysicalDeviceExternalSemaphorePropertiesKHR =
-            (PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)vk::GetInstanceProcAddr(
-                instance(), "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
+            GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>(
+                "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
         vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
         if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1594,8 +1584,8 @@ TEST_F(VkLayerTest, ExternalSyncFdSemaphore) {
     auto esp = LvlInitStruct<VkExternalSemaphorePropertiesKHR>();
 
     auto vkGetPhysicalDeviceExternalSemaphorePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>(
+            "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
     vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1685,8 +1675,8 @@ TEST_F(VkLayerTest, TemporaryExternalFence) {
     auto efi = LvlInitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
     efi.handleType = handle_type;
     auto efp = LvlInitStruct<VkExternalFencePropertiesKHR>();
-    auto vkGetPhysicalDeviceExternalFencePropertiesKHR = (PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR)vk::GetInstanceProcAddr(
-        instance(), "vkGetPhysicalDeviceExternalFencePropertiesKHR");
+    auto vkGetPhysicalDeviceExternalFencePropertiesKHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR>("vkGetPhysicalDeviceExternalFencePropertiesKHR");
     vkGetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1765,8 +1755,8 @@ TEST_F(VkLayerTest, InvalidExternalFence) {
     auto efi = LvlInitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
     efi.handleType = handle_type;
     auto efp = LvlInitStruct<VkExternalFencePropertiesKHR>();
-    auto vkGetPhysicalDeviceExternalFencePropertiesKHR = (PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR)vk::GetInstanceProcAddr(
-        instance(), "vkGetPhysicalDeviceExternalFencePropertiesKHR");
+    auto vkGetPhysicalDeviceExternalFencePropertiesKHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR>("vkGetPhysicalDeviceExternalFencePropertiesKHR");
     vkGetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1847,8 +1837,8 @@ TEST_F(VkLayerTest, ExternalSyncFdFence) {
     auto efi = LvlInitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
     efi.handleType = handle_type;
     auto efp = LvlInitStruct<VkExternalFencePropertiesKHR>();
-    auto vkGetPhysicalDeviceExternalFencePropertiesKHR = (PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR)vk::GetInstanceProcAddr(
-        instance(), "vkGetPhysicalDeviceExternalFencePropertiesKHR");
+    auto vkGetPhysicalDeviceExternalFencePropertiesKHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalFencePropertiesKHR>("vkGetPhysicalDeviceExternalFencePropertiesKHR");
     vkGetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -3894,7 +3884,7 @@ TEST_F(VkLayerTest, HostQueryResetNotEnabled) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto vkResetQueryPoolEXT = GetDeviceProcAddr<PFN_vkResetQueryPoolEXT>("vkResetQueryPoolEXT");
 
     VkQueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
@@ -3903,7 +3893,7 @@ TEST_F(VkLayerTest, HostQueryResetNotEnabled) {
     vk::CreateQueryPool(m_device->device(), &query_pool_create_info, nullptr, &query_pool);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkResetQueryPool-None-02665");
-    fpvkResetQueryPoolEXT(m_device->device(), query_pool, 0, 1);
+    vkResetQueryPoolEXT(m_device->device(), query_pool, 0, 1);
     m_errorMonitor->VerifyFound();
 
     vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
@@ -3928,7 +3918,7 @@ TEST_F(VkLayerTest, HostQueryResetBadFirstQuery) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto vkResetQueryPoolEXT = GetDeviceProcAddr<PFN_vkResetQueryPoolEXT>("vkResetQueryPoolEXT");
 
     VkQueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
@@ -3937,7 +3927,7 @@ TEST_F(VkLayerTest, HostQueryResetBadFirstQuery) {
     vk::CreateQueryPool(m_device->device(), &query_pool_create_info, nullptr, &query_pool);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkResetQueryPool-firstQuery-02666");
-    fpvkResetQueryPoolEXT(m_device->device(), query_pool, 1, 0);
+    vkResetQueryPoolEXT(m_device->device(), query_pool, 1, 0);
     m_errorMonitor->VerifyFound();
 
     if (DeviceValidationVersion() >= VK_API_VERSION_1_2) {
@@ -3972,7 +3962,7 @@ TEST_F(VkLayerTest, HostQueryResetBadRange) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto vkResetQueryPoolEXT = GetDeviceProcAddr<PFN_vkResetQueryPoolEXT>("vkResetQueryPoolEXT");
 
     VkQueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
@@ -3981,7 +3971,7 @@ TEST_F(VkLayerTest, HostQueryResetBadRange) {
     vk::CreateQueryPool(m_device->device(), &query_pool_create_info, nullptr, &query_pool);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkResetQueryPool-firstQuery-02667");
-    fpvkResetQueryPoolEXT(m_device->device(), query_pool, 0, 2);
+    vkResetQueryPoolEXT(m_device->device(), query_pool, 0, 2);
     m_errorMonitor->VerifyFound();
 
     vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
@@ -4006,7 +3996,7 @@ TEST_F(VkLayerTest, HostQueryResetInvalidQueryPool) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto vkResetQueryPoolEXT = GetDeviceProcAddr<PFN_vkResetQueryPoolEXT>("vkResetQueryPoolEXT");
 
     // Create and destroy a query pool.
     VkQueryPool query_pool;
@@ -4018,7 +4008,7 @@ TEST_F(VkLayerTest, HostQueryResetInvalidQueryPool) {
 
     // Attempt to reuse the query pool handle.
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkResetQueryPool-queryPool-parameter");
-    fpvkResetQueryPoolEXT(m_device->device(), query_pool, 0, 1);
+    vkResetQueryPoolEXT(m_device->device(), query_pool, 0, 1);
     m_errorMonitor->VerifyFound();
 }
 
@@ -4041,7 +4031,7 @@ TEST_F(VkLayerTest, HostQueryResetWrongDevice) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
+    auto vkResetQueryPoolEXT = GetDeviceProcAddr<PFN_vkResetQueryPoolEXT>("vkResetQueryPoolEXT");
 
     VkQueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
@@ -4065,7 +4055,7 @@ TEST_F(VkLayerTest, HostQueryResetWrongDevice) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkResetQueryPool-queryPool-parent");
     // Run vk::ResetQueryPoolExt on the wrong device.
-    fpvkResetQueryPoolEXT(second_device, query_pool, 0, 1);
+    vkResetQueryPoolEXT(second_device, query_pool, 0, 1);
     m_errorMonitor->VerifyFound();
 
     vk::DestroyQueryPool(m_device->device(), query_pool, nullptr);
@@ -4582,9 +4572,8 @@ TEST_F(VkLayerTest, QueryPerformanceCreation) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFeatures2KHR>("vkGetPhysicalDeviceFeatures2KHR");
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto performance_features = LvlInitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
     features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&performance_features);
@@ -4594,12 +4583,9 @@ TEST_F(VkLayerTest, QueryPerformanceCreation) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &performance_features));
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
-    ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
-
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        GetInstanceProcAddr<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
     auto queueFamilyProperties = m_device->phy().queue_properties();
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
     std::vector<VkPerformanceCounterKHR> counters;
@@ -4674,10 +4660,8 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
     AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFeatures2KHR>("vkGetPhysicalDeviceFeatures2KHR");
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto performanceFeatures = LvlInitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
     features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&performanceFeatures);
@@ -4691,11 +4675,9 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
-    ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        GetInstanceProcAddr<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
@@ -4748,12 +4730,8 @@ TEST_F(VkLayerTest, QueryPerformanceCounterCommandbufferScope) {
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(device(), queueFamilyIndex, 0, &queue);
 
-    PFN_vkAcquireProfilingLockKHR vkAcquireProfilingLockKHR =
-        (PFN_vkAcquireProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR");
-    ASSERT_TRUE(vkAcquireProfilingLockKHR != nullptr);
-    PFN_vkReleaseProfilingLockKHR vkReleaseProfilingLockKHR =
-        (PFN_vkReleaseProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR");
-    ASSERT_TRUE(vkReleaseProfilingLockKHR != nullptr);
+    auto vkAcquireProfilingLockKHR = GetInstanceProcAddr<PFN_vkAcquireProfilingLockKHR>("vkAcquireProfilingLockKHR");
+    auto vkReleaseProfilingLockKHR = GetInstanceProcAddr<PFN_vkReleaseProfilingLockKHR>("vkReleaseProfilingLockKHR");
 
     {
         VkAcquireProfilingLockInfoKHR lock_info = LvlInitStruct<VkAcquireProfilingLockInfoKHR>();
@@ -4863,9 +4841,8 @@ TEST_F(VkLayerTest, QueryPerformanceCounterRenderPassScope) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFeatures2KHR>("vkGetPhysicalDeviceFeatures2KHR");
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto performanceFeatures = LvlInitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
     features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&performanceFeatures);
@@ -4879,11 +4856,9 @@ TEST_F(VkLayerTest, QueryPerformanceCounterRenderPassScope) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
-    ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        GetInstanceProcAddr<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
@@ -4938,12 +4913,8 @@ TEST_F(VkLayerTest, QueryPerformanceCounterRenderPassScope) {
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(device(), queueFamilyIndex, 0, &queue);
 
-    PFN_vkAcquireProfilingLockKHR vkAcquireProfilingLockKHR =
-        (PFN_vkAcquireProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR");
-    ASSERT_TRUE(vkAcquireProfilingLockKHR != nullptr);
-    PFN_vkReleaseProfilingLockKHR vkReleaseProfilingLockKHR =
-        (PFN_vkReleaseProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR");
-    ASSERT_TRUE(vkReleaseProfilingLockKHR != nullptr);
+    auto vkAcquireProfilingLockKHR = GetInstanceProcAddr<PFN_vkAcquireProfilingLockKHR>("vkAcquireProfilingLockKHR");
+    auto vkReleaseProfilingLockKHR = GetInstanceProcAddr<PFN_vkReleaseProfilingLockKHR>("vkReleaseProfilingLockKHR");
 
     {
         VkAcquireProfilingLockInfoKHR lock_info = LvlInitStruct<VkAcquireProfilingLockInfoKHR>();
@@ -4988,9 +4959,8 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFeatures2KHR>("vkGetPhysicalDeviceFeatures2KHR");
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto performanceFeatures = LvlInitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
     features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&performanceFeatures);
@@ -5004,11 +4974,9 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
-    ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        GetInstanceProcAddr<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
@@ -5063,12 +5031,8 @@ TEST_F(VkLayerTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(device(), queueFamilyIndex, 0, &queue);
 
-    PFN_vkAcquireProfilingLockKHR vkAcquireProfilingLockKHR =
-        (PFN_vkAcquireProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR");
-    ASSERT_TRUE(vkAcquireProfilingLockKHR != nullptr);
-    PFN_vkReleaseProfilingLockKHR vkReleaseProfilingLockKHR =
-        (PFN_vkReleaseProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR");
-    ASSERT_TRUE(vkReleaseProfilingLockKHR != nullptr);
+    auto vkAcquireProfilingLockKHR = GetInstanceProcAddr<PFN_vkAcquireProfilingLockKHR>("vkAcquireProfilingLockKHR");
+    auto vkReleaseProfilingLockKHR = GetInstanceProcAddr<PFN_vkReleaseProfilingLockKHR>("vkReleaseProfilingLockKHR");
 
     {
         VkAcquireProfilingLockInfoKHR lock_info = LvlInitStruct<VkAcquireProfilingLockInfoKHR>();
@@ -5163,10 +5127,8 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFeatures2KHR>("vkGetPhysicalDeviceFeatures2KHR");
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto hostQueryResetFeatures = LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
     auto performanceFeatures = LvlInitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>(&hostQueryResetFeatures);
@@ -5184,16 +5146,12 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
-    ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
-
-    PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR =
-        (PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR != nullptr);
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        GetInstanceProcAddr<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
+    auto vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR>(
+            "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR");
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
@@ -5253,14 +5211,9 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(device(), queueFamilyIndex, 0, &queue);
 
-    PFN_vkAcquireProfilingLockKHR vkAcquireProfilingLockKHR =
-        (PFN_vkAcquireProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR");
-    ASSERT_TRUE(vkAcquireProfilingLockKHR != nullptr);
-    PFN_vkReleaseProfilingLockKHR vkReleaseProfilingLockKHR =
-        (PFN_vkReleaseProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR");
-    ASSERT_TRUE(vkReleaseProfilingLockKHR != nullptr);
-    PFN_vkResetQueryPoolEXT fpvkResetQueryPoolEXT =
-        (PFN_vkResetQueryPoolEXT)vk::GetInstanceProcAddr(instance(), "vkResetQueryPoolEXT");
+    auto vkAcquireProfilingLockKHR = GetInstanceProcAddr<PFN_vkAcquireProfilingLockKHR>("vkAcquireProfilingLockKHR");
+    auto vkReleaseProfilingLockKHR = GetInstanceProcAddr<PFN_vkReleaseProfilingLockKHR>("vkReleaseProfilingLockKHR");
+    auto vkResetQueryPoolEXT = GetDeviceProcAddr<PFN_vkResetQueryPoolEXT>("vkResetQueryPoolEXT");
 
     {
         VkAcquireProfilingLockInfoKHR lock_info = LvlInitStruct<VkAcquireProfilingLockInfoKHR>();
@@ -5290,7 +5243,7 @@ TEST_F(VkLayerTest, QueryPerformanceIncompletePasses) {
         VkCommandBufferBeginInfo command_buffer_begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
         command_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
 
-        fpvkResetQueryPoolEXT(m_device->device(), query_pool, 0, 1);
+        vkResetQueryPoolEXT(m_device->device(), query_pool, 0, 1);
 
         m_commandBuffer->begin(&command_buffer_begin_info);
         vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool, 0, 0);
@@ -5415,9 +5368,8 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR =
-        (PFN_vkGetPhysicalDeviceFeatures2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceFeatures2KHR != nullptr);
+    auto vkGetPhysicalDeviceFeatures2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFeatures2KHR>("vkGetPhysicalDeviceFeatures2KHR");
     VkPhysicalDeviceFeatures2KHR features2 = {};
     auto hostQueryResetFeatures = LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
     auto performanceFeatures = LvlInitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>(&hostQueryResetFeatures);
@@ -5435,16 +5387,9 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR
-        vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
-            (PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR)vk::GetInstanceProcAddr(
-                instance(), "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
-    ASSERT_TRUE(vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR != nullptr);
-
-    PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR =
-        (PFN_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR != nullptr);
+    auto vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR =
+        GetInstanceProcAddr<PFN_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR>(
+            "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR");
 
     auto queueFamilyProperties = m_device->phy().queue_properties();
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
@@ -5494,12 +5439,8 @@ TEST_F(VkLayerTest, QueryPerformanceResetAndBegin) {
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(device(), queueFamilyIndex, 0, &queue);
 
-    PFN_vkAcquireProfilingLockKHR vkAcquireProfilingLockKHR =
-        (PFN_vkAcquireProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkAcquireProfilingLockKHR");
-    ASSERT_TRUE(vkAcquireProfilingLockKHR != nullptr);
-    PFN_vkReleaseProfilingLockKHR vkReleaseProfilingLockKHR =
-        (PFN_vkReleaseProfilingLockKHR)vk::GetInstanceProcAddr(instance(), "vkReleaseProfilingLockKHR");
-    ASSERT_TRUE(vkReleaseProfilingLockKHR != nullptr);
+    auto vkAcquireProfilingLockKHR = GetInstanceProcAddr<PFN_vkAcquireProfilingLockKHR>("vkAcquireProfilingLockKHR");
+    auto vkReleaseProfilingLockKHR = GetInstanceProcAddr<PFN_vkReleaseProfilingLockKHR>("vkReleaseProfilingLockKHR");
 
     {
         VkAcquireProfilingLockInfoKHR lock_info = LvlInitStruct<VkAcquireProfilingLockInfoKHR>();
@@ -5632,9 +5573,8 @@ TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreBadValue) {
         GTEST_SKIP() << "Timeline semaphore not supported, skipping test";
     }
 
-    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
-        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&timelineproperties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &prop2);
@@ -5763,9 +5703,8 @@ TEST_F(VkLayerTest, QueueBindSparseTimelineSemaphoreBadValue) {
         GTEST_SKIP() << "Sparse binding not supported, skipping test";
     }
 
-    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
-        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&timelineproperties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &prop2);
@@ -6281,8 +6220,8 @@ TEST_F(VkLayerTest, InvalidExternalSemaphore) {
     auto esp = LvlInitStruct<VkExternalSemaphorePropertiesKHR>();
 
     auto vkGetPhysicalDeviceExternalSemaphorePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR)vk::GetInstanceProcAddr(
-            instance(), "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>(
+            "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
     vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -6409,9 +6348,8 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
         GTEST_SKIP() << "Timeline semaphore not supported";
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&timelineproperties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &prop2);
@@ -6696,11 +6634,6 @@ TEST_F(VkLayerTest, ImageDrmFormatModifer) {
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
-
-    PFN_vkGetImageDrmFormatModifierPropertiesEXT vkGetImageDrmFormatModifierPropertiesEXT =
-        (PFN_vkGetImageDrmFormatModifierPropertiesEXT)vk::GetInstanceProcAddr(instance(),
-                                                                              "vkGetImageDrmFormatModifierPropertiesEXT");
-    ASSERT_TRUE(vkGetImageDrmFormatModifierPropertiesEXT != nullptr);
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
@@ -7429,9 +7362,8 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto vkGetPhysicalDeviceExternalBufferPropertiesKHR = reinterpret_cast<PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR>(
-        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceExternalBufferPropertiesKHR"));
-    ASSERT_TRUE(vkGetPhysicalDeviceExternalBufferPropertiesKHR != nullptr);
+    auto vkGetPhysicalDeviceExternalBufferPropertiesKHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceExternalBufferPropertiesKHR>("vkGetPhysicalDeviceExternalBufferPropertiesKHR");
 
     // Check for import/export capability
     // export used to feed memory to test import
@@ -7535,9 +7467,7 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
 
 #ifdef _WIN32
     // Export memory to handle
-    auto vkGetMemoryWin32HandleKHR =
-        (PFN_vkGetMemoryWin32HandleKHR)vk::GetInstanceProcAddr(instance(), "vkGetMemoryWin32HandleKHR");
-    ASSERT_TRUE(vkGetMemoryWin32HandleKHR != nullptr);
+    auto vkGetMemoryWin32HandleKHR = GetInstanceProcAddr<PFN_vkGetMemoryWin32HandleKHR>("vkGetMemoryWin32HandleKHR");
     VkMemoryGetWin32HandleInfoKHR mghi_buffer = {VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, nullptr,
                                                  memory_buffer_export.handle(), handle_type};
     VkMemoryGetWin32HandleInfoKHR mghi_image = {VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, nullptr,
@@ -7553,8 +7483,7 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
                                                           handle_type, handle_image};
 #else
     // Export memory to fd
-    auto vkGetMemoryFdKHR = reinterpret_cast<PFN_vkGetMemoryFdKHR>(vk::GetInstanceProcAddr(instance(), "vkGetMemoryFdKHR"));
-    ASSERT_TRUE(vkGetMemoryFdKHR != nullptr);
+    auto vkGetMemoryFdKHR = GetInstanceProcAddr<PFN_vkGetMemoryFdKHR>("vkGetMemoryFdKHR");
 
     auto mgfi_buffer = LvlInitStruct<VkMemoryGetFdInfoKHR>();
     mgfi_buffer.handleType = handle_type;
@@ -8494,9 +8423,8 @@ TEST_F(VkLayerTest, MixedTimelineAndBinarySemaphores) {
         GTEST_SKIP() << "Timeline semaphore not supported";
     }
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
     auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&timelineproperties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &prop2);

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -1770,24 +1770,23 @@ TEST_F(VkLayerTest, CmdDispatchExceedLimits) {
     m_errorMonitor->VerifyFound();
 
     if (khx_dg_ext_available) {
-        PFN_vkCmdDispatchBaseKHR fp_vkCmdDispatchBaseKHR =
-            (PFN_vkCmdDispatchBaseKHR)vk::GetInstanceProcAddr(instance(), "vkCmdDispatchBaseKHR");
+        auto vkCmdDispatchBaseKHR = GetInstanceProcAddr<PFN_vkCmdDispatchBaseKHR>("vkCmdDispatchBaseKHR");
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatchBase-baseGroupX-00427");
-        fp_vkCmdDispatchBaseKHR(m_commandBuffer->handle(), 1, 1, 1, 0, 0, 0);
+        vkCmdDispatchBaseKHR(m_commandBuffer->handle(), 1, 1, 1, 0, 0, 0);
         m_errorMonitor->VerifyFound();
 
         // Base equals or exceeds limit
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatchBase-baseGroupX-00421");
-        fp_vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_count_limit, y_count_limit - 1, z_count_limit - 1, 0, 0, 0);
+        vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_count_limit, y_count_limit - 1, z_count_limit - 1, 0, 0, 0);
         m_errorMonitor->VerifyFound();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatchBase-baseGroupX-00422");
-        fp_vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_count_limit - 1, y_count_limit, z_count_limit - 1, 0, 0, 0);
+        vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_count_limit - 1, y_count_limit, z_count_limit - 1, 0, 0, 0);
         m_errorMonitor->VerifyFound();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatchBase-baseGroupZ-00423");
-        fp_vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_count_limit - 1, y_count_limit - 1, z_count_limit, 0, 0, 0);
+        vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_count_limit - 1, y_count_limit - 1, z_count_limit, 0, 0, 0);
         m_errorMonitor->VerifyFound();
 
         // (Base + count) exceeds limit
@@ -1799,15 +1798,15 @@ TEST_F(VkLayerTest, CmdDispatchExceedLimits) {
         z_count_limit -= z_base;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatchBase-groupCountX-00424");
-        fp_vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_base, y_base, z_base, x_count_limit + 1, y_count_limit, z_count_limit);
+        vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_base, y_base, z_base, x_count_limit + 1, y_count_limit, z_count_limit);
         m_errorMonitor->VerifyFound();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatchBase-groupCountY-00425");
-        fp_vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_base, y_base, z_base, x_count_limit, y_count_limit + 1, z_count_limit);
+        vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_base, y_base, z_base, x_count_limit, y_count_limit + 1, z_count_limit);
         m_errorMonitor->VerifyFound();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatchBase-groupCountZ-00426");
-        fp_vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_base, y_base, z_base, x_count_limit, y_count_limit, z_count_limit + 1);
+        vkCmdDispatchBaseKHR(m_commandBuffer->handle(), x_base, y_base, z_base, x_count_limit, y_count_limit, z_count_limit + 1);
         m_errorMonitor->VerifyFound();
     } else {
         printf("KHX_DEVICE_GROUP_* extensions not supported, skipping CmdDispatchBaseKHR() tests.\n");
@@ -2038,9 +2037,8 @@ TEST_F(VkLayerTest, MissingStorageImageFormatReadForFormat) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceFormatProperties2KHR vkGetPhysicalDeviceFormatProperties2KHR =
-            (PFN_vkGetPhysicalDeviceFormatProperties2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                 "vkGetPhysicalDeviceFormatProperties2KHR");
+    auto vkGetPhysicalDeviceFormatProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFormatProperties2KHR>("vkGetPhysicalDeviceFormatProperties2KHR");
 
     struct {
         VkFormat format;
@@ -2206,9 +2204,8 @@ TEST_F(VkLayerTest, MissingStorageImageFormatWriteForFormat) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceFormatProperties2KHR vkGetPhysicalDeviceFormatProperties2KHR =
-        (PFN_vkGetPhysicalDeviceFormatProperties2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                             "vkGetPhysicalDeviceFormatProperties2KHR");
+    auto vkGetPhysicalDeviceFormatProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFormatProperties2KHR>("vkGetPhysicalDeviceFormatProperties2KHR");
 
     struct {
         VkFormat format;
@@ -2737,9 +2734,8 @@ TEST_F(VkLayerTest, MissingSampledImageDepthComparisonForFormat) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    PFN_vkGetPhysicalDeviceFormatProperties2KHR vkGetPhysicalDeviceFormatProperties2KHR =
-        (PFN_vkGetPhysicalDeviceFormatProperties2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                             "vkGetPhysicalDeviceFormatProperties2KHR");
+    auto vkGetPhysicalDeviceFormatProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceFormatProperties2KHR>("vkGetPhysicalDeviceFormatProperties2KHR");
 
     VkFormat format = VK_FORMAT_UNDEFINED;
     for (uint32_t fmt = VK_FORMAT_R4G4_UNORM_PACK8; fmt < VK_FORMAT_D16_UNORM; fmt++) {
@@ -4064,7 +4060,7 @@ TEST_F(VkLayerTest, VUID_VkVertexInputAttributeDescription_offset_00622) {
         if (maxVertexInputAttributeOffset == 0xFFFFFFFF) {
             // Attempt to artificially lower maximum offset
             PFN_vkSetPhysicalDeviceLimitsEXT fpvkSetPhysicalDeviceLimitsEXT =
-                (PFN_vkSetPhysicalDeviceLimitsEXT)vk::GetInstanceProcAddr(instance(), "vkSetPhysicalDeviceLimitsEXT");
+                GetInstanceProcAddr<PFN_vkSetPhysicalDeviceLimitsEXT, false>("vkSetPhysicalDeviceLimitsEXT");
             if (!fpvkSetPhysicalDeviceLimitsEXT) {
                 GTEST_SKIP() << "All offsets are valid & device_profile_api not found";
             }
@@ -6854,8 +6850,8 @@ TEST_F(VkLayerTest, FramebufferMixedSamplesCoverageReduction) {
     uint32_t combination_count = 0;
     std::vector<VkFramebufferMixedSamplesCombinationNV> combinations;
     auto vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV =
-        reinterpret_cast<PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV>(
-            vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV"));
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV>(
+            "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV");
 
     ASSERT_NO_FATAL_FAILURE(vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(gpu(), &combination_count, nullptr));
     if (combination_count < 1) {
@@ -8831,9 +8827,8 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRatePipelineCombinerOpsLimit) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties =
         LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&fsr_properties);
@@ -9366,9 +9361,8 @@ TEST_F(VkLayerTest, ShaderFloatControl) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     auto shader_float_control = LvlInitStruct<VkPhysicalDeviceFloatControlsProperties>();
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&shader_float_control);
@@ -12217,9 +12211,8 @@ TEST_F(VkLayerTest, ColorBlendAdvanced) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
-        vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     auto blend_operation_advanced_props = LvlInitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
     auto pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&blend_operation_advanced_props);
@@ -12274,10 +12267,8 @@ TEST_F(VkLayerTest, ValidateVariableSampleLocations) {
         GTEST_SKIP() << "VkPhysicalDeviceSampleLocationsPropertiesEXT::variableSampleLocations is supported, skipping.";
     }
 
-    PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT vkGetPhysicalDeviceMultisamplePropertiesEXT =
-        (PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT)vk::GetInstanceProcAddr(instance(),
-                                                                                 "vkGetPhysicalDeviceMultisamplePropertiesEXT");
-    assert(vkGetPhysicalDeviceMultisamplePropertiesEXT != nullptr);
+    auto vkGetPhysicalDeviceMultisamplePropertiesEXT =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT>("vkGetPhysicalDeviceMultisamplePropertiesEXT");
 
     VkAttachmentReference attach = {};
     attach.layout = VK_IMAGE_LAYOUT_GENERAL;
@@ -13563,9 +13554,8 @@ TEST_F(VkLayerTest, TestPipelineRasterizationConservativeStateCreateInfo) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_rasterization_props =
         LvlInitStruct<VkPhysicalDeviceConservativeRasterizationPropertiesEXT>();
     VkPhysicalDeviceProperties2KHR properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&conservative_rasterization_props);
@@ -13673,9 +13663,8 @@ TEST_F(VkLayerTest, TestRuntimeSpirvTransformFeedback) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
     VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props =
         LvlInitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
     VkPhysicalDeviceProperties2 pd_props2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&transform_feedback_props);
@@ -14427,9 +14416,7 @@ TEST_F(VkLayerTest, ComputeImageLayout) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto vkCmdDispatchBaseKHR =
-        reinterpret_cast<PFN_vkCmdDispatchBaseKHR>(vk::GetInstanceProcAddr(instance(), "vkCmdDispatchBaseKHR"));
-    ASSERT_TRUE(vkCmdDispatchBaseKHR != nullptr);
+    auto vkCmdDispatchBaseKHR = GetInstanceProcAddr<PFN_vkCmdDispatchBaseKHR>("vkCmdDispatchBaseKHR");
 
     const char *cs = R"glsl(#version 450
     layout(local_size_x=1) in;
@@ -14495,10 +14482,6 @@ TEST_F(VkLayerTest, ComputeImageLayout_1_1) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
-
-    auto vkCmdDispatchBaseKHR =
-        reinterpret_cast<PFN_vkCmdDispatchBaseKHR>(vk::GetInstanceProcAddr(instance(), "vkCmdDispatchBaseKHR"));
-    ASSERT_TRUE(vkCmdDispatchBaseKHR != nullptr);
 
     const char *cs = R"glsl(#version 450
     layout(local_size_x=1) in;

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -285,9 +285,8 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexInputStride) {
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR =
-        (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
+    auto vkGetPhysicalDeviceProperties2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
 
     // Get the current vertex stride to ensure we pass an incorrect value when creating the graphics pipeline
     auto portability_properties = LvlInitStruct<VkPhysicalDevicePortabilitySubsetPropertiesKHR>();

--- a/tests/vklayertests_ray_tracing.cpp
+++ b/tests/vklayertests_ray_tracing.cpp
@@ -274,9 +274,8 @@ TEST_F(VkLayerTest, RayTracingCopyUnboundAccelerationStructure) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdCopyAccelerationStructureKHR = reinterpret_cast<PFN_vkCmdCopyAccelerationStructureKHR>(
-        vk::GetDeviceProcAddr(device(), "vkCmdCopyAccelerationStructureKHR"));
-    assert(vkCmdCopyAccelerationStructureKHR != nullptr);
+    auto vkCmdCopyAccelerationStructureKHR =
+        GetDeviceProcAddr<PFN_vkCmdCopyAccelerationStructureKHR>("vkCmdCopyAccelerationStructureKHR");
 
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = 4096;
@@ -336,12 +335,9 @@ TEST_F(VkLayerTest, RayTracingCmdCopyUnboundAccelerationStructure) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdCopyAccelerationStructureKHR = reinterpret_cast<PFN_vkCmdCopyAccelerationStructureKHR>(
-        vk::GetDeviceProcAddr(device(), "vkCmdCopyAccelerationStructureKHR"));
-    assert(vkCmdCopyAccelerationStructureKHR != nullptr);
-    auto vkCopyAccelerationStructureKHR =
-        reinterpret_cast<PFN_vkCopyAccelerationStructureKHR>(vk::GetDeviceProcAddr(device(), "vkCopyAccelerationStructureKHR"));
-    assert(vkCopyAccelerationStructureKHR != nullptr);
+    auto vkCmdCopyAccelerationStructureKHR =
+        GetDeviceProcAddr<PFN_vkCmdCopyAccelerationStructureKHR>("vkCmdCopyAccelerationStructureKHR");
+    auto vkCopyAccelerationStructureKHR = GetDeviceProcAddr<PFN_vkCopyAccelerationStructureKHR>("vkCopyAccelerationStructureKHR");
 
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = 4096;
@@ -832,9 +828,8 @@ TEST_F(VkLayerTest, RayTracingValidateCmdTraceRaysKHR) {
         VkShaderObj rgen_shader(this, empty_shader, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2);
         VkShaderObj chit_shader(this, empty_shader, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, SPV_ENV_VULKAN_1_2);
 
-        auto vkCreateRayTracingPipelinesKHR = reinterpret_cast<PFN_vkCreateRayTracingPipelinesKHR>(
-            vk::GetInstanceProcAddr(instance(), "vkCreateRayTracingPipelinesKHR"));
-        ASSERT_TRUE(vkCreateRayTracingPipelinesKHR != nullptr);
+        auto vkCreateRayTracingPipelinesKHR =
+            GetDeviceProcAddr<PFN_vkCreateRayTracingPipelinesKHR>("vkCreateRayTracingPipelinesKHR");
 
         const VkPipelineLayoutObj pipeline_layout(m_device, {});
 
@@ -880,7 +875,6 @@ TEST_F(VkLayerTest, RayTracingValidateCmdTraceRaysKHR) {
 
     const auto vkGetPhysicalDeviceProperties2KHR =
         GetInstanceProcAddr<PFN_vkGetPhysicalDeviceProperties2KHR>("vkGetPhysicalDeviceProperties2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
     auto ray_tracing_properties = LvlInitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&ray_tracing_properties);

--- a/tests/vklayertests_ray_tracing_pipeline.cpp
+++ b/tests/vklayertests_ray_tracing_pipeline.cpp
@@ -901,9 +901,7 @@ TEST_F(VkLayerTest, RayTracingPipelineDeferredOp) {
     const auto vkGetDeferredOperationResultKHR =
         GetInstanceProcAddr<PFN_vkGetDeferredOperationResultKHR>("vkGetDeferredOperationResultKHR");
 
-    PFN_vkDestroyDeferredOperationKHR vkDestroyDeferredOperationKHR =
-        reinterpret_cast<PFN_vkDestroyDeferredOperationKHR>(vk::GetInstanceProcAddr(instance(), "vkDestroyDeferredOperationKHR"));
-    ASSERT_TRUE(vkDestroyDeferredOperationKHR != nullptr);
+    auto vkDestroyDeferredOperationKHR = GetInstanceProcAddr<PFN_vkDestroyDeferredOperationKHR>("vkDestroyDeferredOperationKHR");
 
     const VkPipelineLayoutObj pipeline_layout(m_device, {});
 

--- a/tests/vklayertests_viewport_inheritance.cpp
+++ b/tests/vklayertests_viewport_inheritance.cpp
@@ -734,12 +734,8 @@ TEST_F(VkLayerTest, ViewportInheritanceMultiViewport) {
     vk::CmdSetScissor(set_state_fixed_count_cmd, 0, 2, test_data.kScissorArray);
     vk::EndCommandBuffer(set_state_fixed_count_cmd);
 
-    auto vkCmdSetViewportWithCountEXT =
-        PFN_vkCmdSetViewportWithCountEXT(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetViewportWithCountEXT"));
-    assert(vkCmdSetViewportWithCountEXT);
-    auto vkCmdSetScissorWithCountEXT =
-        PFN_vkCmdSetScissorWithCountEXT(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetScissorWithCountEXT"));
-    assert(vkCmdSetScissorWithCountEXT);
+    auto vkCmdSetViewportWithCountEXT = GetDeviceProcAddr<PFN_vkCmdSetViewportWithCountEXT>("vkCmdSetViewportWithCountEXT");
+    auto vkCmdSetScissorWithCountEXT = GetDeviceProcAddr<PFN_vkCmdSetScissorWithCountEXT>("vkCmdSetScissorWithCountEXT");
 
     VkCommandBuffer set_state_with_count_cmd = test_data.MakeBeginSubpassCommandBuffer(pool, 0, nullptr);
     vkCmdSetViewportWithCountEXT(set_state_with_count_cmd, 2, test_data.kViewportArray);

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -72,10 +72,8 @@ TEST_F(VkLayerTest, InitSwapchainPotentiallyIncompatibleFlag) {
     {
         swapchain_ci.flags = VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR;
 
-        PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR =
-            reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR>(
-                vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSurfaceCapabilities2KHR"));
-        ASSERT_TRUE(vkGetPhysicalDeviceSurfaceCapabilities2KHR != nullptr);
+        auto vkGetPhysicalDeviceSurfaceCapabilities2KHR =
+            GetInstanceProcAddr<PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR>("vkGetPhysicalDeviceSurfaceCapabilities2KHR");
 
         // Get surface protected capabilities
         VkPhysicalDeviceSurfaceInfo2KHR surface_info = LvlInitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
@@ -1082,10 +1080,8 @@ TEST_F(VkLayerTest, SwapchainMinImageCountShared) {
         GTEST_SKIP() << "Cannot find supported shared present mode";
     }
 
-    PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR =
-        (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceSurfaceCapabilities2KHR != nullptr);
+    auto vkGetPhysicalDeviceSurfaceCapabilities2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR>("vkGetPhysicalDeviceSurfaceCapabilities2KHR");
 
     VkSharedPresentSurfaceCapabilitiesKHR shared_present_capabilities = LvlInitStruct<VkSharedPresentSurfaceCapabilitiesKHR>();
     VkSurfaceCapabilities2KHR capabilities = LvlInitStruct<VkSurfaceCapabilities2KHR>(&shared_present_capabilities);
@@ -1207,10 +1203,8 @@ TEST_F(VkLayerTest, SwapchainInvalidUsageShared) {
         GTEST_SKIP() << "Cannot find supported shared present mode";
     }
 
-    PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR =
-        (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
-    ASSERT_TRUE(vkGetPhysicalDeviceSurfaceCapabilities2KHR != nullptr);
+    auto vkGetPhysicalDeviceSurfaceCapabilities2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR>("vkGetPhysicalDeviceSurfaceCapabilities2KHR");
 
     VkSharedPresentSurfaceCapabilitiesKHR shared_present_capabilities = LvlInitStruct<VkSharedPresentSurfaceCapabilitiesKHR>();
     VkSurfaceCapabilities2KHR capabilities = LvlInitStruct<VkSurfaceCapabilities2KHR>(&shared_present_capabilities);
@@ -1455,25 +1449,15 @@ TEST_F(VkLayerTest, DisplayPlaneSurface) {
     }
 
     // Load all VK_KHR_display functions
-    PFN_vkCreateDisplayModeKHR vkCreateDisplayModeKHR =
-        (PFN_vkCreateDisplayModeKHR)vk::GetInstanceProcAddr(instance(), "vkCreateDisplayModeKHR");
-    PFN_vkCreateDisplayPlaneSurfaceKHR vkCreateDisplayPlaneSurfaceKHR =
-        (PFN_vkCreateDisplayPlaneSurfaceKHR)vk::GetInstanceProcAddr(instance(), "vkCreateDisplayPlaneSurfaceKHR");
-    PFN_vkGetDisplayPlaneSupportedDisplaysKHR vkGetDisplayPlaneSupportedDisplaysKHR =
-        (PFN_vkGetDisplayPlaneSupportedDisplaysKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayPlaneSupportedDisplaysKHR");
-    PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR vkGetPhysicalDeviceDisplayPlanePropertiesKHR =
-        (PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR)vk::GetInstanceProcAddr(instance(),
-                                                                                  "vkGetPhysicalDeviceDisplayPlanePropertiesKHR");
-    PFN_vkGetDisplayModePropertiesKHR vkGetDisplayModePropertiesKHR =
-        (PFN_vkGetDisplayModePropertiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayModePropertiesKHR");
-    PFN_vkGetDisplayPlaneCapabilitiesKHR vkGetDisplayPlaneCapabilitiesKHR =
-        (PFN_vkGetDisplayPlaneCapabilitiesKHR)vk::GetInstanceProcAddr(instance(), "vkGetDisplayPlaneCapabilitiesKHR");
-    ASSERT_TRUE(vkCreateDisplayModeKHR != nullptr);
-    ASSERT_TRUE(vkCreateDisplayPlaneSurfaceKHR != nullptr);
-    ASSERT_TRUE(vkGetDisplayPlaneSupportedDisplaysKHR != nullptr);
-    ASSERT_TRUE(vkGetPhysicalDeviceDisplayPlanePropertiesKHR != nullptr);
-    ASSERT_TRUE(vkGetDisplayModePropertiesKHR != nullptr);
-    ASSERT_TRUE(vkGetDisplayPlaneCapabilitiesKHR != nullptr);
+    auto vkCreateDisplayModeKHR = GetInstanceProcAddr<PFN_vkCreateDisplayModeKHR>("vkCreateDisplayModeKHR");
+    auto vkCreateDisplayPlaneSurfaceKHR = GetInstanceProcAddr<PFN_vkCreateDisplayPlaneSurfaceKHR>("vkCreateDisplayPlaneSurfaceKHR");
+    auto vkGetDisplayPlaneSupportedDisplaysKHR =
+        GetInstanceProcAddr<PFN_vkGetDisplayPlaneSupportedDisplaysKHR>("vkGetDisplayPlaneSupportedDisplaysKHR");
+    auto vkGetPhysicalDeviceDisplayPlanePropertiesKHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>("vkGetPhysicalDeviceDisplayPlanePropertiesKHR");
+    auto vkGetDisplayModePropertiesKHR = GetInstanceProcAddr<PFN_vkGetDisplayModePropertiesKHR>("vkGetDisplayModePropertiesKHR");
+    auto vkGetDisplayPlaneCapabilitiesKHR =
+        GetInstanceProcAddr<PFN_vkGetDisplayPlaneCapabilitiesKHR>("vkGetDisplayPlaneCapabilitiesKHR");
 
     uint32_t plane_prop_count = 0;
     vkGetPhysicalDeviceDisplayPlanePropertiesKHR(gpu(), &plane_prop_count, nullptr);
@@ -1834,8 +1818,7 @@ TEST_F(VkLayerTest, PresentIdWait) {
     InitSurface(surface2);
     InitSwapchain(surface2, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR, swapchain2);
 
-    auto vkWaitForPresentKHR = (PFN_vkWaitForPresentKHR)vk::GetDeviceProcAddr(m_device->device(), "vkWaitForPresentKHR");
-    ASSERT_TRUE(vkWaitForPresentKHR != nullptr);
+    auto vkWaitForPresentKHR = GetDeviceProcAddr<PFN_vkWaitForPresentKHR>("vkWaitForPresentKHR");
 
     uint32_t image_count, image_count2;
     vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr);
@@ -1934,8 +1917,7 @@ TEST_F(VkLayerTest, PresentIdWaitFeatures) {
         GTEST_SKIP() << "Cannot create swapchain, skipping test";
     }
 
-    auto vkWaitForPresentKHR = (PFN_vkWaitForPresentKHR)vk::GetDeviceProcAddr(m_device->device(), "vkWaitForPresentKHR");
-    assert(vkWaitForPresentKHR != nullptr);
+    auto vkWaitForPresentKHR = GetDeviceProcAddr<PFN_vkWaitForPresentKHR>("vkWaitForPresentKHR");
 
     uint32_t image_count;
     vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr);
@@ -2087,17 +2069,15 @@ TEST_F(VkLayerTest, TestSurfaceSupportByPhysicalDevice) {
         surface_info.surface = m_surface;
         VkDeviceGroupPresentModeFlagsKHR flags = VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHR;
 
-        PFN_vkGetDeviceGroupSurfacePresentModes2EXT vkGetDeviceGroupSurfacePresentModes2EXT =
-            reinterpret_cast<PFN_vkGetDeviceGroupSurfacePresentModes2EXT>(
-                vk::GetInstanceProcAddr(instance(), "vkGetDeviceGroupSurfacePresentModes2EXT"));
+        auto vkGetDeviceGroupSurfacePresentModes2EXT =
+            GetInstanceProcAddr<PFN_vkGetDeviceGroupSurfacePresentModes2EXT>("vkGetDeviceGroupSurfacePresentModes2EXT");
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetDeviceGroupSurfacePresentModes2EXT-pSurfaceInfo-06213");
         vkGetDeviceGroupSurfacePresentModes2EXT(device(), &surface_info, &flags);
         m_errorMonitor->VerifyFound();
 
-        PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT vkGetPhysicalDeviceSurfacePresentModes2EXT =
-            (PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT)vk::GetInstanceProcAddr(instance(),
-                                                                                    "vkGetPhysicalDeviceSurfacePresentModes2EXT");
+        auto vkGetPhysicalDeviceSurfacePresentModes2EXT =
+            GetInstanceProcAddr<PFN_vkGetPhysicalDeviceSurfacePresentModes2EXT>("vkGetPhysicalDeviceSurfacePresentModes2EXT");
 
         uint32_t count;
         vkGetPhysicalDeviceSurfacePresentModes2EXT(gpu(), &surface_info, &count, nullptr);
@@ -2117,9 +2097,8 @@ TEST_F(VkLayerTest, TestSurfaceSupportByPhysicalDevice) {
     }
 
     if (display_surface_counter) {
-        PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT vkGetPhysicalDeviceSurfaceCapabilities2EXT =
-            (PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT)vk::GetInstanceProcAddr(instance(),
-                                                                                    "vkGetPhysicalDeviceSurfaceCapabilities2EXT");
+        auto vkGetPhysicalDeviceSurfaceCapabilities2EXT =
+            GetInstanceProcAddr<PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT>("vkGetPhysicalDeviceSurfaceCapabilities2EXT");
 
         VkSurfaceCapabilities2EXT capabilities = LvlInitStruct<VkSurfaceCapabilities2EXT>();
 
@@ -2129,9 +2108,8 @@ TEST_F(VkLayerTest, TestSurfaceSupportByPhysicalDevice) {
     }
 
     if (get_surface_capabilities2) {
-        PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR =
-            (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                    "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
+        auto vkGetPhysicalDeviceSurfaceCapabilities2KHR =
+            GetInstanceProcAddr<PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR>("vkGetPhysicalDeviceSurfaceCapabilities2KHR");
 
         VkPhysicalDeviceSurfaceInfo2KHR surface_info = LvlInitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
         surface_info.surface = m_surface;
@@ -2150,8 +2128,8 @@ TEST_F(VkLayerTest, TestSurfaceSupportByPhysicalDevice) {
     }
 
     if (get_surface_capabilities2) {
-        PFN_vkGetPhysicalDeviceSurfaceFormats2KHR vkGetPhysicalDeviceSurfaceFormats2KHR =
-            (PFN_vkGetPhysicalDeviceSurfaceFormats2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSurfaceFormats2KHR");
+        auto vkGetPhysicalDeviceSurfaceFormats2KHR =
+            GetInstanceProcAddr<PFN_vkGetPhysicalDeviceSurfaceFormats2KHR>("vkGetPhysicalDeviceSurfaceFormats2KHR");
 
         VkPhysicalDeviceSurfaceInfo2KHR surface_info = LvlInitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
         surface_info.surface = m_surface;
@@ -2201,10 +2179,10 @@ TEST_F(VkLayerTest, TestvkAcquireFullScreenExclusiveModeEXT) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
-    auto vkAcquireFullScreenExclusiveModeEXT = reinterpret_cast<PFN_vkAcquireFullScreenExclusiveModeEXT>(
-        vk::GetInstanceProcAddr(instance(), "vkAcquireFullScreenExclusiveModeEXT"));
-    auto vkReleaseFullScreenExclusiveModeEXT = reinterpret_cast<PFN_vkReleaseFullScreenExclusiveModeEXT>(
-        vk::GetInstanceProcAddr(instance(), "vkReleaseFullScreenExclusiveModeEXT"));
+    auto vkAcquireFullScreenExclusiveModeEXT =
+        GetInstanceProcAddr<PFN_vkAcquireFullScreenExclusiveModeEXT>("vkAcquireFullScreenExclusiveModeEXT");
+    auto vkReleaseFullScreenExclusiveModeEXT =
+        GetInstanceProcAddr<PFN_vkReleaseFullScreenExclusiveModeEXT>("vkReleaseFullScreenExclusiveModeEXT");
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAcquireFullScreenExclusiveModeEXT-swapchain-02675");
     vkAcquireFullScreenExclusiveModeEXT(device(), m_swapchain);
@@ -2401,8 +2379,8 @@ TEST_F(VkLayerTest, TestSurfaceQueryImageCompressionControlWithoutExtension) {
         GTEST_SKIP() << "Cannot create surface";
     }
 
-    PFN_vkGetPhysicalDeviceSurfaceFormats2KHR vkGetPhysicalDeviceSurfaceFormats2KHR =
-        reinterpret_cast<PFN_vkGetPhysicalDeviceSurfaceFormats2KHR>(vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceSurfaceFormats2KHR"));
+    auto vkGetPhysicalDeviceSurfaceFormats2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceSurfaceFormats2KHR>("vkGetPhysicalDeviceSurfaceFormats2KHR");
 
     auto compression_properties = LvlInitStruct<VkImageCompressionPropertiesEXT>();
     auto surface_info = LvlInitStruct<VkPhysicalDeviceSurfaceInfo2KHR>(&compression_properties);
@@ -2432,9 +2410,8 @@ TEST_F(VkLayerTest, PhysicalDeviceSurfaceCapabilities) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_TRUE(InitSwapchain());
 
-    PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR vkGetPhysicalDeviceSurfaceCapabilities2KHR =
-        (PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR)vk::GetInstanceProcAddr(instance(),
-                                                                                "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
+    auto vkGetPhysicalDeviceSurfaceCapabilities2KHR =
+        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR>("vkGetPhysicalDeviceSurfaceCapabilities2KHR");
 
     VkPhysicalDeviceSurfaceInfo2KHR surface_info = LvlInitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
     surface_info.surface = m_surface;

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -3960,9 +3960,7 @@ TEST_F(VkSyncValTest, TestCopyingToCompressedImage) {
     m_commandBuffer->end();
 
     if (copy_commands_2) {
-        auto vkCmdCopyImage2KHR =
-            reinterpret_cast<PFN_vkCmdCopyImage2KHR>(vk::GetInstanceProcAddr(instance(), "vkCmdCopyImage2KHR"));
-        assert(vkCmdCopyImage2KHR != nullptr);
+        auto vkCmdCopyImage2KHR = GetInstanceProcAddr<PFN_vkCmdCopyImage2KHR>("vkCmdCopyImage2KHR");
 
         m_commandBuffer->reset();
 


### PR DESCRIPTION
Cleans up a lot (not all) places to use the new `GetInstanceProcAddr` and `GetDeviceProcAddr` helper functions