### PR TITLE
layers: Fix printing dynamic states

### DIFF
--- a/layers/core_checks/cmd_buffer_dynamic_validation.cpp
+++ b/layers/core_checks/cmd_buffer_dynamic_validation.cpp
@@ -50,7 +50,7 @@ bool CoreChecks::ValidateCBDynamicStatus(const CMD_BUFFER_STATE &cb_state, CBDyn
                                          const char *msg_code) const {
     if (!(cb_state.status[status])) {
         return LogError(cb_state.commandBuffer(), msg_code, "%s: %s state not set for this command buffer.",
-                        CommandTypeString(cmd_type), DynamicStateString(status).c_str());
+                        CommandTypeString(cmd_type), DynamicStateToString(status));
     }
     return false;
 }
@@ -193,7 +193,7 @@ bool CoreChecks::ValidateDrawDynamicState(const CMD_BUFFER_STATE &cb_state, cons
         skip |= LogError(objlist, vuid.dynamic_state_setting_commands,
                          "%s: %s doesn't set up %s, but it calls the related dynamic state setting commands",
                          CommandTypeString(cmd_type), report_data->FormatHandle(pipeline.pipeline()).c_str(),
-                         DynamicStateString(invalid_status).c_str());
+                         DynamicStatesToString(invalid_status).c_str());
     }
 
     // If Viewport or scissors are dynamic, verify that dynamic count matches PSO count.

--- a/layers/generated/command_validation.cpp
+++ b/layers/generated/command_validation.cpp
@@ -1561,7 +1561,11 @@ static CBDynamicStatus ConvertToCBDynamicStatus(VkDynamicState state) {
     }
 }
 
-std::string DynamicStateString(CBDynamicFlags const &dynamic_state) {
+const char* DynamicStateToString(CBDynamicStatus status) {
+    return string_VkDynamicState(ConvertToDynamicState(status));
+}
+
+std::string DynamicStatesToString(CBDynamicFlags const &dynamic_state) {
     std::string ret;
     // enum is not zero based
     for (int index = 1; index < CB_DYNAMIC_STATUS_NUM; ++index) {

--- a/layers/generated/command_validation.h
+++ b/layers/generated/command_validation.h
@@ -572,7 +572,8 @@ typedef enum CBDynamicStatus {
 } CBDynamicStatus;
 
 using CBDynamicFlags = std::bitset<CB_DYNAMIC_STATUS_NUM>;
-std::string DynamicStateString(CBDynamicFlags const &dynamic_state);
+const char* DynamicStateToString(CBDynamicStatus status);
+std::string DynamicStatesToString(CBDynamicFlags const &dynamic_state);
 struct VkPipelineDynamicStateCreateInfo;
 CBDynamicFlags MakeStaticStateMask(VkPipelineDynamicStateCreateInfo const *info);
 

--- a/scripts/command_validation_generator.py
+++ b/scripts/command_validation_generator.py
@@ -264,7 +264,8 @@ typedef enum CBDynamicStatus {\n'''
 } CBDynamicStatus;
 
 using CBDynamicFlags = std::bitset<CB_DYNAMIC_STATUS_NUM>;
-std::string DynamicStateString(CBDynamicFlags const &dynamic_state);
+const char* DynamicStateToString(CBDynamicStatus status);
+std::string DynamicStatesToString(CBDynamicFlags const &dynamic_state);
 struct VkPipelineDynamicStateCreateInfo;
 CBDynamicFlags MakeStaticStateMask(VkPipelineDynamicStateCreateInfo const *info);
 '''
@@ -527,7 +528,11 @@ static CBDynamicStatus ConvertToCBDynamicStatus(VkDynamicState state) {
 '''
 
         output += '''
-std::string DynamicStateString(CBDynamicFlags const &dynamic_state) {
+const char* DynamicStateToString(CBDynamicStatus status) {
+    return string_VkDynamicState(ConvertToDynamicState(status));
+}
+
+std::string DynamicStatesToString(CBDynamicFlags const &dynamic_state) {
     std::string ret;
     // enum is not zero based
     for (int index = 1; index < CB_DYNAMIC_STATUS_NUM; ++index) {


### PR DESCRIPTION
I realized the REAL issue with https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5135 was the printing logic was wrong, before this PR it was

>  vkCmdDraw: VK_DYNAMIC_STATE_VIEWPORT|VK_DYNAMIC_STATE_SCISSOR|VK_DYNAMIC_STATE_LINE_WIDTH|VK_DYNAMIC_STATE_BLEND_CONSTANTS state not set for this command buffer

but not correctly is

> vkCmdDraw: VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT state not set for this command buffer