### PR TITLE
Add dynamic VK_EXT_line_rasterization

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -169,6 +169,10 @@ struct DrawDispatchVuid {
     const char* descriptor_buffer_set_offset_missing = kVUIDUndefined;
     const char* image_view_dim = kVUIDUndefined;
     const char* image_view_numeric_format = kVUIDUndefined;
+    const char* stippled_rectangular_lines = kVUIDUndefined;
+    const char* stippled_bresenham_lines = kVUIDUndefined;
+    const char* stippled_smooth_lines = kVUIDUndefined;
+    const char* stippled_default_strict = kVUIDUndefined;
 };
 
 struct ValidateBeginQueryVuids {

--- a/layers/core_checks/drawdispatch_validation.cpp
+++ b/layers/core_checks/drawdispatch_validation.cpp
@@ -148,6 +148,10 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDraw-None-08117";
         image_view_dim                     = "VUID-vkCmdDraw-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDraw-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDraw-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDraw-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDraw-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDraw-stippledLineEnable-07498";
     }
 };
 
@@ -278,6 +282,10 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMultiEXT-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawMultiEXT-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawMultiEXT-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawMultiEXT-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawMultiEXT-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawMultiEXT-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawMultiEXT-stippledLineEnable-07498";
     }
 };
 
@@ -409,6 +417,10 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndexed-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawIndexed-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawIndexed-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawIndexed-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawIndexed-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawIndexed-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawIndexed-stippledLineEnable-07498";
     }
 };
 
@@ -540,6 +552,10 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMultiIndexedEXT-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawMultiIndexedEXT-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawMultiIndexedEXT-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawMultiIndexedEXT-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawMultiIndexedEXT-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawMultiIndexedEXT-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawMultiIndexedEXT-stippledLineEnable-07498";
     }
 };
 
@@ -672,6 +688,10 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndirect-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawIndirect-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawIndirect-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawIndirect-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawIndirect-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawIndirect-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawIndirect-stippledLineEnable-07498";
     }
 };
 
@@ -805,6 +825,10 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndexedIndirect-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawIndexedIndirect-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawIndexedIndirect-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawIndexedIndirect-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawIndexedIndirect-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawIndexedIndirect-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawIndexedIndirect-stippledLineEnable-07498";
     }
 };
 
@@ -1012,6 +1036,10 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndirectCount-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawIndirectCount-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawIndirectCount-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawIndirectCount-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawIndirectCount-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawIndirectCount-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawIndirectCount-stippledLineEnable-07498";
     }
 };
 
@@ -1148,6 +1176,10 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndexedIndirectCount-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawIndexedIndirectCount-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawIndexedIndirectCount-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawIndexedIndirectCount-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawIndexedIndirectCount-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawIndexedIndirectCount-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawIndexedIndirectCount-stippledLineEnable-07498";
     }
 };
 
@@ -1412,6 +1444,10 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMeshTasksNV-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawMeshTasksNV-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawMeshTasksNV-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawMeshTasksNV-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawMeshTasksNV-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawMeshTasksNV-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawMeshTasksNV-stippledLineEnable-07498";
     }
 };
 
@@ -1535,6 +1571,10 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawMeshTasksIndirectNV-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawMeshTasksIndirectNV-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawMeshTasksIndirectNV-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawMeshTasksIndirectNV-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawMeshTasksIndirectNV-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawMeshTasksIndirectNV-stippledLineEnable-07498";
     }
 };
 
@@ -1661,6 +1701,10 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawMeshTasksIndirectCountNV-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawMeshTasksIndirectCountNV-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawMeshTasksIndirectCountNV-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawMeshTasksIndirectCountNV-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawMeshTasksIndirectCountNV-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawMeshTasksIndirectCountNV-stippledLineEnable-07498";
     }
 };
 
@@ -1831,6 +1875,10 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         descriptor_buffer_set_offset_missing = "VUID-vkCmdDrawIndirectByteCountEXT-None-08117";
         image_view_dim                     = "VUID-vkCmdDrawIndirectByteCountEXT-viewType-07752";
         image_view_numeric_format          = "VUID-vkCmdDrawIndirectByteCountEXT-format-07753";
+        stippled_rectangular_lines         = "VUID-vkCmdDrawIndirectByteCountEXT-stippledLineEnable-07495";
+        stippled_bresenham_lines           = "VUID-vkCmdDrawIndirectByteCountEXT-stippledLineEnable-07496";
+        stippled_smooth_lines              = "VUID-vkCmdDrawIndirectByteCountEXT-stippledLineEnable-07497";
+        stippled_default_strict            = "VUID-vkCmdDrawIndirectByteCountEXT-stippledLineEnable-07498";
     }
 };
 

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -202,6 +202,10 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
         std::bitset<32> discard_rectangles;
         // VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT
         VkSampleCountFlagBits rasterization_samples;
