### PR TITLE
Make separate Interface Variables 

### DIFF
--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1385,9 +1385,10 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
         bool accesses_2d = false;
         for (const InterfaceVariable& variable : *interface_variables) {
             auto dim = module_state->GetShaderResourceDimensionality(variable);
-            if (dim < 0) continue;
-            auto spvdim = spv::Dim(dim);
-            if (spvdim != spv::Dim1D && spvdim != spv::DimBuffer) accesses_2d = true;
+            if (dim != spv::Dim1D && dim != spv::DimBuffer) {
+                accesses_2d = true;
+                break;
+            }
         }
 
         if (accesses_2d && dimensions < 2) {

--- a/layers/best_practices_utils.cpp
+++ b/layers/best_practices_utils.cpp
@@ -1370,8 +1370,8 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
                                       kThreadGroupDispatchCountAlignmentArm);
     }
 
-    auto interface_variables = module_state->GetInterfaceVariable(entrypoint);
-    if (interface_variables) {
+    auto variables = module_state->GetResourceInterfaceVariable(entrypoint);
+    if (variables) {
         unsigned dimensions = 0;
         if (x > 1) dimensions++;
         if (y > 1) dimensions++;
@@ -1383,7 +1383,7 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
         // There are some false positives here. We could simply have a shader that does this within a 1D grid,
         // or we may have a linearly tiled image, but these cases are quite unlikely in practice.
         bool accesses_2d = false;
-        for (const InterfaceVariable& variable : *interface_variables) {
+        for (const auto& variable : *variables) {
             auto dim = module_state->GetShaderResourceDimensionality(variable);
             if (dim != spv::Dim1D && dim != spv::DimBuffer) {
                 accesses_2d = true;

--- a/layers/descriptor_validation.cpp
+++ b/layers/descriptor_validation.cpp
@@ -880,7 +880,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
             for (const auto &desc_index : binding_info.second.samplers_used_by_image[index]) {
                 const auto *desc =
                     context.descriptor_set.GetDescriptorFromBinding(desc_index.sampler_slot.binding, desc_index.sampler_index);
-                // TODO: This check _shouldn't_ be necessary due to the checks made in FindVariableDescriptorType in
+                // TODO: This check _shouldn't_ be necessary due to the checks made in ResourceInterfaceVariable() in
                 //       shader_validation.cpp. However, without this check some traces still crash.
                 if (desc && (desc->GetClass() == cvdescriptorset::DescriptorClass::PlainSampler)) {
                     const auto *sampler_state = static_cast<const cvdescriptorset::SamplerDescriptor *>(desc)->GetSamplerState();
@@ -1079,7 +1079,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                     if (!stage.descriptor_variables) {
                         continue;
                     }
-                    for (const InterfaceVariable &variable : *stage.descriptor_variables) {
+                    for (const auto &variable : *stage.descriptor_variables) {
                         if (variable.decorations.set == set_index && variable.decorations.binding == binding) {
                             descriptor_writable |= variable.is_writable;
                             descriptor_readable |= variable.is_readable | variable.is_sampler_implicitLod_dref_proj;

--- a/layers/pipeline_state.cpp
+++ b/layers/pipeline_state.cpp
@@ -58,13 +58,13 @@ PipelineStageState::PipelineStageState(const safe_VkPipelineShaderStageCreateInf
       writes_to_gl_layer(module_state->WritesToGlLayer()),
       has_input_attachment_capability(module_state->HasInputAttachmentCapability()) {
     if (entrypoint) {
-        descriptor_variables = module_state->GetInterfaceVariable(*entrypoint);
+        descriptor_variables = module_state->GetResourceInterfaceVariable(*entrypoint);
         if (descriptor_variables) {
             has_writable_descriptor = std::any_of(descriptor_variables->begin(), descriptor_variables->end(),
-                                                  [](const InterfaceVariable &variable) { return variable.is_writable; });
+                                                  [](const auto &variable) { return variable.is_writable; });
 
             has_atomic_descriptor = std::any_of(descriptor_variables->begin(), descriptor_variables->end(),
-                                                [](const InterfaceVariable &variable) { return variable.is_atomic_operation; });
+                                                [](const auto &variable) { return variable.is_atomic_operation; });
         }
         wrote_primitive_shading_rate = WrotePrimitiveShadingRate(stage_flag, *entrypoint, module_state.get());
     }
@@ -158,7 +158,7 @@ PIPELINE_STATE::ActiveSlotMap PIPELINE_STATE::GetActiveSlots(const StageStateVec
             continue;
         }
         // Capture descriptor uses for the pipeline
-        for (const InterfaceVariable &variable : *stage.descriptor_variables) {
+        for (const auto &variable : *stage.descriptor_variables) {
             // While validating shaders capture which slots are used by the pipeline
             auto &entry = active_slots[variable.decorations.set][variable.decorations.binding];
             entry.is_writable |= variable.is_writable;

--- a/layers/pipeline_state.h
+++ b/layers/pipeline_state.h
@@ -87,7 +87,7 @@ extern DescriptorReqFlags DescriptorRequirementsBitsFromFormat(VkFormat fmt);
 struct DescriptorRequirement {
     DescriptorReqFlags reqs;
     bool is_writable;
-    // Copy from StageState.InterfaceVariable. It combines from plural shader stages. The index of array is index of image.
+    // Copy from StageState.ResourceInterfaceVariable. It combines from plural shader stages. The index of array is index of image.
     std::vector<layer_data::unordered_set<SamplerUsedByImage>> samplers_used_by_image;
     // For storage images - list of < OpImageWrite : Texel component length >
     std::vector<std::pair<Instruction, uint32_t>> write_without_formats_component_count_list;
@@ -106,7 +106,7 @@ struct PipelineStageState {
     const safe_VkPipelineShaderStageCreateInfo *create_info;
     VkShaderStageFlagBits stage_flag;
     std::optional<Instruction> entrypoint;
-    const std::vector<InterfaceVariable> *descriptor_variables;
+    const std::vector<ResourceInterfaceVariable> *descriptor_variables;
     bool has_writable_descriptor;
     bool has_atomic_descriptor;
     bool wrote_primitive_shading_rate;

--- a/layers/shader_module.cpp
+++ b/layers/shader_module.cpp
@@ -716,9 +716,8 @@ uint32_t SHADER_MODULE_STATE::GetConstantValueById(uint32_t id) const {
     return value->GetConstantValue();
 }
 
-// Returns an int32_t corresponding to the spv::Dim of the given resource, when positive, and corresponding to an unknown type, when
-// negative.
-int32_t SHADER_MODULE_STATE::GetShaderResourceDimensionality(const InterfaceVariable& resource) const {
+// Returns spv::Dim of the given OpVariable
+spv::Dim SHADER_MODULE_STATE::GetShaderResourceDimensionality(const InterfaceVariable& resource) const {
     const Instruction* type = FindDef(resource.type_id);
     while (true) {
         switch (type->Opcode()) {
@@ -729,9 +728,9 @@ int32_t SHADER_MODULE_STATE::GetShaderResourceDimensionality(const InterfaceVari
                 type = FindDef(type->Word(3));
                 break;
             case spv::OpTypeImage:
-                return type->Word(3);
+                return spv::Dim(type->Word(3));
             default:
-                return -1;
+                return spv::DimMax;
         }
     }
 }

--- a/layers/shader_module.h
+++ b/layers/shader_module.h
@@ -352,7 +352,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     const Instruction *GetConstantDef(uint32_t id) const;
     uint32_t GetConstantValueById(uint32_t id) const;
-    int32_t GetShaderResourceDimensionality(const InterfaceVariable &resource) const;
+    spv::Dim GetShaderResourceDimensionality(const InterfaceVariable &resource) const;
     uint32_t GetLocationsConsumedByType(uint32_t type, bool strip_array_level) const;
     uint32_t GetComponentsConsumedByType(uint32_t type, bool strip_array_level) const;
     uint32_t GetFundamentalType(uint32_t type) const;

--- a/layers/synchronization_validation.cpp
+++ b/layers/synchronization_validation.cpp
@@ -666,7 +666,7 @@ ResourceAccessRange GetBufferRange(VkDeviceSize offset, VkDeviceSize buf_whole_s
 }
 
 SyncStageAccessIndex GetSyncStageAccessIndexsByDescriptorSet(VkDescriptorType descriptor_type,
-                                                             const InterfaceVariable &interface_var,
+                                                             const ResourceInterfaceVariable &variable,
                                                              VkShaderStageFlagBits stage_flag) {
     if (descriptor_type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) {
         assert(stage_flag == VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -683,7 +683,7 @@ SyncStageAccessIndex GetSyncStageAccessIndexsByDescriptorSet(VkDescriptorType de
     // If the desriptorSet is writable, we don't need to care SHADER_READ. SHADER_WRITE is enough.
     // Because if write hazard happens, read hazard might or might not happen.
     // But if write hazard doesn't happen, read hazard is impossible to happen.
-    if (interface_var.is_writable) {
+    if (variable.is_writable) {
         return stage_access->second.storage_write;
     } else if (descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
                descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
@@ -2142,7 +2142,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
         } else if (!stage_state.descriptor_variables) {
             continue;
         }
-        for (const InterfaceVariable &variable : *stage_state.descriptor_variables) {
+        for (const auto &variable : *stage_state.descriptor_variables) {
             const auto *descriptor_set = (*per_sets)[variable.decorations.set].bound_descriptor_set.get();
             if (!descriptor_set) continue;
             auto binding = descriptor_set->GetBinding(variable.decorations.binding);
@@ -2276,7 +2276,7 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
         } else if (!stage_state.descriptor_variables) {
             continue;
         }
-        for (const InterfaceVariable &variable : *stage_state.descriptor_variables) {
+        for (const auto &variable : *stage_state.descriptor_variables) {
             const auto *descriptor_set = (*per_sets)[variable.decorations.set].bound_descriptor_set.get();
             if (!descriptor_set) continue;
             auto binding = descriptor_set->GetBinding(variable.decorations.binding);


### PR DESCRIPTION
Split `InterfaceVariables` into both `UserDefinedInterfaceVariable` and `ResourceInterfaceVariable` as they are used differently. Moved more logic into `ResourceInterfaceVariable` constructor which is done at `Entrypoint` creation time now once