### PR TITLE
Fix Vertex Input Pipeline State

### DIFF
--- a/layers/core_checks/cmd_buffer_dynamic_validation.cpp
+++ b/layers/core_checks/cmd_buffer_dynamic_validation.cpp
@@ -1087,7 +1087,6 @@ bool CoreChecks::PreCallValidateCmdSetColorBlendAdvancedEXT(VkCommandBuffer comm
                                          "extendedDynamicState3ColorBlendAdvanced");
     for (uint32_t attachment = 0U; attachment < attachmentCount; ++attachment) {
         VkColorBlendAdvancedEXT const &advanced = pColorBlendAdvanced[attachment];
-        // VUID-VkColorBlendAdvancedEXT-srcPremultiplied-07505
         if (advanced.srcPremultiplied != VK_FALSE &&
             !phys_dev_ext_props.blend_operation_advanced_props.advancedBlendNonPremultipliedSrcColor) {
             skip |= LogError(cb_state->Handle(), "VUID-VkColorBlendAdvancedEXT-srcPremultiplied-07505",
@@ -1095,7 +1094,6 @@ bool CoreChecks::PreCallValidateCmdSetColorBlendAdvancedEXT(VkCommandBuffer comm
                              "advancedBlendNonPremultipliedSrcColor is not supported.",
                              attachment);
         }
-        // VUID-VkColorBlendAdvancedEXT-dstPremultiplied-07506
         if (advanced.dstPremultiplied != VK_FALSE &&
             !phys_dev_ext_props.blend_operation_advanced_props.advancedBlendNonPremultipliedDstColor) {
             skip |= LogError(cb_state->Handle(), "VUID-VkColorBlendAdvancedEXT-dstPremultiplied-07506",
@@ -1103,7 +1101,6 @@ bool CoreChecks::PreCallValidateCmdSetColorBlendAdvancedEXT(VkCommandBuffer comm
                              "advancedBlendNonPremultipliedDstColor is not supported.",
                              attachment);
         }
-        // VUID-VkColorBlendAdvancedEXT-blendOverlap-07507
         if (advanced.blendOverlap != VK_BLEND_OVERLAP_UNCORRELATED_EXT &&
             !phys_dev_ext_props.blend_operation_advanced_props.advancedBlendCorrelatedOverlap) {
             skip |= LogError(cb_state->Handle(), "VUID-VkColorBlendAdvancedEXT-blendOverlap-07507",

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -423,8 +423,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateUnprotectedBuffer(const CMD_BUFFER_STATE& cb_state, const BUFFER_STATE& buffer_state, const char* cmd_name,
                                    const char* vuid, const char* more_message = "") const;
 
-    bool ValidatePipelineVertexDivisors(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipe_state_vec, const uint32_t count,
-                                        const VkGraphicsPipelineCreateInfo* pipe_cis) const;
+    bool ValidatePipelineVertexDivisors(const safe_VkPipelineVertexInputStateCreateInfo& input_state,
+                                        const std::vector<VkVertexInputBindingDescription>& binding_descriptions,
+                                        const uint32_t pipe_index) const;
     bool ValidatePipelineCacheControlFlags(VkPipelineCreateFlags flags, uint32_t index, const char* caller_name,
                                            const char* vuid) const;
     bool ValidatePipelineProtectedAccessFlags(VkPipelineCreateFlags flags, uint32_t index) const;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -396,6 +396,13 @@ class PIPELINE_STATE : public BASE_NODE {
         return nullptr;
     }
 
+    const VertexInputState::VertexBindingVector *BindingDescriptions() const {
+        if (vertex_input_state) {
+            return &vertex_input_state->binding_descriptions;
+        }
+        return nullptr;
+    }
+
     uint32_t Subpass() const {
         // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
         if (pre_raster_state) {

--- a/layers/stateless/parameter_validation_utils.cpp
+++ b/layers/stateless/parameter_validation_utils.cpp
@@ -2686,6 +2686,16 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                                          "greater than VkPhysicalDeviceLimits::maxVertexInputAttributeOffset (%" PRIu32 ").",
                                          i, d, vertex_attrib_desc.offset, device_limits.maxVertexInputAttributeOffset);
                     }
+
+                    VkFormatProperties properties;
+                    DispatchGetPhysicalDeviceFormatProperties(physical_device, vertex_attrib_desc.format, &properties);
+                    if ((properties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
+                        skip |= LogError(device, "VUID-VkVertexInputAttributeDescription-format-00623",
+                                         "vkCreateGraphicsPipelines: pCreateInfo[%" PRIu32
+                                         "].pVertexInputState->vertexAttributeDescriptions[%d].format "
+                                         "(%s) is not a supported vertex buffer format.",
+                                         i, d, string_VkFormat(vertex_attrib_desc.format));
+                    }
                 }
             }
 

--- a/layers/stateless/parameter_validation_utils.cpp
+++ b/layers/stateless/parameter_validation_utils.cpp
@@ -9018,21 +9018,18 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
     const auto *vertex_attribute_divisor_features =
         LvlFindInChain<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT>(device_createinfo_pnext);
 
-    // VUID-vkCmdSetVertexInputEXT-vertexBindingDescriptionCount-04791
     if (vertexBindingDescriptionCount > device_limits.maxVertexInputBindings) {
         skip |=
             LogError(device, "VUID-vkCmdSetVertexInputEXT-vertexBindingDescriptionCount-04791",
                      "vkCmdSetVertexInputEXT(): vertexBindingDescriptionCount is greater than the maxVertexInputBindings limit");
     }
 
-    // VUID-vkCmdSetVertexInputEXT-vertexAttributeDescriptionCount-04792
     if (vertexAttributeDescriptionCount > device_limits.maxVertexInputAttributes) {
         skip |= LogError(
             device, "VUID-vkCmdSetVertexInputEXT-vertexAttributeDescriptionCount-04792",
             "vkCmdSetVertexInputEXT(): vertexAttributeDescriptionCount is greater than the maxVertexInputAttributes limit");
     }
 
-    // VUID-vkCmdSetVertexInputEXT-binding-04793
     for (uint32_t attribute = 0; attribute < vertexAttributeDescriptionCount; ++attribute) {
         bool binding_found = false;
         for (uint32_t binding = 0; binding < vertexBindingDescriptionCount; ++binding) {
@@ -9080,7 +9077,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
     }
 
     for (uint32_t binding = 0; binding < vertexBindingDescriptionCount; ++binding) {
-        // VUID-VkVertexInputBindingDescription2EXT-binding-04796
         if (pVertexBindingDescriptions[binding].binding > device_limits.maxVertexInputBindings) {
             skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-binding-04796",
                              "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%" PRIu32
@@ -9088,7 +9084,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
                              binding);
         }
 
-        // VUID-VkVertexInputBindingDescription2EXT-stride-04797
         if (pVertexBindingDescriptions[binding].stride > device_limits.maxVertexInputBindingStride) {
             skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-stride-04797",
                              "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%" PRIu32
@@ -9096,7 +9091,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
                              binding);
         }
 
-        // VUID-VkVertexInputBindingDescription2EXT-divisor-04798
         if (pVertexBindingDescriptions[binding].divisor == 0 &&
             (!vertex_attribute_divisor_features || !vertex_attribute_divisor_features->vertexAttributeInstanceRateZeroDivisor)) {
             skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-divisor-04798",
@@ -9107,7 +9101,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
         }
 
         if (pVertexBindingDescriptions[binding].divisor > 1) {
-            // VUID-VkVertexInputBindingDescription2EXT-divisor-04799
             if (!vertex_attribute_divisor_features || !vertex_attribute_divisor_features->vertexAttributeInstanceRateDivisor) {
                 skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-divisor-04799",
                                  "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%" PRIu32
@@ -9115,7 +9108,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
                                  "vertexAttributeInstanceRateDivisor is not enabled",
                                  binding);
             } else {
-                // VUID-VkVertexInputBindingDescription2EXT-divisor-06226
                 if (pVertexBindingDescriptions[binding].divisor >
                     phys_dev_ext_props.vertex_attribute_divisor_props.maxVertexAttribDivisor) {
                     skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-divisor-06226",
@@ -9124,7 +9116,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
                                      binding);
                 }
 
-                // VUID-VkVertexInputBindingDescription2EXT-divisor-06227
                 if (pVertexBindingDescriptions[binding].inputRate != VK_VERTEX_INPUT_RATE_INSTANCE) {
                     skip |= LogError(device, "VUID-VkVertexInputBindingDescription2EXT-divisor-06227",
                                      "vkCmdSetVertexInputEXT(): pVertexBindingDescriptions[%" PRIu32
@@ -9137,7 +9128,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
     }
 
     for (uint32_t attribute = 0; attribute < vertexAttributeDescriptionCount; ++attribute) {
-        // VUID-VkVertexInputAttributeDescription2EXT-location-06228
         if (pVertexAttributeDescriptions[attribute].location > device_limits.maxVertexInputAttributes) {
             skip |= LogError(device, "VUID-VkVertexInputAttributeDescription2EXT-location-06228",
                              "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%" PRIu32
@@ -9145,7 +9135,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
                              attribute);
         }
 
-        // VUID-VkVertexInputAttributeDescription2EXT-binding-06229
         if (pVertexAttributeDescriptions[attribute].binding > device_limits.maxVertexInputBindings) {
             skip |= LogError(device, "VUID-VkVertexInputAttributeDescription2EXT-binding-06229",
                              "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%" PRIu32
@@ -9153,7 +9142,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
                              attribute);
         }
 
-        // VUID-VkVertexInputAttributeDescription2EXT-offset-06230
         if (pVertexAttributeDescriptions[attribute].offset > device_limits.maxVertexInputAttributeOffset) {
             skip |= LogError(device, "VUID-VkVertexInputAttributeDescription2EXT-offset-06230",
                              "vkCmdSetVertexInputEXT(): pVertexAttributeDescriptions[%" PRIu32
@@ -9161,7 +9149,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
                              attribute);
         }
 
-        // VUID-VkVertexInputAttributeDescription2EXT-format-04805
         VkFormatProperties properties;
         DispatchGetPhysicalDeviceFormatProperties(physical_device, pVertexAttributeDescriptions[attribute].format, &properties);
         if ((properties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -4033,7 +4033,8 @@ TEST_F(VkLayerTest, VUID_VkVertexInputAttributeDescription_location_00620) {
     };
     CreatePipelineHelper::OneshotTest(*this, set_attribute, kErrorBit,
                                       vector<string>{"VUID-VkVertexInputAttributeDescription-location-00620",
-                                                     "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615"});
+                                                     "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
+                                                     "VUID-VkVertexInputAttributeDescription-format-00623"});
 }
 
 TEST_F(VkLayerTest, VUID_VkVertexInputAttributeDescription_binding_00621) {
@@ -4054,7 +4055,8 @@ TEST_F(VkLayerTest, VUID_VkVertexInputAttributeDescription_binding_00621) {
     };
     CreatePipelineHelper::OneshotTest(*this, set_attribute, kErrorBit,
                                       vector<string>{"VUID-VkVertexInputAttributeDescription-binding-00621",
-                                                     "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615"});
+                                                     "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
+                                                     "VUID-VkVertexInputAttributeDescription-format-00623"});
 }
 
 TEST_F(VkLayerTest, VertexInputAttributeDescriptionOffset) {
@@ -16350,7 +16352,7 @@ TEST_F(VkLayerTest, MeshShaderEXT) {
             helper.gp_ci_.pInputAssemblyState = nullptr;
         };
         CreatePipelineHelper::OneshotTest(*this, break_vp3, kErrorBit,
-                                          vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-pStages-02097",
+                                          vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-04910",
                                                                "VUID-VkGraphicsPipelineCreateInfo-pStages-02098"}));
 
         // xfb with mesh shader


### PR DESCRIPTION
The combination of `VK_EXT_graphics_pipeline_library` / `VK_EXT_vertex_input_dynamic_state` / `VK_EXT_vertex_attribute_divisor` provides some awful edge cases, this addresses them

- Moves `VUID-VkVertexInputAttributeDescription-format-00623` to stateless (it's counterpart `VUID-VkVertexInputAttributeDescription2EXT-format-04805` is already in stateless)
- make sure `ValidatePipelineVertexDivisors()` (for `VK_EXT_vertex_attribute_divisor`) is not called unless a valid vertex input state is being used
- add missing `VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-04910` label for `VK_EXT_vertex_input_dynamic_state`
- Group this logic all together
- Add `VkPositiveGraphicsLibraryLayerTest` version of other tests to make sure `VK_EXT_graphics_pipeline_library` enabled doesn't throw false Validation Warnings