### PR TITLE
docs: Remove author section

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -12,10 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Lenny Komow <lenny@lunarg.com>
-# Author: Nathaniel Cesario <nathaniel@lunarg.com>
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 name: Android
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -12,10 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Lenny Komow <lenny@lunarg.com>
-# Author: Nathaniel Cesario <nathaniel@lunarg.com>
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 name: Linux (formatting, build, test)
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -12,10 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Lenny Komow <lenny@lunarg.com>
-# Author: Nathaniel Cesario <nathaniel@lunarg.com>
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 name: Windows (build)
 

--- a/layers/VkLayer_khronos_validation.def
+++ b/layers/VkLayer_khronos_validation.def
@@ -2,8 +2,8 @@
 ;;;; Begin Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;
 ; Copyright (c) 2015-2019 The Khronos Group Inc.
-; Copyright (c) 2015-2019 Valve Corporation
-; Copyright (c) 2015-2019 LunarG, Inc.
+; Copyright (c) 2015-2023 Valve Corporation
+; Copyright (c) 2015-2023 LunarG, Inc.
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@
 ; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
-;
-;  Author: Mark Lobodzinski <mark@LunarG.com>
-;
 ;;;;  End Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 LIBRARY VkLayer_khronos_validation

--- a/layers/android_ndk_types.h
+++ b/layers/android_ndk_types.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2018-2021 The Khronos Group Inc.
- * Copyright (c) 2018-2021 Valve Corporation
- * Copyright (c) 2018-2021 LunarG, Inc.
+ * Copyright (c) 2018-2023 Valve Corporation
+ * Copyright (c) 2018-2023 LunarG, Inc.
  * Copyright (C) 2018-2021 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Dave Houlton <daveh@lunarg.com>
  */
 
 // Overview of Android NDK headers:

--- a/layers/best_practices/best_practices_error_enums.h
+++ b/layers/best_practices/best_practices_error_enums.h
@@ -16,10 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Camden Stocker <camden@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #ifndef BEST_PRACTICES_ERROR_ENUMS_H_

--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -15,10 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Camden Stocker <camden@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #include "best_practices/best_practices_validation.h"

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -15,10 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Camden Stocker <camden@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #pragma once

--- a/layers/cast_utils.h
+++ b/layers/cast_utils.h
@@ -13,9 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: John Zulauf <jzulauf@lunarg.com>
- *
  */
 #pragma once
 #ifndef CAST_UTILS_H_

--- a/layers/convert_to_renderpass2.cpp
+++ b/layers/convert_to_renderpass2.cpp
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tobias Hector <@tobski>
  */
 
 #include "convert_to_renderpass2.h"

--- a/layers/convert_to_renderpass2.h
+++ b/layers/convert_to_renderpass2.h
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tobias Hector <@tobski>
  */
 
 #pragma once

--- a/layers/core_checks/android_validation.cpp
+++ b/layers/core_checks/android_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <vector>

--- a/layers/core_checks/buffer_validation.cpp
+++ b/layers/core_checks/buffer_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <algorithm>

--- a/layers/core_checks/cmd_buffer_dynamic_validation.cpp
+++ b/layers/core_checks/cmd_buffer_dynamic_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <sstream>

--- a/layers/core_checks/cmd_buffer_validation.cpp
+++ b/layers/core_checks/cmd_buffer_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <assert.h>

--- a/layers/core_checks/copy_blit_resolve_validation.cpp
+++ b/layers/core_checks/copy_blit_resolve_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <string>

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -16,15 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #pragma once

--- a/layers/core_checks/descriptor_validation.cpp
+++ b/layers/core_checks/descriptor_validation.cpp
@@ -14,11 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tobin Ehlis <tobine@google.com>
- *         John Zulauf <jzulauf@lunarg.com>
- *         Jeremy Kniager <jeremyk@lunarg.com>
- *         Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <valarray>

--- a/layers/core_checks/device_memory_validation.cpp
+++ b/layers/core_checks/device_memory_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <assert.h>

--- a/layers/core_checks/device_validation.cpp
+++ b/layers/core_checks/device_validation.cpp
@@ -15,29 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
- *
+ * 
  * This file deals with anything related to Phyiscal Devices, Logical Devices, or Device Queues Families, Device Masks, etc
  */
 

--- a/layers/core_checks/drawdispatch_validation.cpp
+++ b/layers/core_checks/drawdispatch_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include "chassis.h"

--- a/layers/core_checks/external_object_validation.cpp
+++ b/layers/core_checks/external_object_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include "vk_enum_string_helper.h"

--- a/layers/core_checks/image_layout_validation.cpp
+++ b/layers/core_checks/image_layout_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <assert.h>

--- a/layers/core_checks/image_validation.cpp
+++ b/layers/core_checks/image_validation.cpp
@@ -17,11 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Shannon McPherson <shannon@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #include <string>

--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -16,29 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #include <string>

--- a/layers/core_checks/query_validation.cpp
+++ b/layers/core_checks/query_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <assert.h>

--- a/layers/core_checks/queue_validation.cpp
+++ b/layers/core_checks/queue_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <string>

--- a/layers/core_checks/ray_tracing_validation.cpp
+++ b/layers/core_checks/ray_tracing_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <algorithm>

--- a/layers/core_checks/render_pass_validation.cpp
+++ b/layers/core_checks/render_pass_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <algorithm>

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -15,10 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include "core_checks/shader_validation.h"

--- a/layers/core_checks/shader_validation.h
+++ b/layers/core_checks/shader_validation.h
@@ -15,8 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- *
  * The Shader Validation file is in charge of taking the Shader Module data and validating it
  */
 #ifndef VULKAN_SHADER_VALIDATION_H

--- a/layers/core_checks/synchronization_validation.cpp
+++ b/layers/core_checks/synchronization_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <algorithm>

--- a/layers/core_checks/video_validation.cpp
+++ b/layers/core_checks/video_validation.cpp
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #include <assert.h>

--- a/layers/core_checks/wsi_validation.cpp
+++ b/layers/core_checks/wsi_validation.cpp
@@ -15,28 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Michael Lentine <mlentine@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chia-I Wu <olv@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Ian Elliott <ianelliott@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Jeremy Hayes <jeremy@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
- * Author: Mike Weiblen <mikew@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <algorithm>

