### PR TITLE
cmake: Disable warnings on a per target basis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,23 +97,19 @@ if (VVL_CLANG_TIDY)
     set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY}")
 endif()
 
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-    add_compile_options(-Wconversion
-                        -Wimplicit-fallthrough
-
-                        # TODO These warnings also get turned on with -Wconversion in some versions of clang.
-                        #      Leave off until further investigation.
-                        -Wno-sign-conversion
-                        -Wno-implicit-int-conversion
-                        -Wno-enum-enum-conversion
-                        -Wstring-conversion)
-
-endif()
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
-    add_compile_options(-Wall
-                        -Wextra
-                        -Wno-unused-parameter
-                        -Wno-missing-field-initializers)
+    add_compile_options(
+        -Wall
+        -Wextra
+        -Wpointer-arith
+    )
+    if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+        add_compile_options(
+            -Wconversion
+            -Wimplicit-fallthrough
+            -Wstring-conversion
+        )
+    endif()
 elseif(MSVC)
     # TODO: Update to /W4
     add_compile_options("/W3")

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -89,18 +89,25 @@ if(BUILD_LAYER_SUPPORT_FILES)
     install(TARGETS VkLayer_utils)
 endif()
 
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
+    target_compile_options(VkLayer_utils PRIVATE
+        -Wno-unused-parameter
+        -Wno-missing-field-initializers
+    )
+    if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+        target_compile_options(VkLayer_utils PRIVATE
+            -Wno-sign-conversion
+            -Wno-implicit-int-conversion
+            -Wno-enum-enum-conversion
+        )
+    endif()
+endif()
+
 if(MSVC)
     # Avoid: fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
     add_compile_options("/bigobj")
     add_compile_options("/we4189")
     add_compile_options("/we5038")
-else()
-    add_compile_options(-Wpointer-arith -Wno-unused-function -Wno-sign-compare)
-endif()
-
-# Clang warns about unused const variables. Generated files may purposely contain unused consts, so silence this warning in Clang
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set_source_files_properties(generated/parameter_validation.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-const-variable")
 endif()
 
 # NOTE: LunarG/VulkanTools disables BUILD_LAYERS and BUILD_TESTS to minimize dependencies.
@@ -281,6 +288,20 @@ elseif(ANDROID)
     message(DEBUG "Functions are exported via VVL_EXPORT")
 else()
     target_link_options(VkLayer_khronos_validation PRIVATE LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libVkLayer_khronos_validation.map,-Bsymbolic,--exclude-libs,ALL)
+endif()
+
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
+    target_compile_options(VkLayer_khronos_validation PRIVATE
+        -Wno-unused-parameter
+        -Wno-missing-field-initializers
+    )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(VkLayer_khronos_validation PRIVATE
+            -Wno-sign-conversion
+            -Wno-implicit-int-conversion
+            -Wno-enum-enum-conversion
+        )
+    endif()
 endif()
 
 # Khronos validation additional dependencies

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,7 +96,16 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
     target_compile_options(vk_layer_validation_tests PRIVATE 
         -Wno-sign-compare
         -Wno-shorten-64-to-32
+        -Wno-unused-parameter
+        -Wno-missing-field-initializers
     )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(vk_layer_validation_tests PRIVATE 
+            -Wno-sign-conversion
+            -Wno-implicit-int-conversion
+            -Wno-enum-enum-conversion
+        )
+    endif()
 elseif(MSVC)
     # Disable some signed/unsigned mismatch warnings.
     target_compile_options(vk_layer_validation_tests PRIVATE /wd4267)

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -32,6 +32,22 @@ else()
     target_link_options(VkLayer_device_profile_api PRIVATE LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libVkLayer_device_profile_api.map,-Bsymbolic)
 endif()
 
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
+    target_compile_options(VkLayer_device_profile_api PRIVATE 
+        -Wno-sign-compare
+        -Wno-shorten-64-to-32
+        -Wno-unused-parameter
+        -Wno-missing-field-initializers
+    )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(VkLayer_device_profile_api PRIVATE 
+            -Wno-sign-conversion
+            -Wno-implicit-int-conversion
+            -Wno-enum-enum-conversion
+        )
+    endif()
+endif()
+
 target_include_directories(VkLayer_device_profile_api PRIVATE .)
 
 set(INTERMEDIATE_FILE "${CMAKE_CURRENT_BINARY_DIR}/profiling.json")


### PR DESCRIPTION
Makes fixing warnings more feasible. Since you can tackle the problem one target at a time, instead of having to fix the entire project