### PR TITLE
git: Add git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,98 @@
+# Move Device CoreCheck into own file
+4d196a6c74b7ec9a6f805b7b2959c827a0628cd8
+
+# Move ReleaseProfilingLock in query_validation.cpp
+61314fb36166f07e4f903969721135cbb606a670
+
+# Move External object CoreCheck into own file
+5683b43bc6d73ea9d842bc948d656179d1689090
+
+# Move RenderPass function to RP file
+39e84c7de0d2e44f35f677eab21315e393dedd9b
+
+# Move subpass CoreChecks to RP file
+cb1f0ebd4894ae8665f52722a8bdae27fe172ac1
+
+# Move ValidateImageSampleCount to buffer val
+0e8c94c837447f69f98cb221419eae43495941e9
+
+# Move descriptor CoreChecks to descriptor file
+556b35ee743cc3aa1343f9ed0001bd7096748186
+
+# Move DynamicState CoreCheck to own file
+c0aa4c2ead19dabfaff33ebeffb2a970c6c0b853
+
+# Move RenderPass CoreCheck to own file
+1debf6c59704b9bb1451db5a2b743988a1890e03
+
+# Move device memory CoreCheck to own file
+e2ef1302d50dc02e86630f331643fa30db023178
+
+# Move Query CoreChecks to own file
+8a2cc88d6422d09d0e11a02a5e2b37114edc07cc
+
+# Move Android CoreChecks to own file
+13064d6e68ef6b7f0ec550d82431944a2b45d86c
+
+# Move Video CoreCheck to own file
+c2f132441ea794b50d52c0a4fc94f26d65b8c251
+
+# Move CoreChecks to Ray Tracing file
+d5426ea20669a4d8de34dd3b89685fba73a21c4f
+
+# New pipeline_validation for CoreCheck
+47d0952f89039b20249945fb914d07c140a5ec5f
+
+# New wsi_validation for CoreChecks
+e4a3c3c66bec31f81f485c248d594751c1d96ad1
+
+# Move CreateRenderPassGeneric to source file
+b96a1646e1a5492d1e35b066938b704679b9111b
+
+# Add new test files for ray tracing
+d75d1d3a09191bd92bbaf61aa6ce7d5aa5875580
+
+# Move all Dynamic Rendering test together
+bfdcfe72460c0f0e1b41e76985f8fffa9021268d
+
+# Move ErrorMonitor into it's own files
+5ca4b0389ae2273017f375a33de10aecec757069
+
+# Move AHB tests to own file
+781c919ddf59701ccdb5b2532a7108d38fc21758
+
+# Fix test group and whitespace
+bc6d10d2b4347210cde345b72638b1c0e709a07c
+
+# Refactor positive tests
+26116e41f4aaf70166d3fe25f933a189c665959f
+
+# Fix whitespace error in layer settings file
+c97acd1d3e07757d0269e59f7610670169728c5f
+
+# Remove validationstats script whitespace
+02e231711b24573762ee16d1275ce5d8811d9aaf
+
+# Clean up whitespace in cap info structs
+f7019588d18a7ef57e6b2bbc18d532b79b730587
+
+# clang-format whitespace (sigh)
+e19e20dacd199de47c9f29a05a992e560b5bf5e4
+
+# Clang formatting
+828a3c5745733523eba9018c2b1d23ae5aaff827
+
+# Run clang-format on known-good.json files
+7418c9be681a1a7cd6dbc1542db335c2b744b0bc
+
+# Forgot to run clang-format, fixing
+3a6e61acdd520fce795aa99b0dcc232dff0b67bb
+
+# Fix clang-formatting issues
+525c12999e5612ee9b9ccf58c063068ac226163e
+
+# Fix clang-format errors in descriptor_sets.cpp
+85ebd4089ac347c10ef2819385b2b1b58bda8777
+
+# Fix clang-format errors in core_validation.cpp
+7256b55653e99b31feb465e5d00566249ec57bc3

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
  * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2022 Google, Inc.
+ * Copyright (c) 2015-2023 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
  * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2022 Google, Inc.
+ * Copyright (c) 2015-2023 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
git 2.23 added a `--ignore-revs-file <file>` option
GitHub picks up this file name by default