### PR TITLE
Fix shader binding table with device address == 0

### DIFF
--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (C) 2015-2022 Google Inc.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (C) 2015-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,8 @@
 [[maybe_unused]] static const char *kVUID_Core_BufferMemoryBarrier2_SharingModeExclusiveSameFamily = "UNASSIGNED-CoreValidation-VkBufferMemoryBarrier2KHR-sharing-mode-exclusive-same-family";
 
 [[maybe_unused]] static const char *kVUID_Core_invalidDepthStencilFormat = "UNASSIGNED-CoreValidation-depthStencil-format";
+
+[[maybe_unused]] static const char *kVUID_Core_DeviceAddress_NoAssociatedBuffer = "UNASSIGNED-CoreValidation-VkDeviceAddress-NoAssociatedBuffer";
 
 // clang-format on
 

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -1,8 +1,8 @@
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (C) 2015-2022 Google Inc.
- * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (C) 2015-2023 Google Inc.
+ * Modifications Copyright (C) 2020-2023 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2233,11 +2233,15 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuf
                                                       const char *binding_table_name) const {
     bool skip = false;
 
+    if (binding_table.deviceAddress == 0) {
+        return skip;
+    }
+
     const auto buffer_states = GetBuffersByAddress(binding_table.deviceAddress);
     if (buffer_states.empty()) {
-        // We can get here if for instance deviceAddress is 0
-        skip |= LogError(device, vuid_single_device_memory, "%s: no buffer is associated with %s->deviceAddress (0x%" PRIx64 ").",
-                         rt_func_name, binding_table_name, binding_table.deviceAddress);
+        skip |= LogError(device, kVUID_Core_DeviceAddress_NoAssociatedBuffer,
+                         "%s: no buffer is associated with %s->deviceAddress (0x%" PRIx64 ").", rt_func_name, binding_table_name,
+                         binding_table.deviceAddress);
     } else {
         // Try to find a buffer satisfying all VUIDs
         const bool no_valid_buffer_found = std::none_of(

--- a/tests/vklayertests_ray_tracing.cpp
+++ b/tests/vklayertests_ray_tracing.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (c) 2015-2022 Google, Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -953,10 +953,8 @@ TEST_F(VkLayerTest, RayTracingValidateCmdTraceRaysKHR) {
     {
         VkStridedDeviceAddressRegionKHR invalid_stride = stridebufregion;
         invalid_stride.deviceAddress = 0;
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdTraceRaysKHR-pRayGenShaderBindingTable-03680");
         vkCmdTraceRaysKHR(m_commandBuffer->handle(), &invalid_stride, &stridebufregion, &stridebufregion, &stridebufregion, 100,
                           100, 1);
-        m_errorMonitor->VerifyFound();
     }
 
     // buffer is missing flag VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR
@@ -984,7 +982,6 @@ TEST_F(VkLayerTest, RayTracingValidateCmdTraceRaysKHR) {
     {
         VkStridedDeviceAddressRegionKHR invalid_stride = stridebufregion;
         invalid_stride.deviceAddress = 0;
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdTraceRaysKHR-pMissShaderBindingTable-03683");
         vkCmdTraceRaysKHR(m_commandBuffer->handle(), &stridebufregion, &invalid_stride, &stridebufregion, &stridebufregion, 100,
                           100, 1);
         m_errorMonitor->VerifyFound();
@@ -993,19 +990,15 @@ TEST_F(VkLayerTest, RayTracingValidateCmdTraceRaysKHR) {
     {
         VkStridedDeviceAddressRegionKHR invalid_stride = stridebufregion;
         invalid_stride.deviceAddress = 0;
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdTraceRaysKHR-pHitShaderBindingTable-03687");
         vkCmdTraceRaysKHR(m_commandBuffer->handle(), &stridebufregion, &stridebufregion, &invalid_stride, &stridebufregion, 100,
                           100, 1);
-        m_errorMonitor->VerifyFound();
     }
     // pCallableShaderBindingTable->deviceAddress == 0
     {
         VkStridedDeviceAddressRegionKHR invalid_stride = stridebufregion;
         invalid_stride.deviceAddress = 0;
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdTraceRaysKHR-pCallableShaderBindingTable-03691");
         vkCmdTraceRaysKHR(m_commandBuffer->handle(), &stridebufregion, &stridebufregion, &stridebufregion, &invalid_stride, 100,
                           100, 1);
-        m_errorMonitor->VerifyFound();
     }
 
     m_commandBuffer->end();


### PR DESCRIPTION
- Fix for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5035
(The issue was spotted in the CTS)

When VkStridedDeviceAddressRegionKHR.deviceAddress is 0, the region is considered unused, and this is a valid behaviour, [as per the spec](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkStridedDeviceAddressRegionKHR).

Also, the case where a user provided device address cannot be associated to a buffer using the internal `buffer_address_map_` does not fall under the umbrella of any VUID it seems. So I added `UNASSIGNED-CoreValidation-VkDeviceAddress-NoAssociatedBuffer` to output a proper error for that case. Using an invalid address (or one that became invalid following a buffer destruction) seems likely to me, so better have a custom error.