### PR TITLE
tests: Return std::optional for QueueFamilyIndex

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2668,12 +2668,13 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
     uint32_t ray_tracing_queue_family_index = 0;
 
     // If supported, run on the compute only queue.
-    uint32_t compute_only_queue_family_index = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
-    if (compute_only_queue_family_index != vvl::kU32Max) {
-        const auto &compute_only_queues = m_device->queue_family_queues(compute_only_queue_family_index);
+    const std::optional<uint32_t> compute_only_queue_family_index =
+        m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
+    if (compute_only_queue_family_index) {
+        const auto &compute_only_queues = m_device->queue_family_queues(compute_only_queue_family_index.value());
         if (!compute_only_queues.empty()) {
             ray_tracing_queue = compute_only_queues[0]->handle();
-            ray_tracing_queue_family_index = compute_only_queue_family_index;
+            ray_tracing_queue_family_index = compute_only_queue_family_index.value();
         }
     }
 

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -4634,13 +4634,13 @@ TEST_F(VkPositiveLayerTest, FillBufferCmdPoolTransferQueue) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    uint32_t transfer = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT);
-    if (transfer == vvl::kU32Max) {
+    const std::optional<uint32_t> transfer = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT);
+    if (!transfer) {
         GTEST_SKIP() << "Required queue families not present (non-graphics non-compute capable required)";
     }
-    VkQueueObj *queue = m_device->queue_family_queues(transfer)[0].get();
+    VkQueueObj *queue = m_device->queue_family_queues(transfer.value())[0].get();
 
