### PR TITLE
layers: Remove extra SHADER_MODULE_STATE constructor

### DIFF
--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -2982,7 +2982,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE &pipeline, con
             // The new optimized SPIR-V will NOT match the original SHADER_MODULE_STATE object parsing, so a new SHADER_MODULE_STATE
             // object is needed. This an issue due to each pipeline being able to reuse the same shader module but with different
             // spec constant values.
-            SHADER_MODULE_STATE spec_mod(specialized_spirv);
+            SHADER_MODULE_STATE spec_mod(layer_data::make_span<const uint32_t>(specialized_spirv.data(), specialized_spirv.size()));
 
             // According to https://github.com/KhronosGroup/Vulkan-Docs/issues/1671 anything labeled as "static use" (such as if an
             // input is used or not) don't have to be checked post spec constants freezing since the device compiler is not

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -238,7 +238,7 @@ std::vector<DPFSubstring> DebugPrintf::ParseFormatString(const std::string &form
     return parsed_strings;
 }
 
-std::string DebugPrintf::FindFormatString(std::vector<uint32_t> pgm, uint32_t string_id) {
+std::string DebugPrintf::FindFormatString(layer_data::span<const uint32_t> pgm, uint32_t string_id) {
     std::string format_string;
     SHADER_MODULE_STATE module_state(pgm);
     if (module_state.words_.empty()) {
@@ -313,7 +313,7 @@ void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
         std::stringstream shader_message;
         VkShaderModule shader_module_handle = VK_NULL_HANDLE;
         VkPipeline pipeline_handle = VK_NULL_HANDLE;
-        std::vector<uint32_t> pgm;
+        layer_data::span<const uint32_t> pgm;
 
         DPFOutputRecord *debug_record = reinterpret_cast<DPFOutputRecord *>(&debug_output_buffer[index]);
         // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
@@ -325,7 +325,7 @@ void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
             pgm = it->second.pgm;
         }
         // Search through the shader source for the printf format string for this invocation
-        auto format_string = FindFormatString(pgm, debug_record->format_string_id);
+        const auto format_string = FindFormatString(pgm, debug_record->format_string_id);
         // Break the format string into strings with 1 or 0 value
         auto format_substrings = ParseFormatString(format_string);
         void *values = static_cast<void *>(&debug_record->values);

--- a/layers/gpu_validation/debug_printf.h
+++ b/layers/gpu_validation/debug_printf.h
@@ -95,7 +95,7 @@ class DebugPrintf : public GpuAssistedBase {
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                          void* csm_state_data) override;
     std::vector<DPFSubstring> ParseFormatString(const std::string& format_string);
-    std::string FindFormatString(std::vector<uint32_t> pgm, uint32_t string_id);
+    std::string FindFormatString(layer_data::span<const uint32_t> pgm, uint32_t string_id);
     void AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, DPFBufferInfo& buffer_info,
                                     uint32_t operation_index, uint32_t* const debug_output_buffer);
     void PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,

--- a/layers/gpu_validation/gpu_utils.cpp
+++ b/layers/gpu_validation/gpu_utils.cpp
@@ -1158,7 +1158,7 @@ bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::st
 
 // Extract the filename, line number, and column number from the correct OpLine and build a message string from it.
 // Scan the source (from OpSource) to find the line of source at the reported line number and place it in another message string.
-void UtilGenerateSourceMessages(const std::vector<uint32_t> &pgm, const uint32_t *debug_record, bool from_printf,
+void UtilGenerateSourceMessages(layer_data::span<const uint32_t> pgm, const uint32_t *debug_record, bool from_printf,
                                 std::string &filename_msg, std::string &source_msg) {
     using namespace spvtools;
     std::ostringstream filename_stream;

--- a/layers/gpu_validation/gpu_utils.h
+++ b/layers/gpu_validation/gpu_utils.h
@@ -88,7 +88,7 @@ void UtilGenerateCommonMessage(const debug_report_data *report_data, const VkCom
                                const uint32_t *debug_record, const VkShaderModule shader_module_handle,
                                const VkPipeline pipeline_handle, const VkPipelineBindPoint pipeline_bind_point,
                                const uint32_t operation_index, std::string &msg);
-void UtilGenerateSourceMessages(const std::vector<uint32_t> &pgm, const uint32_t *debug_record, bool from_printf,
+void UtilGenerateSourceMessages(layer_data::span<const uint32_t> pgm, const uint32_t *debug_record, bool from_printf,
                                 std::string &filename_msg, std::string &source_msg);
 
 struct GpuAssistedShaderTracker {

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -1149,7 +1149,7 @@ void GpuAssisted::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
     std::string vuid_msg;
     VkShaderModule shader_module_handle = VK_NULL_HANDLE;
     VkPipeline pipeline_handle = VK_NULL_HANDLE;
-    std::vector<uint32_t> pgm;
+    layer_data::span<const uint32_t> pgm;
     // The first record starts at this offset after the total_words.
     const uint32_t *debug_record = &debug_output_buffer[kDebugOutputDataOffset];
     // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -272,16 +272,12 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     uint32_t gpu_validation_shader_id{std::numeric_limits<uint32_t>::max()};
 
-    SHADER_MODULE_STATE(const uint32_t *code, std::size_t count, spv_target_env env = SPV_ENV_VULKAN_1_0)
+    explicit SHADER_MODULE_STATE(layer_data::span<const uint32_t> code, spv_target_env env = SPV_ENV_VULKAN_1_0)
         : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule),
-          words_(code, code + (count / sizeof(uint32_t))),
+          words_(code.begin(), code.end()),
           static_data_(*this) {
         PreprocessShaderBinary(env);
     }
-
-    template <typename SpirvContainer>
-    SHADER_MODULE_STATE(const SpirvContainer &spirv)
-        : SHADER_MODULE_STATE(spirv.data(), spirv.size() * sizeof(typename SpirvContainer::value_type)) {}
 
     SHADER_MODULE_STATE(const VkShaderModuleCreateInfo &create_info, VkShaderModule shaderModule, spv_target_env env,
                         uint32_t unique_shader_id)


### PR DESCRIPTION
Reduce the number of `SHADER_MODULE_STATE` constructors to only what is needed