### PR TITLE
Improve test coverage with Max Profile

### DIFF
--- a/layers/core_checks/device_validation.cpp
+++ b/layers/core_checks/device_validation.cpp
@@ -15,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * This file deals with anything related to Phyiscal Devices, Logical Devices, or Device Queues Families, Device Masks, etc
  */
 
@@ -195,7 +195,7 @@ bool CoreChecks::ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE *pd_
     vvl::unordered_map<uint32_t, VkQueueGlobalPriorityKHR> global_priorities;
 
     for (uint32_t i = 0; i < info_count; ++i) {
-        const auto requested_queue_family = infos[i].queueFamilyIndex;
+        const uint32_t requested_queue_family = infos[i].queueFamilyIndex;
         const bool protected_create_bit = (infos[i].flags & VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT) != 0;
 
         std::string queue_family_var_name = "pCreateInfo->pQueueCreateInfos[" + std::to_string(i) + "].queueFamilyIndex";
@@ -276,11 +276,11 @@ bool CoreChecks::ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE *pd_
 
         // if using protected flag, make sure queue supports it
         if (protected_create_bit && ((requested_queue_family_props.queueFlags & VK_QUEUE_PROTECTED_BIT) == 0)) {
-            skip |= LogError(
-                pd_state->Handle(), "VUID-VkDeviceQueueCreateInfo-flags-06449",
-                "CreateDevice(): %s (=%" PRIu32
-                ") does not have VK_QUEUE_PROTECTED_BIT supported, but VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT is being used.",
-                queue_family_var_name.c_str(), requested_queue_family);
+            skip |= LogError(pd_state->Handle(), "VUID-VkDeviceQueueCreateInfo-flags-06449",
+                             "CreateDevice(): %s (=%" PRIu32
+                             ") does not have VK_QUEUE_PROTECTED_BIT supported, but pQueueCreateInfos[%" PRIu32
+                             "].flags has VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT.",
+                             queue_family_var_name.c_str(), requested_queue_family, i);
         }
 
         // Verify that requested queue count of queue family is known to be valid at this point in time
@@ -306,13 +306,6 @@ bool CoreChecks::ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE *pd_
                     "].queueFamilyIndex} (=%" PRIu32 ") obtained previously from vkGetPhysicalDeviceQueueFamilyProperties%s (%s).",
                     i, requested_queue_count, i, requested_queue_family, conditional_ext_cmd, count_note.c_str());
             }
-        }
-
-        const VkQueueFlags queue_flags = pd_state->queue_family_properties[requested_queue_family].queueFlags;
-        if ((infos[i].flags == VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT) && ((queue_flags & VK_QUEUE_PROTECTED_BIT) == VK_FALSE)) {
-            skip |= LogError(pd_state->Handle(), "VUID-VkDeviceQueueCreateInfo-flags-06449",
-                             "vkCreateDevice: pCreateInfo->flags set to VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT on a queue that "
-                             "doesn't include VK_QUEUE_PROTECTED_BIT capability");
         }
     }
 

