### PR TITLE
layers: Label VkStridedDeviceAddressRegionKHR 04631 VU

### DIFF
--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -82,8 +82,6 @@
 
 [[maybe_unused]] static const char *kVUID_Core_invalidDepthStencilFormat = "UNASSIGNED-CoreValidation-depthStencil-format";
 
-[[maybe_unused]] static const char *kVUID_Core_DeviceAddress_NoAssociatedBuffer = "UNASSIGNED-CoreValidation-VkDeviceAddress-NoAssociatedBuffer";
-
 // clang-format on
 
 #undef DECORATE_UNUSED

--- a/layers/drawdispatch.cpp
+++ b/layers/drawdispatch.cpp
@@ -2239,7 +2239,7 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuf
 
     const auto buffer_states = GetBuffersByAddress(binding_table.deviceAddress);
     if (buffer_states.empty()) {
-        skip |= LogError(device, kVUID_Core_DeviceAddress_NoAssociatedBuffer,
+        skip |= LogError(device, "VUID-VkStridedDeviceAddressRegionKHR-size-04631",
                          "%s: no buffer is associated with %s->deviceAddress (0x%" PRIx64 ").", rt_func_name, binding_table_name,
                          binding_table.deviceAddress);
     } else {


### PR DESCRIPTION
as discussed in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5635#note_392038 this should just be `VUID-VkStridedDeviceAddressRegionKHR-size-04631` (it is not uncommon to have more than one spot produce the same VUID)