### PR TITLE
layers: Fix extension wrapping VUID 08120

### DIFF
--- a/layers/core_checks/descriptor_validation.cpp
+++ b/layers/core_checks/descriptor_validation.cpp
@@ -4336,7 +4336,7 @@ bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescri
     }
 
     if (checkDataSize && size != dataSize) {
-        if (!IsExtEnabled(device_extensions.vk_ext_descriptor_buffer_density)) {
+        if (!IsExtEnabled(device_extensions.vk_ext_fragment_density_map)) {
             skip |= LogError(device, "VUID-vkGetDescriptorEXT-dataSize-08120",
                              "vkGetDescriptorEXT(): dataSize (%zu) must equal the size of a descriptor (%zu) of type "
                              "VkDescriptorGetInfoEXT::type "


### PR DESCRIPTION
The spec is

```
ifndef::VK_EXT_fragment_density_map[]
  * [[VUID-vkGetDescriptorEXT-dataSize-08120]]
    pname:dataSize must: equal the size of a descriptor of type...
endif::VK_EXT_fragment_density_map[]
ifdef::VK_EXT_fragment_density_map[]
  * [[VUID-vkGetDescriptorEXT-dataSize-08125]]
    pname:dataSize must: equal the size of a descriptor of type...
endif::VK_EXT_fragment_density_map[]
```