### PR TITLE
Validation: Properly validate buffers obtained with GetBuffersByAddress

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -114,6 +114,7 @@ core_validation_sources = [
   "layers/utils/convert_to_renderpass2.h",
   "layers/core_checks/android_validation.cpp",
   "layers/core_checks/buffer_validation.cpp",
+  "layers/core_checks/buffer_address_validation.h",
   "layers/core_checks/cmd_buffer_dynamic_validation.cpp",
   "layers/core_checks/cmd_buffer_validation.cpp",
   "layers/core_checks/copy_blit_resolve_validation.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -152,6 +152,7 @@ target_sources(VkLayer_khronos_validation PRIVATE
     containers/subresource_adapter.h
     core_checks/android_validation.cpp
     core_checks/buffer_validation.cpp
+    core_checks/buffer_address_validation.h
     core_checks/cmd_buffer_dynamic_validation.cpp
     core_checks/cmd_buffer_validation.cpp
     core_checks/copy_blit_resolve_validation.cpp

--- a/layers/containers/range_vector.h
+++ b/layers/containers/range_vector.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2019-2022 The Khronos Group Inc.
+/* Copyright (c) 2019-2023 The Khronos Group Inc.
  * Copyright (c) 2019-2023 Valve Corporation
  * Copyright (c) 2019-2023 LunarG, Inc.
- * Copyright (C) 2019-2022 Google Inc.
+ * Copyright (C) 2019-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
 #include <cassert>
 #include <limits>
 #include <map>
+#include <string>
+#include <sstream>
 #include <utility>
 #include <cstdint>
 #include "custom_containers.h"
@@ -139,6 +141,13 @@ class range_view {
   private:
     const Range &range_;
 };
+
+template <typename Range>
+std::string string_range_hex(const Range &range) {
+    std::stringstream ss;
+    ss << std::hex << "[0x" << range.begin << ", 0x" << range.end << ')';
+    return ss.str();
+}
 
 // Type parameters for the range_map(s)
 struct insert_range_no_split_bounds {

--- a/layers/core_checks/buffer_address_validation.h
+++ b/layers/core_checks/buffer_address_validation.h
@@ -1,0 +1,196 @@
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "state_tracker/buffer_state.h"
+#include "core_validation.h"
+#include "state_tracker/state_tracker.h"
+#include "containers/custom_containers.h"
+#include "error_message/logging.h"
+
+#include <array>
+#include <functional>
+#include <iterator>
+#include <string>
+#include <string_view>
+
+/* This class aims at helping with the validation of a family of VUIDs referring to the same buffer device address.
+   For example, take those VUIDs for VkDescriptorBufferBindingInfoEXT:
+
+   VUID-VkDescriptorBufferBindingInfoEXT-usage-08122:
+   If usage includes VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT, address must be an address within a valid buffer that was
+   created with VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT
+   VUID-VkDescriptorBufferBindingInfoEXT-usage-08123:
+   If usage includes VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, address must be an address within a valid buffer that was
+   created with VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT
+   VUID-VkDescriptorBufferBindingInfoEXT-usage-08124:
+   If usage includes VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT, address must be an address within a valid buffer
+   that was created with VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT
+
+   For usage to be valid, since the mentioned address can refer to multiple buffers, one must find a buffer that satisfies *all*
+   of them. One must *not* consider those VUIDs independantly, each time trying to find a buffer that satisfies the considered VUID
+   but not necessarily the others in the family.
+
+   The VVL heuristic wants that the vast majority of the time, functions calls and structures are valid, thus validation
+   should be fast and avoid to do things related to error logging unless necessary. To comply with that, buffer address
+   validation is done in two passes: one to look for a buffer satisfying all VUIDs of the considered family. If none
+   is found, another pass is done, this time building a per VUID error message (not per buffer) regrouping all buffers
+   violating it. Outputting for each buffer every VUID it violates would lead to unnecessary log clutter.
+   This two pass process is tedious to do without an helper class, hence BufferAddressValidation was created.
+   The idea is to ask for user to provide the only necessary data:
+   a VUID, how it is validated, what to log when a buffer violates it, and a snippet of text appended to the error message header.
+   Then, just a call to LogErrorsIfNoValidBuffer is needed to do validation and, eventually, error logging.
+
+   For an example of how to use BufferAddressValidation, see for instance how "VUID-VkDescriptorBufferBindingInfoEXT-usage-08122"
+   and friends are validated.
+ */
+template <size_t N>
+class BufferAddressValidation {
+  public:
+    using ValidationFunction = std::function<bool(const ValidationStateTracker::BUFFER_STATE_PTR&, std::string* out_error_msg)>;
+    using ErrorMsgHeaderSuffixFunction = std::function<std::string()>;
+
+    struct VuidAndValidation {
+        std::string_view vuid;
+        ValidationFunction validation_func;
+        ErrorMsgHeaderSuffixFunction error_msg_header_suffix_func = []() { return "\n"; };  // text appended to error message header
+    };
+
+    // Look for a buffer that satisfies all VUIDs
+    [[nodiscard]] bool HasValidBuffer(vvl::span<const ValidationStateTracker::BUFFER_STATE_PTR> buffer_list) const noexcept;
+    // For every vuid, build an error mentioning every buffer from buffer_list that violates it, then log this error
+    // using details provided by the other parameters.
+    [[nodiscard]] bool LogInvalidBuffers(const CoreChecks& checker, const LogObjectList& objlist,
+                                         vvl::span<const ValidationStateTracker::BUFFER_STATE_PTR> buffer_list,
+                                         std::string_view api_name, const std::string& device_address_name,
+                                         VkDeviceAddress device_address) const noexcept;
+
+    [[nodiscard]] bool LogErrorsIfNoValidBuffer(const CoreChecks& checker,
+                                                vvl::span<const ValidationStateTracker::BUFFER_STATE_PTR> buffer_list,
+                                                std::string_view api_name, const std::string& device_address_name,
+                                                VkDeviceAddress device_address, const LogObjectList& objlist) const noexcept {
+        bool skip = false;
+        if (!HasValidBuffer(buffer_list)) {
+            skip |= LogInvalidBuffers(checker, objlist, buffer_list, api_name, device_address_name, device_address);
+        }
+        return skip;
+    }
+
+  public:
+    // public to enable using aggregate initialization
+    std::array<VuidAndValidation, N> vuidsAndValidationFunctions;
+
+  private:
+    struct Error {
+        LogObjectList objlist;
+        std::string error_msg;
+        bool Empty() const { return error_msg.empty(); }
+    };
+};
+
+template <size_t N>
+bool BufferAddressValidation<N>::HasValidBuffer(
+    vvl::span<const ValidationStateTracker::BUFFER_STATE_PTR> buffer_list) const noexcept {
+    for (const auto& buffer : buffer_list) {
+        assert(buffer);
+        if (!buffer) {
+            continue;
+        }
+        bool valid_buffer_found = true;
+        for (const auto& vuidAndValidation : vuidsAndValidationFunctions) {
+            if (!vuidAndValidation.validation_func(buffer, nullptr)) {
+                valid_buffer_found = false;
+                break;
+            }
+        }
+        if (valid_buffer_found) return true;
+    }
+
+    return false;
+}
+
+template <size_t N>
+bool BufferAddressValidation<N>::LogInvalidBuffers(const CoreChecks& checker, const LogObjectList& objlist,
+                                                   vvl::span<const ValidationStateTracker::BUFFER_STATE_PTR> buffer_list,
+                                                   std::string_view api_name, const std::string& device_address_name,
+                                                   VkDeviceAddress device_address) const noexcept {
+    std::array<Error, N> errors;
+
+    // Build error message beginning. Then, only per buffer error needs to be appended.
+    std::string error_msg_beginning(api_name);
+    {
+        const std::string address_string = [&]() {
+            std::stringstream address_ss;
+            address_ss << "0x" << std::hex << device_address;
+            return address_ss.str();
+        }();
+        error_msg_beginning += ": No buffer associated to ";
+        error_msg_beginning += device_address_name;
+        error_msg_beginning += " (";
+        error_msg_beginning += address_string;
+        error_msg_beginning +=
+            ") was found such that valid usage passes. "
+            "At least one buffer associated to this device address must be valid. ";
+    }
+
+    // For each buffer, and for each violated VUID, build an error message
+    for (const auto& buffer : buffer_list) {
+        assert(buffer);
+        if (!buffer) {
+            continue;
+        }
+        for (size_t i = 0; i < N; ++i) {
+            [[maybe_unused]] const auto& [vuid, validation_func, error_msg_header_suffix_func] = vuidsAndValidationFunctions[i];
+
+            // Fill buffer_error with error if there is one, and if validation function did fill a buffer error message
+            if (std::string buffer_error; !validation_func(buffer, &buffer_error) && !buffer_error.empty()) {
+                auto& error_objlist = errors[i].objlist;
+                auto& error_msg = errors[i].error_msg;
+
+                if (error_objlist.empty()) {
+                    // Add user provided handles, typically the current command buffer or the device
+                    for (const auto& obj : objlist) {
+                        error_objlist.add(obj);
+                    }
+                }
+                // Add faulty buffer to current vuid LogObjectList
+                error_objlist.add(buffer->Handle());
+
+                // Append faulty buffer error message
+                if (error_msg.empty()) {
+                    error_msg += error_msg_beginning;
+                    error_msg += error_msg_header_suffix_func();
+                }
+                const auto invalid_buffer_index = error_objlist.size() - 1;
+                error_msg += "Object " + std::to_string(invalid_buffer_index) + ": " + buffer_error + '\n';
+            }
+        }
+    }
+
+    // Output the error messages
+    bool skip = false;
+    for (size_t i = 0; i < N; ++i) {
+        const auto& vuidAndValidation = vuidsAndValidationFunctions[i];
+        const auto& error = errors[i];
+        if (!error.Empty()) {
+            skip |= checker.LogError(error.objlist, vuidAndValidation.vuid.data(), "%s", error.error_msg.c_str());
+        }
+    }
+
+    return skip;
+}

--- a/layers/core_checks/drawdispatch_validation.cpp
+++ b/layers/core_checks/drawdispatch_validation.cpp
@@ -19,6 +19,7 @@
 
 #include "chassis.h"
 #include "core_checks/core_validation.h"
+#include "buffer_address_validation.h"
 
 // clang-format off
 struct DispatchVuidsCmdDraw : DrawDispatchVuid {
@@ -2537,7 +2538,7 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(bool isIndirect, VkCommandBuffer comman
     bool skip = ValidateCmdDrawType(*cb_state, true, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, CMD_TRACERAYSKHR);
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
     const PIPELINE_STATE *pipeline_state = cb_state->lastBound[lv_bind_point].pipeline_state;
-    const char *rt_func_name = isIndirect ? "vkCmdTraceRaysIndirectKHR" : "vkCmdTraceRaysKHR";
+    const char *rt_func_name = isIndirect ? "vkCmdTraceRaysIndirectKHR()" : "vkCmdTraceRaysKHR()";
 
     if (!pipeline_state || (pipeline_state && !pipeline_state->pipeline())) {
         const char *vuid = isIndirect ? "VUID-vkCmdTraceRaysIndirectKHR-None-02700" : "VUID-vkCmdTraceRaysKHR-None-02700";

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -66,6 +66,11 @@ struct LogObjectList {
         (..., add(objects));
     }
 
+    [[nodiscard]] auto size() const { return object_list.size(); }
+    [[nodiscard]] auto empty() const { return object_list.empty(); }
+    [[nodiscard]] auto begin() const { return object_list.begin(); }
+    [[nodiscard]] auto end() const { return object_list.end(); }
+
     LogObjectList(){};
 };
 

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -351,6 +351,12 @@ class BINDABLE : public BASE_NODE {
 
         return !HasFullRangeBound();
     }
+
+    bool IsMemoryBound() const {
+        const auto mem_state = MemState();
+        return mem_state && !mem_state->Destroyed();
+    }
+
     void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) override {
         need_to_recache_invalid_memory_ = true;
         BASE_NODE::NotifyInvalidate(invalid_nodes, unlink);

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1567,7 +1567,7 @@ class ValidationStateTracker : public ValidationObject {
     };
     std::vector<DeviceQueueInfo> device_queue_info_list;
     // If vkGetBufferDeviceAddress is called, keep track of buffer <-> address mapping.
-    sparse_container::range_map<VkDeviceAddress, std::vector<std::shared_ptr<BUFFER_STATE>>> buffer_address_map_;
+    sparse_container::range_map<VkDeviceAddress, small_vector<std::shared_ptr<BUFFER_STATE>, 1, size_t>> buffer_address_map_;
     mutable std::shared_mutex buffer_address_lock_;
 
     vl_concurrent_unordered_map<uint64_t, VkFormatFeatureFlags2KHR> ahb_ext_formats_map;

--- a/tests/negative/ray_tracing.cpp
+++ b/tests/negative/ray_tracing.cpp
@@ -1607,8 +1607,6 @@ TEST_F(VkLayerTest, RayTracingBuffersAndBufferDeviceAddressesMapping) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    const auto vkGetBufferDeviceAddressKHR = GetDeviceProcAddr<PFN_vkGetBufferDeviceAddressKHR>("vkGetBufferDeviceAddressKHR");
-
     // Allocate common buffer memory
     auto alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
@@ -1644,10 +1642,8 @@ TEST_F(VkLayerTest, RayTracingBuffersAndBufferDeviceAddressesMapping) {
 
         // Those calls to vkGetBufferDeviceAddressKHR will internally record vbo and ibo device addresses
         {
-            VkBufferDeviceAddressInfo addr_info = {VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, nullptr, vbo.handle()};
-            const VkDeviceAddress vbo_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &addr_info);
-            addr_info.buffer = ibo.handle();
-            const VkDeviceAddress ibo_address = vkGetBufferDeviceAddressKHR(m_device->handle(), &addr_info);
+            const VkDeviceAddress vbo_address = vbo.address(DeviceValidationVersion());
+            const VkDeviceAddress ibo_address = ibo.address(DeviceValidationVersion());
             if (vbo_address != ibo_address) {
                 GTEST_SKIP()
                     << "Bounding two buffers to the same memory location does not result in identical buffer device addresses";


### PR DESCRIPTION
This PR aims at fixing the remaining validation done to buffers obtained through a call to `GetBuffersByAddress`. I also updated `CoreChecks::ValidateRaytracingShaderBindingTable`. To help do this validation, a new helper class is introduced, `BufferAddressValidation`. I explained the problem it tries to solve right above its definition. Copy pasting here for convenience:

### Comment above `BufferAddressValidation` definition:
`BufferAddressValidation`class aims at helping with the validation of a family of VUIDs referring to the same buffer device address. For example, take those VUIDs for VkDescriptorBufferBindingInfoEXT:
*VUID-VkDescriptorBufferBindingInfoEXT-usage-08122*
> If usage includes VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT, address must be an address within a valid buffer that was
   created with VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT

*VUID-VkDescriptorBufferBindingInfoEXT-usage-08123*
> If usage includes VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, address must be an address within a valid buffer that was
   created with VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT

*VUID-VkDescriptorBufferBindingInfoEXT-usage-08124*
> If usage includes VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT, address must be an address within a valid buffer that was 
   created with VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT

For usage to be valid, since the mentioned address can refer to multiple buffers, one must find a buffer that satisfies *all* of them. One must *not* consider those VUIDs independantly, each time trying to find a buffer that satisfies the considered VUID but not necessarily the others in the family.
The VVL heuristic wants that the vast majority of the time, functions calls and structures are valid, thus validation should be fast and avoid to do things related to error logging unless necessary. To comply with that, buffer address validation is done in two passes: one to look for a buffer satisfying all VUIDs of the considered family. If none is found, another pass is done, this time building a per VUID error message (not per buffer) regrouping all buffers violating it. Outputting for each buffer every VUID it violates would lead to unnecessary log clutter. This two pass process is tedious to do without an helper class, hence BufferAddressValidation was created. The idea is to ask for user to provide the only necessary data: a VUID, how it is validated, what to log when a buffer violates it, and a snippet of text appended to the error message header. Then, just a call to `BufferAddressValidation::LogErrorsIfNoValidBuffer` is needed to do validation and, eventually, error logging.

For an example of how to use `BufferAddressValidation`, see for instance how "VUID-VkDescriptorBufferBindingInfoEXT-usage-08122" and friends are validated.

### For reviewers:
1) I strongly advice using split view for the diff, since I totally replaced chunks of code unified view does not really help visualise the difference here.
2) I added a `resize` method in `small_vector`, it probably needs some eyes
