### PR TITLE
docs: Update python executable name on Windows

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -35,7 +35,7 @@ python3 ../scripts/update_deps.py --dir ../external --arch x64 --config debug
 cmake -G Ninja -C ../external/helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
 
 # Windows
-python3 ..\scripts\update_deps.py --dir ..\external --arch x64 --config debug
+python ..\scripts\update_deps.py --dir ..\external --arch x64 --config debug
 cmake -A x64 -C ..\external\helper.cmake -DCMAKE_BUILD_TYPE=Debug ..
 
 cmake --build . --config Debug


### PR DESCRIPTION
According to requirements Python 3.x is required to build the project. Python 3.x Windows distributions usually provide python.exe but not python3.exe. Windows app store distribution has both python3.exe and python.exe.