--- a/layers/core_error_location.cpp
+++ b/layers/core_error_location.cpp
@@ -1,6 +1,6 @@
 /* Copyright (c) 2021-2022 The Khronos Group Inc.
- * Copyright (c) 2021-2022 Valve Corporation
- * Copyright (c) 2021-2022 LunarG, Inc.
+ * Copyright (c) 2021-2023 Valve Corporation
+ * Copyright (c) 2021-2023 LunarG, Inc.
  * Copyright (C) 2021-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #include "core_error_location.h"
 #include <map>

--- a/layers/core_error_location.h
+++ b/layers/core_error_location.h
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #pragma once
 

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -14,14 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Camden Stocker <camden@lunarg.com>
  */
 #ifndef CORE_VALIDATION_ERROR_ENUMS_H_
 #define CORE_VALIDATION_ERROR_ENUMS_H_

--- a/layers/generated/best_practices.cpp
+++ b/layers/generated/best_practices.cpp
@@ -19,10 +19,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
- *
  ****************************************************************************/
 
 

--- a/layers/generated/best_practices.h
+++ b/layers/generated/best_practices.h
@@ -19,10 +19,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
- *
  ****************************************************************************/
 
 

--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -18,9 +18,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
  */
 
 

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -18,9 +18,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
  */
 #pragma once
 

--- a/layers/generated/chassis_dispatch_helper.h
+++ b/layers/generated/chassis_dispatch_helper.h
@@ -18,9 +18,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
  */
 #pragma once
 

--- a/layers/generated/command_validation.cpp
+++ b/layers/generated/command_validation.cpp
@@ -17,9 +17,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Spencer Fricke <s.fricke@samsung.com>
- *
  ****************************************************************************/
 
 #include "vk_layer_logging.h"

--- a/layers/generated/command_validation.h
+++ b/layers/generated/command_validation.h
@@ -17,9 +17,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Spencer Fricke <s.fricke@samsung.com>
- *
  ****************************************************************************/
 
 #pragma once

--- a/layers/generated/enum_flag_bits.h
+++ b/layers/generated/enum_flag_bits.h
@@ -17,9 +17,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@LunarG.com>
- * Author: Dave Houlton <daveh@LunarG.com>
  */
 
 

--- a/layers/generated/gpu_as_inspection_comp.h
+++ b/layers/generated/gpu_as_inspection_comp.h
@@ -7,8 +7,8 @@
 /***************************************************************************
 *
 * Copyright (c) 2021-2022 The Khronos Group Inc.
-* Copyright (c) 2021-2022 Valve Corporation
-* Copyright (c) 2021-2022 LunarG, Inc.
+* Copyright (c) 2021-2023 Valve Corporation
+* Copyright (c) 2021-2023 LunarG, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,10 +21,6 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*
-* Author: Tony Barbour <tony@lunarg.com>
-* Author: Spencer Fricke <spencerfricke@gmail.com>
-*
 ****************************************************************************/
 
 // disassembled SPIR-V

--- a/layers/generated/gpu_pre_dispatch_comp.h
+++ b/layers/generated/gpu_pre_dispatch_comp.h
@@ -7,8 +7,8 @@
 /***************************************************************************
 *
 * Copyright (c) 2021-2022 The Khronos Group Inc.
-* Copyright (c) 2021-2022 Valve Corporation
-* Copyright (c) 2021-2022 LunarG, Inc.
+* Copyright (c) 2021-2023 Valve Corporation
+* Copyright (c) 2021-2023 LunarG, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,10 +21,6 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*
-* Author: Tony Barbour <tony@lunarg.com>
-* Author: Spencer Fricke <spencerfricke@gmail.com>
-*
 ****************************************************************************/
 
 // disassembled SPIR-V

--- a/layers/generated/gpu_pre_draw_vert.h
+++ b/layers/generated/gpu_pre_draw_vert.h
@@ -7,8 +7,8 @@
 /***************************************************************************
 *
 * Copyright (c) 2021-2022 The Khronos Group Inc.
-* Copyright (c) 2021-2022 Valve Corporation
-* Copyright (c) 2021-2022 LunarG, Inc.
+* Copyright (c) 2021-2023 Valve Corporation
+* Copyright (c) 2021-2023 LunarG, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,10 +21,6 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*
-* Author: Tony Barbour <tony@lunarg.com>
-* Author: Spencer Fricke <spencerfricke@gmail.com>
-*
 ****************************************************************************/
 
 // disassembled SPIR-V

--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -18,8 +18,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */
 
 #include <mutex>

--- a/layers/generated/layer_chassis_dispatch.h
+++ b/layers/generated/layer_chassis_dispatch.h
@@ -19,8 +19,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */
 #pragma once
 

--- a/layers/generated/lvt_function_pointers.cpp
+++ b/layers/generated/lvt_function_pointers.cpp
@@ -17,8 +17,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */
 
 

--- a/layers/generated/lvt_function_pointers.h
+++ b/layers/generated/lvt_function_pointers.h
@@ -18,8 +18,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */
 
 

--- a/layers/generated/object_tracker.cpp
+++ b/layers/generated/object_tracker.cpp
@@ -20,10 +20,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- *
  ****************************************************************************/
 
 

--- a/layers/generated/object_tracker.h
+++ b/layers/generated/object_tracker.h
@@ -20,10 +20,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- *
  ****************************************************************************/
 
 

--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -17,9 +17,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@LunarG.com>
- * Author: Dave Houlton <daveh@LunarG.com>
  */
 
 

--- a/layers/generated/parameter_validation.h
+++ b/layers/generated/parameter_validation.h
@@ -17,9 +17,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@LunarG.com>
- * Author: Dave Houlton <daveh@LunarG.com>
  */
 
 

--- a/layers/generated/spirv_grammar_helper.cpp
+++ b/layers/generated/spirv_grammar_helper.cpp
@@ -18,8 +18,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Author: Spencer Fricke <s.fricke@samsung.com>
- *
  * This file is related to anything that is found in the SPIR-V grammar
  * file found in the SPIRV-Headers. Mainly used for SPIR-V util functions.
  *

--- a/layers/generated/spirv_grammar_helper.h
+++ b/layers/generated/spirv_grammar_helper.h
@@ -18,8 +18,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Author: Spencer Fricke <s.fricke@samsung.com>
- *
  * This file is related to anything that is found in the SPIR-V grammar
  * file found in the SPIRV-Headers. Mainly used for SPIR-V util functions.
  *

--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -19,10 +19,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Chris Forbes <chrisforbes@google.com>
- * Author: Cort Stratton <cort@google.com>
- *
  ****************************************************************************/
 #pragma once
 

