### PR TITLE
layers: Fix UpdateDescriptorSets race conditions

### DIFF
--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -793,13 +793,6 @@ TODO: The following variables need to be made const:
     // For a given dynamic offset index in the set, map to associated index of the descriptors in the set
     std::vector<size_t> dynamic_offset_idx_to_descriptor_list_;
 
-TODO: needs to be made atomic
-
-
-```
-    uint64_t change_count_;
-```
-
 TODO: only used by push descriptors and effectively guarded by CMD_BUFFER_STATE locking
 
 ````

--- a/layers/descriptor_sets.cpp
+++ b/layers/descriptor_sets.cpp
@@ -551,7 +551,7 @@ void cvdescriptorset::DescriptorSet::PerformWriteUpdate(ValidationStateTracker *
     }
     if (update->descriptorCount) {
         some_update_ = true;
-        change_count_++;
+        ++change_count_;
     }
 
     if (!IsPushDescriptor() && !(orig_binding.binding_flags & (VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT |
@@ -571,7 +571,7 @@ void cvdescriptorset::DescriptorSet::PerformCopyUpdate(ValidationStateTracker *d
         if (src_iter.updated()) {
             dst.CopyUpdate(this, state_data_, &src, src_iter.CurrentBinding().IsBindless());
             some_update_ = true;
-            change_count_++;
+            ++change_count_;
             dst_iter.updated(true);
         } else {
             dst_iter.updated(false);

--- a/layers/descriptor_sets.h
+++ b/layers/descriptor_sets.h
@@ -1046,7 +1046,7 @@ class DescriptorSet : public BASE_NODE {
 
     // Private helper to set all bound cmd buffers to INVALID state
     void InvalidateBoundCmdBuffers(ValidationStateTracker *state_data);
-    bool some_update_;  // has any part of the set ever been updated?
+    std::atomic<bool> some_update_;  // has any part of the set ever been updated?
     DESCRIPTOR_POOL_STATE *pool_state_;
     const std::shared_ptr<DescriptorSetLayout const> layout_;
     // NOTE: the the backing store for the bindings must be declared *before* it so it will be destructed *after* it
@@ -1055,7 +1055,7 @@ class DescriptorSet : public BASE_NODE {
     std::vector<BindingPtr> bindings_;
     const StateTracker *state_data_;
     uint32_t variable_count_;
-    uint64_t change_count_;
+    std::atomic<uint64_t> change_count_;
 
     // For a given dynamic offset index in the set, map to associated index of the descriptors in the set
     std::vector<std::pair<uint32_t, uint32_t>> dynamic_offset_idx_to_descriptor_list_;


### PR DESCRIPTION
Found running ThreadUpdateDescriptorUpdateAfterBindNoCollision w/ -fsanitize=thread