--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -3161,7 +3161,9 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
             }
 
             if (cb_state->activeRenderPass && phys_dev_ext_props.sample_locations_props.variableSampleLocations == VK_FALSE) {
-                const auto *sample_locations = LvlFindInChain<VkPipelineSampleLocationsStateCreateInfoEXT>(pipeline_state.PNext());
+                const auto *multisample_state = pipeline_state.MultisampleState();
+                const auto *sample_locations =
+                    LvlFindInChain<VkPipelineSampleLocationsStateCreateInfoEXT>(multisample_state->pNext);
                 if (sample_locations && sample_locations->sampleLocationsEnable == VK_TRUE &&
                     !pipeline_state.IsDynamic(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT)) {
                     const VkRenderPassSampleLocationsBeginInfoEXT *sample_locations_begin_info =

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -995,12 +995,13 @@
                     "maxMultiviewInstanceIndex": 4294967000
                 },
                 "VkPhysicalDeviceDiscardRectanglePropertiesEXT": {
-                    "maxDiscardRectangles": 4294967000
+                    "maxDiscardRectangles": 4
                 },
                 "VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX": {
                     "perViewPositionAllComponents": true
                 },
                 "VkPhysicalDeviceSubgroupProperties": {
+                    "subgroupSize": 32,
                     "supportedStages": [
                         "VK_SHADER_STAGE_VERTEX_BIT",
                         "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
@@ -1040,7 +1041,7 @@
                     "filterMinmaxImageComponentMapping": true
                 },
                 "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
-                    "variableSampleLocations": true,
+                    "variableSampleLocations": false,
                     "sampleLocationSampleCounts": [
                         "VK_SAMPLE_COUNT_1_BIT",
                         "VK_SAMPLE_COUNT_2_BIT",
@@ -1053,7 +1054,7 @@
                     "advancedBlendNonPremultipliedSrcColor": true,
                     "advancedBlendNonPremultipliedDstColor": true,
                     "advancedBlendCorrelatedOverlap": true,
-                    "advancedBlendAllOperations": true
+                    "advancedBlendAllOperations": false
                 },
                 "VkPhysicalDeviceInlineUniformBlockProperties": {
                     "maxInlineUniformBlockSize": 2048,
@@ -1168,8 +1169,8 @@
                     "maxDecompressionIndirectCount": 4294967000
                 },
                 "VkPhysicalDeviceShadingRateImagePropertiesNV": {
-                    "shadingRatePaletteSize": 4294967000,
-                    "shadingRateMaxCoarseSamples": 4294967000
+                    "shadingRatePaletteSize": 32,
+                    "shadingRateMaxCoarseSamples": 32
                 },
                 "VkPhysicalDeviceMeshShaderPropertiesNV": {
                     "maxDrawMeshTasksCount": 4294967000,
@@ -1423,12 +1424,12 @@
                         "VK_SHADER_STAGE_MESH_BIT_EXT",
                         "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI"
                     ],
-                    "maxInlineUniformBlockSize": 4294967000,
-                    "maxPerStageDescriptorInlineUniformBlocks": 4294967000,
-                    "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": 4294967000,
-                    "maxDescriptorSetInlineUniformBlocks": 4294967000,
-                    "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": 4294967000,
-                    "maxInlineUniformTotalSize": 4294967000,
+                    "maxInlineUniformBlockSize": 2048,
+                    "maxPerStageDescriptorInlineUniformBlocks": 2048,
+                    "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": 2048,
+                    "maxDescriptorSetInlineUniformBlocks": 2048,
+                    "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": 2048,
+                    "maxInlineUniformTotalSize": 2048,
                     "integerDotProduct8BitUnsignedAccelerated": true,
                     "integerDotProduct8BitSignedAccelerated": true,
                     "integerDotProduct8BitMixedSignednessAccelerated": true,
@@ -1483,9 +1484,9 @@
                         "height": 16
                     },
                     "maxFragmentShadingRateAttachmentTexelSizeAspectRatio": 1,
-                    "primitiveFragmentShadingRateWithMultipleViewports": true,
+                    "primitiveFragmentShadingRateWithMultipleViewports": false,
                     "layeredShadingRateAttachments": true,
-                    "fragmentShadingRateNonTrivialCombinerOps": true,
+                    "fragmentShadingRateNonTrivialCombinerOps": false,
                     "maxFragmentSize": {
                         "width": 16,
                         "height": 16
@@ -1503,7 +1504,7 @@
                 },
                 "VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV": {},
                 "VkPhysicalDeviceProvokingVertexPropertiesEXT": {
-                    "provokingVertexModePerPipeline": true,
+                    "provokingVertexModePerPipeline": false,
                     "transformFeedbackPreservesTriangleFanProvokingVertex": true
                 },
                 "VkPhysicalDeviceDescriptorBufferPropertiesEXT": {
@@ -2147,7 +2148,6 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
@@ -2170,7 +2170,6 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
@@ -2193,7 +2192,6 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
@@ -2653,9 +2651,6 @@
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                            "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -2676,9 +2671,6 @@
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                            "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -2699,9 +2691,6 @@
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT",
-                            "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
-                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
-                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
@@ -3051,12 +3040,12 @@
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                             "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                             "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"
                         ],
@@ -5495,7 +5484,9 @@
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT"
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
+                            "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT"
                         ],
                         "bufferFeatures": [
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
@@ -7258,6 +7249,50 @@
                         "videoCodecOperations": [
                             "VK_VIDEO_CODEC_OPERATION_DECODE_H264_BIT_EXT",
                             "VK_VIDEO_CODEC_OPERATION_DECODE_H265_BIT_EXT"
+                        ]
+                    }
+                },
+                {
+                    "VkQueueFamilyProperties": {
+                        "minImageTransferGranularity": {
+                            "width": 1,
+                            "height": 1,
+                            "depth": 1
+                        },
+                        "queueCount": 1,
+                        "queueFlags": [
+                            "VK_QUEUE_COMPUTE_BIT"
+                        ],
+                        "timestampValidBits": 64
+                    },
+                    "VkQueueFamilyQueryResultStatusProperties2KHR": {
+                        "supported": false
+                    },
+                    "VkVideoQueueFamilyProperties2KHR": {
+                        "videoCodecOperations": [
+
+                        ]
+                    }
+                },
+                {
+                    "VkQueueFamilyProperties": {
+                        "minImageTransferGranularity": {
+                            "width": 4,
+                            "height": 4,
+                            "depth": 4
+                        },
+                        "queueCount": 2,
+                        "queueFlags": [
+                            "VK_QUEUE_TRANSFER_BIT"
+                        ],
+                        "timestampValidBits": 64
+                    },
+                    "VkQueueFamilyQueryResultStatusProperties2KHR": {
+                        "supported": false
+                    },
+                    "VkVideoQueueFamilyProperties2KHR": {
+                        "videoCodecOperations": [
+
                         ]
                     }
                 }

