### PR TITLE
cmake: Check MSVC before installing PDB file

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -326,6 +326,8 @@ endif()
 
 if (WIN32)
     install(FILES ${INTERMEDIATE_FILE} DESTINATION ${LAYER_INSTALL_DIR} RENAME ${OUTPUT_FILE_FINAL_NAME})
+endif()
+if (MSVC)
     install(FILES $<TARGET_PDB_FILE:VkLayer_khronos_validation> DESTINATION ${LAYER_INSTALL_DIR})
 endif()
 


### PR DESCRIPTION
This fixes build in mingw toolchain which does not support PDB file.
Here was the CMake Error:
  Error evaluating generator expression:
    $<TARGET_PDB_FILE:VkLayer_khronos_validation>
  TARGET_PDB_FILE is not supported by the target linker.