+        // VK_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT
+        VkLineRasterizationModeEXT line_rasterization_mode;
+        // VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT
+        bool stippled_line_enable;
 
         // maxColorAttachments is at max 8 on all known implementations currently
         std::bitset<32> color_blend_enable_attachments;    // VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5463,11 +5463,13 @@ void ValidationStateTracker::PostCallRecordCmdSetLineRasterizationModeEXT(VkComm
                                                                           VkLineRasterizationModeEXT lineRasterizationMode) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     cb_state->RecordStateCmd(CMD_SETLINERASTERIZATIONMODEEXT, CB_DYNAMIC_LINE_RASTERIZATION_MODE_EXT_SET);
+    cb_state->dynamic_state_value.line_rasterization_mode = lineRasterizationMode;
 }
 
 void ValidationStateTracker::PostCallRecordCmdSetLineStippleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stippledLineEnable) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     cb_state->RecordStateCmd(CMD_SETLINESTIPPLEENABLEEXT, CB_DYNAMIC_LINE_STIPPLE_ENABLE_EXT_SET);
+    cb_state->dynamic_state_value.stippled_line_enable = stippledLineEnable;
 }
 
 void ValidationStateTracker::PostCallRecordCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer commandBuffer,

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -816,7 +816,7 @@ void VkLayerTest::VKTriangleTest(BsoFailSelect failCase) {
                 LvlInitStruct<VkPipelineRasterizationLineStateCreateInfoEXT>();
             line_state.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT;
             line_state.stippledLineEnable = VK_TRUE;
-            line_state.lineStippleFactor = 0;
+            line_state.lineStippleFactor = 1;
             line_state.lineStipplePattern = 0;
             pipelineobj.SetLineState(&line_state);
             break;

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -10402,6 +10402,157 @@ TEST_F(VkLayerTest, DynamicColorBlendAttchment) {
     m_commandBuffer->end();
 }
 
+TEST_F(VkLayerTest, DynamicRasterizationLine) {
+    TEST_DESCRIPTION("tests VK_EXT_line_rasterization dynamic state");
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    auto line_raster_features = LvlInitStruct<VkPhysicalDeviceLineRasterizationFeaturesEXT>();
+    auto extended_dynamic_state3_features = LvlInitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(&line_raster_features);
+    GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
+    if (!extended_dynamic_state3_features.extendedDynamicState3LineRasterizationMode ||
+        !extended_dynamic_state3_features.extendedDynamicState3LineStippleEnable) {
+        GTEST_SKIP() << "dynamic state 3 features not supported";
+    }
+
+    if (!line_raster_features.rectangularLines || !line_raster_features.bresenhamLines || !line_raster_features.smoothLines) {
+        GTEST_SKIP() << "line rasterization features not supported";
+    }
+
+    line_raster_features.stippledRectangularLines = VK_FALSE;
+    line_raster_features.stippledBresenhamLines = VK_FALSE;
+    line_raster_features.stippledSmoothLines = VK_FALSE;
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state3_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    const auto vkCmdSetLineRasterizationModeEXT =
+        GetDeviceProcAddr<PFN_vkCmdSetLineRasterizationModeEXT>("vkCmdSetLineRasterizationModeEXT");
+    const auto vkCmdSetLineStippleEnableEXT = GetDeviceProcAddr<PFN_vkCmdSetLineStippleEnableEXT>("vkCmdSetLineStippleEnableEXT");
+
+    // set both from dynamic state, don't need a VkPipelineRasterizationLineStateCreateInfoEXT in pNext
+    {
+        CreatePipelineHelper pipe(*this);
+        pipe.InitInfo();
+        const VkDynamicState dyn_states[2] = {VK_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT,
+                                              VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT};
+        auto dyn_state_ci = LvlInitStruct<VkPipelineDynamicStateCreateInfo>();
+        dyn_state_ci.dynamicStateCount = size(dyn_states);
+        dyn_state_ci.pDynamicStates = dyn_states;
+        pipe.dyn_state_ci_ = dyn_state_ci;
+        pipe.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT;  // ignored
+        pipe.line_state_ci_.stippledLineEnable = VK_TRUE;                                        // ignored
+        pipe.line_state_ci_.lineStippleFactor = 1;
+        pipe.InitState();
+        pipe.CreateGraphicsPipeline();
+
+        m_commandBuffer->begin();
+        m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+        vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
+
+        m_errorMonitor->SetUnexpectedError("VUID-vkCmdDraw-stippledLineEnable-07498");  // default values undefined
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-07637");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-07638");
+        vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+        m_errorMonitor->VerifyFound();
+
+        vkCmdSetLineStippleEnableEXT(m_commandBuffer->handle(), VK_TRUE);
+        vkCmdSetLineRasterizationModeEXT(m_commandBuffer->handle(), VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT);
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-stippledLineEnable-07498");
+        vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+        m_errorMonitor->VerifyFound();
+
+        // is valid now
+        vkCmdSetLineStippleEnableEXT(m_commandBuffer->handle(), VK_FALSE);
+        vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+
+        m_commandBuffer->EndRenderPass();
+        m_commandBuffer->end();
+    }
+
+    {
+        CreatePipelineHelper pipe(*this);
+        pipe.InitInfo();
+        const VkDynamicState dyn_states[1] = {VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT};
+        auto dyn_state_ci = LvlInitStruct<VkPipelineDynamicStateCreateInfo>();
+        dyn_state_ci.dynamicStateCount = size(dyn_states);
+        dyn_state_ci.pDynamicStates = dyn_states;
+        pipe.dyn_state_ci_ = dyn_state_ci;
+        pipe.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT;
+        pipe.line_state_ci_.stippledLineEnable = VK_TRUE;  // ignored
+        pipe.line_state_ci_.lineStippleFactor = 1;
+        pipe.InitState();
+        pipe.CreateGraphicsPipeline();
+
+        m_commandBuffer->begin();
+        m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+        vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
+
+        vkCmdSetLineStippleEnableEXT(m_commandBuffer->handle(), VK_TRUE);
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-stippledLineEnable-07495");
+        vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+        m_errorMonitor->VerifyFound();
+
+        m_commandBuffer->EndRenderPass();
+        m_commandBuffer->end();
+    }
+
+    {
+        CreatePipelineHelper pipe(*this);
+        pipe.InitInfo();
+        const VkDynamicState dyn_states[1] = {VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT};
+        auto dyn_state_ci = LvlInitStruct<VkPipelineDynamicStateCreateInfo>();
+        dyn_state_ci.dynamicStateCount = size(dyn_states);
+        dyn_state_ci.pDynamicStates = dyn_states;
+        pipe.dyn_state_ci_ = dyn_state_ci;
+        pipe.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT;
+        pipe.line_state_ci_.lineStippleFactor = 1;
+        pipe.InitState();
+        pipe.CreateGraphicsPipeline();
+
+        m_commandBuffer->begin();
+        m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+        vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
+
+        vkCmdSetLineStippleEnableEXT(m_commandBuffer->handle(), VK_TRUE);
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-stippledLineEnable-07496");
+        vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+        m_errorMonitor->VerifyFound();
+
+        m_commandBuffer->EndRenderPass();
+        m_commandBuffer->end();
+    }
+
+    {
+        CreatePipelineHelper pipe(*this);
+        pipe.InitInfo();
+        const VkDynamicState dyn_states[1] = {VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT};
+        auto dyn_state_ci = LvlInitStruct<VkPipelineDynamicStateCreateInfo>();
+        dyn_state_ci.dynamicStateCount = size(dyn_states);
+        dyn_state_ci.pDynamicStates = dyn_states;
+        pipe.dyn_state_ci_ = dyn_state_ci;
+        pipe.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT;
+        pipe.line_state_ci_.lineStippleFactor = 1;
+        pipe.InitState();
+        pipe.CreateGraphicsPipeline();
+
+        m_commandBuffer->begin();
+        m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+        vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
+
+        vkCmdSetLineStippleEnableEXT(m_commandBuffer->handle(), VK_TRUE);
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-stippledLineEnable-07497");
+        vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+        m_errorMonitor->VerifyFound();
+
+        m_commandBuffer->EndRenderPass();
+        m_commandBuffer->end();
+    }
+}
+
 TEST_F(VkLayerTest, WriteTimeStampInvalidQuery) {
     TEST_DESCRIPTION("Test for invalid query slot in query pool.");
 


### PR DESCRIPTION
Adds the 4 draw time VUs

- `VUID-vkCmdDraw-stippledLineEnable-07495`
- `VUID-vkCmdDraw-stippledLineEnable-07496`
- `VUID-vkCmdDraw-stippledLineEnable-07497`
- `VUID-vkCmdDraw-stippledLineEnable-07498`

Fixes the Pipeline creation VUs (`VkGraphicsPipelineCreateInfo` and `VkPipelineRasterizationLineStateCreateInfoEXT`) to not check `lineRasterizationMode` or `stippledLineEnable` if they are dynamic state