### PR TITLE
layers: Fix formatting of zero flags

### DIFF
--- a/layers/generated/vk_enum_string_helper.h
+++ b/layers/generated/vk_enum_string_helper.h
@@ -1796,7 +1796,7 @@ static inline std::string string_VkAccessFlags(VkAccessFlags input_value)
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkAccessFlagBits(static_cast<VkAccessFlagBits>(0)));
+    if (ret.empty()) ret.append("VkAccessFlags(0)");
     return ret;
 }
 
@@ -1916,7 +1916,7 @@ static inline std::string string_VkImageAspectFlags(VkImageAspectFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkImageAspectFlagBits(static_cast<VkImageAspectFlagBits>(0)));
+    if (ret.empty()) ret.append("VkImageAspectFlags(0)");
     return ret;
 }
 
@@ -2668,7 +2668,7 @@ static inline std::string string_VkFormatFeatureFlags(VkFormatFeatureFlags input
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkFormatFeatureFlagBits(static_cast<VkFormatFeatureFlagBits>(0)));
+    if (ret.empty()) ret.append("VkFormatFeatureFlags(0)");
     return ret;
 }
 
@@ -2731,7 +2731,7 @@ static inline std::string string_VkImageCreateFlags(VkImageCreateFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkImageCreateFlagBits(static_cast<VkImageCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkImageCreateFlags(0)");
     return ret;
 }
 
@@ -2770,7 +2770,7 @@ static inline std::string string_VkSampleCountFlags(VkSampleCountFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSampleCountFlagBits(static_cast<VkSampleCountFlagBits>(0)));
+    if (ret.empty()) ret.append("VkSampleCountFlags(0)");
     return ret;
 }
 
@@ -2871,7 +2871,7 @@ static inline std::string string_VkImageUsageFlags(VkImageUsageFlags input_value
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkImageUsageFlagBits(static_cast<VkImageUsageFlagBits>(0)));
+    if (ret.empty()) ret.append("VkImageUsageFlags(0)");
     return ret;
 }
 
@@ -2898,7 +2898,7 @@ static inline std::string string_VkInstanceCreateFlags(VkInstanceCreateFlags inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkInstanceCreateFlagBits(static_cast<VkInstanceCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkInstanceCreateFlags(0)");
     return ret;
 }
 
@@ -2927,7 +2927,7 @@ static inline std::string string_VkMemoryHeapFlags(VkMemoryHeapFlags input_value
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkMemoryHeapFlagBits(static_cast<VkMemoryHeapFlagBits>(0)));
+    if (ret.empty()) ret.append("VkMemoryHeapFlags(0)");
     return ret;
 }
 
@@ -2970,7 +2970,7 @@ static inline std::string string_VkMemoryPropertyFlags(VkMemoryPropertyFlags inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkMemoryPropertyFlagBits(static_cast<VkMemoryPropertyFlagBits>(0)));
+    if (ret.empty()) ret.append("VkMemoryPropertyFlags(0)");
     return ret;
 }
 
@@ -3032,7 +3032,7 @@ static inline std::string string_VkQueueFlags(VkQueueFlags input_value)
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkQueueFlagBits(static_cast<VkQueueFlagBits>(0)));
+    if (ret.empty()) ret.append("VkQueueFlags(0)");
     return ret;
 }
 
@@ -3059,7 +3059,7 @@ static inline std::string string_VkDeviceQueueCreateFlags(VkDeviceQueueCreateFla
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDeviceQueueCreateFlagBits(static_cast<VkDeviceQueueCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkDeviceQueueCreateFlags(0)");
     return ret;
 }
 
@@ -3138,7 +3138,7 @@ static inline std::string string_VkPipelineStageFlags(VkPipelineStageFlags input
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineStageFlagBits(static_cast<VkPipelineStageFlagBits>(0)));
+    if (ret.empty()) ret.append("VkPipelineStageFlags(0)");
     return ret;
 }
 
@@ -3165,7 +3165,7 @@ static inline std::string string_VkSparseMemoryBindFlags(VkSparseMemoryBindFlags
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSparseMemoryBindFlagBits(static_cast<VkSparseMemoryBindFlagBits>(0)));
+    if (ret.empty()) ret.append("VkSparseMemoryBindFlags(0)");
     return ret;
 }
 
@@ -3196,7 +3196,7 @@ static inline std::string string_VkSparseImageFormatFlags(VkSparseImageFormatFla
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSparseImageFormatFlagBits(static_cast<VkSparseImageFormatFlagBits>(0)));
+    if (ret.empty()) ret.append("VkSparseImageFormatFlags(0)");
     return ret;
 }
 
@@ -3223,7 +3223,7 @@ static inline std::string string_VkFenceCreateFlags(VkFenceCreateFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkFenceCreateFlagBits(static_cast<VkFenceCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkFenceCreateFlags(0)");
     return ret;
 }
 
@@ -3250,7 +3250,7 @@ static inline std::string string_VkEventCreateFlags(VkEventCreateFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkEventCreateFlagBits(static_cast<VkEventCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkEventCreateFlags(0)");
     return ret;
 }
 
@@ -3303,7 +3303,7 @@ static inline std::string string_VkQueryPipelineStatisticFlags(VkQueryPipelineSt
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkQueryPipelineStatisticFlagBits(static_cast<VkQueryPipelineStatisticFlagBits>(0)));
+    if (ret.empty()) ret.append("VkQueryPipelineStatisticFlags(0)");
     return ret;
 }
 
@@ -3383,7 +3383,7 @@ static inline std::string string_VkQueryResultFlags(VkQueryResultFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkQueryResultFlagBits(static_cast<VkQueryResultFlagBits>(0)));
+    if (ret.empty()) ret.append("VkQueryResultFlags(0)");
     return ret;
 }
 
