### PR TITLE
Cleaning: convert const std::vector to std::array

### DIFF
--- a/layers/device_memory_validation.cpp
+++ b/layers/device_memory_validation.cpp
@@ -75,8 +75,8 @@ template <typename HandleT, typename LocType>
 bool CoreChecks::ValidateMemoryIsBoundToImage(HandleT handle, const IMAGE_STATE &image_state, const LocType &location) const {
     bool result = false;
     if (image_state.create_from_swapchain != VK_NULL_HANDLE) {
-        const LogObjectList objlist(handle, image_state.Handle(), image_state.create_from_swapchain);
         if (!image_state.bind_swapchain) {
+            const LogObjectList objlist(handle, image_state.Handle(), image_state.create_from_swapchain);
             result |= LogError(
                 objlist, location.Vuid(),
                 "%s: %s is created by %s, and the image should be bound by calling vkBindImageMemory2(), and the pNext chain "

--- a/layers/generated/vk_extension_helper.h
+++ b/layers/generated/vk_extension_helper.h
@@ -36,6 +36,7 @@
 #include <string>
 #include <utility>
 #include <set>
+#include <array>
 #include <vector>
 #include <cassert>
 
@@ -244,17 +245,17 @@ struct InstanceExtensions {
 
     uint32_t InitFromInstanceCreateInfo(uint32_t requested_api_version, const VkInstanceCreateInfo *pCreateInfo) {
 
-        static const std::vector<const char *> V_1_1_promoted_instance_apis = {
+        constexpr std::array<const char *, 5> V_1_1_promoted_instance_apis = {{
             VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME,
             VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME,
             VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME,
             VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME,
             VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
-        };
-        static const std::vector<const char *> V_1_2_promoted_instance_apis = {
-        };
-        static const std::vector<const char *> V_1_3_promoted_instance_apis = {
-        };
+        }};
+        constexpr std::array<const char *, 0> V_1_2_promoted_instance_apis = {{
+        }};
+        constexpr std::array<const char *, 0> V_1_3_promoted_instance_apis = {{
+        }};
 
         // Initialize struct data, robust to invalid pCreateInfo
         uint32_t api_version = NormalizeApiVersion(requested_api_version);
@@ -1269,7 +1270,7 @@ struct DeviceExtensions : public InstanceExtensions {
         *this = DeviceExtensions(*instance_extensions);
 
 
-        static const std::vector<const char *> V_1_1_promoted_device_apis = {
+        constexpr std::array<const char *, 18> V_1_1_promoted_device_apis = {{
             VK_KHR_16BIT_STORAGE_EXTENSION_NAME,
             VK_KHR_BIND_MEMORY_2_EXTENSION_NAME,
             VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,
@@ -1288,8 +1289,8 @@ struct DeviceExtensions : public InstanceExtensions {
             VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME,
             VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME,
             VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME,
-        };
-        static const std::vector<const char *> V_1_2_promoted_device_apis = {
+        }};
+        constexpr std::array<const char *, 24> V_1_2_promoted_device_apis = {{
             VK_KHR_8BIT_STORAGE_EXTENSION_NAME,
             VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
             VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME,
@@ -1314,8 +1315,8 @@ struct DeviceExtensions : public InstanceExtensions {
             VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME,
             VK_EXT_SEPARATE_STENCIL_USAGE_EXTENSION_NAME,
             VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME,
-        };
-        static const std::vector<const char *> V_1_3_promoted_device_apis = {
+        }};
+        constexpr std::array<const char *, 21> V_1_3_promoted_device_apis = {{
             VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME,
             VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME,
             VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME,
@@ -1337,7 +1338,7 @@ struct DeviceExtensions : public InstanceExtensions {
             VK_EXT_TEXEL_BUFFER_ALIGNMENT_EXTENSION_NAME,
             VK_EXT_TEXTURE_COMPRESSION_ASTC_HDR_EXTENSION_NAME,
             VK_EXT_TOOLING_INFO_EXTENSION_NAME,
-        };
+        }};
 
         // Initialize struct data, robust to invalid pCreateInfo
         uint32_t api_version = NormalizeApiVersion(requested_api_version);

--- a/layers/gpu_validation.cpp
+++ b/layers/gpu_validation.cpp
@@ -271,8 +271,8 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState() {
         if (result != VK_SUCCESS) {
             ReportSetupProblem(device, "Failed to map vertex buffer for acceleration structure build validation.");
         } else {
-            const std::vector<float> vertices = {1.0f, 0.0f, 0.0f, 0.5f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f};
-            std::memcpy(mapped_vbo_buffer, (uint8_t *)vertices.data(), sizeof(float) * vertices.size());
+            constexpr std::array vertices = {1.0f, 0.0f, 0.0f, 0.5f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+            std::memcpy(mapped_vbo_buffer, (uint8_t *)vertices.data(), sizeof(vertices[0]) * vertices.size());
             vmaUnmapMemory(vmaAllocator, vbo_allocation);
         }
     }
@@ -300,8 +300,8 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState() {
         if (result != VK_SUCCESS) {
             ReportSetupProblem(device, "Failed to map index buffer for acceleration structure build validation.");
         } else {
-            const std::vector<uint32_t> indicies = {0, 1, 2};
-            std::memcpy(mapped_ibo_buffer, (uint8_t *)indicies.data(), sizeof(uint32_t) * indicies.size());
+            constexpr std::array<uint32_t, 3> indicies = {0, 1, 2};
+            std::memcpy(mapped_ibo_buffer, (uint8_t *)indicies.data(), sizeof(indicies[0]) * indicies.size());
             vmaUnmapMemory(vmaAllocator, ibo_allocation);
         }
     }

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -685,6 +685,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             '#include <string>',
             '#include <utility>',
             '#include <set>',
+            '#include <array>',
             '#include <vector>',
             '#include <cassert>',
             '',
@@ -839,18 +840,18 @@ class HelperFileOutputGenerator(OutputGenerator):
                     '']),
             struct.extend([
                 '',
-                '        static const std::vector<const char *> V_1_1_promoted_%s_apis = {' % type.lower() ])
+                '        constexpr std::array<const char *, %d> V_1_1_promoted_%s_apis = {{' % (len(promoted_1_1_ext_list), type.lower()) ])
             struct.extend(['            %s,' % extension_dict[ext_name]['define'] for ext_name in promoted_1_1_ext_list])
             struct.extend([
-                '        };',
-                '        static const std::vector<const char *> V_1_2_promoted_%s_apis = {' % type.lower() ])
+                '        }};',
+                '        constexpr std::array<const char *, %d> V_1_2_promoted_%s_apis = {{' % (len(promoted_1_2_ext_list), type.lower()) ])
             struct.extend(['            %s,' % extension_dict[ext_name]['define'] for ext_name in promoted_1_2_ext_list])
             struct.extend([
-                '        };',
-                '        static const std::vector<const char *> V_1_3_promoted_%s_apis = {' % type.lower() ])
+                '        }};',
+                '        constexpr std::array<const char *, %d> V_1_3_promoted_%s_apis = {{' % (len(promoted_1_3_ext_list), type.lower()) ])
             struct.extend(['            %s,' % extension_dict[ext_name]['define'] for ext_name in promoted_1_3_ext_list])
             struct.extend([
-                '        };',
+                '        }};',
                 '',
                 '        // Initialize struct data, robust to invalid pCreateInfo',
                 '        uint32_t api_version = NormalizeApiVersion(requested_api_version);',

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -26,6 +26,8 @@
 #include "cast_utils.h"
 #include "layer_validation_tests.h"
 
+#include <array>
+
 // Global list of sType,size identifiers
 std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info{};
 
@@ -443,7 +445,7 @@ bool FindUnsupportedImage(VkPhysicalDevice gpu, VkImageCreateInfo &image_ci) {
     const VkFormat first_vk_format = static_cast<VkFormat>(1);
     const VkFormat last_vk_format = static_cast<VkFormat>(130);  // avoid compressed/feature protected, otherwise 184
 
-    const std::vector<VkImageTiling> tilings = {VK_IMAGE_TILING_LINEAR, VK_IMAGE_TILING_OPTIMAL};
+    constexpr std::array tilings = {VK_IMAGE_TILING_LINEAR, VK_IMAGE_TILING_OPTIMAL};
     for (const auto tiling : tilings) {
         image_ci.tiling = tiling;
 
@@ -2475,8 +2477,8 @@ void GetSimpleGeometryForAccelerationStructureTests(const VkDeviceObj &device, V
     vbo->init(device, 1024, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, usage, alloc_pnext);
     ibo->init(device, 1024, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, usage, alloc_pnext);
 
-    const std::vector<float> vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
-    const std::vector<uint32_t> indicies = {0, 1, 2};
+    constexpr std::array vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
+    constexpr std::array<uint32_t, 3> indicies = {{0, 1, 2}};
 
     uint8_t *mapped_vbo_buffer_data = (uint8_t *)vbo->memory().map();
     std::memcpy(mapped_vbo_buffer_data + offset, (uint8_t *)vertices.data(), sizeof(float) * vertices.size());
@@ -2646,7 +2648,7 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
 
     VkAccelerationStructureObj bot_level_as(*m_device, bot_level_as_create_info);
 
-    const std::vector<VkGeometryInstanceNV> instances = {
+    const std::array instances = {
         VkGeometryInstanceNV{
             {
                 // clang-format off
@@ -2663,7 +2665,7 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
         },
     };
 
-    VkDeviceSize instance_buffer_size = sizeof(VkGeometryInstanceNV) * instances.size();
+    VkDeviceSize instance_buffer_size = sizeof(instances[0]) * instances.size();
     VkBufferObj instance_buffer;
     instance_buffer.init(*m_device, instance_buffer_size,
                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -42,6 +42,7 @@
 #include "icd-spv.h"
 #include "test_common.h"
 #include "vk_layer_config.h"
+#include "vk_layer_data.h"
 #include "vk_format_utils.h"
 #include "vkrenderframework.h"
 #include "vk_typemap_helper.h"
@@ -571,8 +572,8 @@ struct CreatePipelineHelper {
     //
     // info_override can be any callable that takes a CreatePipelineHeper &
     // flags, error can be any args accepted by "SetDesiredFailure".
-    template <typename Test, typename OverrideFunc, typename Error>
-    static void OneshotTest(Test &test, const OverrideFunc &info_override, const VkFlags flags, const std::vector<Error> &errors) {
+    template <typename Test, typename OverrideFunc, typename ErrorContainer>
+    static void OneshotTest(Test &test, const OverrideFunc &info_override, const VkFlags flags, const ErrorContainer &errors) {
         CreatePipelineHelper helper(test);
         helper.InitInfo();
         info_override(helper);
@@ -586,14 +587,22 @@ struct CreatePipelineHelper {
         }
     }
 
-    template <typename Test, typename OverrideFunc, typename Error>
-    static void OneshotTest(Test &test, const OverrideFunc &info_override, const VkFlags flags, Error error) {
-        OneshotTest(test, info_override, flags, std::vector<Error>(1, error));
+    template <typename Test, typename OverrideFunc>
+    static void OneshotTest(Test &test, const OverrideFunc &info_override, const VkFlags flags, const char *error) {
+        std::array errors = {error};
+        OneshotTest(test, info_override, flags, errors);
+    }
+
+    template <typename Test, typename OverrideFunc>
+    static void OneshotTest(Test &test, const OverrideFunc &info_override, const VkFlags flags, const std::string &error) {
+        std::array errors = {error};
+        OneshotTest(test, info_override, flags, errors);
     }
 
     template <typename Test, typename OverrideFunc>
     static void OneshotTest(Test &test, const OverrideFunc &info_override, const VkFlags flags) {
-        OneshotTest(test, info_override, flags, std::vector<std::string>{});
+        std::array<const char *, 0> errors;
+        OneshotTest(test, info_override, flags, errors);
     }
 };
 

--- a/tests/positive/ray_tracing.cpp
+++ b/tests/positive/ray_tracing.cpp
@@ -105,8 +105,8 @@ TEST_F(VkPositiveLayerTest, RayTracingAccelerationStructureReference) {
         GetInstanceProcAddr<PFN_vkBuildAccelerationStructuresKHR>("vkBuildAccelerationStructuresKHR");
 
     // Build Bottom Level Acceleration Structure
-    const std::vector<float> vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
-    const std::vector<uint32_t> indices = {0, 1, 2};
+    constexpr std::array vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
+    constexpr std::array<uint32_t, 3> indices = {{0, 1, 2}};
     VkAccelerationStructureGeometryKHR blas_geometry = LvlInitStruct<VkAccelerationStructureGeometryKHR>();
     blas_geometry.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_KHR;
     blas_geometry.flags = 0;

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -6575,7 +6575,8 @@ TEST_F(VkLayerTest, ViewportWScalingNV) {
     const std::vector<VkViewport> vp = {
         {0.0f, 0.0f, 64.0f, 64.0f}, {0.0f, 0.0f, 64.0f, 64.0f}, {0.0f, 0.0f, 64.0f, 64.0f}, {0.0f, 0.0f, 64.0f, 64.0f}};
     const std::vector<VkRect2D> sc = {{{0, 0}, {32, 32}}, {{32, 0}, {32, 32}}, {{0, 32}, {32, 32}}, {{32, 32}, {32, 32}}};
-    const std::vector<VkViewportWScalingNV> scale = {{-0.2f, -0.2f}, {0.2f, -0.2f}, {-0.2f, 0.2f}, {0.2f, 0.2f}};
+    constexpr std::array scale = {VkViewportWScalingNV{-0.2f, -0.2f}, VkViewportWScalingNV{0.2f, -0.2f},
+                                  VkViewportWScalingNV{-0.2f, 0.2f}, VkViewportWScalingNV{0.2f, 0.2f}};
 
     const uint32_t vp_count = static_cast<uint32_t>(vp.size());
 

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -4544,9 +4544,9 @@ TEST_F(VkLayerTest, ImageDescriptorLayoutMismatch) {
         kInternal,  // Image layout mismatch is *within* a given command buffer
         kExternal   // Image layout mismatch is with the current state of the image, found at QueueSubmit
     };
-    std::array<TestType, 2> test_list = {{kInternal, kExternal}};
-    const std::vector<std::string> internal_errors = {"VUID-VkDescriptorImageInfo-imageLayout-00344", "VUID-vkCmdDraw-None-02699"};
-    const std::vector<std::string> external_errors = {"UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout"};
+    constexpr std::array test_list = {kInternal, kExternal};
+    constexpr std::array internal_errors = {"VUID-VkDescriptorImageInfo-imageLayout-00344", "VUID-vkCmdDraw-None-02699"};
+    constexpr std::array external_errors = {"UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout"};
 
     // Common steps to create the two classes of errors (or two classes of positives)
     auto do_test = [&](VkImageObj *image, vk_testing::ImageView *view, VkImageAspectFlags aspect_mask, VkImageLayout image_layout,
@@ -4585,7 +4585,7 @@ TEST_F(VkLayerTest, ImageDescriptorLayoutMismatch) {
             if (positive_test || (test_type == kExternal)) {
             } else {
                 for (const auto &err : internal_errors) {
-                    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, err.c_str());
+                    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, err);
                 }
             }
             cmd_buf.Draw(1, 0, 0, 0);
@@ -4601,7 +4601,7 @@ TEST_F(VkLayerTest, ImageDescriptorLayoutMismatch) {
             if (positive_test || (test_type == kInternal)) {
             } else {
                 for (const auto &err : external_errors) {
-                    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, err.c_str());
+                    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, err);
                 }
             }
             vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -4259,11 +4259,10 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
             vsrisci.shadingRateImageEnable = VK_TRUE;
             vsrisci.viewportCount = 2;
         };
-        CreatePipelineHelper::OneshotTest(
-            *this, break_vp, kErrorBit,
-            vector<std::string>({"VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-viewportCount-02054",
-                                 "VUID-VkPipelineViewportStateCreateInfo-viewportCount-01216",
-                                 "VUID-VkPipelineViewportStateCreateInfo-scissorCount-01217"}));
+        constexpr std::array vuids = {"VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-viewportCount-02054",
+                                      "VUID-VkPipelineViewportStateCreateInfo-viewportCount-01216",
+                                      "VUID-VkPipelineViewportStateCreateInfo-scissorCount-01217"};
+        CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit, vuids);
     }
 
     // viewportCounts must match
@@ -4279,9 +4278,8 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
             vsrisci.shadingRateImageEnable = VK_TRUE;
             vsrisci.viewportCount = 0;
         };
-        CreatePipelineHelper::OneshotTest(
-            *this, break_vp, kErrorBit,
-            vector<std::string>({"VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-shadingRateImageEnable-02056"}));
+        CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit,
+                                          "VUID-VkPipelineViewportShadingRateImageStateCreateInfoNV-shadingRateImageEnable-02056");
     }
 
     // pShadingRatePalettes must not be NULL.

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -30,6 +30,8 @@
 #include "layer_validation_tests.h"
 #include "core_validation_error_enums.h"
 
+#include <limits>
+
 TEST_F(VkLayerTest, PSOPolygonModeInvalid) {
     TEST_DESCRIPTION("Attempt to use invalid polygon fill modes.");
     VkPhysicalDeviceFeatures device_features = {};
@@ -391,21 +393,27 @@ TEST_F(VkLayerTest, InvalidTopology) {
     topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428");
 
-    topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY;
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                      std::vector<string>{"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428",
-                                                          "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00429"});
+    {
+        topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY;
+        constexpr std::array vuids = {"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428",
+                                      "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00429"};
+        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
+    }
 
-    topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY;
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                      std::vector<string>{"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428",
-                                                          "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00429"});
+    {
+        topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY;
+        constexpr std::array vuids = {"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428",
+                                      "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00429"};
+        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
+    }
 
-    topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                      std::vector<string>{"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428",
-                                                          "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00430",
-                                                          "VUID-VkGraphicsPipelineCreateInfo-topology-00737"});
+    {
+        topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
+        constexpr std::array vuids = {"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00428",
+                                      "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00430",
+                                      "VUID-VkGraphicsPipelineCreateInfo-topology-00737"};
+        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
+    }
 
     topology = VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY;
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00429");
@@ -453,9 +461,9 @@ TEST_F(VkLayerTest, PrimitiveTopologyListRestart) {
 
     if (m_device->phy().features().tessellationShader) {
         topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
-        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                          std::vector<string>{"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-06253",
-                                                              "VUID-VkGraphicsPipelineCreateInfo-topology-00737"});
+        constexpr std::array vuids = {"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-06253",
+                                      "VUID-VkGraphicsPipelineCreateInfo-topology-00737"};
+        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
     }
 }
 
@@ -1827,9 +1835,9 @@ TEST_F(VkLayerTest, InvalidPipelineCreateState) {
     VkPipelineShaderStageCreateInfo shaderStage = fs.GetStageCreateInfo();  // should be: vs.GetStageCreateInfo();
 
     auto set_info = [&](CreatePipelineHelper &helper) { helper.shader_stages_ = {shaderStage}; };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                      std::vector<std::string>{"VUID-VkGraphicsPipelineCreateInfo-pStages-06896",
-                                                               "VUID-VkGraphicsPipelineCreateInfo-stage-00727"});
+    constexpr std::array vuids = {"VUID-VkGraphicsPipelineCreateInfo-pStages-06896",
+                                  "VUID-VkGraphicsPipelineCreateInfo-stage-00727"};
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
 
     // Finally, check the string validation for the shader stage pName variable.  Correct the shader stage data, and bork the
     // string before calling again
@@ -3913,7 +3921,8 @@ TEST_F(VkLayerTest, PSOLineWidthInvalid) {
     }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    const std::vector<float> test_cases = {-1.0f, 0.0f, NearestSmaller(1.0f), NearestGreater(1.0f), NAN};
+    const std::array test_cases = {-1.0f, 0.0f, NearestSmaller(1.0f), NearestGreater(1.0f),
+                                   std::numeric_limits<float>::quiet_NaN()};
 
     // test VkPipelineRasterizationStateCreateInfo::lineWidth
     for (const auto test_case : test_cases) {
@@ -4236,10 +4245,9 @@ TEST_F(VkLayerTest, InvalidVertexBindingDescriptions) {
         helper.vi_ci_.pVertexAttributeDescriptions = &input_attrib;
         helper.vi_ci_.vertexAttributeDescriptionCount = 1;
     };
-    CreatePipelineHelper::OneshotTest(
-        *this, set_Info, kErrorBit,
-        vector<string>{"VUID-VkPipelineVertexInputStateCreateInfo-vertexBindingDescriptionCount-00613",
-                       "VUID-VkPipelineVertexInputStateCreateInfo-pVertexBindingDescriptions-00616"});
+    constexpr std::array vuids = {"VUID-VkPipelineVertexInputStateCreateInfo-vertexBindingDescriptionCount-00613",
+                                  "VUID-VkPipelineVertexInputStateCreateInfo-pVertexBindingDescriptions-00616"};
+    CreatePipelineHelper::OneshotTest(*this, set_Info, kErrorBit, vuids);
 }
 
 TEST_F(VkLayerTest, InvalidVertexAttributeDescriptions) {
@@ -4276,11 +4284,10 @@ TEST_F(VkLayerTest, InvalidVertexAttributeDescriptions) {
         helper.vi_ci_.pVertexAttributeDescriptions = input_attribs.data();
         helper.vi_ci_.vertexAttributeDescriptionCount = attribute_count;
     };
-    CreatePipelineHelper::OneshotTest(
-        *this, set_Info, kErrorBit,
-        vector<string>{"VUID-VkPipelineVertexInputStateCreateInfo-vertexAttributeDescriptionCount-00614",
-                       "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
-                       "VUID-VkPipelineVertexInputStateCreateInfo-pVertexAttributeDescriptions-00617"});
+    constexpr std::array vuids = {"VUID-VkPipelineVertexInputStateCreateInfo-vertexAttributeDescriptionCount-00614",
+                                  "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
+                                  "VUID-VkPipelineVertexInputStateCreateInfo-pVertexAttributeDescriptions-00617"};
+    CreatePipelineHelper::OneshotTest(*this, set_Info, kErrorBit, vuids);
 }
 
 TEST_F(VkLayerTest, ColorBlendInvalidLogicOp) {
@@ -5035,9 +5042,8 @@ TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByLocation) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(
-        *this, set_info, kErrorBit,
-        std::vector<std::string>{"fragment shader consumes input location 0.0 which is not written by vertex shader"});
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
+                                      "fragment shader consumes input location 0.0 which is not written by vertex shader");
 }
 
 TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByComponent) {
@@ -5760,12 +5766,12 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxVertexOutputComponents) {
                 // just component limit (maxVertexOutputComponents)
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-Location-06272");
                 break;
-            case 1:
+            case 1: {
                 // component and location limit (maxVertexOutputComponents)
-                CreatePipelineHelper::OneshotTest(
-                    *this, set_info, kErrorBit,
-                    vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
+            }
             default:
                 assert(0);
                 [[fallthrough]];
@@ -5930,19 +5936,19 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationControlInputOutputCompone
         };
         // maxTessellationControlPerVertexInputComponents and maxTessellationControlPerVertexOutputComponents
         switch (overflow) {
-            case 2:
+            case 2: {
                 // in and out component limit
-                CreatePipelineHelper::OneshotTest(
-                    *this, set_info, kErrorBit,
-                    vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
-            case 1:
+            }
+            case 1: {
                 // (in and out component limit) and (in and out location limit)
-                CreatePipelineHelper::OneshotTest(
-                    *this, set_info, kErrorBit,
-                    vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
-                                   "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
+                                              "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
+            }
             default:
                 assert(0);
                 [[fallthrough]];
@@ -6051,21 +6057,21 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationEvaluationInputOutputComp
 
         // maxTessellationEvaluationInputComponents and maxTessellationEvaluationOutputComponents
         switch (overflow) {
-            case 2:
-                // in and out component limit
-                CreatePipelineHelper::OneshotTest(
-                    *this, set_info, kErrorBit,
-                    vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
-                break;
-            case 1:
+            case 1: {
                 // (in and out component limit) and (in and out location limit)
-                CreatePipelineHelper::OneshotTest(
-                    *this, set_info, kErrorBit,
-                    vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
-                                   "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
+                                              "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
+            }
+            case 2: {
+                // in and out component limit
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
+                break;
+            }
             default:
-                assert(0);
+                assert(false);
                 [[fallthrough]];
             case 0:
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -6160,20 +6166,20 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
         };
         // maxGeometryInputComponents and maxGeometryOutputComponents
         switch (overflow) {
-            case 2:
-                // in and out component limit
-                CreatePipelineHelper::OneshotTest(
-                    *this, set_info, kErrorBit,
-                    vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
-                break;
-            case 1:
+            case 1: {
                 // (in and out component limit) and (in and out location limit) and maxGeometryTotalOutputComponents
-                CreatePipelineHelper::OneshotTest(
-                    *this, set_info, kErrorBit,
-                    vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
-                                   "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
-                                   "VUID-RuntimeSpirv-Location-06272"});
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
+                                              "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
+                                              "VUID-RuntimeSpirv-Location-06272"};
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
+            }
+            case 2: {
+                // in and out component limit
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
+                break;
+            }
             default:
                 assert(0);
                 [[fallthrough]];
@@ -6230,15 +6236,15 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxFragmentInputComponents) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
         switch (overflow) {
+            case 1: {
+                // component and location limit (maxFragmentInputComponents)
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
+                break;
+            }
             case 2:
                 // just component limit (maxFragmentInputComponents)
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-Location-06272");
-                break;
-            case 1:
-                // component and location limit (maxFragmentInputComponents)
-                CreatePipelineHelper::OneshotTest(
-                    *this, set_info, kErrorBit,
-                    vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
                 break;
             default:
                 assert(0);
@@ -7929,58 +7935,64 @@ TEST_F(VkLayerTest, CreatePipelineCheckLineRasterization) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    CreatePipelineHelper::OneshotTest(
-        *this,
-        [&](CreatePipelineHelper &helper) {
-            helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT;
-            helper.pipe_ms_state_ci_.alphaToCoverageEnable = VK_TRUE;
-        },
-        kErrorBit,
-        std::vector<const char *>{"VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
-                                  "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02769"});
-
-    CreatePipelineHelper::OneshotTest(
-        *this,
-        [&](CreatePipelineHelper &helper) {
-            helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT;
-            helper.line_state_ci_.stippledLineEnable = VK_TRUE;
-        },
-        kErrorBit,
-        std::vector<const char *>{"VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
-                                  "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02769",
-                                  "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02772"});
-
-    CreatePipelineHelper::OneshotTest(
-        *this,
-        [&](CreatePipelineHelper &helper) {
-            helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT;
-            helper.line_state_ci_.stippledLineEnable = VK_TRUE;
-        },
-        kErrorBit,
-        std::vector<const char *>{"VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
-                                  "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02768",
-                                  "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02771"});
-
-    CreatePipelineHelper::OneshotTest(
-        *this,
-        [&](CreatePipelineHelper &helper) {
-            helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT;
-            helper.line_state_ci_.stippledLineEnable = VK_TRUE;
-        },
-        kErrorBit,
-        std::vector<const char *>{"VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
-                                  "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02770",
-                                  "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02773"});
-
-    CreatePipelineHelper::OneshotTest(
-        *this,
-        [&](CreatePipelineHelper &helper) {
-            helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT;
-            helper.line_state_ci_.stippledLineEnable = VK_TRUE;
-        },
-        kErrorBit,
-        std::vector<const char *>{"VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
-                                  "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02774"});
+    {
+        constexpr std::array vuids = {"VUID-VkGraphicsPipelineCreateInfo-lineRasterizationMode-02766",
+                                      "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02769"};
+        CreatePipelineHelper::OneshotTest(
+            *this,
+            [&](CreatePipelineHelper &helper) {
+                helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT;
+                helper.pipe_ms_state_ci_.alphaToCoverageEnable = VK_TRUE;
+            },
+            kErrorBit, vuids);
+    }
+    {
+        constexpr std::array vuids = {"VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
+                                      "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02769",
+                                      "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02772"};
+        CreatePipelineHelper::OneshotTest(
+            *this,
+            [&](CreatePipelineHelper &helper) {
+                helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT;
+                helper.line_state_ci_.stippledLineEnable = VK_TRUE;
+            },
+            kErrorBit, vuids);
+    }
+    {
+        constexpr std::array vuids = {"VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
+                                      "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02768",
+                                      "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02771"};
+        CreatePipelineHelper::OneshotTest(
+            *this,
+            [&](CreatePipelineHelper &helper) {
+                helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT;
+                helper.line_state_ci_.stippledLineEnable = VK_TRUE;
+            },
+            kErrorBit, vuids);
+    }
+    {
+        constexpr std::array vuids = {"VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
+                                      "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-lineRasterizationMode-02770",
+                                      "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02773"};
+        CreatePipelineHelper::OneshotTest(
+            *this,
+            [&](CreatePipelineHelper &helper) {
+                helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT;
+                helper.line_state_ci_.stippledLineEnable = VK_TRUE;
+            },
+            kErrorBit, vuids);
+    }
+    {
+        constexpr std::array vuids = {"VUID-VkGraphicsPipelineCreateInfo-stippledLineEnable-02767",
+                                      "VUID-VkPipelineRasterizationLineStateCreateInfoEXT-stippledLineEnable-02774"};
+        CreatePipelineHelper::OneshotTest(
+            *this,
+            [&](CreatePipelineHelper &helper) {
+                helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT;
+                helper.line_state_ci_.stippledLineEnable = VK_TRUE;
+            },
+            kErrorBit, vuids);
+    }
 
     PFN_vkCmdSetLineStippleEXT vkCmdSetLineStippleEXT =
         (PFN_vkCmdSetLineStippleEXT)vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetLineStippleEXT");
@@ -8340,10 +8352,9 @@ TEST_F(VkLayerTest, VertexStoresAndAtomicsFeatureDisable) {
                 info.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}};
             };
 
+            constexpr std::array vuids = {"VUID-RuntimeSpirv-None-06282", "VUID-RuntimeSpirv-NonWritable-06341"};
             // extra VU for not enabling atomic float support
-            CreatePipelineHelper::OneshotTest(
-                *this, info_override, VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                std::vector<string>{"VUID-RuntimeSpirv-None-06282", "VUID-RuntimeSpirv-NonWritable-06341"});
+            CreatePipelineHelper::OneshotTest(*this, info_override, VK_DEBUG_REPORT_ERROR_BIT_EXT, vuids);
         }
     }
 }
@@ -8395,9 +8406,8 @@ TEST_F(VkLayerTest, FragmentStoresAndAtomicsFeatureDisable) {
             };
 
             // extra VU for not enabling atomic float support
-            CreatePipelineHelper::OneshotTest(
-                *this, info_override, VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                std::vector<string>{"VUID-RuntimeSpirv-None-06282", "VUID-RuntimeSpirv-NonWritable-06340"});
+            constexpr std::array vuids = {"VUID-RuntimeSpirv-None-06282", "VUID-RuntimeSpirv-NonWritable-06340"};
+            CreatePipelineHelper::OneshotTest(*this, info_override, VK_DEBUG_REPORT_ERROR_BIT_EXT, vuids);
         }
     }
 }
@@ -9479,11 +9489,11 @@ TEST_F(VkLayerTest, Storage8and16bitCapability) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-storageBuffer8BitAccess-06328",  // feature
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",        // Int8
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091"});      // StorageBuffer8BitAccess
+            constexpr std::array vuids = {"VUID-RuntimeSpirv-storageBuffer8BitAccess-06328",  // feature
+                                          "VUID-VkShaderModuleCreateInfo-pCode-01091",        // Int8
+                                          "VUID-VkShaderModuleCreateInfo-pCode-01091"};
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
+                                              vuids);  // StorageBuffer8BitAccess
         }
     }
     // uniformAndStorageBuffer8BitAccess
