### PR TITLE
Fix for sparse shader binding table buffer validation

### DIFF
--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -2256,8 +2256,10 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuf
                 if (!(static_cast<uint32_t>(buffer_state->createInfo.usage) & VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR)) {
                     return false;
                 }
-                if (const auto mem_state = buffer_state->MemState(); !mem_state || mem_state->Destroyed()) {
-                    return false;
+                if (!buffer_state->sparse) {
+                    if (const auto mem_state = buffer_state->MemState(); !mem_state || mem_state->Destroyed()) {
+                        return false;
+                    }
                 }
                 if (binding_table.size != 0) {
                     const auto device_address_range = buffer_state->DeviceAddressRange();


### PR DESCRIPTION
(I forgot to add that to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5039)
For the shader binding table buffers mentioned in trace rays commands, their memory binding needs to be validated if and only if the buffer is not sparse.

The concerned VUID family is the one mentioned in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5035
Their definition is the same, only the `deviceAddress` member changes. e.g.:
> VUID-vkCmdTraceRaysKHR-pRayGenShaderBindingTable-03680
If the buffer from which pRayGenShaderBindingTable->deviceAddress was queried is non-sparse then it must be bound completely and contiguously to a single VkDeviceMemory object
