### PR TITLE
layers: Remove macro constants for numeric limits

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -1709,7 +1709,7 @@ bool BestPractices::ValidateAccessLayoutCombination(const std::string& api_name,
                                                     VkImageAspectFlags aspect) const {
     bool skip = false;
 
-    const VkAccessFlags2 all = UINT64_MAX;  // core validation is responsible for detecting undefined flags.
+    const VkAccessFlags2 all = vvl::kU64Max;  // core validation is responsible for detecting undefined flags.
     VkAccessFlags2 allowed = 0;
 
     // Combinations taken from https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2918

--- a/layers/core_checks/device_memory_validation.cpp
+++ b/layers/core_checks/device_memory_validation.cpp
@@ -1035,7 +1035,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                     // since its a non-disjoint image, finding VkImage in map is a duplicate
                     auto it = resources_bound.find(image_state->image());
                     if (it == resources_bound.end()) {
-                        std::array<uint32_t, 3> bound_index = {i, UINT32_MAX, UINT32_MAX};
+                        std::array<uint32_t, 3> bound_index = {i, vvl::kU32Max, vvl::kU32Max};
                         resources_bound.emplace(image_state->image(), bound_index);
                     } else {
                         skip |= LogError(
@@ -1101,11 +1101,11 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
 
                 auto it = resources_bound.find(image_state->image());
                 if (it == resources_bound.end()) {
-                    std::array<uint32_t, 3> bound_index = {UINT32_MAX, UINT32_MAX, UINT32_MAX};
+                    std::array<uint32_t, 3> bound_index = {vvl::kU32Max, vvl::kU32Max, vvl::kU32Max};
                     bound_index[plane] = i;
                     resources_bound.emplace(image_state->image(), bound_index);
                 } else {
-                    if (it->second[plane] == UINT32_MAX) {
+                    if (it->second[plane] == vvl::kU32Max) {
                         it->second[plane] = i;
                     } else {
                         skip |= LogError(bind_info.image, "VUID-vkBindImageMemory2-pBindInfos-04006",
@@ -1382,7 +1382,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
         if (image_state->disjoint == true) {
             uint32_t total_planes = FormatPlaneCount(image_state->createInfo.format);
             for (uint32_t i = 0; i < total_planes; i++) {
-                if (resource.second[i] == UINT32_MAX) {
+                if (resource.second[i] == vvl::kU32Max) {
                     skip |= LogError(resource.first, "VUID-vkBindImageMemory2-pBindInfos-02858",
                                      "%s: Plane %u of the disjoint image was not bound. All %d planes need to bound individually "
                                      "in separate pBindInfos in a single call.",

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -3589,12 +3589,12 @@ bool CoreChecks::ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE &module
     uint64_t invocations = local_size_x * local_size_y;
     // Prevent overflow.
     bool fail = false;
-    if (invocations > UINT32_MAX || invocations > limit) {
+    if (invocations > vvl::kU32Max || invocations > limit) {
         fail = true;
     }
     if (!fail) {
         invocations *= local_size_z;
-        if (invocations > UINT32_MAX || invocations > limit) {
+        if (invocations > vvl::kU32Max || invocations > limit) {
             fail = true;
         }
     }
@@ -3768,12 +3768,12 @@ bool CoreChecks::ValidateTaskMeshWorkGroupSizes(const SHADER_MODULE_STATE &modul
     uint64_t invocations = local_size_x * local_size_y;
     // Prevent overflow.
     bool fail = false;
-    if (invocations > UINT32_MAX || invocations > max_workgroup_size) {
+    if (invocations > vvl::kU32Max || invocations > max_workgroup_size) {
         fail = true;
     }
     if (!fail) {
         invocations *= local_size_z;
-        if (invocations > UINT32_MAX || invocations > max_workgroup_size) {
+        if (invocations > vvl::kU32Max || invocations > max_workgroup_size) {
             fail = true;
         }
     }

--- a/layers/core_checks/wsi_validation.cpp
+++ b/layers/core_checks/wsi_validation.cpp
@@ -1143,7 +1143,7 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, const AcquireVersion 
             }
         }
         const bool too_many_already_acquired = acquired_images > swapchain_image_count - min_image_count;
-        if (timeout == UINT64_MAX && too_many_already_acquired) {
+        if (timeout == vvl::kU64Max && too_many_already_acquired) {
             const char *vuid = version == ACQUIRE_VERSION_2 ? "VUID-vkAcquireNextImage2KHR-surface-07784"
                                                             : "VUID-vkAcquireNextImageKHR-surface-07783";
             const uint32_t acquirable = swapchain_image_count - min_image_count + 1;

--- a/layers/core_error_location.h
+++ b/layers/core_error_location.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2021-2022 The Khronos Group Inc.
- * Copyright (c) 2021-2022 Valve Corporation
- * Copyright (c) 2021-2022 LunarG, Inc.
+ * Copyright (c) 2021-2023 Valve Corporation
+ * Copyright (c) 2021-2023 LunarG, Inc.
  * Copyright (C) 2021-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -130,7 +130,7 @@ enum class Field {
 const std::string& String(Field field);
 
 struct Location {
-    static const uint32_t kNoIndex = std::numeric_limits<uint32_t>::max();
+    static const uint32_t kNoIndex = vvl::kU32Max;
 
     // name of the vulkan function we're checking
     Func function;

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -2214,7 +2214,7 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
                 bda_data[address_index++] = range.begin;
                 bda_data[size_index++] = range.end - range.begin;
             }
-            bda_data[address_index] = UINTPTR_MAX;
+            bda_data[address_index] = std::numeric_limits<uintptr_t>::max();
             bda_data[size_index] = 0;
             vmaUnmapMemory(vmaAllocator, bda_input_block.allocation);
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -996,8 +996,8 @@ void CMD_BUFFER_STATE::ExecuteCommands(vvl::span<const VkCommandBuffer> secondar
 
         // State is trashed after executing secondary command buffers.
         // Importantly, this function runs after CoreChecks::PreCallValidateCmdExecuteCommands.
-        trashedViewportMask = vvl::MaxTypeValue<uint32_t>();
-        trashedScissorMask = vvl::MaxTypeValue<uint32_t>();
+        trashedViewportMask = vvl::MaxTypeValue(trashedViewportMask);
+        trashedScissorMask = vvl::MaxTypeValue(trashedScissorMask);
         trashedViewportCount = true;
         trashedScissorCount = true;
 

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -108,7 +108,7 @@ uint64_t QUEUE_STATE::Submit(CB_SUBMISSION &&submission) {
 
 std::shared_future<void> QUEUE_STATE::Wait(uint64_t until_seq) {
     auto guard = Lock();
-    if (until_seq == UINT64_MAX) {
+    if (until_seq == vvl::kU64Max) {
         until_seq = seq_;
     }
     if (submissions_.empty() || until_seq < submissions_.begin()->seq) {
@@ -138,7 +138,7 @@ void QUEUE_STATE::NotifyAndWait(uint64_t until_seq) {
 
 uint64_t QUEUE_STATE::Notify(uint64_t until_seq) {
     auto guard = Lock();
-    if (until_seq == UINT64_MAX) {
+    if (until_seq == vvl::kU64Max) {
         until_seq = seq_;
     }
     if (request_seq_ < until_seq) {

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -317,12 +317,12 @@ class QUEUE_STATE : public BASE_NODE {
     uint64_t Submit(CB_SUBMISSION &&submission);
 
     // Tell the queue thread that submissions up to the submission with sequence number until_seq have finished
-    uint64_t Notify(uint64_t until_seq = UINT64_MAX);
+    uint64_t Notify(uint64_t until_seq = vvl::kU64Max);
 
     // Tell the queue and then wait for it to finish updating its state.
     // UINT64_MAX means to finish all submissions.
-    void NotifyAndWait(uint64_t until_seq = UINT64_MAX);
-    std::shared_future<void> Wait(uint64_t until_seq = UINT64_MAX);
+    void NotifyAndWait(uint64_t until_seq = vvl::kU64Max);
+    std::shared_future<void> Wait(uint64_t until_seq = vvl::kU64Max);
 
     const uint32_t queueFamilyIndex;
     const VkDeviceQueueCreateFlags flags;

--- a/layers/stateless/parameter_validation_utils.cpp
+++ b/layers/stateless/parameter_validation_utils.cpp
@@ -5194,7 +5194,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetScissor(VkCommandBuffer co
             }
 
             const int64_t x_sum = static_cast<int64_t>(scissor.offset.x) + static_cast<int64_t>(scissor.extent.width);
-            if (x_sum > INT32_MAX) {
+            if (x_sum > vvl::kI32Max) {
                 skip |= LogError(commandBuffer, "VUID-vkCmdSetScissor-offset-00596",
                                  "vkCmdSetScissor: offset.x + extent.width (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
                                  ") of pScissors[%" PRIu32 "] will overflow int32_t.",
@@ -5202,7 +5202,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetScissor(VkCommandBuffer co
             }
 
             const int64_t y_sum = static_cast<int64_t>(scissor.offset.y) + static_cast<int64_t>(scissor.extent.height);
-            if (y_sum > INT32_MAX) {
+            if (y_sum > vvl::kI32Max) {
                 skip |= LogError(commandBuffer, "VUID-vkCmdSetScissor-offset-00597",
                                  "vkCmdSetScissor: offset.y + extent.height (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
                                  ") of pScissors[%" PRIu32 "] will overflow int32_t.",
@@ -6053,7 +6053,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetExclusiveScissorNV(VkComma
             }
 
             const int64_t x_sum = static_cast<int64_t>(scissor.offset.x) + static_cast<int64_t>(scissor.extent.width);
-            if (x_sum > INT32_MAX) {
+            if (x_sum > vvl::kI32Max) {
                 skip |= LogError(commandBuffer, "VUID-vkCmdSetExclusiveScissorNV-offset-02038",
                                  "vkCmdSetExclusiveScissorNV: offset.x + extent.width (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
                                  ") of pScissors[%" PRIu32 "] will overflow int32_t.",
@@ -6061,7 +6061,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetExclusiveScissorNV(VkComma
             }
 
             const int64_t y_sum = static_cast<int64_t>(scissor.offset.y) + static_cast<int64_t>(scissor.extent.height);
-            if (y_sum > INT32_MAX) {
+            if (y_sum > vvl::kI32Max) {
                 skip |= LogError(commandBuffer, "VUID-vkCmdSetExclusiveScissorNV-offset-02039",
                                  "vkCmdSetExclusiveScissorNV: offset.y + extent.height (=%" PRIi32 " + %" PRIu32 " = %" PRIi64
                                  ") of pScissors[%" PRIu32 "] will overflow int32_t.",
@@ -8284,7 +8284,7 @@ bool StatelessValidation::ValidateCmdSetScissorWithCount(VkCommandBuffer command
             }
 
             const int64_t x_sum = static_cast<int64_t>(scissor.offset.x) + static_cast<int64_t>(scissor.extent.width);
-            if (x_sum > INT32_MAX) {
+            if (x_sum > vvl::kI32Max) {
                 skip |= LogError(commandBuffer, "VUID-vkCmdSetScissorWithCount-offset-03400",
                                  "%s: offset.x + extent.width (=%" PRIi32 " + %" PRIu32 " = %" PRIi64 ") of pScissors[%" PRIu32
                                  "] will overflow int32_t.",
@@ -8292,7 +8292,7 @@ bool StatelessValidation::ValidateCmdSetScissorWithCount(VkCommandBuffer command
             }
 
             const int64_t y_sum = static_cast<int64_t>(scissor.offset.y) + static_cast<int64_t>(scissor.extent.height);
-            if (y_sum > INT32_MAX) {
+            if (y_sum > vvl::kI32Max) {
                 skip |= LogError(commandBuffer, "VUID-vkCmdSetScissorWithCount-offset-03401",
                                  "%s: offset.y + extent.height (=%" PRIi32 " + %" PRIu32 " = %" PRIi64 ") of pScissors[%" PRIu32
                                  "] will overflow int32_t.",
@@ -8501,7 +8501,7 @@ bool StatelessValidation::ValidateAccelerationStructureBuildGeometryInfoKHR(
                         "VkIndexType", pInfos[i].pGeometries[j].geometry.triangles.indexType,
                         "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-indexType-parameter");
 
-                    if (pInfos[i].pGeometries[j].geometry.triangles.vertexStride > UINT32_MAX) {
+                    if (pInfos[i].pGeometries[j].geometry.triangles.vertexStride > vvl::kU32Max) {
                         skip |= LogError(device, "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03819",
                                          "%s():vertexStride must be less than or equal to 2^32-1", api_name);
                     }
@@ -8558,7 +8558,7 @@ bool StatelessValidation::ValidateAccelerationStructureBuildGeometryInfoKHR(
                         skip |= LogError(device, "VUID-VkAccelerationStructureGeometryAabbsDataKHR-stride-03545",
                                          "%s(): stride is not a multiple of 8.", api_name);
                     }
-                    if (pInfos[i].pGeometries[j].geometry.aabbs.stride > UINT32_MAX) {
+                    if (pInfos[i].pGeometries[j].geometry.aabbs.stride > vvl::kU32Max) {
                         skip |= LogError(device, "VUID-VkAccelerationStructureGeometryAabbsDataKHR-stride-03820",
                                          "%s(): stride must be less than or equal to 2^32-1.", api_name);
                     }
@@ -8621,7 +8621,7 @@ bool StatelessValidation::ValidateAccelerationStructureBuildGeometryInfoKHR(
                                                              ParameterName::IndexVector{i, j}),
                                                "VkIndexType", pInfos[i].ppGeometries[j]->geometry.triangles.indexType,
                                                "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-indexType-parameter");
-                    if (pInfos[i].ppGeometries[j]->geometry.triangles.vertexStride > UINT32_MAX) {
+                    if (pInfos[i].ppGeometries[j]->geometry.triangles.vertexStride > vvl::kU32Max) {
                         skip |= LogError(device, "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03819",
                                          "%s():vertexStride must be less than or equal to 2^32-1", api_name);
                     }
@@ -8674,7 +8674,7 @@ bool StatelessValidation::ValidateAccelerationStructureBuildGeometryInfoKHR(
                         ParameterName("pInfos[%i].ppGeometries[%i]->geometry.aabbs.pNext", ParameterName::IndexVector{i, j}), NULL,
                         pInfos[i].ppGeometries[j]->geometry.aabbs.pNext, 0, NULL, GeneratedVulkanHeaderVersion,
                         "VUID-VkAccelerationStructureGeometryAabbsDataKHR-pNext-pNext", kVUIDUndefined);
-                    if (pInfos[i].ppGeometries[j]->geometry.aabbs.stride > UINT32_MAX) {
+                    if (pInfos[i].ppGeometries[j]->geometry.aabbs.stride > vvl::kU32Max) {
                         skip |= LogError(device, "VUID-VkAccelerationStructureGeometryAabbsDataKHR-stride-03820",
                                          "%s():stride must be less than or equal to 2^32-1", api_name);
                     }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -656,7 +656,7 @@ ResourceAccessRange GetBufferRange(VkDeviceSize offset, VkDeviceSize buf_whole_s
                                    uint32_t stride) {
     VkDeviceSize range_start = offset + (first_index * stride);
     VkDeviceSize range_size = 0;
-    if (count == UINT32_MAX) {
+    if (count == vvl::kU32Max) {
         range_size = buf_whole_size - range_start;
     } else {
         range_size = count * stride;
@@ -2419,7 +2419,7 @@ bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t indexCount, ui
 
     // TODO: For now, we detect the whole vertex buffer. Index buffer could be changed until SubmitQueue.
     //       We will detect more accurate range in the future.
-    skip |= ValidateDrawVertex(UINT32_MAX, 0, cmd_type);
+    skip |= ValidateDrawVertex(vvl::kU32Max, 0, cmd_type);
     return skip;
 }
 
@@ -2434,7 +2434,7 @@ void CommandBufferAccessContext::RecordDrawVertexIndex(uint32_t indexCount, uint
 
     // TODO: For now, we detect the whole vertex buffer. Index buffer could be changed until SubmitQueue.
     //       We will detect more accurate range in the future.
-    RecordDrawVertex(UINT32_MAX, 0, tag);
+    RecordDrawVertex(vvl::kU32Max, 0, tag);
 }
 
 bool CommandBufferAccessContext::ValidateDrawSubpassAttachment(CMD_TYPE cmd_type) const {
@@ -5530,7 +5530,7 @@ bool SyncValidator::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer
     // TODO: For now, we validate the whole vertex buffer. It might cause some false positive.
     //       VkDrawIndirectCommand buffer could be changed until SubmitQueue.
     //       We will validate the vertex buffer in SubmitQueue in the future.
-    skip |= cb_access_context->ValidateDrawVertex(UINT32_MAX, 0, CMD_DRAWINDIRECT);
+    skip |= cb_access_context->ValidateDrawVertex(vvl::kU32Max, 0, CMD_DRAWINDIRECT);
     return skip;
 }
 
@@ -5552,7 +5552,7 @@ void SyncValidator::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, 
     // TODO: For now, we record the whole vertex buffer. It might cause some false positive.
     //       VkDrawIndirectCommand buffer could be changed until SubmitQueue.
     //       We will record the vertex buffer in SubmitQueue in the future.
-    cb_access_context->RecordDrawVertex(UINT32_MAX, 0, tag);
+    cb_access_context->RecordDrawVertex(vvl::kU32Max, 0, tag);
 }
 
 bool SyncValidator::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -5576,7 +5576,7 @@ bool SyncValidator::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer comman
     // TODO: For now, we validate the whole index and vertex buffer. It might cause some false positive.
     //       VkDrawIndexedIndirectCommand buffer could be changed until SubmitQueue.
     //       We will validate the index and vertex buffer in SubmitQueue in the future.
-    skip |= cb_access_context->ValidateDrawVertexIndex(UINT32_MAX, 0, CMD_DRAWINDEXEDINDIRECT);
+    skip |= cb_access_context->ValidateDrawVertexIndex(vvl::kU32Max, 0, CMD_DRAWINDEXEDINDIRECT);
     return skip;
 }
 
@@ -5598,7 +5598,7 @@ void SyncValidator::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandB
     // TODO: For now, we record the whole index and vertex buffer. It might cause some false positive.
     //       VkDrawIndexedIndirectCommand buffer could be changed until SubmitQueue.
     //       We will record the index and vertex buffer in SubmitQueue in the future.
-    cb_access_context->RecordDrawVertexIndex(UINT32_MAX, 0, tag);
+    cb_access_context->RecordDrawVertexIndex(vvl::kU32Max, 0, tag);
 }
 
 bool SyncValidator::ValidateCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -5623,7 +5623,7 @@ bool SyncValidator::ValidateCmdDrawIndirectCount(VkCommandBuffer commandBuffer, 
     // TODO: For now, we validate the whole vertex buffer. It might cause some false positive.
     //       VkDrawIndirectCommand buffer could be changed until SubmitQueue.
     //       We will validate the vertex buffer in SubmitQueue in the future.
-    skip |= cb_access_context->ValidateDrawVertex(UINT32_MAX, 0, cmd_type);
+    skip |= cb_access_context->ValidateDrawVertex(vvl::kU32Max, 0, cmd_type);
     return skip;
 }
 
@@ -5653,7 +5653,7 @@ void SyncValidator::RecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, Vk
     // TODO: For now, we record the whole vertex buffer. It might cause some false positive.
     //       VkDrawIndirectCommand buffer could be changed until SubmitQueue.
     //       We will record the vertex buffer in SubmitQueue in the future.
-    cb_access_context->RecordDrawVertex(UINT32_MAX, 0, tag);
+    cb_access_context->RecordDrawVertex(vvl::kU32Max, 0, tag);
 }
 
 void SyncValidator::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -5718,7 +5718,7 @@ bool SyncValidator::ValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandB
     // TODO: For now, we validate the whole index and vertex buffer. It might cause some false positive.
     //       VkDrawIndexedIndirectCommand buffer could be changed until SubmitQueue.
     //       We will validate the index and vertex buffer in SubmitQueue in the future.
-    skip |= cb_access_context->ValidateDrawVertexIndex(UINT32_MAX, 0, cmd_type);
+    skip |= cb_access_context->ValidateDrawVertexIndex(vvl::kU32Max, 0, cmd_type);
     return skip;
 }
 
@@ -5748,7 +5748,7 @@ void SyncValidator::RecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuf
     // TODO: For now, we record the whole index and vertex buffer. It might cause some false positive.
     //       VkDrawIndexedIndirectCommand buffer could be changed until SubmitQueue.
     //       We will update the index and vertex buffer in SubmitQueue in the future.
-    cb_access_context->RecordDrawVertexIndex(UINT32_MAX, 0, tag);
+    cb_access_context->RecordDrawVertexIndex(vvl::kU32Max, 0, tag);
 }
 
 void SyncValidator::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -900,24 +900,23 @@ typename Container::size_type EraseIf(Container &c, Predicate &&p) {
 }
 
 template <typename T>
-constexpr T MaxTypeValue(T) {
+constexpr T MaxTypeValue([[maybe_unused]] T) {
     return std::numeric_limits<T>::max();
 }
 
 template <typename T>
-constexpr T MaxTypeValue() {
-    return std::numeric_limits<T>::max();
-}
-
-template <typename T>
-constexpr T MinTypeValue(T) {
+constexpr T MinTypeValue([[maybe_unused]] T) {
     return std::numeric_limits<T>::min();
 }
 
-template <typename T>
-constexpr T MinTypeValue() {
-    return std::numeric_limits<T>::min();
-}
+// Typesafe UINT32_MAX
+constexpr auto kU32Max = std::numeric_limits<uint32_t>::max();
+// Typesafe UINT64_MAX
+constexpr auto kU64Max = std::numeric_limits<uint64_t>::max();
+// Typesafe INT32_MAX
+constexpr auto kI32Max = std::numeric_limits<int32_t>::max();
+// Typesafe INT64_MAX
+constexpr auto kI64Max = std::numeric_limits<int64_t>::max();
 
 template <typename T>
 T GetQuotientCeil(T numerator, T denominator) {

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2669,7 +2669,7 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
 
     // If supported, run on the compute only queue.
     uint32_t compute_only_queue_family_index = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
-    if (compute_only_queue_family_index != UINT32_MAX) {
+    if (compute_only_queue_family_index != vvl::kU32Max) {
         const auto &compute_only_queues = m_device->queue_family_queues(compute_only_queue_family_index);
         if (!compute_only_queues.empty()) {
             ray_tracing_queue = compute_only_queues[0]->handle();

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -813,7 +813,7 @@ class BarrierQueueFamilyBase {
         DOUBLE_COMMAND_BUFFER,
     };
 
-    static const uint32_t kInvalidQueueFamily = UINT32_MAX;
+    static const uint32_t kInvalidQueueFamily = vvl::kU32Max;
     Context *context_;
     VkImageObj image_;
     VkBufferObj buffer_;
@@ -920,7 +920,7 @@ bool FindFormatWithoutSamples(VkPhysicalDevice gpu, VkImageCreateInfo &image_ci)
 bool FindUnsupportedImage(VkPhysicalDevice gpu, VkImageCreateInfo &image_ci);
 
 VkFormat FindFormatWithoutFeatures(VkPhysicalDevice gpu, VkImageTiling tiling,
-                                   VkFormatFeatureFlags undesired_features = UINT32_MAX);
+                                   VkFormatFeatureFlags undesired_features = vvl::kU32Max);
 
 VkExternalMemoryHandleTypeFlags FindSupportedExternalMemoryHandleTypes(const VkLayerTest &test,
                                                                        const VkBufferCreateInfo &buffer_create_info,

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -92,7 +92,7 @@ TEST_F(VkPositiveLayerTest, OwnershipTranfersImage) {
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     uint32_t no_gfx = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
-    if (no_gfx == UINT32_MAX) {
+    if (no_gfx == vvl::kU32Max) {
         GTEST_SKIP() << "Required queue families not present (non-graphics non-compute capable required)";
     }
     VkQueueObj *no_gfx_queue = m_device->queue_family_queues(no_gfx)[0].get();
@@ -133,7 +133,7 @@ TEST_F(VkPositiveLayerTest, OwnershipTranfersBuffer) {
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     uint32_t no_gfx = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
-    if (no_gfx == UINT32_MAX) {
+    if (no_gfx == vvl::kU32Max) {
         GTEST_SKIP() << "Required queue families not present (non-graphics non-compute capable required)";
     }
     VkQueueObj *no_gfx_queue = m_device->queue_family_queues(no_gfx)[0].get();

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -2705,7 +2705,7 @@ TEST_F(VkPositiveLayerTest, SwapchainImageFormatProps) {
 
     uint32_t image_index;
     ASSERT_VK_SUCCESS(vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index));
-    fence.wait(UINT32_MAX);
+    fence.wait(vvl::kU32Max);
 
     VkImageViewCreateInfo ivci = LvlInitStruct<VkImageViewCreateInfo>();
     ivci.image = swapchain_images[image_index];
@@ -4635,7 +4635,7 @@ TEST_F(VkPositiveLayerTest, FillBufferCmdPoolTransferQueue) {
     }
 
     uint32_t transfer = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT);
-    if (transfer == UINT32_MAX) {
+    if (transfer == vvl::kU32Max) {
         GTEST_SKIP() << "Required queue families not present (non-graphics non-compute capable required)";
     }
     VkQueueObj *queue = m_device->queue_family_queues(transfer)[0].get();

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -118,7 +118,7 @@ TEST_F(VkPositiveLayerTest, Sync2OwnershipTranfersImage) {
     }
 
     uint32_t no_gfx = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
-    if (no_gfx == UINT32_MAX) {
+    if (no_gfx == vvl::kU32Max) {
         GTEST_SKIP() << "Required queue families not present (non-graphics capable required)";
     }
     VkQueueObj *no_gfx_queue = m_device->queue_family_queues(no_gfx)[0].get();
@@ -168,7 +168,7 @@ TEST_F(VkPositiveLayerTest, Sync2OwnershipTranfersBuffer) {
     }
 
     uint32_t no_gfx = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
-    if (no_gfx == UINT32_MAX) {
+    if (no_gfx == vvl::kU32Max) {
         GTEST_SKIP() << "Required queue families not present (non-graphics capable required)";
     }
     VkQueueObj *no_gfx_queue = m_device->queue_family_queues(no_gfx)[0].get();

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -6010,7 +6010,7 @@ TEST_F(VkLayerTest, InvalidBarriers) {
     // Create command pool with incompatible queueflags
     const std::vector<VkQueueFamilyProperties> queue_props = m_device->queue_props;
     uint32_t queue_family_index = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT, false);
-    if (queue_family_index == UINT32_MAX) {
+    if (queue_family_index == vvl::kU32Max) {
         GTEST_SKIP() << "No non-graphics queue supporting compute found; skipped";
     }
 
@@ -6464,7 +6464,7 @@ TEST_F(VkLayerTest, Sync2InvalidBarriers) {
     // Create command pool with incompatible queueflags
     const std::vector<VkQueueFamilyProperties> queue_props = m_device->queue_props;
     uint32_t queue_family_index = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT, false);
-    if (queue_family_index == UINT32_MAX) {
+    if (queue_family_index == vvl::kU32Max) {
         GTEST_SKIP() << "No non-graphics queue supporting compute found";
     }
 
@@ -9567,7 +9567,7 @@ TEST_F(VkLayerTest, CreateImageMaxLimitsViolation) {
         VkImageFormatProperties img_limits;
         ASSERT_VK_SUCCESS(GPDIFPHelper(gpu(), &image_ci, &img_limits));
 
-        if (img_limits.maxArrayLayers != UINT32_MAX) {
+        if (img_limits.maxArrayLayers != vvl::kU32Max) {
             image_ci.arrayLayers = img_limits.maxArrayLayers + 1;
             CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-arrayLayers-02256");
         } else {
@@ -9610,7 +9610,7 @@ TEST_F(VkLayerTest, CreateImageMaxLimitsViolation) {
         VkImageFormatProperties img_limits;
         ASSERT_VK_SUCCESS(GPDIFPHelper(gpu(), &image_ci, &img_limits));
 
-        if (dev_limits.maxFramebufferWidth != UINT32_MAX) {
+        if (dev_limits.maxFramebufferWidth != vvl::kU32Max) {
             image_ci.extent = {dev_limits.maxFramebufferWidth + 1, 64, 1};
             if (dev_limits.maxFramebufferWidth + 1 > img_limits.maxExtent.width) {
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-extent-02252");
@@ -9620,7 +9620,7 @@ TEST_F(VkLayerTest, CreateImageMaxLimitsViolation) {
             printf("VkPhysicalDeviceLimits::maxFramebufferWidth is already UINT32_MAX; skipping part of test.\n");
         }
 
-        if (dev_limits.maxFramebufferHeight != UINT32_MAX) {
+        if (dev_limits.maxFramebufferHeight != vvl::kU32Max) {
             image_ci.extent = {64, dev_limits.maxFramebufferHeight + 1, 1};
             if (dev_limits.maxFramebufferHeight + 1 > img_limits.maxExtent.height) {
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-extent-02253");
@@ -10548,7 +10548,7 @@ TEST_F(VkLayerTest, ImageStencilCreate) {
 
     const VkPhysicalDeviceLimits &dev_limits = m_device->props.limits;
 
-    if (dev_limits.maxFramebufferWidth != UINT32_MAX) {
+    if (dev_limits.maxFramebufferWidth != vvl::kU32Max) {
         // depth-stencil format image with VkImageStencilUsageCreateInfo with
         // VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT set cannot have image width exceeding device maximum
         image_create_info.format = VK_FORMAT_D32_SFLOAT_S8_UINT;
@@ -10559,7 +10559,7 @@ TEST_F(VkLayerTest, ImageStencilCreate) {
         printf("VkPhysicalDeviceLimits::maxFramebufferWidth is already UINT32_MAX; skipping part of test.\n");
     }
 
-    if (dev_limits.maxFramebufferHeight != UINT32_MAX) {
+    if (dev_limits.maxFramebufferHeight != vvl::kU32Max) {
         // depth-stencil format image with VkImageStencilUsageCreateInfo with
         // VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT set cannot have image height exceeding device maximum
         image_create_info.format = VK_FORMAT_D32_SFLOAT_S8_UINT;
@@ -13789,7 +13789,7 @@ TEST_F(VkLayerTest, FillBufferCmdPoolUnsupported) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     uint32_t transfer = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT);
-    if (transfer == UINT32_MAX) {
+    if (transfer == vvl::kU32Max) {
         GTEST_SKIP() << "Required queue families not present (non-graphics non-compute capable required)";
     }
     VkQueueObj *queue = m_device->queue_family_queues(transfer)[0].get();

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -4784,7 +4784,7 @@ TEST_F(VkLayerTest, CommandQueueFlags) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     uint32_t queueFamilyIndex = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
-    if (queueFamilyIndex == UINT32_MAX) {
+    if (queueFamilyIndex == vvl::kU32Max) {
         GTEST_SKIP() << "Non-graphics queue family not found";
     } else {
         // Create command pool on a non-graphics queue
@@ -4810,7 +4810,7 @@ TEST_F(VkLayerTest, DepthStencilImageCopyNoGraphicsQueueFlags) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     uint32_t queueFamilyIndex = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
-    if (queueFamilyIndex == UINT32_MAX) {
+    if (queueFamilyIndex == vvl::kU32Max) {
         GTEST_SKIP() << "Non-graphics queue family not found";
     } else {
         // Create Depth image
@@ -4858,7 +4858,7 @@ TEST_F(VkLayerTest, ImageCopyTransferQueueFlags) {
 
     // Should be left with a tranfser queue
     uint32_t queueFamilyIndex = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT);
-    if (queueFamilyIndex == UINT32_MAX) {
+    if (queueFamilyIndex == vvl::kU32Max) {
         GTEST_SKIP() << "Non-graphics/compute queue family not found";
     }
 
@@ -5313,10 +5313,10 @@ TEST_F(VkLayerTest, PushDescriptorSetCmdPushBadArgs) {
     const uint32_t no_gfx_qfi = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
     const uint32_t transfer_only_qfi =
         m_device->QueueFamilyMatching(VK_QUEUE_TRANSFER_BIT, (VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT));
-    if ((UINT32_MAX == transfer_only_qfi) && (UINT32_MAX == no_gfx_qfi)) {
+    if ((vvl::kU32Max == transfer_only_qfi) && (vvl::kU32Max == no_gfx_qfi)) {
         printf("No compute or transfer only queue family, skipping bindpoint and queue tests.\n");
     } else {
-        const uint32_t err_qfi = (UINT32_MAX == no_gfx_qfi) ? transfer_only_qfi : no_gfx_qfi;
+        const uint32_t err_qfi = (vvl::kU32Max == no_gfx_qfi) ? transfer_only_qfi : no_gfx_qfi;
 
         VkCommandPoolObj command_pool(m_device, err_qfi);
         ASSERT_TRUE(command_pool.initialized());
@@ -5336,7 +5336,7 @@ TEST_F(VkLayerTest, PushDescriptorSetCmdPushBadArgs) {
         command_buffer.end();
 
         // If we succeed in testing only one condition above, we need to test the other below.
-        if ((UINT32_MAX != transfer_only_qfi) && (err_qfi != transfer_only_qfi)) {
+        if ((vvl::kU32Max != transfer_only_qfi) && (err_qfi != transfer_only_qfi)) {
             // Need to test the neither compute/gfx supported case separately.
             VkCommandPoolObj tran_command_pool(m_device, transfer_only_qfi);
             ASSERT_TRUE(tran_command_pool.initialized());
@@ -5470,12 +5470,12 @@ TEST_F(VkLayerTest, SetDynScissorParamTests) {
 
     std::vector<TestCase> test_cases = {{{{-1, 0}, {16, 16}}, "VUID-vkCmdSetScissor-x-00595"},
                                         {{{0, -1}, {16, 16}}, "VUID-vkCmdSetScissor-x-00595"},
-                                        {{{1, 0}, {INT32_MAX, 16}}, "VUID-vkCmdSetScissor-offset-00596"},
-                                        {{{INT32_MAX, 0}, {1, 16}}, "VUID-vkCmdSetScissor-offset-00596"},
-                                        {{{0, 0}, {uint32_t{INT32_MAX} + 1, 16}}, "VUID-vkCmdSetScissor-offset-00596"},
-                                        {{{0, 1}, {16, INT32_MAX}}, "VUID-vkCmdSetScissor-offset-00597"},
-                                        {{{0, INT32_MAX}, {16, 1}}, "VUID-vkCmdSetScissor-offset-00597"},
-                                        {{{0, 0}, {16, uint32_t{INT32_MAX} + 1}}, "VUID-vkCmdSetScissor-offset-00597"}};
+                                        {{{1, 0}, {vvl::kI32Max, 16}}, "VUID-vkCmdSetScissor-offset-00596"},
+                                        {{{vvl::kI32Max, 0}, {1, 16}}, "VUID-vkCmdSetScissor-offset-00596"},
+                                        {{{0, 0}, {uint32_t{vvl::kI32Max} + 1, 16}}, "VUID-vkCmdSetScissor-offset-00596"},
+                                        {{{0, 1}, {16, vvl::kI32Max}}, "VUID-vkCmdSetScissor-offset-00597"},
+                                        {{{0, vvl::kI32Max}, {16, 1}}, "VUID-vkCmdSetScissor-offset-00597"},
+                                        {{{0, 0}, {16, uint32_t{vvl::kI32Max} + 1}}, "VUID-vkCmdSetScissor-offset-00597"}};
 
     for (const auto &test_case : test_cases) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, test_case.vuid);
@@ -5611,7 +5611,7 @@ TEST_F(VkLayerTest, MultiDrawTests) {
     vkCmdDrawMultiIndexedEXT(m_commandBuffer->handle(), 3, nullptr, 1, 0, sizeof(VkMultiDrawIndexedInfoEXT), 0);
     m_errorMonitor->VerifyFound();
 
-    if (multi_draw_properties.maxMultiDrawCount < UINT32_MAX) {
+    if (multi_draw_properties.maxMultiDrawCount < vvl::kU32Max) {
         uint32_t draw_count = multi_draw_properties.maxMultiDrawCount + 1;
         std::vector<VkMultiDrawInfoEXT> max_multi_draws(draw_count);
         std::vector<VkMultiDrawIndexedInfoEXT> max_multi_indexed_draws(draw_count);
@@ -6239,12 +6239,12 @@ TEST_F(VkLayerTest, ExclusiveScissorNV) {
         std::vector<TestCase> test_cases = {
             {{{-1, 0}, {16, 16}}, "VUID-vkCmdSetExclusiveScissorNV-x-02037"},
             {{{0, -1}, {16, 16}}, "VUID-vkCmdSetExclusiveScissorNV-x-02037"},
-            {{{1, 0}, {INT32_MAX, 16}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02038"},
-            {{{INT32_MAX, 0}, {1, 16}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02038"},
-            {{{0, 0}, {uint32_t{INT32_MAX} + 1, 16}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02038"},
-            {{{0, 1}, {16, INT32_MAX}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02039"},
-            {{{0, INT32_MAX}, {16, 1}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02039"},
-            {{{0, 0}, {16, uint32_t{INT32_MAX} + 1}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02039"}};
+            {{{1, 0}, {vvl::kI32Max, 16}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02038"},
+            {{{vvl::kI32Max, 0}, {1, 16}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02038"},
+            {{{0, 0}, {uint32_t{vvl::kI32Max} + 1, 16}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02038"},
+            {{{0, 1}, {16, vvl::kI32Max}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02039"},
+            {{{0, vvl::kI32Max}, {16, 1}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02039"},
+            {{{0, 0}, {16, uint32_t{vvl::kI32Max} + 1}}, "VUID-vkCmdSetExclusiveScissorNV-offset-02039"}};
 
         for (const auto &test_case : test_cases) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, test_case.vuid);

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -5721,7 +5721,7 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
         descriptor_write.dstSet = descriptor_set.set_;
 
         // Exceed range limit
-        if (test_case.max_range != UINT32_MAX) {
+        if (test_case.max_range != vvl::kU32Max) {
             buff_info.range = test_case.max_range + 1;
             buff_info.offset = 0;
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, test_case.max_range_vu);

--- a/tests/vklayertests_nvidia_best_practices.cpp
+++ b/tests/vklayertests_nvidia_best_practices.cpp
@@ -152,7 +152,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
     transfer_queue_ci.queueCount = 1;
     transfer_queue_ci.pQueuePriorities = &defaultQueuePriority;
 
-    if (general_queue_ci.queueFamilyIndex == UINT32_MAX || transfer_queue_ci.queueFamilyIndex == UINT32_MAX) {
+    if (general_queue_ci.queueFamilyIndex == vvl::kU32Max || transfer_queue_ci.queueFamilyIndex == vvl::kU32Max) {
         GTEST_SKIP() << "Test requires a general and a transfer queue";
     }
 
@@ -266,7 +266,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
     compute_queue_ci.queueCount = 1;
     compute_queue_ci.pQueuePriorities = &defaultQueuePriority;
 
-    if (general_queue_ci.queueFamilyIndex == UINT32_MAX || compute_queue_ci.queueFamilyIndex == UINT32_MAX) {
+    if (general_queue_ci.queueFamilyIndex == vvl::kU32Max || compute_queue_ci.queueFamilyIndex == vvl::kU32Max) {
         // There's no asynchronous compute queue, skip.
         return;
     }

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -4558,7 +4558,7 @@ TEST_F(VkLayerTest, ValidateStride) {
         m_errorMonitor->VerifyFound();
 
         auto draw_count = m_device->phy().properties().limits.maxDrawIndirectCount;
-        if (draw_count != UINT32_MAX) {
+        if (draw_count != vvl::kU32Max) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndirect-drawCount-02719");
             vk::CmdDrawIndirect(m_commandBuffer->handle(), buffer.handle(), 0, draw_count + 1, 2);
             m_errorMonitor->VerifyFound();
@@ -5698,7 +5698,7 @@ TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreBadValue) {
     }
 
     // Check if we can test violations of maxTimelineSemaphoreValueDifference
-    if (timelineproperties.maxTimelineSemaphoreValueDifference < UINT64_MAX) {
+    if (timelineproperties.maxTimelineSemaphoreValueDifference < vvl::kU64Max) {
         uint64_t bigValue = signalValue + timelineproperties.maxTimelineSemaphoreValueDifference + 1;
         timeline_semaphore_submit_info.pSignalSemaphoreValues = &bigValue;
 
@@ -5706,7 +5706,7 @@ TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreBadValue) {
         vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
         m_errorMonitor->VerifyFound();
 
-        if (signalValue < UINT64_MAX) {
+        if (signalValue < vvl::kU64Max) {
             signalValue++;
             timeline_semaphore_submit_info.pSignalSemaphoreValues = &signalValue;
             waitValue = signalValue + timelineproperties.maxTimelineSemaphoreValueDifference + 1;
@@ -5838,7 +5838,7 @@ TEST_F(VkLayerTest, QueueBindSparseTimelineSemaphoreBadValue) {
     }
 
     // Check if we can test violations of maxTimelineSemaphoreValueDifference
-    if (timelineproperties.maxTimelineSemaphoreValueDifference < UINT64_MAX) {
+    if (timelineproperties.maxTimelineSemaphoreValueDifference < vvl::kU64Max) {
         uint64_t bigValue = signalValue + timelineproperties.maxTimelineSemaphoreValueDifference + 1;
         timeline_semaphore_submit_info.pSignalSemaphoreValues = &bigValue;
 
@@ -5846,7 +5846,7 @@ TEST_F(VkLayerTest, QueueBindSparseTimelineSemaphoreBadValue) {
         vk::QueueBindSparse(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
         m_errorMonitor->VerifyFound();
 
-        if (signalValue < UINT64_MAX) {
+        if (signalValue < vvl::kU64Max) {
             waitValue = bigValue;
 
             submit_info.signalSemaphoreCount = 0;
@@ -5941,7 +5941,7 @@ TEST_F(VkLayerTest, Sync2QueueSubmitTimelineSemaphoreBadValue) {
     }
 
     // Check if we can test violations of maxTimelineSemaphoreValueDifference
-    if (timelineproperties.maxTimelineSemaphoreValueDifference < UINT64_MAX) {
+    if (timelineproperties.maxTimelineSemaphoreValueDifference < vvl::kU64Max) {
         signal_sem_info.value += timelineproperties.maxTimelineSemaphoreValueDifference + 1;
 
         submit_info.waitSemaphoreInfoCount = 0;
@@ -5952,7 +5952,7 @@ TEST_F(VkLayerTest, Sync2QueueSubmitTimelineSemaphoreBadValue) {
         fpQueueSubmit2KHR(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
         m_errorMonitor->VerifyFound();
 
-        if (signal_sem_info.value < UINT64_MAX) {
+        if (signal_sem_info.value < vvl::kU64Max) {
             auto wait_sem_info = LvlInitStruct<VkSemaphoreSubmitInfo>();
             wait_sem_info.semaphore = semaphore.handle();
             wait_sem_info.value = signal_sem_info.value + 1;
@@ -6445,7 +6445,7 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
     ASSERT_VK_SUCCESS(vkSignalSemaphoreKHR(m_device->device(), &semaphore_signal_info));
 
     // Check if we can test violations of maxTimelineSemaphoreValueDifference
-    if (timelineproperties.maxTimelineSemaphoreValueDifference < UINT64_MAX) {
+    if (timelineproperties.maxTimelineSemaphoreValueDifference < vvl::kU64Max) {
         VkSemaphore sem;
 
         semaphore_type_create_info.initialValue = 0;
@@ -6598,7 +6598,7 @@ TEST_F(VkLayerTest, Sync2InvalidSignalSemaphoreValue) {
     ASSERT_VK_SUCCESS(vk::SignalSemaphore(m_device->device(), &semaphore_signal_info));
 
     // Check if we can test violations of maxTimelineSemaphoreValueDifference
-    if (timelineproperties.maxTimelineSemaphoreValueDifference < UINT64_MAX) {
+    if (timelineproperties.maxTimelineSemaphoreValueDifference < vvl::kU64Max) {
         // Regression test for value difference validations ran against binary semaphores
         semaphore_type_create_info.initialValue = 0;
         vk_testing::Semaphore timeline_sem(*m_device, semaphore_create_info);
@@ -8050,7 +8050,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
     }
     {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCount-offset-03400");
-        VkRect2D scissor2 = {{1, 0}, {INT32_MAX, 16}};
+        VkRect2D scissor2 = {{1, 0}, {vvl::kI32Max, 16}};
         vkCmdSetScissorWithCountEXT(commandBuffer.handle(), 1, &scissor2);
         m_errorMonitor->VerifyFound();
         if (vulkan_13) {
@@ -8062,7 +8062,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetScissorWithCount-offset-03401");
-        VkRect2D scissor2 = {{0, 1}, {16, INT32_MAX}};
+        VkRect2D scissor2 = {{0, 1}, {16, vvl::kI32Max}};
         vkCmdSetScissorWithCountEXT(commandBuffer.handle(), 1, &scissor2);
         m_errorMonitor->VerifyFound();
         if (vulkan_13) {
@@ -8542,7 +8542,7 @@ TEST_F(VkLayerTest, MixedTimelineAndBinarySemaphores) {
 
     // the indexes in pWaitSemaphores and pWaitSemaphoreValues should match
     VkSemaphore reversed[2] = {semaphore[1], semaphore[0]};
-    uint64_t reversed_values[2] = {UINT64_MAX /* ignored */, 20};
+    uint64_t reversed_values[2] = {vvl::kU64Max /* ignored */, 20};
     VkPipelineStageFlags wait_stages[2] = {VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT};
     submit_info.signalSemaphoreCount = 0;
     submit_info.pSignalSemaphores = nullptr;
@@ -10209,8 +10209,8 @@ TEST_F(VkLayerTest, ValidateViewportStateScissorOverflow) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkViewport viewport = {0.0f, 0.0f, 64.0f, 64.0f, 0.0f, 1.0f};
-    VkRect2D scissor_x = {{INT32_MAX / 2, 0}, {INT32_MAX / 2 + 64, 64}};
-    VkRect2D scissor_y = {{0, INT32_MAX / 2}, {64, INT32_MAX / 2 + 64}};
+    VkRect2D scissor_x = {{vvl::kI32Max / 2, 0}, {vvl::kI32Max / 2 + 64, 64}};
+    VkRect2D scissor_y = {{0, vvl::kI32Max / 2}, {64, vvl::kI32Max / 2 + 64}};
 
     const auto break_vp_x = [&](CreatePipelineHelper &helper) {
         helper.vp_state_ci_.viewportCount = 1;
@@ -10696,7 +10696,7 @@ TEST_F(VkLayerTest, WaitEventsDifferentQueues) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     uint32_t no_gfx = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
-    if (no_gfx == UINT32_MAX) {
+    if (no_gfx == vvl::kU32Max) {
         GTEST_SKIP() << "Required queue families not present (non-graphics non-compute capable required)";
     }
 

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -860,8 +860,9 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessPerStageDescriptors) {
     }
 
     // Devices that report UINT32_MAX for any of these limits can't run this test
-    if (UINT32_MAX == std::max({max_uniform_buffers, max_storage_buffers, max_sampled_images, max_storage_images, max_samplers})) {
-        GTEST_SKIP() << "Physical device limits report as 2^32-1";
+    if (vvl::kU32Max ==
+        std::max({max_uniform_buffers, max_storage_buffers, max_sampled_images, max_storage_images, max_samplers})) {
+        GTEST_SKIP() << "Physical device limits report as UINT32_MAX";
     }
 
     VkDescriptorSetLayoutBinding dslb = {};
@@ -1190,8 +1191,8 @@ TEST_F(VkLayerTest, CreatePipelineLayoutExcessDescriptorsOverall) {
     }
 
     // Devices that report UINT32_MAX for any of these limits can't run this test
-    if (UINT32_MAX == std::max({sum_dyn_uniform_buffers, sum_uniform_buffers, sum_dyn_storage_buffers, sum_storage_buffers,
-                                sum_sampled_images, sum_storage_images, sum_samplers, sum_input_attachments})) {
+    if (vvl::kU32Max == std::max({sum_dyn_uniform_buffers, sum_uniform_buffers, sum_dyn_storage_buffers, sum_storage_buffers,
+                                  sum_sampled_images, sum_storage_images, sum_samplers, sum_input_attachments})) {
         GTEST_SKIP() << "Physical device limits report as 2^32-1";
     }
 
@@ -1701,7 +1702,7 @@ TEST_F(VkLayerTest, CmdDispatchExceedLimits) {
     uint32_t x_count_limit = m_device->props.limits.maxComputeWorkGroupCount[0];
     uint32_t y_count_limit = m_device->props.limits.maxComputeWorkGroupCount[1];
     uint32_t z_count_limit = m_device->props.limits.maxComputeWorkGroupCount[2];
-    if (std::max({x_count_limit, y_count_limit, z_count_limit}) == UINT32_MAX) {
+    if (std::max({x_count_limit, y_count_limit, z_count_limit}) == vvl::kU32Max) {
         GTEST_SKIP() << "device maxComputeWorkGroupCount limit reports UINT32_MAX";
     }
 
@@ -3249,7 +3250,7 @@ TEST_F(VkLayerTest, VertexAttributeDivisorExtension) {
         }
     };
 
-    if (UINT32_MAX != pdvad_props.maxVertexAttribDivisor) {  // Can't test overflow if maxVAD is UINT32_MAX
+    if (vvl::kU32Max != pdvad_props.maxVertexAttribDivisor) {  // Can't test overflow if maxVAD is UINT32_MAX
         test_cases.push_back(
             {   0,
                 pdvad_props.maxVertexAttribDivisor + 1,
@@ -8158,7 +8159,7 @@ TEST_F(VkLayerTest, NotCompatibleForSet) {
 TEST_F(VkLayerTest, PipelineStageConditionalRenderingWithWrongQueue) {
     TEST_DESCRIPTION("Run CmdPipelineBarrier with VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT and wrong VkQueueFlagBits");
     ASSERT_NO_FATAL_FAILURE(Init());
-    uint32_t only_transfer_queueFamilyIndex = UINT32_MAX;
+    uint32_t only_transfer_queueFamilyIndex = vvl::kU32Max;
 
     const auto q_props = vk_testing::PhysicalDevice(gpu()).queue_properties();
     ASSERT_TRUE(q_props.size() > 0);
@@ -8171,7 +8172,7 @@ TEST_F(VkLayerTest, PipelineStageConditionalRenderingWithWrongQueue) {
         }
     }
 
-    if (only_transfer_queueFamilyIndex == UINT32_MAX) {
+    if (only_transfer_queueFamilyIndex == vvl::kU32Max) {
         GTEST_SKIP() << "Only VK_QUEUE_TRANSFER_BIT Queue is not supported";
     }
 

--- a/tests/vklayertests_ray_tracing.cpp
+++ b/tests/vklayertests_ray_tracing.cpp
@@ -1448,7 +1448,7 @@ TEST_F(VkLayerTest, RayTracingValidateCmdBuildAccelerationStructuresKHR) {
     // Invalid VetexStride and Indexdata
     if (index_type_uint8) {
         VkAccelerationStructureGeometryKHR invalid_geometry_triangles = valid_geometry_triangles;
-        invalid_geometry_triangles.geometry.triangles.vertexStride = UINT32_MAX + 1ull;
+        invalid_geometry_triangles.geometry.triangles.vertexStride = vvl::kU32Max + 1ull;
         VkAccelerationStructureBuildGeometryInfoKHR invalid_build_info_khr = build_info_khr;
         invalid_build_info_khr.pGeometries = &invalid_geometry_triangles;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03819");

--- a/tests/vklayertests_video.cpp
+++ b/tests/vklayertests_video.cpp
@@ -578,13 +578,13 @@ TEST_F(VkVideoLayerTest, BindVideoSessionMemory) {
     }
 
     // Invalid memoryBindIndex
-    uint32_t invalid_bind_index = UINT32_MAX;
+    uint32_t invalid_bind_index = vvl::kU32Max;
     for (uint32_t i = 0; i < mem_req_count; ++i) {
-        if (mem_reqs[i].memoryBindIndex < UINT32_MAX) {
+        if (mem_reqs[i].memoryBindIndex < vvl::kU32Max) {
             invalid_bind_index = mem_reqs[i].memoryBindIndex + 1;
         }
     }
-    if (invalid_bind_index != UINT32_MAX) {
+    if (invalid_bind_index != vvl::kU32Max) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindVideoSessionMemoryKHR-pBindSessionMemoryInfos-07197");
         auto& invalid = bind_info[mem_req_count / 2];
         auto backup = invalid;
@@ -595,8 +595,8 @@ TEST_F(VkVideoLayerTest, BindVideoSessionMemory) {
     }
 
     // Incompatible memory type
-    uint32_t invalid_mem_type_index = UINT32_MAX;
-    uint32_t invalid_mem_type_req_index = UINT32_MAX;
+    uint32_t invalid_mem_type_index = vvl::kU32Max;
+    uint32_t invalid_mem_type_req_index = vvl::kU32Max;
     auto mem_props = m_device->phy().memory_properties();
     for (uint32_t i = 0; i < mem_req_count; ++i) {
         uint32_t mem_type_bits = mem_reqs[i].memoryRequirements.memoryTypeBits;
@@ -607,9 +607,9 @@ TEST_F(VkVideoLayerTest, BindVideoSessionMemory) {
                 break;
             }
         }
-        if (invalid_mem_type_index != UINT32_MAX) break;
+        if (invalid_mem_type_index != vvl::kU32Max) break;
     }
-    if (invalid_mem_type_index != UINT32_MAX) {
+    if (invalid_mem_type_index != vvl::kU32Max) {
         auto& mem_req = mem_reqs[invalid_mem_type_req_index].memoryRequirements;
 
         VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
@@ -631,14 +631,14 @@ TEST_F(VkVideoLayerTest, BindVideoSessionMemory) {
     }
 
     // Incorrectly aligned memoryOffset
-    uint32_t invalid_offset_align_index = UINT32_MAX;
+    uint32_t invalid_offset_align_index = vvl::kU32Max;
     for (uint32_t i = 0; i < mem_req_count; ++i) {
         if (mem_reqs[i].memoryRequirements.alignment > 1) {
             invalid_offset_align_index = i;
             break;
         }
     }
-    if (invalid_offset_align_index != UINT32_MAX) {
+    if (invalid_offset_align_index != vvl::kU32Max) {
         auto& mem_req = mem_reqs[invalid_offset_align_index].memoryRequirements;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindVideoSessionMemoryKHR-pBindSessionMemoryInfos-07199");

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (c) 2015-2022 Google, Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -708,7 +708,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAcquireNextImageKHR-surface-07783");
     uint32_t image_i;
     // NOTE: timeout MUST be UINT64_MAX to trigger the VUID
-    vk::AcquireNextImageKHR(device(), m_swapchain, UINT64_MAX, VK_NULL_HANDLE, error_fence.handle(), &image_i);
+    vk::AcquireNextImageKHR(device(), m_swapchain, vvl::kU64Max, VK_NULL_HANDLE, error_fence.handle(), &image_i);
     m_errorMonitor->VerifyFound();
 
     // Cleanup
@@ -858,7 +858,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
     auto acquire_info = LvlInitStruct<VkAcquireNextImageInfoKHR>();
 
     acquire_info.swapchain = m_swapchain;
-    acquire_info.timeout = UINT64_MAX; // NOTE: timeout MUST be UINT64_MAX to trigger the VUID
+    acquire_info.timeout = vvl::kU64Max;  // NOTE: timeout MUST be UINT64_MAX to trigger the VUID
     acquire_info.fence = error_fence.handle();
     acquire_info.deviceMask = 0x1;
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -1088,7 +1088,7 @@ uint32_t VkDeviceObj::QueueFamilyMatching(VkQueueFlags with, VkQueueFlags withou
             return i;
         }
     }
-    return UINT32_MAX;
+    return vvl::kU32Max;
 }
 
 void VkDeviceObj::SetDeviceQueue() {


### PR DESCRIPTION
Originally I was going to use `std::numeric_limits` or `vvl::MaxTypeValue` everywhere. But this made the code less readable in certain areas.

Instead I created `constexpr` constants in the vvl namespace for the most common use cases in vvl:
```c++
// Typesafe UINT32_MAX
constexpr auto kU32Max = std::numeric_limits<uint32_t>::max();
// Typesafe UINT64_MAX
constexpr auto kU64Max = std::numeric_limits<uint64_t>::max();
// Typesafe INT32_MAX
constexpr auto kI32Max = std::numeric_limits<int32_t>::max();
// Typesafe INT64_MAX
constexpr auto kI64Max = std::numeric_limits<int64_t>::max();
```

Note how `vvl::kU64Max` is the same amount of characters as `UINT64_MAX`

Also these constants are available from the vvl namespace
![image](https://user-images.githubusercontent.com/114601453/216165791-4d8b5f30-469d-4a09-b0d1-352da08b1744.png)

closes #3797