--- a/layers/generated/spirv_validation_helper.cpp
+++ b/layers/generated/spirv_validation_helper.cpp
@@ -18,8 +18,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Author: Spencer Fricke <s.fricke@samsung.com>
- *
  * This file is related to anything that is found in the Vulkan XML related
  * to SPIR-V. Anything related to the SPIR-V grammar belongs in spirv_grammar_helper
  *

--- a/layers/generated/sync_validation_types.cpp
+++ b/layers/generated/sync_validation_types.cpp
@@ -20,14 +20,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisforbes@google.com>
- * Author: John Zulauf<jzulauf@lunarg.com>
- * Author: Tony Barbour <tony@lunarg.com>
- *
  ****************************************************************************/
 
 #include "sync_validation_types.h"

--- a/layers/generated/sync_validation_types.h
+++ b/layers/generated/sync_validation_types.h
@@ -20,14 +20,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisforbes@google.com>
- * Author: John Zulauf<jzulauf@lunarg.com>
- * Author: Tony Barbour <tony@lunarg.com>
- *
  ****************************************************************************/
 
 #pragma once

--- a/layers/generated/thread_safety.cpp
+++ b/layers/generated/thread_safety.cpp
@@ -18,8 +18,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */
 #include "chassis.h"
 #include "layer_chassis_dispatch.h"

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -18,8 +18,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */
 
 #pragma once

--- a/layers/generated/valid_param_values.cpp
+++ b/layers/generated/valid_param_values.cpp
@@ -17,9 +17,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@LunarG.com>
- * Author: Dave Houlton <daveh@LunarG.com>
  */
 
 

--- a/layers/generated/valid_param_values.h
+++ b/layers/generated/valid_param_values.h
@@ -17,9 +17,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@LunarG.com>
- * Author: Dave Houlton <daveh@LunarG.com>
  */
 
 

--- a/layers/generated/vk_dispatch_table_helper.h
+++ b/layers/generated/vk_dispatch_table_helper.h
@@ -18,10 +18,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */
 
 #include <vulkan/vulkan.h>

--- a/layers/generated/vk_enum_string_helper.h
+++ b/layers/generated/vk_enum_string_helper.h
@@ -20,14 +20,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisforbes@google.com>
- * Author: John Zulauf<jzulauf@lunarg.com>
- * Author: Tony Barbour <tony@lunarg.com>
- *
  ****************************************************************************/
 
 

--- a/layers/generated/vk_extension_helper.h
+++ b/layers/generated/vk_extension_helper.h
@@ -20,14 +20,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisforbes@google.com>
- * Author: John Zulauf<jzulauf@lunarg.com>
- * Author: Tony Barbour <tony@lunarg.com>
- *
  ****************************************************************************/
 
 

--- a/layers/generated/vk_format_utils.cpp
+++ b/layers/generated/vk_format_utils.cpp
@@ -19,11 +19,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Spencer Fricke <s.fricke@samsung.com>
- *
  ****************************************************************************/
 
 #include "vk_format_utils.h"

--- a/layers/generated/vk_format_utils.h
+++ b/layers/generated/vk_format_utils.h
@@ -19,11 +19,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Spencer Fricke <s.fricke@samsung.com>
- *
  ****************************************************************************/
 
 #pragma once

--- a/layers/generated/vk_layer_dispatch_table.h
+++ b/layers/generated/vk_layer_dispatch_table.h
@@ -17,9 +17,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
  */
 
 #pragma once

--- a/layers/generated/vk_object_types.h
+++ b/layers/generated/vk_object_types.h
@@ -20,14 +20,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisforbes@google.com>
- * Author: John Zulauf<jzulauf@lunarg.com>
- * Author: Tony Barbour <tony@lunarg.com>
- *
  ****************************************************************************/
 
 

--- a/layers/generated/vk_safe_struct.cpp
+++ b/layers/generated/vk_safe_struct.cpp
@@ -20,14 +20,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisforbes@google.com>
- * Author: John Zulauf<jzulauf@lunarg.com>
- * Author: Tony Barbour <tony@lunarg.com>
- *
  ****************************************************************************/
 
 

--- a/layers/generated/vk_safe_struct.h
+++ b/layers/generated/vk_safe_struct.h
@@ -20,14 +20,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisforbes@google.com>
- * Author: John Zulauf<jzulauf@lunarg.com>
- * Author: Tony Barbour <tony@lunarg.com>
- *
  ****************************************************************************/
 
 

--- a/layers/generated/vk_typemap_helper.h
+++ b/layers/generated/vk_typemap_helper.h
@@ -20,14 +20,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisforbes@google.com>
- * Author: John Zulauf<jzulauf@lunarg.com>
- * Author: Tony Barbour <tony@lunarg.com>
- *
  ****************************************************************************/
 
 #pragma once

--- a/layers/generated/vk_validation_error_messages.h
+++ b/layers/generated/vk_validation_error_messages.h
@@ -17,9 +17,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
  */
 
 #pragma once

--- a/layers/gpu_shaders/gpu_pre_dispatch.comp
+++ b/layers/gpu_shaders/gpu_pre_dispatch.comp
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 The Khronos Group Inc.
-// Copyright (c) 2022 Valve Corporation
-// Copyright (c) 2022 LunarG, Inc.
+// Copyright (c) 2022-2023 Valve Corporation
+// Copyright (c) 2022-2023 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,9 +13,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// * Author: Spencer Fricke <spencerfricke@gmail.com>
-//
 
 #version 450
 #define VAL_OUT_RECORD_SZ 10

--- a/layers/gpu_shaders/gpu_pre_draw.vert
+++ b/layers/gpu_shaders/gpu_pre_draw.vert
@@ -1,6 +1,6 @@
 // Copyright (c) 2021-2022 The Khronos Group Inc.
-// Copyright (c) 2021-2022 Valve Corporation
-// Copyright (c) 2021-2022 LunarG, Inc.
+// Copyright (c) 2021-2023 Valve Corporation
+// Copyright (c) 2021-2023 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,9 +13,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// * Author: Tony Barbour <tony@lunarg.com>
-//
 
 #version 450
 #define VAL_OUT_RECORD_SZ 10

--- a/layers/gpu_shaders/gpu_shaders_constants.h
+++ b/layers/gpu_shaders/gpu_shaders_constants.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2021-2022 The Khronos Group Inc.
-// Copyright (c) 2021-2022 Valve Corporation
-// Copyright (c) 2021-2022 LunarG, Inc.
+// Copyright (c) 2021-2023 Valve Corporation
+// Copyright (c) 2021-2023 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,9 +13,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-// * Author: Tony Barbour <tony@lunarg.com>
-//
 // Values used between the GLSL shaders and the GPU-AV logic
 
 #ifndef GPU_SHADER_CONSTANTS

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tony Barbour <tony@lunarg.com>
  */
 
 #include "gpu_validation/debug_printf.h"

