### PR TITLE
layers: Move some CmdBeginRendering VUs to stateless

### DIFF
--- a/layers/generated/enum_flag_bits.h
+++ b/layers/generated/enum_flag_bits.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2015-2023 The Khronos Group Inc.
  * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (C) 2015-2023 Google Inc.
- * Copyright (c) 2015-2017 Valve Corporation
+ * Copyright (c) 2015-2023 Valve Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -4,7 +4,7 @@
  * Copyright (c) 2015-2023 The Khronos Group Inc.
  * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (C) 2015-2023 Google Inc.
- * Copyright (c) 2015-2017 Valve Corporation
+ * Copyright (c) 2015-2023 Valve Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -10244,6 +10244,7 @@ bool StatelessValidation::PreCallValidateCmdBeginRendering(
             // No xml-driven validation
         }
     }
+    if (!skip) skip |= manual_PreCallValidateCmdBeginRendering(commandBuffer, pRenderingInfo);
     return skip;
 }
 
@@ -11886,6 +11887,7 @@ bool StatelessValidation::PreCallValidateCmdBeginRenderingKHR(
             // No xml-driven validation
         }
     }
+    if (!skip) skip |= manual_PreCallValidateCmdBeginRenderingKHR(commandBuffer, pRenderingInfo);
     return skip;
 }
 

--- a/layers/generated/parameter_validation.h
+++ b/layers/generated/parameter_validation.h
@@ -4,7 +4,7 @@
  * Copyright (c) 2015-2023 The Khronos Group Inc.
  * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (C) 2015-2023 Google Inc.
- * Copyright (c) 2015-2017 Valve Corporation
+ * Copyright (c) 2015-2023 Valve Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/parameter_validation_utils.cpp
+++ b/layers/parameter_validation_utils.cpp
@@ -424,6 +424,13 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         phys_dev_ext_props.fragment_shading_rate_props = fragment_shading_rate_props;
     }
 
+    if (IsExtEnabled(device_extensions.vk_khr_depth_stencil_resolve)) {
+        auto depth_stencil_resolve_props = LvlInitStruct<VkPhysicalDeviceDepthStencilResolveProperties>();
+        auto prop2 = LvlInitStruct<VkPhysicalDeviceProperties2>(&depth_stencil_resolve_props);
+        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        phys_dev_ext_props.depth_stencil_resolve_props = depth_stencil_resolve_props;
+    }
+
     stateless_validation->phys_dev_ext_props = this->phys_dev_ext_props;
 
     // Save app-enabled features in this device's validation object
@@ -9506,6 +9513,11 @@ bool StatelessValidation::ValidateCmdBeginRendering(VkCommandBuffer commandBuffe
             skip |=
                 LogError(commandBuffer, "VUID-VkRenderingInfo-pDepthAttachment-06092",
                          "%s(): pDepthAttachment->imageLayout is can't be VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL.", func_name);
+        } else if (layout == VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL || layout == VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL) {
+            skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pDepthAttachment-07732",
+                             "%s(): pDepthAttachment->imageLayout is can't be VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL or "
+                             "VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL.",
+                             func_name);
         }
 
         if (pRenderingInfo->pDepthAttachment->resolveMode != VK_RESOLVE_MODE_NONE) {
@@ -9513,6 +9525,12 @@ bool StatelessValidation::ValidateCmdBeginRendering(VkCommandBuffer commandBuffe
             if (resolve_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
                 skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pDepthAttachment-06093",
                                  "%s(): pDepthAttachment->resolveImageLayout must not be VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL.",
+                                 func_name);
+            } else if (resolve_layout == VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL ||
+                       resolve_layout == VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL) {
+                skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pDepthAttachment-07733",
+                                 "%s(): pDepthAttachment->resolveImageLayout must not be "
+                                 "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL or VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL.",
                                  func_name);
             }
 
