### PR TITLE
Improve test helpers

### DIFF
--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -905,15 +905,13 @@ TEST_F(VkLayerTest, QueryMemoryCommitmentWithoutLazyProperty) {
     VkImageObj image(m_device);
     image.init_no_mem(*m_device, image_ci);
 
-    auto mem_reqs = image.memory_requirements();
-    // memory_type_index is set to 0 here, but is set properly below
-    auto image_alloc_info = vk_testing::DeviceMemory::alloc_info(mem_reqs.size, 0);
+    const auto mem_reqs = image.memory_requirements();
+    auto image_alloc_info = LvlInitStruct<VkMemoryAllocateInfo>();
+    image_alloc_info.allocationSize = mem_reqs.size;
 
-    bool pass;
     // the last argument is the "forbid" argument for set_memory_type, disallowing
     // that particular memory type rather than requiring it
-    pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &image_alloc_info, 0, VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT);
-    if (!pass) {
+    if (!m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &image_alloc_info, 0, VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)) {
         GTEST_SKIP() << "Failed to set memory type";
     }
     vk_testing::DeviceMemory mem;
@@ -14259,12 +14257,14 @@ TEST_F(VkLayerTest, InvalidQueueBindSparseMemoryType) {
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &buffer_mem_reqs);
-    VkMemoryAllocateInfo buffer_mem_alloc = vk_testing::DeviceMemory::alloc_info(buffer_mem_reqs.size, 0);
+    auto buffer_mem_alloc = LvlInitStruct<VkMemoryAllocateInfo>();
+    buffer_mem_alloc.allocationSize = buffer_mem_reqs.size;
     buffer_mem_alloc.memoryTypeIndex = lazily_allocated_index;
 
     VkMemoryRequirements image_mem_reqs;
     vk::GetImageMemoryRequirements(device(), image.handle(), &image_mem_reqs);
-    VkMemoryAllocateInfo image_mem_alloc = vk_testing::DeviceMemory::alloc_info(image_mem_reqs.size, 0);
+    auto image_mem_alloc = LvlInitStruct<VkMemoryAllocateInfo>();
+    image_mem_alloc.allocationSize = image_mem_reqs.size;
     image_mem_alloc.memoryTypeIndex = lazily_allocated_index;
 
     vk_testing::DeviceMemory buffer_mem;
