### PR TITLE
layers: Rename namespace layer_data to namespace vvl

### DIFF
--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -1,4 +1,4 @@
-<!-- Copyright 2021-2022 LunarG, Inc. -->
+<!-- Copyright 2021-2023 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
@@ -143,7 +143,7 @@ This part of validation checks that all Vulkan objects used by a command buffer 
     // Because weak_ptrs cannot safely be used as hash keys, the parents are stored
     // in a map keyed by VulkanTypedHandle. This also allows looking for specific
     // parent types without locking every weak_ptr.
-    using NodeMap = layer_data::unordered_map<VulkanTypedHandle, std::weak_ptr<BASE_NODE>>;
+    using NodeMap = vvl::unordered_map<VulkanTypedHandle, std::weak_ptr<BASE_NODE>>;
   private:
     ReadLockGuard ReadLockTree() const { return ReadLockGuard(tree_lock_); }
     WriteLockGuard WriteLockTree() { return WriteLockGuard(tree_lock_); }
@@ -356,7 +356,7 @@ Vulkan semaphores are extremely complicated, and timeline semaphores behave very
 For timeline semaphores, the `operations_` multiset stores all pending waits or signals, sorted by the `SemOp::payload` field, which is the user specified value. There can be multiple operations associated with each `payload` value and they can be added in almost any order.  Additionally, one signal operation could cause many wait operations to be completed.  All of these operations could be on different `VkQueues`. Because of this, the code for updating the state of the semaphore is more complex than for `FENCE_STATE`:
 
     // Remove completed operations and return highest sequence numbers for all affected queues
-    using RetireResult = layer_data::unordered_map<QUEUE_STATE *, uint64_t>;
+    using RetireResult = vvl::unordered_map<QUEUE_STATE *, uint64_t>;
     RetireResult Retire(QUEUE_STATE *queue, uint64_t payload);
 
 `RetireResult` makes it possible to handle state changes for several queues.  When called from `QUEUE_STATE::Retire()`, the `RetireResult`(s) for all `CB_SUBMISSIONS` is saved until the end of the current queue's processing, so that Retire() can be called on other queues without any locks held. `SEMAPHORE_STATE::Retire()` can also be called from `vkWaitSemaphores()` or `vkGetSemaphoreCounterValueKHR()`, but these cases are much simpler.
@@ -398,7 +398,7 @@ The only dynamic data in `COMMAND_POOL_STATE` is a set of all the command buffer
 
 
 ```
-    layer_data::unordered_set<VkCommandBuffer> commandBuffers;
+    vvl::unordered_set<VkCommandBuffer> commandBuffers;
 ```
 
 
@@ -633,10 +633,10 @@ For images created with `VK_IMAGE_CREATE_ALIAS_BIT` or bound to the same swapcha
 Each `CMD_BUFFER_STATE` maintains its own copy of the image layout state, in a different data structure:
 
 ```
-   typedef layer_data::unordered_map<const IMAGE_STATE *,
+   typedef vvl::unordered_map<const IMAGE_STATE *,
                                     std::shared_ptr<ImageSubresourceLayoutMap>>  CommandBufferImageLayoutMap;
    CommandBufferImageLayoutMap image_layout_map;
-   typedef layer_data::unordered_map<const GlobalImageLayoutRangeMap *,
+   typedef vvl::unordered_map<const GlobalImageLayoutRangeMap *,
                                      std::shared_ptr<ImageSubresourceLayoutMap>>
                                                                                CommandBufferAliasedLayoutMap;
    CommandBufferAliasedLayoutMap aliased_image_layout_map;  // storage for potentially aliased images
@@ -728,11 +728,11 @@ TODO: Accesses to most of these fields will need to be atomic or lock guarded.
         VkPhysicalDevice gpu;
         uint32_t queue_family_index;
     };
-    layer_data::unordered_map<GpuQueue, bool> gpu_queue_support;
-    layer_data::unordered_map<GpuQueue, bool> gpu_queue_support_;
-    layer_data::unordered_map<VkPhysicalDevice, std::vector<VkPresentModeKHR>> present_modes_;
-    layer_data::unordered_map<VkPhysicalDevice, std::vector<VkSurfaceFormatKHR>> formats_;
-    layer_data::unordered_map<VkPhysicalDevice, VkSurfaceCapabilitiesKHR> capabilities_;
+    vvl::unordered_map<GpuQueue, bool> gpu_queue_support;
+    vvl::unordered_map<GpuQueue, bool> gpu_queue_support_;
+    vvl::unordered_map<VkPhysicalDevice, std::vector<VkPresentModeKHR>> present_modes_;
+    vvl::unordered_map<VkPhysicalDevice, std::vector<VkSurfaceFormatKHR>> formats_;
+    vvl::unordered_map<VkPhysicalDevice, VkSurfaceCapabilitiesKHR> capabilities_;
 ```
 
 
@@ -761,7 +761,7 @@ All of the dynamic data in `DESCRIPTOR_POOL_STATE` is associated with tracking t
 
 ```
    // Collection of all sets in this pool`
-    layer_data::unordered_set<cvdescriptorset::DescriptorSet *> sets;
+    vvl::unordered_set<cvdescriptorset::DescriptorSet *> sets;
     // Available descriptor sets in this pool
     uint32_t availableSets;
     // Available # of descriptors of each type in this pool

