### PR TITLE
layers: Use fallthrough attribute and enable warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ endif()
 # Platform-specific compiler switches
 if(${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
     add_compile_options(-Wconversion
+                        -Wimplicit-fallthrough
 
                         # TODO These warnings also get turned on with -Wconversion in some versions of clang.
                         #      Leave off until further investigation.
@@ -213,12 +214,6 @@ if(${CMAKE_C_COMPILER_ID} MATCHES "(GNU|Clang)")
                         -fno-builtin-memcmp)
 
     set(CMAKE_C_STANDARD 99)
-
-    # For GCC version 7.1 or greater, we need to disable the implicit fallthrough warning since there's no consistent way to satisfy
-    # all compilers until they all accept the C++17 standard.
-    if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.1)
-        add_compile_options(-Wimplicit-fallthrough=0)
-    endif()
 elseif(MSVC)
     # Warn about nested declarations
     add_compile_options("/w34456")

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -5130,6 +5130,7 @@ bool BestPractices::PreCallValidateCreatePipelineLayout(VkDevice device, const V
                             break;
                         case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
                             descriptor_type_size = 1;
+                            break;
                         default:
                             // Unknown type.
                             break;

--- a/layers/buffer_validation.cpp
+++ b/layers/buffer_validation.cpp
@@ -2614,11 +2614,11 @@ static bool RegionIntersects(const RegionType *region0, const RegionType *region
         switch (type) {
             case VK_IMAGE_TYPE_3D:
                 result &= RangesIntersect(region0->srcOffset.z, region0->extent.depth, region1->dstOffset.z, region1->extent.depth);
-                // fall through
+                [[fallthrough]];
             case VK_IMAGE_TYPE_2D:
                 result &=
                     RangesIntersect(region0->srcOffset.y, region0->extent.height, region1->dstOffset.y, region1->extent.height);
-                // fall through
+                [[fallthrough]];
             case VK_IMAGE_TYPE_1D:
                 result &= RangesIntersect(region0->srcOffset.x, region0->extent.width, region1->dstOffset.x, region1->extent.width);
                 break;
@@ -2647,11 +2647,11 @@ static bool RegionIntersectsBlit(const RegionType *region0, const RegionType *re
             case VK_IMAGE_TYPE_3D:
                 result &= RangesIntersect(region0->srcOffsets[0].z, region0->srcOffsets[1].z - region0->srcOffsets[0].z,
                                           region1->dstOffsets[0].z, region1->dstOffsets[1].z - region1->dstOffsets[0].z);
-                // fall through
+                [[fallthrough]];
             case VK_IMAGE_TYPE_2D:
                 result &= RangesIntersect(region0->srcOffsets[0].y, region0->srcOffsets[1].y - region0->srcOffsets[0].y,
                                           region1->dstOffsets[0].y, region1->dstOffsets[1].y - region1->dstOffsets[0].y);
-                // fall through
+                [[fallthrough]];
             case VK_IMAGE_TYPE_1D:
                 result &= RangesIntersect(region0->srcOffsets[0].x, region0->srcOffsets[1].x - region0->srcOffsets[0].x,
                                           region1->dstOffsets[0].x, region1->dstOffsets[1].x - region1->dstOffsets[0].x);
@@ -2787,11 +2787,11 @@ bool CoreChecks::CheckItgExtent(const CMD_BUFFER_STATE &cb_state, const VkExtent
             case VK_IMAGE_TYPE_3D:
                 z_ok = ((0 == SafeModulo(extent->depth, granularity->depth)) ||
                         (subresource_extent->depth == offset_extent_sum.depth));
-                // fall through
+                [[fallthrough]];
             case VK_IMAGE_TYPE_2D:
                 y_ok = ((0 == SafeModulo(extent->height, granularity->height)) ||
                         (subresource_extent->height == offset_extent_sum.height));
-                // fall through
+                [[fallthrough]];
             case VK_IMAGE_TYPE_1D:
                 x_ok = ((0 == SafeModulo(extent->width, granularity->width)) ||
                         (subresource_extent->width == offset_extent_sum.width));

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -2206,7 +2206,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
                 *error_msg = error_str.str();
                 return false;
             }
-            // drop through
+            [[fallthrough]];
         case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER: {
             if (!(usage & VK_IMAGE_USAGE_SAMPLED_BIT)) {
                 error_usage_bit = "VK_IMAGE_USAGE_SAMPLED_BIT";
@@ -3265,7 +3265,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet *dest_set, const 
                 }
             }
         }
-        // Fall through
+        [[fallthrough]];
         case VK_DESCRIPTOR_TYPE_SAMPLER: {
             auto iter = dest_set->FindDescriptor(update->dstBinding, update->dstArrayElement);
             for (uint32_t di = 0; di < update->descriptorCount && !iter.AtEnd(); ++di, ++iter) {

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -99,6 +99,7 @@ void SetValidationEnable(CHECK_ENABLED &enable_data, const ValidationCheckEnable
             break;
         case VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT:
             enable_data[sync_validation_queue_submit] = true;
+            break;
         default:
             assert(true);
     }

--- a/layers/subresource_adapter.cpp
+++ b/layers/subresource_adapter.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2019-2022 The Khronos Group Inc.
- * Copyright (c) 2019-2022 Valve Corporation
- * Copyright (c) 2019-2022 LunarG, Inc.
- * Copyright (C) 2019-2022 Google Inc.
+/* Copyright (c) 2019-2023 The Khronos Group Inc.
+ * Copyright (c) 2019-2023 Valve Corporation
+ * Copyright (c) 2019-2023 LunarG, Inc.
+ * Copyright (C) 2019-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ uint32_t RangeEncoder::LowerBoundWithStartImpl2(VkImageAspectFlags aspect_mask, 
             if (aspect_mask & aspect_bits_[0]) {
                 return 0;
             }
-            // no break
+            [[fallthrough]];
         case 1:
             if (aspect_mask & aspect_bits_[1]) {
                 return 1;
@@ -98,12 +98,12 @@ uint32_t RangeEncoder::LowerBoundWithStartImpl3(VkImageAspectFlags aspect_mask, 
             if (aspect_mask & aspect_bits_[0]) {
                 return 0;
             }
-            // no break
+            [[fallthrough]];
         case 1:
             if ((aspect_mask & aspect_bits_[1])) {
                 return 1;
             }
-            // no break
+            [[fallthrough]];
         case 2:
             if ((aspect_mask & aspect_bits_[2])) {
                 return 2;

--- a/layers/vk_mem_alloc.h
+++ b/layers/vk_mem_alloc.h
@@ -29,6 +29,7 @@
 //    6/05/19 - Make changes to suppress warnings from clang 3.8.0
 //    6/05/19 - Make changes to suppress more warnings from GCC
 //   11/18/20 - Make changes to suppress warnings from clang
+//    1/12/23 - Make changes to suppress -Wimplicit-fallthrough warnings from GCC and clang
 // 
 //
 
@@ -2595,10 +2596,12 @@ VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wtype-limits"
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-compare"
 #pragma clang diagnostic ignored "-Wnullability-completeness"
+#pragma clang diagnostic ignored "-Wimplicit-fallthrough"
 #endif
 #if GCC_VERSION >= 80000
 #pragma GCC diagnostic ignored "-Wclass-memaccess"

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -5777,6 +5777,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxVertexOutputComponents) {
                 break;
             default:
                 assert(0);
+                [[fallthrough]];
             case 0:
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
                 break;
@@ -5953,6 +5954,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationControlInputOutputCompone
                 break;
             default:
                 assert(0);
+                [[fallthrough]];
             case 0:
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
                 break;
@@ -6073,6 +6075,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationEvaluationInputOutputComp
                 break;
             default:
                 assert(0);
+                [[fallthrough]];
             case 0:
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
                 break;
@@ -6182,6 +6185,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
                 break;
             default:
                 assert(0);
+                [[fallthrough]];
             case 0:
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
                 break;
@@ -6247,6 +6251,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxFragmentInputComponents) {
                 break;
             default:
                 assert(0);
+                [[fallthrough]];
             case 0:
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
                 break;


### PR DESCRIPTION
Enables `-Wimplicit-fallthrough` in both gcc and clang. 

`[[fallthrough]]`s and `break`s are added in a few places.

There are no compiler version checks regarding `-Wimplicit-fallthrough` support. The assumption that this warning is supported by GCC/Clang versions that support C++17/`[[fallthrough]]`.

closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4809
