### PR TITLE
layers: Clean up vk_layer_logging.h

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,5 +1,5 @@
 # Copyright (C) 2018-2021 The ANGLE Project Authors.
-# Copyright (C) 2019-2022 LunarG, Inc.
+# Copyright (C) 2019-2023 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -328,6 +328,7 @@ source_set("vulkan_layer_utils") {
     "layers/vk_layer_extension_utils.cpp",
     "layers/vk_layer_extension_utils.h",
     "layers/vk_layer_logging.h",
+    "layers/vk_layer_logging.cpp",
     "layers/vk_layer_utils.cpp",
     "layers/vk_layer_utils.h",
     "layers/vk_mem_alloc.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2014-2022 Valve Corporation
-# Copyright (c) 2014-2022 LunarG, Inc.
+# Copyright (c) 2014-2023 Valve Corporation
+# Copyright (c) 2014-2023 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -265,8 +265,10 @@ endif()
 add_library(VkLayer_utils
             STATIC
             layers/vk_layer_config.cpp
+            layers/vk_layer_logging.cpp
             layers/vk_layer_extension_utils.cpp
             layers/vk_layer_utils.cpp
+            layers/xxhash.c
             layers/generated/vk_format_utils.cpp)
 target_link_libraries(VkLayer_utils PUBLIC Vulkan::Headers)
 if (VVL_ENABLE_ASAN)

--- a/build-android/cmake/layerlib/CMakeLists.txt
+++ b/build-android/cmake/layerlib/CMakeLists.txt
@@ -50,6 +50,7 @@ include_directories(${SRC_DIR}/include
 add_library(layer_utils STATIC
         ${SRC_DIR}/layers/vk_layer_config.cpp
         ${SRC_DIR}/layers/vk_layer_extension_utils.cpp
+        ${SRC_DIR}/layers/vk_layer_logging.cpp
         ${SRC_DIR}/layers/vk_layer_utils.cpp
         ${SRC_DIR}/layers/generated/vk_format_utils.cpp)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_clone}")

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -24,6 +24,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := layer_utils
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_config.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_extension_utils.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_logging.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vk_layer_utils.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/vk_format_utils.cpp
 LOCAL_C_INCLUDES += $(VULKAN_INCLUDE) \

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2014-2022 Valve Corporation
-# Copyright (c) 2014-2022 LunarG, Inc.
+# Copyright (c) 2014-2023 Valve Corporation
+# Copyright (c) 2014-2023 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ if(BUILD_LAYER_SUPPORT_FILES)
         vk_layer_extension_utils.h
         vk_layer_extension_utils.cpp
         vk_layer_logging.h
+        vk_layer_logging.cpp
         vk_layer_utils.h
         vk_layer_utils.cpp
         xxhash.h

--- a/layers/device_memory_state.h
+++ b/layers/device_memory_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (C) 2015-2022 Google Inc.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (C) 2015-2023 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@
 #pragma once
 #include "base_node.h"
 #include "range_vector.h"
+#include "vk_safe_struct.h"
 
 struct MemRange {
     VkDeviceSize offset = 0;

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -2,10 +2,10 @@
 // This file is ***GENERATED***.  Do Not Edit.
 // See layer_chassis_generator.py for modifications.
 
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (c) 2015-2022 Google Inc.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -402,7 +402,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(VkInstance instance, const VkAllocati
     DeactivateInstanceDebugCallbacks(layer_data->report_data);
     FreePnextChain(layer_data->report_data->instance_pnext_chain);
 
-    layer_debug_utils_destroy_instance(layer_data->report_data);
+    LayerDebugUtilsDestroyInstance(layer_data->report_data);
 
     for (auto item = layer_data->object_dispatch.begin(); item != layer_data->object_dispatch.end(); item++) {
         delete *item;
@@ -8781,7 +8781,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(
         intercept->PreCallRecordCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback);
     }
     VkResult result = DispatchCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback);
-    layer_create_report_callback(layer_data->report_data, false, pCreateInfo, pAllocator, pCallback);
+    LayerCreateReportCallback(layer_data->report_data, false, pCreateInfo, pAllocator, pCallback);
     for (ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, result);
@@ -8805,7 +8805,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
         intercept->PreCallRecordDestroyDebugReportCallbackEXT(instance, callback, pAllocator);
     }
     DispatchDestroyDebugReportCallbackEXT(instance, callback, pAllocator);
-    layer_destroy_callback(layer_data->report_data, callback, pAllocator);
+    LayerDestroyCallback(layer_data->report_data, callback, pAllocator);
     for (ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordDestroyDebugReportCallbackEXT(instance, callback, pAllocator);
@@ -10085,7 +10085,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(
         intercept->PreCallRecordCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger);
     }
     VkResult result = DispatchCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger);
-    layer_create_messenger_callback(layer_data->report_data, false, pCreateInfo, pAllocator, pMessenger);
+    LayerCreateMessengerCallback(layer_data->report_data, false, pCreateInfo, pAllocator, pMessenger);
     for (ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, result);
@@ -10109,7 +10109,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
         intercept->PreCallRecordDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
     }
     DispatchDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
