### PR TITLE
Fix debug label segfault

### DIFF
--- a/layers/vk_layer_logging.h
+++ b/layers/vk_layer_logging.h
@@ -439,6 +439,7 @@ static inline void ResetCmdDebugUtilsLabel(debug_report_data *report_data, VkCom
 }
 
 static inline void EraseCmdDebugUtilsLabel(debug_report_data *report_data, VkCommandBuffer command_buffer) {
+    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
     report_data->debugUtilsCmdBufLabels.erase(command_buffer);
 }
 


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5172

The attached regression test causes a crash on most runs both on linux and windows when the fix is not applied.