@@ -9506,11 +9516,11 @@ TEST_F(VkLayerTest, Storage8and16bitCapability) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-uniformAndStorageBuffer8BitAccess-06329",  // feature
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",                  // Int8
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091"});                // UniformAndStorageBuffer8BitAccess
+            constexpr std::array vuids = {"VUID-RuntimeSpirv-uniformAndStorageBuffer8BitAccess-06329",  // feature
+                                          "VUID-VkShaderModuleCreateInfo-pCode-01091",                  // Int8
+                                          "VUID-VkShaderModuleCreateInfo-pCode-01091"};
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
+                                              vuids);  // UniformAndStorageBuffer8BitAccess
         }
     }
 
@@ -9564,11 +9574,11 @@ TEST_F(VkLayerTest, Storage8and16bitCapability) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-storageBuffer16BitAccess-06331",  // feature
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",         // Float16
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091"});       // StorageBuffer16BitAccess
+            constexpr std::array vuids = {"VUID-RuntimeSpirv-storageBuffer16BitAccess-06331",  // feature
+                                          "VUID-VkShaderModuleCreateInfo-pCode-01091",         // Float16
+                                          "VUID-VkShaderModuleCreateInfo-pCode-01091"};
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
+                                              vuids);  // StorageBuffer16BitAccess
         }
     }
 