-    layer_destroy_callback(layer_data->report_data, messenger, pAllocator);
+    LayerDestroyCallback(layer_data->report_data, messenger, pAllocator);
     for (ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -2,10 +2,10 @@
 // This file is ***GENERATED***.  Do Not Edit.
 // See layer_chassis_generator.py for modifications.
 
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (c) 2015-2022 Google Inc.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -4025,148 +4025,35 @@ class ValidationObject {
 
         // Debug Logging Helpers
         bool DECORATE_PRINTF(4, 5) LogError(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-            // Avoid logging cost if msg is to be ignored
-            if (!LogMsgEnabled(report_data, vuid_text, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT,
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
-                return false;
-            }
             va_list argptr;
             va_start(argptr, format);
-            char *str;
-            if (-1 == vasprintf(&str, format, argptr)) {
-                str = nullptr;
-            }
+            const bool result = LogMsg(report_data, kErrorBit, objlist, vuid_text, format, argptr);
             va_end(argptr);
-            return LogMsgLocked(report_data, kErrorBit, objlist, vuid_text, str);
-        }
-
-        template <typename HANDLE_T>
-        bool DECORATE_PRINTF(4, 5) LogError(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-            // Avoid logging cost if msg is to be ignored
-            if (!LogMsgEnabled(report_data, vuid_text, VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT,
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
-                return false;
-            }
-            va_list argptr;
-            va_start(argptr, format);
-            char *str;
-            if (-1 == vasprintf(&str, format, argptr)) {
-                str = nullptr;
-            }
-            va_end(argptr);
-            const LogObjectList objlist(src_object);
-            return LogMsgLocked(report_data, kErrorBit, objlist, vuid_text, str);
-
+            return result;
         }
 
         bool DECORATE_PRINTF(4, 5) LogWarning(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-            // Avoid logging cost if msg is to be ignored
-            if (!LogMsgEnabled(report_data, vuid_text, VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT,
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
-                return false;
-            }
             va_list argptr;
             va_start(argptr, format);
-            char *str;
-            if (-1 == vasprintf(&str, format, argptr)) {
-                str = nullptr;
-            }
+            const bool result = LogMsg(report_data, kWarningBit, objlist, vuid_text, format, argptr);
             va_end(argptr);
-            return LogMsgLocked(report_data, kWarningBit, objlist, vuid_text, str);
-        }
-
-        template <typename HANDLE_T>
-        bool DECORATE_PRINTF(4, 5) LogWarning(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-            // Avoid logging cost if msg is to be ignored
-            if (!LogMsgEnabled(report_data, vuid_text, VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT,
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
-                return false;
-            }
-            va_list argptr;
-            va_start(argptr, format);
-            char *str;
-            if (-1 == vasprintf(&str, format, argptr)) {
-                str = nullptr;
-            }
-            va_end(argptr);
-            const LogObjectList objlist(src_object);
-            return LogMsgLocked(report_data, kWarningBit, objlist, vuid_text, str);
+            return result;
         }
 
         bool DECORATE_PRINTF(4, 5) LogPerformanceWarning(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-            // Avoid logging cost if msg is to be ignored
-            if (!LogMsgEnabled(report_data, vuid_text, VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT,
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)) {
-                return false;
-            }
             va_list argptr;
             va_start(argptr, format);
-            char *str;
-            if (-1 == vasprintf(&str, format, argptr)) {
-                str = nullptr;
-            }
+            const bool result = LogMsg(report_data, kPerformanceWarningBit, objlist, vuid_text, format, argptr);
             va_end(argptr);
-            return LogMsgLocked(report_data, kPerformanceWarningBit, objlist, vuid_text, str);
-        }
-
-        template <typename HANDLE_T>
-        bool DECORATE_PRINTF(4, 5) LogPerformanceWarning(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-            // Avoid logging cost if msg is to be ignored
-            if (!LogMsgEnabled(report_data, vuid_text, VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT,
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)) {
-                return false;
-            }
-            va_list argptr;
-            va_start(argptr, format);
-            char *str;
-            if (-1 == vasprintf(&str, format, argptr)) {
-                str = nullptr;
-            }
-            va_end(argptr);
-            const LogObjectList objlist(src_object);
-            return LogMsgLocked(report_data, kPerformanceWarningBit, objlist, vuid_text, str);
+            return result;
         }
 
         bool DECORATE_PRINTF(4, 5) LogInfo(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-            // Avoid logging cost if msg is to be ignored
-            if (!LogMsgEnabled(report_data, vuid_text, VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
-                return false;
-            }
             va_list argptr;
             va_start(argptr, format);
-            char *str;
-            if (-1 == vasprintf(&str, format, argptr)) {
-                str = nullptr;
-            }
+            const bool result = LogMsg(report_data, kInformationBit, objlist, vuid_text, format, argptr);
             va_end(argptr);
-            return LogMsgLocked(report_data, kInformationBit, objlist, vuid_text, str);
-        }
-
-        template <typename HANDLE_T>
-        bool DECORATE_PRINTF(4, 5) LogInfo(HANDLE_T src_object, const std::string &vuid_text, const char *format, ...) const {
-            std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-            // Avoid logging cost if msg is to be ignored
-            if (!LogMsgEnabled(report_data, vuid_text, VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
-                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) {
-                return false;
-            }
-            va_list argptr;
-            va_start(argptr, format);
-            char *str;
-            if (-1 == vasprintf(&str, format, argptr)) {
-                str = nullptr;
-            }
-            va_end(argptr);
-            const LogObjectList objlist(src_object);
-            return LogMsgLocked(report_data, kInformationBit, objlist, vuid_text, str);
+            return result;
         }
 
         // Handle Wrapping Data

--- a/layers/generated/chassis_dispatch_helper.h
+++ b/layers/generated/chassis_dispatch_helper.h
@@ -2,10 +2,10 @@
 // This file is ***GENERATED***.  Do Not Edit.
 // See layer_chassis_generator.py for modifications.
 
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (c) 2015-2022 Google Inc.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2022 The Khronos Group Inc.
- * Copyright (c) 2020-2022 Valve Corporation
- * Copyright (c) 2020-2022 LunarG, Inc.
+/* Copyright (c) 2020-2023 The Khronos Group Inc.
+ * Copyright (c) 2020-2023 Valve Corporation
+ * Copyright (c) 2020-2023 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,7 @@
  */
 
 #include "layer_options.h"
+#include "xxhash.h"
 
 // Set the local disable flag for the appropriate VALIDATION_CHECK_DISABLE enum
 void SetValidationDisable(CHECK_DISABLED &disable_data, const ValidationCheckDisables disable_id) {

--- a/layers/render_pass_state.h
+++ b/layers/render_pass_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (C) 2015-2022 Google Inc.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (C) 2015-2023 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +27,7 @@
  */
 #pragma once
 #include "base_node.h"
+#include "vk_safe_struct.h"
 
 class IMAGE_VIEW_STATE;
 

--- a/layers/video_session_state.h
+++ b/layers/video_session_state.h
@@ -19,6 +19,7 @@
 
 #include "base_node.h"
 #include "hash_util.h"
+#include "vk_safe_struct.h"
 #include <memory>
 #include <mutex>
 #include <vector>

--- a/layers/vk_layer_logging.cpp
+++ b/layers/vk_layer_logging.cpp
@@ -1,0 +1,572 @@
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
+ * Author: Tobin Ehlis <tobin@lunarg.com>
+ * Author: Mark Young <marky@lunarg.com>
+ * Author: Dave Houlton <daveh@lunarg.com>
+ *
+ */
+#include "vk_layer_logging.h"
+
+#include <csignal>
+#include <cstring>
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+#include <winsock2.h>
+#include <debugapi.h>
+#endif
+
+#include "vk_enum_string_helper.h"
+#include "vk_safe_struct.h"
+#include "vk_validation_error_messages.h"
+#include "xxhash.h"
+
+VKAPI_ATTR void SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks, debug_report_data *debug_data) {
+    // For all callback in list, return their complete set of severities and modes
+    for (const auto &item : callbacks) {
+        if (item.IsUtils()) {
+            debug_data->active_severities |= item.debug_utils_msg_flags;
+            debug_data->active_types |= item.debug_utils_msg_type;
+        } else {
+            VkFlags severities = 0;
+            VkFlags types = 0;
+            DebugReportFlagsToAnnotFlags(item.debug_report_msg_flags, true, &severities, &types);
+            debug_data->active_severities |= severities;
+            debug_data->active_types |= types;
+        }
+    }
+}
+
+VKAPI_ATTR void RemoveDebugUtilsCallback(debug_report_data *debug_data, std::vector<VkLayerDbgFunctionState> &callbacks,
+                                            uint64_t callback) {
+    auto item = callbacks.begin();
+    for (item = callbacks.begin(); item != callbacks.end(); item++) {
+        if (item->IsUtils()) {
+            if (item->debug_utils_callback_object == CastToHandle<VkDebugUtilsMessengerEXT>(callback)) break;
+        } else {
+            if (item->debug_report_callback_object == CastToHandle<VkDebugReportCallbackEXT>(callback)) break;
+        }
+    }
+    if (item != callbacks.end()) {
+        callbacks.erase(item);
+    }
+    SetDebugUtilsSeverityFlags(callbacks, debug_data);
+}
+
+// Returns TRUE if the number of times this message has been logged is over the set limit
+static bool UpdateLogMsgCounts(const debug_report_data *debug_data, int32_t vuid_hash) {
+    auto vuid_count_it = debug_data->duplicate_message_count_map.find(vuid_hash);
+    if (vuid_count_it == debug_data->duplicate_message_count_map.end()) {
+        debug_data->duplicate_message_count_map.emplace(vuid_hash, 1);
+        return false;
+    } else {
+        if (vuid_count_it->second >= debug_data->duplicate_message_limit) {
+            return true;
+        } else {
+            vuid_count_it->second++;
+            return false;
+        }
+    }
+}
+
+static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
+                                 const char *layer_prefix, const char *message, const char *text_vuid) {
+    bool bail = false;
+    std::vector<VkDebugUtilsLabelEXT> queue_labels;
+    std::vector<VkDebugUtilsLabelEXT> cmd_buf_labels;
+
+    // Convert the info to the VK_EXT_debug_utils format
+    VkDebugUtilsMessageTypeFlagsEXT types;
+    VkDebugUtilsMessageSeverityFlagsEXT severity;
+    DebugReportFlagsToAnnotFlags(msg_flags, true, &severity, &types);
+
+    std::vector<std::string> object_labels;
+    // Ensures that push_back will not reallocate, thereby providing pointer
+    // stability for pushed strings.
+    object_labels.reserve(objects.object_list.size());
+
+    std::vector<VkDebugUtilsObjectNameInfoEXT> object_name_info;
+    object_name_info.resize(objects.object_list.size());
+    for (uint32_t i = 0; i < objects.object_list.size(); i++) {
+        object_name_info[i] = LvlInitStruct<VkDebugUtilsObjectNameInfoEXT>();
+        object_name_info[i].objectType = ConvertVulkanObjectToCoreObject(objects.object_list[i].type);
+        object_name_info[i].objectHandle = objects.object_list[i].handle;
+        object_name_info[i].pObjectName = NULL;
+
+        std::string object_label = {};
+        // Look for any debug utils or marker names to use for this object
+        object_label = debug_data->DebugReportGetUtilsObjectName(objects.object_list[i].handle);
+        if (object_label.empty()) {
+            object_label = debug_data->DebugReportGetMarkerObjectName(objects.object_list[i].handle);
+        }
+        if (!object_label.empty()) {
+            object_labels.push_back(std::move(object_label));
+            object_name_info[i].pObjectName = object_labels.back().c_str();
+        }
+
+        // If this is a queue, add any queue labels to the callback data.
+        if (VK_OBJECT_TYPE_QUEUE == object_name_info[i].objectType) {
+            auto label_iter = debug_data->debugUtilsQueueLabels.find(reinterpret_cast<VkQueue>(object_name_info[i].objectHandle));
+            if (label_iter != debug_data->debugUtilsQueueLabels.end()) {
+                auto found_queue_labels = label_iter->second->Export();
+                queue_labels.insert(queue_labels.end(), found_queue_labels.begin(), found_queue_labels.end());
+            }
+            // If this is a command buffer, add any command buffer labels to the callback data.
+        } else if (VK_OBJECT_TYPE_COMMAND_BUFFER == object_name_info[i].objectType) {
+            auto label_iter =
+                debug_data->debugUtilsCmdBufLabels.find(reinterpret_cast<VkCommandBuffer>(object_name_info[i].objectHandle));
+            if (label_iter != debug_data->debugUtilsCmdBufLabels.end()) {
+                auto found_cmd_buf_labels = label_iter->second->Export();
+                cmd_buf_labels.insert(cmd_buf_labels.end(), found_cmd_buf_labels.begin(), found_cmd_buf_labels.end());
+            }
+        }
+    }
+
+    int32_t location = 0;
+    if (text_vuid != nullptr) {
+        // Hash for vuid text
+        location = XXH32(text_vuid, strlen(text_vuid), 8);
+    }
+
+    auto callback_data = LvlInitStruct<VkDebugUtilsMessengerCallbackDataEXT>();
+    callback_data.flags = 0;
+    callback_data.pMessageIdName = text_vuid;
+    callback_data.messageIdNumber = static_cast<int32_t>(location);
+    callback_data.pMessage = NULL;
+    callback_data.queueLabelCount = static_cast<uint32_t>(queue_labels.size());
+    callback_data.pQueueLabels = queue_labels.empty() ? nullptr : queue_labels.data();
+    callback_data.cmdBufLabelCount = static_cast<uint32_t>(cmd_buf_labels.size());
+    callback_data.pCmdBufLabels = cmd_buf_labels.empty() ? nullptr : cmd_buf_labels.data();
+    callback_data.objectCount = static_cast<uint32_t>(object_name_info.size());
+    callback_data.pObjects = object_name_info.data();
+
+    std::ostringstream oss;
+    if (msg_flags & kErrorBit) {
+        oss << "Validation Error: ";
+    } else if (msg_flags & kWarningBit) {
+        oss << "Validation Warning: ";
+    } else if (msg_flags & kPerformanceWarningBit) {
+        oss << "Validation Performance Warning: ";
+    } else if (msg_flags & kInformationBit) {
+        oss << "Validation Information: ";
+    } else if (msg_flags & kDebugBit) {
+        oss << "DEBUG: ";
+    }
+    if (text_vuid != nullptr) {
+        oss << "[ " << text_vuid << " ] ";
+    }
+    uint32_t index = 0;
+    for (const auto &src_object : object_name_info) {
+        if (0 != src_object.objectHandle) {
+            oss << "Object " << index++ << ": handle = 0x" << std::hex << src_object.objectHandle;
+            if (src_object.pObjectName) {
+                oss << ", name = " << src_object.pObjectName << ", type = ";
+            } else {
+                oss << ", type = ";
+            }
+            oss << string_VkObjectType(src_object.objectType) << "; ";
+        } else {
+            oss << "Object " << index++ << ": VK_NULL_HANDLE, type = " << string_VkObjectType(src_object.objectType) << "; ";
+        }
+    }
+    oss << "| MessageID = 0x" << std::hex << location << " | " << message;
+    std::string composite = oss.str();
+
+    const auto callback_list = &debug_data->debug_callback_list;
+    // We only output to default callbacks if there are no non-default callbacks
+    bool use_default_callbacks = true;
+    for (const auto &current_callback : *callback_list) {
+        use_default_callbacks &= current_callback.IsDefault();
+    }
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    if (debug_data->forceDefaultLogCallback) {
+        use_default_callbacks = true;
+    }
+#endif
+
+    for (const auto &current_callback : *callback_list) {
+        // Skip callback if it's a default callback and there are non-default callbacks present
+        if (current_callback.IsDefault() && !use_default_callbacks) continue;
+
+        // VK_EXT_debug_utils callback
+        if (current_callback.IsUtils() && (current_callback.debug_utils_msg_flags & severity) &&
+            (current_callback.debug_utils_msg_type & types)) {
+            callback_data.pMessage = composite.c_str();
+            if (current_callback.debug_utils_callback_function_ptr(static_cast<VkDebugUtilsMessageSeverityFlagBitsEXT>(severity),
+                                                                   types, &callback_data, current_callback.pUserData)) {
+                bail = true;
+            }
+        } else if (!current_callback.IsUtils() && (current_callback.debug_report_msg_flags & msg_flags)) {
+            // VK_EXT_debug_report callback (deprecated)
+            if (current_callback.debug_report_callback_function_ptr(
+                    msg_flags, convertCoreObjectToDebugReportObject(object_name_info[0].objectType),
+                    object_name_info[0].objectHandle, location, 0, layer_prefix, composite.c_str(), current_callback.pUserData)) {
+                bail = true;
+            }
+        }
+    }
+    return bail;
+}
+
+VKAPI_ATTR void LayerDebugUtilsDestroyInstance(debug_report_data *debug_data) { delete debug_data; }
+
+template <typename TCreateInfo, typename TCallback>
+static void LayerCreateCallback(DebugCallbackStatusFlags callback_status, debug_report_data *debug_data,
+                                       const TCreateInfo *create_info, const VkAllocationCallbacks *allocator,
+                                       TCallback *callback) {
+    std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
+
+    debug_data->debug_callback_list.emplace_back(VkLayerDbgFunctionState());
+    auto &callback_state = debug_data->debug_callback_list.back();
+    callback_state.callback_status = callback_status;
+    callback_state.pUserData = create_info->pUserData;
+
+    if (callback_state.IsUtils()) {
+        auto utils_create_info = reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT *>(create_info);
+        auto utils_callback = reinterpret_cast<VkDebugUtilsMessengerEXT *>(callback);
+        if (!(*utils_callback)) {
+            // callback constructed default callbacks have no handle -- so use struct address as unique handle
+            *utils_callback = reinterpret_cast<VkDebugUtilsMessengerEXT>(&callback_state);
+        }
+        callback_state.debug_utils_callback_object = *utils_callback;
+        callback_state.debug_utils_callback_function_ptr = utils_create_info->pfnUserCallback;
+        callback_state.debug_utils_msg_flags = utils_create_info->messageSeverity;
+        callback_state.debug_utils_msg_type = utils_create_info->messageType;
+    } else {  // Debug report callback
+        auto report_create_info = reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT *>(create_info);
+        auto report_callback = reinterpret_cast<VkDebugReportCallbackEXT *>(callback);
+        if (!(*report_callback)) {
+            // Internally constructed default callbacks have no handle -- so use struct address as unique handle
+            *report_callback = reinterpret_cast<VkDebugReportCallbackEXT>(&callback_state);
+        }
+        callback_state.debug_report_callback_object = *report_callback;
+        callback_state.debug_report_callback_function_ptr = report_create_info->pfnCallback;
+        callback_state.debug_report_msg_flags = report_create_info->flags;
+    }
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    // On Android, if the default callback system property is set, force the default callback to be printed
+    std::string forceLayerLog = GetEnvironment(kForceDefaultCallbackKey);
+    int forceDefaultCallback = atoi(forceLayerLog.c_str());
+    if (forceDefaultCallback == 1) {
+        debug_data->forceDefaultLogCallback = true;
+    }
+#endif
+
+    SetDebugUtilsSeverityFlags(debug_data->debug_callback_list, debug_data);
+}
+
+VKAPI_ATTR VkResult LayerCreateMessengerCallback(debug_report_data *debug_data, bool default_callback,
+                                                 const VkDebugUtilsMessengerCreateInfoEXT *create_info,
+                                                 const VkAllocationCallbacks *allocator, VkDebugUtilsMessengerEXT *messenger) {
+    LayerCreateCallback((DEBUG_CALLBACK_UTILS | (default_callback ? DEBUG_CALLBACK_DEFAULT : 0)), debug_data, create_info,
+                        allocator, messenger);
+    return VK_SUCCESS;
+}
+
+VKAPI_ATTR VkResult LayerCreateReportCallback(debug_report_data *debug_data, bool default_callback,
+                                              const VkDebugReportCallbackCreateInfoEXT *create_info,
+                                              const VkAllocationCallbacks *allocator, VkDebugReportCallbackEXT *callback) {
+    LayerCreateCallback((default_callback ? DEBUG_CALLBACK_DEFAULT : 0), debug_data, create_info, allocator, callback);
+    return VK_SUCCESS;
+}
+
+VKAPI_ATTR void ActivateInstanceDebugCallbacks(debug_report_data *debug_data) {
+    auto current = debug_data->instance_pnext_chain;
+    for (;;) {
+        auto create_info = LvlFindInChain<VkDebugUtilsMessengerCreateInfoEXT>(current);
+        if (!create_info) break;
+        current = create_info->pNext;
+        VkDebugUtilsMessengerEXT utils_callback{};
+        LayerCreateCallback((DEBUG_CALLBACK_UTILS | DEBUG_CALLBACK_INSTANCE), debug_data, create_info, nullptr, &utils_callback);
+    }
+    for (;;) {
+        auto create_info = LvlFindInChain<VkDebugReportCallbackCreateInfoEXT>(current);
+        if (!create_info) break;
+        current = create_info->pNext;
+        VkDebugReportCallbackEXT report_callback{};
+        LayerCreateCallback(DEBUG_CALLBACK_INSTANCE, debug_data, create_info, nullptr, &report_callback);
+    }
+}
+
+VKAPI_ATTR void DeactivateInstanceDebugCallbacks(debug_report_data *debug_data) {
+    if (!LvlFindInChain<VkDebugUtilsMessengerCreateInfoEXT>(debug_data->instance_pnext_chain) &&
+        !LvlFindInChain<VkDebugReportCallbackCreateInfoEXT>(debug_data->instance_pnext_chain))
+        return;
+    std::vector<VkDebugUtilsMessengerEXT> instance_utils_callback_handles{};
+    std::vector<VkDebugReportCallbackEXT> instance_report_callback_handles{};
+    for (const auto &item : debug_data->debug_callback_list) {
+        if (item.IsInstance()) {
+            if (item.IsUtils()) {
+                instance_utils_callback_handles.push_back(item.debug_utils_callback_object);
+            } else {
+                instance_report_callback_handles.push_back(item.debug_report_callback_object);
+            }
+        }
+    }
+    for (const auto &item : instance_utils_callback_handles) {
+        LayerDestroyCallback(debug_data, item, nullptr);
+    }
+    for (const auto &item : instance_report_callback_handles) {
+        LayerDestroyCallback(debug_data, item, nullptr);
+    }
+}
+
+// helper for VUID based filtering. This needs to be separate so it can be called before incurring
+// the cost of sprintf()-ing the err_msg needed by LogMsgLocked().
+static bool LogMsgEnabled(const debug_report_data *debug_data, const std::string &vuid_text,
+                                 VkDebugUtilsMessageSeverityFlagsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type) {
+    if (!(debug_data->active_severities & severity) || !(debug_data->active_types & type)) {
+        return false;
+    }
+    // If message is in filter list, bail out very early
+    const uint32_t message_id = XXH32(vuid_text.data(), vuid_text.size(), 8);
+    if (std::find(debug_data->filter_message_ids.begin(), debug_data->filter_message_ids.end(), message_id)
+        != debug_data->filter_message_ids.end()) {
+        return false;
+    }
+    if ((debug_data->duplicate_message_limit > 0) && UpdateLogMsgCounts(debug_data, static_cast<int32_t>(message_id))) {
+        // Count for this particular message is over the limit, ignore it
+        return false;
+    }
+    return true;
+}
+
+VKAPI_ATTR bool LogMsg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects, const std::string &vuid_text, const char *format, va_list argptr) {
+    VkDebugUtilsMessageSeverityFlagsEXT severity;
+    VkDebugUtilsMessageTypeFlagsEXT type;
+
+    DebugReportFlagsToAnnotFlags(msg_flags, false, &severity, &type);
+    std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
+    // Avoid logging cost if msg is to be ignored
+    if (!LogMsgEnabled(debug_data, vuid_text, severity, type)) {
+        return false;
+    }
+
+    // Best guess at an upper bound for message length. At least some of the extra space
+    // should get used to store the VUID URL and text in the common case, without additional allocations.
+    std::string str_plus_spec_text(1024, '\0');
+
+    // vsnprintf() returns the number of characters that *would* have been printed, if there was
+    // enough space. If we have a huge message, reallocate the string and try again.
+    int result;
+    size_t old_size = str_plus_spec_text.size();
+    // The va_list will be destroyed by the call to vsnprintf(), so use a copy in case we need
+    // to try again.
+    va_list arg_copy;
+    va_copy(arg_copy, argptr);
+    result = vsnprintf(str_plus_spec_text.data(), str_plus_spec_text.size(), format, arg_copy);
+    va_end(arg_copy);
+
+    assert(result >= 0);
+    if (result < 0) {
+        str_plus_spec_text = "Message generation failure";
+    } else if (static_cast<size_t>(result) <= old_size) {
+        // Shrink the string to exactly fit the successfully printed string
+        str_plus_spec_text.resize(result);
+    } else {
+        // Grow buffer to fit needed size. Note that the input size to vsnprintf() must
+        // include space for the trailing '\0' character, but the return value DOES NOT
+        // include the `\0' character.
+        str_plus_spec_text.resize(result + 1);
+        // consume the va_list passed to us by the caller
+        result = vsnprintf(str_plus_spec_text.data(), str_plus_spec_text.size(), format, argptr);
+        // remove the `\0' character from the string
+        str_plus_spec_text.resize(result);
+    }
+
+    // Append the spec error text to the error message, unless it's an UNASSIGNED or UNDEFINED vuid
+    if ((vuid_text.find("UNASSIGNED-") == std::string::npos) && (vuid_text.find(kVUIDUndefined) == std::string::npos) &&
+        (vuid_text.rfind("SYNC-", 0) == std::string::npos)) {
+        // Linear search makes no assumptions about the layout of the string table. This is not fast, but it does not need to be at
+        // this point in the error reporting path
+        uint32_t num_vuids = sizeof(vuid_spec_text) / sizeof(vuid_spec_text_pair);
+        const char *spec_text = nullptr;
+        std::string spec_type;
+        for (uint32_t i = 0; i < num_vuids; i++) {
+            if (0 == strcmp(vuid_text.c_str(), vuid_spec_text[i].vuid)) {
+                spec_text = vuid_spec_text[i].spec_text;
+                spec_type = vuid_spec_text[i].url_id;
+                break;
+            }
+        }
+
+        // Construct and append the specification text and link to the appropriate version of the spec
+        if (nullptr != spec_text) {
+            std::string spec_link = "https://www.khronos.org/registry/vulkan/specs/_MAGIC_KHRONOS_SPEC_TYPE_/html/vkspec.html";
+#ifdef ANNOTATED_SPEC_LINK
+            spec_link = ANNOTATED_SPEC_LINK;
+#endif
+            static std::string kAtToken = "_MAGIC_ANNOTATED_SPEC_TYPE_";
+            static std::string kKtToken = "_MAGIC_KHRONOS_SPEC_TYPE_";
+            static std::string kVeToken = "_MAGIC_VERSION_ID_";
+            auto Replace = [](std::string &dest_string, const std::string &to_replace, const std::string &replace_with) {
+                if (dest_string.find(to_replace) != std::string::npos) {
+                    dest_string.replace(dest_string.find(to_replace), to_replace.size(), replace_with);
+                }
+            };
+
+            str_plus_spec_text.append(" The Vulkan spec states: ");
+            str_plus_spec_text.append(spec_text);
+            if (0 == spec_type.compare("default")) {
+                str_plus_spec_text.append(" (https://github.com/KhronosGroup/Vulkan-Docs/search?q=)");
+            } else {
+                str_plus_spec_text.append(" (");
+                str_plus_spec_text.append(spec_link);
+                std::string major_version = std::to_string(VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE));
+                std::string minor_version = std::to_string(VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE));
+                std::string patch_version = std::to_string(VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
+                std::string header_version = major_version + "." + minor_version + "." + patch_version;
+                std::string annotated_spec_type = major_version + "." + minor_version + "-extensions";
+                Replace(str_plus_spec_text, kKtToken, spec_type);
+                Replace(str_plus_spec_text, kAtToken, annotated_spec_type);
+                Replace(str_plus_spec_text, kVeToken, header_version);
+                str_plus_spec_text.append("#");  // CMake hates hashes
+            }
+            str_plus_spec_text.append(vuid_text);
+            str_plus_spec_text.append(")");
+        }
+    }
+
+    return debug_log_msg(debug_data, msg_flags, objects, "Validation", str_plus_spec_text.c_str(), vuid_text.c_str());
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL ReportLogCallback(VkFlags msg_flags, VkDebugReportObjectTypeEXT obj_type, uint64_t src_object,
+                                                 size_t location, int32_t msg_code, const char *layer_prefix, const char *message,
+                                                 void *user_data) {
+    std::ostringstream msg_buffer;
+    char msg_flag_string[30];
+
+    PrintMessageFlags(msg_flags, msg_flag_string);
+
+    msg_buffer << layer_prefix << "(" << msg_flag_string << "): msg_code: " << msg_code << ": " << message << "\n";
+    const std::string tmp = msg_buffer.str();
+    const char *cstr = tmp.c_str();
+
+    fprintf((FILE *)user_data, "%s", cstr);
+    fflush((FILE *)user_data);
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    LOGCONSOLE("%s", cstr);
+#endif
+
+    return false;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL ReportWin32DebugOutputMsg(VkFlags msg_flags, VkDebugReportObjectTypeEXT obj_type,
+                                                         uint64_t src_object, size_t location, int32_t msg_code,
+                                                         const char *layer_prefix, const char *message, void *user_data) {
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    char msg_flag_string[30];
+    char buf[2048];
+
+    PrintMessageFlags(msg_flags, msg_flag_string);
+    _snprintf(buf, sizeof(buf) - 1, "%s (%s): msg_code: %d: %s\n", layer_prefix, msg_flag_string, msg_code, message);
+
+    OutputDebugString(buf);
+#endif
+
+    return false;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL DebugBreakCallback(VkFlags msgFlags, VkDebugReportObjectTypeEXT obj_type,
+                                                                uint64_t src_object, size_t location, int32_t msg_code,
+                                                                const char *layer_prefix, const char *message, void *user_data) {
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    DebugBreak();
+#else
+    raise(SIGTRAP);
+#endif
+
+    return false;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                                    VkDebugUtilsMessageTypeFlagsEXT message_type,
+                                                                    const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
+                                                                    void *user_data) {
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    DebugBreak();
+#else
+    raise(SIGTRAP);
+#endif
+
+    return false;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL MessengerLogCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                    VkDebugUtilsMessageTypeFlagsEXT message_type,
+                                                    const VkDebugUtilsMessengerCallbackDataEXT *callback_data, void *user_data) {
+    std::ostringstream msg_buffer;
+    char msg_severity[30];
+    char msg_type[30];
+
+    PrintMessageSeverity(message_severity, msg_severity);
+    PrintMessageType(message_type, msg_type);
+
+    msg_buffer << callback_data->pMessageIdName << "(" << msg_severity << " / " << msg_type
+        << "): msgNum: " << callback_data->messageIdNumber << " - " << callback_data->pMessage << "\n";
+    msg_buffer << "    Objects: " << callback_data->objectCount << "\n";
+    for (uint32_t obj = 0; obj < callback_data->objectCount; ++obj) {
+        msg_buffer << "        [" << obj << "] " << std::hex << std::showbase
+            << HandleToUint64(callback_data->pObjects[obj].objectHandle) << ", type: " << std::dec << std::noshowbase
+            << callback_data->pObjects[obj].objectType
+            << ", name: " << (callback_data->pObjects[obj].pObjectName ? callback_data->pObjects[obj].pObjectName : "NULL")
+            << "\n";
+    }
+    const std::string tmp = msg_buffer.str();
+    const char *cstr = tmp.c_str();
+    fprintf((FILE *)user_data, "%s", cstr);
+    fflush((FILE *)user_data);
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    LOGCONSOLE("%s", cstr);
+#endif
+
+    return false;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL MessengerWin32DebugOutputMsg(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                            VkDebugUtilsMessageTypeFlagsEXT message_type,
+                                                            const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
+                                                            void *user_data) {
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    std::ostringstream msg_buffer;
+    char msg_severity[30];
+    char msg_type[30];
+
+    PrintMessageSeverity(message_severity, msg_severity);
+    PrintMessageType(message_type, msg_type);
+
+    msg_buffer << callback_data->pMessageIdName << "(" << msg_severity << " / " << msg_type
+               << "): msgNum: " << callback_data->messageIdNumber << " - " << callback_data->pMessage << "\n";
+    msg_buffer << "    Objects: " << callback_data->objectCount << "\n";
+
+    for (uint32_t obj = 0; obj < callback_data->objectCount; ++obj) {
+        msg_buffer << "       [" << obj << "]  " << std::hex << std::showbase
+                   << HandleToUint64(callback_data->pObjects[obj].objectHandle) << ", type: " << std::dec << std::noshowbase
+                   << callback_data->pObjects[obj].objectType
+                   << ", name: " << (callback_data->pObjects[obj].pObjectName ? callback_data->pObjects[obj].pObjectName : "NULL")
+                   << "\n";
+    }
+    const std::string tmp = msg_buffer.str();
+    const char *cstr = tmp.c_str();
+    OutputDebugString(cstr);
+#endif
+
+    return false;
+}

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,49 +24,23 @@
 #ifndef LAYER_LOGGING_H
 #define LAYER_LOGGING_H
 
-#include <cinttypes>
-#include <signal.h>
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdio.h>
-
-#include <algorithm>
 #include <array>
-#include <memory>
+#include <cstdarg>
 #include <mutex>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <utility>
-#include <cstring>
-#ifdef _WIN32
-#include <winsock2.h>
-#include <debugapi.h>
-#endif
 
-#include "vk_typemap_helper.h"
 #include "vk_layer_config.h"
 #include "vk_layer_data.h"
-#include "vulkan/vk_platform.h"
-#include "vulkan/vk_layer.h"
-#include "vk_object_types.h"
-#include "vk_enum_string_helper.h"
-#include "cast_utils.h"
-#include "vk_validation_error_messages.h"
 #include "vk_layer_dispatch_table.h"
-#include "vk_safe_struct.h"
-#include "xxhash.h"
+#include "vk_object_types.h"
+#include "vk_typemap_helper.h"
 
 #if defined __ANDROID__
 #include <android/log.h>
 #define LOGCONSOLE(...) ((void)__android_log_print(ANDROID_LOG_INFO, "VALIDATION", __VA_ARGS__))
 [[maybe_unused]] static const char *kForceDefaultCallbackKey = "debug.vvl.forcelayerlog";
-#else
-#define LOGCONSOLE(...)      \
-    {                        \
-        printf(__VA_ARGS__); \
-        printf("\n");        \
-    }
 #endif
 
 [[maybe_unused]] static const char *kVUIDUndefined = "VUID_Undefined";
@@ -266,6 +240,21 @@ typedef struct _debug_report_data {
 template debug_report_data *GetLayerDataPtr<debug_report_data>(void *data_key,
                                                                std::unordered_map<void *, debug_report_data *> &data_map);
 
+static inline VkDebugReportFlagsEXT DebugAnnotFlagsToReportFlags(VkDebugUtilsMessageSeverityFlagBitsEXT da_severity,
+                                                                 VkDebugUtilsMessageTypeFlagsEXT da_type) {
+    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) return VK_DEBUG_REPORT_ERROR_BIT_EXT;
+    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
+        if (da_type & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)
+            return VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
+        else
+            return VK_DEBUG_REPORT_WARNING_BIT_EXT;
+    }
+    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) return VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
+    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT) return VK_DEBUG_REPORT_DEBUG_BIT_EXT;
+
+    return 0;
+}
+
 static inline void DebugReportFlagsToAnnotFlags(VkDebugReportFlagsEXT dr_flags, bool default_flag_is_spec,
                                                 VkDebugUtilsMessageSeverityFlagsEXT *da_severity,
                                                 VkDebugUtilsMessageTypeFlagsEXT *da_type) {
@@ -295,218 +284,6 @@ static inline void DebugReportFlagsToAnnotFlags(VkDebugReportFlagsEXT dr_flags, 
     }
 }
 
-// Forward Declarations
-static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
-                                 const char *layer_prefix, const char *message, const char *text_vuid);
-
-static void SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks, debug_report_data *debug_data) {
-    // For all callback in list, return their complete set of severities and modes
-    for (const auto &item : callbacks) {
-        if (item.IsUtils()) {
-            debug_data->active_severities |= item.debug_utils_msg_flags;
-            debug_data->active_types |= item.debug_utils_msg_type;
-        } else {
-            VkFlags severities = 0;
-            VkFlags types = 0;
-            DebugReportFlagsToAnnotFlags(item.debug_report_msg_flags, true, &severities, &types);
-            debug_data->active_severities |= severities;
-            debug_data->active_types |= types;
-        }
-    }
-}
-
-static inline void RemoveDebugUtilsCallback(debug_report_data *debug_data, std::vector<VkLayerDbgFunctionState> &callbacks,
-                                            uint64_t callback) {
-    auto item = callbacks.begin();
-    for (item = callbacks.begin(); item != callbacks.end(); item++) {
-        if (item->IsUtils()) {
-            if (item->debug_utils_callback_object == CastToHandle<VkDebugUtilsMessengerEXT>(callback)) break;
-        } else {
-            if (item->debug_report_callback_object == CastToHandle<VkDebugReportCallbackEXT>(callback)) break;
-        }
-    }
-    if (item != callbacks.end()) {
-        callbacks.erase(item);
-    }
-    SetDebugUtilsSeverityFlags(callbacks, debug_data);
-}
-
-// Deletes all debug callback function structs
-static inline void RemoveAllMessageCallbacks(debug_report_data *debug_data, std::vector<VkLayerDbgFunctionState> &callbacks) {
-    callbacks.clear();
-}
-
-// Returns TRUE if the number of times this message has been logged is over the set limit
-static inline bool UpdateLogMsgCounts(const debug_report_data *debug_data, int32_t vuid_hash) {
-    auto vuid_count_it = debug_data->duplicate_message_count_map.find(vuid_hash);
-    if (vuid_count_it == debug_data->duplicate_message_count_map.end()) {
-        debug_data->duplicate_message_count_map.emplace(vuid_hash, 1);
-        return false;
-    } else {
-        if (vuid_count_it->second >= debug_data->duplicate_message_limit) {
-            return true;
-        } else {
-            vuid_count_it->second++;
-            return false;
-        }
-    }
-}
-
-static inline bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
-                                 const char *layer_prefix, const char *message, const char *text_vuid) {
-    bool bail = false;
-    std::vector<VkDebugUtilsLabelEXT> queue_labels;
-    std::vector<VkDebugUtilsLabelEXT> cmd_buf_labels;
-
-    // Convert the info to the VK_EXT_debug_utils format
-    VkDebugUtilsMessageTypeFlagsEXT types;
-    VkDebugUtilsMessageSeverityFlagsEXT severity;
-    DebugReportFlagsToAnnotFlags(msg_flags, true, &severity, &types);
-
-    std::vector<std::string> object_labels;
-    // Ensures that push_back will not reallocate, thereby providing pointer
-    // stability for pushed strings.
-    object_labels.reserve(objects.object_list.size());
-
-    std::vector<VkDebugUtilsObjectNameInfoEXT> object_name_info;
-    object_name_info.resize(objects.object_list.size());
-    for (uint32_t i = 0; i < objects.object_list.size(); i++) {
-        object_name_info[i] = LvlInitStruct<VkDebugUtilsObjectNameInfoEXT>();
-        object_name_info[i].objectType = ConvertVulkanObjectToCoreObject(objects.object_list[i].type);
-        object_name_info[i].objectHandle = objects.object_list[i].handle;
-        object_name_info[i].pObjectName = NULL;
-
-        std::string object_label = {};
-        // Look for any debug utils or marker names to use for this object
-        object_label = debug_data->DebugReportGetUtilsObjectName(objects.object_list[i].handle);
-        if (object_label.empty()) {
-            object_label = debug_data->DebugReportGetMarkerObjectName(objects.object_list[i].handle);
-        }
-        if (!object_label.empty()) {
-            object_labels.push_back(std::move(object_label));
-            object_name_info[i].pObjectName = object_labels.back().c_str();
-        }
-
-        // If this is a queue, add any queue labels to the callback data.
-        if (VK_OBJECT_TYPE_QUEUE == object_name_info[i].objectType) {
-            auto label_iter = debug_data->debugUtilsQueueLabels.find(reinterpret_cast<VkQueue>(object_name_info[i].objectHandle));
-            if (label_iter != debug_data->debugUtilsQueueLabels.end()) {
-                auto found_queue_labels = label_iter->second->Export();
-                queue_labels.insert(queue_labels.end(), found_queue_labels.begin(), found_queue_labels.end());
-            }
-            // If this is a command buffer, add any command buffer labels to the callback data.
-        } else if (VK_OBJECT_TYPE_COMMAND_BUFFER == object_name_info[i].objectType) {
-            auto label_iter =
-                debug_data->debugUtilsCmdBufLabels.find(reinterpret_cast<VkCommandBuffer>(object_name_info[i].objectHandle));
-            if (label_iter != debug_data->debugUtilsCmdBufLabels.end()) {
-                auto found_cmd_buf_labels = label_iter->second->Export();
-                cmd_buf_labels.insert(cmd_buf_labels.end(), found_cmd_buf_labels.begin(), found_cmd_buf_labels.end());
-            }
-        }
-    }
-
-    int32_t location = 0;
-    if (text_vuid != nullptr) {
-        // Hash for vuid text
-        location = XXH32(text_vuid, strlen(text_vuid), 8);
-    }
-
-    auto callback_data = LvlInitStruct<VkDebugUtilsMessengerCallbackDataEXT>();
-    callback_data.flags = 0;
-    callback_data.pMessageIdName = text_vuid;
-    callback_data.messageIdNumber = static_cast<int32_t>(location);
-    callback_data.pMessage = NULL;
-    callback_data.queueLabelCount = static_cast<uint32_t>(queue_labels.size());
-    callback_data.pQueueLabels = queue_labels.empty() ? nullptr : queue_labels.data();
-    callback_data.cmdBufLabelCount = static_cast<uint32_t>(cmd_buf_labels.size());
-    callback_data.pCmdBufLabels = cmd_buf_labels.empty() ? nullptr : cmd_buf_labels.data();
-    callback_data.objectCount = static_cast<uint32_t>(object_name_info.size());
-    callback_data.pObjects = object_name_info.data();
-
-    std::ostringstream oss;
-    if (msg_flags & kErrorBit) {
-        oss << "Validation Error: ";
-    } else if (msg_flags & kWarningBit) {
-        oss << "Validation Warning: ";
-    } else if (msg_flags & kPerformanceWarningBit) {
-        oss << "Validation Performance Warning: ";
-    } else if (msg_flags & kInformationBit) {
-        oss << "Validation Information: ";
-    } else if (msg_flags & kDebugBit) {
-        oss << "DEBUG: ";
-    }
-    if (text_vuid != nullptr) {
-        oss << "[ " << text_vuid << " ] ";
-    }
-    uint32_t index = 0;
-    for (const auto &src_object : object_name_info) {
-        if (0 != src_object.objectHandle) {
-            oss << "Object " << index++ << ": handle = 0x" << std::hex << src_object.objectHandle;
-            if (src_object.pObjectName) {
-                oss << ", name = " << src_object.pObjectName << ", type = ";
-            } else {
-                oss << ", type = ";
-            }
-            oss << string_VkObjectType(src_object.objectType) << "; ";
-        } else {
-            oss << "Object " << index++ << ": VK_NULL_HANDLE, type = " << string_VkObjectType(src_object.objectType) << "; ";
-        }
-    }
-    oss << "| MessageID = 0x" << std::hex << location << " | " << message;
-    std::string composite = oss.str();
-
-    const auto callback_list = &debug_data->debug_callback_list;
-    // We only output to default callbacks if there are no non-default callbacks
-    bool use_default_callbacks = true;
-    for (const auto &current_callback : *callback_list) {
-        use_default_callbacks &= current_callback.IsDefault();
-    }
-
-#if defined __ANDROID__
-    if (debug_data->forceDefaultLogCallback) {
-        use_default_callbacks = true;
-    }
-#endif
-
-    for (const auto &current_callback : *callback_list) {
-        // Skip callback if it's a default callback and there are non-default callbacks present
-        if (current_callback.IsDefault() && !use_default_callbacks) continue;
-
-        // VK_EXT_debug_utils callback
-        if (current_callback.IsUtils() && (current_callback.debug_utils_msg_flags & severity) &&
-            (current_callback.debug_utils_msg_type & types)) {
-            callback_data.pMessage = composite.c_str();
-            if (current_callback.debug_utils_callback_function_ptr(static_cast<VkDebugUtilsMessageSeverityFlagBitsEXT>(severity),
-                                                                   types, &callback_data, current_callback.pUserData)) {
-                bail = true;
-            }
-        } else if (!current_callback.IsUtils() && (current_callback.debug_report_msg_flags & msg_flags)) {
-            // VK_EXT_debug_report callback (deprecated)
-            if (current_callback.debug_report_callback_function_ptr(
-                    msg_flags, convertCoreObjectToDebugReportObject(object_name_info[0].objectType),
-                    object_name_info[0].objectHandle, location, 0, layer_prefix, composite.c_str(), current_callback.pUserData)) {
-                bail = true;
-            }
-        }
-    }
-    return bail;
-}
-
-static inline VkDebugReportFlagsEXT DebugAnnotFlagsToReportFlags(VkDebugUtilsMessageSeverityFlagBitsEXT da_severity,
-                                                                 VkDebugUtilsMessageTypeFlagsEXT da_type) {
-    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) return VK_DEBUG_REPORT_ERROR_BIT_EXT;
-    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
-        if (da_type & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)
-            return VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT;
-        else
-            return VK_DEBUG_REPORT_WARNING_BIT_EXT;
-    }
-    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT) return VK_DEBUG_REPORT_INFORMATION_BIT_EXT;
-    if (da_severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT) return VK_DEBUG_REPORT_DEBUG_BIT_EXT;
-
-    return 0;
-}
-
 static inline LogMessageTypeFlags DebugAnnotFlagsToMsgTypeFlags(VkDebugUtilsMessageSeverityFlagBitsEXT da_severity,
                                                                 VkDebugUtilsMessageTypeFlagsEXT da_type) {
     LogMessageTypeFlags msg_type_flags = 0;
@@ -526,347 +303,58 @@ static inline LogMessageTypeFlags DebugAnnotFlagsToMsgTypeFlags(VkDebugUtilsMess
     return msg_type_flags;
 }
 
-static inline void layer_debug_utils_destroy_instance(debug_report_data *debug_data) {
-    if (debug_data) {
-        std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
-        RemoveAllMessageCallbacks(debug_data, debug_data->debug_callback_list);
-        lock.unlock();
-        delete (debug_data);
-    }
-}
+VKAPI_ATTR bool LogMsg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
+                       const std::string &vuid_text, const char *format, va_list argptr);
+
+VKAPI_ATTR VkResult LayerCreateMessengerCallback(debug_report_data *debug_data, bool default_callback,
+                                                 const VkDebugUtilsMessengerCreateInfoEXT *create_info,
+                                                 const VkAllocationCallbacks *allocator, VkDebugUtilsMessengerEXT *messenger);
+
+VKAPI_ATTR VkResult LayerCreateReportCallback(debug_report_data *debug_data, bool default_callback,
+                                              const VkDebugReportCallbackCreateInfoEXT *create_info,
+                                              const VkAllocationCallbacks *allocator, VkDebugReportCallbackEXT *callback);
 
 template <typename T>