@@ -3420,7 +3420,7 @@ static inline std::string string_VkBufferCreateFlags(VkBufferCreateFlags input_v
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkBufferCreateFlagBits(static_cast<VkBufferCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkBufferCreateFlags(0)");
     return ret;
 }
 
@@ -3499,7 +3499,7 @@ static inline std::string string_VkBufferUsageFlags(VkBufferUsageFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkBufferUsageFlagBits(static_cast<VkBufferUsageFlagBits>(0)));
+    if (ret.empty()) ret.append("VkBufferUsageFlags(0)");
     return ret;
 }
 
@@ -3566,7 +3566,7 @@ static inline std::string string_VkImageViewCreateFlags(VkImageViewCreateFlags i
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkImageViewCreateFlagBits(static_cast<VkImageViewCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkImageViewCreateFlags(0)");
     return ret;
 }
 
@@ -3616,7 +3616,7 @@ static inline std::string string_VkPipelineCacheCreateFlags(VkPipelineCacheCreat
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineCacheCreateFlagBits(static_cast<VkPipelineCacheCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkPipelineCacheCreateFlags(0)");
     return ret;
 }
 
@@ -3807,7 +3807,7 @@ static inline std::string string_VkColorComponentFlags(VkColorComponentFlags inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkColorComponentFlagBits(static_cast<VkColorComponentFlagBits>(0)));
+    if (ret.empty()) ret.append("VkColorComponentFlags(0)");
     return ret;
 }
 
@@ -3917,7 +3917,7 @@ static inline std::string string_VkPipelineCreateFlags(VkPipelineCreateFlags inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineCreateFlagBits(static_cast<VkPipelineCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkPipelineCreateFlags(0)");
     return ret;
 }
 
@@ -3946,7 +3946,7 @@ static inline std::string string_VkPipelineShaderStageCreateFlags(VkPipelineShad
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineShaderStageCreateFlagBits(static_cast<VkPipelineShaderStageCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkPipelineShaderStageCreateFlags(0)");
     return ret;
 }
 
@@ -4009,7 +4009,7 @@ static inline std::string string_VkShaderStageFlags(VkShaderStageFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkShaderStageFlagBits(static_cast<VkShaderStageFlagBits>(0)));
+    if (ret.empty()) ret.append("VkShaderStageFlags(0)");
     return ret;
 }
 
@@ -4042,7 +4042,7 @@ static inline std::string string_VkCullModeFlags(VkCullModeFlags input_value)
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkCullModeFlagBits(static_cast<VkCullModeFlagBits>(0)));
+    if (ret.empty()) ret.append("VkCullModeFlags(0)");
     return ret;
 }
 
@@ -4290,7 +4290,7 @@ static inline std::string string_VkPipelineDepthStencilStateCreateFlags(VkPipeli
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineDepthStencilStateCreateFlagBits(static_cast<VkPipelineDepthStencilStateCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkPipelineDepthStencilStateCreateFlags(0)");
     return ret;
 }
 
@@ -4342,7 +4342,7 @@ static inline std::string string_VkPipelineColorBlendStateCreateFlags(VkPipeline
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineColorBlendStateCreateFlagBits(static_cast<VkPipelineColorBlendStateCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkPipelineColorBlendStateCreateFlags(0)");
     return ret;
 }
 
@@ -4410,7 +4410,7 @@ static inline std::string string_VkPipelineLayoutCreateFlags(VkPipelineLayoutCre
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineLayoutCreateFlagBits(static_cast<VkPipelineLayoutCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkPipelineLayoutCreateFlags(0)");
     return ret;
 }
 
@@ -4504,7 +4504,7 @@ static inline std::string string_VkSamplerCreateFlags(VkSamplerCreateFlags input
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSamplerCreateFlagBits(static_cast<VkSamplerCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkSamplerCreateFlags(0)");
     return ret;
 }
 
@@ -4548,7 +4548,7 @@ static inline std::string string_VkDescriptorPoolCreateFlags(VkDescriptorPoolCre
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDescriptorPoolCreateFlagBits(static_cast<VkDescriptorPoolCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkDescriptorPoolCreateFlags(0)");
     return ret;
 }
 
@@ -4626,7 +4626,7 @@ static inline std::string string_VkDescriptorSetLayoutCreateFlags(VkDescriptorSe
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDescriptorSetLayoutCreateFlagBits(static_cast<VkDescriptorSetLayoutCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkDescriptorSetLayoutCreateFlags(0)");
     return ret;
 }
 
@@ -4653,7 +4653,7 @@ static inline std::string string_VkAttachmentDescriptionFlags(VkAttachmentDescri
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkAttachmentDescriptionFlagBits(static_cast<VkAttachmentDescriptionFlagBits>(0)));
+    if (ret.empty()) ret.append("VkAttachmentDescriptionFlags(0)");
     return ret;
 }
 
@@ -4718,7 +4718,7 @@ static inline std::string string_VkDependencyFlags(VkDependencyFlags input_value
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDependencyFlagBits(static_cast<VkDependencyFlagBits>(0)));
+    if (ret.empty()) ret.append("VkDependencyFlags(0)");
     return ret;
 }
 
@@ -4745,7 +4745,7 @@ static inline std::string string_VkFramebufferCreateFlags(VkFramebufferCreateFla
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkFramebufferCreateFlagBits(static_cast<VkFramebufferCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkFramebufferCreateFlags(0)");
     return ret;
 }
 
@@ -4789,7 +4789,7 @@ static inline std::string string_VkRenderPassCreateFlags(VkRenderPassCreateFlags
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkRenderPassCreateFlagBits(static_cast<VkRenderPassCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkRenderPassCreateFlags(0)");
     return ret;
 }
 
@@ -4830,7 +4830,7 @@ static inline std::string string_VkSubpassDescriptionFlags(VkSubpassDescriptionF
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSubpassDescriptionFlagBits(static_cast<VkSubpassDescriptionFlagBits>(0)));
+    if (ret.empty()) ret.append("VkSubpassDescriptionFlags(0)");
     return ret;
 }
 
@@ -4861,7 +4861,7 @@ static inline std::string string_VkCommandPoolCreateFlags(VkCommandPoolCreateFla
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkCommandPoolCreateFlagBits(static_cast<VkCommandPoolCreateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkCommandPoolCreateFlags(0)");
     return ret;
 }
 
@@ -4888,7 +4888,7 @@ static inline std::string string_VkCommandPoolResetFlags(VkCommandPoolResetFlags
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkCommandPoolResetFlagBits(static_cast<VkCommandPoolResetFlagBits>(0)));
+    if (ret.empty()) ret.append("VkCommandPoolResetFlags(0)");
     return ret;
 }
 
@@ -4932,7 +4932,7 @@ static inline std::string string_VkCommandBufferUsageFlags(VkCommandBufferUsageF
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkCommandBufferUsageFlagBits(static_cast<VkCommandBufferUsageFlagBits>(0)));
+    if (ret.empty()) ret.append("VkCommandBufferUsageFlags(0)");
     return ret;
 }
 
@@ -4959,7 +4959,7 @@ static inline std::string string_VkQueryControlFlags(VkQueryControlFlags input_v
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkQueryControlFlagBits(static_cast<VkQueryControlFlagBits>(0)));
+    if (ret.empty()) ret.append("VkQueryControlFlags(0)");
     return ret;
 }
 
@@ -4986,7 +4986,7 @@ static inline std::string string_VkCommandBufferResetFlags(VkCommandBufferResetF
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkCommandBufferResetFlagBits(static_cast<VkCommandBufferResetFlagBits>(0)));
+    if (ret.empty()) ret.append("VkCommandBufferResetFlags(0)");
     return ret;
 }
 
@@ -5034,7 +5034,7 @@ static inline std::string string_VkStencilFaceFlags(VkStencilFaceFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkStencilFaceFlagBits(static_cast<VkStencilFaceFlagBits>(0)));
+    if (ret.empty()) ret.append("VkStencilFaceFlags(0)");
     return ret;
 }
 
@@ -5090,7 +5090,7 @@ static inline std::string string_VkSubgroupFeatureFlags(VkSubgroupFeatureFlags i
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSubgroupFeatureFlagBits(static_cast<VkSubgroupFeatureFlagBits>(0)));
+    if (ret.empty()) ret.append("VkSubgroupFeatureFlags(0)");
     return ret;
 }
 
