### PR TITLE
cmake: Apply -Wno-shorten-64-to-32 to tests only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
                         # TODO These warnings also get turned on with -Wconversion in some versions of clang.
                         #      Leave off until further investigation.
                         -Wno-sign-conversion
-                        -Wno-shorten-64-to-32
                         -Wno-implicit-int-conversion
                         -Wno-enum-enum-conversion
                         -Wstring-conversion)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -93,7 +93,10 @@ target_include_directories(vk_layer_validation_tests PRIVATE
 )
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
-    target_compile_options(vk_layer_validation_tests PRIVATE "-Wno-sign-compare")
+    target_compile_options(vk_layer_validation_tests PRIVATE 
+        -Wno-sign-compare
+        -Wno-shorten-64-to-32
+    )
 elseif(MSVC)
     # Disable some signed/unsigned mismatch warnings.
     target_compile_options(vk_layer_validation_tests PRIVATE /wd4267)


### PR DESCRIPTION
Layer code doesn't need this warning disabled.