-static inline void layer_destroy_callback(debug_report_data *debug_data, T callback, const VkAllocationCallbacks *allocator) {
+static inline void LayerDestroyCallback(debug_report_data *debug_data, T callback, const VkAllocationCallbacks *allocator) {
     std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
     RemoveDebugUtilsCallback(debug_data, debug_data->debug_callback_list, CastToUint64(callback));
 }
 
-template <typename TCreateInfo, typename TCallback>
-static inline void layer_create_callback(DebugCallbackStatusFlags callback_status, debug_report_data *debug_data,
-                                         const TCreateInfo *create_info, const VkAllocationCallbacks *allocator,
-                                         TCallback *callback) {
-    std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
+VKAPI_ATTR void ActivateInstanceDebugCallbacks(debug_report_data *debug_data);
 
-    debug_data->debug_callback_list.emplace_back(VkLayerDbgFunctionState());
-    auto &callback_state = debug_data->debug_callback_list.back();
-    callback_state.callback_status = callback_status;
-    callback_state.pUserData = create_info->pUserData;
+VKAPI_ATTR void DeactivateInstanceDebugCallbacks(debug_report_data *debug_data);
 
-    if (callback_state.IsUtils()) {
-        auto utils_create_info = reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT *>(create_info);
-        auto utils_callback = reinterpret_cast<VkDebugUtilsMessengerEXT *>(callback);
-        if (!(*utils_callback)) {
-            // callback constructed default callbacks have no handle -- so use struct address as unique handle
-            *utils_callback = reinterpret_cast<VkDebugUtilsMessengerEXT>(&callback_state);
-        }
-        callback_state.debug_utils_callback_object = *utils_callback;
-        callback_state.debug_utils_callback_function_ptr = utils_create_info->pfnUserCallback;
-        callback_state.debug_utils_msg_flags = utils_create_info->messageSeverity;
-        callback_state.debug_utils_msg_type = utils_create_info->messageType;
-    } else {  // Debug report callback
-        auto report_create_info = reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT *>(create_info);
-        auto report_callback = reinterpret_cast<VkDebugReportCallbackEXT *>(callback);
-        if (!(*report_callback)) {
-            // Internally constructed default callbacks have no handle -- so use struct address as unique handle
-            *report_callback = reinterpret_cast<VkDebugReportCallbackEXT>(&callback_state);
-        }
-        callback_state.debug_report_callback_object = *report_callback;
-        callback_state.debug_report_callback_function_ptr = report_create_info->pfnCallback;
-        callback_state.debug_report_msg_flags = report_create_info->flags;
-    }
+VKAPI_ATTR void SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks, debug_report_data *debug_data);
 
-#if defined __ANDROID__
-    // On Android, if the default callback system property is set, force the default callback to be printed
-    std::string forceLayerLog = GetEnvironment(kForceDefaultCallbackKey);
-    int forceDefaultCallback = atoi(forceLayerLog.c_str());
-    if (forceDefaultCallback == 1) {
-        debug_data->forceDefaultLogCallback = true;
-    }
-#endif
+VKAPI_ATTR void RemoveDebugUtilsCallback(debug_report_data *debug_data, std::vector<VkLayerDbgFunctionState> &callbacks,
+                                         uint64_t callback);
 
-    SetDebugUtilsSeverityFlags(debug_data->debug_callback_list, debug_data);
-}
+VKAPI_ATTR void LayerDebugUtilsDestroyInstance(debug_report_data *debug_data);
 
