### PR TITLE
Fix VK_EXT_image_2d_view_of_3d check

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -738,7 +738,7 @@ bool BestPractices::PreCallValidateAllocateMemory(VkDevice device, const VkMemor
     }
 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
-        if (!device_extensions.vk_ext_pageable_device_local_memory &&
+        if (!IsExtEnabled(device_extensions.vk_ext_pageable_device_local_memory) &&
             !LvlFindInChain<VkMemoryPriorityAllocateInfoEXT>(pAllocateInfo->pNext)) {
             skip |= LogPerformanceWarning(
                 device, kVUID_BestPractices_AllocateMemory_SetPriority,
@@ -3502,7 +3502,7 @@ bool BestPractices::ValidateBuildAccelerationStructure(VkCommandBuffer commandBu
 bool BestPractices::ValidateBindMemory(VkDevice device, VkDeviceMemory memory) const {
     bool skip = false;
 
-    if (VendorCheckEnabled(kBPVendorNVIDIA) && device_extensions.vk_ext_pageable_device_local_memory) {
+    if (VendorCheckEnabled(kBPVendorNVIDIA) && IsExtEnabled(device_extensions.vk_ext_pageable_device_local_memory)) {
         auto mem_info = std::static_pointer_cast<const bp_state::DeviceMemory>(Get<DEVICE_MEMORY_STATE>(memory));
         if (!mem_info->dynamic_priority) {
             skip |=

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -5585,17 +5585,17 @@ bool CoreChecks::ValidateCreateImageViewSubresourceRange(const IMAGE_STATE *imag
     subresource_range_error_codes.base_mip_err = "VUID-VkImageViewCreateInfo-subresourceRange-01478";
     subresource_range_error_codes.mip_count_err = "VUID-VkImageViewCreateInfo-subresourceRange-01718";
     subresource_range_error_codes.base_layer_err =
-        is_khr_maintenance1
-            ? (is_3_d_to_2_d_map ? "VUID-VkImageViewCreateInfo-image-02724"
-                                 : (device_extensions.vk_ext_image_2d_view_of_3d ? "VUID-VkImageViewCreateInfo-image-06724"
-                                                                                 : "VUID-VkImageViewCreateInfo-image-01482"))
-            : "VUID-VkImageViewCreateInfo-subresourceRange-01480";
+        is_khr_maintenance1 ? (is_3_d_to_2_d_map ? "VUID-VkImageViewCreateInfo-image-02724"
+                                                 : (IsExtEnabled(device_extensions.vk_ext_image_2d_view_of_3d)
+                                                        ? "VUID-VkImageViewCreateInfo-image-06724"
+                                                        : "VUID-VkImageViewCreateInfo-image-01482"))
+                            : "VUID-VkImageViewCreateInfo-subresourceRange-01480";
     subresource_range_error_codes.layer_count_err =
-        is_khr_maintenance1
-            ? (is_3_d_to_2_d_map ? "VUID-VkImageViewCreateInfo-subresourceRange-02725"
-                                 : (device_extensions.vk_ext_image_2d_view_of_3d ? "VUID-VkImageViewCreateInfo-subresourceRange-06725"
-                                                                                 : "VUID-VkImageViewCreateInfo-subresourceRange-01483"))
-            : "VUID-VkImageViewCreateInfo-subresourceRange-01719";
+        is_khr_maintenance1 ? (is_3_d_to_2_d_map ? "VUID-VkImageViewCreateInfo-subresourceRange-02725"
+                                                 : (IsExtEnabled(device_extensions.vk_ext_image_2d_view_of_3d)
+                                                        ? "VUID-VkImageViewCreateInfo-subresourceRange-06725"
+                                                        : "VUID-VkImageViewCreateInfo-subresourceRange-01483"))
+                            : "VUID-VkImageViewCreateInfo-subresourceRange-01719";
 
     return ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_layer_count, subresourceRange,
                                          "vkCreateImageView", "pCreateInfo->subresourceRange", image_layer_count_var_name,
@@ -6428,7 +6428,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                 if (IsExtEnabled(device_extensions.vk_khr_maintenance1)) {
                     if (view_type != VK_IMAGE_VIEW_TYPE_3D) {
                         if ((view_type == VK_IMAGE_VIEW_TYPE_2D || view_type == VK_IMAGE_VIEW_TYPE_2D_ARRAY)) {
-                            if (device_extensions.vk_ext_image_2d_view_of_3d) {
+                            if (IsExtEnabled(device_extensions.vk_ext_image_2d_view_of_3d)) {
                                 if (!(image_flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT)) {
                                     if (view_type == VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
                                         skip |= LogError(

--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -1287,7 +1287,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
         }
     }
 
-    if (device_extensions.vk_ext_primitives_generated_query) {
+    if (IsExtEnabled(device_extensions.vk_ext_primitives_generated_query)) {
         bool primitives_generated_query_with_rasterizer_discard =
             enabled_features.primitives_generated_query_features.primitivesGeneratedQueryWithRasterizerDiscard == VK_TRUE;
         bool primitives_generated_query_with_non_zero_streams =

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -2103,7 +2103,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
     // KHR_maintenance1 allows rendering into 2D or 2DArray views which slice a 3D image,
     // but not binding them to descriptor sets.
     if (iv_state->IsDepthSliced()) {
-        if (!device_extensions.vk_ext_image_2d_view_of_3d) {
+        if (!IsExtEnabled(device_extensions.vk_ext_image_2d_view_of_3d)) {
             if (iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D) {
                 *error_code = "VUID-VkDescriptorImageInfo-imageView-06711";
                 *error_msg = "ImageView must not be a 2D view of a 3D image";
@@ -2342,7 +2342,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
         return false;
     }
 
-    if (device_extensions.vk_ext_image_2d_view_of_3d && iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D &&
+    if (IsExtEnabled(device_extensions.vk_ext_image_2d_view_of_3d) && iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D &&
         image_node->createInfo.imageType == VK_IMAGE_TYPE_3D) {
         if ((type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) || (type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) ||
             (type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)) {

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -2102,16 +2102,65 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
 
     // KHR_maintenance1 allows rendering into 2D or 2DArray views which slice a 3D image,
     // but not binding them to descriptor sets.
-    if (iv_state->IsDepthSliced()) {
-        if (!IsExtEnabled(device_extensions.vk_ext_image_2d_view_of_3d)) {
-            if (iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D) {
-                *error_code = "VUID-VkDescriptorImageInfo-imageView-06711";
-                *error_msg = "ImageView must not be a 2D view of a 3D image";
-                return false;
-            }
-        } else if (iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
+    if (iv_state->IsDepthSliced() && image_node->createInfo.imageType == VK_IMAGE_TYPE_3D) {
+        if (iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
             *error_code = "VUID-VkDescriptorImageInfo-imageView-06712";
             *error_msg = "ImageView must not be a 2DArray view of a 3D image";
+            return false;
+        }
+
+        // vk_ext_image_2d_view_of_3d allows use of VIEW_TYPE_2D in descriptor
+        if (IsExtEnabled(device_extensions.vk_ext_image_2d_view_of_3d)) {
+            if ((type != VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) && (type != VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) &&
+                (type != VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)) {
+                *error_code = "UNASSIGNED-VkWriteDescriptorSet-descriptorType";
+                std::stringstream error_str;
+                error_str << "ImageView (" << report_data->FormatHandle(image_view)
+                          << ") , is a 2D image view created from 3D image (" << report_data->FormatHandle(image)
+                          << ") , written to a descriptor of type " << string_VkDescriptorType(type)
+                          << " but needs to be a descriptor type of VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, "
+                             "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, or VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER";
+                *error_msg = error_str.str();
+                return false;
+            }
+
+            if (type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE && !enabled_features.image_2d_view_of_3d_features.image2DViewOf3D) {
+                *error_code = "VUID-VkDescriptorImageInfo-descriptorType-06713";
+                std::stringstream error_str;
+                error_str << "ImageView (" << report_data->FormatHandle(image_view)
+                          << ") , is a 2D image view created from 3D image (" << report_data->FormatHandle(image)
+                          << ") , written to a descriptor of type VK_DESCRIPTOR_TYPE_STORAGE_IMAGE"
+                          << " and the image2DViewOf3D feature is not enabled";
+                *error_msg = error_str.str();
+                return false;
+            }
+
+            if ((type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE || type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) &&
+                !enabled_features.image_2d_view_of_3d_features.sampler2DViewOf3D) {
+                *error_code = "VUID-VkDescriptorImageInfo-descriptorType-06714";
+                std::stringstream error_str;
+                error_str << "ImageView (" << report_data->FormatHandle(image_view)
+                          << ") , is a 2D image view created from 3D image (" << report_data->FormatHandle(image)
+                          << ") , written to a descriptor of type " << string_VkDescriptorType(type)
+                          << " and the image2DViewOf3D feature is not enabled";
+                *error_msg = error_str.str();
+                return false;
+            }
+
+            if (!(image_node->createInfo.flags & VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT)) {
+                *error_code = "UNASSIGNED-VkDescriptorImageInfo-compatibleBit";
+                std::stringstream error_str;
+                error_str << "ImageView (" << report_data->FormatHandle(image_view)
+                          << ") , is a 2D image view created from 3D image (" << report_data->FormatHandle(image)
+                          << ") , written to a descriptor of type " << string_VkDescriptorType(type)
+                          << " but the image used to create the image view was not created with "
+                             "VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT set";
+                *error_msg = error_str.str();
+                return false;
+            }
+        } else if (iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D) {
+            *error_code = "VUID-VkDescriptorImageInfo-imageView-06711";
+            *error_msg = "ImageView must not be a 2D view of a 3D image";
             return false;
         }
     }
@@ -2340,45 +2389,6 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
                   << ") that is not 0.0";
         *error_msg = error_str.str();
         return false;
-    }
-
-    if (IsExtEnabled(device_extensions.vk_ext_image_2d_view_of_3d) && iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D &&
-        image_node->createInfo.imageType == VK_IMAGE_TYPE_3D) {
-        if ((type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) || (type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) ||
-            (type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)) {
-            if (!(image_node->createInfo.flags & VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT)) {
-                *error_code = "VUID-VkWriteDescriptorSet-descriptorType-06710";
-                std::stringstream error_str;
-                error_str << "ImageView (" << report_data->FormatHandle(image_view)
-                          << ") , is a 2D image view created from 3D image (" << report_data->FormatHandle(image)
-                          << ") , written to a descriptor of type " << string_VkDescriptorType(type)
-                          << " but the image used to create the image view was not created with "
-                             "VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT set";
-                *error_msg = error_str.str();
-                return false;
-            }
-            if (type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE && !enabled_features.image_2d_view_of_3d_features.image2DViewOf3D) {
-                *error_code = "VUID-VkDescriptorImageInfo-descriptorType-06713";
-                std::stringstream error_str;
-                error_str << "ImageView (" << report_data->FormatHandle(image_view)
-                          << ") , is a 2D image view created from 3D image (" << report_data->FormatHandle(image)
-                          << ") , written to a descriptor of type VK_DESCRIPTOR_TYPE_STORAGE_IMAGE"
-                          << " and the image2DViewOf3D feature is not enabled";
-                *error_msg = error_str.str();
-                return false;
-            }
-            if ((type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE || type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) &&
-                !enabled_features.image_2d_view_of_3d_features.sampler2DViewOf3D) {
-                *error_code = "VUID-VkDescriptorImageInfo-descriptorType-06714";
-                std::stringstream error_str;
-                error_str << "ImageView (" << report_data->FormatHandle(image_view)
-                          << ") , is a 2D image view created from 3D image (" << report_data->FormatHandle(image)
-                          << ") , written to a descriptor of type " << string_VkDescriptorType(type)
-                          << " and the image2DViewOf3D feature is not enabled";
-                *error_msg = error_str.str();
-                return false;
-            }
-        }
     }
 
     return true;

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -14817,7 +14817,7 @@ TEST_F(VkLayerTest, Image2DViewOf3D) {
     view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     view_2d.init(*m_device, view_ci);
     descriptor_set.WriteDescriptorImageInfo(0, view_2d.handle(), VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-06710");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-VkDescriptorImageInfo-compatibleBit");
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
     descriptor_set.descriptor_writes.clear();


### PR DESCRIPTION
- Created a internal Spec Fix to split `VUID-VkWriteDescriptorSet-descriptorType-06710` into proper 2 different VUs https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5626/
- collapsed logic together
- Make sure to use `IsExtEnabled`
- Fix bug as `VK_IMAGE_VIEW_TYPE_2D_ARRAY` (`VUID-VkDescriptorImageInfo-imageView-06712`) is called regardless of the extension being enabled or not

Original PR (cc @Tony-LunarG) https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3989