@@ -5123,7 +5123,7 @@ static inline std::string string_VkPeerMemoryFeatureFlags(VkPeerMemoryFeatureFla
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPeerMemoryFeatureFlagBits(static_cast<VkPeerMemoryFeatureFlagBits>(0)));
+    if (ret.empty()) ret.append("VkPeerMemoryFeatureFlags(0)");
     return ret;
 }
 
@@ -5154,7 +5154,7 @@ static inline std::string string_VkMemoryAllocateFlags(VkMemoryAllocateFlags inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkMemoryAllocateFlagBits(static_cast<VkMemoryAllocateFlagBits>(0)));
+    if (ret.empty()) ret.append("VkMemoryAllocateFlags(0)");
     return ret;
 }
 
@@ -5289,7 +5289,7 @@ static inline std::string string_VkExternalMemoryHandleTypeFlags(VkExternalMemor
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalMemoryHandleTypeFlagBits(static_cast<VkExternalMemoryHandleTypeFlagBits>(0)));
+    if (ret.empty()) ret.append("VkExternalMemoryHandleTypeFlags(0)");
     return ret;
 }
 
@@ -5320,7 +5320,7 @@ static inline std::string string_VkExternalMemoryFeatureFlags(VkExternalMemoryFe
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalMemoryFeatureFlagBits(static_cast<VkExternalMemoryFeatureFlagBits>(0)));
+    if (ret.empty()) ret.append("VkExternalMemoryFeatureFlags(0)");
     return ret;
 }
 
@@ -5353,7 +5353,7 @@ static inline std::string string_VkExternalFenceHandleTypeFlags(VkExternalFenceH
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalFenceHandleTypeFlagBits(static_cast<VkExternalFenceHandleTypeFlagBits>(0)));
+    if (ret.empty()) ret.append("VkExternalFenceHandleTypeFlags(0)");
     return ret;
 }
 
@@ -5382,7 +5382,7 @@ static inline std::string string_VkExternalFenceFeatureFlags(VkExternalFenceFeat
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalFenceFeatureFlagBits(static_cast<VkExternalFenceFeatureFlagBits>(0)));
+    if (ret.empty()) ret.append("VkExternalFenceFeatureFlags(0)");
     return ret;
 }
 
@@ -5409,7 +5409,7 @@ static inline std::string string_VkFenceImportFlags(VkFenceImportFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkFenceImportFlagBits(static_cast<VkFenceImportFlagBits>(0)));
+    if (ret.empty()) ret.append("VkFenceImportFlags(0)");
     return ret;
 }
 
@@ -5436,7 +5436,7 @@ static inline std::string string_VkSemaphoreImportFlags(VkSemaphoreImportFlags i
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSemaphoreImportFlagBits(static_cast<VkSemaphoreImportFlagBits>(0)));
+    if (ret.empty()) ret.append("VkSemaphoreImportFlags(0)");
     return ret;
 }
 
@@ -5473,7 +5473,7 @@ static inline std::string string_VkExternalSemaphoreHandleTypeFlags(VkExternalSe
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalSemaphoreHandleTypeFlagBits(static_cast<VkExternalSemaphoreHandleTypeFlagBits>(0)));
+    if (ret.empty()) ret.append("VkExternalSemaphoreHandleTypeFlags(0)");
     return ret;
 }
 
@@ -5502,7 +5502,7 @@ static inline std::string string_VkExternalSemaphoreFeatureFlags(VkExternalSemap
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalSemaphoreFeatureFlagBits(static_cast<VkExternalSemaphoreFeatureFlagBits>(0)));
+    if (ret.empty()) ret.append("VkExternalSemaphoreFeatureFlags(0)");
     return ret;
 }
 
