### PR TITLE
tests: Add MockICD support for Ray Tracing tests

### DIFF
--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -747,6 +747,9 @@
                 },
                 "VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM": {
                     "multiviewPerViewViewports": true
+                },
+                "VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT": {
+                    "pipelineLibraryGroupHandles": true
                 }
             },
             "properties": {
@@ -1233,27 +1236,33 @@
                     "maxPreferredMeshWorkGroupInvocations": 4294967000
                 },
                 "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
-                    "maxGeometryCount": 4294967000,
-                    "maxInstanceCount": 4294967000,
-                    "maxPrimitiveCount": 4294967000,
-                    "maxPerStageDescriptorAccelerationStructures": 4294967000,
-                    "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": 4294967000,
-                    "maxDescriptorSetAccelerationStructures": 4294967000,
-                    "maxDescriptorSetUpdateAfterBindAccelerationStructures": 4294967000
+                    "maxGeometryCount": 16777215,
+                    "maxInstanceCount": 16777215,
+                    "maxPrimitiveCount": 16777215,
+                    "maxPerStageDescriptorAccelerationStructures": 2048,
+                    "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": 2048,
+                    "maxDescriptorSetAccelerationStructures": 2048,
+                    "maxDescriptorSetUpdateAfterBindAccelerationStructures": 2048
                 },
                 "VkPhysicalDeviceRayTracingPipelinePropertiesKHR": {
-                    "maxRayRecursionDepth": 4294967000,
-                    "maxShaderGroupStride": 4294967000,
-                    "maxRayDispatchInvocationCount": 4294967000,
-                    "maxRayHitAttributeSize": 4294967000
+                    "maxRayDispatchInvocationCount": 1073741824,
+                    "maxRayHitAttributeSize": 32,
+                    "maxRayRecursionDepth": 31,
+                    "maxShaderGroupStride": 4096,
+                    "shaderGroupBaseAlignment": 64,
+                    "shaderGroupHandleAlignment": 32,
+                    "shaderGroupHandleCaptureReplaySize": 32,
+                    "shaderGroupHandleSize": 32
                 },
                 "VkPhysicalDeviceRayTracingPropertiesNV": {
-                    "maxRecursionDepth": 4294967000,
-                    "maxShaderGroupStride": 4294967000,
-                    "maxGeometryCount": 4294967000,
-                    "maxInstanceCount": 4294967000,
-                    "maxTriangleCount": 4294967000,
-                    "maxDescriptorSetAccelerationStructures": 4294967000
+                    "maxDescriptorSetAccelerationStructures": 2048,
+                    "maxGeometryCount": 16777215,
+                    "maxInstanceCount": 16777215,
+                    "maxRecursionDepth": 31,
+                    "maxShaderGroupStride": 4096,
+                    "maxTriangleCount": 536870911,
+                    "shaderGroupBaseAlignment": 64,
+                    "shaderGroupHandleSize": 32
                 },
                 "VkPhysicalDeviceFragmentDensityMapPropertiesEXT": {
                     "fragmentDensityInvocations": true,
@@ -1598,8 +1607,7 @@
                 "VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM": {
                     "shaderCoreCount": 4294967000,
                     "shaderWarpsPerCore": 4294967000
-                },
-                "VkPhysicalDeviceRayTracingInvocationReorderPropertiesNV": {}
+                }
             },
             "extensions": {
                 "VK_AMD_buffer_marker": 1,
@@ -1702,6 +1710,7 @@
                 "VK_EXT_pipeline_properties": 1,
                 "VK_EXT_pipeline_protected_access": 1,
                 "VK_EXT_pipeline_robustness": 1,
+                "VK_EXT_pipeline_library_group_handles": 1,
                 "VK_EXT_post_depth_coverage": 1,
                 "VK_EXT_primitive_topology_list_restart": 1,
                 "VK_EXT_primitives_generated_query": 1,

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -2590,7 +2590,7 @@ void Barrier2QueueFamilyTestHelper::operator()(const std::string &img_err, const
 };
 
 bool InitFrameworkForRayTracingTest(VkRenderFramework *framework, bool is_khr, VkPhysicalDeviceFeatures2KHR *features2,
-                                    VkValidationFeaturesEXT *enabled_features, bool mockicd_valid) {
+                                    VkValidationFeaturesEXT *enabled_features) {
     framework->AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     framework->AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
     if (is_khr) {
@@ -2609,11 +2609,6 @@ bool InitFrameworkForRayTracingTest(VkRenderFramework *framework, bool is_khr, V
     framework->InitFramework(&framework->Monitor(), enabled_features);
     if (!framework->AreRequiredExtensionsEnabled()) {
         printf("%s device extension not supported, skipping test\n", framework->RequiredExtensionsNotSupported().c_str());
-        return false;
-    }
-
-    if (!mockicd_valid && (framework->IsPlatform(kMockICD))) {
-        printf("Test not supported by MockICD, skipping tests\n");
         return false;
     }
 
@@ -2721,8 +2716,8 @@ void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
+    if (gpu_assisted && IsPlatform(kMockICD)) {
+        GTEST_SKIP() << "GPU-AV can't run on MockICD";
     }
 
     VkPhysicalDeviceFeatures2KHR features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>();

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -957,7 +957,7 @@ void CreateBufferViewTest(VkLayerTest &test, const VkBufferViewCreateInfo *pCrea
 void CreateImageViewTest(VkLayerTest &test, const VkImageViewCreateInfo *pCreateInfo, const std::string &code = "");
 
 bool InitFrameworkForRayTracingTest(VkRenderFramework *framework, bool is_khr, VkPhysicalDeviceFeatures2KHR *features2 = nullptr,
-                                    VkValidationFeaturesEXT *enabled_features = nullptr, bool mockicd_valid = false);
+                                    VkValidationFeaturesEXT *enabled_features = nullptr);
 
 void GetSimpleGeometryForAccelerationStructureTests(const VkDeviceObj &device, VkBufferObj *vbo, VkBufferObj *ibo,
                                                     VkGeometryNV *geometry, VkDeviceSize offset = 0, bool buffer_device_address = false);

--- a/tests/positive/ray_tracing.cpp
+++ b/tests/positive/ray_tracing.cpp
@@ -67,9 +67,6 @@ TEST_F(VkPositiveLayerTest, RayTracingAccelerationStructureReference) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }

--- a/tests/vklayertests_buffer_image_memory_sampler.cpp
+++ b/tests/vklayertests_buffer_image_memory_sampler.cpp
@@ -10928,9 +10928,6 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXT) {
         GTEST_SKIP() << "bufferDeviceAddressCaptureReplay feature not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
     buffer_device_address_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &buffer_device_address_features));
@@ -10986,10 +10983,6 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXTDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
-
     auto buffer_device_address_features = LvlInitStruct<VkPhysicalDeviceBufferAddressFeaturesEXT>();
     buffer_device_address_features.bufferDeviceAddress = VK_FALSE;
     buffer_device_address_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
@@ -11026,10 +11019,6 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
-    }
-
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     auto buffer_device_address_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
@@ -11139,10 +11128,6 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
-    }
-
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
     }
 
     auto buffer_device_address_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -12276,10 +12276,6 @@ TEST_F(VkLayerTest, DescriptorBufferNotEnabled) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kMockICD)) {
-        // TODO - Issue https://github.com/KhronosGroup/Vulkan-Tools/issues/743
-        GTEST_SKIP() << "MockICD missing VK_KHR_buffer_device_address";
-    }
 
     auto buffer_device_address_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
     auto acceleration_structure_features =