-    VkCommandPoolObj pool(m_device, transfer, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+    VkCommandPoolObj pool(m_device, transfer.value(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     VkCommandBufferObj cb(m_device, &pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
 
     VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -12900,10 +12900,9 @@ TEST_F(VkLayerTest, DescriptorBufferBindingAndOffsets) {
         m_errorMonitor->VerifyFound();
 
         {
-            const uint32_t no_gfx_qfi = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
-            const uint32_t INVALID_QUEUE = std::numeric_limits<uint32_t>::max();
-            if (INVALID_QUEUE != no_gfx_qfi) {
-                VkCommandPoolObj command_pool(m_device, no_gfx_qfi);
+            const std::optional<uint32_t> no_gfx_qfi = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
+            if (no_gfx_qfi) {
+                VkCommandPoolObj command_pool(m_device, no_gfx_qfi.value());
                 ASSERT_TRUE(command_pool.initialized());
                 VkCommandBufferObj command_buffer(m_device, &command_pool);
 
@@ -13134,14 +13133,13 @@ TEST_F(VkLayerTest, DescriptorBufferInvalidBindPoint) {
     }
 
     {
-        const uint32_t no_gfx_qfi = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
-        const uint32_t INVALID_QUEUE = std::numeric_limits<uint32_t>::max();
-        if (INVALID_QUEUE == no_gfx_qfi) {
+        const std::optional<uint32_t> no_gfx_qfi = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
+        if (!no_gfx_qfi) {
             GTEST_SKIP() << "No compute and transfer only queue family, skipping bindpoint and queue tests.";
             return;
         }
 
-        VkCommandPoolObj command_pool(m_device, no_gfx_qfi);
+        VkCommandPoolObj command_pool(m_device, no_gfx_qfi.value());
         ASSERT_TRUE(command_pool.initialized());
         VkCommandBufferObj command_buffer(m_device, &command_pool);
 

--- a/tests/vklayertests_nvidia_best_practices.cpp
+++ b/tests/vklayertests_nvidia_best_practices.cpp
@@ -141,19 +141,28 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
         GTEST_SKIP() << "Test requires sparseBinding";
     }
 
-    VkDeviceQueueCreateInfo general_queue_ci = LvlInitStruct<VkDeviceQueueCreateInfo>();
-    general_queue_ci.queueFamilyIndex = m_device->QueueFamilyMatching(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_SPARSE_BINDING_BIT, 0);
+    auto general_queue_ci = LvlInitStruct<VkDeviceQueueCreateInfo>();
     general_queue_ci.queueCount = 1;
     general_queue_ci.pQueuePriorities = &defaultQueuePriority;
+    {
+        const std::optional<uint32_t> familyIndex =
+            m_device->QueueFamilyMatching(VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_SPARSE_BINDING_BIT, 0);
+        if (!familyIndex) {
+            GTEST_SKIP() << "Required queue families not present";
+        }
+        general_queue_ci.queueFamilyIndex = familyIndex.value();
+    }
 
-    VkDeviceQueueCreateInfo transfer_queue_ci = LvlInitStruct<VkDeviceQueueCreateInfo>();
-    transfer_queue_ci.queueFamilyIndex = m_device->QueueFamilyMatching(VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT,
-                                                                       VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT);
+    auto transfer_queue_ci = LvlInitStruct<VkDeviceQueueCreateInfo>();
     transfer_queue_ci.queueCount = 1;
     transfer_queue_ci.pQueuePriorities = &defaultQueuePriority;
-
-    if (general_queue_ci.queueFamilyIndex == vvl::kU32Max || transfer_queue_ci.queueFamilyIndex == vvl::kU32Max) {
-        GTEST_SKIP() << "Test requires a general and a transfer queue";
+    {
+        const std::optional<uint32_t> familyIndex = m_device->QueueFamilyMatching(
+            VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT, VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT);
+        if (!familyIndex) {
+            GTEST_SKIP() << "Required queue families not present";
+        }
+        transfer_queue_ci.queueFamilyIndex = familyIndex.value();
     }
 
     VkDeviceQueueCreateInfo queue_cis[2] = {
@@ -256,19 +265,26 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
     }
     InitState();
 
-    VkDeviceQueueCreateInfo general_queue_ci = LvlInitStruct<VkDeviceQueueCreateInfo>();
-    general_queue_ci.queueFamilyIndex = m_device->QueueFamilyMatching(VK_QUEUE_GRAPHICS_BIT, 0);
+    auto general_queue_ci = LvlInitStruct<VkDeviceQueueCreateInfo>();
     general_queue_ci.queueCount = 1;
     general_queue_ci.pQueuePriorities = &defaultQueuePriority;
+    {
+        const std::optional<uint32_t> queueFamily = m_device->QueueFamilyMatching(VK_QUEUE_GRAPHICS_BIT, 0);
+        if (!queueFamily) {
+            GTEST_SKIP() << "Required queue families not present";
+        }
+        general_queue_ci.queueFamilyIndex = queueFamily.value();
+    }
 
-    VkDeviceQueueCreateInfo compute_queue_ci = LvlInitStruct<VkDeviceQueueCreateInfo>();
-    compute_queue_ci.queueFamilyIndex = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
+    auto compute_queue_ci = LvlInitStruct<VkDeviceQueueCreateInfo>();
     compute_queue_ci.queueCount = 1;
     compute_queue_ci.pQueuePriorities = &defaultQueuePriority;
-
-    if (general_queue_ci.queueFamilyIndex == vvl::kU32Max || compute_queue_ci.queueFamilyIndex == vvl::kU32Max) {
-        // There's no asynchronous compute queue, skip.
-        return;
+    {
+        const std::optional<uint32_t> queueFamily = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
+        if (!queueFamily) {
+            GTEST_SKIP() << "Required queue families not present";
+        }
+        compute_queue_ci.queueFamilyIndex = queueFamily.value();
     }
 
     VkDeviceQueueCreateInfo queue_cis[2] = {

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -32,6 +32,7 @@
 #include "vk_format_utils.h"
 #include "vk_extension_helper.h"
 #include "vk_layer_settings_ext.h"
+#include "layer_validation_tests.h"
 
 using std::string;
 using std::strncmp;
@@ -1080,15 +1081,15 @@ VkDeviceObj::VkDeviceObj(uint32_t id, VkPhysicalDevice obj, vector<const char *>
     queue_props = phy().queue_properties();
 }
 
-uint32_t VkDeviceObj::QueueFamilyMatching(VkQueueFlags with, VkQueueFlags without, bool all_bits) {
-    for (uint32_t i = 0; i < queue_props.size(); i++) {
-        auto flags = queue_props[i].queueFlags;
-        bool matches = all_bits ? (flags & with) == with : (flags & with) != 0;
+std::optional<uint32_t> VkDeviceObj::QueueFamilyMatching(VkQueueFlags with, VkQueueFlags without, bool all_bits) {
+    for (uint32_t i = 0; i < size32(queue_props); i++) {
+        const auto flags = queue_props[i].queueFlags;
+        const bool matches = all_bits ? (flags & with) == with : (flags & with) != 0;
         if (matches && ((flags & without) == 0) && (queue_props[i].queueCount > 0)) {
             return i;
         }
     }
-    return vvl::kU32Max;
+    return {};
 }
 
 void VkDeviceObj::SetDeviceQueue() {

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -66,8 +66,8 @@ class VkDeviceObj : public vk_testing::Device {
                 VkPhysicalDeviceFeatures *features = nullptr, void *create_device_pnext = nullptr);
 
     // Find a queue family with and without desired capabilities
-    uint32_t QueueFamilyMatching(VkQueueFlags with, VkQueueFlags without, bool all_bits = true);
-    uint32_t QueueFamilyWithoutCapabilities(VkQueueFlags capabilities) {
+    std::optional<uint32_t> QueueFamilyMatching(VkQueueFlags with, VkQueueFlags without, bool all_bits = true);
+    std::optional<uint32_t> QueueFamilyWithoutCapabilities(VkQueueFlags capabilities) {
         // an all_bits match with 0 matches all
         return QueueFamilyMatching(VkQueueFlags(0), capabilities, true /* all_bits with */);
     }


### PR DESCRIPTION
Cleaner than checking UINT32_MAX, and less error prone due to stricter type checking.