@@ -9592,11 +9602,11 @@ TEST_F(VkLayerTest, Storage8and16bitCapability) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-uniformAndStorageBuffer16BitAccess-06332",  // feature
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",                   // Float16
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091"});                 // UniformAndStorageBuffer16BitAccess
+            constexpr std::array vuids = {"VUID-RuntimeSpirv-uniformAndStorageBuffer16BitAccess-06332",  // feature
+                                          "VUID-VkShaderModuleCreateInfo-pCode-01091",                   // Float16
+                                          "VUID-VkShaderModuleCreateInfo-pCode-01091"};
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
+                                              vuids);  // UniformAndStorageBuffer16BitAccess
         }
     }
 
@@ -9623,11 +9633,12 @@ TEST_F(VkLayerTest, Storage8and16bitCapability) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.pipeline_layout_ci_ = pipeline_layout_info;
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-storagePushConstant16-06333",  // feature
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",      // Float16
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091"});    // StoragePushConstant16
+            constexpr std::array vuids = {
+                "VUID-RuntimeSpirv-storagePushConstant16-06333",  // feature
+                "VUID-VkShaderModuleCreateInfo-pCode-01091",      // Float16
+                "VUID-VkShaderModuleCreateInfo-pCode-01091"       // StoragePushConstant16
+            };
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
         }
     }
 
