### PR TITLE
VUIDs for external memory compatibility when creating resource

### DIFF
--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -178,6 +178,21 @@ static inline int MostSignificantBit(uint32_t mask) {
 #endif
 }
 
+// Iterates over all set bits and calls the callback with a bit mask corresponding to each flag.
+// FlagBits and Flags follow Vulkan naming convensions for flag types.
+// An example of a more efficient implementation: https://lemire.me/blog/2018/02/21/iterating-over-set-bits-quickly/
+template <typename FlagBits, typename Flags, typename Callback>
+void IterateFlags(Flags flags, Callback callback) {
+    uint32_t bit_shift = 0;
+    while (flags) {
+        if (flags & 1) {
+            if (!callback(static_cast<FlagBits>(1ull << bit_shift))) return;
+        }
+        flags >>= 1;
+        ++bit_shift;
+    }
+}
+
 static inline uint32_t SampleCountSize(VkSampleCountFlagBits sample_count) {
     uint32_t size = 0;
     switch (sample_count) {

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -285,7 +285,7 @@ class VkLayerTest : public VkRenderFramework {
     }
 
     template <typename Proc, bool assert_proc = true>
-    [[nodiscard]] const Proc GetInstanceProcAddr(const char *proc_name) noexcept {
+    [[nodiscard]] const Proc GetInstanceProcAddr(const char *proc_name) const noexcept {
         static_assert(std::is_pointer_v<Proc>);
 
         auto proc = reinterpret_cast<Proc>(vk::GetInstanceProcAddr(instance(), proc_name));
@@ -314,7 +314,7 @@ class VkLayerTest : public VkRenderFramework {
     bool m_enableWSI;
 
     void SetTargetApiVersion(uint32_t target_api_version);
-    uint32_t DeviceValidationVersion();
+    uint32_t DeviceValidationVersion() const;
     bool LoadDeviceProfileLayer(
         PFN_vkSetPhysicalDeviceFormatPropertiesEXT &fpvkSetPhysicalDeviceFormatPropertiesEXT,
         PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT &fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT);
@@ -921,6 +921,21 @@ bool FindUnsupportedImage(VkPhysicalDevice gpu, VkImageCreateInfo &image_ci);
 
 VkFormat FindFormatWithoutFeatures(VkPhysicalDevice gpu, VkImageTiling tiling,
                                    VkFormatFeatureFlags undesired_features = UINT32_MAX);
+
+VkExternalMemoryHandleTypeFlags FindSupportedExternalMemoryHandleTypes(const VkLayerTest &test,
+                                                                       const VkBufferCreateInfo &buffer_create_info,
+                                                                       VkExternalMemoryFeatureFlags requested_features,
+                                                                       bool find_single_flag = false);
+
+VkExternalMemoryHandleTypeFlags FindSupportedExternalMemoryHandleTypes(const VkLayerTest &test,
+                                                                       const VkImageCreateInfo &image_create_info,
+                                                                       VkExternalMemoryFeatureFlags requested_features,
+                                                                       bool find_single_flag = false);
+
+VkExternalMemoryHandleTypeFlagsNV FindSupportedExternalMemoryHandleTypesNV(const VkLayerTest &test,
+                                                                           const VkImageCreateInfo &image_create_info,
+                                                                           VkExternalMemoryFeatureFlagsNV requested_features,
+                                                                           bool find_single_flag = false);
 
 void SetImageLayout(VkDeviceObj *device, VkImageAspectFlags aspect, VkImage image, VkImageLayout image_layout);
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -128,12 +128,12 @@ VkRenderFramework::~VkRenderFramework() {
     debug_reporter_.error_monitor_.Finish();
 }
 
-VkPhysicalDevice VkRenderFramework::gpu() {
+VkPhysicalDevice VkRenderFramework::gpu() const {
     EXPECT_NE((VkInstance)0, instance_);  // Invalid to request gpu before instance exists
     return gpu_;
 }
 
-const VkPhysicalDeviceProperties &VkRenderFramework::physDevProps() {
+const VkPhysicalDeviceProperties &VkRenderFramework::physDevProps() const {
     EXPECT_NE((VkPhysicalDevice)0, gpu_);  // Invalid to request physical device properties before gpu
     return physDevProps_;
 }

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -158,15 +158,15 @@ const std::unordered_map<PlatformType, std::string, std::hash<int>> vk_gpu_table
 
 class VkRenderFramework : public VkTestFramework {
   public:
-    VkInstance instance() { return instance_; }
-    VkDevice device() { return m_device->device(); }
+    VkInstance instance() const { return instance_; }
+    VkDevice device() const { return m_device->device(); }
     VkDeviceObj *DeviceObj() const { return m_device; }
-    VkPhysicalDevice gpu();
-    VkRenderPass renderPass() { return m_renderPass; }
+    VkPhysicalDevice gpu() const;
+    VkRenderPass renderPass() const { return m_renderPass; }
     const VkRenderPassCreateInfo &RenderPassInfo() const { return m_renderPass_info; };
-    VkFramebuffer framebuffer() { return m_framebuffer; }
+    VkFramebuffer framebuffer() const { return m_framebuffer; }
     ErrorMonitor &Monitor();
-    const VkPhysicalDeviceProperties &physDevProps();
+    const VkPhysicalDeviceProperties &physDevProps() const;
 
     bool InstanceLayerSupported(const char *layer_name, uint32_t spec_version = 0, uint32_t impl_version = 0);
     bool InstanceExtensionSupported(const char *extension_name, uint32_t spec_version = 0);


### PR DESCRIPTION
VUIDs: 00920, 00990, 00991. (fixes part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4539)

External memory types specified in buffer/image create info structures should be compatible.
The compatibility property also includes supported status. If a handle type is not supported, it is not reported as compatible (even with itself).

Fixes to existing tests where new VUs detected issues.
