### PR TITLE
layers: Fix GetPDFormatProperties

### DIFF
--- a/layers/core_checks/device_validation.cpp
+++ b/layers/core_checks/device_validation.cpp
@@ -653,7 +653,11 @@ VkFormatProperties3KHR CoreChecks::GetPDFormatProperties(const VkFormat format) 
     auto fmt_props_2 = LvlInitStruct<VkFormatProperties2>(&fmt_props_3);
 
     if (has_format_feature2) {
-        DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
+        if (api_version == VK_API_VERSION_1_0) {
+            DispatchGetPhysicalDeviceFormatProperties2KHR(physical_device, format, &fmt_props_2);
+        } else {
+            DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
+        }
     } else {
         VkFormatProperties format_properties;
         DispatchGetPhysicalDeviceFormatProperties(physical_device, format, &format_properties);


### PR DESCRIPTION
Tries to address https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5185

as explained in the issue, there is a case where Vulkan 1.0 is used, `vkGetPhysicalDeviceFormatProperties2` is not promoted yet, but `VK_KHR_format_feature_flags2` is still supported

Note this is a draft because there are many more cases of `DispatchGetPhysicalDeviceFormatProperties2` that would need to be `DispatchGetPhysicalDeviceFormatProperties2KHR`, but before doing that work, want to make sure it solves a real problem first