### PR TITLE
build: Remove VS2015 support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -195,7 +195,7 @@ cmake -S . -B build/ --preset dev
 - Microsoft [Visual Studio](https://www.visualstudio.com/)
   - Versions
     - [2022](https://www.visualstudio.com/vs/downloads/)
-    - [2015-2019](https://www.visualstudio.com/vs/older-downloads/)
+    - [2017-2019](https://www.visualstudio.com/vs/older-downloads/)
   - The Community Edition of each of the above versions is sufficient, as
     well as any more capable edition.
 - [CMake 3.17.2](https://cmake.org/files/v3.17/cmake-3.17.2-win64-x64.zip) is the minimum CMake version supported.  [CMake 3.19.3](https://cmake.org/files/v3.19/cmake-3.19.3-win64-x64.zip) is recommended.
@@ -413,8 +413,7 @@ Follow the setup steps for Linux or OSX above, then from your terminal:
 
 #### Windows
 
-Follow the setup steps for Windows above, then from Developer Command Prompt
-for VS2015:
+Follow the setup steps for Windows above, then from the Developer Command Prompt:
 
     cd build-android
     update_external_sources_android.bat

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -94,9 +94,6 @@ if(MSVC)
     add_compile_options("/bigobj")
     add_compile_options("/we4189")
     add_compile_options("/we5038")
-    # Turn off transitional "changed behavior" warning message for Visual Studio versions prior to 2015. The changed behavior is
-    # that constructor initializers are now fixed to clear the struct members.
-    add_compile_options("$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19>>:/wd4351>")
 else()
     add_compile_options(-Wpointer-arith -Wno-unused-function -Wno-sign-compare)
 endif()
@@ -276,8 +273,6 @@ endif()
 # Khronos validation additional dependencies
 if (USE_ROBIN_HOOD_HASHING)
     target_link_libraries(VkLayer_khronos_validation PRIVATE robin_hood::robin_hood)
-    # This warning produces what look like false positives in robin_hood.h with Visual Studio 2015
-    target_compile_options(VkLayer_khronos_validation PRIVATE "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,19.1>>:/wd4996>")
 endif()
 # Order matters here. VkLayer_utils should be the last link library to ensure mimalloc overrides are picked up correctly.
 # Otherwise, libraries after VkLayer_utils will not benefit from this performance improvement.

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2022 The Khronos Group Inc.
  * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,44 +22,11 @@
 
 #include "vktestframework.h"
 #include "vkrenderframework.h"
-#include <filesystem>
-
-// For versions prior to VS 2015, suppress the warning
-// caused by the inconsistent redefinition of snprintf
-// between a vulkan header and a glslang header.
-#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
-#pragma warning(push)
-#pragma warning(disable : 4005)
-#endif
-// TODO FIXME remove this once glslang doesn't define this
-#undef BadValue
 #include "glslang/SPIRV/GlslangToSpv.h"
 #include "glslang/SPIRV/SPVRemapper.h"
-#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/)
-#pragma warning(pop)
-#endif
-#include <limits.h>
+#include <filesystem>
+#include <climits>
 #include <cmath>
-
-#if defined(PATH_MAX) && !defined(MAX_PATH)
-#define MAX_PATH PATH_MAX
-#endif
-
-#ifdef _WIN32
-#define ERR_EXIT(err_msg, err_class)                 \
-    do {                                             \
-        MessageBox(NULL, err_msg, err_class, MB_OK); \
-        exit(1);                                     \
-    } while (0)
-#else  // _WIN32
-
-#define ERR_EXIT(err_msg, err_class) \
-    do {                             \
-        printf(err_msg);             \
-        fflush(stdout);              \
-        exit(1);                     \
-    } while (0)
-#endif  // _WIN32
 
 // Command-line options
 enum TOptions {


### PR DESCRIPTION
> VS2015 is no longer supported

Here is my source in case someone needs it:
https://www.lunarg.com/wp-content/uploads/2023/01/Progress-Report-DEC2021-Vulkan-Ecosystem-Survey-Public-Report.pdf

> Deprecate Visual Studio 2015 - Completed
a. SDK and several repositories will no longer build, test, and support VS2015