-static inline VkResult layer_create_messenger_callback(debug_report_data *debug_data, bool default_callback,
-                                                       const VkDebugUtilsMessengerCreateInfoEXT *create_info,
-                                                       const VkAllocationCallbacks *allocator,
-                                                       VkDebugUtilsMessengerEXT *messenger) {
-    layer_create_callback((DEBUG_CALLBACK_UTILS | (default_callback ? DEBUG_CALLBACK_DEFAULT : 0)), debug_data, create_info,
-                          allocator, messenger);
-    return VK_SUCCESS;
-}
+VKAPI_ATTR VkBool32 VKAPI_CALL ReportLogCallback(VkFlags msg_flags, VkDebugReportObjectTypeEXT obj_type, uint64_t src_object,
+                                                 size_t location, int32_t msg_code, const char *layer_prefix, const char *message,
+                                                 void *user_data);
 
-static inline VkResult layer_create_report_callback(debug_report_data *debug_data, bool default_callback,
-                                                    const VkDebugReportCallbackCreateInfoEXT *create_info,
-                                                    const VkAllocationCallbacks *allocator, VkDebugReportCallbackEXT *callback) {
-    layer_create_callback((default_callback ? DEBUG_CALLBACK_DEFAULT : 0), debug_data, create_info, allocator, callback);
-    return VK_SUCCESS;
-}
+VKAPI_ATTR VkBool32 VKAPI_CALL ReportWin32DebugOutputMsg(VkFlags msg_flags, VkDebugReportObjectTypeEXT obj_type,
+                                                         uint64_t src_object, size_t location, int32_t msg_code,
+                                                         const char *layer_prefix, const char *message, void *user_data);
 
