### PR TITLE
Apply render pass final transitions even if attachment is not used

### DIFF
--- a/layers/render_pass_state.cpp
+++ b/layers/render_pass_state.cpp
@@ -213,8 +213,8 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
 
         for (uint32_t attachment = 0; attachment < attachment_count; ++attachment) {
             const auto final_layout = rp->createInfo.pAttachments[attachment].finalLayout;
-            // Add final transitions for attachments that were used and change layout.
-            if ((last[attachment] != VK_SUBPASS_EXTERNAL) && final_layout != attachment_layout[attachment]) {
+            // Add final transitions for attachments at the end of the render pass.
+            if (final_layout != attachment_layout[attachment]) {
                 final_transitions.emplace_back(last[attachment], attachment, attachment_layout[attachment], final_layout);
             }
         }


### PR DESCRIPTION
I noticed this mistake, perhaps reflecting an older state of the spec. The current spec says this:
> If an attachment is not used by any subpass, `loadOp`, `storeOp`, `stencilStoreOp`, and `stencilLoadOp` will be ignored for that attachment, and no load or store ops will be performed. However, any transition specified by `initialLayout` and `finalLayout` will still be executed.

The code previously added the transition to `finalLayout` only if the attachment was used at least one subpass (via the `last` variable) but that is wrong.