### PR TITLE
layers: Add GetBitWidth SPIR-V helper

### DIFF
--- a/layers/shader_instruction.h
+++ b/layers/shader_instruction.h
@@ -68,6 +68,7 @@ class Instruction {
     }
 
     uint32_t GetConstantValue() const;
+    uint32_t GetBitWidth() const;
     AtomicInstructionInfo GetAtomicInfo(const SHADER_MODULE_STATE& module_state) const;
     spv::BuiltIn GetBuiltIn() const;
 


### PR DESCRIPTION
- Move the `GetBitWidth` logic into a per-`Instruction` function to be reused
- cleaned up `GetNumComponentsInBaseType` and `GetTypeBitsSize` a bit to be consistent with other similar helper functions