-static inline void ActivateInstanceDebugCallbacks(debug_report_data *debug_data) {
-    auto current = debug_data->instance_pnext_chain;
-    for (;;) {
-        auto create_info = LvlFindInChain<VkDebugUtilsMessengerCreateInfoEXT>(current);
-        if (!create_info) break;
-        current = create_info->pNext;
-        VkDebugUtilsMessengerEXT utils_callback{};
-        layer_create_callback((DEBUG_CALLBACK_UTILS | DEBUG_CALLBACK_INSTANCE), debug_data, create_info, nullptr, &utils_callback);
-    }
-    for (;;) {
-        auto create_info = LvlFindInChain<VkDebugReportCallbackCreateInfoEXT>(current);
-        if (!create_info) break;
-        current = create_info->pNext;
-        VkDebugReportCallbackEXT report_callback{};
-        layer_create_callback(DEBUG_CALLBACK_INSTANCE, debug_data, create_info, nullptr, &report_callback);
-    }
-}
+VKAPI_ATTR VkBool32 VKAPI_CALL DebugBreakCallback(VkFlags msgFlags, VkDebugReportObjectTypeEXT obj_type, uint64_t src_object,
+                                                  size_t location, int32_t msg_code, const char *layer_prefix, const char *message,
+                                                  void *user_data);
 
