### PR TITLE
Fix test issues encountered using Swiftshader

### DIFF
--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -2065,6 +2065,9 @@ TEST_F(VkPositiveLayerTest, FenceSemThreadRace) {
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (IsDriver(VK_DRIVER_ID_GOOGLE_SWIFTSHADER)) {
+        GTEST_SKIP() << "This test hangs on SwiftShader.";
+    }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -8280,7 +8280,12 @@ TEST_F(VkLayerTest, ExerciseGetImageSubresourceLayout) {
         VkFormat format = VK_FORMAT_D32_SFLOAT;
         VkFormatProperties image_format_properties;
         vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), format, &image_format_properties);
-        if ((image_format_properties.linearTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) > 0) {
+        VkImageFormatProperties format_limits{};
+        VkResult result =
+            vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_LINEAR,
+                                                       VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0, &format_limits);
+        if ((result == VK_SUCCESS) &&
+            ImageFormatAndFeaturesSupported(gpu(), format, VK_IMAGE_TILING_LINEAR, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
             VkImageObj img(m_device);
             img.InitNoLayout(32, 32, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
 
@@ -8298,7 +8303,12 @@ TEST_F(VkLayerTest, ExerciseGetImageSubresourceLayout) {
         VkFormat format = VK_FORMAT_S8_UINT;
         VkFormatProperties image_format_properties;
         vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), format, &image_format_properties);
-        if ((image_format_properties.linearTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) > 0) {
+        VkImageFormatProperties format_limits{};
+        VkResult result =
+            vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_LINEAR,
+                                                       VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0, &format_limits);
+        if ((result == VK_SUCCESS) &&
+            ImageFormatAndFeaturesSupported(gpu(), format, VK_IMAGE_TILING_LINEAR, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
             VkImageObj img(m_device);
             img.InitNoLayout(32, 32, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
 
@@ -14354,7 +14364,7 @@ TEST_F(VkLayerTest, InvalidMultiSampleImageView) {
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     VkImageFormatProperties image_format_properties;
-    vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), image_create_info.format, image_create_info.imageType,
+    vk::GetPhysicalDeviceImageFormatProperties(gpu(), image_create_info.format, image_create_info.imageType,
                                                image_create_info.tiling, image_create_info.usage, image_create_info.flags,
                                                &image_format_properties);
 

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -11243,10 +11243,15 @@ TEST_F(VkLayerTest, CreateImageYcbcrFormats) {
 
     // invalid imageType
     image_create_info.imageType = VK_IMAGE_TYPE_1D;
-    // Can't just set height to 1 as stateless valdiation will hit 04713 first
-    m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-imageType-00956");
-    m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-extent-02253");
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-06412");
+    // Check that image format is valid
+    if (vk::GetPhysicalDeviceImageFormatProperties(gpu(), mp_format, image_create_info.imageType, image_create_info.tiling,
+                                                   image_create_info.usage, image_create_info.flags,
+                                                   &image_format_props) == VK_SUCCESS) {
+        // Can't just set height to 1 as stateless validation will hit 04713 first
+        m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-imageType-00956");
+        m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-extent-02253");
+        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-06412");
+    }
     image_create_info = reset_create_info;
 
     // Test using a format that doesn't support disjoint

--- a/tests/vklayertests_dynamic_rendering.cpp
+++ b/tests/vklayertests_dynamic_rendering.cpp
@@ -6104,6 +6104,10 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingDepthStenci
 
     VkImageObj image(m_device);
     auto depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+    if (depth_stencil_format == VK_FORMAT_D32_SFLOAT_S8_UINT) {
+        GTEST_SKIP() << "Insufficient depth-stencil formats supported";
+    }
+
     image.Init(32, 32, 1, depth_stencil_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView imageView = image.targetView(depth_stencil_format, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 

--- a/tests/vklayertests_dynamic_rendering.cpp
+++ b/tests/vklayertests_dynamic_rendering.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
  * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (c) 2015-2022 Google, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2021-2022 ARM, Inc. All rights reserved.
@@ -738,6 +738,10 @@ TEST_F(VkLayerTest, DynamicRenderingGraphicsPipelineCreateInfo) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+
+    if (m_device->props.limits.maxGeometryOutputVertices == 0) {
+        GTEST_SKIP() << "Device doesn't support required maxGeometryOutputVertices";
+    }
 
     const VkPipelineLayoutObj pl(m_device);
     VkPipelineObj pipe(m_device);

--- a/tests/vklayertests_nvidia_best_practices.cpp
+++ b/tests/vklayertests_nvidia_best_practices.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (c) 2022 NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -660,6 +660,10 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_SwitchTessGeometryMesh)
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+
+    if (m_device->props.limits.maxGeometryOutputVertices <= 3) {
+        GTEST_SKIP() << "Device doesn't support requried maxGeometryOutputVertices";
+    }
 
     char const *vsSource = R"glsl(
         #version 450

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -8043,20 +8043,21 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
 
     vk::CmdEndRenderPass(commandBuffer.handle());
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewportWithCount-viewportCount-03394");
-    m_errorMonitor->SetUnexpectedError("VUID-vkCmdSetViewportWithCount-viewportCount-arraylength");
-    VkViewport viewport2 = {
-        0, 0, 1, 1, 0.0f, 0.0f,
-    };
-    vkCmdSetViewportWithCountEXT(commandBuffer.handle(), 0, &viewport2);
-    m_errorMonitor->VerifyFound();
-    if (vulkan_13) {
+    if (features2.features.multiViewport) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewportWithCount-viewportCount-03394");
         m_errorMonitor->SetUnexpectedError("VUID-vkCmdSetViewportWithCount-viewportCount-arraylength");
-        vkCmdSetViewportWithCount(commandBuffer.handle(), 0, &viewport2);
+        VkViewport viewport2 = {
+            0, 0, 1, 1, 0.0f, 0.0f,
+        };
+        vkCmdSetViewportWithCountEXT(commandBuffer.handle(), 0, &viewport2);
         m_errorMonitor->VerifyFound();
+        if (vulkan_13) {
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewportWithCount-viewportCount-03394");
+            m_errorMonitor->SetUnexpectedError("VUID-vkCmdSetViewportWithCount-viewportCount-arraylength");
+            vkCmdSetViewportWithCount(commandBuffer.handle(), 0, &viewport2);
+            m_errorMonitor->VerifyFound();
+        }
     }
-
     {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCount-offset-03400");
         VkRect2D scissor2 = {{1, 0}, {INT32_MAX, 16}};
@@ -8081,15 +8082,17 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
         }
     }
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCount-scissorCount-03397");
-    m_errorMonitor->SetUnexpectedError("VUID-vkCmdSetScissorWithCount-scissorCount-arraylength");
-    vkCmdSetScissorWithCountEXT(commandBuffer.handle(), 0, 0);
-    m_errorMonitor->VerifyFound();
-    if (vulkan_13) {
+    if (features2.features.multiViewport) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCount-scissorCount-03397");
         m_errorMonitor->SetUnexpectedError("VUID-vkCmdSetScissorWithCount-scissorCount-arraylength");
-        vkCmdSetScissorWithCount(commandBuffer.handle(), 0, 0);
+        vkCmdSetScissorWithCountEXT(commandBuffer.handle(), 0, 0);
         m_errorMonitor->VerifyFound();
+        if (vulkan_13) {
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCount-scissorCount-03397");
+            m_errorMonitor->SetUnexpectedError("VUID-vkCmdSetScissorWithCount-scissorCount-arraylength");
+            vkCmdSetScissorWithCount(commandBuffer.handle(), 0, 0);
+            m_errorMonitor->VerifyFound();
+        }
     }
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCount-x-03399");

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -14857,6 +14857,12 @@ TEST_F(VkLayerTest, IncompatibleScissorCountAndViewportCount) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
+    VkPhysicalDeviceFeatures features{};
+    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    if (features.multiViewport == false) {
+        GTEST_SKIP() << "multiViewport feature not supported by device";
+    }
+
     VkViewport viewports[2] = {{0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f}};
 
     auto set_viewport_state_createinfo = [&](CreatePipelineHelper &helper) {

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -10780,6 +10780,10 @@ TEST_F(VkLayerTest, ValidateGeometryShaderEnabled) {
     ASSERT_NO_FATAL_FAILURE(Init(&deviceFeatures));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
+    if (m_device->props.limits.maxGeometryOutputVertices == 0) {
+        GTEST_SKIP() << "Device doesn't support geometry shaders";
+    }
+
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj gs(this, bindStateGeomShaderText, VK_SHADER_STAGE_GEOMETRY_BIT);
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -450,10 +450,13 @@ TEST_F(VkLayerTest, PrimitiveTopologyListRestart) {
 
     topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-06252");
-    topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                      std::vector<string>{"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-06253",
-                                                          "VUID-VkGraphicsPipelineCreateInfo-topology-00737"});
+
+    if (m_device->phy().features().tessellationShader) {
+        topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
+        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
+                                          std::vector<string>{"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-06253",
+                                                              "VUID-VkGraphicsPipelineCreateInfo-topology-00737"});
+    }
 }
 
 TEST_F(VkLayerTest, PointSizeGeomShaderDontWrite) {


### PR DESCRIPTION
Using swiftshader as the ICD on Windows, running the validation tests generated errors, hangs, or  crashes on the following tests:

- VkNvidiaBestPracticesLayerTest.BindPipeline_SwitchTessGeometryMesh
- VkPositiveLayerTest.FenceSemThreadRace
- VkLayerTest.ExerciseGetImageSubresourceLayout
- VkLayerTest.CreateImageYcbcrFormats
- VkLayerTest.ResolveInvalidUsage  
- VkLayerTest.DynamicRenderingGraphicsPipelineCreateInfo
- VkLayerTest.DynamicRenderingAndExecuteCommandsWithMismatchingDepthStencilImageViewFormat
- VkLayerTest.ValidateExtendedDynamicStateEnabled
- VkLayerTest.PrimitiveTopologyListRestart
- VkLayerTest.ValidateGeometryShaderEnabled
- VkLayerTest.IncompatibleScissorCountAndViewportCount