### PR TITLE
ci: Use concurrency to prevent duplicate jobs for workflows

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -15,6 +15,11 @@
 
 name: Android
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
     push:
     pull_request:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -15,6 +15,11 @@
 
 name: Linux (formatting, build, test)
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
     push:
     pull_request:

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -15,6 +15,11 @@
 
 name: macOS (build)
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
     push:
     pull_request:

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -15,6 +15,11 @@
 
 name: Windows (build)
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
     push:
     pull_request:


### PR DESCRIPTION
GitHub docs for reference:
https://docs.github.com/en/actions/using-jobs/using-concurrency

By default GitHub actions doesn't cancel old runs of workflows.

With the new `concurrency` support you can cancel in progress runs now.

This makes it so you don't have to manually cancel old runs when you force push. IE saving CI/developer time.