--- a/layers/gpu_validation/debug_printf.h
+++ b/layers/gpu_validation/debug_printf.h
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tony Barbour <tony@lunarg.com>
  */
 
 #pragma once

--- a/layers/gpu_validation/gpu_utils.cpp
+++ b/layers/gpu_validation/gpu_utils.cpp
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tony Barbour <tony@lunarg.com>
  */
 
 #include "gpu_validation/gpu_utils.h"

--- a/layers/gpu_validation/gpu_utils.h
+++ b/layers/gpu_validation/gpu_utils.h
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tony Barbour <tony@lunarg.com>
  */
 #pragma once
 #include "chassis.h"

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -13,9 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Tony Barbour <tony@lunarg.com>
  */
 
 #include <climits>

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -13,9 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Karl Schultz <karl@lunarg.com>
- * Author: Tony Barbour <tony@lunarg.com>
  */
 
 #pragma once

--- a/layers/gpu_validation/gpu_vuids.h
+++ b/layers/gpu_validation/gpu_vuids.h
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tony Barbour <tony@lunarg.com>
  */
 
 #include "gpu_validation/gpu_validation.h"

--- a/layers/hash_util.h
+++ b/layers/hash_util.h
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 #ifndef HASH_UTIL_H_
 #define HASH_UTIL_H_

--- a/layers/hash_vk_types.h
+++ b/layers/hash_vk_types.h
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 #ifndef HASH_VK_TYPES_H_
 #define HASH_VK_TYPES_H_

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -14,10 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
  */
 
 #include "layer_options.h"

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -14,10 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
  */
 
 #include "chassis.h"

--- a/layers/object_lifetime_validation.h
+++ b/layers/object_lifetime_validation.h
@@ -14,10 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Tobin Ehlis <tobine@google.com>
  */
 
 // clang-format off

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -14,10 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Tobin Ehlis <tobin@lunarg.com>
  */
 
 #include "chassis.h"

--- a/layers/qfo_transfer.h
+++ b/layers/qfo_transfer.h
@@ -15,14 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 #pragma once
 #include "vk_layer_data.h"

--- a/layers/state_tracker/base_node.cpp
+++ b/layers/state_tracker/base_node.cpp
@@ -15,15 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #include "state_tracker/base_node.h"
 #include "vk_layer_utils.h"

--- a/layers/state_tracker/base_node.h
+++ b/layers/state_tracker/base_node.h
@@ -15,15 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #pragma once
 

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -16,16 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 #include "state_tracker/buffer_state.h"
 #include "layer_chassis_dispatch.h"

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -16,16 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 #pragma once
 #include "state_tracker/device_memory_state.h"

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -16,15 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 #include "state_tracker/cmd_buffer_state.h"
 #include "state_tracker/render_pass_state.h"

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -16,15 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 #pragma once
 #include "state_tracker/base_node.h"

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -14,11 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tobin Ehlis <tobine@google.com>
- *         John Zulauf <jzulauf@lunarg.com>
- *         Jeremy Kniager <jeremyk@lunarg.com>
- *         Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include "state_tracker/descriptor_sets.h"

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -14,9 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tobin Ehlis <tobine@google.com>
- *         John Zulauf <jzulauf@lunarg.com>
  */
 #ifndef CORE_VALIDATION_DESCRIPTOR_SETS_H_
 #define CORE_VALIDATION_DESCRIPTOR_SETS_H_

--- a/layers/state_tracker/device_memory_state.cpp
+++ b/layers/state_tracker/device_memory_state.cpp
@@ -15,15 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #include "state_tracker/device_memory_state.h"
 #include "state_tracker/image_state.h"

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -15,15 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #pragma once
 #include "state_tracker/base_node.h"

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -15,14 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 #pragma once
 #include "state_tracker/base_node.h"

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -16,16 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 #include "state_tracker/image_state.h"
 #include "state_tracker/pipeline_state.h"

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -16,16 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 #pragma once
 

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -15,16 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
  */
 
 #include "state_tracker/pipeline_layout_state.h"

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -15,16 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
  */
 
 #pragma once

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -15,15 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #include "state_tracker/pipeline_state.h"
 #include "state_tracker/descriptor_sets.h"

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -15,15 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #pragma once
 #include "hash_vk_types.h"

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
  */
 
 #include "state_tracker/pipeline_sub_state.h"

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
  */
 
 #pragma once

--- a/layers/state_tracker/query_state.h
+++ b/layers/state_tracker/query_state.h
@@ -16,15 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 #pragma once
 #include "state_tracker/base_node.h"

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -15,14 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 #include "state_tracker/queue_state.h"
 #include "state_tracker/cmd_buffer_state.h"

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -15,14 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 #pragma once
 #include "state_tracker/base_node.h"

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -15,15 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #pragma once
 #include "state_tracker/device_memory_state.h"

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -15,15 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include "state_tracker/render_pass_state.h"

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -15,15 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #pragma once
 #include "state_tracker/base_node.h"

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -15,14 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 #pragma once
 #include "state_tracker/base_node.h"

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -11,8 +11,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Spencer Fricke <spencerfricke@gmail.com>
  */
 
 #include "state_tracker/shader_instruction.h"

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -11,9 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Spencer Fricke <spencerfricke@gmail.com>
- *
+ * 
  * The Shader Instruction file is in charge of holding instruction information
  */
 #pragma once

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -11,8 +11,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Spencer Fricke <s.fricke@samsung.com>
  */
 
 #include "state_tracker/shader_module.h"

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -11,9 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Spencer Fricke <s.fricke@samsung.com>
- *
+ * 
  * The Shader Module file is in charge of all things around creating and parsing an internal representation of a shader module
  */
 #ifndef VULKAN_SHADER_MODULE_H

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -16,12 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Shannon McPherson <shannon@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #include <algorithm>

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -16,14 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtneygo@google.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #pragma once

--- a/layers/state_tracker/video_session_state.cpp
+++ b/layers/state_tracker/video_session_state.cpp
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 #include "state_tracker/video_session_state.h"
 #include "state_tracker/image_state.h"

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -12,8 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 #pragma once
 