@@ -9539,6 +9557,11 @@ bool StatelessValidation::ValidateCmdBeginRendering(VkCommandBuffer commandBuffe
             skip |=
                 LogError(commandBuffer, "VUID-VkRenderingInfo-pStencilAttachment-06094",
                          "%s(): pStencilAttachment->imageLayout is can't be VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL.", func_name);
+        } else if (layout == VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL || layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL) {
+            skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pStencilAttachment-07734",
+                             "%s(): pStencilAttachment->imageLayout is can't be VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL or "
+                             "VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL.",
+                             func_name);
         }
 
         if (pRenderingInfo->pStencilAttachment->resolveMode != VK_RESOLVE_MODE_NONE) {
@@ -9546,6 +9569,12 @@ bool StatelessValidation::ValidateCmdBeginRendering(VkCommandBuffer commandBuffe
             if (resolve_layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
                 skip |=
                     LogError(commandBuffer, "VUID-VkRenderingInfo-pStencilAttachment-06095",
+                             "%s(): pStencilAttachment->resolveImageLayout must not be VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL.",
+                             func_name);
+            } else if (resolve_layout == VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL ||
+                       resolve_layout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL) {
+                skip |=
+                    LogError(commandBuffer, "VUID-VkRenderingInfo-pStencilAttachment-07735",
                              "%s(): pStencilAttachment->resolveImageLayout must not be VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL.",
                              func_name);
             }

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -74,6 +74,7 @@ class StatelessValidation : public ValidationObject {
         VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced_props;
         VkPhysicalDeviceMaintenance4PropertiesKHR maintenance4_props;
         VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_props;
+        VkPhysicalDeviceDepthStencilResolveProperties depth_stencil_resolve_props;
     };
     DeviceExtensionProperties phys_dev_ext_props = {};
 

--- a/layers/stateless_validation.h
+++ b/layers/stateless_validation.h
@@ -73,6 +73,7 @@ class StatelessValidation : public ValidationObject {
         VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT vertex_attribute_divisor_props;
         VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced_props;
         VkPhysicalDeviceMaintenance4PropertiesKHR maintenance4_props;
+        VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_props;
     };
     DeviceExtensionProperties phys_dev_ext_props = {};
 
@@ -1527,6 +1528,9 @@ class StatelessValidation : public ValidationObject {
                                                       const VkSubpassBeginInfo *) const;
     bool manual_PreCallValidateCmdBeginRenderPass2(VkCommandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                    const VkSubpassBeginInfo *) const;
+    bool ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo, CMD_TYPE cmd_type) const;
+    bool manual_PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo) const;
+    bool manual_PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo) const;
 
     bool manual_PreCallValidateCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
                                                          uint32_t discardRectangleCount, const VkRect2D *pDiscardRectangles) const;

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -280,6 +280,8 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkCmdBeginRenderPass',
             'vkCmdBeginRenderPass2KHR',
             'vkCmdBeginRenderPass2',
+            'vkCmdBeginRendering',
+            'vkCmdBeginRenderingKHR',
             'vkCmdSetDiscardRectangleEXT',
             'vkGetQueryPoolResults',
             'vkCmdBeginConditionalRenderingEXT',
@@ -361,7 +363,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
         copyright += ' * Copyright (c) 2015-2023 The Khronos Group Inc.\n'
         copyright += ' * Copyright (c) 2015-2023 LunarG, Inc.\n'
         copyright += ' * Copyright (C) 2015-2023 Google Inc.\n'
-        copyright += ' * Copyright (c) 2015-2017 Valve Corporation\n'
+        copyright += ' * Copyright (c) 2015-2023 Valve Corporation\n'
         copyright += ' *\n'
         copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
         copyright += ' * you may not use this file except in compliance with the License.\n'


### PR DESCRIPTION
The `ValidateCmdBeginRendering` was growing quite large and there are some new VUs that need to be added, this first moves more checks to statelesss