### PR TITLE
layers: Fix check for VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT

### DIFF
--- a/layers/core_validation.cpp
+++ b/layers/core_validation.cpp
@@ -487,7 +487,7 @@ bool CoreChecks::ValidateDrawDynamicState(const CMD_BUFFER_STATE &cb_state, cons
 
     // vkCmdSetDiscardRectangleEXT needs to be set on each rectangle
     const auto *discard_rectangle_state = LvlFindInChain<VkPipelineDiscardRectangleStateCreateInfoEXT>(pipeline.PNext());
-    if (discard_rectangle_state) {
+    if (discard_rectangle_state && pipeline.IsDynamic(VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT)) {
         for (uint32_t i = 0; i < discard_rectangle_state->discardRectangleCount; i++) {
             if (!cb_state.dynamic_state_value.discard_rectangles.test(i)) {
                 const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());


### PR DESCRIPTION
Fix bug were `dEQP-VK.draw.renderpass.discard_rectangles.inclusive_rect_1` was setting `VkPipelineDiscardRectangleStateCreateInfoEXT` but not `VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT` and the layers were still checking if the dynamic state was set

cc @Tony-LunarG 