@@ -5611,7 +5611,7 @@ static inline std::string string_VkResolveModeFlags(VkResolveModeFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkResolveModeFlagBits(static_cast<VkResolveModeFlagBits>(0)));
+    if (ret.empty()) ret.append("VkResolveModeFlags(0)");
     return ret;
 }
 
@@ -5644,7 +5644,7 @@ static inline std::string string_VkDescriptorBindingFlags(VkDescriptorBindingFla
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDescriptorBindingFlagBits(static_cast<VkDescriptorBindingFlagBits>(0)));
+    if (ret.empty()) ret.append("VkDescriptorBindingFlags(0)");
     return ret;
 }
 
@@ -5699,7 +5699,7 @@ static inline std::string string_VkSemaphoreWaitFlags(VkSemaphoreWaitFlags input
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSemaphoreWaitFlagBits(static_cast<VkSemaphoreWaitFlagBits>(0)));
+    if (ret.empty()) ret.append("VkSemaphoreWaitFlags(0)");
     return ret;
 }
 
@@ -5730,7 +5730,7 @@ static inline std::string string_VkPipelineCreationFeedbackFlags(VkPipelineCreat
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineCreationFeedbackFlagBits(static_cast<VkPipelineCreationFeedbackFlagBits>(0)));
+    if (ret.empty()) ret.append("VkPipelineCreationFeedbackFlags(0)");
     return ret;
 }
 
@@ -5769,7 +5769,7 @@ static inline std::string string_VkToolPurposeFlags(VkToolPurposeFlags input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkToolPurposeFlagBits(static_cast<VkToolPurposeFlagBits>(0)));
+    if (ret.empty()) ret.append("VkToolPurposeFlags(0)");
     return ret;
 }
 
@@ -5880,7 +5880,7 @@ static inline std::string string_VkPipelineStageFlags2(VkPipelineStageFlags2 inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineStageFlagBits2(static_cast<uint64_t>(0)));
+    if (ret.empty()) ret.append("VkPipelineStageFlags2(0)");
     return ret;
 }
 
@@ -5995,7 +5995,7 @@ static inline std::string string_VkAccessFlags2(VkAccessFlags2 input_value)
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkAccessFlagBits2(static_cast<uint64_t>(0)));
+    if (ret.empty()) ret.append("VkAccessFlags2(0)");
     return ret;
 }
 
@@ -6022,7 +6022,7 @@ static inline std::string string_VkSubmitFlags(VkSubmitFlags input_value)
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSubmitFlagBits(static_cast<VkSubmitFlagBits>(0)));
+    if (ret.empty()) ret.append("VkSubmitFlags(0)");
     return ret;
 }
 
@@ -6055,7 +6055,7 @@ static inline std::string string_VkRenderingFlags(VkRenderingFlags input_value)
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkRenderingFlagBits(static_cast<VkRenderingFlagBits>(0)));
+    if (ret.empty()) ret.append("VkRenderingFlags(0)");
     return ret;
 }
 
@@ -6168,7 +6168,7 @@ static inline std::string string_VkFormatFeatureFlags2(VkFormatFeatureFlags2 inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkFormatFeatureFlagBits2(static_cast<uint64_t>(0)));
+    if (ret.empty()) ret.append("VkFormatFeatureFlags2(0)");
     return ret;
 }
 
