### PR TITLE
layers: Improve external memory messages

### DIFF
--- a/layers/core_checks/buffer_validation.cpp
+++ b/layers/core_checks/buffer_validation.cpp
@@ -315,10 +315,11 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
         const auto compatible_types = external_buffer_properties.externalMemoryProperties.compatibleHandleTypes;
 
         if ((external_memory_info->handleTypes & compatible_types) != external_memory_info->handleTypes) {
-            skip |= LogError(device, "VUID-VkBufferCreateInfo-pNext-00920",
-                             "vkCreateBuffer(): VkBufferCreateInfo pNext chain contains VkExternalMemoryBufferCreateInfo with "
-                             "unsupported or incompatible handleTypes flags (%s).",
-                             string_VkExternalMemoryHandleTypeFlags(external_memory_info->handleTypes).c_str());
+            skip |= LogError(
+                device, "VUID-VkBufferCreateInfo-pNext-00920",
+                "vkCreateBuffer(): VkBufferCreateInfo pNext chain contains VkExternalMemoryBufferCreateInfo with handleTypes flags "
+                "(%s) that are not reported as compatible by vkGetPhysicalDeviceExternalBufferProperties.",
+                string_VkExternalMemoryHandleTypeFlags(external_memory_info->handleTypes).c_str());
         }
     }
 

--- a/layers/core_checks/image_validation.cpp
+++ b/layers/core_checks/image_validation.cpp
@@ -489,12 +489,11 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                 string_VkImageUsageFlags(image_info.usage).c_str(), string_VkImageCreateFlags(image_info.flags).c_str(),
                 string_VkResult(result));
         } else if ((external_memory_create_info->handleTypes & compatible_types) != external_memory_create_info->handleTypes) {
-            const bool single_flag = GetBitSetCount(external_memory_create_info->handleTypes) == 1;
-            skip |= LogError(device, "VUID-VkImageCreateInfo-pNext-00990",
-                             "vkCreateImage(): VkImageCreateInfo pNext chain contains VkExternalMemoryImageCreateInfo with "
-                             "%s (%s).",
-                             single_flag ? "unsupported flag" : "incompatible flags",
-                             string_VkExternalMemoryHandleTypeFlags(external_memory_create_info->handleTypes).c_str());
+            skip |=
+                LogError(device, "VUID-VkImageCreateInfo-pNext-00990",
+                         "vkCreateImage(): VkImageCreateInfo pNext chain contains VkExternalMemoryImageCreateInfo with handleTypes "
+                         "flags (%s)  that are not reported as compatible by vkGetPhysicalDeviceImageFormatProperties2.",
+                         string_VkExternalMemoryHandleTypeFlags(external_memory_create_info->handleTypes).c_str());
         }
     } else if (external_memory_create_info_nv && external_memory_create_info_nv->handleTypes != 0) {
         if (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
@@ -524,12 +523,11 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                              string_VkImageCreateFlags(pCreateInfo->flags).c_str(), string_VkResult(result));
         } else if ((external_memory_create_info_nv->handleTypes & compatible_types) !=
                    external_memory_create_info_nv->handleTypes) {
-            const bool single_flag = GetBitSetCount(external_memory_create_info_nv->handleTypes) == 1;
-            skip |= LogError(device, "VUID-VkImageCreateInfo-pNext-00991",
-                             "vkCreateImage(): VkImageCreateInfo pNext chain contains VkExternalMemoryImageCreateInfoNV with "
-                             "%s (%s).",
-                             single_flag ? "unsupported flag" : "incompatible flags",
-                             string_VkExternalMemoryHandleTypeFlagsNV(external_memory_create_info_nv->handleTypes).c_str());
+            skip |= LogError(
+                device, "VUID-VkImageCreateInfo-pNext-00991",
+                "vkCreateImage(): VkImageCreateInfo pNext chain contains VkExternalMemoryImageCreateInfoNV with handleTypes flags "
+                "(%s) that are not reported as compatible by vkGetPhysicalDeviceExternalImageFormatPropertiesNV.",
+                string_VkExternalMemoryHandleTypeFlagsNV(external_memory_create_info_nv->handleTypes).c_str());
         }
     }
 


### PR DESCRIPTION
The original version tried to derive too much information from `VkExternalMemoryProperties::compatibleHandleTypes`. It tried to categorize situation as _not supported_ or _not compatible_ which is not something defined by spec and it's more safe just to say that flags are not reported as compatible (for support checks there is a separate bitmask `VkExternalMemoryProperties::externalMemoryFeatures`).

The original motivation to categorize between supported/compatible based on `VkExternalMemoryProperties::compatibleHandleTypes` flags is that some android devices report a flag as not compatible with itself even if it is reported as supported by `VkExternalMemoryProperties::externalMemoryFeatures`. It's violation of spec which states that each handle type flag **must** be compatible with itself.