### PR TITLE
Add VU 07272

### DIFF
--- a/layers/sync_vuid_maps.cpp
+++ b/layers/sync_vuid_maps.cpp
@@ -366,12 +366,12 @@ static const std::map<VkAccessFlags2KHR, std::array<Entry, 6>> kAccessMask2Commo
      }}},
     {VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR,
      {{
-         {Key(Struct::VkMemoryBarrier2, Field::srcAccessMask), "UNASSIGNED-VkMemoryBarrier2-srcAccessMask-SHADER_BINDING_TABLE_READ"},
-         {Key(Struct::VkMemoryBarrier2, Field::dstAccessMask), "UNASSIGNED-VkMemoryBarrier2-dstAccessMask-SHADER_BINDING_TABLE_READ"},
-         {Key(Struct::VkBufferMemoryBarrier2, Field::srcAccessMask), "UNASSIGNED-VkBufferMemoryBarrier2-srcAccessMask-SHADER_BINDING_TABLE_READ"},
-         {Key(Struct::VkBufferMemoryBarrier2, Field::dstAccessMask), "UNASSIGNED-VkBufferMemoryBarrier2-dstAccessMask-SHADER_BINDING_TABLE_READ"},
-         {Key(Struct::VkImageMemoryBarrier2, Field::srcAccessMask), "UNASSIGNED-VkImageMemoryBarrier2-srcAccessMask-SHADER_BINDING_TABLE_READ"},
-         {Key(Struct::VkImageMemoryBarrier2, Field::dstAccessMask), "UNASSIGNED-VkImageMemoryBarrier2-dstAccessMask-SHADER_BINDING_TABLE_READ"},
+         {Key(Struct::VkMemoryBarrier2, Field::srcAccessMask), "VUID-VkMemoryBarrier2-srcAccessMask-07272"},
+         {Key(Struct::VkMemoryBarrier2, Field::dstAccessMask), "VUID-VkMemoryBarrier2-dstAccessMask-07272"},
+         {Key(Struct::VkBufferMemoryBarrier2, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2-srcAccessMask-07272"},
+         {Key(Struct::VkBufferMemoryBarrier2, Field::dstAccessMask), "VUID-VkBufferMemoryBarrier2-dstAccessMask-07272"},
+         {Key(Struct::VkImageMemoryBarrier2, Field::srcAccessMask), "VUID-VkImageMemoryBarrier2-srcAccessMask-07272"},
+         {Key(Struct::VkImageMemoryBarrier2, Field::dstAccessMask), "VUID-VkImageMemoryBarrier2-dstAccessMask-07272"},
      }}},
     {VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT_KHR,
      {{

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -15572,6 +15572,11 @@ TEST_F(VkLayerTest, TestBarrierAccessSync2) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryBarrier2-srcAccessMask-03906");
     m_commandBuffer->PipelineBarrier2KHR(&dependency_info);
 
+    mem_barrier.srcAccessMask = VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR;
+    mem_barrier.srcStageMask = VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryBarrier2-srcAccessMask-07272");
+    m_commandBuffer->PipelineBarrier2KHR(&dependency_info);
+
     mem_barrier.srcAccessMask = VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT;
     mem_barrier.srcStageMask = VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryBarrier2-srcAccessMask-03907");
@@ -15653,6 +15658,10 @@ TEST_F(VkLayerTest, TestBarrierAccessSync2) {
 
     mem_barrier.dstAccessMask = VK_ACCESS_2_SHADER_STORAGE_READ_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryBarrier2-dstAccessMask-03906");
+    m_commandBuffer->PipelineBarrier2KHR(&dependency_info);
+
+    mem_barrier.dstAccessMask = VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryBarrier2-dstAccessMask-07272");
     m_commandBuffer->PipelineBarrier2KHR(&dependency_info);
 
     mem_barrier.dstAccessMask = VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT;


### PR DESCRIPTION
`UNASSIGNED-{barrier}-{accesMask}-SHADER_BINDING_TABLE_READ` now has a definition: `VUID-{barrier}-{accesMask}-07272`