@@ -6211,7 +6211,7 @@ static inline std::string string_VkSurfaceTransformFlagsKHR(VkSurfaceTransformFl
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSurfaceTransformFlagBitsKHR(static_cast<VkSurfaceTransformFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkSurfaceTransformFlagsKHR(0)");
     return ret;
 }
 
@@ -6306,7 +6306,7 @@ static inline std::string string_VkCompositeAlphaFlagsKHR(VkCompositeAlphaFlagsK
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkCompositeAlphaFlagBitsKHR(static_cast<VkCompositeAlphaFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkCompositeAlphaFlagsKHR(0)");
     return ret;
 }
 
@@ -6339,7 +6339,7 @@ static inline std::string string_VkSwapchainCreateFlagsKHR(VkSwapchainCreateFlag
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSwapchainCreateFlagBitsKHR(static_cast<VkSwapchainCreateFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkSwapchainCreateFlagsKHR(0)");
     return ret;
 }
 
@@ -6372,7 +6372,7 @@ static inline std::string string_VkDeviceGroupPresentModeFlagsKHR(VkDeviceGroupP
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDeviceGroupPresentModeFlagBitsKHR(static_cast<VkDeviceGroupPresentModeFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkDeviceGroupPresentModeFlagsKHR(0)");
     return ret;
 }
 
@@ -6405,7 +6405,7 @@ static inline std::string string_VkDisplayPlaneAlphaFlagsKHR(VkDisplayPlaneAlpha
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDisplayPlaneAlphaFlagBitsKHR(static_cast<VkDisplayPlaneAlphaFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkDisplayPlaneAlphaFlagsKHR(0)");
     return ret;
 }
 
@@ -6444,7 +6444,7 @@ static inline std::string string_VkVideoCodecOperationFlagsKHR(VkVideoCodecOpera
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoCodecOperationFlagBitsKHR(static_cast<VkVideoCodecOperationFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoCodecOperationFlagsKHR(0)");
     return ret;
 }
 
@@ -6479,7 +6479,7 @@ static inline std::string string_VkVideoChromaSubsamplingFlagsKHR(VkVideoChromaS
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoChromaSubsamplingFlagBitsKHR(static_cast<VkVideoChromaSubsamplingFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoChromaSubsamplingFlagsKHR(0)");
     return ret;
 }
 
@@ -6512,7 +6512,7 @@ static inline std::string string_VkVideoComponentBitDepthFlagsKHR(VkVideoCompone
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoComponentBitDepthFlagBitsKHR(static_cast<VkVideoComponentBitDepthFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoComponentBitDepthFlagsKHR(0)");
     return ret;
 }
 
@@ -6541,7 +6541,7 @@ static inline std::string string_VkVideoCapabilityFlagsKHR(VkVideoCapabilityFlag
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoCapabilityFlagBitsKHR(static_cast<VkVideoCapabilityFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoCapabilityFlagsKHR(0)");
     return ret;
 }
 
@@ -6568,7 +6568,7 @@ static inline std::string string_VkVideoSessionCreateFlagsKHR(VkVideoSessionCrea
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoSessionCreateFlagBitsKHR(static_cast<VkVideoSessionCreateFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoSessionCreateFlagsKHR(0)");
     return ret;
 }
 
@@ -6603,7 +6603,7 @@ static inline std::string string_VkVideoCodingControlFlagsKHR(VkVideoCodingContr
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoCodingControlFlagBitsKHR(static_cast<VkVideoCodingControlFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoCodingControlFlagsKHR(0)");
     return ret;
 }
 
@@ -6647,7 +6647,7 @@ static inline std::string string_VkVideoDecodeCapabilityFlagsKHR(VkVideoDecodeCa
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoDecodeCapabilityFlagBitsKHR(static_cast<VkVideoDecodeCapabilityFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoDecodeCapabilityFlagsKHR(0)");
     return ret;
 }
 
@@ -6680,7 +6680,7 @@ static inline std::string string_VkVideoDecodeUsageFlagsKHR(VkVideoDecodeUsageFl
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoDecodeUsageFlagBitsKHR(static_cast<VkVideoDecodeUsageFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoDecodeUsageFlagsKHR(0)");
     return ret;
 }
 
@@ -6711,7 +6711,7 @@ static inline std::string string_VkVideoDecodeH264PictureLayoutFlagsKHR(VkVideoD
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoDecodeH264PictureLayoutFlagBitsKHR(static_cast<VkVideoDecodeH264PictureLayoutFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoDecodeH264PictureLayoutFlagsKHR(0)");
     return ret;
 }
 
@@ -6744,7 +6744,7 @@ static inline std::string string_VkRenderingFlagsKHR(VkRenderingFlagsKHR input_v
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkRenderingFlagBitsKHR(static_cast<VkRenderingFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkRenderingFlagsKHR(0)");
     return ret;
 }
 
@@ -6777,7 +6777,7 @@ static inline std::string string_VkPeerMemoryFeatureFlagsKHR(VkPeerMemoryFeature
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPeerMemoryFeatureFlagBitsKHR(static_cast<VkPeerMemoryFeatureFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkPeerMemoryFeatureFlagsKHR(0)");
     return ret;
 }
 
@@ -6808,7 +6808,7 @@ static inline std::string string_VkMemoryAllocateFlagsKHR(VkMemoryAllocateFlagsK
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkMemoryAllocateFlagBitsKHR(static_cast<VkMemoryAllocateFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkMemoryAllocateFlagsKHR(0)");
     return ret;
 }
 
@@ -6859,7 +6859,7 @@ static inline std::string string_VkExternalMemoryHandleTypeFlagsKHR(VkExternalMe
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalMemoryHandleTypeFlagBitsKHR(static_cast<VkExternalMemoryHandleTypeFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkExternalMemoryHandleTypeFlagsKHR(0)");
     return ret;
 }
 
@@ -6890,7 +6890,7 @@ static inline std::string string_VkExternalMemoryFeatureFlagsKHR(VkExternalMemor
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalMemoryFeatureFlagBitsKHR(static_cast<VkExternalMemoryFeatureFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkExternalMemoryFeatureFlagsKHR(0)");
     return ret;
 }
 
@@ -6927,7 +6927,7 @@ static inline std::string string_VkExternalSemaphoreHandleTypeFlagsKHR(VkExterna
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalSemaphoreHandleTypeFlagBitsKHR(static_cast<VkExternalSemaphoreHandleTypeFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkExternalSemaphoreHandleTypeFlagsKHR(0)");
     return ret;
 }
 
@@ -6956,7 +6956,7 @@ static inline std::string string_VkExternalSemaphoreFeatureFlagsKHR(VkExternalSe
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalSemaphoreFeatureFlagBitsKHR(static_cast<VkExternalSemaphoreFeatureFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkExternalSemaphoreFeatureFlagsKHR(0)");
     return ret;
 }
 
@@ -6983,7 +6983,7 @@ static inline std::string string_VkSemaphoreImportFlagsKHR(VkSemaphoreImportFlag
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSemaphoreImportFlagBitsKHR(static_cast<VkSemaphoreImportFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkSemaphoreImportFlagsKHR(0)");
     return ret;
 }
 
@@ -7029,7 +7029,7 @@ static inline std::string string_VkExternalFenceHandleTypeFlagsKHR(VkExternalFen
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalFenceHandleTypeFlagBitsKHR(static_cast<VkExternalFenceHandleTypeFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkExternalFenceHandleTypeFlagsKHR(0)");
     return ret;
 }
 
@@ -7058,7 +7058,7 @@ static inline std::string string_VkExternalFenceFeatureFlagsKHR(VkExternalFenceF
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalFenceFeatureFlagBitsKHR(static_cast<VkExternalFenceFeatureFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkExternalFenceFeatureFlagsKHR(0)");
     return ret;
 }
 
@@ -7085,7 +7085,7 @@ static inline std::string string_VkFenceImportFlagsKHR(VkFenceImportFlagsKHR inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkFenceImportFlagBitsKHR(static_cast<VkFenceImportFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkFenceImportFlagsKHR(0)");
     return ret;
 }
 
@@ -7181,7 +7181,7 @@ static inline std::string string_VkPerformanceCounterDescriptionFlagsKHR(VkPerfo
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPerformanceCounterDescriptionFlagBitsKHR(static_cast<VkPerformanceCounterDescriptionFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkPerformanceCounterDescriptionFlagsKHR(0)");
     return ret;
 }
 
@@ -7378,7 +7378,7 @@ static inline std::string string_VkResolveModeFlagsKHR(VkResolveModeFlagsKHR inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkResolveModeFlagBitsKHR(static_cast<VkResolveModeFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkResolveModeFlagsKHR(0)");
     return ret;
 }
 
@@ -7418,7 +7418,7 @@ static inline std::string string_VkSemaphoreWaitFlagsKHR(VkSemaphoreWaitFlagsKHR
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSemaphoreWaitFlagBitsKHR(static_cast<VkSemaphoreWaitFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkSemaphoreWaitFlagsKHR(0)");
     return ret;
 }
 
@@ -7484,7 +7484,7 @@ static inline std::string string_VkVideoEncodeCapabilityFlagsKHR(VkVideoEncodeCa
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeCapabilityFlagBitsKHR(static_cast<VkVideoEncodeCapabilityFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeCapabilityFlagsKHR(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -7519,7 +7519,7 @@ static inline std::string string_VkVideoEncodeRateControlModeFlagsKHR(VkVideoEnc
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeRateControlModeFlagBitsKHR(static_cast<VkVideoEncodeRateControlModeFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeRateControlModeFlagsKHR(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -7558,7 +7558,7 @@ static inline std::string string_VkVideoEncodeUsageFlagsKHR(VkVideoEncodeUsageFl
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeUsageFlagBitsKHR(static_cast<VkVideoEncodeUsageFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeUsageFlagsKHR(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -7595,7 +7595,7 @@ static inline std::string string_VkVideoEncodeContentFlagsKHR(VkVideoEncodeConte
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeContentFlagBitsKHR(static_cast<VkVideoEncodeContentFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeContentFlagsKHR(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -7730,7 +7730,7 @@ static inline std::string string_VkPipelineStageFlags2KHR(VkPipelineStageFlags2K
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineStageFlagBits2KHR(static_cast<uint64_t>(0)));
+    if (ret.empty()) ret.append("VkPipelineStageFlags2KHR(0)");
     return ret;
 }
 
@@ -7845,7 +7845,7 @@ static inline std::string string_VkAccessFlags2KHR(VkAccessFlags2KHR input_value
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkAccessFlagBits2KHR(static_cast<uint64_t>(0)));
+    if (ret.empty()) ret.append("VkAccessFlags2KHR(0)");
     return ret;
 }
 
@@ -7872,7 +7872,7 @@ static inline std::string string_VkSubmitFlagsKHR(VkSubmitFlagsKHR input_value)
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSubmitFlagBitsKHR(static_cast<VkSubmitFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkSubmitFlagsKHR(0)");
     return ret;
 }
 
@@ -7985,7 +7985,7 @@ static inline std::string string_VkFormatFeatureFlags2KHR(VkFormatFeatureFlags2K
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkFormatFeatureFlagBits2KHR(static_cast<uint64_t>(0)));
+    if (ret.empty()) ret.append("VkFormatFeatureFlags2KHR(0)");
     return ret;
 }
 
@@ -8020,7 +8020,7 @@ static inline std::string string_VkDebugReportFlagsEXT(VkDebugReportFlagsEXT inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDebugReportFlagBitsEXT(static_cast<VkDebugReportFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkDebugReportFlagsEXT(0)");
     return ret;
 }
 
@@ -8198,7 +8198,7 @@ static inline std::string string_VkVideoEncodeH264CapabilityFlagsEXT(VkVideoEnco
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeH264CapabilityFlagBitsEXT(static_cast<VkVideoEncodeH264CapabilityFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeH264CapabilityFlagsEXT(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -8233,7 +8233,7 @@ static inline std::string string_VkVideoEncodeH264InputModeFlagsEXT(VkVideoEncod
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeH264InputModeFlagBitsEXT(static_cast<VkVideoEncodeH264InputModeFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeH264InputModeFlagsEXT(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -8268,7 +8268,7 @@ static inline std::string string_VkVideoEncodeH264OutputModeFlagsEXT(VkVideoEnco
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeH264OutputModeFlagBitsEXT(static_cast<VkVideoEncodeH264OutputModeFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeH264OutputModeFlagsEXT(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -8368,7 +8368,7 @@ static inline std::string string_VkVideoEncodeH265CapabilityFlagsEXT(VkVideoEnco
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeH265CapabilityFlagBitsEXT(static_cast<VkVideoEncodeH265CapabilityFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeH265CapabilityFlagsEXT(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -8403,7 +8403,7 @@ static inline std::string string_VkVideoEncodeH265InputModeFlagsEXT(VkVideoEncod
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeH265InputModeFlagBitsEXT(static_cast<VkVideoEncodeH265InputModeFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeH265InputModeFlagsEXT(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -8438,7 +8438,7 @@ static inline std::string string_VkVideoEncodeH265OutputModeFlagsEXT(VkVideoEnco
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeH265OutputModeFlagBitsEXT(static_cast<VkVideoEncodeH265OutputModeFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeH265OutputModeFlagsEXT(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -8473,7 +8473,7 @@ static inline std::string string_VkVideoEncodeH265CtbSizeFlagsEXT(VkVideoEncodeH
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeH265CtbSizeFlagBitsEXT(static_cast<VkVideoEncodeH265CtbSizeFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeH265CtbSizeFlagsEXT(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -8510,7 +8510,7 @@ static inline std::string string_VkVideoEncodeH265TransformBlockSizeFlagsEXT(VkV
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkVideoEncodeH265TransformBlockSizeFlagBitsEXT(static_cast<VkVideoEncodeH265TransformBlockSizeFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkVideoEncodeH265TransformBlockSizeFlagsEXT(0)");
     return ret;
 }
 #endif // VK_ENABLE_BETA_EXTENSIONS
@@ -8578,7 +8578,7 @@ static inline std::string string_VkExternalMemoryHandleTypeFlagsNV(VkExternalMem
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalMemoryHandleTypeFlagBitsNV(static_cast<VkExternalMemoryHandleTypeFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkExternalMemoryHandleTypeFlagsNV(0)");
     return ret;
 }
 
@@ -8609,7 +8609,7 @@ static inline std::string string_VkExternalMemoryFeatureFlagsNV(VkExternalMemory
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExternalMemoryFeatureFlagBitsNV(static_cast<VkExternalMemoryFeatureFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkExternalMemoryFeatureFlagsNV(0)");
     return ret;
 }
 
@@ -8683,7 +8683,7 @@ static inline std::string string_VkConditionalRenderingFlagsEXT(VkConditionalRen
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkConditionalRenderingFlagBitsEXT(static_cast<VkConditionalRenderingFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkConditionalRenderingFlagsEXT(0)");
     return ret;
 }
 
@@ -8710,7 +8710,7 @@ static inline std::string string_VkSurfaceCounterFlagsEXT(VkSurfaceCounterFlagsE
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkSurfaceCounterFlagBitsEXT(static_cast<VkSurfaceCounterFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkSurfaceCounterFlagsEXT(0)");
     return ret;
 }
 
@@ -8833,7 +8833,7 @@ static inline std::string string_VkDebugUtilsMessageSeverityFlagsEXT(VkDebugUtil
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDebugUtilsMessageSeverityFlagBitsEXT(static_cast<VkDebugUtilsMessageSeverityFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkDebugUtilsMessageSeverityFlagsEXT(0)");
     return ret;
 }
 
@@ -8866,7 +8866,7 @@ static inline std::string string_VkDebugUtilsMessageTypeFlagsEXT(VkDebugUtilsMes
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDebugUtilsMessageTypeFlagBitsEXT(static_cast<VkDebugUtilsMessageTypeFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkDebugUtilsMessageTypeFlagsEXT(0)");
     return ret;
 }
 
@@ -8957,7 +8957,7 @@ static inline std::string string_VkDescriptorBindingFlagsEXT(VkDescriptorBinding
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDescriptorBindingFlagBitsEXT(static_cast<VkDescriptorBindingFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkDescriptorBindingFlagsEXT(0)");
     return ret;
 }
 
@@ -9126,7 +9126,7 @@ static inline std::string string_VkGeometryFlagsKHR(VkGeometryFlagsKHR input_val
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkGeometryFlagBitsKHR(static_cast<VkGeometryFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkGeometryFlagsKHR(0)");
     return ret;
 }
 
@@ -9155,7 +9155,7 @@ static inline std::string string_VkGeometryFlagsNV(VkGeometryFlagsNV input_value
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkGeometryFlagBitsNV(static_cast<VkGeometryFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkGeometryFlagsNV(0)");
     return ret;
 }
 
@@ -9192,7 +9192,7 @@ static inline std::string string_VkGeometryInstanceFlagsKHR(VkGeometryInstanceFl
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkGeometryInstanceFlagBitsKHR(static_cast<VkGeometryInstanceFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkGeometryInstanceFlagsKHR(0)");
     return ret;
 }
 
@@ -9229,7 +9229,7 @@ static inline std::string string_VkGeometryInstanceFlagsNV(VkGeometryInstanceFla
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkGeometryInstanceFlagBitsNV(static_cast<VkGeometryInstanceFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkGeometryInstanceFlagsNV(0)");
     return ret;
 }
 
@@ -9272,7 +9272,7 @@ static inline std::string string_VkBuildAccelerationStructureFlagsKHR(VkBuildAcc
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkBuildAccelerationStructureFlagBitsKHR(static_cast<VkBuildAccelerationStructureFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkBuildAccelerationStructureFlagsKHR(0)");
     return ret;
 }
 
@@ -9315,7 +9315,7 @@ static inline std::string string_VkBuildAccelerationStructureFlagsNV(VkBuildAcce
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkBuildAccelerationStructureFlagBitsNV(static_cast<VkBuildAccelerationStructureFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkBuildAccelerationStructureFlagsNV(0)");
     return ret;
 }
 
@@ -9444,7 +9444,7 @@ static inline std::string string_VkPipelineCreationFeedbackFlagsEXT(VkPipelineCr
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPipelineCreationFeedbackFlagBitsEXT(static_cast<VkPipelineCreationFeedbackFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkPipelineCreationFeedbackFlagsEXT(0)");
     return ret;
 }
 
@@ -9550,7 +9550,7 @@ static inline std::string string_VkToolPurposeFlagsEXT(VkToolPurposeFlagsEXT inp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkToolPurposeFlagBitsEXT(static_cast<VkToolPurposeFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkToolPurposeFlagsEXT(0)");
     return ret;
 }
 
@@ -9737,7 +9737,7 @@ static inline std::string string_VkPresentScalingFlagsEXT(VkPresentScalingFlagsE
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPresentScalingFlagBitsEXT(static_cast<VkPresentScalingFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkPresentScalingFlagsEXT(0)");
     return ret;
 }
 
@@ -9768,7 +9768,7 @@ static inline std::string string_VkPresentGravityFlagsEXT(VkPresentGravityFlagsE
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkPresentGravityFlagBitsEXT(static_cast<VkPresentGravityFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkPresentGravityFlagsEXT(0)");
     return ret;
 }
 
@@ -9795,7 +9795,7 @@ static inline std::string string_VkIndirectStateFlagsNV(VkIndirectStateFlagsNV i
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkIndirectStateFlagBitsNV(static_cast<VkIndirectStateFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkIndirectStateFlagsNV(0)");
     return ret;
 }
 
@@ -9853,7 +9853,7 @@ static inline std::string string_VkIndirectCommandsLayoutUsageFlagsNV(VkIndirect
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkIndirectCommandsLayoutUsageFlagBitsNV(static_cast<VkIndirectCommandsLayoutUsageFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkIndirectCommandsLayoutUsageFlagsNV(0)");
     return ret;
 }
 
@@ -9905,7 +9905,7 @@ static inline std::string string_VkDeviceDiagnosticsConfigFlagsNV(VkDeviceDiagno
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDeviceDiagnosticsConfigFlagBitsNV(static_cast<VkDeviceDiagnosticsConfigFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkDeviceDiagnosticsConfigFlagsNV(0)");
     return ret;
 }
 
@@ -9945,7 +9945,7 @@ static inline std::string string_VkExportMetalObjectTypeFlagsEXT(VkExportMetalOb
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkExportMetalObjectTypeFlagBitsEXT(static_cast<VkExportMetalObjectTypeFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkExportMetalObjectTypeFlagsEXT(0)");
     return ret;
 }
 #endif // VK_USE_PLATFORM_METAL_EXT
@@ -9979,7 +9979,7 @@ static inline std::string string_VkGraphicsPipelineLibraryFlagsEXT(VkGraphicsPip
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkGraphicsPipelineLibraryFlagBitsEXT(static_cast<VkGraphicsPipelineLibraryFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkGraphicsPipelineLibraryFlagsEXT(0)");
     return ret;
 }
 
@@ -10073,7 +10073,7 @@ static inline std::string string_VkImageCompressionFlagsEXT(VkImageCompressionFl
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkImageCompressionFlagBitsEXT(static_cast<VkImageCompressionFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkImageCompressionFlagsEXT(0)");
     return ret;
 }
 
@@ -10148,7 +10148,7 @@ static inline std::string string_VkImageCompressionFixedRateFlagsEXT(VkImageComp
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkImageCompressionFixedRateFlagBitsEXT(static_cast<VkImageCompressionFixedRateFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkImageCompressionFixedRateFlagsEXT(0)");
     return ret;
 }
 
@@ -10209,7 +10209,7 @@ static inline std::string string_VkDeviceAddressBindingFlagsEXT(VkDeviceAddressB
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkDeviceAddressBindingFlagBitsEXT(static_cast<VkDeviceAddressBindingFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkDeviceAddressBindingFlagsEXT(0)");
     return ret;
 }
 
@@ -10260,7 +10260,7 @@ static inline std::string string_VkImageConstraintsInfoFlagsFUCHSIA(VkImageConst
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkImageConstraintsInfoFlagBitsFUCHSIA(static_cast<VkImageConstraintsInfoFlagBitsFUCHSIA>(0)));
+    if (ret.empty()) ret.append("VkImageConstraintsInfoFlagsFUCHSIA(0)");
     return ret;
 }
 #endif // VK_USE_PLATFORM_FUCHSIA
@@ -10303,7 +10303,7 @@ static inline std::string string_VkBuildMicromapFlagsEXT(VkBuildMicromapFlagsEXT
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkBuildMicromapFlagBitsEXT(static_cast<VkBuildMicromapFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkBuildMicromapFlagsEXT(0)");
     return ret;
 }
 
@@ -10341,7 +10341,7 @@ static inline std::string string_VkMicromapCreateFlagsEXT(VkMicromapCreateFlagsE
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkMicromapCreateFlagBitsEXT(static_cast<VkMicromapCreateFlagBitsEXT>(0)));
+    if (ret.empty()) ret.append("VkMicromapCreateFlagsEXT(0)");
     return ret;
 }
 
@@ -10443,7 +10443,7 @@ static inline std::string string_VkMemoryDecompressionMethodFlagsNV(VkMemoryDeco
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkMemoryDecompressionMethodFlagBitsNV(static_cast<uint64_t>(0)));
+    if (ret.empty()) ret.append("VkMemoryDecompressionMethodFlagsNV(0)");
     return ret;
 }
 
@@ -10528,7 +10528,7 @@ static inline std::string string_VkOpticalFlowGridSizeFlagsNV(VkOpticalFlowGridS
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkOpticalFlowGridSizeFlagBitsNV(static_cast<VkOpticalFlowGridSizeFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkOpticalFlowGridSizeFlagsNV(0)");
     return ret;
 }
 
@@ -10565,7 +10565,7 @@ static inline std::string string_VkOpticalFlowUsageFlagsNV(VkOpticalFlowUsageFla
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkOpticalFlowUsageFlagBitsNV(static_cast<VkOpticalFlowUsageFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkOpticalFlowUsageFlagsNV(0)");
     return ret;
 }
 
@@ -10644,7 +10644,7 @@ static inline std::string string_VkOpticalFlowSessionCreateFlagsNV(VkOpticalFlow
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkOpticalFlowSessionCreateFlagBitsNV(static_cast<VkOpticalFlowSessionCreateFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkOpticalFlowSessionCreateFlagsNV(0)");
     return ret;
 }
 
@@ -10671,7 +10671,7 @@ static inline std::string string_VkOpticalFlowExecuteFlagsNV(VkOpticalFlowExecut
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkOpticalFlowExecuteFlagBitsNV(static_cast<VkOpticalFlowExecuteFlagBitsNV>(0)));
+    if (ret.empty()) ret.append("VkOpticalFlowExecuteFlagsNV(0)");
     return ret;
 }
 
@@ -10728,7 +10728,7 @@ static inline std::string string_VkAccelerationStructureCreateFlagsKHR(VkAcceler
         ++index;
         input_value >>= 1;
     }
-    if( ret.empty()) ret.append(string_VkAccelerationStructureCreateFlagBitsKHR(static_cast<VkAccelerationStructureCreateFlagBitsKHR>(0)));
+    if (ret.empty()) ret.append("VkAccelerationStructureCreateFlagsKHR(0)");
     return ret;
 }
 

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -445,7 +445,7 @@ class HelperFileOutputGenerator(OutputGenerator):
             outstring += '        ++index;\n'
             outstring += '        input_value >>= 1;\n'
             outstring += '    }\n'
-            outstring += '    if( ret.empty()) ret.append(string_%s(static_cast<%s>(0)));\n' % (groupName, groupType)
+            outstring += '    if (ret.empty()) ret.append("%s(0)");\n' % flagsName
             outstring += '    return ret;\n'
             outstring += '}\n'
 


### PR DESCRIPTION
The `string_***FlagBits()` family of functions format zero _***FlagBits_  variables as `"Unhandled FlagBits"` because zero is not a valid flag.
But zero is a valid value of _***Flags_ variable.

Previous Flags formatting:
"flags (Unhandled VkImageCreateFlags)"
New Flags formatting:
"flags (VkImageCreateFlags(0))"

The formatting of FlagBits remains unchanged.