### PR TITLE
layers: Fix GCC release build with -Werror

### DIFF
--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -79,7 +79,7 @@ struct InterfaceVariable {
 
     DecorationSet decorations;
     bool descriptor{false};  // if interfacing with descriptors
-    VkShaderStageFlagBits stage;
+    VkShaderStageFlagBits stage{VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM};
 
     // List of samplers that sample a given image. The index of array is index of image.
     std::vector<layer_data::unordered_set<SamplerUsedByImage>> samplers_used_by_image;


### PR DESCRIPTION
Fixes a warning on gcc 12.2 when building release with -Werror.