### PR TITLE
cmake: Build a shared library instead of module

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -213,7 +213,7 @@ if (NOT BUILD_LAYERS)
     return()
 endif()
 
-add_library(VkLayer_khronos_validation MODULE)
+add_library(VkLayer_khronos_validation SHARED)
 
 target_sources(VkLayer_khronos_validation PRIVATE
     ${CHASSIS_LIBRARY_FILES}


### PR DESCRIPTION
If we use MODULE, cmake doesn't set SONAME which we should set. MODULE is meant only for runtime explicit dynamic linking with dlopen

Signed-off-by: Nick Sarnie <sarnex@gentoo.org>