### PR TITLE
Fix dynamic rasterizationSamples

### DIFF
--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -1982,7 +1982,6 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const PIPELINE_STATE &
                                                           const uint32_t pipe_index) const {
     bool skip = false;
     const auto *multisample_state = pipeline.MultisampleState();
-    const uint32_t raster_samples = static_cast<uint32_t>(pipeline.GetNumSamples());
     if (subpass_desc && multisample_state) {
         const auto &rp_state = pipeline.RenderPassState();
         auto accum_color_samples = [subpass_desc, &rp_state](uint32_t &samples) {
@@ -1994,6 +1993,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const PIPELINE_STATE &
             }
         };
 
+        const uint32_t raster_samples = SampleCountSize(multisample_state->rasterizationSamples);
         if (!pipeline.IsDynamic(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT)) {
             if (!(IsExtEnabled(device_extensions.vk_amd_mixed_attachment_samples) ||
                   IsExtEnabled(device_extensions.vk_nv_framebuffer_mixed_samples) ||

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -207,6 +207,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
         // VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT
         // maxDiscardRectangles is at max 8 on all known implementations currently
         std::bitset<32> discard_rectangles;
+        // VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT
+        VkSampleCountFlagBits rasterization_samples;
     } dynamic_state_value;
 
     std::string begin_rendering_func_name;
@@ -547,6 +549,20 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
             }
         }
         return false;
+    }
+
+    // For given pipeline, return number of MSAA samples, or one if MSAA disabled
+    VkSampleCountFlagBits GetRasterizationSamples(const PIPELINE_STATE &pipeline) const {
+        VkSampleCountFlagBits rasterization_samples = VK_SAMPLE_COUNT_1_BIT;
+        if (pipeline.IsDynamic(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT)) {
+            rasterization_samples = dynamic_state_value.rasterization_samples;
+        } else {
+            const auto ms_state = pipeline.MultisampleState();
+            if (ms_state) {
+                rasterization_samples = ms_state->rasterizationSamples;
+            }
+        }
+        return rasterization_samples;
     }
 
     bool RasterizationDisabled() const;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -352,15 +352,6 @@ class PIPELINE_STATE : public BASE_NODE {
         return nullptr;
     }
 
-    // For given pipeline, return number of MSAA samples, or one if MSAA disabled
-    VkSampleCountFlagBits GetNumSamples() const {
-        const auto ms_state = MultisampleState();
-        if (ms_state) {
-            return ms_state->rasterizationSamples;
-        }
-        return VK_SAMPLE_COUNT_1_BIT;
-    }
-
     const safe_VkPipelineRasterizationStateCreateInfo *RasterizationState() const {
         // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
         if (pre_raster_state) {

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5325,6 +5325,7 @@ void ValidationStateTracker::PostCallRecordCmdSetRasterizationSamplesEXT(VkComma
                                                                          VkSampleCountFlagBits rasterizationSamples) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     cb_state->RecordStateCmd(CMD_SETRASTERIZATIONSAMPLESEXT, CB_DYNAMIC_RASTERIZATION_SAMPLES_EXT_SET);
+    cb_state->dynamic_state_value.rasterization_samples = rasterizationSamples;
 }
 
 void ValidationStateTracker::PostCallRecordCmdSetSampleMaskEXT(VkCommandBuffer commandBuffer, VkSampleCountFlagBits samples,


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5136

There is [future spec language](https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5678) for this as well

The 3 main things done in the 2 layer commits

- Group all the checks in `ValidateGraphicsPipelineMultisampleState` that were dependent of the pipeline using `VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT`
- Move the `GetNumSamples` from `PIPELINE_STATE` to `CMD_BUFFER_STATE` (and rename to `GetRasterizationSamples`)
- Track `vkCmdSetRasterizationSamplesEXT` value being set