### PR TITLE
Initialize descriptor_variables in synchronization validation

### DIFF
--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -97,7 +97,7 @@ struct PipelineStageState {
     const safe_VkPipelineShaderStageCreateInfo *create_info;
     VkShaderStageFlagBits stage_flag;
     std::optional<Instruction> entrypoint;
-    const std::vector<ResourceInterfaceVariable> *descriptor_variables;
+    const std::vector<ResourceInterfaceVariable> *descriptor_variables = {};
     bool has_writable_descriptor;
     bool has_atomic_descriptor;
     bool wrote_primitive_shading_rate;


### PR DESCRIPTION
Fixes a crash in dEQP-VK.pipeline.monolithic.shader_module_identifier.pipeline_from_id.*