### PR TITLE
syncval Revert "Apply render pass final transitions always"

### DIFF
--- a/layers/render_pass_state.cpp
+++ b/layers/render_pass_state.cpp
@@ -213,8 +213,8 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
 
         for (uint32_t attachment = 0; attachment < attachment_count; ++attachment) {
             const auto final_layout = rp->createInfo.pAttachments[attachment].finalLayout;
-            // Add final transitions for attachments at the end of the render pass.
-            if (final_layout != attachment_layout[attachment]) {
+            // Add final transitions for attachments that were used and change layout.
+            if ((last[attachment] != VK_SUBPASS_EXTERNAL) && final_layout != attachment_layout[attachment]) {
                 final_transitions.emplace_back(last[attachment], attachment, attachment_layout[attachment], final_layout);
             }
         }


### PR DESCRIPTION
The change as written causes CTS crashes, as it doesn't make changes to the consumers of the altered data structures.

This reverts commit 41709ca1e50273aa7452fdb04f0c03cde0e53a01.