### PR TITLE
tests: Fix jump to null function pointer

### DIFF
--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
- * Copyright (c) 2015-2022 Google, Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -10103,8 +10103,8 @@ TEST_F(VkLayerTest, ExtensionNotEnabled) {
         if (DeviceExtensionSupported(dev_ext)) {
             m_device_extension_names.push_back(dev_ext);
         } else {
-            printf("Did not find required device extension %s; skipped.\n", dev_ext);
-            break;
+            // Need to get out of the test now so that the subsequent code doesn't try to use an extension that isn't enabled.
+            GTEST_SKIP() << "Did not find required device extension: " << dev_ext;
         }
     }
 


### PR DESCRIPTION
Found on lavapipe 22.3.2.

Lavapipe doesn't support the VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION.

This test uses this extension by calling one of its functions to test the case where one of its dependent extensions isn't enabled.  The trouble with this is that if the sampler extension isn't supported, the test should not call the extension function and should skip the rest of the test.

This commit modifies the check for the extension to skip the test in this situation.