-static inline void DeactivateInstanceDebugCallbacks(debug_report_data *debug_data) {
-    if (!LvlFindInChain<VkDebugUtilsMessengerCreateInfoEXT>(debug_data->instance_pnext_chain) &&
-        !LvlFindInChain<VkDebugReportCallbackCreateInfoEXT>(debug_data->instance_pnext_chain))
-        return;
-    std::vector<VkDebugUtilsMessengerEXT> instance_utils_callback_handles{};
-    std::vector<VkDebugReportCallbackEXT> instance_report_callback_handles{};
-    for (const auto &item : debug_data->debug_callback_list) {
-        if (item.IsInstance()) {
-            if (item.IsUtils()) {
-                instance_utils_callback_handles.push_back(item.debug_utils_callback_object);
-            } else {
-                instance_report_callback_handles.push_back(item.debug_report_callback_object);
-            }
-        }
-    }
-    for (const auto &item : instance_utils_callback_handles) {
-        layer_destroy_callback(debug_data, item, nullptr);
-    }
-    for (const auto &item : instance_report_callback_handles) {
-        layer_destroy_callback(debug_data, item, nullptr);
-    }
-}
+VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                      VkDebugUtilsMessageTypeFlagsEXT message_type,
+                                                      const VkDebugUtilsMessengerCallbackDataEXT *callback_data, void *user_data);
 