--- a/tests/device_profiles/pixel_6_adreno.json
+++ b/tests/device_profiles/pixel_6_adreno.json
@@ -408,6 +408,21 @@
                         "VK_SHADER_STAGE_ALL"
                     ]
                 },
+                "VkPhysicalDeviceSubgroupProperties": {
+                    "subgroupSize": 64,
+                    "supportedStages": [
+                        "VK_SHADER_STAGE_COMPUTE_BIT"
+                    ],
+                    "supportedOperations": [
+                        "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                        "VK_SUBGROUP_FEATURE_VOTE_BIT",
+                        "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                        "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                        "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                        "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT"
+                    ],
+                    "quadOperationsInAllStages": false
+                },
                 "VkPhysicalDeviceMaintenance3PropertiesKHR": {
                     "maxMemoryAllocationSize": 1073741824,
                     "maxPerSetDescriptors": 4294967295

--- a/tests/device_profiles/pixel_6_mali.json
+++ b/tests/device_profiles/pixel_6_mali.json
@@ -547,6 +547,24 @@
                         "VK_SHADER_STAGE_ALL"
                     ]
                 },
+                "VkPhysicalDeviceSubgroupProperties": {
+                    "subgroupSize": 16,
+                    "supportedStages": [
+                        "VK_SHADER_STAGE_FRAGMENT_BIT",
+                        "VK_SHADER_STAGE_COMPUTE_BIT"
+                    ],
+                    "supportedOperations": [
+                        "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                        "VK_SUBGROUP_FEATURE_VOTE_BIT",
+                        "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                        "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                        "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                        "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                        "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                        "VK_SUBGROUP_FEATURE_QUAD_BIT"
+                    ],
+                    "quadOperationsInAllStages": false
+                },
                 "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
                     "maxCustomBorderColorSamplers": 4294967295
                 },

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -206,7 +206,7 @@ TEST_F(VkPositiveLayerTest, SurfacelessQueryTest) {
     }
 
     if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
