### PR TITLE
layers: Check pipeline state for 06053 and 06054

### DIFF
--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -2862,7 +2862,8 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE &
         const auto raster_state = pipeline.RasterizationState();
         const bool has_rasterization = raster_state && (raster_state->rasterizerDiscardEnable == VK_FALSE);
         if (has_rasterization) {
-            if (((rendering_struct->depthAttachmentFormat != VK_FORMAT_UNDEFINED) ||
+            if (pipeline.fragment_shader_state && pipeline.fragment_output_state &&
+                ((rendering_struct->depthAttachmentFormat != VK_FORMAT_UNDEFINED) ||
                  (rendering_struct->stencilAttachmentFormat != VK_FORMAT_UNDEFINED)) &&
                 !pipeline.DepthStencilState()) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06053",
@@ -2873,7 +2874,7 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE &
                                  string_VkFormat(rendering_struct->stencilAttachmentFormat));
             }
 
-            if ((rendering_struct->colorAttachmentCount != 0) && !color_blend_state &&
+            if (pipeline.fragment_output_state && (rendering_struct->colorAttachmentCount != 0) && !color_blend_state &&
                 pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass == VK_NULL_HANDLE) {
                 skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06054",
                                  "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -385,7 +385,8 @@ void Device::wait() { EXPECT(vk::DeviceWaitIdle(handle()) == VK_SUCCESS); }
 
 VkResult Device::wait(const std::vector<const Fence *> &fences, bool wait_all, uint64_t timeout) {
     const std::vector<VkFence> fence_handles = MakeVkHandles<VkFence>(fences);
-    VkResult err = vk::WaitForFences(handle(), static_cast<uint32_t>(fence_handles.size()), fence_handles.data(), wait_all, timeout);
+    VkResult err =
+        vk::WaitForFences(handle(), static_cast<uint32_t>(fence_handles.size()), fence_handles.data(), wait_all, timeout);
     EXPECT(err == VK_SUCCESS || err == VK_TIMEOUT);
 
     return err;


### PR DESCRIPTION
The spec says:

```
VUID-VkGraphicsPipelineCreateInfo-renderPass-06053
If renderPass is VK_NULL_HANDLE, the pipeline is being created with fragment shader state and fragment output interface state, and either of VkPipelineRenderingCreateInfo::depthAttachmentFormat or VkPipelineRenderingCreateInfo::stencilAttachmentFormat are not VK_FORMAT_UNDEFINED, pDepthStencilState must be....
```
```
VUID-VkGraphicsPipelineCreateInfo-renderPass-06054
If renderPass is VK_NULL_HANDLE, the pipeline is being created with fragment output interface state, and VkPipelineRenderingCreateInfo::colorAttachmentCount is not equal to 0, pColorBlendState must be .....
```

