### PR TITLE
Using InterfaceVariable in EntryPoint 

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -1370,7 +1370,7 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
                                       kThreadGroupDispatchCountAlignmentArm);
     }
 
-    auto descriptor_uses = module_state->CollectInterfaceByDescriptorSlot(entrypoint_optional);
+    auto interface_variables = module_state->GetInterfaceVariable(entrypoint);
 
     unsigned dimensions = 0;
     if (x > 1) dimensions++;
@@ -1383,8 +1383,8 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
     // There are some false positives here. We could simply have a shader that does this within a 1D grid,
     // or we may have a linearly tiled image, but these cases are quite unlikely in practice.
     bool accesses_2d = false;
-    for (const auto& usage : descriptor_uses) {
-        auto dim = module_state->GetShaderResourceDimensionality(usage.second);
+    for (const InterfaceVariable& variable : *interface_variables) {
+        auto dim = module_state->GetShaderResourceDimensionality(variable);
         if (dim < 0) continue;
         auto spvdim = spv::Dim(dim);
         if (spvdim != spv::Dim1D && spvdim != spv::DimBuffer) accesses_2d = true;

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (C) 2015-2022 Google Inc.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (C) 2015-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1082,11 +1082,13 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                 assert(set_index != std::numeric_limits<uint32_t>::max());
                 const auto pipeline = context.cb_state.GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS);
                 for (const auto &stage : pipeline->stage_state) {
-                    for (const auto &descriptor : stage.descriptor_uses) {
-                        if (descriptor.first.set == set_index && descriptor.first.binding == binding) {
-                            descriptor_writable |= descriptor.second.is_writable;
-                            descriptor_readable |=
-                                descriptor.second.is_readable | descriptor.second.is_sampler_implicitLod_dref_proj;
+                    if (!stage.descriptor_variables) {
+                        continue;
+                    }
+                    for (const InterfaceVariable &variable : *stage.descriptor_variables) {
+                        if (variable.decorations.set == set_index && variable.decorations.binding == binding) {
+                            descriptor_writable |= variable.is_writable;
+                            descriptor_readable |= variable.is_readable | variable.is_sampler_implicitLod_dref_proj;
                             break;
                         }
                     }

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -32,21 +32,21 @@
 #include "shader_module.h"
 #include "enum_flag_bits.h"
 
-static bool WrotePrimitiveShadingRate(VkShaderStageFlagBits stage_flag, std::optional<Instruction> entrypoint,
+static bool WrotePrimitiveShadingRate(VkShaderStageFlagBits stage_flag, const Instruction &entrypoint,
                                       const SHADER_MODULE_STATE *module_state) {
-    bool primitiverate_written = false;
-    if (entrypoint && (stage_flag == VK_SHADER_STAGE_VERTEX_BIT || stage_flag == VK_SHADER_STAGE_GEOMETRY_BIT ||
-                       stage_flag == VK_SHADER_STAGE_MESH_BIT_NV)) {
+    bool primitive_rate_written = false;
+    if (stage_flag == VK_SHADER_STAGE_VERTEX_BIT || stage_flag == VK_SHADER_STAGE_GEOMETRY_BIT ||
+        stage_flag == VK_SHADER_STAGE_MESH_BIT_NV) {
         for (const Instruction *inst : module_state->GetBuiltinDecorationList()) {
             if (inst->GetBuiltIn() == spv::BuiltInPrimitiveShadingRateKHR) {
-                primitiverate_written = module_state->IsBuiltInWritten(inst, *entrypoint);
+                primitive_rate_written = module_state->IsBuiltInWritten(inst, entrypoint);
             }
-            if (primitiverate_written) {
+            if (primitive_rate_written) {
                 break;
             }
         }
     }
-    return primitiverate_written;
+    return primitive_rate_written;
 }
 
 PipelineStageState::PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *stage,
@@ -173,7 +173,7 @@ PIPELINE_STATE::ActiveSlotMap PIPELINE_STATE::GetActiveSlots(const StageStateVec
             if (variable.is_write_without_format) reqs |= DESCRIPTOR_REQ_IMAGE_WRITE_WITHOUT_FORMAT;
             if (variable.is_dref_operation) reqs |= DESCRIPTOR_REQ_IMAGE_DREF;
 
-            if (variable.samplers_used_by_image.size()) {
+            if (!variable.samplers_used_by_image.empty()) {
                 if (variable.samplers_used_by_image.size() > entry.samplers_used_by_image.size()) {
                     entry.samplers_used_by_image.resize(variable.samplers_used_by_image.size());
                 }

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (C) 2015-2022 Google Inc.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (C) 2015-2023 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,10 +106,7 @@ struct PipelineStageState {
     const safe_VkPipelineShaderStageCreateInfo *create_info;
     VkShaderStageFlagBits stage_flag;
     std::optional<Instruction> entrypoint;
-    // Used to map each descriptor binding to the OpVariable decorated with it
-    // <(set, binding), OpVariable>
-    using DescriptorUse = std::pair<DescriptorSlot, InterfaceVariable>;
-    std::vector<DescriptorUse> descriptor_uses;
+    const std::vector<InterfaceVariable> *descriptor_variables;
     bool has_writable_descriptor;
     bool has_atomic_descriptor;
     bool wrote_primitive_shading_rate;

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -74,7 +74,7 @@ enum FORMAT_TYPE {
 typedef std::pair<uint32_t, uint32_t> location_t;
 
 struct DecorationSet {
-    enum {
+    enum FlagBit {
         patch_bit = 1 << 0,
         block_bit = 1 << 1,
         buffer_block_bit = 1 << 2,
@@ -87,16 +87,24 @@ struct DecorationSet {
     };
     static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
 
+    // bits to know if things have been set or not by a Decoration
     uint32_t flags = 0;
+
+    // When being used as an User-defined Variable (input, output, rtx)
     uint32_t location = kInvalidValue;
     uint32_t component = 0;
+
+    // For input attachments
     uint32_t input_attachment_index = 0;
+
+    // For descriptors
     uint32_t descriptor_set = 0;
     uint32_t binding = 0;
+
     uint32_t builtin = kInvalidValue;
-    uint32_t spec_const_id = kInvalidValue;
 
     void Add(uint32_t decoration, uint32_t value);
+    bool Has(FlagBit flag_bit) const { return (flags & flag_bit) != 0; }
 };
 
 struct SHADER_MODULE_STATE : public BASE_NODE {

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -175,6 +175,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         // All ids that can be accessed from the entry point
         layer_data::unordered_set<uint32_t> accessible_ids;
 
+        layer_data::unordered_set<uint32_t> attachment_indexes;
+
         StructInfo push_constant_used_in_shader;
 
         EntryPoint(const SHADER_MODULE_STATE &module_state, const Instruction &entrypoint);
@@ -286,6 +288,14 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         }
         return nullptr;
     }
+    const layer_data::unordered_set<uint32_t> *GetAttachmentIndexes(const Instruction &entrypoint) const {
+        for (const auto &entry_point : static_data_.entry_points) {
+            if (entry_point.entrypoint_insn == entrypoint) {
+                return &entry_point.attachment_indexes;
+            }
+        }
+        return nullptr;
+    }
 
     const layer_data::unordered_map<uint32_t, std::vector<const Instruction *>> &GetExecutionModeInstructions() const {
         return static_data_.execution_mode_inst;
@@ -345,7 +355,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     std::map<location_t, InterfaceVariable> CollectInterfaceByLocation(const Instruction &entrypoint, spv::StorageClass sinterface,
                                                                        bool is_array_of_verts) const;
     std::vector<uint32_t> CollectBuiltinBlockMembers(const Instruction &entrypoint, uint32_t storageClass) const;
-    std::vector<std::pair<uint32_t, InterfaceVariable>> CollectInterfaceByInputAttachmentIndex(const Instruction &entrypoint) const;
 
     uint32_t GetNumComponentsInBaseType(const Instruction *insn) const;
     uint32_t GetTypeBitsSize(const Instruction *insn) const;

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022 The Khronos Group Inc.
+/* Copyright (c) 2021-2023 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,8 +47,6 @@ struct InterfaceVariable {
     std::vector<std::pair<Instruction, uint32_t>> write_without_formats_component_count_list;
 
     bool is_patch{false};
-    bool is_block_member{false};
-    bool is_relaxed_precision{false};
     bool is_readable{false};
     bool is_writable{false};
     bool is_atomic_operation{false};
@@ -77,21 +75,15 @@ typedef std::pair<uint32_t, uint32_t> location_t;
 
 struct DecorationSet {
     enum {
-        location_bit = 1 << 0,
-        patch_bit = 1 << 1,
-        relaxed_precision_bit = 1 << 2,
-        block_bit = 1 << 3,
-        buffer_block_bit = 1 << 4,
-        component_bit = 1 << 5,
-        input_attachment_index_bit = 1 << 6,
-        descriptor_set_bit = 1 << 7,
-        binding_bit = 1 << 8,
-        nonwritable_bit = 1 << 9,
-        builtin_bit = 1 << 10,
-        nonreadable_bit = 1 << 11,
-        per_vertex_bit = 1 << 12,
-        passthrough_bit = 1 << 13,
-        aliased_bit = 1 << 14,
+        patch_bit = 1 << 0,
+        block_bit = 1 << 1,
+        buffer_block_bit = 1 << 2,
+        nonwritable_bit = 1 << 3,
+        builtin_bit = 1 << 4,
+        nonreadable_bit = 1 << 5,
+        per_vertex_bit = 1 << 6,
+        passthrough_bit = 1 << 7,
+        aliased_bit = 1 << 8,
     };
     static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
 

--- a/layers/shader_validation.cpp
+++ b/layers/shader_validation.cpp
@@ -244,10 +244,12 @@ bool CoreChecks::ValidateShaderInputAttachment(const SHADER_MODULE_STATE &module
     if (rp_state && !rp_state->UsesDynamicRendering()) {
         auto rpci = rp_state->createInfo.ptr();
         const uint32_t subpass = pipeline.Subpass();
-        auto input_attachment_uses = module_state.CollectInterfaceByInputAttachmentIndex(entrypoint);
-        for (const auto &use : input_attachment_uses) {
+        auto attachment_indexes = module_state.GetAttachmentIndexes(entrypoint);
+        if (!attachment_indexes) {
+            return skip;
+        }
+        for (const uint32_t index : *attachment_indexes) {
             auto input_attachments = rpci->pSubpasses[subpass].pInputAttachments;
-            const uint32_t index = use.first;
 
             // Same error, but provide more useful message 'how' VK_ATTACHMENT_UNUSED is derived
             if (!input_attachments) {


### PR DESCRIPTION
Currently the shader validation code gets the same information from many different ways resulting in a tangled mess.

This attempts to move more information over to `InterfaceVariable` and then have it at a per-EntryPoint level (which will be needed to support multiple entry points correctly)

This is just a first step PR, the biggest issue is an "Interface Variable" being used for a descriptor is not being treated the same as the Input/Output shader stage interface variables, but yet are sharing some of the same logic. The Input/Output interface is a slight more tricky due to the fact it can have `OpMemberDecorate`

In the process of trying to refactor this, had some generic cleanup as well