### PR TITLE
github: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# ~~~
+# Copyright (c) 2023 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+* @KhronosGroup/VVL-CODEOWNERS


### PR DESCRIPTION
CODEOWNERS serve as a form of living documentation for who owns the repo.

GitHub has very nice integration features for CODEOWNERS.

At AMD I used it to automatically add CODEOWNERS to new PRs (no more manually picking individual users, or waiting for owners to find the PR).

And require approval from CODEOWNERS (currently any 1 approval is all it takes, they don't have to be a CODEOWNER).

I've added everyone who is active on VVL to this PR to gather thoughts.

Official docs for [github owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