+        GTEST_SKIP() << "VK_GOOGLE_surfaceless_query not supported on desktop";
     }
 
     // Use the VK_GOOGLE_surfaceless_query extension to query the available formats and

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -3930,12 +3930,6 @@ TEST_F(VkPositiveLayerTest, ImageDrmFormatModifier) {
 TEST_F(VkPositiveLayerTest, AllowedDuplicateStype) {
     TEST_DESCRIPTION("Pass duplicate structs to whose vk.xml definition contains allowduplicate=true");
 
-    ASSERT_NO_FATAL_FAILURE(InitFramework());
-
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
-
     VkInstance instance;
 
     VkInstanceCreateInfo ici = LvlInitStruct<VkInstanceCreateInfo>();
@@ -3960,10 +3954,6 @@ TEST_F(VkPositiveLayerTest, MeshShaderOnly) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
-    }
-
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     // Create a device that enables mesh_shader

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -1993,10 +1993,6 @@ TEST_F(VkPositiveLayerTest, MeshShaderPointSize) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
-
     // Create a device that enables mesh_shader
     auto mesh_shader_features = LvlInitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
@@ -2479,9 +2475,8 @@ TEST_F(VkPositiveLayerTest, SpecializationWordBoundryOffset) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    // need real device to produce output to check
     if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
+        GTEST_SKIP() << "Test not supported by MockICD, need real device to produce output to check";
     }
 
     // glslang currenlty turned the GLSL to

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -4892,10 +4892,6 @@ TEST_F(VkLayerTest, InvalidTexelBufferAlignment) {
         GTEST_SKIP() << "texelBufferAlignment feature not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
-
     auto align_props = LvlInitStruct<VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT>();
     GetPhysicalDeviceProperties2(align_props);
 
@@ -14776,10 +14772,6 @@ TEST_F(VkLayerTest, CopyMutableDescriptors) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
-    }
-    // TODO - Currently not working on MockICD with Profiles
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
     auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -5661,9 +5661,6 @@ TEST_F(VkLayerTest, IndirectDrawTests) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -6250,10 +6247,6 @@ TEST_F(VkLayerTest, MeshShaderNV) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
-    }
-
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     // Create a device that enables mesh_shader

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -233,10 +233,6 @@ TEST_F(VkLayerTest, PrivateDataFeature) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
-
     // feature not enabled
     ASSERT_NO_FATAL_FAILURE(InitState());
 
@@ -3556,10 +3552,6 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
-
     // Create a device that enables shading_rate_image but disables multiViewport
     auto shading_rate_image_features = LvlInitStruct<VkPhysicalDeviceShadingRateImageFeaturesNV>();
     auto features2 = GetPhysicalDeviceFeatures2(shading_rate_image_features);
@@ -6819,10 +6811,6 @@ TEST_F(VkLayerTest, InvalidSpirvExtension) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD, doesn't support Vulkan 1.1+";
-    }
 
     const char *vertex_source = R"spirv(
                OpCapability Shader

--- a/tests/vklayertests_query.cpp
+++ b/tests/vklayertests_query.cpp
@@ -602,6 +602,9 @@ TEST_F(VkLayerQueryTest, QueryPerformanceIncompletePasses) {
     if (!host_query_reset_features.hostQueryReset) {
         GTEST_SKIP() << "Missing host query reset.";
     }
+    if (IsPlatform(kMockICD)) {
+        GTEST_SKIP() << "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR doens't match up with profile queues";
+    }
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &performance_features, pool_flags));

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -681,9 +681,6 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD, will throw a std::bad_alloc sometimes";
-    }
     ASSERT_TRUE(InitSwapchain());
     uint32_t image_count;
     ASSERT_VK_SUCCESS(vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr));
@@ -830,9 +827,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD, will throw a std::bad_alloc sometimes";
-    }
+
     ASSERT_TRUE(InitSwapchain());
     uint32_t image_count;
     ASSERT_VK_SUCCESS(vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr));


### PR DESCRIPTION
Along with https://github.com/KhronosGroup/Vulkan-Tools/pull/745 this change adds about 60 tests to run on the Max Profile CI run (runs 1438 tests, skips 284)

Also fixed 2 bugs in the code not caught from tests not being ran