### PR TITLE
Cleanup OpVariable access status code

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -848,7 +848,7 @@ class CoreChecks : public ValidationStateTracker {
     VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) const;
 
     bool ValidateShaderStageWritableOrAtomicDescriptor(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
-                                                       bool has_writable_descriptor, bool has_atomic_descriptor) const;
+                                                       bool has_descriptor_written_to, bool has_atomic_descriptor) const;
     bool ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE& module_state,
                                               safe_VkPipelineShaderStageCreateInfo const* pStage, const PIPELINE_STATE& pipeline,
                                               const Instruction& entrypoint) const;

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -241,6 +241,7 @@ bool CoreChecks::ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER
     return skip;
 }
 
+// Validate use of input attachments against subpass structure
 bool CoreChecks::ValidateShaderInputAttachment(const SHADER_MODULE_STATE &module_state, const Instruction &entrypoint,
                                                const PIPELINE_STATE &pipeline) const {
     bool skip = false;
@@ -3271,7 +3272,6 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE &pipeline, con
         }
     }
 
-    // Validate use of input attachments against subpass structure
     if (pStage->stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
         skip |= ValidateShaderInputAttachment(module_state, entrypoint, pipeline);
     } else if (pStage->stage == VK_SHADER_STAGE_COMPUTE_BIT) {

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -249,11 +249,11 @@ bool CoreChecks::ValidateShaderInputAttachment(const SHADER_MODULE_STATE &module
     if (rp_state && !rp_state->UsesDynamicRendering()) {
         auto rpci = rp_state->createInfo.ptr();
         const uint32_t subpass = pipeline.Subpass();
-        auto attachment_indexes = module_state.GetAttachmentIndexes(entrypoint);
-        if (!attachment_indexes) {
+        auto input_attachment_indexes = module_state.GetAttachmentIndexes(entrypoint);
+        if (!input_attachment_indexes) {
             return skip;
         }
-        for (const uint32_t index : *attachment_indexes) {
+        for (const uint32_t index : *input_attachment_indexes) {
             auto input_attachments = rpci->pSubpasses[subpass].pInputAttachments;
 
             // Same error, but provide more useful message 'how' VK_ATTACHMENT_UNUSED is derived
@@ -695,10 +695,10 @@ bool CoreChecks::RequireFeature(const SHADER_MODULE_STATE &module_state, VkBool3
 }
 
 bool CoreChecks::ValidateShaderStageWritableOrAtomicDescriptor(const SHADER_MODULE_STATE &module_state, VkShaderStageFlagBits stage,
-                                                               bool has_writable_descriptor, bool has_atomic_descriptor) const {
+                                                               bool has_descriptor_written_to, bool has_atomic_descriptor) const {
     bool skip = false;
 
-    if (has_writable_descriptor || has_atomic_descriptor) {
+    if (has_descriptor_written_to || has_atomic_descriptor) {
         switch (stage) {
             case VK_SHADER_STAGE_FRAGMENT_BIT:
                 skip |= RequireFeature(module_state, enabled_features.core.fragmentStoresAndAtomics, "fragmentStoresAndAtomics",
@@ -3164,7 +3164,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE &pipeline, con
     }
 
     skip |= ValidateTransformFeedback(module_state, pipeline);
-    skip |= ValidateShaderStageWritableOrAtomicDescriptor(module_state, pStage->stage, stage_state.has_writable_descriptor,
+    skip |= ValidateShaderStageWritableOrAtomicDescriptor(module_state, pStage->stage, stage_state.has_descriptor_written_to,
                                                           stage_state.has_atomic_descriptor);
     skip |= ValidateShaderStageInputOutputLimits(module_state, pStage, pipeline, entrypoint);
     skip |= ValidateShaderStageMaxResources(module_state, pStage->stage, pipeline);

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -50,8 +50,8 @@ PipelineStageState::PipelineStageState(const safe_VkPipelineShaderStageCreateInf
     if (entrypoint) {
         descriptor_variables = module_state->GetResourceInterfaceVariable(*entrypoint);
         if (descriptor_variables) {
-            has_writable_descriptor = std::any_of(descriptor_variables->begin(), descriptor_variables->end(),
-                                                  [](const auto &variable) { return variable.is_writable; });
+            has_descriptor_written_to = std::any_of(descriptor_variables->begin(), descriptor_variables->end(),
+                                                    [](const auto &variable) { return variable.is_written_to; });
 
             has_atomic_descriptor = std::any_of(descriptor_variables->begin(), descriptor_variables->end(),
                                                 [](const auto &variable) { return variable.is_atomic_operation; });
@@ -163,7 +163,7 @@ PIPELINE_STATE::ActiveSlotMap PIPELINE_STATE::GetActiveSlots(const StageStateVec
         for (const auto &variable : *stage.descriptor_variables) {
             // While validating shaders capture which slots are used by the pipeline
             auto &entry = active_slots[variable.decorations.set][variable.decorations.binding];
-            entry.is_writable |= variable.is_writable;
+            entry.is_written_to |= variable.is_written_to;
 
             auto &reqs = entry.reqs;
             reqs |= stage.module_state->DescriptorTypeToReqs(variable.type_id);

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -77,14 +77,14 @@ extern DescriptorReqFlags DescriptorRequirementsBitsFromFormat(VkFormat fmt);
 
 struct DescriptorRequirement {
     DescriptorReqFlags reqs;
-    bool is_writable;
+    bool is_written_to;
     // Copy from StageState.ResourceInterfaceVariable. It combines from plural shader stages. The index of array is index of image.
     std::vector<vvl::unordered_set<SamplerUsedByImage>> samplers_used_by_image;
     // For storage images - list of < OpImageWrite : Texel component length >
     std::vector<std::pair<Instruction, uint32_t>> write_without_formats_component_count_list;
     // OpTypeImage the variable points to, null if doesn't use the image
     uint32_t image_sampled_type_width = 0;
-    DescriptorRequirement() : reqs(0), is_writable(false) {}
+    DescriptorRequirement() : reqs(0), is_written_to(false) {}
 };
 
 inline bool operator==(const DescriptorRequirement &a, const DescriptorRequirement &b) noexcept { return a.reqs == b.reqs; }
@@ -100,7 +100,7 @@ struct PipelineStageState {
     VkShaderStageFlagBits stage_flag;
     std::optional<Instruction> entrypoint;
     const std::vector<ResourceInterfaceVariable> *descriptor_variables = {};
-    bool has_writable_descriptor;
+    bool has_descriptor_written_to;
     bool has_atomic_descriptor;
     bool wrote_primitive_shading_rate;
     bool writes_to_gl_layer;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -41,9 +41,6 @@ void DecorationSet::Add(uint32_t decoration, uint32_t value) {
         case spv::DecorationComponent:
             component = value;
             break;
-        case spv::DecorationInputAttachmentIndex:
-            input_attachment_index = value;
-            break;
         case spv::DecorationDescriptorSet:
             set = value;
             break;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -235,7 +235,7 @@ SHADER_MODULE_STATE::EntryPoint::EntryPoint(const SHADER_MODULE_STATE& module_st
                     if (def->Opcode() == spv::OpVariable && def->StorageClass() == spv::StorageClassUniformConstant) {
                         const uint32_t num_locations = module_state.GetLocationsConsumedByType(def->Word(1), false);
                         for (uint32_t offset = 0; offset < num_locations; offset++) {
-                            attachment_indexes.insert(attachment_index + offset);
+                            input_attachment_indexes.insert(attachment_index + offset);
                         }
                     }
                 }
@@ -1251,7 +1251,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const SHADER_MODULE_STATE& 
                 const uint32_t image_write_load_id = CheckObjectIDFromOpLoad(
                     id, static_data_.image_write_load_ids, static_data_.load_members, static_data_.accesschain_members);
                 if (image_write_load_id != 0) {
-                    is_writable = true;
+                    is_written_to = true;
                     if (is_image_without_format) {
                         is_write_without_format = true;
                         for (const auto& entry : static_data_.image_write_load_id_map) {
@@ -1264,7 +1264,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const SHADER_MODULE_STATE& 
                 }
                 if (CheckObjectIDFromOpLoad(id, static_data_.image_read_load_ids, static_data_.load_members,
                                             static_data_.accesschain_members) != 0) {
-                    is_readable = true;
+                    is_read_from = true;
                     if (is_image_without_format) {
                         is_read_without_format = true;
                     }
@@ -1375,7 +1375,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const SHADER_MODULE_STATE& 
             if (is_storage_buffer && nonwritable_members.size() != type->Length() - 2) {
                 for (auto oid : static_data_.store_pointer_ids) {
                     if (id == oid) {
-                        is_writable = true;
+                        is_written_to = true;
                         return;
                     }
                     auto accesschain_it = static_data_.accesschain_members.find(oid);
@@ -1383,13 +1383,13 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const SHADER_MODULE_STATE& 
                         continue;
                     }
                     if (accesschain_it->second.first == id) {
-                        is_writable = true;
+                        is_written_to = true;
                         return;
                     }
                 }
                 if (CheckObjectIDFromOpLoad(id, static_data_.atomic_store_pointer_ids, static_data_.image_texel_pointer_members,
                                             static_data_.accesschain_members) != 0) {
-                    is_writable = true;
+                    is_written_to = true;
                     return;
                 }
             }

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -53,9 +53,6 @@ struct DecorationSet {
     uint32_t location = kInvalidValue;
     uint32_t component = 0;
 
-    // For input attachments
-    uint32_t input_attachment_index = 0;
-
     // For descriptors
     uint32_t set = 0;
     uint32_t binding = 0;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -108,8 +108,8 @@ struct ResourceInterfaceVariable {
     // Sampled Type width of the OpTypeImage the variable points to, 0 if doesn't use the image
     uint32_t image_sampled_type_width = 0;
 
-    bool is_readable{false};
-    bool is_writable{false};
+    bool is_read_from{false};
+    bool is_written_to{false};
     bool is_atomic_operation{false};
     bool is_sampler_sampled{false};
     bool is_sampler_implicitLod_dref_proj{false};
@@ -202,7 +202,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
         std::vector<UserDefinedInterfaceVariable> user_defined_interface_variables;
         std::vector<ResourceInterfaceVariable> resource_interface_variables;
-        vvl::unordered_set<uint32_t> attachment_indexes;
+        vvl::unordered_set<uint32_t> input_attachment_indexes;
 
         StructInfo push_constant_used_in_shader;
 
@@ -314,7 +314,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     const vvl::unordered_set<uint32_t> *GetAttachmentIndexes(const Instruction &entrypoint) const {
         for (const auto &entry_point : static_data_.entry_points) {
             if (entry_point.entrypoint_insn == entrypoint) {
-                return &entry_point.attachment_indexes;
+                return &entry_point.input_attachment_indexes;
             }
         }
         return nullptr;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -263,6 +263,9 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         vvl::unordered_map<uint32_t, uint32_t> load_members;                              // <result id, pointer>
         vvl::unordered_map<uint32_t, std::pair<uint32_t, uint32_t>> accesschain_members;  // <result id, <base,index[0]>>
         vvl::unordered_map<uint32_t, uint32_t> image_texel_pointer_members;               // <result id, image>
+
+        uint32_t FindIDFromLoad(uint32_t object_id, const std::vector<uint32_t> &operator_members) const;
+        uint32_t FindIDFromAtomic(uint32_t object_id, const std::vector<uint32_t> &operator_members) const;
     };
 
     // This is the SPIR-V module data content

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -678,7 +678,7 @@ SyncStageAccessIndex GetSyncStageAccessIndexsByDescriptorSet(VkDescriptorType de
     // If the desriptorSet is writable, we don't need to care SHADER_READ. SHADER_WRITE is enough.
     // Because if write hazard happens, read hazard might or might not happen.
     // But if write hazard doesn't happen, read hazard is impossible to happen.
-    if (variable.is_writable) {
+    if (variable.is_written_to) {
         return stage_access->second.storage_write;
     } else if (descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
                descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||


### PR DESCRIPTION
In the attempt to fix https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5302 I ran into some spec clarification issues that need to be resolved first. This PR pulls out the "clean up" part of the change I was planning to make. 

The goal is nothing functional should have change in this PR and make the next PR have less noise to review