### PR TITLE
deps: Update SPIR-V Tools and Headers version

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -22,13 +22,13 @@
             "name": "SPIRV-Tools",
             "url": "https://github.com/KhronosGroup/SPIRV-Tools.git",
             "sub_dir": "shaderc/third_party/spirv-tools",
-            "commit": "40f5bf59c6acb4754a0bffd3c53a715732883a12"
+            "commit": "d87f61605b3647fbceae9aaa922fce0031afdc63"
         },
         {
             "name": "SPIRV-Headers",
             "url": "https://github.com/KhronosGroup/SPIRV-Headers.git",
             "sub_dir": "shaderc/third_party/spirv-tools/external/spirv-headers",
-            "commit": "1d31a100405cf8783ca7a31e31cdd727c9fc54c3"
+            "commit": "34d04647d384e0aed037e7a2662a655fc39841bb"
         },
         {
             "name": "robin-hood-hashing",

--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -3,10 +3,10 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (c) 2015-2022 Google Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,4 +26,4 @@
  ****************************************************************************/
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "40f5bf59c6acb4754a0bffd3c53a715732883a12"
+#define SPIRV_TOOLS_COMMIT_ID "d87f61605b3647fbceae9aaa922fce0031afdc63"

--- a/scripts/external_revision_generator.py
+++ b/scripts/external_revision_generator.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2015-2022 The Khronos Group Inc.
-# Copyright (c) 2015-2022 Valve Corporation
-# Copyright (c) 2015-2022 LunarG, Inc.
-# Copyright (c) 2015-2022 Google Inc.
+# Copyright (c) 2015-2023 The Khronos Group Inc.
+# Copyright (c) 2015-2023 Valve Corporation
+# Copyright (c) 2015-2023 LunarG, Inc.
+# Copyright (c) 2015-2023 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,10 +38,10 @@ def generate(symbol_name, commit_id, output_header_file):
         copyright += '\n'
         copyright += '/***************************************************************************\n'
         copyright += ' *\n'
-        copyright += ' * Copyright (c) 2015-2022 The Khronos Group Inc.\n'
-        copyright += ' * Copyright (c) 2015-2022 Valve Corporation\n'
-        copyright += ' * Copyright (c) 2015-2022 LunarG, Inc.\n'
-        copyright += ' * Copyright (c) 2015-2022 Google Inc.\n'
+        copyright += ' * Copyright (c) 2015-2023 The Khronos Group Inc.\n'
+        copyright += ' * Copyright (c) 2015-2023 Valve Corporation\n'
+        copyright += ' * Copyright (c) 2015-2023 LunarG, Inc.\n'
+        copyright += ' * Copyright (c) 2015-2023 Google Inc.\n'
         copyright += ' *\n'
         copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
         copyright += ' * you may not use this file except in compliance with the License.\n'

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -25,7 +25,7 @@
             "sub_dir": "SPIRV-Headers",
             "build_dir": "SPIRV-Headers/build",
             "install_dir": "SPIRV-Headers/build/install",
-            "commit": "1d31a100405cf8783ca7a31e31cdd727c9fc54c3"
+            "commit": "34d04647d384e0aed037e7a2662a655fc39841bb"
         },
         {
             "name": "SPIRV-Tools",
@@ -36,7 +36,7 @@
             "cmake_options": [
                 "-DSPIRV-Headers_SOURCE_DIR={repo_dir}/../SPIRV-Headers"
             ],
-            "commit": "40f5bf59c6acb4754a0bffd3c53a715732883a12"
+            "commit": "d87f61605b3647fbceae9aaa922fce0031afdc63"
         },
         {
             "name": "robin-hood-hashing",


### PR DESCRIPTION
Current SPIR-V Tools had build issue that is now fixed

closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4947