### PR TITLE
layers: Handle SAMPLED_READ in sync2 validation

### DIFF
--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -685,9 +685,13 @@ SyncStageAccessIndex GetSyncStageAccessIndexsByDescriptorSet(VkDescriptorType de
     // But if write hazard doesn't happen, read hazard is impossible to happen.
     if (interface_var.is_writable) {
         return stage_access->second.storage_write;
+    } else if (descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
+               descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+               descriptor_type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) {
+        return stage_access->second.sampled_read;
+    } else {
+        return stage_access->second.storage_read;
     }
-    // TODO: sampled_read
-    return stage_access->second.storage_read;
 }
 
 bool IsImageLayoutDepthWritable(VkImageLayout image_layout) {


### PR DESCRIPTION
Ran into this when moving over to sync2 in Granite. A COMBINED_IMAGE_SAMPLER was trying to access STORAGE_READ rather than SAMPLED_READ, causing false positive. This fixed the issue for me, but I don't know the sync validation code enough to know if this fix is complete.