--- a/layers/stateless/parameter_validation_utils.cpp
+++ b/layers/stateless/parameter_validation_utils.cpp
@@ -14,9 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@LunarG.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include <cmath>

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -14,9 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Dustin Graves <dustin@lunarg.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */
 
 #pragma once

--- a/layers/sync/sync_utils.cpp
+++ b/layers/sync/sync_utils.cpp
@@ -13,10 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Locke Lin <locke@lunarg.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #include "sync/sync_utils.h"
 #include "state_tracker/state_tracker.h"

--- a/layers/sync/sync_utils.h
+++ b/layers/sync/sync_utils.h
@@ -13,10 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Locke Lin <locke@lunarg.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #pragma once

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -13,10 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Locke Lin <locke@lunarg.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #include <algorithm>

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -13,10 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Locke Lin <locke@lunarg.com>
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 
 #pragma once

--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #include "sync/sync_vuid_maps.h"
 #include "core_error_location.h"

--- a/layers/sync/sync_vuid_maps.h
+++ b/layers/sync/sync_vuid_maps.h
@@ -14,8 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Jeremy Gebben <jeremyg@lunarg.com>
  */
 #pragma once
 #include <string>

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -16,11 +16,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Tobin Ehlis <tobin@lunarg.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
  **************************************************************************/
 #include "vk_layer_config.h"
 

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -13,9 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Jon Ashburn <jon@lunarg.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
  **************************************************************************/
 #pragma once
 

--- a/layers/vk_layer_data.h
+++ b/layers/vk_layer_data.h
@@ -13,10 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Jeff Bolz <jbolz@nvidia.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
 
  */
 

--- a/layers/vk_layer_extension_utils.cpp
+++ b/layers/vk_layer_extension_utils.cpp
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-2020 The Khronos Group Inc.
- * Copyright (c) 2015-2020 Valve Corporation
- * Copyright (c) 2015-2020 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- *
  */
 
 #include <string.h>

--- a/layers/vk_layer_extension_utils.h
+++ b/layers/vk_layer_extension_utils.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- *
  */
 
 #include "vulkan/vk_layer.h"

--- a/layers/vk_layer_logging.cpp
+++ b/layers/vk_layer_logging.cpp
@@ -13,12 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Tobin Ehlis <tobin@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- *
  */
 #include "vk_layer_logging.h"
 

--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -13,12 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Tobin Ehlis <tobin@lunarg.com>
- * Author: Mark Young <marky@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- *
  */
 
 #pragma once

--- a/layers/vk_layer_settings_ext.h
+++ b/layers/vk_layer_settings_ext.h
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 The Khronos Group Inc.
- * Copyright (c) 2020 Valve Corporation
- * Copyright (c) 2020-2022 LunarG, Inc.
+ * Copyright (c) 2020-2023 Valve Corporation
+ * Copyright (c) 2020-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Schuchardt <mikes@lunarg.com>
  */
 
 #pragma once

--- a/layers/vk_layer_utils.cpp
+++ b/layers/vk_layer_utils.cpp
@@ -13,10 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- *
  */
 
 #include "vk_layer_utils.h"

--- a/layers/vk_layer_utils.h
+++ b/layers/vk_layer_utils.h
@@ -14,11 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #pragma once

--- a/scripts/antialias_source.py
+++ b/scripts/antialias_source.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2020 Valve Corporation
-# Copyright (c) 2020 LunarG, Inc.
+# Copyright (c) 2020-2023 Valve Corporation
+# Copyright (c) 2020-2023 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mike Schuchardt <mikes@lunarg.com>
 
 # Scrub source code of "aliases" -- extension types and enums that have been promoted to core.
 #

--- a/scripts/best_practices_generator.py
+++ b/scripts/best_practices_generator.py
@@ -15,9 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
-# Author: Nadav Geva <nadav.geva@amd.com>
 
 import os,re,sys,string,json
 import xml.etree.ElementTree as etree
@@ -169,10 +166,6 @@ class BestPracticesOutputGenerator(OutputGenerator):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
-        copyright += ' * Author: Nadav Geva <nadav.geva@amd.com>\n'
-        copyright += ' *\n'
         copyright += ' ****************************************************************************/\n'
         self.otwrite('both', copyright)
         self.newline()

--- a/scripts/check_code_format.py
+++ b/scripts/check_code_format.py
@@ -13,12 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
-# Author: Mike Schuchardt <mikes@lunarg.com>
-# Author: Nathaniel Cesario <nathaniel@lunarg.com>
-# Author: Karl Schultz <karl@lunarg.com>
-# Author: Tony Barbour <tony@lunarg.com>
 
 # Script to determine if source code in Pull Request is properly formatted.
 #

--- a/scripts/command_validation_generator.py
+++ b/scripts/command_validation_generator.py
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Spencer Fricke <s.fricke@samsung.com>
 
 import os,re,sys,string,json
 import xml.etree.ElementTree as etree
@@ -156,9 +154,6 @@ class CommandValidationOutputGenerator(OutputGenerator):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Spencer Fricke <s.fricke@samsung.com>\n'
-        copyright += ' *\n'
         copyright += ' ****************************************************************************/\n'
         write(copyright, file=self.outFile)
 

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -15,8 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 import os
 import sys

--- a/scripts/common_codegen.py
+++ b/scripts/common_codegen.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2017, 2019-2021 The Khronos Group Inc.
-# Copyright (c) 2015-2017, 2019-2021 Valve Corporation
-# Copyright (c) 2015-2017, 2019-2021 LunarG, Inc.
+# Copyright (c) 2015-2021 The Khronos Group Inc.
+# Copyright (c) 2015-2023 Valve Corporation
+# Copyright (c) 2015-2023 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 import os,re,sys,string
 import xml.etree.ElementTree as etree
