### PR TITLE
bp: Add DescriptorTypeNotInPool support

### DIFF
--- a/layers/best_practices/best_practices_error_enums.h
+++ b/layers/best_practices/best_practices_error_enums.h
@@ -135,6 +135,7 @@
 [[maybe_unused]] static const char *kVUID_BestPractices_SemaphoreCount = "UNASSIGNED-BestPractices-SemaphoreCount";
 [[maybe_unused]] static const char *kVUID_BestPractices_EmptyDescriptorPool =
     "UNASSIGNED-BestPractices-EmptyDescriptorPool";
+[[maybe_unused]] static const char *kVUID_BestPractices_DescriptorTypeNotInPool = "UNASSIGNED-BestPractices-DescriptorTypeNotInPool";
 [[maybe_unused]] static const char *kVUID_BestPractices_ClearValueWithoutLoadOpClear = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueWithoutLoadOpClear";
 [[maybe_unused]] static const char *kVUID_BestPractices_ClearValueCountHigherThanAttachmentCount = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueCountHigherThanAttachmentCount";
 [[maybe_unused]] static const char *kVUID_BestPractices_StoreOpDontCareThenLoadOpLoad = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-StoreOpDontCareThenLoadOpLoad";

--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -678,6 +678,24 @@ bool BestPractices::PreCallValidateAllocateDescriptorSets(VkDevice device, const
                                    pAllocateInfo->descriptorSetCount, report_data->FormatHandle(pool_state->Handle()).c_str(),
                                    pool_state->GetAvailableSets());
             }
+
+            for (uint32_t i = 0; i < pAllocateInfo->descriptorSetCount; i++) {
+                auto layout = Get<cvdescriptorset::DescriptorSetLayout>(pAllocateInfo->pSetLayouts[i]);
+                if (layout) {  // if null, this is validated/logged in object_tracker
+                    const uint32_t binding_count = layout->GetBindingCount();
+                    for (uint32_t j = 0; j < binding_count; ++j) {
+                        const VkDescriptorType type = layout->GetTypeFromIndex(j);
+                        if (!pool_state->IsAvailableType(type)) {
+                            // This check would be caught by validation if VK_KHR_maintenance1 was not enabled
+                            skip |= LogWarning(pool_state->Handle(), kVUID_BestPractices_DescriptorTypeNotInPool,
+                                               "vkAllocateDescriptorSets(): pSetLayouts[%" PRIu32 "] binding %" PRIu32
+                                               " was created with %s but the "
+                                               "Descriptor Pool was not created with this type",
+                                               i, j, string_VkDescriptorType(type));
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -70,6 +70,13 @@ class DESCRIPTOR_POOL_STATE : public BASE_NODE {
         return iter != available_counts_.end() ? iter->second : 0;
     }
 
+    // The type map is only created once so can guarantee this will find if type was used
+    // Unlike GetAvailableCount, this won't give a false positive that it just ran out of an available count
+    bool IsAvailableType(uint32_t type) const {
+        auto guard = ReadLock();
+        return available_counts_.find(type) != available_counts_.end();
+    }
+
     uint32_t GetAvailableSets() const {
         auto guard = ReadLock();
         return available_sets_;

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1542,8 +1542,6 @@ TEST_F(VkBestPracticesLayerTest, OverAllocateFromDescriptorPool) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    // Create Pool w/ 1 Sampler descriptor, but try to alloc Uniform Buffer
-    // descriptor from it
     VkDescriptorPoolSize ds_type_count = {};
     ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
     ds_type_count.descriptorCount = 2;
@@ -2258,4 +2256,56 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
 
         m_commandBuffer->end();
     }
+}
+
+TEST_F(VkBestPracticesLayerTest, DescriptorTypeNotInPool) {
+    TEST_DESCRIPTION("With maintenance1, allocate descriptor with type not in pool");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);  // Need VK_KHR_maintenance1
+    ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "At least Vulkan version 1.1 is required";
+    }
+
+    // Create Pool with 2 Sampler descriptors, but try to alloc
+    // - 1 Sampler
+    // - 1 Uniform Buffer
+    VkDescriptorPoolSize ds_type_count = {};
+    ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
+    ds_type_count.descriptorCount = 2;
+
+    VkDescriptorPoolCreateInfo ds_pool_ci = LvlInitStruct<VkDescriptorPoolCreateInfo>();
+    ds_pool_ci.flags = 0;
+    ds_pool_ci.maxSets = 2;
+    ds_pool_ci.poolSizeCount = 1;
+    ds_pool_ci.pPoolSizes = &ds_type_count;
+
+    vk_testing::DescriptorPool ds_pool(*m_device, ds_pool_ci);
+
+    VkDescriptorSetLayoutBinding dsl_binding_sampler = {};
+    dsl_binding_sampler.binding = 0;
+    dsl_binding_sampler.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+    dsl_binding_sampler.descriptorCount = 1;
+    dsl_binding_sampler.stageFlags = VK_SHADER_STAGE_ALL;
+    dsl_binding_sampler.pImmutableSamplers = nullptr;
+
+    VkDescriptorSetLayoutBinding dsl_binding_uniform = {};
+    dsl_binding_uniform.binding = 1;
+    dsl_binding_uniform.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    dsl_binding_uniform.descriptorCount = 1;
+    dsl_binding_uniform.stageFlags = VK_SHADER_STAGE_ALL;
+    dsl_binding_uniform.pImmutableSamplers = nullptr;
+
+    const VkDescriptorSetLayoutObj ds_layout(m_device, {dsl_binding_sampler, dsl_binding_uniform});
+
+    VkDescriptorSet descriptor_set;
+    VkDescriptorSetAllocateInfo alloc_info = LvlInitStruct<VkDescriptorSetAllocateInfo>();
+    alloc_info.descriptorSetCount = 1;
+    alloc_info.descriptorPool = ds_pool.handle();
+    alloc_info.pSetLayouts = &ds_layout.handle();
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-DescriptorTypeNotInPool");
+    vk::AllocateDescriptorSets(m_device->device(), &alloc_info, &descriptor_set);
+    m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5167 (cc @zhangyiwei)

This will check, for example, if the `VkDescriptorPool` was created `VkDescriptorType` of `{SAMPLER, STORAGE_BUFFER}` but then when calling `vkAllocateDescriptorSets` with a `VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER` it will throw a best practice warning (if using `VK_KHR_maintenance1`/Vulkan 1.1)