### PR TITLE
cmake: Remove unused CMake code

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -268,8 +268,6 @@ target_sources(VkLayer_khronos_validation PRIVATE
     vk_layer_settings_ext.h
 )
 
-target_compile_definitions(VkLayer_khronos_validation PUBLIC ${KHRONOS_LAYER_COMPILE_DEFINITIONS})
-
 if(MSVC)
     target_link_options(VkLayer_khronos_validation PRIVATE /DEF:${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_khronos_validation.def)
 elseif(MINGW)


### PR DESCRIPTION
KHRONOS_LAYER_COMPILE_DEFINITIONS isn't set anywhere