@@ -9663,13 +9674,14 @@ TEST_F(VkLayerTest, Storage8and16bitCapability) {
             const auto set_info = [&](CreatePipelineHelper &helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-storageInputOutput16-06334",  // feature vert
-                               "VUID-RuntimeSpirv-storageInputOutput16-06334",  // feature frag
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",     // Float16 vert
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",     // StorageInputOutput16 vert
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091"});   // StorageInputOutput16 frag
+            constexpr std::array vuids = {
+                "VUID-RuntimeSpirv-storageInputOutput16-06334",  // feature vert
+                "VUID-RuntimeSpirv-storageInputOutput16-06334",  // feature frag
+                "VUID-VkShaderModuleCreateInfo-pCode-01091",     // Float16 vert
+                "VUID-VkShaderModuleCreateInfo-pCode-01091",     // StorageInputOutput16 vert
+                "VUID-VkShaderModuleCreateInfo-pCode-01091"      // StorageInputOutput16 frag
+            };
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
         }
     }
 
@@ -9693,11 +9705,12 @@ TEST_F(VkLayerTest, Storage8and16bitCapability) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-storageBuffer16BitAccess-06331",  // feature
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",         // Int16
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091"});       // StorageBuffer16BitAccess
+            constexpr std::array vuids = {
+                "VUID-RuntimeSpirv-storageBuffer16BitAccess-06331",  // feature
+                "VUID-VkShaderModuleCreateInfo-pCode-01091",         // Int16
+                "VUID-VkShaderModuleCreateInfo-pCode-01091"          // StorageBuffer16BitAccess
+            };
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
         }
     }
 
