### PR TITLE
layers: Cleanup CMD_BUFFER_STATE::ExecuteCommands

### DIFF
--- a/layers/cmd_buffer_state.h
+++ b/layers/cmd_buffer_state.h
@@ -442,7 +442,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
 
     void BeginRendering(CMD_TYPE cmd_type, const VkRenderingInfo *pRenderingInfo);
 
-    void ExecuteCommands(uint32_t commandBuffersCount, const VkCommandBuffer *pCommandBuffers);
+    void ExecuteCommands(layer_data::span<const VkCommandBuffer> secondary_command_buffers);
 
     void UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_bind_point, const PIPELINE_LAYOUT_STATE &pipeline_layout,
                                        uint32_t first_set, uint32_t set_count, const VkDescriptorSet *pDescriptorSets,

--- a/layers/state_tracker.cpp
+++ b/layers/state_tracker.cpp
@@ -3564,7 +3564,7 @@ void ValidationStateTracker::PreCallRecordCmdExecuteCommands(VkCommandBuffer com
                                                              const VkCommandBuffer *pCommandBuffers) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
 
-    cb_state->ExecuteCommands(commandBuffersCount, pCommandBuffers);
+    cb_state->ExecuteCommands({pCommandBuffers, commandBuffersCount});
 }
 
 void ValidationStateTracker::PostCallRecordMapMemory(VkDevice device, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size,


### PR DESCRIPTION
- Use span
- Use MaxTypeValue
- Use |=
- Use emplace_back