### PR TITLE
cmake: Set default build directory for presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,6 +10,7 @@
       "name": "dev",
       "displayName": "Generic Developer Preset",
       "description": "Sets common developer flags",
+      "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
         "BUILD_TESTS": "ON",
         "BUILD_WERROR": "ON",


### PR DESCRIPTION
VS Code uses `out` directory by default. This PR suggests to use `build` name instead.

When mixing command line and IDE development, it was possible to end up with two build directories which might be confusing. It also allows to switch to IDE after command line session without rebuilding (assuming build settings in the preset match the command line settings).