@@ -9721,11 +9734,12 @@ TEST_F(VkLayerTest, Storage8and16bitCapability) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-uniformAndStorageBuffer16BitAccess-06332",  // feature
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",                   // Int16
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091"});                 // UniformAndStorageBuffer16BitAccess
+            constexpr std::array vuids = {
+                "VUID-RuntimeSpirv-uniformAndStorageBuffer16BitAccess-06332",  // feature
+                "VUID-VkShaderModuleCreateInfo-pCode-01091",                   // Int16
+                "VUID-VkShaderModuleCreateInfo-pCode-01091"                    // UniformAndStorageBuffer16BitAccess
+            };
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
         }
     }
 
@@ -9752,11 +9766,12 @@ TEST_F(VkLayerTest, Storage8and16bitCapability) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
                 helper.pipeline_layout_ci_ = pipeline_layout_info;
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-storagePushConstant16-06333",  // feature
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",      // Int16
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091"});    // StoragePushConstant16
+            constexpr std::array vuids = {
+                "VUID-RuntimeSpirv-storagePushConstant16-06333",  // feature
+                "VUID-VkShaderModuleCreateInfo-pCode-01091",      // Int16
+                "VUID-VkShaderModuleCreateInfo-pCode-01091"       // StoragePushConstant16
+            };
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
         }
     }
 
