### PR TITLE
tests: Fix new CI warnings on macos-min-sdk

### DIFF
--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -269,11 +269,11 @@ void Device::init(std::vector<const char *> &extensions, VkPhysicalDeviceFeature
     enabled_extensions_ = extensions;
 
     VkDeviceCreateInfo dev_info = LvlInitStruct<VkDeviceCreateInfo>(create_device_pnext);
-    dev_info.queueCreateInfoCount = create_queue_infos.size();
+    dev_info.queueCreateInfoCount = static_cast<uint32_t>(create_queue_infos.size());
     dev_info.pQueueCreateInfos = create_queue_infos.data();
     dev_info.enabledLayerCount = 0;
     dev_info.ppEnabledLayerNames = NULL;
-    dev_info.enabledExtensionCount = extensions.size();
+    dev_info.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
     dev_info.ppEnabledExtensionNames = extensions.data();
 
     VkPhysicalDeviceFeatures all_features;
@@ -385,7 +385,7 @@ void Device::wait() { EXPECT(vk::DeviceWaitIdle(handle()) == VK_SUCCESS); }
 
 VkResult Device::wait(const std::vector<const Fence *> &fences, bool wait_all, uint64_t timeout) {
     const std::vector<VkFence> fence_handles = MakeVkHandles<VkFence>(fences);
-    VkResult err = vk::WaitForFences(handle(), fence_handles.size(), fence_handles.data(), wait_all, timeout);
+    VkResult err = vk::WaitForFences(handle(), static_cast<uint32_t>(fence_handles.size()), fence_handles.data(), wait_all, timeout);
     EXPECT(err == VK_SUCCESS || err == VK_TIMEOUT);
 
     return err;
@@ -393,7 +393,8 @@ VkResult Device::wait(const std::vector<const Fence *> &fences, bool wait_all, u
 
 void Device::update_descriptor_sets(const std::vector<VkWriteDescriptorSet> &writes,
                                     const std::vector<VkCopyDescriptorSet> &copies) {
-    vk::UpdateDescriptorSets(handle(), writes.size(), writes.data(), copies.size(), copies.data());
+    vk::UpdateDescriptorSets(handle(), static_cast<uint32_t>(writes.size()), writes.data(), static_cast<uint32_t>(copies.size()),
+                             copies.data());
 }
 
 VkResult Queue::submit(const std::vector<const CommandBuffer *> &cmds, const Fence &fence, bool expect_success) {
@@ -980,7 +981,7 @@ NON_DISPATCHABLE_HANDLE_DTOR(PipelineLayout, vk::DestroyPipelineLayout)
 void PipelineLayout::init(const Device &dev, VkPipelineLayoutCreateInfo &info,
                           const std::vector<const DescriptorSetLayout *> &layouts) {
     const std::vector<VkDescriptorSetLayout> layout_handles = MakeVkHandles<VkDescriptorSetLayout>(layouts);
-    info.setLayoutCount = layout_handles.size();
+    info.setLayoutCount = static_cast<uint32_t>(layout_handles.size());
     info.pSetLayouts = layout_handles.data();
 
     init(dev, info);
@@ -1019,7 +1020,7 @@ std::vector<DescriptorSet *> DescriptorPool::alloc_sets(const Device &dev,
     set_handles.resize(layout_handles.size());
 
     VkDescriptorSetAllocateInfo alloc_info = LvlInitStruct<VkDescriptorSetAllocateInfo>();
-    alloc_info.descriptorSetCount = layout_handles.size();
+    alloc_info.descriptorSetCount = static_cast<uint32_t>(layout_handles.size());
     alloc_info.descriptorPool = handle();
     alloc_info.pSetLayouts = layout_handles.data();
     VkResult err = vk::AllocateDescriptorSets(device(), &alloc_info, set_handles.data());

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -1202,18 +1202,18 @@ inline VkWriteDescriptorSet Device::write_descriptor_set(const DescriptorSet &se
 inline VkWriteDescriptorSet Device::write_descriptor_set(const DescriptorSet &set, uint32_t binding, uint32_t array_element,
                                                          VkDescriptorType type,
                                                          const std::vector<VkDescriptorImageInfo> &image_info) {
-    return write_descriptor_set(set, binding, array_element, type, image_info.size(), &image_info[0]);
+    return write_descriptor_set(set, binding, array_element, type, static_cast<uint32_t>(image_info.size()), &image_info[0]);
 }
 
 inline VkWriteDescriptorSet Device::write_descriptor_set(const DescriptorSet &set, uint32_t binding, uint32_t array_element,
                                                          VkDescriptorType type,
                                                          const std::vector<VkDescriptorBufferInfo> &buffer_info) {
-    return write_descriptor_set(set, binding, array_element, type, buffer_info.size(), &buffer_info[0]);
+    return write_descriptor_set(set, binding, array_element, type, static_cast<uint32_t>(buffer_info.size()), &buffer_info[0]);
 }
 
 inline VkWriteDescriptorSet Device::write_descriptor_set(const DescriptorSet &set, uint32_t binding, uint32_t array_element,
                                                          VkDescriptorType type, const std::vector<VkBufferView> &buffer_views) {
-    return write_descriptor_set(set, binding, array_element, type, buffer_views.size(), &buffer_views[0]);
+    return write_descriptor_set(set, binding, array_element, type, static_cast<uint32_t>(buffer_views.size()), &buffer_views[0]);
 }
 
 inline VkCopyDescriptorSet Device::copy_descriptor_set(const DescriptorSet &src_set, uint32_t src_binding,
@@ -1265,7 +1265,7 @@ struct GraphicsPipelineFromLibraries {
     GraphicsPipelineFromLibraries(const Device &dev, layer_data::span<VkPipeline> libs, VkGraphicsPipelineCreateInfo *ci = nullptr)
         : libs(libs) {
         link_info = LvlInitStruct<VkPipelineLibraryCreateInfoKHR>();
-        link_info.libraryCount = libs.size();
+        link_info.libraryCount = static_cast<uint32_t>(libs.size());
         link_info.pLibraries = libs.data();
 
         if (ci) {

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -720,7 +720,7 @@ char **VkTestFramework::ReadFileData(const char *fileName) {
         ptr_len += (len);
         if (count < len) {
             if (count == 0) {
-                m_num_shader_strings = (i + 1);
+                m_num_shader_strings = (static_cast<int>(i) + 1);
                 break;
             }
             len = count;


### PR DESCRIPTION
That's interesting compilers did not report this before (and not only on macos).