### PR TITLE
Vuid exernal memory 00656

### DIFF
--- a/layers/core_checks/device_memory_validation.cpp
+++ b/layers/core_checks/device_memory_validation.cpp
@@ -545,18 +545,63 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory mem, V
             }
 
             // Validate export memory handles
-            if ((mem_info->export_handle_type_flags != 0) &&
-                ((mem_info->export_handle_type_flags & buffer_state->external_memory_handle) == 0)) {
-                const char *vuid =
-                    bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memory-02726" : "VUID-vkBindBufferMemory-memory-02726";
-                const LogObjectList objlist(buffer, mem);
-                skip |= LogError(objlist, vuid,
+            if (mem_info->export_handle_type_flags != 0) {
+                auto external_buffer_info = LvlInitStruct<VkPhysicalDeviceExternalBufferInfo>();
+                external_buffer_info.flags = buffer_state->createInfo.flags;
+                external_buffer_info.usage = buffer_state->createInfo.usage;
+                auto external_buffer_properties = LvlInitStruct<VkExternalBufferProperties>();
+                bool export_supported = true;
+
+                // Check export operation support
+                auto check_export_support = [&](VkExternalMemoryHandleTypeFlagBits flag) {
+                    external_buffer_info.handleType = flag;
+                    DispatchGetPhysicalDeviceExternalBufferProperties(physical_device, &external_buffer_info,
+                                                                      &external_buffer_properties);
+                    if ((external_buffer_properties.externalMemoryProperties.externalMemoryFeatures &
+                         VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT) == 0) {
+                        export_supported = false;
+                        const LogObjectList objlist(buffer, mem);
+                        skip |= LogError(objlist, "VUID-VkExportMemoryAllocateInfo-handleTypes-00656",
+                                         "%s: The VkDeviceMemory (%s) has VkExportMemoryAllocateInfo::handleTypes with the %s flag "
+                                         "set, which does not support VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT with the buffer "
+                                         "create flags (%s) and usage flags (%s).",
+                                         api_name, report_data->FormatHandle(mem).c_str(),
+                                         string_VkExternalMemoryHandleTypeFlagBits(flag),
+                                         string_VkBufferCreateFlags(external_buffer_info.flags).c_str(),
+                                         string_VkBufferUsageFlags(external_buffer_info.usage).c_str());
+                    }
+                };
+                IterateFlags<VkExternalMemoryHandleTypeFlagBits>(mem_info->export_handle_type_flags, check_export_support);
+
+                // The types of external memory handles must be compatible
+                const auto compatible_types = external_buffer_properties.externalMemoryProperties.compatibleHandleTypes;
+                if (export_supported &&
+                    (mem_info->export_handle_type_flags & compatible_types) != mem_info->export_handle_type_flags) {
+                    const LogObjectList objlist(buffer, mem);
+                    skip |= LogError(objlist, "VUID-VkExportMemoryAllocateInfo-handleTypes-00656",
+                                     "%s: The VkDeviceMemory (%s) has VkExportMemoryAllocateInfo::handleTypes (%s) that are not "
+                                     "reported as compatible by vkGetPhysicalDeviceExternalBufferProperties with the buffer create "
+                                     "flags (%s) and usage flags (%s).",
+                                     api_name, report_data->FormatHandle(mem).c_str(),
+                                     string_VkExternalMemoryHandleTypeFlags(mem_info->export_handle_type_flags).c_str(),
+                                     string_VkBufferCreateFlags(external_buffer_info.flags).c_str(),
+                                     string_VkBufferUsageFlags(external_buffer_info.usage).c_str());
+                }
+
+                // Check if the memory meets the buffer's external memory requirements
+                if ((mem_info->export_handle_type_flags & buffer_state->external_memory_handle) == 0) {
+                    const char *vuid =
+                        bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memory-02726" : "VUID-vkBindBufferMemory-memory-02726";
+                    const LogObjectList objlist(buffer, mem);
+                    skip |=
+                        LogError(objlist, vuid,
                                  "%s: The VkDeviceMemory (%s) has an external handleType of %s which does not include at least one "
                                  "handle from VkBuffer (%s) handleType %s.",
                                  api_name, report_data->FormatHandle(mem).c_str(),
                                  string_VkExternalMemoryHandleTypeFlags(mem_info->export_handle_type_flags).c_str(),
                                  report_data->FormatHandle(buffer).c_str(),
                                  string_VkExternalMemoryHandleTypeFlags(buffer_state->external_memory_handle).c_str());
+                }
             }
 
             // Validate import memory handles
@@ -1159,18 +1204,83 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                 }
 
                 // Validate export memory handles
-                if ((mem_info->export_handle_type_flags != 0) &&
-                    ((mem_info->export_handle_type_flags & image_state->external_memory_handle) == 0)) {
-                    const char *vuid =
-                        bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-memory-02728" : "VUID-vkBindImageMemory-memory-02728";
-                    const LogObjectList objlist(bind_info.image, bind_info.memory);
-                    skip |= LogError(objlist, vuid,
+                if (mem_info->export_handle_type_flags != 0) {
+                    auto external_image_info = LvlInitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
+                    auto image_info = LvlInitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_image_info);
+                    image_info.format = image_state->createInfo.format;
+                    image_info.type = image_state->createInfo.imageType;
+                    image_info.tiling = image_state->createInfo.tiling;
+                    image_info.usage = image_state->createInfo.usage;
+                    image_info.flags = image_state->createInfo.flags;
+                    auto external_image_properties = LvlInitStruct<VkExternalImageFormatProperties>();
+                    auto image_properties = LvlInitStruct<VkImageFormatProperties2>(&external_image_properties);
+                    bool export_supported = true;
+
+                    // Check export operation support
+                    auto check_export_support = [&](VkExternalMemoryHandleTypeFlagBits flag) {
+                        external_image_info.handleType = flag;
+                        auto result =
+                            DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_info, &image_properties);
+                        if (result != VK_SUCCESS) {
+                            export_supported = false;
+                            const LogObjectList objlist(bind_info.image, bind_info.memory);
+                            skip |= LogError(
+                                objlist, "VUID-VkExportMemoryAllocateInfo-handleTypes-00656",
+                                "%s: The handle type (%s) specified by the memory's VkExportMemoryAllocateInfo, and format (%s), "
+                                "type (%s), tiling (%s), usage (%s), flags (%s) specified by the image's VkImageCreateInfo is not "
+                                "supported combination of parameters. vkGetPhysicalDeviceImageFormatProperties2 returned back %s.",
+                                api_name, string_VkExternalMemoryHandleTypeFlagBits(flag), string_VkFormat(image_info.format),
+                                string_VkImageType(image_info.type), string_VkImageTiling(image_info.tiling),
+                                string_VkImageUsageFlags(image_info.usage).c_str(),
+                                string_VkImageCreateFlags(image_info.flags).c_str(), string_VkResult(result));
+                        } else if ((external_image_properties.externalMemoryProperties.externalMemoryFeatures &
+                                    VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT) == 0) {
+                            export_supported = false;
+                            const LogObjectList objlist(bind_info.image, bind_info.memory);
+                            skip |= LogError(objlist, "VUID-VkExportMemoryAllocateInfo-handleTypes-00656",
+                                             "%s: The VkDeviceMemory (%s) has VkExportMemoryAllocateInfo::handleTypes with the %s "
+                                             "flag set, which does not support VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT with the "
+                                             "image create format (%s), type (%s), tiling (%s), usage (%s), flags (%s).",
+                                             api_name, report_data->FormatHandle(bind_info.memory).c_str(),
+                                             string_VkExternalMemoryHandleTypeFlagBits(flag), string_VkFormat(image_info.format),
+                                             string_VkImageType(image_info.type), string_VkImageTiling(image_info.tiling),
+                                             string_VkImageUsageFlags(image_info.usage).c_str(),
+                                             string_VkImageCreateFlags(image_info.flags).c_str());
+                        }
+                    };
+                    IterateFlags<VkExternalMemoryHandleTypeFlagBits>(mem_info->export_handle_type_flags, check_export_support);
+
+                    // The types of external memory handles must be compatible
+                    const auto compatible_types = external_image_properties.externalMemoryProperties.compatibleHandleTypes;
+                    if (export_supported &&
+                        (mem_info->export_handle_type_flags & compatible_types) != mem_info->export_handle_type_flags) {
+                        const LogObjectList objlist(bind_info.image, bind_info.memory);
+                        skip |=
+                            LogError(objlist, "VUID-VkExportMemoryAllocateInfo-handleTypes-00656",
+                                     "%s: The VkDeviceMemory (%s) has VkExportMemoryAllocateInfo::handleTypes (%s) that are not "
+                                     "reported as compatible by vkGetPhysicalDeviceImageFormatProperties2 with the image create "
+                                     "format (%s), type (%s), tiling (%s), usage (%s), flags (%s).",
+                                     api_name, report_data->FormatHandle(bind_info.memory).c_str(),
+                                     string_VkExternalMemoryHandleTypeFlags(mem_info->export_handle_type_flags).c_str(),
+                                     string_VkFormat(image_info.format), string_VkImageType(image_info.type),
+                                     string_VkImageTiling(image_info.tiling), string_VkImageUsageFlags(image_info.usage).c_str(),
+                                     string_VkImageCreateFlags(image_info.flags).c_str());
+                    }
+
+                    // Check if the memory meets the image's external memory requirements
+                    if ((mem_info->export_handle_type_flags & image_state->external_memory_handle) == 0) {
+                        const char *vuid =
+                            bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-memory-02728" : "VUID-vkBindImageMemory-memory-02728";
+                        const LogObjectList objlist(bind_info.image, bind_info.memory);
+                        skip |=
+                            LogError(objlist, vuid,
                                      "%s: The VkDeviceMemory (%s) has an external handleType of %s which does not include at least "
                                      "one handle from VkImage (%s) handleType %s.",
                                      error_prefix, report_data->FormatHandle(bind_info.memory).c_str(),
                                      string_VkExternalMemoryHandleTypeFlags(mem_info->export_handle_type_flags).c_str(),
                                      report_data->FormatHandle(bind_info.image).c_str(),
                                      string_VkExternalMemoryHandleTypeFlags(image_state->external_memory_handle).c_str());
+                    }
                 }
 
                 // Validate import memory handles

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -911,18 +911,21 @@ VkFormat FindFormatWithoutFeatures(VkPhysicalDevice gpu, VkImageTiling tiling,
 
 VkExternalMemoryHandleTypeFlags FindSupportedExternalMemoryHandleTypes(const VkLayerTest &test,
                                                                        const VkBufferCreateInfo &buffer_create_info,
-                                                                       VkExternalMemoryFeatureFlags requested_features,
-                                                                       bool find_single_flag = false);
+                                                                       VkExternalMemoryFeatureFlags requested_features);
 
 VkExternalMemoryHandleTypeFlags FindSupportedExternalMemoryHandleTypes(const VkLayerTest &test,
                                                                        const VkImageCreateInfo &image_create_info,
-                                                                       VkExternalMemoryFeatureFlags requested_features,
-                                                                       bool find_single_flag = false);
+                                                                       VkExternalMemoryFeatureFlags requested_features);
 
 VkExternalMemoryHandleTypeFlagsNV FindSupportedExternalMemoryHandleTypesNV(const VkLayerTest &test,
                                                                            const VkImageCreateInfo &image_create_info,
-                                                                           VkExternalMemoryFeatureFlagsNV requested_features,
-                                                                           bool find_single_flag = false);
+                                                                           VkExternalMemoryFeatureFlagsNV requested_features);
+
+VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(const VkLayerTest &test, const VkBufferCreateInfo &buffer_create_info,
+                                                         VkExternalMemoryHandleTypeFlagBits handle_type);
+
+VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(const VkLayerTest &test, const VkImageCreateInfo &image_create_info,
+                                                         VkExternalMemoryHandleTypeFlagBits handle_type);
 
 void SetImageLayout(VkDeviceObj *device, VkImageAspectFlags aspect, VkImage image, VkImageLayout image_layout);
 


### PR DESCRIPTION
Commit 1. Clean up and fixes of existing tests to make sure they will work with VU 00656.
Commit 2 and 3. Implement and test VUID 00656.

Fixes one item from https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4539

VU 00656 is about external memory handle types associated with a _memory object_. The type of the handles should be supported and compatible as defined in the spec. Previously similar VUs 00920/00990 were implemented and they are concerned with the handle types associated with the _resource_ itself (buffer or image).