--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -104,7 +104,7 @@ bool BestPractices::VendorCheckEnabled(BPVendorFlags vendors) const {
 
 const char* VendorSpecificTag(BPVendorFlags vendors) {
     // Cache built vendor tags in a map
-    static layer_data::unordered_map<BPVendorFlags, std::string> tag_map;
+    static vvl::unordered_map<BPVendorFlags, std::string> tag_map;
 
     auto res = tag_map.find(vendors);
     if (res == tag_map.end()) {
@@ -830,8 +830,8 @@ void BestPractices::ManualPostCallRecordAllocateMemory(VkDevice device, const Vk
     }
 }
 
-void BestPractices::ValidateReturnCodes(const char* api_name, VkResult result, layer_data::span<const VkResult> error_codes,
-                                        layer_data::span<const VkResult> success_codes) const {
+void BestPractices::ValidateReturnCodes(const char* api_name, VkResult result, vvl::span<const VkResult> error_codes,
+                                        vvl::span<const VkResult> success_codes) const {
     auto error = std::find(error_codes.begin(), error_codes.end(), result);
     if (error != error_codes.end()) {
         constexpr std::array common_failure_codes = {VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT};
@@ -4409,10 +4409,10 @@ bool BestPractices::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindI
     for (uint32_t bind_idx = 0; bind_idx < bindInfoCount; bind_idx++) {
         const VkBindSparseInfo& bind_info = pBindInfo[bind_idx];
         // Store sparse binding image_state and after binding is complete make sure that any requiring metadata have it bound
-        layer_data::unordered_set<const IMAGE_STATE*> sparse_images;
+        vvl::unordered_set<const IMAGE_STATE*> sparse_images;
         // Track images getting metadata bound by this call in a set, it'll be recorded into the image_state
         // in RecordQueueBindSparse.
-        layer_data::unordered_set<const IMAGE_STATE*> sparse_images_with_metadata;
+        vvl::unordered_set<const IMAGE_STATE*> sparse_images_with_metadata;
         // If we're binding sparse image memory make sure reqs were queried and note if metadata is required and bound
         for (uint32_t i = 0; i < bind_info.imageBindCount; ++i) {
             const auto& image_bind = bind_info.pImageBinds[i];

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -698,8 +698,8 @@ class BestPractices : public ValidationStateTracker {
     bool PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                             const VkClearAttachment* pAttachments, uint32_t rectCount,
                                             const VkClearRect* pRects) const override;
-    void ValidateReturnCodes(const char* api_name, VkResult result, layer_data::span<const VkResult> error_codes,
-                             layer_data::span<const VkResult> success_codes) const;
+    void ValidateReturnCodes(const char* api_name, VkResult result, vvl::span<const VkResult> error_codes,
+                             vvl::span<const VkResult> success_codes) const;
     bool ValidateCmdResolveImage(VkCommandBuffer command_buffer, VkImage src_image, VkImage dst_image, CMD_TYPE cmd_type) const;
     bool PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                         VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
@@ -1079,6 +1079,6 @@ class BestPractices : public ValidationStateTracker {
     std::set<std::array<uint32_t, 4>> clear_colors_;
     mutable std::shared_mutex clear_colors_lock_;
 
-    layer_data::unordered_set<VkPipeline> pipelines_used_in_frame_;
+    vvl::unordered_set<VkPipeline> pipelines_used_in_frame_;
     mutable std::shared_mutex pipeline_lock_;
 };

--- a/layers/core_checks/core_validation.cpp
+++ b/layers/core_checks/core_validation.cpp
@@ -782,7 +782,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE &cb_state, CMD_T
                             std::set_difference(binding_req_map.begin(), binding_req_map.end(),
                                                 set_info.validated_set_binding_req_map.begin(),
                                                 set_info.validated_set_binding_req_map.end(),
-                                                layer_data::insert_iterator<BindingReqMap>(delta_reqs, delta_reqs.begin()));
+                                                vvl::insert_iterator<BindingReqMap>(delta_reqs, delta_reqs.begin()));
                             result |=
                                 ValidateDrawState(*descriptor_set, delta_reqs, set_info.dynamicOffsets, cb_state, function, vuid);
                         } else {
@@ -1197,7 +1197,7 @@ struct CommandBufferSubmitState {
             for (const auto &cmd_info : descriptor_set.second) {
                 // dynamic data isn't allowed in UPDATE_AFTER_BIND, so dynamicOffsets is always empty.
                 std::vector<uint32_t> dynamic_offsets;
-                std::optional<layer_data::unordered_map<VkImageView, VkImageLayout>> checked_layouts;
+                std::optional<vvl::unordered_map<VkImageView, VkImageLayout>> checked_layouts;
 
                 std::string function = loc.StringFunc();
                 function += ", ";
@@ -2490,7 +2490,7 @@ bool CoreChecks::ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo *pC
                             const VkRenderPassFragmentDensityMapCreateInfoEXT *fdm_attachment;
                             fdm_attachment = LvlFindInChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci->pNext);
                             if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
-                                uint32_t ceiling_width = layer_data::GetQuotientCeil(
+                                uint32_t ceiling_width = vvl::GetQuotientCeil(
                                     pCreateInfo->width,
                                     phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width);
                                 if (mip_width < ceiling_width) {
@@ -2504,7 +2504,7 @@ bool CoreChecks::ValidateFramebufferCreateInfo(const VkFramebufferCreateInfo *pC
                                         "width: %u, the ceiling value: %u\n",
                                         i, subresource_range.baseMipLevel, i, i, mip_width, ceiling_width);
                                 }
-                                uint32_t ceiling_height = layer_data::GetQuotientCeil(
+                                uint32_t ceiling_height = vvl::GetQuotientCeil(
                                     pCreateInfo->height,
                                     phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height);
                                 if (mip_height < ceiling_height) {
@@ -3065,7 +3065,7 @@ bool CoreChecks::ValidateFramebuffer(VkCommandBuffer primaryBuffer, const CMD_BU
 bool CoreChecks::ValidateSecondaryCommandBufferState(const CMD_BUFFER_STATE &cb_state, const CMD_BUFFER_STATE &sub_cb_state) const {
     bool skip = false;
 
-    layer_data::unordered_set<int> active_types;
+    vvl::unordered_set<int> active_types;
     if (!disabled[query_validation]) {
         for (const auto &query_object : cb_state.activeQueries) {
             auto query_pool_state = Get<QUERY_POOL_STATE>(query_object.pool);
@@ -3350,7 +3350,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
     assert(cb_state);
     bool skip = false;
-    layer_data::unordered_set<const CMD_BUFFER_STATE *> linked_command_buffers;
+    vvl::unordered_set<const CMD_BUFFER_STATE *> linked_command_buffers;
     ViewportScissorInheritanceTracker viewport_scissor_inheritance{*this};
 
     if (enabled_features.inherited_viewport_scissor_features.inheritedViewportScissor2D) {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -207,7 +207,7 @@ struct SubresourceRangeErrorCodes {
     const char *base_mip_err, *mip_count_err, *base_layer_err, *layer_count_err;
 };
 
-typedef layer_data::unordered_map<const IMAGE_STATE*, std::optional<GlobalImageLayoutRangeMap>> GlobalImageLayoutMap;
+typedef vvl::unordered_map<const IMAGE_STATE*, std::optional<GlobalImageLayoutRangeMap>> GlobalImageLayoutMap;
 
 // Much of the data stored in CMD_BUFFER_STATE is only used by core validation, and is
 // set up by Record calls in class CoreChecks. Because both the state tracker and
@@ -250,11 +250,11 @@ struct SemaphoreSubmitState {
     const CoreChecks* core;
     VkQueue queue;
     VkQueueFlags queue_flags;
-    layer_data::unordered_set<VkSemaphore> signaled_semaphores;
-    layer_data::unordered_set<VkSemaphore> unsignaled_semaphores;
-    layer_data::unordered_set<VkSemaphore> internal_semaphores;
-    layer_data::unordered_map<VkSemaphore, uint64_t> timeline_signals;
-    layer_data::unordered_map<VkSemaphore, uint64_t> timeline_waits;
+    vvl::unordered_set<VkSemaphore> signaled_semaphores;
+    vvl::unordered_set<VkSemaphore> unsignaled_semaphores;
+    vvl::unordered_set<VkSemaphore> internal_semaphores;
+    vvl::unordered_map<VkSemaphore, uint64_t> timeline_signals;
+    vvl::unordered_map<VkSemaphore, uint64_t> timeline_waits;
 
     SemaphoreSubmitState(const CoreChecks* core_, VkQueue q_, VkQueueFlags queue_flags_)
         : core(core_), queue(q_), queue_flags(queue_flags_) {}
@@ -748,7 +748,7 @@ class CoreChecks : public ValidationStateTracker {
         const VkFramebuffer framebuffer;
         bool record_time_validate;
         const std::vector<uint32_t>& dynamic_offsets;
-        std::optional<layer_data::unordered_map<VkImageView, VkImageLayout>>& checked_layouts;
+        std::optional<vvl::unordered_map<VkImageView, VkImageLayout>>& checked_layouts;
     };
     using DescriptorBindingInfo = std::pair<const uint32_t, DescriptorRequirement>;
 

--- a/layers/core_checks/descriptor_validation.cpp
+++ b/layers/core_checks/descriptor_validation.cpp
@@ -364,7 +364,7 @@ bool CoreChecks::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const
                                                           const VkAllocationCallbacks *pAllocator,
                                                           VkDescriptorSetLayout *pSetLayout) const {
     bool skip = false;
-    layer_data::unordered_set<uint32_t> bindings;
+    vvl::unordered_set<uint32_t> bindings;
     uint64_t total_descriptors = 0;
 
     const auto *flags_pCreateInfo = LvlFindInChain<VkDescriptorSetLayoutBindingFlagsCreateInfo>(pCreateInfo->pNext);
@@ -737,7 +737,7 @@ unsigned DescriptorRequirementsBitsFromFormat(VkFormat fmt) {
 bool CoreChecks::ValidateDrawState(const DescriptorSet &descriptor_set, const BindingReqMap &bindings,
                                    const std::vector<uint32_t> &dynamic_offsets, const CMD_BUFFER_STATE &cb_state,
                                    const char *caller, const DrawDispatchVuid &vuids) const {
-    std::optional<layer_data::unordered_map<VkImageView, VkImageLayout>> checked_layouts;
+    std::optional<vvl::unordered_map<VkImageView, VkImageLayout>> checked_layouts;
     if (descriptor_set.GetTotalDescriptorCount() > cvdescriptorset::PrefilterBindRequestMap::kManyDescriptors_) {
         checked_layouts.emplace();
     }

--- a/layers/core_checks/device_memory_validation.cpp
+++ b/layers/core_checks/device_memory_validation.cpp
@@ -947,7 +947,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
     // Track all image sub resources if they are bound for bind_image_mem_2
     // uint32_t[3] is which index in pBindInfos for max 3 planes
     // Non disjoint images act as a single plane
-    layer_data::unordered_map<VkImage, std::array<uint32_t, 3>> resources_bound;
+    vvl::unordered_map<VkImage, std::array<uint32_t, 3>> resources_bound;
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         if (bind_image_mem_2 == true) {

--- a/layers/core_checks/device_validation.cpp
+++ b/layers/core_checks/device_validation.cpp
@@ -78,7 +78,7 @@ bool CoreChecks::ValidatePhysicalDeviceQueueFamilies(uint32_t queue_family_count
                                                      const char *vuid) const {
     bool skip = false;
     if (queue_families) {
-        layer_data::unordered_set<uint32_t> set;
+        vvl::unordered_set<uint32_t> set;
         for (uint32_t i = 0; i < queue_family_count; ++i) {
             std::string parameter_name = std::string(array_parameter_name) + "[" + std::to_string(i) + "]";
 
@@ -213,8 +213,8 @@ bool CoreChecks::ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE *pd_
         uint32_t protected_index;
         create_flags(uint32_t a, uint32_t b) : unprocted_index(a), protected_index(b) {}
     };
-    layer_data::unordered_map<uint32_t, create_flags> queue_family_map;
-    layer_data::unordered_map<uint32_t, VkQueueGlobalPriorityKHR> global_priorities;
+    vvl::unordered_map<uint32_t, create_flags> queue_family_map;
+    vvl::unordered_map<uint32_t, VkQueueGlobalPriorityKHR> global_priorities;
 
     for (uint32_t i = 0; i < info_count; ++i) {
         const auto requested_queue_family = infos[i].queueFamilyIndex;

--- a/layers/core_checks/image_validation.cpp
+++ b/layers/core_checks/image_validation.cpp
@@ -63,7 +63,7 @@ bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo *pCreateInf
         }
 #endif
     } else if (image_tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
-        layer_data::unordered_set<uint64_t> drm_format_modifiers;
+        vvl::unordered_set<uint64_t> drm_format_modifiers;
         const VkImageDrmFormatModifierExplicitCreateInfoEXT *drm_explicit =
             LvlFindInChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pCreateInfo->pNext);
         const VkImageDrmFormatModifierListCreateInfoEXT *drm_implicit =

--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -281,7 +281,7 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
 
     const uint32_t active_shaders = pipeline.active_shaders;
     if (pipeline.pre_raster_state || pipeline.fragment_shader_state) {
-        layer_data::unordered_set<VkShaderStageFlags> unique_stage_set;
+        vvl::unordered_set<VkShaderStageFlags> unique_stage_set;
         const auto stages = pipeline.GetShaderStages();
         for (const auto &stage : stages) {
             if (!unique_stage_set.insert(stage.stage).second) {
@@ -642,9 +642,9 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
                 for (size_t i = 0; i < num_set_layouts; ++i) {
                     const auto pre_raster_dsl = (i < pre_raster_set_layouts.size())
                                                     ? pre_raster_set_layouts[i]
-                                                    : layer_data::base_type<decltype(pre_raster_set_layouts)>::value_type{};
+                                                    : vvl::base_type<decltype(pre_raster_set_layouts)>::value_type{};
                     const auto fs_dsl = (i < fs_set_layouts.size()) ? fs_set_layouts[i]
-                                                                    : layer_data::base_type<decltype(fs_set_layouts)>::value_type{};
+                                                                    : vvl::base_type<decltype(fs_set_layouts)>::value_type{};
                     const char *vuid_tmp = nullptr;
                     std::ostringstream msg("vkCreateGraphicsPipelines(): ");
                     msg << "pCreateInfos[" << pipe_index << "] ";
@@ -1158,7 +1158,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkP
         if (!pipeline) {
             continue;
         }
-        using CIType = layer_data::base_type<decltype(pCreateInfos)>;
+        using CIType = vvl::base_type<decltype(pCreateInfos)>;
         if (pipeline->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
             std::shared_ptr<const PIPELINE_STATE> base_pipeline;
             const auto bpi = pipeline->BasePipelineIndex<CIType>();
@@ -1197,7 +1197,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
         if (!pipeline) {
             continue;
         }
-        using CIType = layer_data::base_type<decltype(pCreateInfos)>;
+        using CIType = vvl::base_type<decltype(pCreateInfos)>;
         if (pipeline->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
             std::shared_ptr<const PIPELINE_STATE> base_pipeline;
             const auto bpi = pipeline->BasePipelineIndex<CIType>();

--- a/layers/core_checks/render_pass_validation.cpp
+++ b/layers/core_checks/render_pass_validation.cpp
@@ -1097,7 +1097,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
 }
 
 static bool FindDependency(const uint32_t index, const uint32_t dependent, const std::vector<DAGNode> &subpass_to_node,
-                           layer_data::unordered_set<uint32_t> &processed_nodes) {
+                           vvl::unordered_set<uint32_t> &processed_nodes) {
     // If we have already checked this node we have not found a dependency path so return false.
     if (processed_nodes.count(index)) return false;
     processed_nodes.insert(index);
@@ -1130,7 +1130,7 @@ bool CoreChecks::CheckDependencyExists(const VkRenderPass renderpass, const uint
         auto next_elem = std::find(node.next.begin(), node.next.end(), sp.index);
         if (prev_elem == node.prev.end() && next_elem == node.next.end()) {
             // If no dependency exits an implicit dependency still might. If not, throw an error.
-            layer_data::unordered_set<uint32_t> processed_nodes;
+            vvl::unordered_set<uint32_t> processed_nodes;
             if (!(FindDependency(subpass, sp.index, subpass_to_node, processed_nodes) ||
                   FindDependency(sp.index, subpass, subpass_to_node, processed_nodes))) {
                 skip |=
@@ -1380,7 +1380,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
         std::vector<VkImageLayout> attachment_layouts(pCreateInfo->attachmentCount);
 
         // Track if attachments are used as input as well as another type
-        layer_data::unordered_set<uint32_t> input_attachments;
+        vvl::unordered_set<uint32_t> input_attachments;
 
         if (!IsExtEnabled(device_extensions.vk_huawei_subpass_shading)) {
             if (subpass.pipelineBindPoint != VK_PIPELINE_BIND_POINT_GRAPHICS) {
@@ -2002,7 +2002,7 @@ bool CoreChecks::ValidateDependencies(FRAMEBUFFER_STATE const *framebuffer, REND
         }
     }
     // Find for each attachment the subpasses that use them.
-    layer_data::unordered_set<uint32_t> attachment_indices;
+    vvl::unordered_set<uint32_t> attachment_indices;
     for (uint32_t i = 0; i < create_info->subpassCount; ++i) {
         const VkSubpassDescription2 &subpass = create_info->pSubpasses[i];
         attachment_indices.clear();
@@ -3122,7 +3122,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
 
         if (!non_zero_device_render_area) {
             if (static_cast<int64_t>(view_state->image_state->createInfo.extent.width) <
-                layer_data::GetQuotientCeil(
+                vvl::GetQuotientCeil(
                     x_adjusted_extent,
                     static_cast<int64_t>(rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width))) {
                 const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-06119"
@@ -3138,7 +3138,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
             }
 
             if (static_cast<int64_t>(view_state->image_state->createInfo.extent.height) <
-                layer_data::GetQuotientCeil(
+                vvl::GetQuotientCeil(
                     y_adjusted_extent,
                     static_cast<int64_t>(rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height))) {
                 const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-06121"
@@ -3163,7 +3163,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
 
                     IMAGE_STATE *image_state = view_state->image_state.get();
                     if (image_state->createInfo.extent.width <
-                        layer_data::GetQuotientCeil(
+                        vvl::GetQuotientCeil(
                             offset_x + width,
                             rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width)) {
                         skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06120",
@@ -3176,7 +3176,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                                          rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width);
                     }
                     if (image_state->createInfo.extent.height <
-                        layer_data::GetQuotientCeil(
+                        vvl::GetQuotientCeil(
                             offset_y + height,
                             rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height)) {
                         skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06122",
@@ -3342,7 +3342,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
             auto view_state = Get<IMAGE_VIEW_STATE>(fragment_density_map_attachment_info->imageView);
             IMAGE_STATE *image_state = view_state->image_state.get();
             if (image_state->createInfo.extent.width <
-                layer_data::GetQuotientCeil(
+                vvl::GetQuotientCeil(
                     x_adjusted_extent,
                     static_cast<int64_t>(phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width))) {
                 const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-06112"
@@ -3358,7 +3358,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                     phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width);
             }
             if (image_state->createInfo.extent.height <
-                layer_data::GetQuotientCeil(
+                vvl::GetQuotientCeil(
                     y_adjusted_extent,
                     static_cast<int64_t>(phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height))) {
                 const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-06114"
@@ -3469,7 +3469,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                 auto view_state = Get<IMAGE_VIEW_STATE>(fragment_density_map_attachment_info->imageView);
                 IMAGE_STATE *image_state = view_state->image_state.get();
                 if (image_state->createInfo.extent.width <
-                    layer_data::GetQuotientCeil(offset_x + width,
+                    vvl::GetQuotientCeil(offset_x + width,
                                                 phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width)) {
                     skip |= LogError(
                         commandBuffer, "VUID-VkRenderingInfo-pNext-06113",
@@ -3482,7 +3482,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                         width, phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width);
                 }
                 if (image_state->createInfo.extent.height <
-                    layer_data::GetQuotientCeil(offset_y + height,
+                    vvl::GetQuotientCeil(offset_y + height,
                                                 phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height)) {
                     skip |= LogError(
                         commandBuffer, "VUID-VkRenderingInfo-pNext-06115",

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -1269,7 +1269,7 @@ void GetSpecConstantValue(StageCreateInfo const *pStage, uint32_t spec_id, void 
 // Returns true if the value has been accurately filled out.
 static bool GetIntConstantValue(const Instruction *insn, const SHADER_MODULE_STATE &module_state,
                                 safe_VkPipelineShaderStageCreateInfo const *pStage,
-                                const layer_data::unordered_map<uint32_t, uint32_t> &id_to_spec_id, uint32_t *value) {
+                                const vvl::unordered_map<uint32_t, uint32_t> &id_to_spec_id, uint32_t *value) {
     const Instruction *type_id = module_state.FindDef(insn->Word(1));
     if (type_id->Opcode() != spv::OpTypeInt || type_id->Word(2) != 32) {
         return false;
@@ -1326,9 +1326,9 @@ bool CoreChecks::ValidateCooperativeMatrix(const SHADER_MODULE_STATE &module_sta
     bool skip = false;
 
     // Map SPIR-V result ID to specialization constant id (SpecId decoration value)
-    layer_data::unordered_map<uint32_t, uint32_t> id_to_spec_id;
+    vvl::unordered_map<uint32_t, uint32_t> id_to_spec_id;
     // Map SPIR-V result ID to the ID of its type.
-    layer_data::unordered_map<uint32_t, uint32_t> id_to_type_id;
+    vvl::unordered_map<uint32_t, uint32_t> id_to_type_id;
 
     struct CoopMatType {
         uint32_t scope, rows, cols;
@@ -1338,7 +1338,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const SHADER_MODULE_STATE &module_sta
         CoopMatType() : scope(0), rows(0), cols(0), component_type(VK_COMPONENT_TYPE_MAX_ENUM_NV), all_constant(false) {}
 
         void Init(uint32_t id, const SHADER_MODULE_STATE &module_state, safe_VkPipelineShaderStageCreateInfo const *pStage,
-                  const layer_data::unordered_map<uint32_t, uint32_t> &id_to_spec_id) {
+                  const vvl::unordered_map<uint32_t, uint32_t> &id_to_spec_id) {
             const Instruction *insn = module_state.FindDef(id);
             uint32_t component_type_id = insn->Word(2);
             uint32_t scope_id = insn->Word(3);
@@ -2658,7 +2658,7 @@ bool CoreChecks::ValidateTransformFeedback(const SHADER_MODULE_STATE &module_sta
         return skip;
     }
 
-    layer_data::unordered_set<uint32_t> emitted_streams;
+    vvl::unordered_set<uint32_t> emitted_streams;
     bool output_points = false;
     // TODO - Don't do a full loop here over the module
     for (const Instruction &insn : module_state.GetInstructions()) {
@@ -2982,7 +2982,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE &pipeline, con
             // The new optimized SPIR-V will NOT match the original SHADER_MODULE_STATE object parsing, so a new SHADER_MODULE_STATE
             // object is needed. This an issue due to each pipeline being able to reuse the same shader module but with different
             // spec constant values.
-            SHADER_MODULE_STATE spec_mod(layer_data::make_span<const uint32_t>(specialized_spirv.data(), specialized_spirv.size()));
+            SHADER_MODULE_STATE spec_mod(vvl::make_span<const uint32_t>(specialized_spirv.data(), specialized_spirv.size()));
 
             // According to https://github.com/KhronosGroup/Vulkan-Docs/issues/1671 anything labeled as "static use" (such as if an
             // input is used or not) don't have to be checked post spec constants freezing since the device compiler is not
@@ -2990,7 +2990,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE &pipeline, con
             // "static use" rules and need to be validated still.
 
             // see ValidateComputeSharedMemory() for details why we might track max block size
-            layer_data::unordered_set<uint32_t> aliased_id;
+            vvl::unordered_set<uint32_t> aliased_id;
             bool find_max_block = false;
 
             uint32_t workgroup_size_id = 0;  // result id can't be zero

--- a/layers/core_checks/shader_validation.h
+++ b/layers/core_checks/shader_validation.h
@@ -150,7 +150,7 @@ class ValidationCache {
     // we don't store negative results, as we would have to also store what was
     // wrong with them; also, we expect they will get fixed, so we're less
     // likely to see them again.
-    layer_data::unordered_set<uint32_t> good_shader_hashes_;
+    vvl::unordered_set<uint32_t> good_shader_hashes_;
     mutable std::shared_mutex lock_;
 };
 

--- a/layers/core_checks/video_validation.cpp
+++ b/layers/core_checks/video_validation.cpp
@@ -252,7 +252,7 @@ bool CoreChecks::ValidateDecodeH264ParametersAddInfo(const VkVideoDecodeH264Sess
                                                      const VIDEO_SESSION_PARAMETERS_STATE *template_state) const {
     bool skip = false;
 
-    layer_data::unordered_set<VIDEO_SESSION_PARAMETERS_STATE::ParameterKey> keys;
+    vvl::unordered_set<VIDEO_SESSION_PARAMETERS_STATE::ParameterKey> keys;
     auto template_data = template_state ? template_state->Lock() : VIDEO_SESSION_PARAMETERS_STATE::ReadOnlyAccessor();
 
     if (add_info) {
@@ -320,7 +320,7 @@ bool CoreChecks::ValidateDecodeH265ParametersAddInfo(const VkVideoDecodeH265Sess
                                                      const VIDEO_SESSION_PARAMETERS_STATE *template_state) const {
     bool skip = false;
 
-    layer_data::unordered_set<VIDEO_SESSION_PARAMETERS_STATE::ParameterKey> keys;
+    vvl::unordered_set<VIDEO_SESSION_PARAMETERS_STATE::ParameterKey> keys;
     auto template_data = template_state ? template_state->Lock() : VIDEO_SESSION_PARAMETERS_STATE::ReadOnlyAccessor();
 
     if (add_info) {
@@ -908,7 +908,7 @@ bool CoreChecks::PreCallValidateBindVideoSessionMemoryKHR(VkDevice device, VkVid
 
     if (pBindSessionMemoryInfos) {
         {
-            layer_data::unordered_set<uint32_t> memory_bind_indices;
+            vvl::unordered_set<uint32_t> memory_bind_indices;
             for (uint32_t i = 0; i < bindSessionMemoryInfoCount; ++i) {
                 uint32_t mem_bind_index = pBindSessionMemoryInfos[i].memoryBindIndex;
                 if (memory_bind_indices.find(mem_bind_index) != memory_bind_indices.end()) {

--- a/layers/generated/best_practices.h
+++ b/layers/generated/best_practices.h
@@ -1990,7 +1990,7 @@ void PostCallRecordGetRayTracingCaptureReplayShaderGroupHandlesKHR(
 
 
 
-const layer_data::unordered_map<std::string, DeprecationData>  deprecated_extensions = {
+const vvl::unordered_map<std::string, DeprecationData>  deprecated_extensions = {
     {"VK_AMD_draw_indirect_count", {kExtPromoted, "VK_KHR_draw_indirect_count"}},
     {"VK_AMD_gpu_shader_half_float", {kExtDeprecated, "VK_KHR_shader_float16_int8"}},
     {"VK_AMD_gpu_shader_int16", {kExtDeprecated, "VK_KHR_shader_float16_int8"}},
@@ -2087,7 +2087,7 @@ const layer_data::unordered_map<std::string, DeprecationData>  deprecated_extens
     {"VK_VALVE_mutable_descriptor_type", {kExtPromoted, "VK_EXT_mutable_descriptor_type"}},
 };
 
-const layer_data::unordered_map<std::string, std::string> special_use_extensions = {
+const vvl::unordered_map<std::string, std::string> special_use_extensions = {
     {"VK_AMD_buffer_marker", "devtools"},
     {"VK_AMD_shader_info", "devtools"},
     {"VK_EXT_border_color_swizzle", "glemulation, d3demulation"},

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -87,7 +87,7 @@ typedef struct {
     void* funcptr;
 } function_data;
 
-extern const layer_data::unordered_map<std::string, function_data> name_to_funcptr_map;
+extern const vvl::unordered_map<std::string, function_data> name_to_funcptr_map;
 
 // Manually written functions
 
@@ -15063,7 +15063,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountEXT(
 #ifdef _MSC_VER
 #pragma warning( suppress: 6262 ) // VS analysis: this uses more than 16 kiB, which is fine here at global scope
 #endif
-const layer_data::unordered_map<std::string, function_data> name_to_funcptr_map = {
+const vvl::unordered_map<std::string, function_data> name_to_funcptr_map = {
     {"vk_layerGetPhysicalDeviceProcAddr", {kFuncTypeInst, (void*)GetPhysicalDeviceProcAddr}},
     {"vkCreateInstance", {kFuncTypeInst, (void*)CreateInstance}},
     {"vkDestroyInstance", {kFuncTypeInst, (void*)DestroyInstance}},

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -61,7 +61,7 @@ struct HashedUint64 {
     size_t operator()(const uint64_t &t) const { return t >> HASHED_UINT64_SHIFT; }
 
     static uint64_t hash(uint64_t id) {
-        uint64_t h = (uint64_t)layer_data::hash<uint64_t>()(id);
+        uint64_t h = (uint64_t)vvl::hash<uint64_t>()(id);
         id |= h << HASHED_UINT64_SHIFT;
         return id;
     }
@@ -4074,18 +4074,18 @@ class ValidationObject {
         // Reverse map display handles
         vl_concurrent_unordered_map<VkDisplayKHR, uint64_t, 0> display_id_reverse_mapping;
         // Wrapping Descriptor Template Update structures requires access to the template createinfo structs
-        layer_data::unordered_map<uint64_t, std::unique_ptr<TEMPLATE_STATE>> desc_template_createinfo_map;
+        vvl::unordered_map<uint64_t, std::unique_ptr<TEMPLATE_STATE>> desc_template_createinfo_map;
         struct SubpassesUsageStates {
-            layer_data::unordered_set<uint32_t> subpasses_using_color_attachment;
-            layer_data::unordered_set<uint32_t> subpasses_using_depthstencil_attachment;
+            vvl::unordered_set<uint32_t> subpasses_using_color_attachment;
+            vvl::unordered_set<uint32_t> subpasses_using_depthstencil_attachment;
         };
         // Uses unwrapped handles
-        layer_data::unordered_map<VkRenderPass, SubpassesUsageStates> renderpasses_states;
+        vvl::unordered_map<VkRenderPass, SubpassesUsageStates> renderpasses_states;
         // Map of wrapped swapchain handles to arrays of wrapped swapchain image IDs
         // Each swapchain has an immutable list of wrapped swapchain image IDs -- always return these IDs if they exist
-        layer_data::unordered_map<VkSwapchainKHR, std::vector<VkImage>> swapchain_wrapped_image_handle_map;
+        vvl::unordered_map<VkSwapchainKHR, std::vector<VkImage>> swapchain_wrapped_image_handle_map;
         // Map of wrapped descriptor pools to set of wrapped descriptor sets allocated from each pool
-        layer_data::unordered_map<VkDescriptorPool, layer_data::unordered_set<VkDescriptorSet>> pool_descriptor_sets_map;
+        vvl::unordered_map<VkDescriptorPool, vvl::unordered_set<VkDescriptorSet>> pool_descriptor_sets_map;
 
 
         // Unwrap a handle.

--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -1356,7 +1356,7 @@ void DispatchGetPrivateData(
     layer_data->device_dispatch_table.GetPrivateData(device, objectType, objectHandle, privateDataSlot, pData);
 }
 
-layer_data::unordered_map<VkCommandBuffer, VkCommandPool> secondary_cb_map{};
+vvl::unordered_map<VkCommandBuffer, VkCommandPool> secondary_cb_map{};
 
 std::shared_mutex dispatch_secondary_cb_map_mutex;
 

--- a/layers/generated/spirv_grammar_helper.cpp
+++ b/layers/generated/spirv_grammar_helper.cpp
@@ -43,7 +43,7 @@ struct InstructionInfo {
 // of a given SPIR-V opcode instruction
 //
 // clang-format off
-static const layer_data::unordered_map<uint32_t, InstructionInfo> kInstructionTable {
+static const vvl::unordered_map<uint32_t, InstructionInfo> kInstructionTable {
     {spv::OpNop, {"OpNop", false, false, 0, 0, 0}},
     {spv::OpUndef, {"OpUndef", true, true, 0, 0, 0}},
     {spv::OpSourceContinued, {"OpSourceContinued", false, false, 0, 0, 0}},

--- a/layers/generated/sync_validation_types.cpp
+++ b/layers/generated/sync_validation_types.cpp
@@ -37,8 +37,8 @@
 // Unique bit for each  stage/access combination
 
 // Map of the StageAccessIndices from the StageAccess Bit
-const layer_data::unordered_map<SyncStageAccessFlags, SyncStageAccessIndex>& syncStageAccessIndexByStageAccessBit() {
-    static const layer_data::unordered_map<SyncStageAccessFlags, SyncStageAccessIndex> variable = {
+const vvl::unordered_map<SyncStageAccessFlags, SyncStageAccessIndex>& syncStageAccessIndexByStageAccessBit() {
+    static const vvl::unordered_map<SyncStageAccessFlags, SyncStageAccessIndex> variable = {
         { SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ_BIT, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ },
         { SYNC_DRAW_INDIRECT_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT, SYNC_DRAW_INDIRECT_TRANSFORM_FEEDBACK_COUNTER_READ_EXT },
         { SYNC_INDEX_INPUT_INDEX_READ_BIT, SYNC_INDEX_INPUT_INDEX_READ },

--- a/layers/generated/sync_validation_types.h
+++ b/layers/generated/sync_validation_types.h
@@ -271,7 +271,7 @@ static const SyncStageAccessFlags SYNC_IMAGE_LAYOUT_TRANSITION_BIT = (SyncStageA
 static const SyncStageAccessFlags SYNC_QUEUE_FAMILY_OWNERSHIP_TRANSFER_BIT = (SyncStageAccessFlags(1) << SYNC_QUEUE_FAMILY_OWNERSHIP_TRANSFER);
 
 // Map of the StageAccessIndices from the StageAccess Bit
-const layer_data::unordered_map<SyncStageAccessFlags, SyncStageAccessIndex>& syncStageAccessIndexByStageAccessBit();
+const vvl::unordered_map<SyncStageAccessFlags, SyncStageAccessIndex>& syncStageAccessIndexByStageAccessBit();
 
 struct SyncStageAccessInfoType {
     const char *name;

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -283,8 +283,8 @@ public:
     WriteLockGuard WriteLock() override;
 
     vl_concurrent_unordered_map<VkCommandBuffer, VkCommandPool, 6> command_pool_map;
-    layer_data::unordered_map<VkCommandPool, layer_data::unordered_set<VkCommandBuffer>> pool_command_buffers_map;
-    layer_data::unordered_map<VkDevice, layer_data::unordered_set<VkQueue>> device_queues_map;
+    vvl::unordered_map<VkCommandPool, vvl::unordered_set<VkCommandBuffer>> pool_command_buffers_map;
+    vvl::unordered_map<VkDevice, vvl::unordered_set<VkQueue>> device_queues_map;
 
     // Track per-descriptorsetlayout and per-descriptorset whether read_only is used.
     // This is used to (sloppily) implement the relaxed externsync rules for read_only

--- a/layers/generated/valid_param_values.cpp
+++ b/layers/generated/valid_param_values.cpp
@@ -34,7 +34,7 @@ std::vector<VkPipelineCacheHeaderVersion> ValidationObject::ValidParamValues() c
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPipelineCacheHeaderVersionEnums = { VK_PIPELINE_CACHE_HEADER_VERSION_ONE,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPipelineCacheHeaderVersion>> ExtendedVkPipelineCacheHeaderVersionEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPipelineCacheHeaderVersion>> ExtendedVkPipelineCacheHeaderVersionEnums = {
     };
     std::vector<VkPipelineCacheHeaderVersion> values(CoreVkPipelineCacheHeaderVersionEnums.cbegin(), CoreVkPipelineCacheHeaderVersionEnums.cend());
     std::set<VkPipelineCacheHeaderVersion> unique_exts;
@@ -55,7 +55,7 @@ std::vector<VkImageLayout> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkImageLayoutEnums = { VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_PREINITIALIZED,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkImageLayout>> ExtendedVkImageLayoutEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkImageLayout>> ExtendedVkImageLayoutEnums = {
         { &DeviceExtensions::vk_khr_maintenance2, { VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,  } },
         { &DeviceExtensions::vk_khr_separate_depth_stencil_layouts, { VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL,  } },
         { &DeviceExtensions::vk_khr_synchronization2, { VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL,  } },
@@ -87,7 +87,7 @@ std::vector<VkObjectType> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkObjectTypeEnums = { VK_OBJECT_TYPE_UNKNOWN, VK_OBJECT_TYPE_INSTANCE, VK_OBJECT_TYPE_PHYSICAL_DEVICE, VK_OBJECT_TYPE_DEVICE, VK_OBJECT_TYPE_QUEUE, VK_OBJECT_TYPE_SEMAPHORE, VK_OBJECT_TYPE_COMMAND_BUFFER, VK_OBJECT_TYPE_FENCE, VK_OBJECT_TYPE_DEVICE_MEMORY, VK_OBJECT_TYPE_BUFFER, VK_OBJECT_TYPE_IMAGE, VK_OBJECT_TYPE_EVENT, VK_OBJECT_TYPE_QUERY_POOL, VK_OBJECT_TYPE_BUFFER_VIEW, VK_OBJECT_TYPE_IMAGE_VIEW, VK_OBJECT_TYPE_SHADER_MODULE, VK_OBJECT_TYPE_PIPELINE_CACHE, VK_OBJECT_TYPE_PIPELINE_LAYOUT, VK_OBJECT_TYPE_RENDER_PASS, VK_OBJECT_TYPE_PIPELINE, VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT, VK_OBJECT_TYPE_SAMPLER, VK_OBJECT_TYPE_DESCRIPTOR_POOL, VK_OBJECT_TYPE_DESCRIPTOR_SET, VK_OBJECT_TYPE_FRAMEBUFFER, VK_OBJECT_TYPE_COMMAND_POOL,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkObjectType>> ExtendedVkObjectTypeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkObjectType>> ExtendedVkObjectTypeEnums = {
         { &DeviceExtensions::vk_khr_sampler_ycbcr_conversion, { VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION,  } },
         { &DeviceExtensions::vk_khr_descriptor_update_template, { VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE,  } },
         { &DeviceExtensions::vk_ext_private_data, { VK_OBJECT_TYPE_PRIVATE_DATA_SLOT,  } },
@@ -127,7 +127,7 @@ std::vector<VkFormat> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkFormatEnums = { VK_FORMAT_UNDEFINED, VK_FORMAT_R4G4_UNORM_PACK8, VK_FORMAT_R4G4B4A4_UNORM_PACK16, VK_FORMAT_B4G4R4A4_UNORM_PACK16, VK_FORMAT_R5G6B5_UNORM_PACK16, VK_FORMAT_B5G6R5_UNORM_PACK16, VK_FORMAT_R5G5B5A1_UNORM_PACK16, VK_FORMAT_B5G5R5A1_UNORM_PACK16, VK_FORMAT_A1R5G5B5_UNORM_PACK16, VK_FORMAT_R8_UNORM, VK_FORMAT_R8_SNORM, VK_FORMAT_R8_USCALED, VK_FORMAT_R8_SSCALED, VK_FORMAT_R8_UINT, VK_FORMAT_R8_SINT, VK_FORMAT_R8_SRGB, VK_FORMAT_R8G8_UNORM, VK_FORMAT_R8G8_SNORM, VK_FORMAT_R8G8_USCALED, VK_FORMAT_R8G8_SSCALED, VK_FORMAT_R8G8_UINT, VK_FORMAT_R8G8_SINT, VK_FORMAT_R8G8_SRGB, VK_FORMAT_R8G8B8_UNORM, VK_FORMAT_R8G8B8_SNORM, VK_FORMAT_R8G8B8_USCALED, VK_FORMAT_R8G8B8_SSCALED, VK_FORMAT_R8G8B8_UINT, VK_FORMAT_R8G8B8_SINT, VK_FORMAT_R8G8B8_SRGB, VK_FORMAT_B8G8R8_UNORM, VK_FORMAT_B8G8R8_SNORM, VK_FORMAT_B8G8R8_USCALED, VK_FORMAT_B8G8R8_SSCALED, VK_FORMAT_B8G8R8_UINT, VK_FORMAT_B8G8R8_SINT, VK_FORMAT_B8G8R8_SRGB, VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8A8_SNORM, VK_FORMAT_R8G8B8A8_USCALED, VK_FORMAT_R8G8B8A8_SSCALED, VK_FORMAT_R8G8B8A8_UINT, VK_FORMAT_R8G8B8A8_SINT, VK_FORMAT_R8G8B8A8_SRGB, VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_B8G8R8A8_SNORM, VK_FORMAT_B8G8R8A8_USCALED, VK_FORMAT_B8G8R8A8_SSCALED, VK_FORMAT_B8G8R8A8_UINT, VK_FORMAT_B8G8R8A8_SINT, VK_FORMAT_B8G8R8A8_SRGB, VK_FORMAT_A8B8G8R8_UNORM_PACK32, VK_FORMAT_A8B8G8R8_SNORM_PACK32, VK_FORMAT_A8B8G8R8_USCALED_PACK32, VK_FORMAT_A8B8G8R8_SSCALED_PACK32, VK_FORMAT_A8B8G8R8_UINT_PACK32, VK_FORMAT_A8B8G8R8_SINT_PACK32, VK_FORMAT_A8B8G8R8_SRGB_PACK32, VK_FORMAT_A2R10G10B10_UNORM_PACK32, VK_FORMAT_A2R10G10B10_SNORM_PACK32, VK_FORMAT_A2R10G10B10_USCALED_PACK32, VK_FORMAT_A2R10G10B10_SSCALED_PACK32, VK_FORMAT_A2R10G10B10_UINT_PACK32, VK_FORMAT_A2R10G10B10_SINT_PACK32, VK_FORMAT_A2B10G10R10_UNORM_PACK32, VK_FORMAT_A2B10G10R10_SNORM_PACK32, VK_FORMAT_A2B10G10R10_USCALED_PACK32, VK_FORMAT_A2B10G10R10_SSCALED_PACK32, VK_FORMAT_A2B10G10R10_UINT_PACK32, VK_FORMAT_A2B10G10R10_SINT_PACK32, VK_FORMAT_R16_UNORM, VK_FORMAT_R16_SNORM, VK_FORMAT_R16_USCALED, VK_FORMAT_R16_SSCALED, VK_FORMAT_R16_UINT, VK_FORMAT_R16_SINT, VK_FORMAT_R16_SFLOAT, VK_FORMAT_R16G16_UNORM, VK_FORMAT_R16G16_SNORM, VK_FORMAT_R16G16_USCALED, VK_FORMAT_R16G16_SSCALED, VK_FORMAT_R16G16_UINT, VK_FORMAT_R16G16_SINT, VK_FORMAT_R16G16_SFLOAT, VK_FORMAT_R16G16B16_UNORM, VK_FORMAT_R16G16B16_SNORM, VK_FORMAT_R16G16B16_USCALED, VK_FORMAT_R16G16B16_SSCALED, VK_FORMAT_R16G16B16_UINT, VK_FORMAT_R16G16B16_SINT, VK_FORMAT_R16G16B16_SFLOAT, VK_FORMAT_R16G16B16A16_UNORM, VK_FORMAT_R16G16B16A16_SNORM, VK_FORMAT_R16G16B16A16_USCALED, VK_FORMAT_R16G16B16A16_SSCALED, VK_FORMAT_R16G16B16A16_UINT, VK_FORMAT_R16G16B16A16_SINT, VK_FORMAT_R16G16B16A16_SFLOAT, VK_FORMAT_R32_UINT, VK_FORMAT_R32_SINT, VK_FORMAT_R32_SFLOAT, VK_FORMAT_R32G32_UINT, VK_FORMAT_R32G32_SINT, VK_FORMAT_R32G32_SFLOAT, VK_FORMAT_R32G32B32_UINT, VK_FORMAT_R32G32B32_SINT, VK_FORMAT_R32G32B32_SFLOAT, VK_FORMAT_R32G32B32A32_UINT, VK_FORMAT_R32G32B32A32_SINT, VK_FORMAT_R32G32B32A32_SFLOAT, VK_FORMAT_R64_UINT, VK_FORMAT_R64_SINT, VK_FORMAT_R64_SFLOAT, VK_FORMAT_R64G64_UINT, VK_FORMAT_R64G64_SINT, VK_FORMAT_R64G64_SFLOAT, VK_FORMAT_R64G64B64_UINT, VK_FORMAT_R64G64B64_SINT, VK_FORMAT_R64G64B64_SFLOAT, VK_FORMAT_R64G64B64A64_UINT, VK_FORMAT_R64G64B64A64_SINT, VK_FORMAT_R64G64B64A64_SFLOAT, VK_FORMAT_B10G11R11_UFLOAT_PACK32, VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, VK_FORMAT_D16_UNORM, VK_FORMAT_X8_D24_UNORM_PACK32, VK_FORMAT_D32_SFLOAT, VK_FORMAT_S8_UINT, VK_FORMAT_D16_UNORM_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_BC1_RGB_UNORM_BLOCK, VK_FORMAT_BC1_RGB_SRGB_BLOCK, VK_FORMAT_BC1_RGBA_UNORM_BLOCK, VK_FORMAT_BC1_RGBA_SRGB_BLOCK, VK_FORMAT_BC2_UNORM_BLOCK, VK_FORMAT_BC2_SRGB_BLOCK, VK_FORMAT_BC3_UNORM_BLOCK, VK_FORMAT_BC3_SRGB_BLOCK, VK_FORMAT_BC4_UNORM_BLOCK, VK_FORMAT_BC4_SNORM_BLOCK, VK_FORMAT_BC5_UNORM_BLOCK, VK_FORMAT_BC5_SNORM_BLOCK, VK_FORMAT_BC6H_UFLOAT_BLOCK, VK_FORMAT_BC6H_SFLOAT_BLOCK, VK_FORMAT_BC7_UNORM_BLOCK, VK_FORMAT_BC7_SRGB_BLOCK, VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK, VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK, VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK, VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK, VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK, VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK, VK_FORMAT_EAC_R11_UNORM_BLOCK, VK_FORMAT_EAC_R11_SNORM_BLOCK, VK_FORMAT_EAC_R11G11_UNORM_BLOCK, VK_FORMAT_EAC_R11G11_SNORM_BLOCK, VK_FORMAT_ASTC_4x4_UNORM_BLOCK, VK_FORMAT_ASTC_4x4_SRGB_BLOCK, VK_FORMAT_ASTC_5x4_UNORM_BLOCK, VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_FORMAT_ASTC_5x5_UNORM_BLOCK, VK_FORMAT_ASTC_5x5_SRGB_BLOCK, VK_FORMAT_ASTC_6x5_UNORM_BLOCK, VK_FORMAT_ASTC_6x5_SRGB_BLOCK, VK_FORMAT_ASTC_6x6_UNORM_BLOCK, VK_FORMAT_ASTC_6x6_SRGB_BLOCK, VK_FORMAT_ASTC_8x5_UNORM_BLOCK, VK_FORMAT_ASTC_8x5_SRGB_BLOCK, VK_FORMAT_ASTC_8x6_UNORM_BLOCK, VK_FORMAT_ASTC_8x6_SRGB_BLOCK, VK_FORMAT_ASTC_8x8_UNORM_BLOCK, VK_FORMAT_ASTC_8x8_SRGB_BLOCK, VK_FORMAT_ASTC_10x5_UNORM_BLOCK, VK_FORMAT_ASTC_10x5_SRGB_BLOCK, VK_FORMAT_ASTC_10x6_UNORM_BLOCK, VK_FORMAT_ASTC_10x6_SRGB_BLOCK, VK_FORMAT_ASTC_10x8_UNORM_BLOCK, VK_FORMAT_ASTC_10x8_SRGB_BLOCK, VK_FORMAT_ASTC_10x10_UNORM_BLOCK, VK_FORMAT_ASTC_10x10_SRGB_BLOCK, VK_FORMAT_ASTC_12x10_UNORM_BLOCK, VK_FORMAT_ASTC_12x10_SRGB_BLOCK, VK_FORMAT_ASTC_12x12_UNORM_BLOCK, VK_FORMAT_ASTC_12x12_SRGB_BLOCK,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFormat>> ExtendedVkFormatEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFormat>> ExtendedVkFormatEnums = {
         { &DeviceExtensions::vk_khr_sampler_ycbcr_conversion, { VK_FORMAT_G8B8G8R8_422_UNORM, VK_FORMAT_B8G8R8G8_422_UNORM, VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM, VK_FORMAT_G8_B8R8_2PLANE_422_UNORM, VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM, VK_FORMAT_R10X6_UNORM_PACK16, VK_FORMAT_R10X6G10X6_UNORM_2PACK16, VK_FORMAT_R10X6G10X6B10X6A10X6_UNORM_4PACK16, VK_FORMAT_G10X6B10X6G10X6R10X6_422_UNORM_4PACK16, VK_FORMAT_B10X6G10X6R10X6G10X6_422_UNORM_4PACK16, VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16, VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16, VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_422_UNORM_3PACK16, VK_FORMAT_G10X6_B10X6R10X6_2PLANE_422_UNORM_3PACK16, VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_444_UNORM_3PACK16, VK_FORMAT_R12X4_UNORM_PACK16, VK_FORMAT_R12X4G12X4_UNORM_2PACK16, VK_FORMAT_R12X4G12X4B12X4A12X4_UNORM_4PACK16, VK_FORMAT_G12X4B12X4G12X4R12X4_422_UNORM_4PACK16, VK_FORMAT_B12X4G12X4R12X4G12X4_422_UNORM_4PACK16, VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_420_UNORM_3PACK16, VK_FORMAT_G12X4_B12X4R12X4_2PLANE_420_UNORM_3PACK16, VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_422_UNORM_3PACK16, VK_FORMAT_G12X4_B12X4R12X4_2PLANE_422_UNORM_3PACK16, VK_FORMAT_G12X4_B12X4_R12X4_3PLANE_444_UNORM_3PACK16, VK_FORMAT_G16B16G16R16_422_UNORM, VK_FORMAT_B16G16R16G16_422_UNORM, VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_FORMAT_G16_B16R16_2PLANE_420_UNORM, VK_FORMAT_G16_B16_R16_3PLANE_422_UNORM, VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_FORMAT_G16_B16_R16_3PLANE_444_UNORM,  } },
         { &DeviceExtensions::vk_ext_ycbcr_2plane_444_formats, { VK_FORMAT_G8_B8R8_2PLANE_444_UNORM, VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16, VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16, VK_FORMAT_G16_B16R16_2PLANE_444_UNORM,  } },
         { &DeviceExtensions::vk_ext_4444_formats, { VK_FORMAT_A4R4G4B4_UNORM_PACK16, VK_FORMAT_A4B4G4R4_UNORM_PACK16,  } },
@@ -154,7 +154,7 @@ std::vector<VkImageTiling> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkImageTilingEnums = { VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_TILING_LINEAR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkImageTiling>> ExtendedVkImageTilingEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkImageTiling>> ExtendedVkImageTilingEnums = {
         { &DeviceExtensions::vk_ext_image_drm_format_modifier, { VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT,  } },
     };
     std::vector<VkImageTiling> values(CoreVkImageTilingEnums.cbegin(), CoreVkImageTilingEnums.cend());
@@ -176,7 +176,7 @@ std::vector<VkImageType> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkImageTypeEnums = { VK_IMAGE_TYPE_1D, VK_IMAGE_TYPE_2D, VK_IMAGE_TYPE_3D,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkImageType>> ExtendedVkImageTypeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkImageType>> ExtendedVkImageTypeEnums = {
     };
     std::vector<VkImageType> values(CoreVkImageTypeEnums.cbegin(), CoreVkImageTypeEnums.cend());
     std::set<VkImageType> unique_exts;
@@ -197,7 +197,7 @@ std::vector<VkQueryType> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkQueryTypeEnums = { VK_QUERY_TYPE_OCCLUSION, VK_QUERY_TYPE_PIPELINE_STATISTICS, VK_QUERY_TYPE_TIMESTAMP,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkQueryType>> ExtendedVkQueryTypeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkQueryType>> ExtendedVkQueryTypeEnums = {
         { &DeviceExtensions::vk_khr_video_queue, { VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR,  } },
         { &DeviceExtensions::vk_ext_transform_feedback, { VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT,  } },
         { &DeviceExtensions::vk_khr_performance_query, { VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR,  } },
@@ -229,7 +229,7 @@ std::vector<VkSharingMode> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkSharingModeEnums = { VK_SHARING_MODE_EXCLUSIVE, VK_SHARING_MODE_CONCURRENT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSharingMode>> ExtendedVkSharingModeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSharingMode>> ExtendedVkSharingModeEnums = {
     };
     std::vector<VkSharingMode> values(CoreVkSharingModeEnums.cbegin(), CoreVkSharingModeEnums.cend());
     std::set<VkSharingMode> unique_exts;
@@ -250,7 +250,7 @@ std::vector<VkComponentSwizzle> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkComponentSwizzleEnums = { VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_ZERO, VK_COMPONENT_SWIZZLE_ONE, VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkComponentSwizzle>> ExtendedVkComponentSwizzleEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkComponentSwizzle>> ExtendedVkComponentSwizzleEnums = {
     };
     std::vector<VkComponentSwizzle> values(CoreVkComponentSwizzleEnums.cbegin(), CoreVkComponentSwizzleEnums.cend());
     std::set<VkComponentSwizzle> unique_exts;
@@ -271,7 +271,7 @@ std::vector<VkImageViewType> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkImageViewTypeEnums = { VK_IMAGE_VIEW_TYPE_1D, VK_IMAGE_VIEW_TYPE_2D, VK_IMAGE_VIEW_TYPE_3D, VK_IMAGE_VIEW_TYPE_CUBE, VK_IMAGE_VIEW_TYPE_1D_ARRAY, VK_IMAGE_VIEW_TYPE_2D_ARRAY, VK_IMAGE_VIEW_TYPE_CUBE_ARRAY,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkImageViewType>> ExtendedVkImageViewTypeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkImageViewType>> ExtendedVkImageViewTypeEnums = {
     };
     std::vector<VkImageViewType> values(CoreVkImageViewTypeEnums.cbegin(), CoreVkImageViewTypeEnums.cend());
     std::set<VkImageViewType> unique_exts;
@@ -292,7 +292,7 @@ std::vector<VkBlendFactor> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkBlendFactorEnums = { VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_SRC_COLOR, VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR, VK_BLEND_FACTOR_DST_COLOR, VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR, VK_BLEND_FACTOR_SRC_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VK_BLEND_FACTOR_DST_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA, VK_BLEND_FACTOR_CONSTANT_COLOR, VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR, VK_BLEND_FACTOR_CONSTANT_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA, VK_BLEND_FACTOR_SRC_ALPHA_SATURATE, VK_BLEND_FACTOR_SRC1_COLOR, VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR, VK_BLEND_FACTOR_SRC1_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkBlendFactor>> ExtendedVkBlendFactorEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkBlendFactor>> ExtendedVkBlendFactorEnums = {
     };
     std::vector<VkBlendFactor> values(CoreVkBlendFactorEnums.cbegin(), CoreVkBlendFactorEnums.cend());
     std::set<VkBlendFactor> unique_exts;
@@ -313,7 +313,7 @@ std::vector<VkBlendOp> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkBlendOpEnums = { VK_BLEND_OP_ADD, VK_BLEND_OP_SUBTRACT, VK_BLEND_OP_REVERSE_SUBTRACT, VK_BLEND_OP_MIN, VK_BLEND_OP_MAX,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkBlendOp>> ExtendedVkBlendOpEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkBlendOp>> ExtendedVkBlendOpEnums = {
         { &DeviceExtensions::vk_ext_blend_operation_advanced, { VK_BLEND_OP_ZERO_EXT, VK_BLEND_OP_SRC_EXT, VK_BLEND_OP_DST_EXT, VK_BLEND_OP_SRC_OVER_EXT, VK_BLEND_OP_DST_OVER_EXT, VK_BLEND_OP_SRC_IN_EXT, VK_BLEND_OP_DST_IN_EXT, VK_BLEND_OP_SRC_OUT_EXT, VK_BLEND_OP_DST_OUT_EXT, VK_BLEND_OP_SRC_ATOP_EXT, VK_BLEND_OP_DST_ATOP_EXT, VK_BLEND_OP_XOR_EXT, VK_BLEND_OP_MULTIPLY_EXT, VK_BLEND_OP_SCREEN_EXT, VK_BLEND_OP_OVERLAY_EXT, VK_BLEND_OP_DARKEN_EXT, VK_BLEND_OP_LIGHTEN_EXT, VK_BLEND_OP_COLORDODGE_EXT, VK_BLEND_OP_COLORBURN_EXT, VK_BLEND_OP_HARDLIGHT_EXT, VK_BLEND_OP_SOFTLIGHT_EXT, VK_BLEND_OP_DIFFERENCE_EXT, VK_BLEND_OP_EXCLUSION_EXT, VK_BLEND_OP_INVERT_EXT, VK_BLEND_OP_INVERT_RGB_EXT, VK_BLEND_OP_LINEARDODGE_EXT, VK_BLEND_OP_LINEARBURN_EXT, VK_BLEND_OP_VIVIDLIGHT_EXT, VK_BLEND_OP_LINEARLIGHT_EXT, VK_BLEND_OP_PINLIGHT_EXT, VK_BLEND_OP_HARDMIX_EXT, VK_BLEND_OP_HSL_HUE_EXT, VK_BLEND_OP_HSL_SATURATION_EXT, VK_BLEND_OP_HSL_COLOR_EXT, VK_BLEND_OP_HSL_LUMINOSITY_EXT, VK_BLEND_OP_PLUS_EXT, VK_BLEND_OP_PLUS_CLAMPED_EXT, VK_BLEND_OP_PLUS_CLAMPED_ALPHA_EXT, VK_BLEND_OP_PLUS_DARKER_EXT, VK_BLEND_OP_MINUS_EXT, VK_BLEND_OP_MINUS_CLAMPED_EXT, VK_BLEND_OP_CONTRAST_EXT, VK_BLEND_OP_INVERT_OVG_EXT, VK_BLEND_OP_RED_EXT, VK_BLEND_OP_GREEN_EXT, VK_BLEND_OP_BLUE_EXT,  } },
     };
     std::vector<VkBlendOp> values(CoreVkBlendOpEnums.cbegin(), CoreVkBlendOpEnums.cend());
@@ -335,7 +335,7 @@ std::vector<VkCompareOp> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkCompareOpEnums = { VK_COMPARE_OP_NEVER, VK_COMPARE_OP_LESS, VK_COMPARE_OP_EQUAL, VK_COMPARE_OP_LESS_OR_EQUAL, VK_COMPARE_OP_GREATER, VK_COMPARE_OP_NOT_EQUAL, VK_COMPARE_OP_GREATER_OR_EQUAL, VK_COMPARE_OP_ALWAYS,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCompareOp>> ExtendedVkCompareOpEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCompareOp>> ExtendedVkCompareOpEnums = {
     };
     std::vector<VkCompareOp> values(CoreVkCompareOpEnums.cbegin(), CoreVkCompareOpEnums.cend());
     std::set<VkCompareOp> unique_exts;
@@ -356,7 +356,7 @@ std::vector<VkDynamicState> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDynamicStateEnums = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR, VK_DYNAMIC_STATE_LINE_WIDTH, VK_DYNAMIC_STATE_DEPTH_BIAS, VK_DYNAMIC_STATE_BLEND_CONSTANTS, VK_DYNAMIC_STATE_DEPTH_BOUNDS, VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK, VK_DYNAMIC_STATE_STENCIL_WRITE_MASK, VK_DYNAMIC_STATE_STENCIL_REFERENCE,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDynamicState>> ExtendedVkDynamicStateEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDynamicState>> ExtendedVkDynamicStateEnums = {
         { &DeviceExtensions::vk_ext_extended_dynamic_state, { VK_DYNAMIC_STATE_CULL_MODE, VK_DYNAMIC_STATE_FRONT_FACE, VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY, VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT, VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT, VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE, VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE, VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE, VK_DYNAMIC_STATE_DEPTH_COMPARE_OP, VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE, VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE, VK_DYNAMIC_STATE_STENCIL_OP,  } },
         { &DeviceExtensions::vk_ext_extended_dynamic_state2, { VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE, VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE, VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE, VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT, VK_DYNAMIC_STATE_LOGIC_OP_EXT,  } },
         { &DeviceExtensions::vk_nv_clip_space_w_scaling, { VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV,  } },
@@ -390,7 +390,7 @@ std::vector<VkFrontFace> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkFrontFaceEnums = { VK_FRONT_FACE_COUNTER_CLOCKWISE, VK_FRONT_FACE_CLOCKWISE,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFrontFace>> ExtendedVkFrontFaceEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFrontFace>> ExtendedVkFrontFaceEnums = {
     };
     std::vector<VkFrontFace> values(CoreVkFrontFaceEnums.cbegin(), CoreVkFrontFaceEnums.cend());
     std::set<VkFrontFace> unique_exts;
@@ -411,7 +411,7 @@ std::vector<VkVertexInputRate> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkVertexInputRateEnums = { VK_VERTEX_INPUT_RATE_VERTEX, VK_VERTEX_INPUT_RATE_INSTANCE,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkVertexInputRate>> ExtendedVkVertexInputRateEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkVertexInputRate>> ExtendedVkVertexInputRateEnums = {
     };
     std::vector<VkVertexInputRate> values(CoreVkVertexInputRateEnums.cbegin(), CoreVkVertexInputRateEnums.cend());
     std::set<VkVertexInputRate> unique_exts;
@@ -432,7 +432,7 @@ std::vector<VkPrimitiveTopology> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPrimitiveTopologyEnums = { VK_PRIMITIVE_TOPOLOGY_POINT_LIST, VK_PRIMITIVE_TOPOLOGY_LINE_LIST, VK_PRIMITIVE_TOPOLOGY_LINE_STRIP, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN, VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY, VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY, VK_PRIMITIVE_TOPOLOGY_PATCH_LIST,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPrimitiveTopology>> ExtendedVkPrimitiveTopologyEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPrimitiveTopology>> ExtendedVkPrimitiveTopologyEnums = {
     };
     std::vector<VkPrimitiveTopology> values(CoreVkPrimitiveTopologyEnums.cbegin(), CoreVkPrimitiveTopologyEnums.cend());
     std::set<VkPrimitiveTopology> unique_exts;
@@ -453,7 +453,7 @@ std::vector<VkPolygonMode> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPolygonModeEnums = { VK_POLYGON_MODE_FILL, VK_POLYGON_MODE_LINE, VK_POLYGON_MODE_POINT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPolygonMode>> ExtendedVkPolygonModeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPolygonMode>> ExtendedVkPolygonModeEnums = {
         { &DeviceExtensions::vk_nv_fill_rectangle, { VK_POLYGON_MODE_FILL_RECTANGLE_NV,  } },
     };
     std::vector<VkPolygonMode> values(CoreVkPolygonModeEnums.cbegin(), CoreVkPolygonModeEnums.cend());
@@ -475,7 +475,7 @@ std::vector<VkStencilOp> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkStencilOpEnums = { VK_STENCIL_OP_KEEP, VK_STENCIL_OP_ZERO, VK_STENCIL_OP_REPLACE, VK_STENCIL_OP_INCREMENT_AND_CLAMP, VK_STENCIL_OP_DECREMENT_AND_CLAMP, VK_STENCIL_OP_INVERT, VK_STENCIL_OP_INCREMENT_AND_WRAP, VK_STENCIL_OP_DECREMENT_AND_WRAP,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkStencilOp>> ExtendedVkStencilOpEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkStencilOp>> ExtendedVkStencilOpEnums = {
     };
     std::vector<VkStencilOp> values(CoreVkStencilOpEnums.cbegin(), CoreVkStencilOpEnums.cend());
     std::set<VkStencilOp> unique_exts;
@@ -496,7 +496,7 @@ std::vector<VkLogicOp> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkLogicOpEnums = { VK_LOGIC_OP_CLEAR, VK_LOGIC_OP_AND, VK_LOGIC_OP_AND_REVERSE, VK_LOGIC_OP_COPY, VK_LOGIC_OP_AND_INVERTED, VK_LOGIC_OP_NO_OP, VK_LOGIC_OP_XOR, VK_LOGIC_OP_OR, VK_LOGIC_OP_NOR, VK_LOGIC_OP_EQUIVALENT, VK_LOGIC_OP_INVERT, VK_LOGIC_OP_OR_REVERSE, VK_LOGIC_OP_COPY_INVERTED, VK_LOGIC_OP_OR_INVERTED, VK_LOGIC_OP_NAND, VK_LOGIC_OP_SET,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkLogicOp>> ExtendedVkLogicOpEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkLogicOp>> ExtendedVkLogicOpEnums = {
     };
     std::vector<VkLogicOp> values(CoreVkLogicOpEnums.cbegin(), CoreVkLogicOpEnums.cend());
     std::set<VkLogicOp> unique_exts;
@@ -517,7 +517,7 @@ std::vector<VkBorderColor> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkBorderColorEnums = { VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK, VK_BORDER_COLOR_INT_TRANSPARENT_BLACK, VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK, VK_BORDER_COLOR_INT_OPAQUE_BLACK, VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE, VK_BORDER_COLOR_INT_OPAQUE_WHITE,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkBorderColor>> ExtendedVkBorderColorEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkBorderColor>> ExtendedVkBorderColorEnums = {
         { &DeviceExtensions::vk_ext_custom_border_color, { VK_BORDER_COLOR_FLOAT_CUSTOM_EXT, VK_BORDER_COLOR_INT_CUSTOM_EXT,  } },
     };
     std::vector<VkBorderColor> values(CoreVkBorderColorEnums.cbegin(), CoreVkBorderColorEnums.cend());
@@ -539,7 +539,7 @@ std::vector<VkFilter> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkFilterEnums = { VK_FILTER_NEAREST, VK_FILTER_LINEAR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFilter>> ExtendedVkFilterEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFilter>> ExtendedVkFilterEnums = {
         { &DeviceExtensions::vk_img_filter_cubic, { VK_FILTER_CUBIC_EXT,  } },
         { &DeviceExtensions::vk_ext_filter_cubic, { VK_FILTER_CUBIC_EXT,  } },
     };
@@ -562,7 +562,7 @@ std::vector<VkSamplerAddressMode> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkSamplerAddressModeEnums = { VK_SAMPLER_ADDRESS_MODE_REPEAT, VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE, VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSamplerAddressMode>> ExtendedVkSamplerAddressModeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSamplerAddressMode>> ExtendedVkSamplerAddressModeEnums = {
         { &DeviceExtensions::vk_khr_sampler_mirror_clamp_to_edge, { VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE,  } },
     };
     std::vector<VkSamplerAddressMode> values(CoreVkSamplerAddressModeEnums.cbegin(), CoreVkSamplerAddressModeEnums.cend());
@@ -584,7 +584,7 @@ std::vector<VkSamplerMipmapMode> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkSamplerMipmapModeEnums = { VK_SAMPLER_MIPMAP_MODE_NEAREST, VK_SAMPLER_MIPMAP_MODE_LINEAR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSamplerMipmapMode>> ExtendedVkSamplerMipmapModeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSamplerMipmapMode>> ExtendedVkSamplerMipmapModeEnums = {
     };
     std::vector<VkSamplerMipmapMode> values(CoreVkSamplerMipmapModeEnums.cbegin(), CoreVkSamplerMipmapModeEnums.cend());
     std::set<VkSamplerMipmapMode> unique_exts;
@@ -605,7 +605,7 @@ std::vector<VkDescriptorType> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDescriptorTypeEnums = { VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDescriptorType>> ExtendedVkDescriptorTypeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDescriptorType>> ExtendedVkDescriptorTypeEnums = {
         { &DeviceExtensions::vk_ext_inline_uniform_block, { VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK,  } },
         { &DeviceExtensions::vk_khr_acceleration_structure, { VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR,  } },
         { &DeviceExtensions::vk_nv_ray_tracing, { VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV,  } },
@@ -632,7 +632,7 @@ std::vector<VkAttachmentLoadOp> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkAttachmentLoadOpEnums = { VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_LOAD_OP_DONT_CARE,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAttachmentLoadOp>> ExtendedVkAttachmentLoadOpEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAttachmentLoadOp>> ExtendedVkAttachmentLoadOpEnums = {
         { &DeviceExtensions::vk_ext_load_store_op_none, { VK_ATTACHMENT_LOAD_OP_NONE_EXT,  } },
     };
     std::vector<VkAttachmentLoadOp> values(CoreVkAttachmentLoadOpEnums.cbegin(), CoreVkAttachmentLoadOpEnums.cend());
@@ -654,7 +654,7 @@ std::vector<VkAttachmentStoreOp> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkAttachmentStoreOpEnums = { VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_STORE_OP_DONT_CARE,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAttachmentStoreOp>> ExtendedVkAttachmentStoreOpEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAttachmentStoreOp>> ExtendedVkAttachmentStoreOpEnums = {
         { &DeviceExtensions::vk_qcom_render_pass_store_ops, { VK_ATTACHMENT_STORE_OP_NONE,  } },
     };
     std::vector<VkAttachmentStoreOp> values(CoreVkAttachmentStoreOpEnums.cbegin(), CoreVkAttachmentStoreOpEnums.cend());
@@ -676,7 +676,7 @@ std::vector<VkPipelineBindPoint> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPipelineBindPointEnums = { VK_PIPELINE_BIND_POINT_GRAPHICS, VK_PIPELINE_BIND_POINT_COMPUTE,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPipelineBindPoint>> ExtendedVkPipelineBindPointEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPipelineBindPoint>> ExtendedVkPipelineBindPointEnums = {
         { &DeviceExtensions::vk_nv_ray_tracing, { VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR,  } },
         { &DeviceExtensions::vk_khr_ray_tracing_pipeline, { VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR,  } },
         { &DeviceExtensions::vk_huawei_subpass_shading, { VK_PIPELINE_BIND_POINT_SUBPASS_SHADING_HUAWEI,  } },
@@ -700,7 +700,7 @@ std::vector<VkCommandBufferLevel> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkCommandBufferLevelEnums = { VK_COMMAND_BUFFER_LEVEL_PRIMARY, VK_COMMAND_BUFFER_LEVEL_SECONDARY,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCommandBufferLevel>> ExtendedVkCommandBufferLevelEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCommandBufferLevel>> ExtendedVkCommandBufferLevelEnums = {
     };
     std::vector<VkCommandBufferLevel> values(CoreVkCommandBufferLevelEnums.cbegin(), CoreVkCommandBufferLevelEnums.cend());
     std::set<VkCommandBufferLevel> unique_exts;
@@ -721,7 +721,7 @@ std::vector<VkIndexType> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkIndexTypeEnums = { VK_INDEX_TYPE_UINT16, VK_INDEX_TYPE_UINT32,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkIndexType>> ExtendedVkIndexTypeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkIndexType>> ExtendedVkIndexTypeEnums = {
         { &DeviceExtensions::vk_nv_ray_tracing, { VK_INDEX_TYPE_NONE_KHR,  } },
         { &DeviceExtensions::vk_ext_index_type_uint8, { VK_INDEX_TYPE_UINT8_EXT,  } },
     };
@@ -744,7 +744,7 @@ std::vector<VkSubpassContents> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkSubpassContentsEnums = { VK_SUBPASS_CONTENTS_INLINE, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSubpassContents>> ExtendedVkSubpassContentsEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSubpassContents>> ExtendedVkSubpassContentsEnums = {
     };
     std::vector<VkSubpassContents> values(CoreVkSubpassContentsEnums.cbegin(), CoreVkSubpassContentsEnums.cend());
     std::set<VkSubpassContents> unique_exts;
@@ -765,7 +765,7 @@ std::vector<VkTessellationDomainOrigin> ValidationObject::ValidParamValues() con
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkTessellationDomainOriginEnums = { VK_TESSELLATION_DOMAIN_ORIGIN_UPPER_LEFT, VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkTessellationDomainOrigin>> ExtendedVkTessellationDomainOriginEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkTessellationDomainOrigin>> ExtendedVkTessellationDomainOriginEnums = {
     };
     std::vector<VkTessellationDomainOrigin> values(CoreVkTessellationDomainOriginEnums.cbegin(), CoreVkTessellationDomainOriginEnums.cend());
     std::set<VkTessellationDomainOrigin> unique_exts;
@@ -786,7 +786,7 @@ std::vector<VkSamplerYcbcrModelConversion> ValidationObject::ValidParamValues() 
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkSamplerYcbcrModelConversionEnums = { VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY, VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_IDENTITY, VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_709, VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_601, VK_SAMPLER_YCBCR_MODEL_CONVERSION_YCBCR_2020,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSamplerYcbcrModelConversion>> ExtendedVkSamplerYcbcrModelConversionEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSamplerYcbcrModelConversion>> ExtendedVkSamplerYcbcrModelConversionEnums = {
     };
     std::vector<VkSamplerYcbcrModelConversion> values(CoreVkSamplerYcbcrModelConversionEnums.cbegin(), CoreVkSamplerYcbcrModelConversionEnums.cend());
     std::set<VkSamplerYcbcrModelConversion> unique_exts;
@@ -807,7 +807,7 @@ std::vector<VkSamplerYcbcrRange> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkSamplerYcbcrRangeEnums = { VK_SAMPLER_YCBCR_RANGE_ITU_FULL, VK_SAMPLER_YCBCR_RANGE_ITU_NARROW,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSamplerYcbcrRange>> ExtendedVkSamplerYcbcrRangeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSamplerYcbcrRange>> ExtendedVkSamplerYcbcrRangeEnums = {
     };
     std::vector<VkSamplerYcbcrRange> values(CoreVkSamplerYcbcrRangeEnums.cbegin(), CoreVkSamplerYcbcrRangeEnums.cend());
     std::set<VkSamplerYcbcrRange> unique_exts;
@@ -828,7 +828,7 @@ std::vector<VkChromaLocation> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkChromaLocationEnums = { VK_CHROMA_LOCATION_COSITED_EVEN, VK_CHROMA_LOCATION_MIDPOINT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkChromaLocation>> ExtendedVkChromaLocationEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkChromaLocation>> ExtendedVkChromaLocationEnums = {
     };
     std::vector<VkChromaLocation> values(CoreVkChromaLocationEnums.cbegin(), CoreVkChromaLocationEnums.cend());
     std::set<VkChromaLocation> unique_exts;
@@ -849,7 +849,7 @@ std::vector<VkDescriptorUpdateTemplateType> ValidationObject::ValidParamValues()
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDescriptorUpdateTemplateTypeEnums = { VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDescriptorUpdateTemplateType>> ExtendedVkDescriptorUpdateTemplateTypeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDescriptorUpdateTemplateType>> ExtendedVkDescriptorUpdateTemplateTypeEnums = {
         { &DeviceExtensions::vk_khr_push_descriptor, { VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR, VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR,  } },
         { &DeviceExtensions::vk_khr_descriptor_update_template, { VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR,  } },
     };
@@ -872,7 +872,7 @@ std::vector<VkSamplerReductionMode> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkSamplerReductionModeEnums = { VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE, VK_SAMPLER_REDUCTION_MODE_MIN, VK_SAMPLER_REDUCTION_MODE_MAX,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSamplerReductionMode>> ExtendedVkSamplerReductionModeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSamplerReductionMode>> ExtendedVkSamplerReductionModeEnums = {
     };
     std::vector<VkSamplerReductionMode> values(CoreVkSamplerReductionModeEnums.cbegin(), CoreVkSamplerReductionModeEnums.cend());
     std::set<VkSamplerReductionMode> unique_exts;
@@ -893,7 +893,7 @@ std::vector<VkSemaphoreType> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkSemaphoreTypeEnums = { VK_SEMAPHORE_TYPE_BINARY, VK_SEMAPHORE_TYPE_TIMELINE,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSemaphoreType>> ExtendedVkSemaphoreTypeEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkSemaphoreType>> ExtendedVkSemaphoreTypeEnums = {
     };
     std::vector<VkSemaphoreType> values(CoreVkSemaphoreTypeEnums.cbegin(), CoreVkSemaphoreTypeEnums.cend());
     std::set<VkSemaphoreType> unique_exts;
@@ -914,7 +914,7 @@ std::vector<VkPresentModeKHR> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPresentModeKHREnums = { VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_FIFO_KHR, VK_PRESENT_MODE_FIFO_RELAXED_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPresentModeKHR>> ExtendedVkPresentModeKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPresentModeKHR>> ExtendedVkPresentModeKHREnums = {
         { &DeviceExtensions::vk_khr_shared_presentable_image, { VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR, VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR,  } },
     };
     std::vector<VkPresentModeKHR> values(CoreVkPresentModeKHREnums.cbegin(), CoreVkPresentModeKHREnums.cend());
@@ -936,7 +936,7 @@ std::vector<VkColorSpaceKHR> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkColorSpaceKHREnums = { VK_COLOR_SPACE_SRGB_NONLINEAR_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkColorSpaceKHR>> ExtendedVkColorSpaceKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkColorSpaceKHR>> ExtendedVkColorSpaceKHREnums = {
         { &DeviceExtensions::vk_ext_swapchain_colorspace, { VK_COLOR_SPACE_DISPLAY_P3_NONLINEAR_EXT, VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT, VK_COLOR_SPACE_DISPLAY_P3_LINEAR_EXT, VK_COLOR_SPACE_DCI_P3_NONLINEAR_EXT, VK_COLOR_SPACE_BT709_LINEAR_EXT, VK_COLOR_SPACE_BT709_NONLINEAR_EXT, VK_COLOR_SPACE_BT2020_LINEAR_EXT, VK_COLOR_SPACE_HDR10_ST2084_EXT, VK_COLOR_SPACE_DOLBYVISION_EXT, VK_COLOR_SPACE_HDR10_HLG_EXT, VK_COLOR_SPACE_ADOBERGB_LINEAR_EXT, VK_COLOR_SPACE_ADOBERGB_NONLINEAR_EXT, VK_COLOR_SPACE_PASS_THROUGH_EXT, VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT,  } },
         { &DeviceExtensions::vk_amd_display_native_hdr, { VK_COLOR_SPACE_DISPLAY_NATIVE_AMD,  } },
     };
@@ -959,7 +959,7 @@ std::vector<VkQueueGlobalPriorityKHR> ValidationObject::ValidParamValues() const
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkQueueGlobalPriorityKHREnums = { VK_QUEUE_GLOBAL_PRIORITY_LOW_KHR, VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_KHR, VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR, VK_QUEUE_GLOBAL_PRIORITY_REALTIME_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkQueueGlobalPriorityKHR>> ExtendedVkQueueGlobalPriorityKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkQueueGlobalPriorityKHR>> ExtendedVkQueueGlobalPriorityKHREnums = {
     };
     std::vector<VkQueueGlobalPriorityKHR> values(CoreVkQueueGlobalPriorityKHREnums.cbegin(), CoreVkQueueGlobalPriorityKHREnums.cend());
     std::set<VkQueueGlobalPriorityKHR> unique_exts;
@@ -980,7 +980,7 @@ std::vector<VkFragmentShadingRateCombinerOpKHR> ValidationObject::ValidParamValu
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkFragmentShadingRateCombinerOpKHREnums = { VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR, VK_FRAGMENT_SHADING_RATE_COMBINER_OP_REPLACE_KHR, VK_FRAGMENT_SHADING_RATE_COMBINER_OP_MIN_KHR, VK_FRAGMENT_SHADING_RATE_COMBINER_OP_MAX_KHR, VK_FRAGMENT_SHADING_RATE_COMBINER_OP_MUL_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFragmentShadingRateCombinerOpKHR>> ExtendedVkFragmentShadingRateCombinerOpKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFragmentShadingRateCombinerOpKHR>> ExtendedVkFragmentShadingRateCombinerOpKHREnums = {
     };
     std::vector<VkFragmentShadingRateCombinerOpKHR> values(CoreVkFragmentShadingRateCombinerOpKHREnums.cbegin(), CoreVkFragmentShadingRateCombinerOpKHREnums.cend());
     std::set<VkFragmentShadingRateCombinerOpKHR> unique_exts;
@@ -1002,7 +1002,7 @@ std::vector<VkVideoEncodeTuningModeKHR> ValidationObject::ValidParamValues() con
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkVideoEncodeTuningModeKHREnums = { VK_VIDEO_ENCODE_TUNING_MODE_DEFAULT_KHR, VK_VIDEO_ENCODE_TUNING_MODE_HIGH_QUALITY_KHR, VK_VIDEO_ENCODE_TUNING_MODE_LOW_LATENCY_KHR, VK_VIDEO_ENCODE_TUNING_MODE_ULTRA_LOW_LATENCY_KHR, VK_VIDEO_ENCODE_TUNING_MODE_LOSSLESS_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkVideoEncodeTuningModeKHR>> ExtendedVkVideoEncodeTuningModeKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkVideoEncodeTuningModeKHR>> ExtendedVkVideoEncodeTuningModeKHREnums = {
     };
     std::vector<VkVideoEncodeTuningModeKHR> values(CoreVkVideoEncodeTuningModeKHREnums.cbegin(), CoreVkVideoEncodeTuningModeKHREnums.cend());
     std::set<VkVideoEncodeTuningModeKHR> unique_exts;
@@ -1024,7 +1024,7 @@ std::vector<VkDebugReportObjectTypeEXT> ValidationObject::ValidParamValues() con
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDebugReportObjectTypeEXTEnums = { VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDebugReportObjectTypeEXT>> ExtendedVkDebugReportObjectTypeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDebugReportObjectTypeEXT>> ExtendedVkDebugReportObjectTypeEXTEnums = {
         { &DeviceExtensions::vk_khr_sampler_ycbcr_conversion, { VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT,  } },
         { &DeviceExtensions::vk_khr_descriptor_update_template, { VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT,  } },
         { &DeviceExtensions::vk_nvx_binary_import, { VK_DEBUG_REPORT_OBJECT_TYPE_CU_MODULE_NVX_EXT, VK_DEBUG_REPORT_OBJECT_TYPE_CU_FUNCTION_NVX_EXT,  } },
@@ -1051,7 +1051,7 @@ std::vector<VkRasterizationOrderAMD> ValidationObject::ValidParamValues() const 
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkRasterizationOrderAMDEnums = { VK_RASTERIZATION_ORDER_STRICT_AMD, VK_RASTERIZATION_ORDER_RELAXED_AMD,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkRasterizationOrderAMD>> ExtendedVkRasterizationOrderAMDEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkRasterizationOrderAMD>> ExtendedVkRasterizationOrderAMDEnums = {
     };
     std::vector<VkRasterizationOrderAMD> values(CoreVkRasterizationOrderAMDEnums.cbegin(), CoreVkRasterizationOrderAMDEnums.cend());
     std::set<VkRasterizationOrderAMD> unique_exts;
@@ -1073,7 +1073,7 @@ std::vector<VkVideoEncodeH264RateControlStructureEXT> ValidationObject::ValidPar
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkVideoEncodeH264RateControlStructureEXTEnums = { VK_VIDEO_ENCODE_H264_RATE_CONTROL_STRUCTURE_UNKNOWN_EXT, VK_VIDEO_ENCODE_H264_RATE_CONTROL_STRUCTURE_FLAT_EXT, VK_VIDEO_ENCODE_H264_RATE_CONTROL_STRUCTURE_DYADIC_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkVideoEncodeH264RateControlStructureEXT>> ExtendedVkVideoEncodeH264RateControlStructureEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkVideoEncodeH264RateControlStructureEXT>> ExtendedVkVideoEncodeH264RateControlStructureEXTEnums = {
     };
     std::vector<VkVideoEncodeH264RateControlStructureEXT> values(CoreVkVideoEncodeH264RateControlStructureEXTEnums.cbegin(), CoreVkVideoEncodeH264RateControlStructureEXTEnums.cend());
     std::set<VkVideoEncodeH264RateControlStructureEXT> unique_exts;
@@ -1096,7 +1096,7 @@ std::vector<VkVideoEncodeH265RateControlStructureEXT> ValidationObject::ValidPar
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkVideoEncodeH265RateControlStructureEXTEnums = { VK_VIDEO_ENCODE_H265_RATE_CONTROL_STRUCTURE_UNKNOWN_EXT, VK_VIDEO_ENCODE_H265_RATE_CONTROL_STRUCTURE_FLAT_EXT, VK_VIDEO_ENCODE_H265_RATE_CONTROL_STRUCTURE_DYADIC_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkVideoEncodeH265RateControlStructureEXT>> ExtendedVkVideoEncodeH265RateControlStructureEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkVideoEncodeH265RateControlStructureEXT>> ExtendedVkVideoEncodeH265RateControlStructureEXTEnums = {
     };
     std::vector<VkVideoEncodeH265RateControlStructureEXT> values(CoreVkVideoEncodeH265RateControlStructureEXTEnums.cbegin(), CoreVkVideoEncodeH265RateControlStructureEXTEnums.cend());
     std::set<VkVideoEncodeH265RateControlStructureEXT> unique_exts;
@@ -1118,7 +1118,7 @@ std::vector<VkShaderInfoTypeAMD> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkShaderInfoTypeAMDEnums = { VK_SHADER_INFO_TYPE_STATISTICS_AMD, VK_SHADER_INFO_TYPE_BINARY_AMD, VK_SHADER_INFO_TYPE_DISASSEMBLY_AMD,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkShaderInfoTypeAMD>> ExtendedVkShaderInfoTypeAMDEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkShaderInfoTypeAMD>> ExtendedVkShaderInfoTypeAMDEnums = {
     };
     std::vector<VkShaderInfoTypeAMD> values(CoreVkShaderInfoTypeAMDEnums.cbegin(), CoreVkShaderInfoTypeAMDEnums.cend());
     std::set<VkShaderInfoTypeAMD> unique_exts;
@@ -1139,7 +1139,7 @@ std::vector<VkValidationCheckEXT> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkValidationCheckEXTEnums = { VK_VALIDATION_CHECK_ALL_EXT, VK_VALIDATION_CHECK_SHADERS_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkValidationCheckEXT>> ExtendedVkValidationCheckEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkValidationCheckEXT>> ExtendedVkValidationCheckEXTEnums = {
     };
     std::vector<VkValidationCheckEXT> values(CoreVkValidationCheckEXTEnums.cbegin(), CoreVkValidationCheckEXTEnums.cend());
     std::set<VkValidationCheckEXT> unique_exts;
@@ -1160,7 +1160,7 @@ std::vector<VkPipelineRobustnessBufferBehaviorEXT> ValidationObject::ValidParamV
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPipelineRobustnessBufferBehaviorEXTEnums = { VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT, VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DISABLED_EXT, VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT, VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPipelineRobustnessBufferBehaviorEXT>> ExtendedVkPipelineRobustnessBufferBehaviorEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPipelineRobustnessBufferBehaviorEXT>> ExtendedVkPipelineRobustnessBufferBehaviorEXTEnums = {
     };
     std::vector<VkPipelineRobustnessBufferBehaviorEXT> values(CoreVkPipelineRobustnessBufferBehaviorEXTEnums.cbegin(), CoreVkPipelineRobustnessBufferBehaviorEXTEnums.cend());
     std::set<VkPipelineRobustnessBufferBehaviorEXT> unique_exts;
@@ -1181,7 +1181,7 @@ std::vector<VkPipelineRobustnessImageBehaviorEXT> ValidationObject::ValidParamVa
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPipelineRobustnessImageBehaviorEXTEnums = { VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT, VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DISABLED_EXT, VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT, VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPipelineRobustnessImageBehaviorEXT>> ExtendedVkPipelineRobustnessImageBehaviorEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPipelineRobustnessImageBehaviorEXT>> ExtendedVkPipelineRobustnessImageBehaviorEXTEnums = {
     };
     std::vector<VkPipelineRobustnessImageBehaviorEXT> values(CoreVkPipelineRobustnessImageBehaviorEXTEnums.cbegin(), CoreVkPipelineRobustnessImageBehaviorEXTEnums.cend());
     std::set<VkPipelineRobustnessImageBehaviorEXT> unique_exts;
@@ -1202,7 +1202,7 @@ std::vector<VkDisplayPowerStateEXT> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDisplayPowerStateEXTEnums = { VK_DISPLAY_POWER_STATE_OFF_EXT, VK_DISPLAY_POWER_STATE_SUSPEND_EXT, VK_DISPLAY_POWER_STATE_ON_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDisplayPowerStateEXT>> ExtendedVkDisplayPowerStateEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDisplayPowerStateEXT>> ExtendedVkDisplayPowerStateEXTEnums = {
     };
     std::vector<VkDisplayPowerStateEXT> values(CoreVkDisplayPowerStateEXTEnums.cbegin(), CoreVkDisplayPowerStateEXTEnums.cend());
     std::set<VkDisplayPowerStateEXT> unique_exts;
@@ -1223,7 +1223,7 @@ std::vector<VkDeviceEventTypeEXT> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDeviceEventTypeEXTEnums = { VK_DEVICE_EVENT_TYPE_DISPLAY_HOTPLUG_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDeviceEventTypeEXT>> ExtendedVkDeviceEventTypeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDeviceEventTypeEXT>> ExtendedVkDeviceEventTypeEXTEnums = {
     };
     std::vector<VkDeviceEventTypeEXT> values(CoreVkDeviceEventTypeEXTEnums.cbegin(), CoreVkDeviceEventTypeEXTEnums.cend());
     std::set<VkDeviceEventTypeEXT> unique_exts;
@@ -1244,7 +1244,7 @@ std::vector<VkDisplayEventTypeEXT> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDisplayEventTypeEXTEnums = { VK_DISPLAY_EVENT_TYPE_FIRST_PIXEL_OUT_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDisplayEventTypeEXT>> ExtendedVkDisplayEventTypeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDisplayEventTypeEXT>> ExtendedVkDisplayEventTypeEXTEnums = {
     };
     std::vector<VkDisplayEventTypeEXT> values(CoreVkDisplayEventTypeEXTEnums.cbegin(), CoreVkDisplayEventTypeEXTEnums.cend());
     std::set<VkDisplayEventTypeEXT> unique_exts;
@@ -1265,7 +1265,7 @@ std::vector<VkViewportCoordinateSwizzleNV> ValidationObject::ValidParamValues() 
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkViewportCoordinateSwizzleNVEnums = { VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_X_NV, VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_X_NV, VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Y_NV, VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Y_NV, VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Z_NV, VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Z_NV, VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_W_NV, VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_W_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkViewportCoordinateSwizzleNV>> ExtendedVkViewportCoordinateSwizzleNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkViewportCoordinateSwizzleNV>> ExtendedVkViewportCoordinateSwizzleNVEnums = {
     };
     std::vector<VkViewportCoordinateSwizzleNV> values(CoreVkViewportCoordinateSwizzleNVEnums.cbegin(), CoreVkViewportCoordinateSwizzleNVEnums.cend());
     std::set<VkViewportCoordinateSwizzleNV> unique_exts;
@@ -1286,7 +1286,7 @@ std::vector<VkDiscardRectangleModeEXT> ValidationObject::ValidParamValues() cons
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDiscardRectangleModeEXTEnums = { VK_DISCARD_RECTANGLE_MODE_INCLUSIVE_EXT, VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDiscardRectangleModeEXT>> ExtendedVkDiscardRectangleModeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDiscardRectangleModeEXT>> ExtendedVkDiscardRectangleModeEXTEnums = {
     };
     std::vector<VkDiscardRectangleModeEXT> values(CoreVkDiscardRectangleModeEXTEnums.cbegin(), CoreVkDiscardRectangleModeEXTEnums.cend());
     std::set<VkDiscardRectangleModeEXT> unique_exts;
@@ -1307,7 +1307,7 @@ std::vector<VkConservativeRasterizationModeEXT> ValidationObject::ValidParamValu
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkConservativeRasterizationModeEXTEnums = { VK_CONSERVATIVE_RASTERIZATION_MODE_DISABLED_EXT, VK_CONSERVATIVE_RASTERIZATION_MODE_OVERESTIMATE_EXT, VK_CONSERVATIVE_RASTERIZATION_MODE_UNDERESTIMATE_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkConservativeRasterizationModeEXT>> ExtendedVkConservativeRasterizationModeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkConservativeRasterizationModeEXT>> ExtendedVkConservativeRasterizationModeEXTEnums = {
     };
     std::vector<VkConservativeRasterizationModeEXT> values(CoreVkConservativeRasterizationModeEXTEnums.cbegin(), CoreVkConservativeRasterizationModeEXTEnums.cend());
     std::set<VkConservativeRasterizationModeEXT> unique_exts;
@@ -1328,7 +1328,7 @@ std::vector<VkBlendOverlapEXT> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkBlendOverlapEXTEnums = { VK_BLEND_OVERLAP_UNCORRELATED_EXT, VK_BLEND_OVERLAP_DISJOINT_EXT, VK_BLEND_OVERLAP_CONJOINT_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkBlendOverlapEXT>> ExtendedVkBlendOverlapEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkBlendOverlapEXT>> ExtendedVkBlendOverlapEXTEnums = {
     };
     std::vector<VkBlendOverlapEXT> values(CoreVkBlendOverlapEXTEnums.cbegin(), CoreVkBlendOverlapEXTEnums.cend());
     std::set<VkBlendOverlapEXT> unique_exts;
@@ -1349,7 +1349,7 @@ std::vector<VkCoverageModulationModeNV> ValidationObject::ValidParamValues() con
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkCoverageModulationModeNVEnums = { VK_COVERAGE_MODULATION_MODE_NONE_NV, VK_COVERAGE_MODULATION_MODE_RGB_NV, VK_COVERAGE_MODULATION_MODE_ALPHA_NV, VK_COVERAGE_MODULATION_MODE_RGBA_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCoverageModulationModeNV>> ExtendedVkCoverageModulationModeNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCoverageModulationModeNV>> ExtendedVkCoverageModulationModeNVEnums = {
     };
     std::vector<VkCoverageModulationModeNV> values(CoreVkCoverageModulationModeNVEnums.cbegin(), CoreVkCoverageModulationModeNVEnums.cend());
     std::set<VkCoverageModulationModeNV> unique_exts;
@@ -1370,7 +1370,7 @@ std::vector<VkShadingRatePaletteEntryNV> ValidationObject::ValidParamValues() co
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkShadingRatePaletteEntryNVEnums = { VK_SHADING_RATE_PALETTE_ENTRY_NO_INVOCATIONS_NV, VK_SHADING_RATE_PALETTE_ENTRY_16_INVOCATIONS_PER_PIXEL_NV, VK_SHADING_RATE_PALETTE_ENTRY_8_INVOCATIONS_PER_PIXEL_NV, VK_SHADING_RATE_PALETTE_ENTRY_4_INVOCATIONS_PER_PIXEL_NV, VK_SHADING_RATE_PALETTE_ENTRY_2_INVOCATIONS_PER_PIXEL_NV, VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_PIXEL_NV, VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_2X1_PIXELS_NV, VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_1X2_PIXELS_NV, VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_2X2_PIXELS_NV, VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_4X2_PIXELS_NV, VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_2X4_PIXELS_NV, VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_4X4_PIXELS_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkShadingRatePaletteEntryNV>> ExtendedVkShadingRatePaletteEntryNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkShadingRatePaletteEntryNV>> ExtendedVkShadingRatePaletteEntryNVEnums = {
     };
     std::vector<VkShadingRatePaletteEntryNV> values(CoreVkShadingRatePaletteEntryNVEnums.cbegin(), CoreVkShadingRatePaletteEntryNVEnums.cend());
     std::set<VkShadingRatePaletteEntryNV> unique_exts;
@@ -1391,7 +1391,7 @@ std::vector<VkCoarseSampleOrderTypeNV> ValidationObject::ValidParamValues() cons
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkCoarseSampleOrderTypeNVEnums = { VK_COARSE_SAMPLE_ORDER_TYPE_DEFAULT_NV, VK_COARSE_SAMPLE_ORDER_TYPE_CUSTOM_NV, VK_COARSE_SAMPLE_ORDER_TYPE_PIXEL_MAJOR_NV, VK_COARSE_SAMPLE_ORDER_TYPE_SAMPLE_MAJOR_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCoarseSampleOrderTypeNV>> ExtendedVkCoarseSampleOrderTypeNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCoarseSampleOrderTypeNV>> ExtendedVkCoarseSampleOrderTypeNVEnums = {
     };
     std::vector<VkCoarseSampleOrderTypeNV> values(CoreVkCoarseSampleOrderTypeNVEnums.cbegin(), CoreVkCoarseSampleOrderTypeNVEnums.cend());
     std::set<VkCoarseSampleOrderTypeNV> unique_exts;
@@ -1412,7 +1412,7 @@ std::vector<VkRayTracingShaderGroupTypeKHR> ValidationObject::ValidParamValues()
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkRayTracingShaderGroupTypeKHREnums = { VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR, VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR, VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkRayTracingShaderGroupTypeKHR>> ExtendedVkRayTracingShaderGroupTypeKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkRayTracingShaderGroupTypeKHR>> ExtendedVkRayTracingShaderGroupTypeKHREnums = {
     };
     std::vector<VkRayTracingShaderGroupTypeKHR> values(CoreVkRayTracingShaderGroupTypeKHREnums.cbegin(), CoreVkRayTracingShaderGroupTypeKHREnums.cend());
     std::set<VkRayTracingShaderGroupTypeKHR> unique_exts;
@@ -1433,7 +1433,7 @@ std::vector<VkGeometryTypeKHR> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkGeometryTypeKHREnums = { VK_GEOMETRY_TYPE_TRIANGLES_KHR, VK_GEOMETRY_TYPE_AABBS_KHR, VK_GEOMETRY_TYPE_INSTANCES_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkGeometryTypeKHR>> ExtendedVkGeometryTypeKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkGeometryTypeKHR>> ExtendedVkGeometryTypeKHREnums = {
     };
     std::vector<VkGeometryTypeKHR> values(CoreVkGeometryTypeKHREnums.cbegin(), CoreVkGeometryTypeKHREnums.cend());
     std::set<VkGeometryTypeKHR> unique_exts;
@@ -1454,7 +1454,7 @@ std::vector<VkAccelerationStructureTypeKHR> ValidationObject::ValidParamValues()
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkAccelerationStructureTypeKHREnums = { VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR, VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR, VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAccelerationStructureTypeKHR>> ExtendedVkAccelerationStructureTypeKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAccelerationStructureTypeKHR>> ExtendedVkAccelerationStructureTypeKHREnums = {
     };
     std::vector<VkAccelerationStructureTypeKHR> values(CoreVkAccelerationStructureTypeKHREnums.cbegin(), CoreVkAccelerationStructureTypeKHREnums.cend());
     std::set<VkAccelerationStructureTypeKHR> unique_exts;
@@ -1476,7 +1476,7 @@ std::vector<VkCopyAccelerationStructureModeKHR> ValidationObject::ValidParamValu
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkCopyAccelerationStructureModeKHREnums = { VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR, VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR, VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR, VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCopyAccelerationStructureModeKHR>> ExtendedVkCopyAccelerationStructureModeKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCopyAccelerationStructureModeKHR>> ExtendedVkCopyAccelerationStructureModeKHREnums = {
     };
     std::vector<VkCopyAccelerationStructureModeKHR> values(CoreVkCopyAccelerationStructureModeKHREnums.cbegin(), CoreVkCopyAccelerationStructureModeKHREnums.cend());
     std::set<VkCopyAccelerationStructureModeKHR> unique_exts;
@@ -1497,7 +1497,7 @@ std::vector<VkAccelerationStructureMemoryRequirementsTypeNV> ValidationObject::V
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkAccelerationStructureMemoryRequirementsTypeNVEnums = { VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAccelerationStructureMemoryRequirementsTypeNV>> ExtendedVkAccelerationStructureMemoryRequirementsTypeNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAccelerationStructureMemoryRequirementsTypeNV>> ExtendedVkAccelerationStructureMemoryRequirementsTypeNVEnums = {
     };
     std::vector<VkAccelerationStructureMemoryRequirementsTypeNV> values(CoreVkAccelerationStructureMemoryRequirementsTypeNVEnums.cbegin(), CoreVkAccelerationStructureMemoryRequirementsTypeNVEnums.cend());
     std::set<VkAccelerationStructureMemoryRequirementsTypeNV> unique_exts;
@@ -1518,7 +1518,7 @@ std::vector<VkTimeDomainEXT> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkTimeDomainEXTEnums = { VK_TIME_DOMAIN_DEVICE_EXT, VK_TIME_DOMAIN_CLOCK_MONOTONIC_EXT, VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT, VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkTimeDomainEXT>> ExtendedVkTimeDomainEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkTimeDomainEXT>> ExtendedVkTimeDomainEXTEnums = {
     };
     std::vector<VkTimeDomainEXT> values(CoreVkTimeDomainEXTEnums.cbegin(), CoreVkTimeDomainEXTEnums.cend());
     std::set<VkTimeDomainEXT> unique_exts;
@@ -1539,7 +1539,7 @@ std::vector<VkMemoryOverallocationBehaviorAMD> ValidationObject::ValidParamValue
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkMemoryOverallocationBehaviorAMDEnums = { VK_MEMORY_OVERALLOCATION_BEHAVIOR_DEFAULT_AMD, VK_MEMORY_OVERALLOCATION_BEHAVIOR_ALLOWED_AMD, VK_MEMORY_OVERALLOCATION_BEHAVIOR_DISALLOWED_AMD,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkMemoryOverallocationBehaviorAMD>> ExtendedVkMemoryOverallocationBehaviorAMDEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkMemoryOverallocationBehaviorAMD>> ExtendedVkMemoryOverallocationBehaviorAMDEnums = {
     };
     std::vector<VkMemoryOverallocationBehaviorAMD> values(CoreVkMemoryOverallocationBehaviorAMDEnums.cbegin(), CoreVkMemoryOverallocationBehaviorAMDEnums.cend());
     std::set<VkMemoryOverallocationBehaviorAMD> unique_exts;
@@ -1560,7 +1560,7 @@ std::vector<VkPerformanceConfigurationTypeINTEL> ValidationObject::ValidParamVal
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPerformanceConfigurationTypeINTELEnums = { VK_PERFORMANCE_CONFIGURATION_TYPE_COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED_INTEL,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPerformanceConfigurationTypeINTEL>> ExtendedVkPerformanceConfigurationTypeINTELEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPerformanceConfigurationTypeINTEL>> ExtendedVkPerformanceConfigurationTypeINTELEnums = {
     };
     std::vector<VkPerformanceConfigurationTypeINTEL> values(CoreVkPerformanceConfigurationTypeINTELEnums.cbegin(), CoreVkPerformanceConfigurationTypeINTELEnums.cend());
     std::set<VkPerformanceConfigurationTypeINTEL> unique_exts;
@@ -1581,7 +1581,7 @@ std::vector<VkQueryPoolSamplingModeINTEL> ValidationObject::ValidParamValues() c
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkQueryPoolSamplingModeINTELEnums = { VK_QUERY_POOL_SAMPLING_MODE_MANUAL_INTEL,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkQueryPoolSamplingModeINTEL>> ExtendedVkQueryPoolSamplingModeINTELEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkQueryPoolSamplingModeINTEL>> ExtendedVkQueryPoolSamplingModeINTELEnums = {
     };
     std::vector<VkQueryPoolSamplingModeINTEL> values(CoreVkQueryPoolSamplingModeINTELEnums.cbegin(), CoreVkQueryPoolSamplingModeINTELEnums.cend());
     std::set<VkQueryPoolSamplingModeINTEL> unique_exts;
@@ -1602,7 +1602,7 @@ std::vector<VkPerformanceOverrideTypeINTEL> ValidationObject::ValidParamValues()
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPerformanceOverrideTypeINTELEnums = { VK_PERFORMANCE_OVERRIDE_TYPE_NULL_HARDWARE_INTEL, VK_PERFORMANCE_OVERRIDE_TYPE_FLUSH_GPU_CACHES_INTEL,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPerformanceOverrideTypeINTEL>> ExtendedVkPerformanceOverrideTypeINTELEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPerformanceOverrideTypeINTEL>> ExtendedVkPerformanceOverrideTypeINTELEnums = {
     };
     std::vector<VkPerformanceOverrideTypeINTEL> values(CoreVkPerformanceOverrideTypeINTELEnums.cbegin(), CoreVkPerformanceOverrideTypeINTELEnums.cend());
     std::set<VkPerformanceOverrideTypeINTEL> unique_exts;
@@ -1623,7 +1623,7 @@ std::vector<VkPerformanceParameterTypeINTEL> ValidationObject::ValidParamValues(
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPerformanceParameterTypeINTELEnums = { VK_PERFORMANCE_PARAMETER_TYPE_HW_COUNTERS_SUPPORTED_INTEL, VK_PERFORMANCE_PARAMETER_TYPE_STREAM_MARKER_VALID_BITS_INTEL,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPerformanceParameterTypeINTEL>> ExtendedVkPerformanceParameterTypeINTELEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPerformanceParameterTypeINTEL>> ExtendedVkPerformanceParameterTypeINTELEnums = {
     };
     std::vector<VkPerformanceParameterTypeINTEL> values(CoreVkPerformanceParameterTypeINTELEnums.cbegin(), CoreVkPerformanceParameterTypeINTELEnums.cend());
     std::set<VkPerformanceParameterTypeINTEL> unique_exts;
@@ -1644,7 +1644,7 @@ std::vector<VkPerformanceValueTypeINTEL> ValidationObject::ValidParamValues() co
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkPerformanceValueTypeINTELEnums = { VK_PERFORMANCE_VALUE_TYPE_UINT32_INTEL, VK_PERFORMANCE_VALUE_TYPE_UINT64_INTEL, VK_PERFORMANCE_VALUE_TYPE_FLOAT_INTEL, VK_PERFORMANCE_VALUE_TYPE_BOOL_INTEL, VK_PERFORMANCE_VALUE_TYPE_STRING_INTEL,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPerformanceValueTypeINTEL>> ExtendedVkPerformanceValueTypeINTELEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkPerformanceValueTypeINTEL>> ExtendedVkPerformanceValueTypeINTELEnums = {
     };
     std::vector<VkPerformanceValueTypeINTEL> values(CoreVkPerformanceValueTypeINTELEnums.cbegin(), CoreVkPerformanceValueTypeINTELEnums.cend());
     std::set<VkPerformanceValueTypeINTEL> unique_exts;
@@ -1665,7 +1665,7 @@ std::vector<VkValidationFeatureEnableEXT> ValidationObject::ValidParamValues() c
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkValidationFeatureEnableEXTEnums = { VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT, VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT, VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT, VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT, VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkValidationFeatureEnableEXT>> ExtendedVkValidationFeatureEnableEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkValidationFeatureEnableEXT>> ExtendedVkValidationFeatureEnableEXTEnums = {
     };
     std::vector<VkValidationFeatureEnableEXT> values(CoreVkValidationFeatureEnableEXTEnums.cbegin(), CoreVkValidationFeatureEnableEXTEnums.cend());
     std::set<VkValidationFeatureEnableEXT> unique_exts;
@@ -1686,7 +1686,7 @@ std::vector<VkValidationFeatureDisableEXT> ValidationObject::ValidParamValues() 
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkValidationFeatureDisableEXTEnums = { VK_VALIDATION_FEATURE_DISABLE_ALL_EXT, VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT, VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT, VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT, VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT, VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT, VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT, VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHE_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkValidationFeatureDisableEXT>> ExtendedVkValidationFeatureDisableEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkValidationFeatureDisableEXT>> ExtendedVkValidationFeatureDisableEXTEnums = {
     };
     std::vector<VkValidationFeatureDisableEXT> values(CoreVkValidationFeatureDisableEXTEnums.cbegin(), CoreVkValidationFeatureDisableEXTEnums.cend());
     std::set<VkValidationFeatureDisableEXT> unique_exts;
@@ -1707,7 +1707,7 @@ std::vector<VkComponentTypeNV> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkComponentTypeNVEnums = { VK_COMPONENT_TYPE_FLOAT16_NV, VK_COMPONENT_TYPE_FLOAT32_NV, VK_COMPONENT_TYPE_FLOAT64_NV, VK_COMPONENT_TYPE_SINT8_NV, VK_COMPONENT_TYPE_SINT16_NV, VK_COMPONENT_TYPE_SINT32_NV, VK_COMPONENT_TYPE_SINT64_NV, VK_COMPONENT_TYPE_UINT8_NV, VK_COMPONENT_TYPE_UINT16_NV, VK_COMPONENT_TYPE_UINT32_NV, VK_COMPONENT_TYPE_UINT64_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkComponentTypeNV>> ExtendedVkComponentTypeNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkComponentTypeNV>> ExtendedVkComponentTypeNVEnums = {
     };
     std::vector<VkComponentTypeNV> values(CoreVkComponentTypeNVEnums.cbegin(), CoreVkComponentTypeNVEnums.cend());
     std::set<VkComponentTypeNV> unique_exts;
@@ -1728,7 +1728,7 @@ std::vector<VkScopeNV> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkScopeNVEnums = { VK_SCOPE_DEVICE_NV, VK_SCOPE_WORKGROUP_NV, VK_SCOPE_SUBGROUP_NV, VK_SCOPE_QUEUE_FAMILY_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkScopeNV>> ExtendedVkScopeNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkScopeNV>> ExtendedVkScopeNVEnums = {
     };
     std::vector<VkScopeNV> values(CoreVkScopeNVEnums.cbegin(), CoreVkScopeNVEnums.cend());
     std::set<VkScopeNV> unique_exts;
@@ -1749,7 +1749,7 @@ std::vector<VkCoverageReductionModeNV> ValidationObject::ValidParamValues() cons
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkCoverageReductionModeNVEnums = { VK_COVERAGE_REDUCTION_MODE_MERGE_NV, VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCoverageReductionModeNV>> ExtendedVkCoverageReductionModeNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCoverageReductionModeNV>> ExtendedVkCoverageReductionModeNVEnums = {
     };
     std::vector<VkCoverageReductionModeNV> values(CoreVkCoverageReductionModeNVEnums.cbegin(), CoreVkCoverageReductionModeNVEnums.cend());
     std::set<VkCoverageReductionModeNV> unique_exts;
@@ -1770,7 +1770,7 @@ std::vector<VkProvokingVertexModeEXT> ValidationObject::ValidParamValues() const
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkProvokingVertexModeEXTEnums = { VK_PROVOKING_VERTEX_MODE_FIRST_VERTEX_EXT, VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkProvokingVertexModeEXT>> ExtendedVkProvokingVertexModeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkProvokingVertexModeEXT>> ExtendedVkProvokingVertexModeEXTEnums = {
     };
     std::vector<VkProvokingVertexModeEXT> values(CoreVkProvokingVertexModeEXTEnums.cbegin(), CoreVkProvokingVertexModeEXTEnums.cend());
     std::set<VkProvokingVertexModeEXT> unique_exts;
@@ -1792,7 +1792,7 @@ std::vector<VkFullScreenExclusiveEXT> ValidationObject::ValidParamValues() const
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkFullScreenExclusiveEXTEnums = { VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT, VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT, VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT, VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFullScreenExclusiveEXT>> ExtendedVkFullScreenExclusiveEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFullScreenExclusiveEXT>> ExtendedVkFullScreenExclusiveEXTEnums = {
     };
     std::vector<VkFullScreenExclusiveEXT> values(CoreVkFullScreenExclusiveEXTEnums.cbegin(), CoreVkFullScreenExclusiveEXTEnums.cend());
     std::set<VkFullScreenExclusiveEXT> unique_exts;
@@ -1814,7 +1814,7 @@ std::vector<VkLineRasterizationModeEXT> ValidationObject::ValidParamValues() con
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkLineRasterizationModeEXTEnums = { VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT, VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT, VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT, VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkLineRasterizationModeEXT>> ExtendedVkLineRasterizationModeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkLineRasterizationModeEXT>> ExtendedVkLineRasterizationModeEXTEnums = {
     };
     std::vector<VkLineRasterizationModeEXT> values(CoreVkLineRasterizationModeEXTEnums.cbegin(), CoreVkLineRasterizationModeEXTEnums.cend());
     std::set<VkLineRasterizationModeEXT> unique_exts;
@@ -1835,7 +1835,7 @@ std::vector<VkIndirectCommandsTokenTypeNV> ValidationObject::ValidParamValues() 
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkIndirectCommandsTokenTypeNVEnums = { VK_INDIRECT_COMMANDS_TOKEN_TYPE_SHADER_GROUP_NV, VK_INDIRECT_COMMANDS_TOKEN_TYPE_STATE_FLAGS_NV, VK_INDIRECT_COMMANDS_TOKEN_TYPE_INDEX_BUFFER_NV, VK_INDIRECT_COMMANDS_TOKEN_TYPE_VERTEX_BUFFER_NV, VK_INDIRECT_COMMANDS_TOKEN_TYPE_PUSH_CONSTANT_NV, VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_NV, VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_NV, VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_TASKS_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkIndirectCommandsTokenTypeNV>> ExtendedVkIndirectCommandsTokenTypeNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkIndirectCommandsTokenTypeNV>> ExtendedVkIndirectCommandsTokenTypeNVEnums = {
         { &DeviceExtensions::vk_ext_mesh_shader, { VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_MESH_TASKS_NV,  } },
     };
     std::vector<VkIndirectCommandsTokenTypeNV> values(CoreVkIndirectCommandsTokenTypeNVEnums.cbegin(), CoreVkIndirectCommandsTokenTypeNVEnums.cend());
@@ -1857,7 +1857,7 @@ std::vector<VkFragmentShadingRateNV> ValidationObject::ValidParamValues() const 
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkFragmentShadingRateNVEnums = { VK_FRAGMENT_SHADING_RATE_1_INVOCATION_PER_PIXEL_NV, VK_FRAGMENT_SHADING_RATE_1_INVOCATION_PER_1X2_PIXELS_NV, VK_FRAGMENT_SHADING_RATE_1_INVOCATION_PER_2X1_PIXELS_NV, VK_FRAGMENT_SHADING_RATE_1_INVOCATION_PER_2X2_PIXELS_NV, VK_FRAGMENT_SHADING_RATE_1_INVOCATION_PER_2X4_PIXELS_NV, VK_FRAGMENT_SHADING_RATE_1_INVOCATION_PER_4X2_PIXELS_NV, VK_FRAGMENT_SHADING_RATE_1_INVOCATION_PER_4X4_PIXELS_NV, VK_FRAGMENT_SHADING_RATE_2_INVOCATIONS_PER_PIXEL_NV, VK_FRAGMENT_SHADING_RATE_4_INVOCATIONS_PER_PIXEL_NV, VK_FRAGMENT_SHADING_RATE_8_INVOCATIONS_PER_PIXEL_NV, VK_FRAGMENT_SHADING_RATE_16_INVOCATIONS_PER_PIXEL_NV, VK_FRAGMENT_SHADING_RATE_NO_INVOCATIONS_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFragmentShadingRateNV>> ExtendedVkFragmentShadingRateNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkFragmentShadingRateNV>> ExtendedVkFragmentShadingRateNVEnums = {
     };
     std::vector<VkFragmentShadingRateNV> values(CoreVkFragmentShadingRateNVEnums.cbegin(), CoreVkFragmentShadingRateNVEnums.cend());
     std::set<VkFragmentShadingRateNV> unique_exts;
@@ -1878,7 +1878,7 @@ std::vector<VkAccelerationStructureMotionInstanceTypeNV> ValidationObject::Valid
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkAccelerationStructureMotionInstanceTypeNVEnums = { VK_ACCELERATION_STRUCTURE_MOTION_INSTANCE_TYPE_STATIC_NV, VK_ACCELERATION_STRUCTURE_MOTION_INSTANCE_TYPE_MATRIX_MOTION_NV, VK_ACCELERATION_STRUCTURE_MOTION_INSTANCE_TYPE_SRT_MOTION_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAccelerationStructureMotionInstanceTypeNV>> ExtendedVkAccelerationStructureMotionInstanceTypeNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAccelerationStructureMotionInstanceTypeNV>> ExtendedVkAccelerationStructureMotionInstanceTypeNVEnums = {
     };
     std::vector<VkAccelerationStructureMotionInstanceTypeNV> values(CoreVkAccelerationStructureMotionInstanceTypeNVEnums.cbegin(), CoreVkAccelerationStructureMotionInstanceTypeNVEnums.cend());
     std::set<VkAccelerationStructureMotionInstanceTypeNV> unique_exts;
@@ -1899,7 +1899,7 @@ std::vector<VkDeviceFaultAddressTypeEXT> ValidationObject::ValidParamValues() co
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDeviceFaultAddressTypeEXTEnums = { VK_DEVICE_FAULT_ADDRESS_TYPE_NONE_EXT, VK_DEVICE_FAULT_ADDRESS_TYPE_READ_INVALID_EXT, VK_DEVICE_FAULT_ADDRESS_TYPE_WRITE_INVALID_EXT, VK_DEVICE_FAULT_ADDRESS_TYPE_EXECUTE_INVALID_EXT, VK_DEVICE_FAULT_ADDRESS_TYPE_INSTRUCTION_POINTER_UNKNOWN_EXT, VK_DEVICE_FAULT_ADDRESS_TYPE_INSTRUCTION_POINTER_INVALID_EXT, VK_DEVICE_FAULT_ADDRESS_TYPE_INSTRUCTION_POINTER_FAULT_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDeviceFaultAddressTypeEXT>> ExtendedVkDeviceFaultAddressTypeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDeviceFaultAddressTypeEXT>> ExtendedVkDeviceFaultAddressTypeEXTEnums = {
     };
     std::vector<VkDeviceFaultAddressTypeEXT> values(CoreVkDeviceFaultAddressTypeEXTEnums.cbegin(), CoreVkDeviceFaultAddressTypeEXTEnums.cend());
     std::set<VkDeviceFaultAddressTypeEXT> unique_exts;
@@ -1920,7 +1920,7 @@ std::vector<VkDeviceFaultVendorBinaryHeaderVersionEXT> ValidationObject::ValidPa
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDeviceFaultVendorBinaryHeaderVersionEXTEnums = { VK_DEVICE_FAULT_VENDOR_BINARY_HEADER_VERSION_ONE_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDeviceFaultVendorBinaryHeaderVersionEXT>> ExtendedVkDeviceFaultVendorBinaryHeaderVersionEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDeviceFaultVendorBinaryHeaderVersionEXT>> ExtendedVkDeviceFaultVendorBinaryHeaderVersionEXTEnums = {
     };
     std::vector<VkDeviceFaultVendorBinaryHeaderVersionEXT> values(CoreVkDeviceFaultVendorBinaryHeaderVersionEXTEnums.cbegin(), CoreVkDeviceFaultVendorBinaryHeaderVersionEXTEnums.cend());
     std::set<VkDeviceFaultVendorBinaryHeaderVersionEXT> unique_exts;
@@ -1941,7 +1941,7 @@ std::vector<VkDeviceAddressBindingTypeEXT> ValidationObject::ValidParamValues() 
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDeviceAddressBindingTypeEXTEnums = { VK_DEVICE_ADDRESS_BINDING_TYPE_BIND_EXT, VK_DEVICE_ADDRESS_BINDING_TYPE_UNBIND_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDeviceAddressBindingTypeEXT>> ExtendedVkDeviceAddressBindingTypeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDeviceAddressBindingTypeEXT>> ExtendedVkDeviceAddressBindingTypeEXTEnums = {
     };
     std::vector<VkDeviceAddressBindingTypeEXT> values(CoreVkDeviceAddressBindingTypeEXTEnums.cbegin(), CoreVkDeviceAddressBindingTypeEXTEnums.cend());
     std::set<VkDeviceAddressBindingTypeEXT> unique_exts;
@@ -1962,7 +1962,7 @@ std::vector<VkMicromapTypeEXT> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkMicromapTypeEXTEnums = { VK_MICROMAP_TYPE_OPACITY_MICROMAP_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkMicromapTypeEXT>> ExtendedVkMicromapTypeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkMicromapTypeEXT>> ExtendedVkMicromapTypeEXTEnums = {
     };
     std::vector<VkMicromapTypeEXT> values(CoreVkMicromapTypeEXTEnums.cbegin(), CoreVkMicromapTypeEXTEnums.cend());
     std::set<VkMicromapTypeEXT> unique_exts;
@@ -1983,7 +1983,7 @@ std::vector<VkCopyMicromapModeEXT> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkCopyMicromapModeEXTEnums = { VK_COPY_MICROMAP_MODE_CLONE_EXT, VK_COPY_MICROMAP_MODE_SERIALIZE_EXT, VK_COPY_MICROMAP_MODE_DESERIALIZE_EXT, VK_COPY_MICROMAP_MODE_COMPACT_EXT,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCopyMicromapModeEXT>> ExtendedVkCopyMicromapModeEXTEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkCopyMicromapModeEXT>> ExtendedVkCopyMicromapModeEXTEnums = {
     };
     std::vector<VkCopyMicromapModeEXT> values(CoreVkCopyMicromapModeEXTEnums.cbegin(), CoreVkCopyMicromapModeEXTEnums.cend());
     std::set<VkCopyMicromapModeEXT> unique_exts;
@@ -2004,7 +2004,7 @@ std::vector<VkAccelerationStructureBuildTypeKHR> ValidationObject::ValidParamVal
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkAccelerationStructureBuildTypeKHREnums = { VK_ACCELERATION_STRUCTURE_BUILD_TYPE_HOST_KHR, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_HOST_OR_DEVICE_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAccelerationStructureBuildTypeKHR>> ExtendedVkAccelerationStructureBuildTypeKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkAccelerationStructureBuildTypeKHR>> ExtendedVkAccelerationStructureBuildTypeKHREnums = {
     };
     std::vector<VkAccelerationStructureBuildTypeKHR> values(CoreVkAccelerationStructureBuildTypeKHREnums.cbegin(), CoreVkAccelerationStructureBuildTypeKHREnums.cend());
     std::set<VkAccelerationStructureBuildTypeKHR> unique_exts;
@@ -2025,7 +2025,7 @@ std::vector<VkDirectDriverLoadingModeLUNARG> ValidationObject::ValidParamValues(
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkDirectDriverLoadingModeLUNARGEnums = { VK_DIRECT_DRIVER_LOADING_MODE_EXCLUSIVE_LUNARG, VK_DIRECT_DRIVER_LOADING_MODE_INCLUSIVE_LUNARG,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDirectDriverLoadingModeLUNARG>> ExtendedVkDirectDriverLoadingModeLUNARGEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkDirectDriverLoadingModeLUNARG>> ExtendedVkDirectDriverLoadingModeLUNARGEnums = {
     };
     std::vector<VkDirectDriverLoadingModeLUNARG> values(CoreVkDirectDriverLoadingModeLUNARGEnums.cbegin(), CoreVkDirectDriverLoadingModeLUNARGEnums.cend());
     std::set<VkDirectDriverLoadingModeLUNARG> unique_exts;
@@ -2046,7 +2046,7 @@ std::vector<VkOpticalFlowPerformanceLevelNV> ValidationObject::ValidParamValues(
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkOpticalFlowPerformanceLevelNVEnums = { VK_OPTICAL_FLOW_PERFORMANCE_LEVEL_UNKNOWN_NV, VK_OPTICAL_FLOW_PERFORMANCE_LEVEL_SLOW_NV, VK_OPTICAL_FLOW_PERFORMANCE_LEVEL_MEDIUM_NV, VK_OPTICAL_FLOW_PERFORMANCE_LEVEL_FAST_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkOpticalFlowPerformanceLevelNV>> ExtendedVkOpticalFlowPerformanceLevelNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkOpticalFlowPerformanceLevelNV>> ExtendedVkOpticalFlowPerformanceLevelNVEnums = {
     };
     std::vector<VkOpticalFlowPerformanceLevelNV> values(CoreVkOpticalFlowPerformanceLevelNVEnums.cbegin(), CoreVkOpticalFlowPerformanceLevelNVEnums.cend());
     std::set<VkOpticalFlowPerformanceLevelNV> unique_exts;
@@ -2067,7 +2067,7 @@ std::vector<VkOpticalFlowSessionBindingPointNV> ValidationObject::ValidParamValu
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkOpticalFlowSessionBindingPointNVEnums = { VK_OPTICAL_FLOW_SESSION_BINDING_POINT_UNKNOWN_NV, VK_OPTICAL_FLOW_SESSION_BINDING_POINT_INPUT_NV, VK_OPTICAL_FLOW_SESSION_BINDING_POINT_REFERENCE_NV, VK_OPTICAL_FLOW_SESSION_BINDING_POINT_HINT_NV, VK_OPTICAL_FLOW_SESSION_BINDING_POINT_FLOW_VECTOR_NV, VK_OPTICAL_FLOW_SESSION_BINDING_POINT_BACKWARD_FLOW_VECTOR_NV, VK_OPTICAL_FLOW_SESSION_BINDING_POINT_COST_NV, VK_OPTICAL_FLOW_SESSION_BINDING_POINT_BACKWARD_COST_NV, VK_OPTICAL_FLOW_SESSION_BINDING_POINT_GLOBAL_FLOW_NV,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkOpticalFlowSessionBindingPointNV>> ExtendedVkOpticalFlowSessionBindingPointNVEnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkOpticalFlowSessionBindingPointNV>> ExtendedVkOpticalFlowSessionBindingPointNVEnums = {
     };
     std::vector<VkOpticalFlowSessionBindingPointNV> values(CoreVkOpticalFlowSessionBindingPointNVEnums.cbegin(), CoreVkOpticalFlowSessionBindingPointNVEnums.cend());
     std::set<VkOpticalFlowSessionBindingPointNV> unique_exts;
@@ -2088,7 +2088,7 @@ std::vector<VkShaderGroupShaderKHR> ValidationObject::ValidParamValues() const {
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array CoreVkShaderGroupShaderKHREnums = { VK_SHADER_GROUP_SHADER_GENERAL_KHR, VK_SHADER_GROUP_SHADER_CLOSEST_HIT_KHR, VK_SHADER_GROUP_SHADER_ANY_HIT_KHR, VK_SHADER_GROUP_SHADER_INTERSECTION_KHR,  };
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkShaderGroupShaderKHR>> ExtendedVkShaderGroupShaderKHREnums = {
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<VkShaderGroupShaderKHR>> ExtendedVkShaderGroupShaderKHREnums = {
     };
     std::vector<VkShaderGroupShaderKHR> values(CoreVkShaderGroupShaderKHREnums.cbegin(), CoreVkShaderGroupShaderKHREnums.cend());
     std::set<VkShaderGroupShaderKHR> unique_exts;

--- a/layers/generated/vk_dispatch_table_helper.h
+++ b/layers/generated/vk_dispatch_table_helper.h
@@ -615,7 +615,7 @@ static VKAPI_ATTR void VKAPI_CALL StubCmdDrawMeshTasksIndirectCountEXT(VkCommand
 
 
 
-const layer_data::unordered_map<std::string, std::string> api_extension_map {
+const vvl::unordered_map<std::string, std::string> api_extension_map {
     {"vkAcquireFullScreenExclusiveModeEXT", "VK_EXT_full_screen_exclusive"},
     {"vkAcquireNextImage2KHR", "VK_KHR_swapchain"},
     {"vkAcquireNextImageKHR", "VK_KHR_swapchain"},

--- a/layers/generated/vk_extension_helper.h
+++ b/layers/generated/vk_extension_helper.h
@@ -115,7 +115,7 @@ struct InstanceExtensions {
        InstanceReqVec requirements;
     };
 
-    typedef layer_data::unordered_map<std::string,InstanceInfo> InstanceInfoMap;
+    typedef vvl::unordered_map<std::string,InstanceInfo> InstanceInfoMap;
     static const InstanceInfoMap &get_info_map() {
         static const InstanceInfoMap info_map = {
             {"VK_VERSION_1_1", InstanceInfo(&InstanceExtensions::vk_feature_version_1_1, {})},
@@ -662,7 +662,7 @@ struct DeviceExtensions : public InstanceExtensions {
        DeviceReqVec requirements;
     };
 
-    typedef layer_data::unordered_map<std::string,DeviceInfo> DeviceInfoMap;
+    typedef vvl::unordered_map<std::string,DeviceInfo> DeviceInfoMap;
     static const DeviceInfoMap &get_info_map() {
         static const DeviceInfoMap info_map = {
             {"VK_VERSION_1_1", DeviceInfo(&DeviceExtensions::vk_feature_version_1_1, {})},

--- a/layers/generated/vk_format_utils.cpp
+++ b/layers/generated/vk_format_utils.cpp
@@ -73,7 +73,7 @@ struct hash<VkFormat> {
 }
 
 // clang-format off
-static const layer_data::unordered_map<VkFormat, FORMAT_INFO> kVkFormatTable = {
+static const vvl::unordered_map<VkFormat, FORMAT_INFO> kVkFormatTable = {
     {VK_FORMAT_A1R5G5B5_UNORM_PACK16,
         {FORMAT_COMPATIBILITY_CLASS::_16BIT, 2, 1, {1, 1, 1}, 4,
         {{COMPONENT_TYPE::A, 1}, {COMPONENT_TYPE::R, 5}, {COMPONENT_TYPE::G, 5}, {COMPONENT_TYPE::B, 5}} }},
@@ -838,7 +838,7 @@ struct MULTIPLANE_COMPATIBILITY {
 
 // Source: Vulkan spec Table 47. Plane Format Compatibility Table
 // clang-format off
-static const layer_data::unordered_map<VkFormat, MULTIPLANE_COMPATIBILITY> kVkMultiplaneCompatibilityMap {
+static const vvl::unordered_map<VkFormat, MULTIPLANE_COMPATIBILITY> kVkMultiplaneCompatibilityMap {
     { VK_FORMAT_G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16, {{
         { 1, 1, VK_FORMAT_R10X6_UNORM_PACK16 },
         { 2, 2, VK_FORMAT_R10X6G10X6_UNORM_2PACK16 }

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -80,7 +80,7 @@ void DebugPrintf::DestroyBuffer(DPFBufferInfo &buffer_info) {
 }
 
 // Call the SPIR-V Optimizer to run the instrumentation pass on the shader.
-bool DebugPrintf::InstrumentShader(const layer_data::span<const uint32_t> &input, std::vector<uint32_t> &new_pgm,
+bool DebugPrintf::InstrumentShader(const vvl::span<const uint32_t> &input, std::vector<uint32_t> &new_pgm,
                                    uint32_t *unique_shader_id) {
     if (aborted) return false;
     if (input[0] != spv::MagicNumber) return false;
@@ -128,7 +128,7 @@ void DebugPrintf::PreCallRecordCreateShaderModule(VkDevice device, const VkShade
                                                   const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                                   void *csm_state_data) {
     create_shader_module_api_state *csm_state = reinterpret_cast<create_shader_module_api_state *>(csm_state_data);
-    const bool pass = InstrumentShader(layer_data::make_span(pCreateInfo->pCode, pCreateInfo->codeSize / sizeof(uint32_t)),
+    const bool pass = InstrumentShader(vvl::make_span(pCreateInfo->pCode, pCreateInfo->codeSize / sizeof(uint32_t)),
                                        csm_state->instrumented_pgm, &csm_state->unique_shader_id);
     if (pass) {
         csm_state->instrumented_create_info.pCode = csm_state->instrumented_pgm.data();
@@ -238,7 +238,7 @@ std::vector<DPFSubstring> DebugPrintf::ParseFormatString(const std::string &form
     return parsed_strings;
 }
 
-std::string DebugPrintf::FindFormatString(layer_data::span<const uint32_t> pgm, uint32_t string_id) {
+std::string DebugPrintf::FindFormatString(vvl::span<const uint32_t> pgm, uint32_t string_id) {
     std::string format_string;
     SHADER_MODULE_STATE module_state(pgm);
     if (module_state.words_.empty()) {
@@ -313,7 +313,7 @@ void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
         std::stringstream shader_message;
         VkShaderModule shader_module_handle = VK_NULL_HANDLE;
         VkPipeline pipeline_handle = VK_NULL_HANDLE;
-        layer_data::span<const uint32_t> pgm;
+        vvl::span<const uint32_t> pgm;
 
         DPFOutputRecord *debug_record = reinterpret_cast<DPFOutputRecord *>(&debug_output_buffer[index]);
         // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned

--- a/layers/gpu_validation/debug_printf.h
+++ b/layers/gpu_validation/debug_printf.h
@@ -89,13 +89,13 @@ class DebugPrintf : public GpuAssistedBase {
     }
 
     void CreateDevice(const VkDeviceCreateInfo* pCreateInfo) override;
-    bool InstrumentShader(const layer_data::span<const uint32_t>& input, std::vector<uint32_t>& new_pgm,
+    bool InstrumentShader(const vvl::span<const uint32_t>& input, std::vector<uint32_t>& new_pgm,
                           uint32_t* unique_shader_id) override;
     void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                          void* csm_state_data) override;
     std::vector<DPFSubstring> ParseFormatString(const std::string& format_string);
-    std::string FindFormatString(layer_data::span<const uint32_t> pgm, uint32_t string_id);
+    std::string FindFormatString(vvl::span<const uint32_t> pgm, uint32_t string_id);
     void AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, DPFBufferInfo& buffer_info,
                                     uint32_t operation_index, uint32_t* const debug_output_buffer);
     void PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,

--- a/layers/gpu_validation/gpu_utils.cpp
+++ b/layers/gpu_validation/gpu_utils.cpp
@@ -1158,7 +1158,7 @@ bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::st
 
 // Extract the filename, line number, and column number from the correct OpLine and build a message string from it.
 // Scan the source (from OpSource) to find the line of source at the reported line number and place it in another message string.
-void UtilGenerateSourceMessages(layer_data::span<const uint32_t> pgm, const uint32_t *debug_record, bool from_printf,
+void UtilGenerateSourceMessages(vvl::span<const uint32_t> pgm, const uint32_t *debug_record, bool from_printf,
                                 std::string &filename_msg, std::string &source_msg) {
     using namespace spvtools;
     std::ostringstream filename_stream;

--- a/layers/gpu_validation/gpu_utils.h
+++ b/layers/gpu_validation/gpu_utils.h
@@ -51,7 +51,7 @@ class UtilDescriptorSetManager {
     };
     VkDevice device;
     uint32_t num_bindings_in_set;
-    layer_data::unordered_map<VkDescriptorPool, struct PoolTracker> desc_pool_map_;
+    vvl::unordered_map<VkDescriptorPool, struct PoolTracker> desc_pool_map_;
     mutable std::mutex lock_;
 };
 
@@ -88,7 +88,7 @@ void UtilGenerateCommonMessage(const debug_report_data *report_data, const VkCom
                                const uint32_t *debug_record, const VkShaderModule shader_module_handle,
                                const VkPipeline pipeline_handle, const VkPipelineBindPoint pipeline_bind_point,
                                const uint32_t operation_index, std::string &msg);
-void UtilGenerateSourceMessages(layer_data::span<const uint32_t> pgm, const uint32_t *debug_record, bool from_printf,
+void UtilGenerateSourceMessages(vvl::span<const uint32_t> pgm, const uint32_t *debug_record, bool from_printf,
                                 std::string &filename_msg, std::string &source_msg);
 
 struct GpuAssistedShaderTracker {
@@ -212,7 +212,7 @@ class GpuAssistedBase : public ValidationStateTracker {
                                          const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
                                          const VkPipelineBindPoint bind_point, const SafeCreateInfo &modified_create_infos);
 
-    virtual bool InstrumentShader(const layer_data::span<const uint32_t> &input, std::vector<uint32_t> &new_pgm,
+    virtual bool InstrumentShader(const vvl::span<const uint32_t> &input, std::vector<uint32_t> &new_pgm,
                                   uint32_t *unique_shader_id) = 0;
 
   public:

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -899,7 +899,7 @@ void GpuAssisted::PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass r
     ValidationStateTracker::PreCallRecordDestroyRenderPass(device, renderPass, pAllocator);
 }
 
-bool GpuValidateShader(const layer_data::span<const uint32_t> &input, bool SetRelaxBlockLayout, bool SetScalerBlockLayout,
+bool GpuValidateShader(const vvl::span<const uint32_t> &input, bool SetRelaxBlockLayout, bool SetScalerBlockLayout,
                        std::string &error) {
     // Use SPIRV-Tools validator to try and catch any issues with the module
     spv_target_env spirv_environment = SPV_ENV_VULKAN_1_1;
@@ -915,7 +915,7 @@ bool GpuValidateShader(const layer_data::span<const uint32_t> &input, bool SetRe
 }
 
 // Call the SPIR-V Optimizer to run the instrumentation pass on the shader.
-bool GpuAssisted::InstrumentShader(const layer_data::span<const uint32_t> &input, std::vector<uint32_t> &new_pgm,
+bool GpuAssisted::InstrumentShader(const vvl::span<const uint32_t> &input, std::vector<uint32_t> &new_pgm,
                                    uint32_t *unique_shader_id) {
     if (aborted) return false;
     if (input[0] != spv::MagicNumber) return false;
@@ -980,7 +980,7 @@ void GpuAssisted::PreCallRecordCreateShaderModule(VkDevice device, const VkShade
                                                   const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                                   void *csm_state_data) {
     create_shader_module_api_state *csm_state = reinterpret_cast<create_shader_module_api_state *>(csm_state_data);
-    const bool pass = InstrumentShader(layer_data::make_span(pCreateInfo->pCode, pCreateInfo->codeSize / sizeof(uint32_t)),
+    const bool pass = InstrumentShader(vvl::make_span(pCreateInfo->pCode, pCreateInfo->codeSize / sizeof(uint32_t)),
                                        csm_state->instrumented_pgm, &csm_state->unique_shader_id);
     if (pass) {
         csm_state->instrumented_create_info.pCode = csm_state->instrumented_pgm.data();
@@ -1149,7 +1149,7 @@ void GpuAssisted::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
     std::string vuid_msg;
     VkShaderModule shader_module_handle = VK_NULL_HANDLE;
     VkPipeline pipeline_handle = VK_NULL_HANDLE;
-    layer_data::span<const uint32_t> pgm;
+    vvl::span<const uint32_t> pgm;
     // The first record starts at this offset after the total_words.
     const uint32_t *debug_record = &debug_output_buffer[kDebugOutputDataOffset];
     // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -28,7 +28,7 @@ class GpuAssisted;
 struct GpuAssistedDeviceMemoryBlock {
     VkBuffer buffer;
     VmaAllocation allocation;
-    layer_data::unordered_map<uint32_t, const cvdescriptorset::DescriptorBinding*> update_at_submit;
+    vvl::unordered_map<uint32_t, const cvdescriptorset::DescriptorBinding*> update_at_submit;
 };
 
 struct GpuAssistedPreDrawResources {
@@ -199,7 +199,7 @@ class GpuAssisted : public GpuAssistedBase {
                                                       VkBuffer scratch, VkDeviceSize scratchOffset) override;
     void ProcessAccelerationStructureBuildValidationBuffer(VkQueue queue, gpuav_state::CommandBuffer* cb_node);
     void PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator) override;
-    bool InstrumentShader(const layer_data::span<const uint32_t>& input, std::vector<uint32_t>& new_pgm,
+    bool InstrumentShader(const vvl::span<const uint32_t>& input, std::vector<uint32_t>& new_pgm,
                           uint32_t* unique_shader_id) override;
     void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,

--- a/layers/hash_util.h
+++ b/layers/hash_util.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2021 Valve Corporation
- * Copyright (c) 2015-2021 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (C) 2015-2021 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,13 +41,13 @@ bool similar_for_nullity(const T *const lhs, const T *const rhs) {
 // Wrap std hash to avoid manual casts for the holes in std::hash (in C++11)
 template <typename Value>
 size_t HashWithUnderlying(Value value, typename std::enable_if<!std::is_enum<Value>::value, void *>::type = nullptr) {
-    return layer_data::hash<Value>()(value);
+    return vvl::hash<Value>()(value);
 }
 
 template <typename Value>
 size_t HashWithUnderlying(Value value, typename std::enable_if<std::is_enum<Value>::value, void *>::type = nullptr) {
     using Underlying = typename std::underlying_type<Value>::type;
-    return layer_data::hash<Underlying>()(static_cast<const Underlying &>(value));
+    return vvl::hash<Underlying>()(static_cast<const Underlying &>(value));
 }
 
 class HashCombiner {
@@ -125,7 +125,7 @@ struct IsOrderedContainer {
 // which are invariant with resize/insert), with the hash and equality
 // template arguments wrapped in a shared pointer dereferencing
 // function object
-template <typename T, typename Hasher = layer_data::hash<T>, typename KeyEqual = std::equal_to<T>>
+template <typename T, typename Hasher = vvl::hash<T>, typename KeyEqual = std::equal_to<T>>
 class Dictionary {
   public:
     using Def = T;
@@ -152,7 +152,7 @@ class Dictionary {
     struct KeyValueEqual {
         bool operator()(const Id &lhs, const Id &rhs) const { return KeyEqual()(*lhs, *rhs); }
     };
-    using Dict = layer_data::unordered_set<Id, HashKeyValue, KeyValueEqual>;
+    using Dict = vvl::unordered_set<Id, HashKeyValue, KeyValueEqual>;
     using Lock = std::mutex;
     using Guard = std::lock_guard<Lock>;
     Lock lock;

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -36,7 +36,7 @@ typedef struct {
     bool *fine_grained_locking;
 } ConfigAndEnvSettings;
 
-static const layer_data::unordered_map<std::string, VkValidationFeatureDisableEXT> VkValFeatureDisableLookup = {
+static const vvl::unordered_map<std::string, VkValidationFeatureDisableEXT> VkValFeatureDisableLookup = {
     {"VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT", VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT},
     {"VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT", VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT},
     {"VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT", VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT},
@@ -47,7 +47,7 @@ static const layer_data::unordered_map<std::string, VkValidationFeatureDisableEX
     {"VK_VALIDATION_FEATURE_DISABLE_ALL_EXT", VK_VALIDATION_FEATURE_DISABLE_ALL_EXT},
 };
 
-static const layer_data::unordered_map<std::string, VkValidationFeatureEnableEXT> VkValFeatureEnableLookup = {
+static const vvl::unordered_map<std::string, VkValidationFeatureEnableEXT> VkValFeatureEnableLookup = {
     {"VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT", VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT},
     {"VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT",
      VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT},
@@ -56,18 +56,18 @@ static const layer_data::unordered_map<std::string, VkValidationFeatureEnableEXT
     {"VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT", VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT},
 };
 
-static const layer_data::unordered_map<std::string, VkValidationFeatureEnable> VkValFeatureEnableLookup2 = {
+static const vvl::unordered_map<std::string, VkValidationFeatureEnable> VkValFeatureEnableLookup2 = {
     {"VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION", VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION},
 };
 
-static const layer_data::unordered_map<std::string, ValidationCheckDisables> ValidationDisableLookup = {
+static const vvl::unordered_map<std::string, ValidationCheckDisables> ValidationDisableLookup = {
     {"VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE", VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE},
     {"VALIDATION_CHECK_DISABLE_OBJECT_IN_USE", VALIDATION_CHECK_DISABLE_OBJECT_IN_USE},
     {"VALIDATION_CHECK_DISABLE_QUERY_VALIDATION", VALIDATION_CHECK_DISABLE_QUERY_VALIDATION},
     {"VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION", VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION},
 };
 
-static const layer_data::unordered_map<std::string, ValidationCheckEnables> ValidationEnableLookup = {
+static const vvl::unordered_map<std::string, ValidationCheckEnables> ValidationEnableLookup = {
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM},
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD},
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG},

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -43,7 +43,7 @@ struct ObjTrackState {
     VulkanObjectType object_type;                                  // Object type identifier
     ObjectStatusFlags status;                                      // Object state
     uint64_t parent_object;                                        // Parent object
-    std::unique_ptr<layer_data::unordered_set<uint64_t> > child_objects;  // Child objects (used for VkDescriptorPool only)
+    std::unique_ptr<vvl::unordered_set<uint64_t> > child_objects;  // Child objects (used for VkDescriptorPool only)
 };
 
 typedef vl_concurrent_unordered_map<uint64_t, std::shared_ptr<ObjTrackState>, 6> object_map_type;
@@ -200,7 +200,7 @@ class ObjectLifetimes : public ValidationObject {
             num_total_objects++;
 
             if (object_type == kVulkanObjectTypeDescriptorPool) {
-                pNewObjNode->child_objects.reset(new layer_data::unordered_set<uint64_t>);
+                pNewObjNode->child_objects.reset(new vvl::unordered_set<uint64_t>);
             }
         }
     }

--- a/layers/qfo_transfer.h
+++ b/layers/qfo_transfer.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (C) 2015-2022 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -161,7 +161,7 @@ using QFOTransferBarrierHash = hash_util::HasHashMember<TransferBarrier>;
 
 // Command buffers store the set of barriers recorded
 template <typename TransferBarrier>
-using QFOTransferBarrierSet = layer_data::unordered_set<TransferBarrier, QFOTransferBarrierHash<TransferBarrier>>;
+using QFOTransferBarrierSet = vvl::unordered_set<TransferBarrier, QFOTransferBarrierHash<TransferBarrier>>;
 
 template <typename TransferBarrier>
 struct QFOTransferBarrierSets {
@@ -181,7 +181,7 @@ using GlobalQFOTransferBarrierMap =
 // Submit queue uses the Scoreboard to track all release/acquire operations in a batch.
 template <typename TransferBarrier>
 using QFOTransferCBScoreboard =
-    layer_data::unordered_map<TransferBarrier, const CMD_BUFFER_STATE *, QFOTransferBarrierHash<TransferBarrier>>;
+    vvl::unordered_map<TransferBarrier, const CMD_BUFFER_STATE *, QFOTransferBarrierHash<TransferBarrier>>;
 
 template <typename TransferBarrier>
 struct QFOTransferCBScoreboards {

--- a/layers/range_vector.h
+++ b/layers/range_vector.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2019-2022 The Khronos Group Inc.
- * Copyright (c) 2019-2022 Valve Corporation
- * Copyright (c) 2019-2022 LunarG, Inc.
+ * Copyright (c) 2019-2023 Valve Corporation
+ * Copyright (c) 2019-2023 LunarG, Inc.
  * Copyright (C) 2019-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1820,14 +1820,14 @@ struct update_prefer_source {
         return false;
     }
 
-    std::optional<T> insert(const T &src) const { return std::optional<T>(layer_data::in_place, src); }
+    std::optional<T> insert(const T &src) const { return std::optional<T>(vvl::in_place, src); }
 };
 
 template <typename T>
 struct update_prefer_dest {
     bool update(T &dst, const T &src) const { return false; }
 
-    std::optional<T> insert(const T &src) const { return std::optional<T>(layer_data::in_place, src); }
+    std::optional<T> insert(const T &src) const { return std::optional<T>(vvl::in_place, src); }
 };
 
 template <typename RangeMap, typename SourceIterator = typename RangeMap::const_iterator>

--- a/layers/sparse_containers.h
+++ b/layers/sparse_containers.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020-2021 The Khronos Group Inc.
- * Copyright (c) 2020-2021 Valve Corporation
- * Copyright (c) 2020-2021 LunarG, Inc.
+ * Copyright (c) 2020-2023 Valve Corporation
+ * Copyright (c) 2020-2023 LunarG, Inc.
  * Copyright (C) 2020-2021 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,7 +90,7 @@ class SparseVector {
     typedef IndexType_ IndexType;
     typedef T value_type;
     typedef value_type ValueType;
-    typedef layer_data::unordered_map<IndexType, ValueType> SparseType;
+    typedef vvl::unordered_map<IndexType, ValueType> SparseType;
     typedef std::vector<ValueType> DenseType;
 
     SparseVector(IndexType start, IndexType end)

--- a/layers/state_tracker/base_node.h
+++ b/layers/state_tracker/base_node.h
@@ -55,7 +55,7 @@ class BASE_NODE : public std::enable_shared_from_this<BASE_NODE> {
     // Because weak_ptrs cannot safely be used as hash keys, the parents are stored
     // in a map keyed by VulkanTypedHandle. This also allows looking for specific
     // parent types without locking every weak_ptr.
-    using NodeMap = layer_data::unordered_map<VulkanTypedHandle, std::weak_ptr<BASE_NODE>>;
+    using NodeMap = vvl::unordered_map<VulkanTypedHandle, std::weak_ptr<BASE_NODE>>;
     using NodeList = small_vector<std::shared_ptr<BASE_NODE>, 4, uint32_t>;
 
     template <typename Handle>

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -43,7 +43,7 @@ class BUFFER_STATE : public BINDABLE {
     const VkMemoryRequirements *const memory_requirements_pointer = &requirements;
     bool memory_requirements_checked;
 
-    layer_data::unordered_set<std::shared_ptr<const VideoProfileDesc>> supported_video_profiles;
+    vvl::unordered_set<std::shared_ptr<const VideoProfileDesc>> supported_video_profiles;
 
     BUFFER_STATE(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo);
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -944,7 +944,7 @@ void CMD_BUFFER_STATE::End(VkResult result) {
     }
 }
 
-void CMD_BUFFER_STATE::ExecuteCommands(layer_data::span<const VkCommandBuffer> secondary_command_buffers) {
+void CMD_BUFFER_STATE::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_command_buffers) {
     RecordCmd(CMD_EXECUTECOMMANDS);
     for (const VkCommandBuffer sub_command_buffer : secondary_command_buffers) {
         auto sub_cb_state = dev_data->GetWrite<CMD_BUFFER_STATE>(sub_command_buffer);
@@ -996,8 +996,8 @@ void CMD_BUFFER_STATE::ExecuteCommands(layer_data::span<const VkCommandBuffer> s
 
         // State is trashed after executing secondary command buffers.
         // Importantly, this function runs after CoreChecks::PreCallValidateCmdExecuteCommands.
-        trashedViewportMask = layer_data::MaxTypeValue<uint32_t>();
-        trashedScissorMask = layer_data::MaxTypeValue<uint32_t>();
+        trashedViewportMask = vvl::MaxTypeValue<uint32_t>();
+        trashedScissorMask = vvl::MaxTypeValue<uint32_t>();
         trashedViewportCount = true;
         trashedScissorCount = true;
 
@@ -1128,7 +1128,7 @@ void CMD_BUFFER_STATE::UpdatePipelineState(CMD_TYPE cmd_type, const VkPipelineBi
                     std::set_difference(binding_req_map.begin(), binding_req_map.end(),
                                         set_info.validated_set_binding_req_map.begin(),
                                         set_info.validated_set_binding_req_map.end(),
-                                        layer_data::insert_iterator<BindingReqMap>(delta_reqs, delta_reqs.begin()));
+                                        vvl::insert_iterator<BindingReqMap>(delta_reqs, delta_reqs.begin()));
                     descriptor_set->UpdateDrawState(dev_data, this, cmd_type, pipe, delta_reqs);
                 } else {
                     descriptor_set->UpdateDrawState(dev_data, this, cmd_type, pipe, binding_req_map);

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -84,14 +84,14 @@ class DESCRIPTOR_POOL_STATE : public BASE_NODE {
 
     const uint32_t maxSets;  // Max descriptor sets allowed in this pool
     const safe_VkDescriptorPoolCreateInfo createInfo;
-    using TypeCountMap = layer_data::unordered_map<uint32_t, uint32_t>;
+    using TypeCountMap = vvl::unordered_map<uint32_t, uint32_t>;
     const TypeCountMap maxDescriptorTypeCount;  // Max # of descriptors of each type in this pool
   private:
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock_); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock_); }
     uint32_t available_sets_;        // Available descriptor sets in this pool
     TypeCountMap available_counts_;  // Available # of descriptors of each type in this pool
-    layer_data::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> sets_;  // Collection of all sets in this pool
+    vvl::unordered_map<VkDescriptorSet, cvdescriptorset::DescriptorSet *> sets_;  // Collection of all sets in this pool
     ValidationStateTracker *dev_data_;
     mutable std::shared_mutex lock_;
 };
@@ -225,7 +225,7 @@ class DescriptorSetLayoutDef {
 
     // Convenience data structures for rapid lookup of various descriptor set layout properties
     std::set<uint32_t> non_empty_bindings_;  // Containing non-emtpy bindings in numerical order
-    layer_data::unordered_map<uint32_t, uint32_t> binding_to_index_map_;
+    vvl::unordered_map<uint32_t, uint32_t> binding_to_index_map_;
     // The following map allows an non-iterative lookup of a binding from a global index...
     std::vector<IndexRange> global_index_range_;  // range is exclusive of .end
 
@@ -876,7 +876,7 @@ class DescriptorSet : public BASE_NODE {
 
     // Track work that has been bound or validated to avoid duplicate work, important when large descriptor arrays
     // are present
-    typedef layer_data::unordered_set<uint32_t> TrackedBindings;
+    typedef vvl::unordered_set<uint32_t> TrackedBindings;
     static void FilterOneBindingReq(const BindingReqMap::value_type &binding_req_pair, BindingReqMap *out_req,
                                     const TrackedBindings &set, uint32_t limit);
     void FilterBindingReqs(const CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &, const BindingReqMap &in_req,
@@ -949,13 +949,13 @@ class DescriptorSet : public BASE_NODE {
     // For the lifespan of a given command buffer recording, do lazy evaluation, caching, and dirtying of
     // expensive validation operation (typically per-draw)
     // Track the validation caching of bindings vs. the command buffer and draw state
-    typedef layer_data::unordered_map<uint32_t, uint64_t> VersionedBindings;
+    typedef vvl::unordered_map<uint32_t, uint64_t> VersionedBindings;
     // this structure is stored in a map in CMD_BUFFER_STATE, with an entry for every descriptor set.
     struct CachedValidation {
         TrackedBindings command_binding_and_usage;  // Persistent for the life of the recording
         TrackedBindings non_dynamic_buffers;        // Persistent for the life of the recording
         TrackedBindings dynamic_buffers;            // Dirtied (flushed) each BindDescriptorSet
-        layer_data::unordered_map<const PIPELINE_STATE *, VersionedBindings>
+        vvl::unordered_map<const PIPELINE_STATE *, VersionedBindings>
             image_samplers;  // Tested vs. changes to CB's ImageLayout
     };
     const DescriptorSetLayout &Layout() const { return *layout_; }

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -100,7 +100,7 @@ struct MEM_BINDING {
 class BindableMemoryTracker {
   public:
     using BoundMemoryRange = std::map<VkDeviceMemory, std::vector<sparse_container::range<VkDeviceSize>>>;
-    using DeviceMemoryState = layer_data::unordered_set<std::shared_ptr<DEVICE_MEMORY_STATE>>;
+    using DeviceMemoryState = vvl::unordered_set<std::shared_ptr<DEVICE_MEMORY_STATE>>;
 };
 
 // Dummy memory tracker for swapchains

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -130,7 +130,7 @@ class PHYSICAL_DEVICE_STATE : public BASE_NODE {
     uint32_t display_plane_property_count = 0;
 
     // Map of queue family index to QUEUE_FAMILY_PERF_COUNTERS
-    layer_data::unordered_map<uint32_t, std::unique_ptr<QUEUE_FAMILY_PERF_COUNTERS>> perf_counters;
+    vvl::unordered_map<uint32_t, std::unique_ptr<QUEUE_FAMILY_PERF_COUNTERS>> perf_counters;
 
     // Surfaceless Query extension needs 'global' surface_state data
     SURFACELESS_QUERY_STATE surfaceless_query_state{};

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -109,7 +109,7 @@ class ImageSubresourceLayoutMap {
         struct Updater {
             bool update(LayoutEntry& dst, const LayoutEntry& src) const { return dst.Update(src); }
             std::optional<LayoutEntry> insert(const LayoutEntry& src) const {
-                return std::optional<LayoutEntry>(layer_data::in_place, src);
+                return std::optional<LayoutEntry>(vvl::in_place, src);
             }
         };
     };

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -742,7 +742,7 @@ bool SURFACE_STATE::GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) con
 }
 
 // Save data from vkGetPhysicalDeviceSurfacePresentModes
-void SURFACE_STATE::SetPresentModes(VkPhysicalDevice phys_dev, layer_data::span<const VkPresentModeKHR> modes) {
+void SURFACE_STATE::SetPresentModes(VkPhysicalDevice phys_dev, vvl::span<const VkPresentModeKHR> modes) {
     auto guard = Lock();
     assert(phys_dev);
     for (auto new_present_mode : modes) {
@@ -813,7 +813,7 @@ VkSurfaceCapabilitiesKHR SURFACE_STATE::GetCapabilities(VkPhysicalDevice phys_de
 }
 
 void SURFACE_STATE::SetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
-                                       layer_data::span<const VkPresentModeKHR> compatible_modes) {
+                                       vvl::span<const VkPresentModeKHR> compatible_modes) {
     auto guard = Lock();
     assert(phys_dev);
 

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -133,7 +133,7 @@ class IMAGE_STATE : public BINDABLE {
 
     std::shared_ptr<GlobalImageLayoutRangeMap> layout_range_map;
 
-    layer_data::unordered_set<std::shared_ptr<const VideoProfileDesc>> supported_video_profiles;
+    vvl::unordered_set<std::shared_ptr<const VideoProfileDesc>> supported_video_profiles;
 
     IMAGE_STATE(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo,
                 VkFormatFeatureFlags2KHR features);
@@ -373,7 +373,7 @@ class SURFACE_STATE : public BASE_NODE {
     void SetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi, bool supported);
     bool GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) const;
 
-    void SetPresentModes(VkPhysicalDevice phys_dev, layer_data::span<const VkPresentModeKHR> modes);
+    void SetPresentModes(VkPhysicalDevice phys_dev, vvl::span<const VkPresentModeKHR> modes);
     std::vector<VkPresentModeKHR> GetPresentModes(VkPhysicalDevice phys_dev) const;
 
     void SetFormats(VkPhysicalDevice phys_dev, std::vector<VkSurfaceFormatKHR> &&fmts);
@@ -383,7 +383,7 @@ class SURFACE_STATE : public BASE_NODE {
     VkSurfaceCapabilitiesKHR GetCapabilities(VkPhysicalDevice phys_dev) const;
 
     void SetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
-                            layer_data::span<const VkPresentModeKHR> compatible_modes);
+                            vvl::span<const VkPresentModeKHR> compatible_modes);
     std::vector<VkPresentModeKHR> GetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode) const;
     void SetPresentModeCapabilities(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
                                     const VkSurfaceCapabilitiesKHR &caps,
@@ -397,10 +397,10 @@ class SURFACE_STATE : public BASE_NODE {
   private:
     std::unique_lock<std::mutex> Lock() const { return std::unique_lock<std::mutex>(lock_); }
     mutable std::mutex lock_;
-    mutable layer_data::unordered_map<GpuQueue, bool> gpu_queue_support_;
-    mutable layer_data::unordered_map<VkPhysicalDevice, std::vector<VkSurfaceFormatKHR>> formats_;
-    mutable layer_data::unordered_map<VkPhysicalDevice, VkSurfaceCapabilitiesKHR> capabilities_;
-    mutable layer_data::unordered_map<VkPhysicalDevice,
-                                      layer_data::unordered_map<VkPresentModeKHR, std::optional<std::shared_ptr<PresentModeState>>>>
+    mutable vvl::unordered_map<GpuQueue, bool> gpu_queue_support_;
+    mutable vvl::unordered_map<VkPhysicalDevice, std::vector<VkSurfaceFormatKHR>> formats_;
+    mutable vvl::unordered_map<VkPhysicalDevice, VkSurfaceCapabilitiesKHR> capabilities_;
+    mutable vvl::unordered_map<VkPhysicalDevice,
+                                      vvl::unordered_map<VkPresentModeKHR, std::optional<std::shared_ptr<PresentModeState>>>>
         present_modes_data_;
 };

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -113,7 +113,7 @@ static PushConstantRangesId GetCanonicalId(const VkPipelineLayoutCreateInfo *inf
     return push_constant_ranges_dict.look_up(std::move(ranges));
 }
 
-static PushConstantRangesId GetPushConstantRangesFromLayouts(const layer_data::span<const PIPELINE_LAYOUT_STATE *const> &layouts) {
+static PushConstantRangesId GetPushConstantRangesFromLayouts(const vvl::span<const PIPELINE_LAYOUT_STATE *const> &layouts) {
     PushConstantRangesId ret{};
     for (const auto *layout : layouts) {
         if (layout && layout->push_constant_ranges) {
@@ -137,7 +137,7 @@ static PIPELINE_LAYOUT_STATE::SetLayoutVector GetSetLayouts(ValidationStateTrack
     return set_layouts;
 }
 
-static PIPELINE_LAYOUT_STATE::SetLayoutVector GetSetLayouts(const layer_data::span<const PIPELINE_LAYOUT_STATE *const> &layouts) {
+static PIPELINE_LAYOUT_STATE::SetLayoutVector GetSetLayouts(const vvl::span<const PIPELINE_LAYOUT_STATE *const> &layouts) {
     PIPELINE_LAYOUT_STATE::SetLayoutVector set_layouts;
     size_t num_layouts = 0;
     for (const auto &layout : layouts) {
@@ -192,7 +192,7 @@ static std::vector<PipelineLayoutCompatId> GetCompatForSet(const PIPELINE_LAYOUT
     return set_compat_ids;
 }
 
-VkPipelineLayoutCreateFlags GetCreateFlags(const layer_data::span<const PIPELINE_LAYOUT_STATE *const> &layouts) {
+VkPipelineLayoutCreateFlags GetCreateFlags(const vvl::span<const PIPELINE_LAYOUT_STATE *const> &layouts) {
     VkPipelineLayoutCreateFlags flags = 0;
     for (const auto &layout : layouts) {
         if (layout) {
@@ -210,7 +210,7 @@ PIPELINE_LAYOUT_STATE::PIPELINE_LAYOUT_STATE(ValidationStateTracker *dev_data, V
       set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges)),
       create_flags(pCreateInfo->flags) {}
 
-PIPELINE_LAYOUT_STATE::PIPELINE_LAYOUT_STATE(const layer_data::span<const PIPELINE_LAYOUT_STATE *const> &layouts)
+PIPELINE_LAYOUT_STATE::PIPELINE_LAYOUT_STATE(const vvl::span<const PIPELINE_LAYOUT_STATE *const> &layouts)
     : BASE_NODE(static_cast<VkPipelineLayout>(VK_NULL_HANDLE), kVulkanObjectTypePipelineLayout),
       set_layouts(GetSetLayouts(layouts)),
       push_constant_ranges(GetPushConstantRangesFromLayouts(layouts)),  // TODO is this correct?

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -87,10 +87,10 @@ class PIPELINE_LAYOUT_STATE : public BASE_NODE {
 
     PIPELINE_LAYOUT_STATE(ValidationStateTracker *dev_data, VkPipelineLayout l, const VkPipelineLayoutCreateInfo *pCreateInfo);
     // Merge 2 or more non-overlapping layouts
-    PIPELINE_LAYOUT_STATE(const layer_data::span<const PIPELINE_LAYOUT_STATE *const> &layouts);
+    PIPELINE_LAYOUT_STATE(const vvl::span<const PIPELINE_LAYOUT_STATE *const> &layouts);
     template <typename Container>
     PIPELINE_LAYOUT_STATE(const Container &layouts)
-        : PIPELINE_LAYOUT_STATE(layer_data::span<const PIPELINE_LAYOUT_STATE *const>{layouts}) {}
+        : PIPELINE_LAYOUT_STATE(vvl::span<const PIPELINE_LAYOUT_STATE *const>{layouts}) {}
 
     VkPipelineLayout layout() const { return handle_.Cast<VkPipelineLayout>(); }
 

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -242,8 +242,8 @@ static bool UsesShaderModuleId(const PIPELINE_STATE::StageStateVec &stages) {
     return result;
 }
 
-static layer_data::unordered_set<uint32_t> GetFSOutputLocations(const PIPELINE_STATE::StageStateVec &stage_states) {
-    layer_data::unordered_set<uint32_t> result;
+static vvl::unordered_set<uint32_t> GetFSOutputLocations(const PIPELINE_STATE::StageStateVec &stage_states) {
+    vvl::unordered_set<uint32_t> result;
     for (const auto &stage : stage_states) {
         if (!stage.entrypoint) {
             continue;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -88,7 +88,7 @@ struct DescriptorRequirement {
     DescriptorReqFlags reqs;
     bool is_writable;
     // Copy from StageState.ResourceInterfaceVariable. It combines from plural shader stages. The index of array is index of image.
-    std::vector<layer_data::unordered_set<SamplerUsedByImage>> samplers_used_by_image;
+    std::vector<vvl::unordered_set<SamplerUsedByImage>> samplers_used_by_image;
     // For storage images - list of < OpImageWrite : Texel component length >
     std::vector<std::pair<Instruction, uint32_t>> write_without_formats_component_count_list;
     DescriptorRequirement() : reqs(0), is_writable(false) {}
@@ -198,10 +198,10 @@ class PIPELINE_STATE : public BASE_NODE {
         return false;
     }
 
-    const layer_data::unordered_set<uint32_t> fragmentShader_writable_output_location_list;
+    const vvl::unordered_set<uint32_t> fragmentShader_writable_output_location_list;
 
     // Capture which slots (set#->bindings) are actually used by the shaders of this pipeline
-    using ActiveSlotMap = layer_data::unordered_map<uint32_t, BindingReqMap>;
+    using ActiveSlotMap = vvl::unordered_map<uint32_t, BindingReqMap>;
     // NOTE: this map is 'almost' const and used in performance critical code paths.
     // The values of existing entries in the DescriptorRequirement::samplers_used_by_image map
     // are updated at various times. Locking requirements are TBD.
@@ -470,18 +470,18 @@ class PIPELINE_STATE : public BASE_NODE {
         return create_info.graphics.pDynamicState;
     }
 
-    layer_data::span<const safe_VkPipelineShaderStageCreateInfo> GetShaderStages() const {
+    vvl::span<const safe_VkPipelineShaderStageCreateInfo> GetShaderStages() const {
         switch (create_info.graphics.sType) {
             case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO:
-                return layer_data::span<const safe_VkPipelineShaderStageCreateInfo>{create_info.graphics.pStages,
+                return vvl::span<const safe_VkPipelineShaderStageCreateInfo>{create_info.graphics.pStages,
                                                                                     create_info.graphics.stageCount};
             case VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO:
-                return layer_data::span<const safe_VkPipelineShaderStageCreateInfo>{&create_info.compute.stage, 1};
+                return vvl::span<const safe_VkPipelineShaderStageCreateInfo>{&create_info.compute.stage, 1};
             case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV:
-                return layer_data::span<const safe_VkPipelineShaderStageCreateInfo>{create_info.raytracing.pStages,
+                return vvl::span<const safe_VkPipelineShaderStageCreateInfo>{create_info.raytracing.pStages,
                                                                                     create_info.raytracing.stageCount};
             case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR:
-                return layer_data::span<const safe_VkPipelineShaderStageCreateInfo>{create_info.raytracing.pStages,
+                return vvl::span<const safe_VkPipelineShaderStageCreateInfo>{create_info.raytracing.pStages,
                                                                                     create_info.raytracing.stageCount};
             default:
                 assert(false);

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -47,7 +47,7 @@ struct VertexInputState {
     using VertexBindingVector = std::vector<VkVertexInputBindingDescription>;
     VertexBindingVector binding_descriptions;
 
-    using VertexBindingIndexMap = layer_data::unordered_map<uint32_t, uint32_t>;
+    using VertexBindingIndexMap = vvl::unordered_map<uint32_t, uint32_t>;
     VertexBindingIndexMap binding_to_index_map;
 
     using VertexAttrVector = std::vector<VkVertexInputAttributeDescription>;

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -101,7 +101,7 @@ class RENDER_PASS_STATE : public BASE_NODE {
     const std::vector<SubpassVec> self_dependencies;
     using DAGNodeVec = std::vector<DAGNode>;
     const DAGNodeVec subpass_to_node;
-    using FirstReadMap = layer_data::unordered_map<uint32_t, bool>;
+    using FirstReadMap = vvl::unordered_map<uint32_t, bool>;
     const FirstReadMap attachment_first_read;
     const SubpassVec attachment_first_subpass;
     const SubpassVec attachment_last_subpass;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -125,7 +125,7 @@ SHADER_MODULE_STATE::EntryPoint::EntryPoint(const SHADER_MODULE_STATE& module_st
         //
         // TODO: The set of interesting opcodes here was determined by eyeballing the SPIRV spec. It might be worth
         // converting parts of this to be generated from the machine-readable spec instead.
-        layer_data::unordered_set<uint32_t> worklist;
+        vvl::unordered_set<uint32_t> worklist;
         worklist.insert(entrypoint_insn.Word(2));
 
         while (!worklist.empty()) {
@@ -1005,7 +1005,7 @@ void SHADER_MODULE_STATE::RunUsedStruct(uint32_t offset, uint32_t access_chain_w
     }
 }
 
-void SHADER_MODULE_STATE::SetUsedStructMember(const uint32_t variable_id, layer_data::unordered_set<uint32_t>& accessible_ids,
+void SHADER_MODULE_STATE::SetUsedStructMember(const uint32_t variable_id, vvl::unordered_set<uint32_t>& accessible_ids,
                                               const StructInfo& data) const {
     for (const auto& id : accessible_ids) {
         const Instruction* insn = FindDef(id);
@@ -1141,7 +1141,7 @@ bool SHADER_MODULE_STATE::IsBuiltInWritten(const Instruction* builtin_insn, cons
     if (!init_complete && (type == spv::OpMemberDecorate)) return false;
 
     bool found_write = false;
-    layer_data::unordered_set<uint32_t> worklist;
+    vvl::unordered_set<uint32_t> worklist;
     worklist.insert(entrypoint.Word(2));
 
     // Follow instructions in call graph looking for writes to target
@@ -1196,8 +1196,8 @@ bool SHADER_MODULE_STATE::IsBuiltInWritten(const Instruction* builtin_insn, cons
 // Returns the id from load_members that matched the object_id, otherwise returns zero
 static uint32_t CheckObjectIDFromOpLoad(
     uint32_t object_id, const std::vector<uint32_t>& operator_members,
-    const layer_data::unordered_map<uint32_t, uint32_t>& load_members,
-    const layer_data::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>>& accesschain_members) {
+    const vvl::unordered_map<uint32_t, uint32_t>& load_members,
+    const vvl::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>>& accesschain_members) {
     for (auto load_id : operator_members) {
         if (object_id == load_id) return load_id;
         auto load_it = load_members.find(load_id);
@@ -1362,7 +1362,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const SHADER_MODULE_STATE& 
         }
 
         case spv::OpTypeStruct: {
-            layer_data::unordered_set<uint32_t> nonwritable_members;
+            vvl::unordered_set<uint32_t> nonwritable_members;
             const bool is_storage_buffer = (storage_class == spv::StorageClassStorageBuffer) ||
                                            (module_state.GetDecorationSet(type->Word(1)).Has(DecorationSet::buffer_block_bit));
             for (const Instruction* insn : static_data_.member_decoration_inst) {
@@ -1398,11 +1398,11 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const SHADER_MODULE_STATE& 
     }
 }
 
-layer_data::unordered_set<uint32_t> SHADER_MODULE_STATE::CollectWritableOutputLocationinFS(const Instruction& entrypoint) const {
-    layer_data::unordered_set<uint32_t> location_list;
+vvl::unordered_set<uint32_t> SHADER_MODULE_STATE::CollectWritableOutputLocationinFS(const Instruction& entrypoint) const {
+    vvl::unordered_set<uint32_t> location_list;
     const auto outputs = CollectInterfaceByLocation(entrypoint, spv::StorageClassOutput, false);
-    layer_data::unordered_set<uint32_t> store_pointer_ids;
-    layer_data::unordered_map<uint32_t, uint32_t> accesschain_members;
+    vvl::unordered_set<uint32_t> store_pointer_ids;
+    vvl::unordered_map<uint32_t, uint32_t> accesschain_members;
 
     for (const Instruction& insn : GetInstructions()) {
         switch (insn.Opcode()) {
@@ -1460,8 +1460,8 @@ bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, User
         return false;
     }
 
-    layer_data::unordered_map<uint32_t, uint32_t> member_components;
-    layer_data::unordered_map<uint32_t, uint32_t> member_patch;
+    vvl::unordered_map<uint32_t, uint32_t> member_components;
+    vvl::unordered_map<uint32_t, uint32_t> member_patch;
 
     // Walk all the OpMemberDecorate for type's result id -- first pass, collect components.
     for (const Instruction* insn : static_data_.member_decoration_inst) {

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4221,7 +4221,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
             if (compatible_modes && compatible_modes->pPresentModes) {
                 surface_state->SetCompatibleModes(
                     physicalDevice, surface_present_mode->presentMode,
-                    layer_data::span<const VkPresentModeKHR>(compatible_modes->pPresentModes, compatible_modes->presentModeCount));
+                    vvl::span<const VkPresentModeKHR>(compatible_modes->pPresentModes, compatible_modes->presentModeCount));
             }
             if (present_scaling_caps) {
                 surface_state->SetPresentModeCapabilities(physicalDevice, surface_present_mode->presentMode,
@@ -4270,7 +4270,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfacePresentModesK
         if (surface) {
             auto surface_state = Get<SURFACE_STATE>(surface);
             surface_state->SetPresentModes(physicalDevice,
-                                           layer_data::span<const VkPresentModeKHR>(pPresentModes, *pPresentModeCount));
+                                           vvl::span<const VkPresentModeKHR>(pPresentModes, *pPresentModeCount));
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
             assert(pd_state);

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -455,20 +455,20 @@ class ValidationStateTracker : public ValidationObject {
     // device address. For purposes of valid usage, if multiple VkBuffer objects can be attributed to
     // a device address, a VkBuffer is selected such that valid usage passes, if it exists.
     using BUFFER_STATE_PTR = std::shared_ptr<BUFFER_STATE>;
-    layer_data::span<BUFFER_STATE_PTR> GetBuffersByAddress(VkDeviceAddress address) {
+    vvl::span<BUFFER_STATE_PTR> GetBuffersByAddress(VkDeviceAddress address) {
         ReadLockGuard guard(buffer_address_lock_);
         auto found_it = buffer_address_map_.find(address);
         if (found_it == buffer_address_map_.end()) {
-            return layer_data::make_span<BUFFER_STATE_PTR>(nullptr, static_cast<size_t>(0));
+            return vvl::make_span<BUFFER_STATE_PTR>(nullptr, static_cast<size_t>(0));
         }
         return found_it->second;
     }
 
-    layer_data::span<const BUFFER_STATE_PTR> GetBuffersByAddress(VkDeviceAddress address) const {
+    vvl::span<const BUFFER_STATE_PTR> GetBuffersByAddress(VkDeviceAddress address) const {
         ReadLockGuard guard(buffer_address_lock_);
         auto found_it = buffer_address_map_.find(address);
         if (found_it == buffer_address_map_.end()) {
-            return layer_data::make_span<const BUFFER_STATE_PTR>(nullptr, static_cast<size_t>(0));
+            return vvl::make_span<const BUFFER_STATE_PTR>(nullptr, static_cast<size_t>(0));
         }
         return found_it->second;
     }
@@ -1526,7 +1526,7 @@ class ValidationStateTracker : public ValidationObject {
 
   protected:
     // tracks which queue family index were used when creating the device for quick lookup
-    layer_data::unordered_set<uint32_t> queue_family_index_set;
+    vvl::unordered_set<uint32_t> queue_family_index_set;
     // The queue count can different for the same queueFamilyIndex if the create flag are different
     struct DeviceQueueInfo {
         uint32_t index;  // from VkDeviceCreateInfo

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -29,7 +29,7 @@ class ValidationStateTracker;
 class IMAGE_STATE;
 class IMAGE_VIEW_STATE;
 
-using SupportedVideoProfiles = layer_data::unordered_set<std::shared_ptr<const class VideoProfileDesc>>;
+using SupportedVideoProfiles = vvl::unordered_set<std::shared_ptr<const class VideoProfileDesc>>;
 
 // The VideoProfileDesc contains the entire video profile description, which includes all
 // parameters specified in VkVideoProfileInfoKHR and its pNext chain. This includes any
@@ -146,7 +146,7 @@ class VideoProfileDesc : public std::enable_shared_from_this<VideoProfileDesc> {
 
       private:
         std::mutex mutex_;
-        layer_data::unordered_set<VideoProfileDesc const *, VideoProfileDesc::hash, VideoProfileDesc::compare> set_;
+        vvl::unordered_set<VideoProfileDesc const *, VideoProfileDesc::hash, VideoProfileDesc::compare> set_;
 
         std::shared_ptr<const VideoProfileDesc> GetOrCreate(const ValidationStateTracker *dev_data,
                                                             VkVideoProfileInfoKHR const *profile);
@@ -196,8 +196,8 @@ class VideoPictureResource {
     VkImageSubresourceRange GetImageSubresourceRange(IMAGE_VIEW_STATE const *image_view_state, uint32_t layer);
 };
 
-using VideoPictureResources = layer_data::unordered_set<VideoPictureResource, VideoPictureResource::hash>;
-using BoundVideoPictureResources = layer_data::unordered_map<VideoPictureResource, int32_t, VideoPictureResource::hash>;
+using VideoPictureResources = vvl::unordered_set<VideoPictureResource, VideoPictureResource::hash>;
+using BoundVideoPictureResources = vvl::unordered_map<VideoPictureResource, int32_t, VideoPictureResource::hash>;
 
 struct VideoPictureID {
     // Used by H.264 to indicate it's a top field picture
@@ -289,7 +289,7 @@ class VideoSessionDeviceState {
     bool initialized_;
     std::vector<bool> is_active_;
     std::vector<VideoPictureResources> all_pictures_;
-    std::vector<layer_data::unordered_map<VideoPictureID, VideoPictureResource, VideoPictureID::hash>> pictures_per_id_;
+    std::vector<vvl::unordered_map<VideoPictureID, VideoPictureResource, VideoPictureID::hash>> pictures_per_id_;
 };
 
 class VIDEO_SESSION_STATE : public BASE_NODE {
@@ -298,7 +298,7 @@ class VIDEO_SESSION_STATE : public BASE_NODE {
         VkMemoryRequirements requirements;
         bool bound;
     };
-    using MemoryBindingMap = layer_data::unordered_map<uint32_t, MemoryBindingInfo>;
+    using MemoryBindingMap = vvl::unordered_map<uint32_t, MemoryBindingInfo>;
 
     const safe_VkVideoSessionCreateInfoKHR create_info;
     std::shared_ptr<const VideoProfileDesc> profile;
@@ -372,16 +372,16 @@ class VIDEO_SESSION_PARAMETERS_STATE : public BASE_NODE {
     using ParameterKey = uint32_t;
 
     struct H264Parameters {
-        layer_data::unordered_map<H264SPSKey, StdVideoH264SequenceParameterSet> sps;
-        layer_data::unordered_map<H264PPSKey, StdVideoH264PictureParameterSet> pps;
+        vvl::unordered_map<H264SPSKey, StdVideoH264SequenceParameterSet> sps;
+        vvl::unordered_map<H264PPSKey, StdVideoH264PictureParameterSet> pps;
         uint32_t spsCapacity;
         uint32_t ppsCapacity;
     };
 
     struct H265Parameters {
-        layer_data::unordered_map<H265VPSKey, StdVideoH265VideoParameterSet> vps;
-        layer_data::unordered_map<H265SPSKey, StdVideoH265SequenceParameterSet> sps;
-        layer_data::unordered_map<H265PPSKey, StdVideoH265PictureParameterSet> pps;
+        vvl::unordered_map<H265VPSKey, StdVideoH265VideoParameterSet> vps;
+        vvl::unordered_map<H265SPSKey, StdVideoH265SequenceParameterSet> sps;
+        vvl::unordered_map<H265PPSKey, StdVideoH265PictureParameterSet> pps;
         uint32_t vpsCapacity;
         uint32_t spsCapacity;
         uint32_t ppsCapacity;
@@ -495,4 +495,4 @@ class VIDEO_SESSION_PARAMETERS_STATE : public BASE_NODE {
 using VideoSessionUpdateList =
     std::vector<std::function<bool(const ValidationStateTracker *dev_data, const VIDEO_SESSION_STATE *vs_state,
                                    VideoSessionDeviceState &dev_state, bool do_validate)>>;
-using VideoSessionUpdateMap = layer_data::unordered_map<VkVideoSessionKHR, VideoSessionUpdateList>;
+using VideoSessionUpdateMap = vvl::unordered_map<VkVideoSessionKHR, VideoSessionUpdateList>;

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -53,8 +53,8 @@ class StatelessValidation : public ValidationObject {
     safe_VkPhysicalDeviceFeatures2 physical_device_features2;
     void *device_createinfo_pnext;
     const VkPhysicalDeviceFeatures &physical_device_features = physical_device_features2.features;
-    layer_data::unordered_map<VkPhysicalDevice, VkPhysicalDeviceProperties *> physical_device_properties_map;
-    layer_data::unordered_map<VkPhysicalDevice, layer_data::unordered_set<std::string>> device_extensions_enumerated{};
+    vvl::unordered_map<VkPhysicalDevice, VkPhysicalDeviceProperties *> physical_device_properties_map;
+    vvl::unordered_map<VkPhysicalDevice, vvl::unordered_set<std::string>> device_extensions_enumerated{};
 
     // Override chassis read/write locks for this validation object
     // This override takes a deferred lock. i.e. it is not acquired.
@@ -79,8 +79,8 @@ class StatelessValidation : public ValidationObject {
     DeviceExtensionProperties phys_dev_ext_props = {};
 
     struct SubpassesUsageStates {
-        layer_data::unordered_set<uint32_t> subpasses_using_color_attachment;
-        layer_data::unordered_set<uint32_t> subpasses_using_depthstencil_attachment;
+        vvl::unordered_set<uint32_t> subpasses_using_color_attachment;
+        vvl::unordered_set<uint32_t> subpasses_using_depthstencil_attachment;
         std::vector<VkSubpassDescriptionFlags> subpasses_flags;
         uint32_t color_attachment_count;
     };
@@ -89,7 +89,7 @@ class StatelessValidation : public ValidationObject {
     // updating a map of the renderpass usage states, and these accesses need thread protection. Use a mutex separate from the
     // parent object's to maintain that functionality.
     mutable std::mutex renderpass_map_mutex;
-    layer_data::unordered_map<VkRenderPass, SubpassesUsageStates> renderpasses_states;
+    vvl::unordered_map<VkRenderPass, SubpassesUsageStates> renderpasses_states;
 
     // Constructor for stateles validation tracking
     StatelessValidation() : device_createinfo_pnext(nullptr) { container_type = LayerObjectTypeParameterValidation; }
@@ -520,8 +520,8 @@ class StatelessValidation : public ValidationObject {
         bool skip_call = false;
 
         if (next != nullptr) {
-            layer_data::unordered_set<const void *> cycle_check;
-            layer_data::unordered_set<VkStructureType, layer_data::hash<int>> unique_stype_check;
+            vvl::unordered_set<const void *> cycle_check;
+            vvl::unordered_set<VkStructureType, vvl::hash<int>> unique_stype_check;
 
             const char *disclaimer =
                 "This error is based on the Valid Usage documentation for version %d of the Vulkan header.  It is possible that "

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -367,7 +367,7 @@ class SignaledSemaphores {
         // TODO add timeline semaphore support.
     };
 
-    using SignalMap = layer_data::unordered_map<VkSemaphore, std::shared_ptr<Signal>>;
+    using SignalMap = vvl::unordered_map<VkSemaphore, std::shared_ptr<Signal>>;
     using iterator = SignalMap::iterator;
     using const_iterator = SignalMap::const_iterator;
     using mapped_type = SignalMap::mapped_type;
@@ -390,7 +390,7 @@ class SignaledSemaphores {
     void Import(VkSemaphore sem, std::shared_ptr<Signal> &&move_from);
     void Reset();
     std::shared_ptr<const Signal> GetPrev(VkSemaphore sem) const;
-    layer_data::unordered_map<VkSemaphore, std::shared_ptr<Signal>> signaled_;
+    vvl::unordered_map<VkSemaphore, std::shared_ptr<Signal>> signaled_;
     const SignaledSemaphores *prev_;  // Allowing this type to act as a writable overlay
 };
 
@@ -1259,7 +1259,7 @@ struct SyncEventState {
 
 class SyncEventsContext {
   public:
-    using Map = layer_data::unordered_map<const EVENT_STATE *, std::shared_ptr<SyncEventState>>;
+    using Map = vvl::unordered_map<const EVENT_STATE *, std::shared_ptr<SyncEventState>>;
     using iterator = Map::iterator;
     using const_iterator = Map::const_iterator;
 
@@ -1347,7 +1347,7 @@ class RenderPassAccessContext {
 class CommandExecutionContext {
   public:
     using AccessLog = std::vector<ResourceUsageRecord>;
-    using CommandBufferSet = layer_data::unordered_set<std::shared_ptr<const CMD_BUFFER_STATE>>;
+    using CommandBufferSet = vvl::unordered_set<std::shared_ptr<const CMD_BUFFER_STATE>>;
     CommandExecutionContext() : sync_state_(nullptr) {}
     CommandExecutionContext(const SyncValidator *sync_validator) : sync_state_(sync_validator) {}
     virtual ~CommandExecutionContext() = default;
@@ -1750,8 +1750,8 @@ class QueueBatchContext : public CommandExecutionContext {
         std::string func_name_;
     };
 
-    using ConstBatchSet = layer_data::unordered_set<std::shared_ptr<const QueueBatchContext>>;
-    using BatchSet = layer_data::unordered_set<std::shared_ptr<QueueBatchContext>>;
+    using ConstBatchSet = vvl::unordered_set<std::shared_ptr<const QueueBatchContext>>;
+    using BatchSet = vvl::unordered_set<std::shared_ptr<QueueBatchContext>>;
     static constexpr bool TruePred(const std::shared_ptr<const QueueBatchContext> &) { return true; }
     struct CmdBufferEntry {
         uint32_t index = 0;
@@ -1913,12 +1913,12 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
     mutable std::atomic<ResourceUsageTag> tag_limit_{1};  // This is reserved in Validation phase, thus mutable and atomic
     ResourceUsageRange ReserveGlobalTagRange(size_t tag_count) const;  // Note that the tag_limit_ is mutable this has side effects
 
-    using QueueSyncStatesMap = layer_data::unordered_map<VkQueue, std::shared_ptr<QueueSyncState>>;
-    layer_data::unordered_map<VkQueue, std::shared_ptr<QueueSyncState>> queue_sync_states_;
+    using QueueSyncStatesMap = vvl::unordered_map<VkQueue, std::shared_ptr<QueueSyncState>>;
+    vvl::unordered_map<VkQueue, std::shared_ptr<QueueSyncState>> queue_sync_states_;
     QueueId queue_id_limit_ = QueueSyncState::kQueueIdBase;
     SignaledSemaphores signaled_semaphores_;
 
-    using SignaledFences = layer_data::unordered_map<VkFence, FenceSyncState>;
+    using SignaledFences = vvl::unordered_map<VkFence, FenceSyncState>;
     using SignaledFence = SignaledFences::value_type;
     SignaledFences waitable_fences_;
 

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -136,7 +136,7 @@ VK_LAYER_EXPORT FILE *getLayerLogOutput(const char *option, const char *layer_na
 }
 
 // Map option strings to flag enum values
-VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(const string &option, layer_data::unordered_map<string, VkFlags> const &enum_data,
+VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(const string &option, vvl::unordered_map<string, VkFlags> const &enum_data,
                                             uint32_t option_default) {
     VkDebugReportFlagsEXT flags = option_default;
     string option_list = layer_config.GetOption(option.c_str());

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ typedef enum VkLayerDbgActionBits {
 } VkLayerDbgActionBits;
 typedef VkFlags VkLayerDbgActionFlags;
 
-const layer_data::unordered_map<std::string, VkFlags> debug_actions_option_definitions = {
+const vvl::unordered_map<std::string, VkFlags> debug_actions_option_definitions = {
     {std::string("VK_DBG_LAYER_ACTION_IGNORE"), VK_DBG_LAYER_ACTION_IGNORE},
     {std::string("VK_DBG_LAYER_ACTION_CALLBACK"), VK_DBG_LAYER_ACTION_CALLBACK},
     {std::string("VK_DBG_LAYER_ACTION_LOG_MSG"), VK_DBG_LAYER_ACTION_LOG_MSG},
@@ -81,14 +81,14 @@ const layer_data::unordered_map<std::string, VkFlags> debug_actions_option_defin
 #endif
     {std::string("VK_DBG_LAYER_ACTION_DEFAULT"), VK_DBG_LAYER_ACTION_DEFAULT}};
 
-const layer_data::unordered_map<std::string, VkFlags> report_flags_option_definitions = {
+const vvl::unordered_map<std::string, VkFlags> report_flags_option_definitions = {
     {std::string("warn"), VK_DEBUG_REPORT_WARNING_BIT_EXT},
     {std::string("info"), VK_DEBUG_REPORT_INFORMATION_BIT_EXT},
     {std::string("perf"), VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT},
     {std::string("error"), VK_DEBUG_REPORT_ERROR_BIT_EXT},
     {std::string("debug"), VK_DEBUG_REPORT_DEBUG_BIT_EXT}};
 
-const layer_data::unordered_map<std::string, VkFlags> log_msg_type_option_definitions = {{std::string("warn"), kWarningBit},
+const vvl::unordered_map<std::string, VkFlags> log_msg_type_option_definitions = {{std::string("warn"), kWarningBit},
                                                                                   {std::string("info"), kInformationBit},
                                                                                   {std::string("perf"), kPerformanceWarningBit},
                                                                                   {std::string("error"), kErrorBit},
@@ -100,7 +100,7 @@ VK_LAYER_EXPORT const SettingsFileInfo *GetLayerSettingsFileInfo();
 
 VK_LAYER_EXPORT FILE *getLayerLogOutput(const char *option, const char *layer_name);
 VK_LAYER_EXPORT VkFlags GetLayerOptionFlags(const std::string &option,
-                                            layer_data::unordered_map<std::string, VkFlags> const &enum_data,
+                                            vvl::unordered_map<std::string, VkFlags> const &enum_data,
                                             uint32_t option_default);
 
 VK_LAYER_EXPORT void setLayerOption(const char *option, const char *val);

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-2017, 2019-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2017, 2019-2022 Valve Corporation
- * Copyright (c) 2015-2017, 2019-2022 LunarG, Inc.
+ * Copyright (c) 2015-2017, 2019-2023 Valve Corporation
+ * Copyright (c) 2015-2017, 2019-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,7 @@
 
  */
 
-#ifndef LAYER_DATA_H
-#define LAYER_DATA_H
+#pragma once
 
 #include <cmath>
 
@@ -44,7 +43,7 @@
 #endif
 
 // namespace aliases to allow map and set implementations to easily be swapped out
-namespace layer_data {
+namespace vvl {
 
 #ifdef USE_ROBIN_HOOD_HASHING
 template <typename T>
@@ -113,7 +112,7 @@ template <typename T>
 using insert_iterator = std::insert_iterator<T>;
 #endif
 
-}  // namespace layer_data
+}  // namespace vvl
 
 // A vector class with "small string optimization" -- meaning that the class contains a fixed working store for N elements.
 // Useful in in situations where the needed size is unknown, but the typical size is known  If size increases beyond the
@@ -678,9 +677,8 @@ class value_type_helper_set {
 };
 
 template <typename Key, typename T, int N = 1>
-class small_unordered_map
-    : public small_container<Key, typename layer_data::unordered_map<Key, T>::value_type, layer_data::unordered_map<Key, T>,
-                             value_type_helper_map<layer_data::unordered_map<Key, T>>, N> {
+class small_unordered_map : public small_container<Key, typename vvl::unordered_map<Key, T>::value_type, vvl::unordered_map<Key, T>,
+                                                   value_type_helper_map<vvl::unordered_map<Key, T>>, N> {
   public:
     T &operator[](const Key &key) {
         for (int i = 0; i < N; ++i) {
@@ -706,7 +704,7 @@ class small_unordered_map
 };
 
 template <typename Key, int N = 1>
-class small_unordered_set : public small_container<Key, Key, layer_data::unordered_set<Key>, value_type_helper_set<Key>, N> {};
+class small_unordered_set : public small_container<Key, Key, vvl::unordered_set<Key>, value_type_helper_set<Key>, N> {};
 
 // For the given data key, look up the layer_data instance from given layer_data_map
 template <typename DATA_T>
@@ -753,7 +751,7 @@ void FreeLayerDataPtr(void *data_key, std::unordered_map<void *, DATA_T *> &laye
     layer_data_map.erase(got);
 }
 
-namespace layer_data {
+namespace vvl {
 
 inline constexpr std::in_place_t in_place{};
 
@@ -927,5 +925,4 @@ T GetQuotientCeil(T numerator, T denominator) {
     return static_cast<T>(std::ceil(static_cast<double>(numerator) / static_cast<double>(denominator)));
 }
 
-}  // namespace layer_data
-#endif  // LAYER_DATA_H
+}  // namespace vvl

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -166,16 +166,16 @@ typedef struct _debug_report_data {
     VkDebugUtilsMessageTypeFlagsEXT active_types{0};
     bool queueLabelHasInsert{false};
     bool cmdBufLabelHasInsert{false};
-    layer_data::unordered_map<uint64_t, std::string> debugObjectNameMap;
-    layer_data::unordered_map<uint64_t, std::string> debugUtilsObjectNameMap;
-    layer_data::unordered_map<VkQueue, std::unique_ptr<LoggingLabelState>> debugUtilsQueueLabels;
-    layer_data::unordered_map<VkCommandBuffer, std::unique_ptr<LoggingLabelState>> debugUtilsCmdBufLabels;
+    vvl::unordered_map<uint64_t, std::string> debugObjectNameMap;
+    vvl::unordered_map<uint64_t, std::string> debugUtilsObjectNameMap;
+    vvl::unordered_map<VkQueue, std::unique_ptr<LoggingLabelState>> debugUtilsQueueLabels;
+    vvl::unordered_map<VkCommandBuffer, std::unique_ptr<LoggingLabelState>> debugUtilsCmdBufLabels;
     std::vector<uint32_t> filter_message_ids{};
     // This mutex is defined as mutable since the normal usage for a debug report object is as 'const'. The mutable keyword allows
     // the layers to continue this pattern, but also allows them to use/change this specific member for synchronization purposes.
     mutable std::mutex debug_output_mutex;
     int32_t duplicate_message_limit = 0;
-    mutable layer_data::unordered_map<uint32_t, int32_t> duplicate_message_count_map{};
+    mutable vvl::unordered_map<uint32_t, int32_t> duplicate_message_count_map{};
     const void *instance_pnext_chain{};
     bool forceDefaultLogCallback{false};
 

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -448,7 +448,7 @@ class LockedSharedPtr : public std::shared_ptr<T> {
 //
 // snapshot: Return an array of elements (key, value pairs) that satisfy an optional
 // predicate. This can be used as a substitute for iterators in exceptional cases.
-template <typename Key, typename T, int BUCKETSLOG2 = 2, typename Hash = layer_data::hash<Key>>
+template <typename Key, typename T, int BUCKETSLOG2 = 2, typename Hash = vvl::hash<Key>>
 class vl_concurrent_unordered_map {
   public:
     template <typename... Args>
@@ -578,7 +578,7 @@ class vl_concurrent_unordered_map {
   private:
     static const int BUCKETS = (1 << BUCKETSLOG2);
 
-    layer_data::unordered_map<Key, T, Hash> maps[BUCKETS];
+    vvl::unordered_map<Key, T, Hash> maps[BUCKETS];
     struct {
         mutable std::shared_mutex lock;
         // Put each lock on its own cache line to avoid false cache line sharing.

--- a/scripts/best_practices_generator.py
+++ b/scripts/best_practices_generator.py
@@ -195,7 +195,7 @@ class BestPracticesOutputGenerator(OutputGenerator):
                 self.otwrite('both', '\n')
 
             # Output data structure containing extension deprecation data
-            ext_deprecation_data = 'const layer_data::unordered_map<std::string, DeprecationData>  deprecated_extensions = {\n'
+            ext_deprecation_data = 'const vvl::unordered_map<std::string, DeprecationData>  deprecated_extensions = {\n'
             for ext in sorted(self.extension_info):
                 ext_data = self.extension_info[ext]
                 reason = ext_data[0]
@@ -206,7 +206,7 @@ class BestPracticesOutputGenerator(OutputGenerator):
             self.otwrite('hdr', ext_deprecation_data)
 
             # Output data structure containing extension special use data
-            ext_specialuse_data = 'const layer_data::unordered_map<std::string, std::string> special_use_extensions = {\n'
+            ext_specialuse_data = 'const vvl::unordered_map<std::string, std::string> special_use_extensions = {\n'
             for ext in sorted(self.extension_info):
                 spec_use_data = self.extension_info[ext]
                 special_uses = spec_use_data[2]

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -232,7 +232,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
     def OutputExtEnabledFunction(self):
         ext_fcn = ''
         # First, write out our static data structure -- map of all APIs that are part of extensions to their extension.
-        ext_fcn += 'const layer_data::unordered_map<std::string, std::string> api_extension_map {\n'
+        ext_fcn += 'const vvl::unordered_map<std::string, std::string> api_extension_map {\n'
         api_ext = dict()
         handles = GetHandleTypes(self.registry.tree)
         features = self.registry.tree.findall('feature') + self.registry.tree.findall('extensions/extension')

--- a/scripts/format_utils_generator.py
+++ b/scripts/format_utils_generator.py
@@ -321,7 +321,7 @@ struct hash<VkFormat> {
 }
 
 // clang-format off
-static const layer_data::unordered_map<VkFormat, FORMAT_INFO> kVkFormatTable = {
+static const vvl::unordered_map<VkFormat, FORMAT_INFO> kVkFormatTable = {
 '''
             for f, info in sorted(self.allFormats.items()):
                 output += '    {{{},\n'.format(f)
@@ -357,7 +357,7 @@ struct MULTIPLANE_COMPATIBILITY {
 
 // Source: Vulkan spec Table 47. Plane Format Compatibility Table
 // clang-format off
-static const layer_data::unordered_map<VkFormat, MULTIPLANE_COMPATIBILITY> kVkMultiplaneCompatibilityMap {
+static const vvl::unordered_map<VkFormat, MULTIPLANE_COMPATIBILITY> kVkMultiplaneCompatibilityMap {
 '''
 
             for f in sorted(self.planarFormats.keys()):

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -776,7 +776,7 @@ class HelperFileOutputGenerator(OutputGenerator):
                 '       %s requirements;' % req_vec_type,
                 '    };',
                 '',
-                '    typedef layer_data::unordered_map<std::string,%s> %s;' % (info_type, info_map_type),
+                '    typedef vvl::unordered_map<std::string,%s> %s;' % (info_type, info_map_type),
                 '    static const %s &get_info_map() {' %info_map_type,
                 '        static const %s info_map = {' % info_map_type ])
             struct.extend([

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -1204,7 +1204,7 @@ void DispatchGetPrivateData(
     layer_data->device_dispatch_table.GetPrivateData(device, objectType, objectHandle, privateDataSlot, pData);
 }
 
-layer_data::unordered_map<VkCommandBuffer, VkCommandPool> secondary_cb_map{};
+vvl::unordered_map<VkCommandBuffer, VkCommandPool> secondary_cb_map{};
 
 std::shared_mutex dispatch_secondary_cb_map_mutex;
 

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -252,7 +252,7 @@ struct HashedUint64 {
     size_t operator()(const uint64_t &t) const { return t >> HASHED_UINT64_SHIFT; }
 
     static uint64_t hash(uint64_t id) {
-        uint64_t h = (uint64_t)layer_data::hash<uint64_t>()(id);
+        uint64_t h = (uint64_t)vvl::hash<uint64_t>()(id);
         id |= h << HASHED_UINT64_SHIFT;
         return id;
     }
@@ -486,18 +486,18 @@ class ValidationObject {
         // Reverse map display handles
         vl_concurrent_unordered_map<VkDisplayKHR, uint64_t, 0> display_id_reverse_mapping;
         // Wrapping Descriptor Template Update structures requires access to the template createinfo structs
-        layer_data::unordered_map<uint64_t, std::unique_ptr<TEMPLATE_STATE>> desc_template_createinfo_map;
+        vvl::unordered_map<uint64_t, std::unique_ptr<TEMPLATE_STATE>> desc_template_createinfo_map;
         struct SubpassesUsageStates {
-            layer_data::unordered_set<uint32_t> subpasses_using_color_attachment;
-            layer_data::unordered_set<uint32_t> subpasses_using_depthstencil_attachment;
+            vvl::unordered_set<uint32_t> subpasses_using_color_attachment;
+            vvl::unordered_set<uint32_t> subpasses_using_depthstencil_attachment;
         };
         // Uses unwrapped handles
-        layer_data::unordered_map<VkRenderPass, SubpassesUsageStates> renderpasses_states;
+        vvl::unordered_map<VkRenderPass, SubpassesUsageStates> renderpasses_states;
         // Map of wrapped swapchain handles to arrays of wrapped swapchain image IDs
         // Each swapchain has an immutable list of wrapped swapchain image IDs -- always return these IDs if they exist
-        layer_data::unordered_map<VkSwapchainKHR, std::vector<VkImage>> swapchain_wrapped_image_handle_map;
+        vvl::unordered_map<VkSwapchainKHR, std::vector<VkImage>> swapchain_wrapped_image_handle_map;
         // Map of wrapped descriptor pools to set of wrapped descriptor sets allocated from each pool
-        layer_data::unordered_map<VkDescriptorPool, layer_data::unordered_set<VkDescriptorSet>> pool_descriptor_sets_map;
+        vvl::unordered_map<VkDescriptorPool, vvl::unordered_set<VkDescriptorSet>> pool_descriptor_sets_map;
 
 
         // Unwrap a handle.
@@ -634,7 +634,7 @@ typedef struct {
     void* funcptr;
 } function_data;
 
-extern const layer_data::unordered_map<std::string, function_data> name_to_funcptr_map;
+extern const vvl::unordered_map<std::string, function_data> name_to_funcptr_map;
 
 // Manually written functions
 
@@ -1754,7 +1754,7 @@ VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVe
             write('#ifdef _MSC_VER', file=self.outFile)
             write('#pragma warning( suppress: 6262 ) // VS analysis: this uses more than 16 kiB, which is fine here at global scope', file=self.outFile)
             write('#endif', file=self.outFile)
-            write('const layer_data::unordered_map<std::string, function_data> name_to_funcptr_map = {', file=self.outFile)
+            write('const vvl::unordered_map<std::string, function_data> name_to_funcptr_map = {', file=self.outFile)
             write('\n'.join(self.intercepts), file=self.outFile)
             write('};\n', file=self.outFile)
             self.newline()

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -970,7 +970,7 @@ std::vector<{groupName}> ValidationObject::ValidParamValues() const {{
     //      a span of the container. This does not work for applications which create and destroy many instances and
     //      devices over the lifespan of the project (e.g., VLT).
     constexpr std::array Core{groupName}Enums = {{ {enum_entry_map["core"]} }};
-    static const layer_data::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<{groupName}>> Extended{groupName}Enums = {{\n'''
+    static const vvl::unordered_map<const ExtEnabled DeviceExtensions::*, std::vector<{groupName}>> Extended{groupName}Enums = {{\n'''
                         for k,v in enum_entry_map.items():
                             if k != 'core':
                                 enum_entry += f'        {{ &DeviceExtensions::{k.lower()}, {{ {v} }} }},\n'

--- a/scripts/spirv_grammar_generator.py
+++ b/scripts/spirv_grammar_generator.py
@@ -306,7 +306,7 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
             output += '// of a given SPIR-V opcode instruction\n'
             output += '//\n'
             output += '// clang-format off\n'
-            output += 'static const layer_data::unordered_map<uint32_t, InstructionInfo> kInstructionTable {\n'
+            output += 'static const vvl::unordered_map<uint32_t, InstructionInfo> kInstructionTable {\n'
             for opcode, info in sorted(self.opcodes.items()):
                 output += f'    {{spv::{info["name"]}, {{"{info["name"]}", {info["hasType"]}, {info["hasResult"]}, {info["memoryScopePosition"]}, {info["executionScopePosition"]}, {info["imageOperandsPosition"]}}}}},\n'
             output += '};\n'

--- a/scripts/sync_val_gen.py
+++ b/scripts/sync_val_gen.py
@@ -692,7 +692,7 @@ def StageAccessEnums(stage_accesses, config):
 
     map_name = var_prefix + 'StageAccessIndexByStageAccessBit'
     output.append('// Map of the StageAccessIndices from the StageAccess Bit')
-    typename = 'layer_data::unordered_map<{}, {}>'.format(sync_mask_name, ordinal_name)
+    typename = 'vvl::unordered_map<{}, {}>'.format(sync_mask_name, ordinal_name)
     if config['is_source']:
         output.append('const {}& {}() {{'.format(typename, map_name))
         output.append('{}static const {} variable = {{'.format(indent, typename))

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -420,8 +420,8 @@ public:
     WriteLockGuard WriteLock() override;
 
     vl_concurrent_unordered_map<VkCommandBuffer, VkCommandPool, 6> command_pool_map;
-    layer_data::unordered_map<VkCommandPool, layer_data::unordered_set<VkCommandBuffer>> pool_command_buffers_map;
-    layer_data::unordered_map<VkDevice, layer_data::unordered_set<VkQueue>> device_queues_map;
+    vvl::unordered_map<VkCommandPool, vvl::unordered_set<VkCommandBuffer>> pool_command_buffers_map;
+    vvl::unordered_map<VkDevice, vvl::unordered_set<VkQueue>> device_queues_map;
 
     // Track per-descriptorsetlayout and per-descriptorset whether read_only is used.
     // This is used to (sloppily) implement the relaxed externsync rules for read_only

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -2150,7 +2150,7 @@ TEST_F(VkPositiveLayerTest, SubmitFenceButWaitIdle) {
     auto pool_create_info = LvlInitStruct<VkCommandPoolCreateInfo>();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
     pool_create_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-    std::optional<vk_testing::CommandPool> command_pool(layer_data::in_place, *m_device, pool_create_info);
+    std::optional<vk_testing::CommandPool> command_pool(vvl::in_place, *m_device, pool_create_info);
 
     // create a raw command buffer because we'll just the destroy the pool.
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -10598,19 +10598,19 @@ TEST_F(VkLayerTest, MeshShaderEXTDrawCmds) {
     uint32_t max_group_count_Y = mesh_shader_properties.maxTaskWorkGroupCount[1];
     uint32_t max_group_count_Z = mesh_shader_properties.maxTaskWorkGroupCount[2];
 
-    if (max_group_count_X < layer_data::MaxTypeValue(max_group_count_X)) {
+    if (max_group_count_X < vvl::MaxTypeValue(max_group_count_X)) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawMeshTasksEXT-TaskEXT-07322");
-        max_group_count_X = layer_data::MaxTypeValue(max_group_count_X);
+        max_group_count_X = vvl::MaxTypeValue(max_group_count_X);
     }
 
-    if (max_group_count_Y < layer_data::MaxTypeValue(max_group_count_Y)) {
+    if (max_group_count_Y < vvl::MaxTypeValue(max_group_count_Y)) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawMeshTasksEXT-TaskEXT-07323");
-        max_group_count_Y = layer_data::MaxTypeValue(max_group_count_Y);
+        max_group_count_Y = vvl::MaxTypeValue(max_group_count_Y);
     }
 
-    if (max_group_count_Z < layer_data::MaxTypeValue(max_group_count_Z)) {
+    if (max_group_count_Z < vvl::MaxTypeValue(max_group_count_Z)) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawMeshTasksEXT-TaskEXT-07324");
-        max_group_count_Z = layer_data::MaxTypeValue(max_group_count_Z);
+        max_group_count_Z = vvl::MaxTypeValue(max_group_count_Z);
     }
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawMeshTasksEXT-TaskEXT-07325");
@@ -10621,7 +10621,7 @@ TEST_F(VkLayerTest, MeshShaderEXTDrawCmds) {
     vkCmdDrawMeshTasksIndirectEXT(m_commandBuffer->handle(), buffer.handle(), 0, 2, sizeof(VkDrawMeshTasksIndirectCommandEXT));
     m_errorMonitor->VerifyFound();
 
-    if (m_device->props.limits.maxDrawIndirectCount < layer_data::MaxTypeValue(m_device->props.limits.maxDrawIndirectCount)) {
+    if (m_device->props.limits.maxDrawIndirectCount < vvl::MaxTypeValue(m_device->props.limits.maxDrawIndirectCount)) {
         m_errorMonitor->SetUnexpectedError("VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-02718");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-02719");
         vkCmdDrawMeshTasksIndirectEXT(m_commandBuffer->handle(), buffer.handle(), 0,

--- a/tests/vklayertests_debug_printf.cpp
+++ b/tests/vklayertests_debug_printf.cpp
@@ -543,7 +543,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPL) {
     ASSERT_VK_SUCCESS(vi.CreateGraphicsPipeline(true, false));
 
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, shader_source);
-    vk_testing::GraphicsPipelineLibraryStage pre_raster_stage(layer_data::span<const uint32_t>{vs_spv});
+    vk_testing::GraphicsPipelineLibraryStage pre_raster_stage(vvl::span<const uint32_t>{vs_spv});
 
     CreatePipelineHelper pre_raster(*this);
     pre_raster.InitPreRasterLibInfo(1, &pre_raster_stage.stage_ci);
@@ -809,7 +809,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragment) {
     fragment_set.UpdateDescriptorSets();
 
     {
-        layer_data::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.memory().map()),
+        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.memory().map()),
                                              static_cast<uint32_t>(buffer_create_info.size) / sizeof(uint32_t));
         for (auto &v : vert_data) {
             v = 0x01030507;
@@ -817,7 +817,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragment) {
         vs_buffer.memory().unmap();
     }
     {
-        layer_data::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.memory().map()),
+        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.memory().map()),
                                              static_cast<uint32_t>(buffer_create_info.size) / sizeof(uint32_t));
         for (auto &v : frag_data) {
             v = 0x02040608;
@@ -968,7 +968,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragmentIndependentSets) {
     fragment_set.UpdateDescriptorSets();
 
     {
-        layer_data::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.memory().map()),
+        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.memory().map()),
                                              static_cast<uint32_t>(buffer_create_info.size) / sizeof(uint32_t));
         for (auto &v : vert_data) {
             v = 0x01030507;
@@ -976,7 +976,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragmentIndependentSets) {
         vs_buffer.memory().unmap();
     }
     {
-        layer_data::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.memory().map()),
+        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.memory().map()),
                                              static_cast<uint32_t>(buffer_create_info.size) / sizeof(uint32_t));
         for (auto &v : frag_data) {
             v = 0x02040608;

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -1882,12 +1882,12 @@ TEST_F(VkLayerTest, RenderPassBeginInvalidRenderArea) {
                         vuid);
 
     m_renderPassBeginInfo.renderArea.offset.x = 1;
-    m_renderPassBeginInfo.renderArea.extent.width = layer_data::MaxTypeValue(m_renderPassBeginInfo.renderArea.extent.width) - 1;
+    m_renderPassBeginInfo.renderArea.extent.width = vvl::MaxTypeValue(m_renderPassBeginInfo.renderArea.extent.width) - 1;
     TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &m_renderPassBeginInfo, rp2Supported, vuid,
                         vuid);
 
-    m_renderPassBeginInfo.renderArea.offset.x = layer_data::MaxTypeValue(m_renderPassBeginInfo.renderArea.offset.x);
-    m_renderPassBeginInfo.renderArea.extent.width = layer_data::MaxTypeValue(m_renderPassBeginInfo.renderArea.extent.width);
+    m_renderPassBeginInfo.renderArea.offset.x = vvl::MaxTypeValue(m_renderPassBeginInfo.renderArea.offset.x);
+    m_renderPassBeginInfo.renderArea.extent.width = vvl::MaxTypeValue(m_renderPassBeginInfo.renderArea.extent.width);
     TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &m_renderPassBeginInfo, rp2Supported, vuid,
                         vuid);
 
@@ -1895,7 +1895,7 @@ TEST_F(VkLayerTest, RenderPassBeginInvalidRenderArea) {
     m_renderPassBeginInfo.renderArea.offset.x = 0;
     m_renderPassBeginInfo.renderArea.extent.width = 256;
     m_renderPassBeginInfo.renderArea.offset.y = 1;
-    m_renderPassBeginInfo.renderArea.extent.height = layer_data::MaxTypeValue(m_renderPassBeginInfo.renderArea.extent.height) - 1;
+    m_renderPassBeginInfo.renderArea.extent.height = vvl::MaxTypeValue(m_renderPassBeginInfo.renderArea.extent.height) - 1;
     TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &m_renderPassBeginInfo, rp2Supported, vuid,
                         vuid);
 }

--- a/tests/vklayertests_dynamic_rendering.cpp
+++ b/tests/vklayertests_dynamic_rendering.cpp
@@ -2344,13 +2344,13 @@ TEST_F(VkLayerTest, DynamicRenderingTestFragmentDensityMapRenderArea) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = 1;
-    begin_rendering_info.renderArea.extent.width = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06112");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.x = layer_data::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
-    begin_rendering_info.renderArea.extent.width = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
+    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06112");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -2364,13 +2364,13 @@ TEST_F(VkLayerTest, DynamicRenderingTestFragmentDensityMapRenderArea) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 1;
-    begin_rendering_info.renderArea.extent.height = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06114");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.y = layer_data::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
-    begin_rendering_info.renderArea.extent.height = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
+    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06114");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -2742,14 +2742,14 @@ TEST_F(VkLayerTest, DynamicRenderingAreaGreaterThanAttachmentExtent) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = 1;
-    begin_rendering_info.renderArea.extent.width = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-imageView-06075");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-renderArea-06073");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.x = layer_data::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
-    begin_rendering_info.renderArea.extent.width = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
+    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-imageView-06075");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-renderArea-06073");
     m_commandBuffer->BeginRendering(begin_rendering_info);
@@ -2764,14 +2764,14 @@ TEST_F(VkLayerTest, DynamicRenderingAreaGreaterThanAttachmentExtent) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 1;
-    begin_rendering_info.renderArea.extent.height = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-imageView-06076");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-renderArea-06074");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.y = layer_data::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
-    begin_rendering_info.renderArea.extent.height = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
+    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-imageView-06076");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-renderArea-06074");
     m_commandBuffer->BeginRendering(begin_rendering_info);
@@ -2845,13 +2845,13 @@ TEST_F(VkLayerTest, DynamicRenderingDeviceGroupAreaGreaterThanAttachmentExtent) 
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = 1;
-    begin_rendering_info.renderArea.extent.width = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06079");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.x = layer_data::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
-    begin_rendering_info.renderArea.extent.width = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
+    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06079");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -2865,13 +2865,13 @@ TEST_F(VkLayerTest, DynamicRenderingDeviceGroupAreaGreaterThanAttachmentExtent) 
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 1;
-    begin_rendering_info.renderArea.extent.height = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06080");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.y = layer_data::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
-    begin_rendering_info.renderArea.extent.height = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
+    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06080");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -3834,13 +3834,13 @@ TEST_F(VkLayerTest, DynamicRenderingRenderArea) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = 1;
-    begin_rendering_info.renderArea.extent.width = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-renderArea-06073");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.x = layer_data::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
-    begin_rendering_info.renderArea.extent.width = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
+    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-renderArea-06073");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -3853,13 +3853,13 @@ TEST_F(VkLayerTest, DynamicRenderingRenderArea) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 1;
-    begin_rendering_info.renderArea.extent.height = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-renderArea-06074");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.y = layer_data::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
-    begin_rendering_info.renderArea.extent.height = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
+    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-renderArea-06074");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -5368,13 +5368,13 @@ TEST_F(VkLayerTest, DynamicRenderingFragmentShadingRateAttachmentSizeWithDeviceG
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = 1;
-    begin_rendering_info.renderArea.extent.width = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06119");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.x = layer_data::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
-    begin_rendering_info.renderArea.extent.width = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
+    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06119");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -5399,13 +5399,13 @@ TEST_F(VkLayerTest, DynamicRenderingFragmentShadingRateAttachmentSizeWithDeviceG
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 1;
-    begin_rendering_info.renderArea.extent.height = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06120");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.y = layer_data::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
-    begin_rendering_info.renderArea.extent.height = layer_data::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
+    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06120");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -16561,44 +16561,44 @@ TEST_F(VkLayerTest, MeshShaderEXTRuntimeSpirv) {
     uint32_t max_mesh_output_vertices = mesh_shader_properties.maxMeshOutputVertices;
     uint32_t max_mesh_output_primitives = mesh_shader_properties.maxMeshOutputPrimitives;
 
-    if (max_task_workgroup_size_x < layer_data::MaxTypeValue(max_task_workgroup_size_x)) {
+    if (max_task_workgroup_size_x < vvl::MaxTypeValue(max_task_workgroup_size_x)) {
         error_vuids.push_back("VUID-RuntimeSpirv-TaskEXT-07291");
         max_task_workgroup_size_x += 1;
     }
 
-    if (max_task_workgroup_size_y < layer_data::MaxTypeValue(max_task_workgroup_size_y)) {
+    if (max_task_workgroup_size_y < vvl::MaxTypeValue(max_task_workgroup_size_y)) {
         error_vuids.push_back("VUID-RuntimeSpirv-TaskEXT-07292");
         max_task_workgroup_size_y += 1;
     }
 
-    if (max_task_workgroup_size_z < layer_data::MaxTypeValue(max_task_workgroup_size_z)) {
+    if (max_task_workgroup_size_z < vvl::MaxTypeValue(max_task_workgroup_size_z)) {
         error_vuids.push_back("VUID-RuntimeSpirv-TaskEXT-07293");
         max_task_workgroup_size_z += 1;
     }
     error_vuids.push_back("VUID-RuntimeSpirv-TaskEXT-07294");
 
-    if (max_mesh_workgroup_size_x < layer_data::MaxTypeValue(max_mesh_workgroup_size_x)) {
+    if (max_mesh_workgroup_size_x < vvl::MaxTypeValue(max_mesh_workgroup_size_x)) {
         error_vuids.push_back("VUID-RuntimeSpirv-MeshEXT-07295");
         max_mesh_workgroup_size_x += 1;
     }
 
-    if (max_mesh_workgroup_size_y < layer_data::MaxTypeValue(max_mesh_workgroup_size_y)) {
+    if (max_mesh_workgroup_size_y < vvl::MaxTypeValue(max_mesh_workgroup_size_y)) {
         error_vuids.push_back("VUID-RuntimeSpirv-MeshEXT-07296");
         max_mesh_workgroup_size_y += 1;
     }
 
-    if (max_mesh_workgroup_size_z < layer_data::MaxTypeValue(max_mesh_workgroup_size_z)) {
+    if (max_mesh_workgroup_size_z < vvl::MaxTypeValue(max_mesh_workgroup_size_z)) {
         error_vuids.push_back("VUID-RuntimeSpirv-MeshEXT-07297");
         max_mesh_workgroup_size_z += 1;
     }
     error_vuids.push_back("VUID-RuntimeSpirv-MeshEXT-07298");
 
-    if (max_mesh_output_vertices < layer_data::MaxTypeValue(max_mesh_output_vertices)) {
+    if (max_mesh_output_vertices < vvl::MaxTypeValue(max_mesh_output_vertices)) {
         error_vuids_1.push_back("VUID-RuntimeSpirv-MeshEXT-07115");
         max_mesh_output_vertices += 1;
     }
 
-    if (max_mesh_output_primitives < layer_data::MaxTypeValue(max_mesh_output_primitives)) {
+    if (max_mesh_output_primitives < vvl::MaxTypeValue(max_mesh_output_primitives)) {
         error_vuids_1.push_back("VUID-RuntimeSpirv-MeshEXT-07116");
         max_mesh_output_primitives += 1;
     }

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -1239,11 +1239,11 @@ inline VkCommandBufferAllocateInfo CommandBuffer::create_info(VkCommandPool cons
 }
 
 struct GraphicsPipelineLibraryStage {
-    layer_data::span<const uint32_t> spv;
+    vvl::span<const uint32_t> spv;
     VkShaderModuleCreateInfo shader_ci;
     VkPipelineShaderStageCreateInfo stage_ci;
 
-    GraphicsPipelineLibraryStage(layer_data::span<const uint32_t> spv, VkShaderStageFlagBits stage = VK_SHADER_STAGE_VERTEX_BIT,
+    GraphicsPipelineLibraryStage(vvl::span<const uint32_t> spv, VkShaderStageFlagBits stage = VK_SHADER_STAGE_VERTEX_BIT,
                                  const char *name = "main")
         : spv(spv) {
         shader_ci = LvlInitStruct<VkShaderModuleCreateInfo>();
@@ -1258,11 +1258,11 @@ struct GraphicsPipelineLibraryStage {
 };
 
 struct GraphicsPipelineFromLibraries {
-    layer_data::span<VkPipeline> libs;
+    vvl::span<VkPipeline> libs;
     VkPipelineLibraryCreateInfoKHR link_info;
     vk_testing::Pipeline pipe;
 
-    GraphicsPipelineFromLibraries(const Device &dev, layer_data::span<VkPipeline> libs, VkGraphicsPipelineCreateInfo *ci = nullptr)
+    GraphicsPipelineFromLibraries(const Device &dev, vvl::span<VkPipeline> libs, VkGraphicsPipelineCreateInfo *ci = nullptr)
         : libs(libs) {
         link_info = LvlInitStruct<VkPipelineLibraryCreateInfoKHR>();
         link_info.libraryCount = static_cast<uint32_t>(libs.size());


### PR DESCRIPTION
Been thinking about doing this for a while since `layer_data::` is very annoying to type.

This also helps make address https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3797 more palatable for developers to use.

`layer_data::MaxTypeValue` vs `vvl::MaxTypeValue`
`layer_data::span` vs `vvl::span`