@@ -9792,13 +9807,14 @@ TEST_F(VkLayerTest, Storage8and16bitCapability) {
             const auto set_info = [&](CreatePipelineHelper &helper) {
                 helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-storageInputOutput16-06334",  // feature vert
-                               "VUID-RuntimeSpirv-storageInputOutput16-06334",  // feature frag
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",     // Int16 vert
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091",     // StorageInputOutput16 vert
-                               "VUID-VkShaderModuleCreateInfo-pCode-01091"});   // StorageInputOutput16 frag
+            constexpr std::array vuids = {
+                "VUID-RuntimeSpirv-storageInputOutput16-06334",  // feature vert
+                "VUID-RuntimeSpirv-storageInputOutput16-06334",  // feature frag
+                "VUID-VkShaderModuleCreateInfo-pCode-01091",     // Int16 vert
+                "VUID-VkShaderModuleCreateInfo-pCode-01091",     // StorageInputOutput16 vert
+                "VUID-VkShaderModuleCreateInfo-pCode-01091"      // StorageInputOutput16 frag
+            };
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
         }
     }
 }
@@ -10087,10 +10103,11 @@ TEST_F(VkLayerTest, Storage8and16bitFeatures) {
             const auto set_info = [&](CreatePipelineHelper &helper) {
                 helper.shader_stages_ = {vs->GetStageCreateInfo(), fs->GetStageCreateInfo()};
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-storageInputOutput16-06334",    // StorageInputOutput16 vert
-                               "VUID-RuntimeSpirv-storageInputOutput16-06334"});  // StorageInputOutput16 frag
+            constexpr std::array vuids = {
+                "VUID-RuntimeSpirv-storageInputOutput16-06334",  // StorageInputOutput16 vert
+                "VUID-RuntimeSpirv-storageInputOutput16-06334"   // StorageInputOutput16 frag
+            };
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
         }
     }
 
