### PR TITLE
cmake: Add VVL_CLANG_TIDY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,6 @@ set(VVL_CPP_STANDARD 17 CACHE STRING "Set the C++ standard to build against.")
 set(CMAKE_CXX_STANDARD ${VVL_CPP_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
 set(CMAKE_VISIBILITY_INLINES_HIDDEN "YES")
@@ -86,6 +85,15 @@ elseif (VVL_ENABLE_TSAN)
     add_compile_options(-fsanitize=thread)
     add_compile_options(-fno-omit-frame-pointer) # Get nicer stack traces in error messages
     add_link_options(-fsanitize=thread)
+endif()
+
+option(VVL_CLANG_TIDY "Use clang-tidy")
+if (VVL_CLANG_TIDY)
+    find_program(CLANG_TIDY NAMES clang-tidy)
+    if(NOT CLANG_TIDY)
+        message(FATAL_ERROR "clang-tidy not found!")
+    endif()
+    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY}")
 endif()
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")


### PR DESCRIPTION
This allows us to being the process of integrating clang-tidy into our CI process.

The [Makefile Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#makefile-generators) and the [Ninja](https://cmake.org/cmake/help/latest/generator/Ninja.html#generator:Ninja) generator will run this tool along with the compiler and report a warning if the tool reports any problems.

For VS and XCode users it looks like this clang-tidy cannot be run as part of the build:
https://discourse.cmake.org/t/how-to-add-clang-tidy-to-open-source-project/7311

>  the VS and XCode buildsystems don’t support running arbitrary commands to compile a file, which is required to run clang-tidy. This is beyond our control. 

However, VS and XCode both recognize clang-tidy and will display the warnings users even if they don't directly integrate it into their build system.