@@ -25,10 +23,10 @@ from collections import namedtuple, OrderedDict
 # Copyright text prefixing all headers (list of strings).
 prefixStrings = [
     '/*',
-    '** Copyright (c) 2015-2017, 2019-2021 The Khronos Group Inc.',
-    '** Copyright (c) 2015-2017, 2019-2021 Valve Corporation',
-    '** Copyright (c) 2015-2017, 2019-2021 LunarG, Inc.',
-    '** Copyright (c) 2015-2017, 2019-2021 Google Inc.',
+    '** Copyright (c) 2015-2021 The Khronos Group Inc.',
+    '** Copyright (c) 2015-2023 Valve Corporation',
+    '** Copyright (c) 2015-2023 LunarG, Inc.',
+    '** Copyright (c) 2015-2021 Google Inc.',
     '**',
     '** Licensed under the Apache License, Version 2.0 (the "License");',
     '** you may not use this file except in compliance with the License.',

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -16,8 +16,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 import os,re,sys
 import xml.etree.ElementTree as etree
@@ -116,10 +114,6 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>\n'
-        copyright += ' * Author: Jon Ashburn <jon@lunarg.com>\n'
-        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
         copyright += ' */\n'
 
         preamble = ''

--- a/scripts/external_revision_generator.py
+++ b/scripts/external_revision_generator.py
@@ -16,9 +16,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Cort Stratton <cort@google.com>
-# Author: Jean-Francois Roy <jfroy@google.com>
 
 import argparse
 import hashlib
@@ -54,10 +51,6 @@ def generate(symbol_name, commit_id, output_header_file):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Chris Forbes <chrisforbes@google.com>\n'
-        copyright += ' * Author: Cort Stratton <cort@google.com>\n'
-        copyright += ' *\n'
         copyright += ' ****************************************************************************/\n'
         header_file.write(copyright)
         # Contents

--- a/scripts/format_utils_generator.py
+++ b/scripts/format_utils_generator.py
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Spencer Fricke <s.fricke@samsung.com>
 
 import sys
 from generator import *
@@ -141,11 +139,6 @@ class FormatUtilsOutputGenerator(OutputGenerator):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
-        copyright += ' * Author: Dave Houlton <daveh@lunarg.com>\n'
-        copyright += ' * Author: Spencer Fricke <s.fricke@samsung.com>\n'
-        copyright += ' *\n'
         copyright += ' ****************************************************************************/\n'
         write(copyright, file=self.outFile)
         if self.sourceFile:

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -15,8 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mike Schuchardt <mikes@lunarg.com>
 
 import argparse
 import filecmp

--- a/scripts/generate_spirv.py
+++ b/scripts/generate_spirv.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2016-2022 Valve Corporation
-# Copyright (c) 2016-2022 LunarG, Inc.
+# Copyright (c) 2016-2023 Valve Corporation
+# Copyright (c) 2016-2023 LunarG, Inc.
 # Copyright (c) 2016-2022 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Tony Barbour <tony@lunarg.com>
-# Author: Spencer Fricke <spencerfricke@gmail.com>
 #
 # Compile GLSL to SPIR-V. Depends on glslangValidator
 
@@ -87,8 +84,8 @@ def write(words, disassembled, filename, outfilename = None):
 /***************************************************************************
 *
 * Copyright (c) 2021-2022 The Khronos Group Inc.
-* Copyright (c) 2021-2022 Valve Corporation
-* Copyright (c) 2021-2022 LunarG, Inc.
+* Copyright (c) 2021-2023 Valve Corporation
+* Copyright (c) 2021-2023 LunarG, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -101,9 +98,6 @@ def write(words, disassembled, filename, outfilename = None):
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-*
-* Author: Tony Barbour <tony@lunarg.com>
-* Author: Spencer Fricke <spencerfricke@gmail.com>
 *
 ****************************************************************************/
 

--- a/scripts/github_ci_android.py
+++ b/scripts/github_ci_android.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2020-2021 Valve Corporation
-# Copyright (c) 2020-2021 LunarG, Inc.
+# Copyright (c) 2020-2023 Valve Corporation
+# Copyright (c) 2020-2023 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 import os
 import argparse

--- a/scripts/github_ci_build_desktop.py
+++ b/scripts/github_ci_build_desktop.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2020-2021 Valve Corporation
+# Copyright (c) 2020-2023 Valve Corporation
 # Copyright (c) 2020-2023 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,9 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
-# Author: Nathaniel Cesario <nathaniel@lunarg.com>
 
 import os
 import argparse

--- a/scripts/github_ci_gn.py
+++ b/scripts/github_ci_gn.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2020-2021 Valve Corporation
-# Copyright (c) 2020-2021 LunarG, Inc.
+# Copyright (c) 2020-2023 Valve Corporation
+# Copyright (c) 2020-2023 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 import os
 import argparse

--- a/scripts/github_ci_win_linux.py
+++ b/scripts/github_ci_win_linux.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2020-2021, 2023 Valve Corporation
-# Copyright (c) 2020-2021, 2023 LunarG, Inc.
+# Copyright (c) 2020-2023 Valve Corporation
+# Copyright (c) 2020-2023 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 import os
 import argparse

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -16,10 +16,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
-# Author: Tobin Ehlis <tobine@google.com>
-# Author: John Zulauf <jzulauf@lunarg.com>
 
 import os,re,sys
 import xml.etree.ElementTree as etree
@@ -170,14 +166,6 @@ class HelperFileOutputGenerator(OutputGenerator):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
-        copyright += ' * Author: Courtney Goeltzenleuchter <courtneygo@google.com>\n'
-        copyright += ' * Author: Tobin Ehlis <tobine@google.com>\n'
-        copyright += ' * Author: Chris Forbes <chrisforbes@google.com>\n'
-        copyright += ' * Author: John Zulauf<jzulauf@lunarg.com>\n'
-        copyright += ' * Author: Tony Barbour <tony@lunarg.com>\n'
-        copyright += ' *\n'
         copyright += ' ****************************************************************************/\n'
         write(copyright, file=self.outFile)
     #

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -16,9 +16,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Tobin Ehlis <tobine@google.com>
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 import os,re,sys
 import xml.etree.ElementTree as etree
@@ -145,8 +142,6 @@ class LayerChassisDispatchOutputGenerator(OutputGenerator):
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */"""
 
     inline_custom_source_preamble = """

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -16,10 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author: Tobin Ehlis <tobine@google.com>
-# Author: Mark Lobodzinski <mark@lunarg.com>
-# Author: Nadav Geva <nadav.geva@amd.com>
-#
 # This script generates the dispatch portion of a factory layer which intercepts
 # all Vulkan  functions. The resultant factory layer allows rapid development of
 # layers and interceptors.
@@ -563,9 +559,6 @@ class ValidationObject {
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
  */"""
 
     inline_custom_source_preamble_1 = """

--- a/scripts/layer_dispatch_table_generator.py
+++ b/scripts/layer_dispatch_table_generator.py
@@ -16,9 +16,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Young <marky@lunarg.com>
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 import os,re,sys
 import xml.etree.ElementTree as etree
@@ -129,9 +126,6 @@ class LayerDispatchTableOutputGenerator(OutputGenerator):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
-        copyright += ' * Author: Mark Young <marky@lunarg.com>\n'
         copyright += ' */\n'
 
         preamble = ''

--- a/scripts/lvt_file_generator.py
+++ b/scripts/lvt_file_generator.py
@@ -15,8 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 import os,re,sys
 import xml.etree.ElementTree as etree
@@ -189,8 +187,6 @@ class LvtFileOutputGenerator(OutputGenerator):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
         copyright += ' */\n'
         write(copyright, file=self.outFile)
     #

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -16,9 +16,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mark Lobodzinski <mark@lunarg.com>
-# Author: Dave Houlton <daveh@lunarg.com>
 
 import os,re,sys,string,json
 import xml.etree.ElementTree as etree
@@ -448,10 +445,6 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Mark Lobodzinski <mark@lunarg.com>\n'
-        copyright += ' * Author: Dave Houlton <daveh@lunarg.com>\n'
-        copyright += ' *\n'
         copyright += ' ****************************************************************************/\n'
         self.otwrite('both', copyright)
         self.newline()

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -16,10 +16,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Dustin Graves <dustin@lunarg.com>
-# Author: Mark Lobodzinski <mark@lunarg.com>
-# Author: Dave Houlton <daveh@lunarg.com>
 
 import os,re,sys,string,json
 import xml.etree.ElementTree as etree
@@ -390,9 +386,6 @@ class ParameterValidationOutputGenerator(OutputGenerator):
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@LunarG.com>
- * Author: Dave Houlton <daveh@LunarG.com>
  */\n\n'''
     #
     # Increases the global indent variable

--- a/scripts/spirv_grammar_generator.py
+++ b/scripts/spirv_grammar_generator.py
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Spencer Fricke <s.fricke@samsung.com>
 
 import os,re,sys,string,json
 import xml.etree.ElementTree as etree
@@ -153,8 +151,6 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Spencer Fricke <s.fricke@samsung.com>\n'
         copyright += ' *\n'
         copyright += ' * This file is related to anything that is found in the SPIR-V grammar\n'
         copyright += ' * file found in the SPIRV-Headers. Mainly used for SPIR-V util functions.\n'

--- a/scripts/spirv_validation_generator.py
+++ b/scripts/spirv_validation_generator.py
@@ -13,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Spencer Fricke <s.fricke@samsung.com>
 
 import os,re,sys,string,json
 import xml.etree.ElementTree as etree
@@ -212,8 +210,6 @@ class SpirvValidationHelperOutputGenerator(OutputGenerator):
         copyright += ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n'
         copyright += ' * See the License for the specific language governing permissions and\n'
         copyright += ' * limitations under the License.\n'
-        copyright += ' *\n'
-        copyright += ' * Author: Spencer Fricke <s.fricke@samsung.com>\n'
         copyright += ' *\n'
         copyright += ' * This file is related to anything that is found in the Vulkan XML related\n'
         copyright += ' * to SPIR-V. Anything related to the SPIR-V grammar belongs in spirv_grammar_helper\n'

--- a/scripts/sync_val_gen.py
+++ b/scripts/sync_val_gen.py
@@ -16,9 +16,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: John Zulauf <jzulauf@lunarg.com>
-# Author: Jeremy Gebben <jeremyg@lunarg.com>
 import os
 import json
 import re

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -17,9 +17,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Mike Stroyan <stroyan@google.com>
-# Author: Mark Lobodzinski <mark@lunarg.com>
 
 import os,re,sys
 from generator import *
@@ -148,8 +145,6 @@ class ThreadOutputGenerator(OutputGenerator):
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */"""
 
  # Note that the inline_custom_header_preamble template below contains three embedded template expansion identifiers.

--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -15,11 +15,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Author: Tobin Ehlis <tobine@google.com>
-# Author: Dave Houlton <daveh@lunarg.com>
-# Author: Shannon McPherson <shannon@lunarg.com>
-
 import argparse
 import common_codegen
 import csv
@@ -463,9 +458,6 @@ class OutputDatabase:
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
  */
 
 #pragma once

--- a/tests/icd-spv.h
+++ b/tests/icd-spv.h
@@ -1,15 +1,13 @@
 /*
  * Copyright (c) 2015-2016 The Khronos Group Inc.
- * Copyright (c) 2015-2016 Valve Corporation
- * Copyright (c) 2015-2016 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Cody Northrop <cody@lunarg.com>
  */
 
 #ifndef ICD_SPV_H

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 #include "cast_utils.h"
 #include "enum_flag_bits.h"

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #ifndef VKLAYERTEST_H

--- a/tests/layers/VkLayer_device_profile_api.def
+++ b/tests/layers/VkLayer_device_profile_api.def
@@ -1,7 +1,7 @@
 ;;;; Begin Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;
-; Copyright (c) 2017 Valve Corporation
-; Copyright (c) 2017 LunarG, Inc.
+; Copyright (c) 2017-2023 Valve Corporation
+; Copyright (c) 2017-2023 LunarG, Inc.
 ;
 ; Licensed under the Apache License, Version 2.0 (the "License");
 ; you may not use this file except in compliance with the License.
@@ -14,9 +14,6 @@
 ; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ; See the License for the specific language governing permissions and
 ; limitations under the License.
-;
-;  Author: Arda Coskunses <arda@lunarg.com>
-;
 ;;;;  End Copyright Notice ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 LIBRARY VkLayer_device_profile_api

--- a/tests/layers/device_profile_api.cpp
+++ b/tests/layers/device_profile_api.cpp
@@ -15,10 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Arda Coskunses <arda@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
  */
 #include <string.h>
 #include <stdlib.h>

--- a/tests/layers/vk_lunarg_device_profile_api_layer.h
+++ b/tests/layers/vk_lunarg_device_profile_api_layer.h
@@ -1,7 +1,7 @@
 /*
  *
- * Copyright (c) 2016-2022 Valve Corporation
- * Copyright (c) 2016-2022 LunarG, Inc.
+ * Copyright (c) 2016-2023 Valve Corporation
+ * Copyright (c) 2016-2023 LunarG, Inc.
  * Copyright (c) 2016-2022 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Arda Coskunses <arda@lunarg.com>
- *
  */
 
 #ifndef __VK_DEVICE_PROFILE_API_H__

--- a/tests/positive/android_hardware_buffer.cpp
+++ b/tests/positive/android_hardware_buffer.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/best_practices.cpp
+++ b/tests/positive/best_practices.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/graphics_library.cpp
+++ b/tests/positive/graphics_library.cpp
@@ -9,8 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/instance.cpp
+++ b/tests/positive/instance.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/ray_tracing.cpp
+++ b/tests/positive/ray_tracing.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/ray_tracing_pipeline.cpp
+++ b/tests/positive/ray_tracing_pipeline.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/tooling.cpp
+++ b/tests/positive/tooling.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #include "../layer_validation_tests.h"

--- a/tests/positive/video.cpp
+++ b/tests/positive/video.cpp
@@ -7,8 +7,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #include "../vklayertests_video.h"

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
  */
 
 #ifndef TEST_COMMON_H

--- a/tests/vklayertests_amd_best_practices.cpp
+++ b/tests/vklayertests_amd_best_practices.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -9,9 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
  */
 
 #include "cast_utils.h"

--- a/tests/vklayertests_android_hardware_buffer.cpp
+++ b/tests/vklayertests_android_hardware_buffer.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (c) 2015-2022 Google, Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -10,20 +10,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include "layer_validation_tests.h"

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -9,9 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
  */
 
 #include "cast_utils.h"

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -10,9 +10,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Camden Stocker <camden@lunarg.com>
- * Author: Nadav Geva <nadav.geva@amd.com>
  */
 
 #include "cast_utils.h"

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -10,20 +10,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include <type_traits>

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -10,20 +10,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include "cast_utils.h"

--- a/tests/vklayertests_debug_printf.cpp
+++ b/tests/vklayertests_debug_printf.cpp
@@ -9,10 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
  */
 
 #include "layer_validation_tests.h"

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -11,21 +11,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
- * Author: Quentin Huot-Marchand <quentin.huot-marchand@arm.com
  */
 
 #include "cast_utils.h"

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -9,9 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
  */
 
 #include "layer_validation_tests.h"

--- a/tests/vklayertests_graphics_library.cpp
+++ b/tests/vklayertests_graphics_library.cpp
@@ -9,8 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
  */
 
 #include "layer_validation_tests.h"

--- a/tests/vklayertests_imageless_framebuffer.cpp
+++ b/tests/vklayertests_imageless_framebuffer.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  * Copyright (c) 2015-2022 Google, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -10,20 +10,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include "cast_utils.h"

--- a/tests/vklayertests_nvidia_best_practices.cpp
+++ b/tests/vklayertests_nvidia_best_practices.cpp
@@ -9,8 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Rodrigo Locatti <rlocatti@nvidia.com>
  */
 
 #include <chrono>

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -10,20 +10,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include "cast_utils.h"

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -10,20 +10,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include "cast_utils.h"

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -1,15 +1,13 @@
 /*
  * Copyright (c) 2020-2022 The Khronos Group Inc.
- * Copyright (c) 2020-2022 Valve Corporation
- * Copyright (c) 2020-2022 LunarG, Inc.
+ * Copyright (c) 2020-2023 Valve Corporation
+ * Copyright (c) 2020-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Nathaniel Cesario <nathaniel@lunarg.com>
  */
 
 #include "cast_utils.h"

--- a/tests/vklayertests_ray_tracing.cpp
+++ b/tests/vklayertests_ray_tracing.cpp
@@ -10,20 +10,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include "layer_validation_tests.h"

--- a/tests/vklayertests_ray_tracing_gpu.cpp
+++ b/tests/vklayertests_ray_tracing_gpu.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020-2022 The Khronos Group Inc.
- * Copyright (c) 2020-2022 Valve Corporation
- * Copyright (c) 2020-2022 LunarG, Inc.
+ * Copyright (c) 2020-2023 Valve Corporation
+ * Copyright (c) 2020-2023 LunarG, Inc.
  * Copyright (c) 2020-2022 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -9,9 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Tony Barbour <tony@LunarG.com>
  */
 
 #include "layer_validation_tests.h"

--- a/tests/vklayertests_ray_tracing_pipeline.cpp
+++ b/tests/vklayertests_ray_tracing_pipeline.cpp
@@ -10,20 +10,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include "layer_validation_tests.h"

--- a/tests/vklayertests_video.cpp
+++ b/tests/vklayertests_video.cpp
@@ -7,8 +7,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #include "vklayertests_video.h"

--- a/tests/vklayertests_video.h
+++ b/tests/vklayertests_video.h
@@ -7,8 +7,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Daniel Rakos <daniel.rakos@rastergrid.com>
  */
 
 #ifndef VKLAYERTESTS_VIDEO_H

--- a/tests/vklayertests_viewport_inheritance.cpp
+++ b/tests/vklayertests_viewport_inheritance.cpp
@@ -7,8 +7,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: David Zhao Akeley <dakeley@nvidia.com>
  */
 
 #include <array>

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -10,20 +10,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
- * Author: Tobias Hector <tobias.hector@amd.com>
  */
 
 #include "layer_validation_tests.h"

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -15,10 +15,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Dave Houlton <daveh@lunarg.com>
  */
 
 #include "vkrenderframework.h"

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -14,9 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Dave Houlton <daveh@lunarg.com>
  */
 
 #ifndef VKRENDERFRAMEWORK_H

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -9,19 +9,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Chris Forbes <chrisf@ijw.co.nz>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Mark Lobodzinski <mark@lunarg.com>
- * Author: Mike Stroyan <mike@LunarG.com>
- * Author: Tobin Ehlis <tobine@google.com>
- * Author: Tony Barbour <tony@LunarG.com>
- * Author: Cody Northrop <cnorthrop@google.com>
- * Author: Dave Houlton <daveh@lunarg.com>
- * Author: Jeremy Kniager <jeremyk@lunarg.com>
- * Author: Shannon McPherson <shannon@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 #include <type_traits>
 

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -14,9 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Tony Barbour <tony@LunarG.com>
  */
 
 #include "vktestbinding.h"

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -14,10 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Cody Northrop <cody@lunarg.com>
- * Author: John Zulauf <jzulauf@lunarg.com>
  */
 
 #ifndef VKTESTBINDING_H

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -14,10 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Chia-I Wu <olvaffe@gmail.com>
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Tony Barbour <tony@LunarG.com>
  */
 
 #include "vktestframework.h"

--- a/tests/vktestframework.h
+++ b/tests/vktestframework.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2022 Valve Corporation
- * Copyright (c) 2015-2022 LunarG, Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Courtney Goeltzenleuchter <courtney@LunarG.com>
- * Author: Tony Barbour <tony@LunarG.com>
  */
 
 #ifndef VKTESTFRAMEWORK_H


### PR DESCRIPTION
Arguments for removing the author section at the top of files is:
1.) It's not getting updated
2.) Has emails of devs who no longer work on vvl
3.) Takes up room
4.) If you need to figure out who wrote something you use git