@@ -10246,10 +10263,11 @@ TEST_F(VkLayerTest, Storage8and16bitFeatures) {
             const auto set_info = [&](CreatePipelineHelper &helper) {
                 helper.shader_stages_ = {vs->GetStageCreateInfo(), fs->GetStageCreateInfo()};
             };
-            CreatePipelineHelper::OneshotTest(
-                *this, set_info, kErrorBit,
-                vector<string>{"VUID-RuntimeSpirv-storageInputOutput16-06334",    // StorageInputOutput16 vert
-                               "VUID-RuntimeSpirv-storageInputOutput16-06334"});  // StorageInputOutput16 frag
+            constexpr std::array vuids = {
+                "VUID-RuntimeSpirv-storageInputOutput16-06334",  // StorageInputOutput16 vert
+                "VUID-RuntimeSpirv-storageInputOutput16-06334"   // StorageInputOutput16 frag
+            };
+            CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
         }
     }
 
@@ -10766,9 +10784,8 @@ TEST_F(VkLayerTest, ValidateGeometryShaderEnabled) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
 
-    CreatePipelineHelper::OneshotTest(
-        *this, set_info, kErrorBit,
-        std::vector<string>{"VUID-VkPipelineShaderStageCreateInfo-stage-00704", "VUID-VkShaderModuleCreateInfo-pCode-01091"});
+    constexpr std::array vuids = {"VUID-VkPipelineShaderStageCreateInfo-stage-00704", "VUID-VkShaderModuleCreateInfo-pCode-01091"};
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
 }
 
 TEST_F(VkLayerTest, ValidateTessellationShaderEnabled) {
@@ -10820,12 +10837,10 @@ TEST_F(VkLayerTest, ValidateTessellationShaderEnabled) {
         helper.shader_stages_.emplace_back(tcs.GetStageCreateInfo());
         helper.shader_stages_.emplace_back(tes.GetStageCreateInfo());
     };
-
-    CreatePipelineHelper::OneshotTest(
-        *this, set_info, kErrorBit,
-        std::vector<string>{"VUID-VkPipelineShaderStageCreateInfo-stage-00705", "VUID-VkShaderModuleCreateInfo-pCode-01091",
-                            "VUID-VkShaderModuleCreateInfo-pCode-01091",
-                            "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00430"});
+    constexpr std::array vuids = {"VUID-VkPipelineShaderStageCreateInfo-stage-00705", "VUID-VkShaderModuleCreateInfo-pCode-01091",
+                                  "VUID-VkShaderModuleCreateInfo-pCode-01091",
+                                  "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-00430"};
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
 }
 
 TEST_F(VkLayerTest, CreateComputesPipelineWithBadBasePointer) {
@@ -11291,10 +11306,9 @@ TEST_F(VkLayerTest, PipelineAdvancedBlendInvalidBlendOps) {
             color_blend_state.pAttachments = attachment_states;
             helper.gp_ci_.pColorBlendState = &color_blend_state;
         };
-        CreatePipelineHelper::OneshotTest(
-            *this, set_info_color, kErrorBit,
-            std::vector<string>{"VUID-VkPipelineColorBlendAttachmentState-advancedBlendIndependentBlend-01407",
-                                "VUID-VkPipelineColorBlendAttachmentState-advancedBlendIndependentBlend-01408"});
+        constexpr std::array vuids = {"VUID-VkPipelineColorBlendAttachmentState-advancedBlendIndependentBlend-01407",
+                                      "VUID-VkPipelineColorBlendAttachmentState-advancedBlendIndependentBlend-01408"};
+        CreatePipelineHelper::OneshotTest(*this, set_info_color, kErrorBit, vuids);
     }
 }
 

