### PR TITLE
layers: Allow binding empty DS with empty layout

### DIFF
--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -166,13 +166,7 @@ bool CoreChecks::VerifySetLayoutCompatibility(const cvdescriptorset::DescriptorS
     if (descriptor_set.IsPushDescriptor()) return true;
     const auto *layout_node = pipeline_layout.set_layouts[layoutIndex].get();
     if (layout_node) {
-        if ((descriptor_set.GetBindingCount() > 0) && (layout_node->GetBindingCount() > 0)) {
-            return VerifySetLayoutCompatibility(*layout_node, *descriptor_set.GetLayout(), errorMsg);
-        } else {
-            // Only a null DSL can be used to "skip" a descriptor set a bind time, not an empty one.
-            errorMsg = "Descriptor set " + report_data->FormatHandle(descriptor_set.Handle()) + " is empty (has no bindings). Use VK_NULL_HANDLE to indicate this set is unused if using VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT.";
-            return false;
-        }
+        return VerifySetLayoutCompatibility(*layout_node, *descriptor_set.GetLayout(), errorMsg);
     } else {
         // It's possible the DSL is null when creating a graphics pipeline library, in which case we can't verify compatibility
         // here.

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2022 The Khronos Group Inc.
  * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (c) 2015-2022 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1321,4 +1321,16 @@ TEST_F(VkPositiveLayerTest, MultipleThreadsUsingHostOnlyDescriptorSet) {
 
     std::array<std::thread, 2> threads = {std::thread(testing_thread1), std::thread(testing_thread2)};
     for (auto &t : threads) t.join();
+}
+
+TEST_F(VkPositiveLayerTest, BindingEmptyDescriptorSets) {
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    OneOffDescriptorSet empty_ds(m_device, {});
+    const VkPipelineLayoutObj pipeline_layout(m_device, {&empty_ds.layout_});
+
+    m_commandBuffer->begin();
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
+                              &empty_ds.set_, 0, nullptr);
+    m_commandBuffer->end();
 }


### PR DESCRIPTION
Allow an empty descriptor set to be bound if the current layout also
defines an empty descriptor set.