### PR TITLE
tests: Fix tests for use with Profile layer

### DIFF
--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -726,7 +726,7 @@ TEST_F(VkPositiveLayerTest, BindSparseMetadata) {
     // Find requirements for metadata aspect
     const VkSparseImageMemoryRequirements *metadata_reqs = nullptr;
     for (auto const &aspect_sparse_reqs : sparse_reqs) {
-        if (aspect_sparse_reqs.formatProperties.aspectMask == VK_IMAGE_ASPECT_METADATA_BIT) {
+        if ((aspect_sparse_reqs.formatProperties.aspectMask & VK_IMAGE_ASPECT_METADATA_BIT) != 0) {
             metadata_reqs = &aspect_sparse_reqs;
         }
     }
@@ -1830,6 +1830,12 @@ TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
+    constexpr uint32_t test_extent_value = 10;
+    if (m_surface_capabilities.minImageExtent.width < test_extent_value ||
+        m_surface_capabilities.minImageExtent.height < test_extent_value) {
+        GTEST_SKIP() << "minImageExtent is not large enough";
+    }
+
     auto image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = m_surface_formats[0].format;
@@ -1914,7 +1920,7 @@ TEST_F(VkPositiveLayerTest, TransferImageToSwapchainDeviceGroup) {
     copy_region.dstSubresource.layerCount = 1;
     copy_region.srcOffset = {0, 0, 0};
     copy_region.dstOffset = {0, 0, 0};
-    copy_region.extent = {10, 10, 1};
+    copy_region.extent = {test_extent_value, test_extent_value, 1};
     vk::CmdCopyImage(m_commandBuffer->handle(), src_Image.handle(), VK_IMAGE_LAYOUT_GENERAL, peer_image.handle(),
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -12002,7 +12002,6 @@ TEST_F(VkLayerTest, MultisampledRenderToSingleSampled) {
         m_commandBuffer->BeginRendering(begin_rendering_info);
         m_errorMonitor->VerifyFound();
 
-        ms_render_to_ss.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
         attach_desc[0].samples = VK_SAMPLE_COUNT_1_BIT;
         subpass.pDepthStencilAttachment = nullptr;
         rpci.attachmentCount = 1;

--- a/tests/vklayertests_imageless_framebuffer.cpp
+++ b/tests/vklayertests_imageless_framebuffer.cpp
@@ -1494,8 +1494,8 @@ TEST_F(VkLayerTest, RenderPassCreateFragmentDensityMapReferenceToInvalidAttachme
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
-        GTEST_SKIP() << "At least Vulkan version 1.1 is required";
+    if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "Test requires Vulkan version 1.0";
     }
 
     VkPhysicalDeviceFragmentDensityMapFeaturesEXT fdm_features = LvlInitStruct<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>();
@@ -1514,7 +1514,7 @@ TEST_F(VkLayerTest, RenderPassCreateFragmentDensityMapReferenceToInvalidAttachme
     VkAttachmentDescription attach = {};
     attach.format = VK_FORMAT_R8G8_UNORM;
     attach.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    attach.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attach.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
     attach.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attach.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -1550,7 +1550,8 @@ TEST_F(VkLayerTest, RenderPassCreateFragmentDensityMapReferenceToInvalidAttachme
 
     VkImageObj image(m_device);
     image.Init(image_create_info);
-    VkImageView imageView = image.targetView(VK_FORMAT_R8G8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 4);
+    VkImageView imageView =
+        image.targetView(VK_FORMAT_R8G8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 4, VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
     VkFramebufferCreateInfo fb_info = LvlInitStruct<VkFramebufferCreateInfo>();
     fb_info.renderPass = renderPass;
@@ -1564,4 +1565,6 @@ TEST_F(VkLayerTest, RenderPassCreateFragmentDensityMapReferenceToInvalidAttachme
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-02744");
     vk::CreateFramebuffer(device(), &fb_info, nullptr, &framebuffer);
     m_errorMonitor->VerifyFound();
+
+    vk::DestroyRenderPass(device(), renderPass, nullptr);
 }

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -335,6 +335,12 @@ TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
+    constexpr uint32_t test_extent_value = 10;
+    if (m_surface_capabilities.minImageExtent.width < test_extent_value ||
+        m_surface_capabilities.minImageExtent.height < test_extent_value) {
+        GTEST_SKIP() << "minImageExtent is not large enough";
+    }
+
     auto image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = m_surface_formats[0].format;
@@ -396,7 +402,7 @@ TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
     copy_region.dstSubresource.layerCount = 1;
     copy_region.srcOffset = {0, 0, 0};
     copy_region.dstOffset = {0, 0, 0};
-    copy_region.extent = {10, 10, 1};
+    copy_region.extent = {test_extent_value, test_extent_value, 1};
     vk::CmdCopyImage(m_commandBuffer->handle(), src_Image.handle(), VK_IMAGE_LAYOUT_GENERAL, peer_image.handle(),
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 


### PR DESCRIPTION
Clean up some tests in order for Profile layer and MockICD to run with them

`MultisampledRenderToSingleSampled` and `RenderPassCreateFragmentDensityMapReferenceToInvalidAttachment` were not valid tests (not being tested in CI it seems)