--- a/tests/vklayertests_ray_tracing.cpp
+++ b/tests/vklayertests_ray_tracing.cpp
@@ -2068,10 +2068,10 @@ TEST_F(VkLayerTest, NVRayTracingValidateGeometry) {
     VkBufferObj unbound_buffer;
     unbound_buffer.init_no_mem(*m_device, unbound_buffer_ci);
 
-    const std::vector<float> vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
-    const std::vector<uint32_t> indicies = {0, 1, 2};
-    const std::vector<float> aabbs = {0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f};
-    const std::vector<float> transforms = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f};
+    constexpr std::array vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
+    constexpr std::array<uint32_t, 3> indicies = {0, 1, 2};
+    constexpr std::array aabbs = {0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f};
+    constexpr std::array transforms = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f};
 
     uint8_t *mapped_vbo_buffer_data = (uint8_t *)vbo.memory().map();
     std::memcpy(mapped_vbo_buffer_data, (uint8_t *)vertices.data(), sizeof(float) * vertices.size());


### PR DESCRIPTION
- https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5105

Use `std::array` instead of `std::vector` where the change is straightforward. 
Used `layer_data::span` here: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5140/commits/2655edcc019e78564cf2dc0124f36af2e039a25f#diff-5d94eb97b814705828a8d76adbc1ae6b9f737b290575780736e7899cdc9fd7cdR5780