### PR TITLE
Log VUIDs using a string_view

### DIFF
--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -300,7 +300,7 @@ static inline LogMessageTypeFlags DebugAnnotFlagsToMsgTypeFlags(VkDebugUtilsMess
 }
 
 VKAPI_ATTR bool LogMsg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
-                       const std::string &vuid_text, const char *format, va_list argptr);
+                       std::string_view vuid_text, const char *format, va_list argptr);
 
 VKAPI_ATTR VkResult LayerCreateMessengerCallback(debug_report_data *debug_data, bool default_callback,
                                                  const VkDebugUtilsMessengerCreateInfoEXT *create_info,

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -4033,7 +4033,7 @@ class ValidationObject {
         }
 
         // Debug Logging Helpers
-        bool DECORATE_PRINTF(4, 5) LogError(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
+        bool DECORATE_PRINTF(4, 5) LogError(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
             va_list argptr;
             va_start(argptr, format);
             const bool result = LogMsg(report_data, kErrorBit, objlist, vuid_text, format, argptr);
@@ -4041,7 +4041,7 @@ class ValidationObject {
             return result;
         }
 
-        bool DECORATE_PRINTF(4, 5) LogWarning(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
+        bool DECORATE_PRINTF(4, 5) LogWarning(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
             va_list argptr;
             va_start(argptr, format);
             const bool result = LogMsg(report_data, kWarningBit, objlist, vuid_text, format, argptr);
@@ -4049,7 +4049,7 @@ class ValidationObject {
             return result;
         }
 
-        bool DECORATE_PRINTF(4, 5) LogPerformanceWarning(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
+        bool DECORATE_PRINTF(4, 5) LogPerformanceWarning(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
             va_list argptr;
             va_start(argptr, format);
             const bool result = LogMsg(report_data, kPerformanceWarningBit, objlist, vuid_text, format, argptr);
@@ -4057,7 +4057,7 @@ class ValidationObject {
             return result;
         }
 
-        bool DECORATE_PRINTF(4, 5) LogInfo(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
+        bool DECORATE_PRINTF(4, 5) LogInfo(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
             va_list argptr;
             va_start(argptr, format);
             const bool result = LogMsg(report_data, kInformationBit, objlist, vuid_text, format, argptr);

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -413,7 +413,7 @@ class ValidationObject {
         }
 
         // Debug Logging Helpers
-        bool DECORATE_PRINTF(4, 5) LogError(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
+        bool DECORATE_PRINTF(4, 5) LogError(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
             va_list argptr;
             va_start(argptr, format);
             const bool result = LogMsg(report_data, kErrorBit, objlist, vuid_text, format, argptr);
@@ -421,7 +421,7 @@ class ValidationObject {
             return result;
         }
 
-        bool DECORATE_PRINTF(4, 5) LogWarning(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
+        bool DECORATE_PRINTF(4, 5) LogWarning(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
             va_list argptr;
             va_start(argptr, format);
             const bool result = LogMsg(report_data, kWarningBit, objlist, vuid_text, format, argptr);
@@ -429,7 +429,7 @@ class ValidationObject {
             return result;
         }
 
-        bool DECORATE_PRINTF(4, 5) LogPerformanceWarning(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
+        bool DECORATE_PRINTF(4, 5) LogPerformanceWarning(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
             va_list argptr;
             va_start(argptr, format);
             const bool result = LogMsg(report_data, kPerformanceWarningBit, objlist, vuid_text, format, argptr);
@@ -437,7 +437,7 @@ class ValidationObject {
             return result;
         }
 
-        bool DECORATE_PRINTF(4, 5) LogInfo(const LogObjectList &objlist, const std::string &vuid_text, const char *format, ...) const {
+        bool DECORATE_PRINTF(4, 5) LogInfo(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
             va_list argptr;
             va_start(argptr, format);
             const bool result = LogMsg(report_data, kInformationBit, objlist, vuid_text, format, argptr);


### PR DESCRIPTION
Most (if not all) VUIDs are defined as string literals, so this PR should prevent a bunch of string constructions.