-#ifdef WIN32
-static inline int vasprintf(char **strp, char const *fmt, va_list ap) {
-    *strp = nullptr;
-    int size = _vscprintf(fmt, ap);
-    if (size >= 0) {
-        *strp = (char *)malloc(size + 1);
-        if (!*strp) {
-            return -1;
-        }
-        _vsnprintf(*strp, size + 1, fmt, ap);
-    }
-    return size;
-}
-#endif
+VKAPI_ATTR VkBool32 VKAPI_CALL MessengerLogCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                    VkDebugUtilsMessageTypeFlagsEXT message_type,
+                                                    const VkDebugUtilsMessengerCallbackDataEXT *callback_data, void *user_data);
 
-// helper for VUID based filtering. This needs to be separate so it can be called before incurring
-// the cost of sprintf()-ing the err_msg needed by LogMsgLocked().
-static inline bool LogMsgEnabled(const debug_report_data *debug_data, const std::string &vuid_text,
-                                 VkDebugUtilsMessageSeverityFlagsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type) {
-    if (!(debug_data->active_severities & severity) || !(debug_data->active_types & type)) {
-        return false;
-    }
-    // If message is in filter list, bail out very early
-    const uint32_t message_id = XXH32(vuid_text.data(), vuid_text.size(), 8);
-    if (std::find(debug_data->filter_message_ids.begin(), debug_data->filter_message_ids.end(), message_id)
-        != debug_data->filter_message_ids.end()) {
-        return false;
-    }
-    if ((debug_data->duplicate_message_limit > 0) && UpdateLogMsgCounts(debug_data, static_cast<int32_t>(message_id))) {
-        // Count for this particular message is over the limit, ignore it
-        return false;
-    }
-    return true;
-}
-
-static inline bool LogMsgLocked(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
-                                const std::string &vuid_text, char *err_msg) {
-    std::string str_plus_spec_text(err_msg ? err_msg : "Allocation failure");
-
-    // Append the spec error text to the error message, unless it's an UNASSIGNED or UNDEFINED vuid
-    if ((vuid_text.find("UNASSIGNED-") == std::string::npos) && (vuid_text.find(kVUIDUndefined) == std::string::npos) &&
-        (vuid_text.rfind("SYNC-", 0) == std::string::npos)) {
-        // Linear search makes no assumptions about the layout of the string table. This is not fast, but it does not need to be at
-        // this point in the error reporting path
-        uint32_t num_vuids = sizeof(vuid_spec_text) / sizeof(vuid_spec_text_pair);
-        const char *spec_text = nullptr;
-        std::string spec_type;
-        for (uint32_t i = 0; i < num_vuids; i++) {
-            if (0 == strcmp(vuid_text.c_str(), vuid_spec_text[i].vuid)) {
-                spec_text = vuid_spec_text[i].spec_text;
-                spec_type = vuid_spec_text[i].url_id;
-                break;
-            }
-        }
-
-        // Construct and append the specification text and link to the appropriate version of the spec
-        if (nullptr != spec_text) {
-            std::string spec_link = "https://www.khronos.org/registry/vulkan/specs/_MAGIC_KHRONOS_SPEC_TYPE_/html/vkspec.html";
-#ifdef ANNOTATED_SPEC_LINK
-            spec_link = ANNOTATED_SPEC_LINK;
-#endif
-            static std::string kAtToken = "_MAGIC_ANNOTATED_SPEC_TYPE_";
-            static std::string kKtToken = "_MAGIC_KHRONOS_SPEC_TYPE_";
-            static std::string kVeToken = "_MAGIC_VERSION_ID_";
-            auto Replace = [](std::string &dest_string, const std::string &to_replace, const std::string &replace_with) {
-                if (dest_string.find(to_replace) != std::string::npos) {
-                    dest_string.replace(dest_string.find(to_replace), to_replace.size(), replace_with);
-                }
-            };
-
-            str_plus_spec_text.append(" The Vulkan spec states: ");
-            str_plus_spec_text.append(spec_text);
-            if (0 == spec_type.compare("default")) {
-                str_plus_spec_text.append(" (https://github.com/KhronosGroup/Vulkan-Docs/search?q=)");
-            } else {
-                str_plus_spec_text.append(" (");
-                str_plus_spec_text.append(spec_link);
-                std::string major_version = std::to_string(VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE));
-                std::string minor_version = std::to_string(VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE));
-                std::string patch_version = std::to_string(VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
-                std::string header_version = major_version + "." + minor_version + "." + patch_version;
-                std::string annotated_spec_type = major_version + "." + minor_version + "-extensions";
-                Replace(str_plus_spec_text, kKtToken, spec_type);
-                Replace(str_plus_spec_text, kAtToken, annotated_spec_type);
-                Replace(str_plus_spec_text, kVeToken, header_version);
-                str_plus_spec_text.append("#");  // CMake hates hashes
-            }
-            str_plus_spec_text.append(vuid_text);
-            str_plus_spec_text.append(")");
-        }
-    }
-
-    bool result = debug_log_msg(debug_data, msg_flags, objects, "Validation", str_plus_spec_text.c_str(), vuid_text.c_str());
-    free(err_msg);
-    return result;
-}
-
-static inline VKAPI_ATTR VkBool32 VKAPI_CALL report_log_callback(VkFlags msg_flags, VkDebugReportObjectTypeEXT obj_type,
-                                                                 uint64_t src_object, size_t location, int32_t msg_code,
-                                                                 const char *layer_prefix, const char *message, void *user_data) {
-    std::ostringstream msg_buffer;
-    char msg_flag_string[30];
-
-    PrintMessageFlags(msg_flags, msg_flag_string);
-
-    msg_buffer << layer_prefix << "(" << msg_flag_string << "): msg_code: " << msg_code << ": " << message << "\n";
-    const std::string tmp = msg_buffer.str();
-    const char *cstr = tmp.c_str();
-
-    fprintf((FILE *)user_data, "%s", cstr);
-    fflush((FILE *)user_data);
-
-#if defined __ANDROID__
-    LOGCONSOLE("%s", cstr);
-#endif
-
-    return false;
-}
-
-static inline VKAPI_ATTR VkBool32 VKAPI_CALL report_win32_debug_output_msg(VkFlags msg_flags, VkDebugReportObjectTypeEXT obj_type,
-                                                                           uint64_t src_object, size_t location, int32_t msg_code,
-                                                                           const char *layer_prefix, const char *message,
-                                                                           void *user_data) {
-#ifdef WIN32
-    char msg_flag_string[30];
-    char buf[2048];
-
-    PrintMessageFlags(msg_flags, msg_flag_string);
-    _snprintf(buf, sizeof(buf) - 1, "%s (%s): msg_code: %d: %s\n", layer_prefix, msg_flag_string, msg_code, message);
-
-    OutputDebugString(buf);
-#endif
-
-    return false;
-}
-
-static inline VKAPI_ATTR VkBool32 VKAPI_CALL DebugBreakCallback(VkFlags msgFlags, VkDebugReportObjectTypeEXT obj_type,
-                                                                uint64_t src_object, size_t location, int32_t msg_code,
-                                                                const char *layer_prefix, const char *message, void *user_data) {
-#ifdef WIN32
-    DebugBreak();
-#else
-    raise(SIGTRAP);
-#endif
-
-    return false;
-}
-
-static inline VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
-                                                                    VkDebugUtilsMessageTypeFlagsEXT message_type,
-                                                                    const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
-                                                                    void *user_data) {
-#ifdef WIN32
-    DebugBreak();
-#else
-    raise(SIGTRAP);
-#endif
-
-    return false;
-}
-
-static inline VKAPI_ATTR VkBool32 VKAPI_CALL messenger_log_callback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
-                                                                    VkDebugUtilsMessageTypeFlagsEXT message_type,
-                                                                    const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
-                                                                    void *user_data) {
-    std::ostringstream msg_buffer;
-    char msg_severity[30];
-    char msg_type[30];
-
-    PrintMessageSeverity(message_severity, msg_severity);
-    PrintMessageType(message_type, msg_type);
-
-    msg_buffer << callback_data->pMessageIdName << "(" << msg_severity << " / " << msg_type
-               << "): msgNum: " << callback_data->messageIdNumber << " - " << callback_data->pMessage << "\n";
-    msg_buffer << "    Objects: " << callback_data->objectCount << "\n";
-    for (uint32_t obj = 0; obj < callback_data->objectCount; ++obj) {
-        msg_buffer << "        [" << obj << "] " << std::hex << std::showbase
-                   << HandleToUint64(callback_data->pObjects[obj].objectHandle) << ", type: " << std::dec << std::noshowbase
-                   << callback_data->pObjects[obj].objectType
-                   << ", name: " << (callback_data->pObjects[obj].pObjectName ? callback_data->pObjects[obj].pObjectName : "NULL")
-                   << "\n";
-    }
-    const std::string tmp = msg_buffer.str();
-    const char *cstr = tmp.c_str();
-    fprintf((FILE *)user_data, "%s", cstr);
-    fflush((FILE *)user_data);
-
-#if defined __ANDROID__
-    LOGCONSOLE("%s", cstr);
-#endif
-
-    return false;
-}
-
-static inline VKAPI_ATTR VkBool32 VKAPI_CALL messenger_win32_debug_output_msg(
-    VkDebugUtilsMessageSeverityFlagBitsEXT message_severity, VkDebugUtilsMessageTypeFlagsEXT message_type,
-    const VkDebugUtilsMessengerCallbackDataEXT *callback_data, void *user_data) {
-#ifdef WIN32
-    std::ostringstream msg_buffer;
-    char msg_severity[30];
-    char msg_type[30];
-
-    PrintMessageSeverity(message_severity, msg_severity);
-    PrintMessageType(message_type, msg_type);
-
-    msg_buffer << callback_data->pMessageIdName << "(" << msg_severity << " / " << msg_type
-               << "): msgNum: " << callback_data->messageIdNumber << " - " << callback_data->pMessage << "\n";
-    msg_buffer << "    Objects: " << callback_data->objectCount << "\n";
-
-    for (uint32_t obj = 0; obj < callback_data->objectCount; ++obj) {
-        msg_buffer << "       [" << obj << "]  " << std::hex << std::showbase
-                   << HandleToUint64(callback_data->pObjects[obj].objectHandle) << ", type: " << std::dec << std::noshowbase
-                   << callback_data->pObjects[obj].objectType
-                   << ", name: " << (callback_data->pObjects[obj].pObjectName ? callback_data->pObjects[obj].pObjectName : "NULL")
-                   << "\n";
-    }
-    const std::string tmp = msg_buffer.str();
-    const char *cstr = tmp.c_str();
-    OutputDebugString(cstr);
-#endif
-
-    return false;
-}
+VKAPI_ATTR VkBool32 VKAPI_CALL MessengerWin32DebugOutputMsg(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                                                            VkDebugUtilsMessageTypeFlagsEXT message_type,
+                                                            const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
+                                                            void *user_data);
 
 template <typename Map>
 static LoggingLabelState *GetLoggingLabelState(Map *map, typename Map::key_type key, bool insert) {

--- a/layers/vk_layer_utils.cpp
+++ b/layers/vk_layer_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2016, 2020-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2016, 2020-2022 Valve Corporation
- * Copyright (c) 2015-2016, 2020-2022 LunarG, Inc.
+/* Copyright (c) 2015-2016, 2020-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2016, 2020-2023 Valve Corporation
+ * Copyright (c) 2015-2016, 2020-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,17 +130,17 @@ VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_dat
     if (debug_action & VK_DBG_LAYER_ACTION_LOG_MSG) {
         const char *log_filename = getLayerOption(log_filename_key.c_str());
         FILE *log_output = getLayerLogOutput(log_filename, layer_identifier);
-        dbg_create_info.pfnUserCallback = messenger_log_callback;
+        dbg_create_info.pfnUserCallback = MessengerLogCallback;
         dbg_create_info.pUserData = (void *)log_output;
-        layer_create_messenger_callback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &messenger);
+        LayerCreateMessengerCallback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &messenger);
     }
 
     messenger = VK_NULL_HANDLE;
 
     if (debug_action & VK_DBG_LAYER_ACTION_DEBUG_OUTPUT) {
-        dbg_create_info.pfnUserCallback = messenger_win32_debug_output_msg;
+        dbg_create_info.pfnUserCallback = MessengerWin32DebugOutputMsg;
         dbg_create_info.pUserData = NULL;
-        layer_create_messenger_callback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &messenger);
+        LayerCreateMessengerCallback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &messenger);
     }
 
     messenger = VK_NULL_HANDLE;
@@ -148,7 +148,7 @@ VK_LAYER_EXPORT void layer_debug_messenger_actions(debug_report_data *report_dat
     if (debug_action & VK_DBG_LAYER_ACTION_BREAK) {
         dbg_create_info.pfnUserCallback = MessengerBreakCallback;
         dbg_create_info.pUserData = NULL;
-        layer_create_messenger_callback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &messenger);
+        LayerCreateMessengerCallback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &messenger);
     }
 }
 
@@ -176,9 +176,9 @@ VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data, 
         FILE *log_output = getLayerLogOutput(log_filename, layer_identifier);
         auto dbg_create_info = LvlInitStruct<VkDebugReportCallbackCreateInfoEXT>();
         dbg_create_info.flags = report_flags;
-        dbg_create_info.pfnCallback = report_log_callback;
+        dbg_create_info.pfnCallback = ReportLogCallback;
         dbg_create_info.pUserData = (void *)log_output;
-        layer_create_report_callback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &callback);
+        LayerCreateReportCallback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &callback);
     }
 
     callback = VK_NULL_HANDLE;
@@ -186,9 +186,9 @@ VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data, 
     if (debug_action & VK_DBG_LAYER_ACTION_DEBUG_OUTPUT) {
         auto dbg_create_info = LvlInitStruct<VkDebugReportCallbackCreateInfoEXT>();
         dbg_create_info.flags = report_flags;
-        dbg_create_info.pfnCallback = report_win32_debug_output_msg;
+        dbg_create_info.pfnCallback = ReportWin32DebugOutputMsg;
         dbg_create_info.pUserData = NULL;
-        layer_create_report_callback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &callback);
+        LayerCreateReportCallback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &callback);
     }
 
     callback = VK_NULL_HANDLE;
@@ -198,7 +198,7 @@ VK_LAYER_EXPORT void layer_debug_report_actions(debug_report_data *report_data, 
         dbg_create_info.flags = report_flags;
         dbg_create_info.pfnCallback = DebugBreakCallback;
         dbg_create_info.pUserData = NULL;
-        layer_create_report_callback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &callback);
+        LayerCreateReportCallback(report_data, default_layer_callback, &dbg_create_info, pAllocator, &callback);
     }
 }
 

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2017, 2019-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2017, 2019-2022 Valve Corporation
- * Copyright (c) 2015-2017, 2019-2022 LunarG, Inc.
+/* Copyright (c) 2015-2017, 2019-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2017, 2019-2023 Valve Corporation
+ * Copyright (c) 2015-2017, 2019-2023 LunarG, Inc.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,8 +25,8 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstring>
 #include <functional>
-#include <stdbool.h>
 #include <string>
 #include <vector>
 #include <bitset>

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (c) 2015-2022 Google, Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google, Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -375,7 +375,10 @@ TEST_F(VkLayerTest, DuplicateMessageLimit) {
     m_errorMonitor->SetDesiredFailureMsg((kErrorBit | kWarningBit), "VUID-VkPhysicalDeviceProperties2-pNext-pNext");
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
     m_errorMonitor->VerifyFound();
-    m_errorMonitor->SetDesiredFailureMsg((kErrorBit | kWarningBit), "VUID-VkPhysicalDeviceProperties2-pNext-pNext");
+    // VUID-VkPhysicalDeviceProperties2-pNext-pNext produces a massive ~3600 character log message, which hits a
+    // complex string buffer reallocation path inside of the logging code. Make sure it successfully prints out
+    // the very end of the message.
+    m_errorMonitor->SetDesiredFailureMsg((kErrorBit | kWarningBit), "is undefined and may not work correctly with validation enabled");
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
     m_errorMonitor->VerifyFound();
 

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (c) 2015-2022 Google, Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 
 #include "cast_utils.h"
 #include "layer_validation_tests.h"
+#include "vk_enum_string_helper.h"
 
 TEST_F(VkSyncValTest, SyncBufferCopyHazards) {
     AddOptionalExtensions(VK_AMD_BUFFER_MARKER_EXTENSION_NAME);


### PR DESCRIPTION
Add vk_layer_logging.cpp, so that most of the logging functions can be de-inlined. This appears to reduce compiled code size for the validation layer by 11% to 33% (on linux).

Change LogMsgLocked() to LogMsg() and restructure it to avoid duplicated code in class ValidationObject.

Remove use of vasprintf() and use stack buffers and snprintf() instead. vasprintf() calls malloc internally and VVL must call free. When overriding malloc, this gets complicated because libc and VVL can end up using different malloc and free implementations.