@@ -14320,8 +14320,8 @@ TEST_F(VkLayerTest, QueueBindSparse_InvalidSparseMemoryBindSize) {
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
-    VkMemoryAllocateInfo buffer_mem_alloc =
-        vk_testing::DeviceMemory::alloc_info(buffer_mem_reqs.size, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    const auto buffer_mem_alloc =
+        vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     vk_testing::DeviceMemory buffer_mem;
     buffer_mem.init(*m_device, buffer_mem_alloc);
@@ -14367,8 +14367,8 @@ TEST_F(VkLayerTest, QueueBindSparse_InvalidSparseMemoryBindResourceOffset) {
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
-    VkMemoryAllocateInfo buffer_mem_alloc =
-        vk_testing::DeviceMemory::alloc_info(buffer_mem_reqs.size, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    const auto buffer_mem_alloc =
+        vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     vk_testing::DeviceMemory buffer_mem;
     buffer_mem.init(*m_device, buffer_mem_alloc);
@@ -14416,8 +14416,8 @@ TEST_F(VkLayerTest, QueueBindSparse_InvalidSparseMemoryBindSizeResourceOffset) {
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
-    VkMemoryAllocateInfo buffer_mem_alloc =
-        vk_testing::DeviceMemory::alloc_info(buffer_mem_reqs.size, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    const auto buffer_mem_alloc =
+        vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     vk_testing::DeviceMemory buffer_mem;
     buffer_mem.init(*m_device, buffer_mem_alloc);
@@ -14465,8 +14465,8 @@ TEST_F(VkLayerTest, QueueBindSparse_InvalidSparseMemoryBindSizeMemoryOffset) {
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
-    VkMemoryAllocateInfo buffer_mem_alloc =
-        vk_testing::DeviceMemory::alloc_info(buffer_mem_reqs.size, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    const auto buffer_mem_alloc =
+        vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     vk_testing::DeviceMemory buffer_mem;
     buffer_mem.init(*m_device, buffer_mem_alloc);
@@ -16098,8 +16098,8 @@ TEST_F(VkLayerTest, InvalidVkSparseImageMemoryBind) {
 
     VkMemoryRequirements image_mem_reqs;
     vk::GetImageMemoryRequirements(m_device->handle(), image.handle(), &image_mem_reqs);
-    VkMemoryAllocateInfo image_mem_alloc =
-        vk_testing::DeviceMemory::alloc_info(image_mem_reqs.size, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    const auto image_mem_alloc =
+        vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, image_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     vk_testing::DeviceMemory image_mem;
     image_mem.init(*m_device, image_mem_alloc);

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -661,7 +661,10 @@ VkMemoryRequirements Buffer::memory_requirements() const {
 }
 
 void Buffer::bind_memory(const DeviceMemory &mem, VkDeviceSize mem_offset) {
-    EXPECT(vk::BindBufferMemory(device(), handle(), mem.handle(), mem_offset) == VK_SUCCESS);
+    const auto result = vk::BindBufferMemory(device(), handle(), mem.handle(), mem_offset);
+    // Allow successful calls and the calls that cause validation errors (but not actual Vulkan errors).
+    // In the case of a validation error, it's part of the test logic how to handle it.
+    EXPECT(result == VK_SUCCESS || result == VK_ERROR_VALIDATION_FAILED_EXT);
 }
 
 void Buffer::bind_memory(const Device &dev, VkMemoryPropertyFlags mem_props, VkDeviceSize mem_offset) {
@@ -733,7 +736,10 @@ VkMemoryRequirements Image::memory_requirements() const {
 }
 
 void Image::bind_memory(const DeviceMemory &mem, VkDeviceSize mem_offset) {
-    EXPECT(vk::BindImageMemory(device(), handle(), mem.handle(), mem_offset) == VK_SUCCESS);
+    const auto result = vk::BindImageMemory(device(), handle(), mem.handle(), mem_offset);
+    // Allow successful calls and the calls that cause validation errors (but not actual Vulkan errors).
+    // In the case of a validation error, it's part of the test logic how to handle it.
+    EXPECT(result == VK_SUCCESS || result == VK_ERROR_VALIDATION_FAILED_EXT);
 }
 
 VkSubresourceLayout Image::subresource_layout(const VkImageSubresource &subres) const {

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -490,9 +490,10 @@ void DeviceMemory::unmap() const { vk::UnmapMemory(device(), handle()); }
 
 VkMemoryAllocateInfo DeviceMemory::get_resource_alloc_info(const Device &dev, const VkMemoryRequirements &reqs,
                                                            VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
-    VkMemoryAllocateInfo info = alloc_info(reqs.size, 0, alloc_info_pnext);
-    EXPECT(dev.phy().set_memory_type(reqs.memoryTypeBits, &info, mem_props));
-    return info;
+    auto alloc_info = LvlInitStruct<VkMemoryAllocateInfo>(alloc_info_pnext);
+    alloc_info.allocationSize = reqs.size;
+    EXPECT(dev.phy().set_memory_type(reqs.memoryTypeBits, &alloc_info, mem_props));
+    return alloc_info;
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(Fence, vk::DestroyFence)

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -490,15 +490,7 @@ void DeviceMemory::unmap() const { vk::UnmapMemory(device(), handle()); }
 
 VkMemoryAllocateInfo DeviceMemory::get_resource_alloc_info(const Device &dev, const VkMemoryRequirements &reqs,
                                                            VkMemoryPropertyFlags mem_props) {
-    // Find appropriate memory type for given reqs
-    VkPhysicalDeviceMemoryProperties dev_mem_props = dev.phy().memory_properties();
-    uint32_t mem_type_index = 0;
-    for (mem_type_index = 0; mem_type_index < dev_mem_props.memoryTypeCount; ++mem_type_index) {
-        if (mem_props == (mem_props & dev_mem_props.memoryTypes[mem_type_index].propertyFlags)) break;
-    }
-    // If we exceeded types, then this device doesn't have the memory we need
-    assert(mem_type_index < dev_mem_props.memoryTypeCount);
-    VkMemoryAllocateInfo info = alloc_info(reqs.size, mem_type_index);
+    VkMemoryAllocateInfo info = alloc_info(reqs.size, 0);
     EXPECT(dev.phy().set_memory_type(reqs.memoryTypeBits, &info, mem_props));
     return info;
 }

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -325,9 +325,9 @@ class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
     // vkUnmapMemory()
     void unmap() const;
 
-    static VkMemoryAllocateInfo alloc_info(VkDeviceSize size, uint32_t memory_type_index);
+    static VkMemoryAllocateInfo alloc_info(VkDeviceSize size, uint32_t memory_type_index, void *alloc_info_pnext = nullptr);
     static VkMemoryAllocateInfo get_resource_alloc_info(const vk_testing::Device &dev, const VkMemoryRequirements &reqs,
-                                                        VkMemoryPropertyFlags mem_props);
+                                                        VkMemoryPropertyFlags mem_props, void *alloc_info_pnext = nullptr);
 };
 
 class Fence : public internal::NonDispHandle<VkFence> {
@@ -504,7 +504,8 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
     void bind_memory(const Device &dev, VkMemoryPropertyFlags mem_props, VkDeviceSize mem_offset);
 
     const VkBufferCreateInfo &create_info() const { return create_info_; }
-    static VkBufferCreateInfo create_info(VkDeviceSize size, VkFlags usage, const std::vector<uint32_t> *queue_families = nullptr);
+    static VkBufferCreateInfo create_info(VkDeviceSize size, VkFlags usage, const std::vector<uint32_t> *queue_families = nullptr,
+                                          void *create_info_pnext = nullptr);
 
     VkBufferMemoryBarrier buffer_memory_barrier(VkFlags output_mask, VkFlags input_mask, VkDeviceSize offset,
                                                 VkDeviceSize size) const {
@@ -574,13 +575,15 @@ class Image : public internal::NonDispHandle<VkImage> {
   public:
     explicit Image() : NonDispHandle(), format_features_(0) {}
     explicit Image(const Device &dev, const VkImageCreateInfo &info) : format_features_(0) { init(dev, info); }
+    explicit Image(const Device &dev, const VkImageCreateInfo &info, VkMemoryPropertyFlags mem_props,
+                   void *alloc_info_pnext = nullptr);
     explicit Image(const Device &dev, const VkImageCreateInfo &info, NoMemT) : format_features_(0) { init_no_mem(dev, info); }
 
     ~Image() noexcept;
     void destroy() noexcept;
 
     // vkCreateImage()
-    void init(const Device &dev, const VkImageCreateInfo &info, VkMemoryPropertyFlags mem_props);
+    void init(const Device &dev, const VkImageCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext = nullptr);
     void init(const Device &dev, const VkImageCreateInfo &info) { init(dev, info, 0); }
     void init_no_mem(const Device &dev, const VkImageCreateInfo &info);
 
@@ -999,15 +1002,16 @@ class SamplerYcbcrConversion : public internal::NonDispHandle<VkSamplerYcbcrConv
     bool khr_ = false;
 };
 
-inline VkMemoryAllocateInfo DeviceMemory::alloc_info(VkDeviceSize size, uint32_t memory_type_index) {
-    VkMemoryAllocateInfo info = LvlInitStruct<VkMemoryAllocateInfo>();
+inline VkMemoryAllocateInfo DeviceMemory::alloc_info(VkDeviceSize size, uint32_t memory_type_index, void *alloc_info_pnext) {
+    VkMemoryAllocateInfo info = LvlInitStruct<VkMemoryAllocateInfo>(alloc_info_pnext);
     info.allocationSize = size;
     info.memoryTypeIndex = memory_type_index;
     return info;
 }
 
-inline VkBufferCreateInfo Buffer::create_info(VkDeviceSize size, VkFlags usage, const std::vector<uint32_t> *queue_families) {
-    VkBufferCreateInfo info = LvlInitStruct<VkBufferCreateInfo>();
+inline VkBufferCreateInfo Buffer::create_info(VkDeviceSize size, VkFlags usage, const std::vector<uint32_t> *queue_families,
+                                              void *create_info_pnext) {
+    VkBufferCreateInfo info = LvlInitStruct<VkBufferCreateInfo>(create_info_pnext);
     info.size = size;
     info.usage = usage;
 

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -325,7 +325,6 @@ class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
     // vkUnmapMemory()
     void unmap() const;
 
-    static VkMemoryAllocateInfo alloc_info(VkDeviceSize size, uint32_t memory_type_index, void *alloc_info_pnext = nullptr);
     static VkMemoryAllocateInfo get_resource_alloc_info(const vk_testing::Device &dev, const VkMemoryRequirements &reqs,
                                                         VkMemoryPropertyFlags mem_props, void *alloc_info_pnext = nullptr);
 };
@@ -1001,13 +1000,6 @@ class SamplerYcbcrConversion : public internal::NonDispHandle<VkSamplerYcbcrConv
 
     bool khr_ = false;
 };
-
-inline VkMemoryAllocateInfo DeviceMemory::alloc_info(VkDeviceSize size, uint32_t memory_type_index, void *alloc_info_pnext) {
-    VkMemoryAllocateInfo info = LvlInitStruct<VkMemoryAllocateInfo>(alloc_info_pnext);
-    info.allocationSize = size;
-    info.memoryTypeIndex = memory_type_index;
-    return info;
-}
 
 inline VkBufferCreateInfo Buffer::create_info(VkDeviceSize size, VkFlags usage, const std::vector<uint32_t> *queue_families,
                                               void *create_info_pnext) {


### PR DESCRIPTION
Commit 1.  Reverts a3d60640e6f0cb403493d4744881b5e78a8955f8.
That change duplicates what `EXPECT(set_memory_type())` already does, and arguably `set_memory_type()` does it better because it checks only memory types supported by the resource but not all types. Successfully run local test session without this code.

Commit 2.  Adds optional `pNext` to create_info/allocate_info helpers which is similar to how `pNext` is used in other places (for example, `LvLInitStruct`).

Commit 3.  Allows to use `vk_testing::Buffer` and `vk_testing::Image` in the negative tests when BindMemory causes validation error.

Commit 4.  (thanks Juan!) Removes `DeviceMemory::alloc_info` which brings little value and instead `DeviceMemory::get_resource_alloc_info`  can provide  a larger chunk of functionality.