@@ -12682,11 +12678,6 @@ TEST_F(VkLayerTest, DescriptorBufferBindingAndOffsets) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    if (IsPlatform(kMockICD)) {
-        // TODO - Issue https://github.com/KhronosGroup/Vulkan-Tools/issues/743
-        GTEST_SKIP() << "MockICD missing VK_KHR_buffer_device_address";
-    }
-
     auto descriptor_buffer_features = LvlInitStruct<VkPhysicalDeviceDescriptorBufferFeaturesEXT>();
     auto buffer_device_address_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>(&descriptor_buffer_features);
     GetPhysicalDeviceFeatures2(buffer_device_address_features);
@@ -12932,11 +12923,6 @@ TEST_F(VkLayerTest, DescriptorBufferInconsistentBuffer) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    if (IsPlatform(kMockICD)) {
-        // TODO - Issue https://github.com/KhronosGroup/Vulkan-Tools/issues/743
-        GTEST_SKIP() << "MockICD missing VK_KHR_buffer_device_address";
-    }
-
     auto descriptor_buffer_features = LvlInitStruct<VkPhysicalDeviceDescriptorBufferFeaturesEXT>();
     auto buffer_device_address_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>(&descriptor_buffer_features);
     GetPhysicalDeviceFeatures2(buffer_device_address_features);
@@ -13161,11 +13147,6 @@ TEST_F(VkLayerTest, DescriptorBufferDescriptorGetInfo) {
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
-    }
-
-    if (IsPlatform(kMockICD)) {
-        // TODO - Issue https://github.com/KhronosGroup/Vulkan-Tools/issues/743
-        GTEST_SKIP() << "MockICD missing VK_KHR_buffer_device_address";
     }
 
     const bool acceleration_structure = IsExtensionsEnabled(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);

--- a/tests/vklayertests_ray_tracing_pipeline.cpp
+++ b/tests/vklayertests_ray_tracing_pipeline.cpp
@@ -916,7 +916,9 @@ TEST_F(VkLayerTest, RayTracingPipelineDeferredOp) {
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
-
+    if (IsPlatform(kMockICD)) {
+        GTEST_SKIP() << "vkGetDeferredOperationResultKHR not supported by MockICD";
+    }
     // Needed for Ray Tracing
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
@@ -1215,7 +1217,7 @@ TEST_F(VkLayerTest, RayTracingPipelineLibraryGroupHandlesEXT) {
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
     auto pipeline_library_group_handles_features =
         LvlInitStruct<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT>(&ray_tracing_features);
-    auto features2 = GetPhysicalDeviceFeatures2(ray_tracing_features);
+    GetPhysicalDeviceFeatures2(pipeline_library_group_handles_features);
 
     if (!ray_tracing_features.rayTracingPipeline) {
         GTEST_SKIP() << "Feature rayTracing is not supported.";
@@ -1227,7 +1229,7 @@ TEST_F(VkLayerTest, RayTracingPipelineLibraryGroupHandlesEXT) {
         GTEST_SKIP() << "rayTracingShaderGroupHandleCaptureReplay not enabled";
     }
     pipeline_library_group_handles_features.pipelineLibraryGroupHandles = false;
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pipeline_library_group_handles_features));
     const VkPipelineLayoutObj pipeline_layout(m_device, {});
 
     VkShaderObj chit_shader(this, bindStateRTShaderText, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, SPV_ENV_VULKAN_1_2);


### PR DESCRIPTION
waiting on https://github.com/KhronosGroup/Vulkan-Tools/pull/747

Adds about 50+ tests and allows for testing most Ray Tracing without needing a supported physical device