### PR TITLE
cmake: Fix using DEF file with mingw

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -264,8 +264,10 @@ target_sources(VkLayer_khronos_validation PRIVATE
 
 target_compile_definitions(VkLayer_khronos_validation PUBLIC ${KHRONOS_LAYER_COMPILE_DEFINITIONS})
 
-if(WIN32)
+if(MSVC)
     target_link_options(VkLayer_khronos_validation PRIVATE /DEF:${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_khronos_validation.def)
+elseif(MINGW)
+    target_sources(VkLayer_khronos_validation PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_khronos_validation.def)
 elseif(APPLE)
     set_target_properties(VkLayer_khronos_validation PROPERTIES SUFFIX ".dylib")
 else()


### PR DESCRIPTION
```
This checks MSVC before adding /DEF: linker option and
use the .def file as a source file for mingw toolchain.
Within binutils' ld, the .def file is added as any other
object file to the linker’s command line[1]. This is also
true in clang used in mingw environment.

Otherwise, the following error is shown in mingw:
c++: error: no such file or directory: '/DEF:C:/Vulkan-ValidationLayers/layers/VkLayer_khronos_validation.def'

[1]: https://sourceware.org/binutils/docs/ld/WIN32.html
```