### PR TITLE
Ignore fields with VkMemoryBarrier2 pNext

### DIFF
--- a/layers/convert_to_renderpass2.h
+++ b/layers/convert_to_renderpass2.h
@@ -19,4 +19,4 @@
 #pragma once
 #include "vk_safe_struct.h"
 
-void ConvertVkRenderPassCreateInfoToV2KHR(const VkRenderPassCreateInfo& in_struct, safe_VkRenderPassCreateInfo2* out_struct);
+safe_VkRenderPassCreateInfo2 ConvertVkRenderPassCreateInfoToV2KHR(const VkRenderPassCreateInfo& create_info);

--- a/layers/core_checks/render_pass_validation.cpp
+++ b/layers/core_checks/render_pass_validation.cpp
@@ -2388,8 +2388,7 @@ bool CoreChecks::PreCallValidateCreateRenderPass(VkDevice device, const VkRender
     }
 
     if (!skip) {
-        safe_VkRenderPassCreateInfo2 create_info_2;
-        ConvertVkRenderPassCreateInfoToV2KHR(*pCreateInfo, &create_info_2);
+        safe_VkRenderPassCreateInfo2 create_info_2 = ConvertVkRenderPassCreateInfoToV2KHR(*pCreateInfo);
         skip |= ValidateCreateRenderPass(device, RENDER_PASS_VERSION_1, create_info_2.ptr(), "vkCreateRenderPass()");
     }
 

--- a/layers/core_checks/render_pass_validation.cpp
+++ b/layers/core_checks/render_pass_validation.cpp
@@ -189,6 +189,28 @@ bool CoreChecks::ValidateDependencyCompatibility(const char *type1_string, const
     const auto &primary_dep = rp1_state.createInfo.pDependencies[dependency];
     const auto &secondary_dep = rp2_state.createInfo.pDependencies[dependency];
 
+    VkPipelineStageFlags2 primary_src_stage_mask = primary_dep.srcStageMask;
+    VkPipelineStageFlags2 primary_dst_stage_mask = primary_dep.dstStageMask;
+    VkAccessFlags2 primary_src_access_mask = primary_dep.srcAccessMask;
+    VkAccessFlags2 primary_dst_access_mask = primary_dep.dstAccessMask;
+    VkPipelineStageFlags2 secondary_src_stage_mask = secondary_dep.srcStageMask;
+    VkPipelineStageFlags2 secondary_dst_stage_mask = secondary_dep.dstStageMask;
+    VkAccessFlags2 secondary_src_access_mask = secondary_dep.srcAccessMask;
+    VkAccessFlags2 secondary_dst_access_mask = secondary_dep.dstAccessMask;
+
+    if (const auto primary_barrier = LvlFindInChain<VkMemoryBarrier2KHR>(rp1_state.createInfo.pNext); primary_barrier) {
+        primary_src_stage_mask = primary_barrier->srcStageMask;
+        primary_dst_stage_mask = primary_barrier->dstStageMask;
+        primary_src_access_mask = primary_barrier->srcAccessMask;
+        primary_dst_access_mask = primary_barrier->dstAccessMask;
+    }
+    if (const auto secondary_barrier = LvlFindInChain<VkMemoryBarrier2KHR>(rp2_state.createInfo.pNext); secondary_barrier) {
+        secondary_src_stage_mask = secondary_barrier->srcStageMask;
+        secondary_dst_stage_mask = secondary_barrier->dstStageMask;
+        secondary_src_access_mask = secondary_barrier->srcAccessMask;
+        secondary_dst_access_mask = secondary_barrier->dstAccessMask;
+    }
+
     if (primary_dep.srcSubpass != secondary_dep.srcSubpass) {
         std::stringstream ss;
         ss << "First srcSubpass is " << primary_dep.srcSubpass << ", but second srcSubpass is " << secondary_dep.srcSubpass << ".";
@@ -199,28 +221,28 @@ bool CoreChecks::ValidateDependencyCompatibility(const char *type1_string, const
         ss << "First dstSubpass is " << primary_dep.dstSubpass << ", but second dstSubpass is " << secondary_dep.dstSubpass << ".";
         skip |= LogInvalidDependencyMessage(type1_string, rp1_state, type2_string, rp2_state, ss.str().c_str(), caller, error_code);
     }
-    if (primary_dep.srcStageMask != secondary_dep.srcStageMask) {
+    if (primary_src_stage_mask != secondary_src_stage_mask) {
         std::stringstream ss;
-        ss << "First srcStageMask is " << string_VkPipelineStageFlags(primary_dep.srcStageMask) << ", but second srcStageMask is "
-           << string_VkPipelineStageFlags(secondary_dep.srcStageMask) << ".";
+        ss << "First srcStageMask is " << string_VkPipelineStageFlags2(primary_src_stage_mask) << ", but second srcStageMask is "
+           << string_VkPipelineStageFlags2(secondary_src_stage_mask) << ".";
         skip |= LogInvalidDependencyMessage(type1_string, rp1_state, type2_string, rp2_state, ss.str().c_str(), caller, error_code);
     }
-    if (primary_dep.dstStageMask != secondary_dep.dstStageMask) {
+    if (primary_dst_stage_mask != secondary_dst_stage_mask) {
         std::stringstream ss;
-        ss << "First dstStageMask is " << string_VkPipelineStageFlags(primary_dep.dstStageMask) << ", but second dstStageMask is "
-           << string_VkPipelineStageFlags(secondary_dep.dstStageMask) << ".";
+        ss << "First dstStageMask is " << string_VkPipelineStageFlags2(primary_dst_stage_mask) << ", but second dstStageMask is "
+           << string_VkPipelineStageFlags2(secondary_dst_stage_mask) << ".";
         skip |= LogInvalidDependencyMessage(type1_string, rp1_state, type2_string, rp2_state, ss.str().c_str(), caller, error_code);
     }
-    if (primary_dep.srcAccessMask != secondary_dep.srcAccessMask) {
+    if (primary_src_access_mask != secondary_src_access_mask) {
         std::stringstream ss;
-        ss << "First srcAccessMask is " << string_VkAccessFlags(primary_dep.srcAccessMask) << ", but second srcAccessMask is "
-           << string_VkAccessFlags(secondary_dep.srcAccessMask) << ".";
+        ss << "First srcAccessMask is " << string_VkAccessFlags2(primary_src_access_mask) << ", but second srcAccessMask is "
+           << string_VkAccessFlags2(secondary_src_access_mask) << ".";
         skip |= LogInvalidDependencyMessage(type1_string, rp1_state, type2_string, rp2_state, ss.str().c_str(), caller, error_code);
     }
-    if (primary_dep.dstAccessMask != secondary_dep.dstAccessMask) {
+    if (primary_dst_access_mask != secondary_dst_access_mask) {
         std::stringstream ss;
-        ss << "First dstAccessMask is " << string_VkAccessFlags(primary_dep.dstAccessMask) << ", but second dstAccessMask is "
-           << string_VkAccessFlags(secondary_dep.dstAccessMask) << ".";
+        ss << "First dstAccessMask is " << string_VkAccessFlags2(primary_dst_access_mask) << ", but second dstAccessMask is "
+           << string_VkAccessFlags2(secondary_dst_access_mask) << ".";
         skip |= LogInvalidDependencyMessage(type1_string, rp1_state, type2_string, rp2_state, ss.str().c_str(), caller, error_code);
     }
     if (primary_dep.dependencyFlags != secondary_dep.dependencyFlags) {

--- a/layers/core_checks/synchronization_validation.cpp
+++ b/layers/core_checks/synchronization_validation.cpp
@@ -1428,35 +1428,10 @@ bool CoreChecks::ValidateSubpassDependency(const LogObjectList &objects, const L
     VkMemoryBarrier2KHR converted_barrier;
     const auto *mem_barrier = LvlFindInChain<VkMemoryBarrier2KHR>(dependency.pNext);
 
-    if (mem_barrier && enabled_features.core13.synchronization2) {
-        if (dependency.srcAccessMask != 0) {
-            skip |= LogError(objects, "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcAccessMask",
-                             "%s is non-zero when a VkMemoryBarrier2KHR is present in pNext.",
-                             loc.dot(Field::srcAccessMask).Message().c_str());
-        }
-        if (dependency.dstAccessMask != 0) {
-            skip |= LogError(objects, "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstAccessMask",
-                             "%s dstAccessMask is non-zero when a VkMemoryBarrier2KHR is present in pNext.",
-                             loc.dot(Field::dstAccessMask).Message().c_str());
-        }
-        if (dependency.srcStageMask != 0) {
-            skip |= LogError(objects, "UNASSIGNED-CoreChecks-VkSubpassDependency2-srcStageMask",
-                             "%s srcStageMask is non-zero when a VkMemoryBarrier2KHR is present in pNext.",
-                             loc.dot(Field::srcStageMask).Message().c_str());
-        }
-        if (dependency.dstStageMask != 0) {
-            skip |= LogError(objects, "UNASSIGNED-CoreChecks-VkSubpassDependency2-dstStageMask",
-                             "%s dstStageMask is non-zero when a VkMemoryBarrier2KHR is present in pNext.",
-                             loc.dot(Field::dstStageMask).Message().c_str());
-        }
+    if (mem_barrier) {
         loc = in_loc.dot(Field::pNext);
         converted_barrier = *mem_barrier;
     } else {
-        if (mem_barrier) {
-            skip |= LogError(objects, "UNASSIGNED-CoreChecks-VkSubpassDependency2-pNext",
-                             "%s a VkMemoryBarrier2KHR is present in pNext but synchronization2 is not enabled.",
-                             loc.Message().c_str());
-        }
         // use the subpass dependency flags, upconverted into wider synchronization2 fields.
         converted_barrier.srcStageMask = dependency.srcStageMask;
         converted_barrier.dstStageMask = dependency.dstStageMask;

--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -9350,13 +9350,25 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(
 
                 skip |= ValidateStructPnext("vkCreateRenderPass2", ParameterName("pCreateInfo->pDependencies[%i].pNext", ParameterName::IndexVector{ dependencyIndex }), "VkMemoryBarrier2", pCreateInfo->pDependencies[dependencyIndex].pNext, allowed_structs_VkSubpassDependency2.size(), allowed_structs_VkSubpassDependency2.data(), GeneratedVulkanHeaderVersion, "VUID-VkSubpassDependency2-pNext-pNext", "VUID-VkSubpassDependency2-sType-unique", false, true);
 
-                skip |= ValidateFlags("vkCreateRenderPass2", ParameterName("pCreateInfo->pDependencies[%i].srcStageMask", ParameterName::IndexVector{ dependencyIndex }), "VkPipelineStageFlagBits", AllVkPipelineStageFlagBits, pCreateInfo->pDependencies[dependencyIndex].srcStageMask, kOptionalFlags, "VUID-VkSubpassDependency2-srcStageMask-parameter");
+                if (!LvlFindInChain<VkMemoryBarrier2>(pCreateInfo->pDependencies[dependencyIndex].pNext))
+                {
+                    skip |= ValidateFlags("vkCreateRenderPass2", ParameterName("pCreateInfo->pDependencies[%i].srcStageMask", ParameterName::IndexVector{ dependencyIndex }), "VkPipelineStageFlagBits", AllVkPipelineStageFlagBits, pCreateInfo->pDependencies[dependencyIndex].srcStageMask, kOptionalFlags, "VUID-VkSubpassDependency2-srcStageMask-parameter");
+                }
 
-                skip |= ValidateFlags("vkCreateRenderPass2", ParameterName("pCreateInfo->pDependencies[%i].dstStageMask", ParameterName::IndexVector{ dependencyIndex }), "VkPipelineStageFlagBits", AllVkPipelineStageFlagBits, pCreateInfo->pDependencies[dependencyIndex].dstStageMask, kOptionalFlags, "VUID-VkSubpassDependency2-dstStageMask-parameter");
+                if (!LvlFindInChain<VkMemoryBarrier2>(pCreateInfo->pDependencies[dependencyIndex].pNext))
+                {
+                    skip |= ValidateFlags("vkCreateRenderPass2", ParameterName("pCreateInfo->pDependencies[%i].dstStageMask", ParameterName::IndexVector{ dependencyIndex }), "VkPipelineStageFlagBits", AllVkPipelineStageFlagBits, pCreateInfo->pDependencies[dependencyIndex].dstStageMask, kOptionalFlags, "VUID-VkSubpassDependency2-dstStageMask-parameter");
+                }
 
-                skip |= ValidateFlags("vkCreateRenderPass2", ParameterName("pCreateInfo->pDependencies[%i].srcAccessMask", ParameterName::IndexVector{ dependencyIndex }), "VkAccessFlagBits", AllVkAccessFlagBits, pCreateInfo->pDependencies[dependencyIndex].srcAccessMask, kOptionalFlags, "VUID-VkSubpassDependency2-srcAccessMask-parameter");
+                if (!LvlFindInChain<VkMemoryBarrier2>(pCreateInfo->pDependencies[dependencyIndex].pNext))
+                {
+                    skip |= ValidateFlags("vkCreateRenderPass2", ParameterName("pCreateInfo->pDependencies[%i].srcAccessMask", ParameterName::IndexVector{ dependencyIndex }), "VkAccessFlagBits", AllVkAccessFlagBits, pCreateInfo->pDependencies[dependencyIndex].srcAccessMask, kOptionalFlags, "VUID-VkSubpassDependency2-srcAccessMask-parameter");
+                }
 
-                skip |= ValidateFlags("vkCreateRenderPass2", ParameterName("pCreateInfo->pDependencies[%i].dstAccessMask", ParameterName::IndexVector{ dependencyIndex }), "VkAccessFlagBits", AllVkAccessFlagBits, pCreateInfo->pDependencies[dependencyIndex].dstAccessMask, kOptionalFlags, "VUID-VkSubpassDependency2-dstAccessMask-parameter");
+                if (!LvlFindInChain<VkMemoryBarrier2>(pCreateInfo->pDependencies[dependencyIndex].pNext))
+                {
+                    skip |= ValidateFlags("vkCreateRenderPass2", ParameterName("pCreateInfo->pDependencies[%i].dstAccessMask", ParameterName::IndexVector{ dependencyIndex }), "VkAccessFlagBits", AllVkAccessFlagBits, pCreateInfo->pDependencies[dependencyIndex].dstAccessMask, kOptionalFlags, "VUID-VkSubpassDependency2-dstAccessMask-parameter");
+                }
 
                 skip |= ValidateFlags("vkCreateRenderPass2", ParameterName("pCreateInfo->pDependencies[%i].dependencyFlags", ParameterName::IndexVector{ dependencyIndex }), "VkDependencyFlagBits", AllVkDependencyFlagBits, pCreateInfo->pDependencies[dependencyIndex].dependencyFlags, kOptionalFlags, "VUID-VkSubpassDependency2-dependencyFlags-parameter");
             }
@@ -12675,13 +12687,25 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2KHR(
 
                 skip |= ValidateStructPnext("vkCreateRenderPass2KHR", ParameterName("pCreateInfo->pDependencies[%i].pNext", ParameterName::IndexVector{ dependencyIndex }), "VkMemoryBarrier2", pCreateInfo->pDependencies[dependencyIndex].pNext, allowed_structs_VkSubpassDependency2.size(), allowed_structs_VkSubpassDependency2.data(), GeneratedVulkanHeaderVersion, "VUID-VkSubpassDependency2-pNext-pNext", "VUID-VkSubpassDependency2-sType-unique", false, true);
 
-                skip |= ValidateFlags("vkCreateRenderPass2KHR", ParameterName("pCreateInfo->pDependencies[%i].srcStageMask", ParameterName::IndexVector{ dependencyIndex }), "VkPipelineStageFlagBits", AllVkPipelineStageFlagBits, pCreateInfo->pDependencies[dependencyIndex].srcStageMask, kOptionalFlags, "VUID-VkSubpassDependency2-srcStageMask-parameter");
+                if (!LvlFindInChain<VkMemoryBarrier2>(pCreateInfo->pDependencies[dependencyIndex].pNext))
+                {
+                    skip |= ValidateFlags("vkCreateRenderPass2KHR", ParameterName("pCreateInfo->pDependencies[%i].srcStageMask", ParameterName::IndexVector{ dependencyIndex }), "VkPipelineStageFlagBits", AllVkPipelineStageFlagBits, pCreateInfo->pDependencies[dependencyIndex].srcStageMask, kOptionalFlags, "VUID-VkSubpassDependency2-srcStageMask-parameter");
+                }
 
-                skip |= ValidateFlags("vkCreateRenderPass2KHR", ParameterName("pCreateInfo->pDependencies[%i].dstStageMask", ParameterName::IndexVector{ dependencyIndex }), "VkPipelineStageFlagBits", AllVkPipelineStageFlagBits, pCreateInfo->pDependencies[dependencyIndex].dstStageMask, kOptionalFlags, "VUID-VkSubpassDependency2-dstStageMask-parameter");
+                if (!LvlFindInChain<VkMemoryBarrier2>(pCreateInfo->pDependencies[dependencyIndex].pNext))
+                {
+                    skip |= ValidateFlags("vkCreateRenderPass2KHR", ParameterName("pCreateInfo->pDependencies[%i].dstStageMask", ParameterName::IndexVector{ dependencyIndex }), "VkPipelineStageFlagBits", AllVkPipelineStageFlagBits, pCreateInfo->pDependencies[dependencyIndex].dstStageMask, kOptionalFlags, "VUID-VkSubpassDependency2-dstStageMask-parameter");
+                }
 
-                skip |= ValidateFlags("vkCreateRenderPass2KHR", ParameterName("pCreateInfo->pDependencies[%i].srcAccessMask", ParameterName::IndexVector{ dependencyIndex }), "VkAccessFlagBits", AllVkAccessFlagBits, pCreateInfo->pDependencies[dependencyIndex].srcAccessMask, kOptionalFlags, "VUID-VkSubpassDependency2-srcAccessMask-parameter");
+                if (!LvlFindInChain<VkMemoryBarrier2>(pCreateInfo->pDependencies[dependencyIndex].pNext))
+                {
+                    skip |= ValidateFlags("vkCreateRenderPass2KHR", ParameterName("pCreateInfo->pDependencies[%i].srcAccessMask", ParameterName::IndexVector{ dependencyIndex }), "VkAccessFlagBits", AllVkAccessFlagBits, pCreateInfo->pDependencies[dependencyIndex].srcAccessMask, kOptionalFlags, "VUID-VkSubpassDependency2-srcAccessMask-parameter");
+                }
 
-                skip |= ValidateFlags("vkCreateRenderPass2KHR", ParameterName("pCreateInfo->pDependencies[%i].dstAccessMask", ParameterName::IndexVector{ dependencyIndex }), "VkAccessFlagBits", AllVkAccessFlagBits, pCreateInfo->pDependencies[dependencyIndex].dstAccessMask, kOptionalFlags, "VUID-VkSubpassDependency2-dstAccessMask-parameter");
+                if (!LvlFindInChain<VkMemoryBarrier2>(pCreateInfo->pDependencies[dependencyIndex].pNext))
+                {
+                    skip |= ValidateFlags("vkCreateRenderPass2KHR", ParameterName("pCreateInfo->pDependencies[%i].dstAccessMask", ParameterName::IndexVector{ dependencyIndex }), "VkAccessFlagBits", AllVkAccessFlagBits, pCreateInfo->pDependencies[dependencyIndex].dstAccessMask, kOptionalFlags, "VUID-VkSubpassDependency2-dstAccessMask-parameter");
+                }
 
                 skip |= ValidateFlags("vkCreateRenderPass2KHR", ParameterName("pCreateInfo->pDependencies[%i].dependencyFlags", ParameterName::IndexVector{ dependencyIndex }), "VkDependencyFlagBits", AllVkDependencyFlagBits, pCreateInfo->pDependencies[dependencyIndex].dependencyFlags, kOptionalFlags, "VUID-VkSubpassDependency2-dependencyFlags-parameter");
             }

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -244,8 +244,7 @@ RENDER_PASS_STATE::RENDER_PASS_STATE(VkRenderPass rp, VkRenderPassCreateInfo2 co
 }
 
 static safe_VkRenderPassCreateInfo2 ConvertCreateInfo(const VkRenderPassCreateInfo &create_info) {
-    safe_VkRenderPassCreateInfo2 create_info_2;
-    ConvertVkRenderPassCreateInfoToV2KHR(create_info, &create_info_2);
+    safe_VkRenderPassCreateInfo2 create_info_2 = ConvertVkRenderPassCreateInfoToV2KHR(create_info);
     return create_info_2;
 }
 

--- a/layers/stateless/parameter_validation_utils.cpp
+++ b/layers/stateless/parameter_validation_utils.cpp
@@ -5039,8 +5039,7 @@ bool StatelessValidation::ValidateCreateRenderPass(VkDevice device, const VkRend
 bool StatelessValidation::manual_PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
                                                                  const VkAllocationCallbacks *pAllocator,
                                                                  VkRenderPass *pRenderPass) const {
-    safe_VkRenderPassCreateInfo2 create_info_2;
-    ConvertVkRenderPassCreateInfoToV2KHR(*pCreateInfo, &create_info_2);
+    safe_VkRenderPassCreateInfo2 create_info_2 = ConvertVkRenderPassCreateInfoToV2KHR(*pCreateInfo);
     return ValidateCreateRenderPass(device, create_info_2.ptr(), pAllocator, pRenderPass, RENDER_PASS_VERSION_1);
 }
 

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -928,10 +928,9 @@ class StatelessValidation : public ValidationObject {
 
     enum RenderPassCreateVersion { RENDER_PASS_VERSION_1 = 0, RENDER_PASS_VERSION_2 = 1 };
 
-    template <typename RenderPassCreateInfoGeneric>
-    bool ValidateSubpassGraphicsFlags(const debug_report_data *report_data, const RenderPassCreateInfoGeneric *pCreateInfo,
-                                      uint32_t dependency_index, uint32_t subpass, VkPipelineStageFlags2KHR stages,
-                                      const char *vuid, const char *target, const char *func_name) const {
+    bool ValidateSubpassGraphicsFlags(const debug_report_data *report_data, const VkRenderPassCreateInfo2 *pCreateInfo,
+                                      uint32_t dependency_index, uint32_t subpass, VkPipelineStageFlags2 stages, const char *vuid,
+                                      const char *target, const char *func_name) const {
         bool skip = false;
         // make sure we consider all of the expanded and un-expanded graphics bits to be valid
         const auto kExcludeStages = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT_KHR | VK_PIPELINE_STAGE_2_COPY_BIT_KHR |
@@ -963,10 +962,9 @@ class StatelessValidation : public ValidationObject {
         return skip;
     }
 
-    template <typename RenderPassCreateInfoGeneric>
-    bool CreateRenderPassGeneric(VkDevice device, const RenderPassCreateInfoGeneric *pCreateInfo,
-                                 const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
-                                 RenderPassCreateVersion rp_version) const;
+    bool ValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
+                                  const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
+                                  RenderPassCreateVersion rp_version) const;
 
     template <typename T>
     void RecordRenderPass(VkRenderPass renderPass, const T *pCreateInfo) {

--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -228,8 +228,7 @@ void TestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice device, co
     }
 
     if (rp2_supported && nullptr != rp2_vuid) {
-        safe_VkRenderPassCreateInfo2 create_info2;
-        ConvertVkRenderPassCreateInfoToV2KHR(*create_info, &create_info2);
+        safe_VkRenderPassCreateInfo2 create_info2 = ConvertVkRenderPassCreateInfoToV2KHR(*create_info);
 
         PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
             (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR");
@@ -263,8 +262,7 @@ void PositiveTestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice de
     if (rp2_supported) {
         PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
             (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR");
-        safe_VkRenderPassCreateInfo2 create_info2;
-        ConvertVkRenderPassCreateInfoToV2KHR(*create_info, &create_info2);
+        safe_VkRenderPassCreateInfo2 create_info2 = ConvertVkRenderPassCreateInfoToV2KHR(*create_info);
 
         err = vkCreateRenderPass2KHR(device, create_info2.ptr(), nullptr, &render_pass);
         if (err == VK_SUCCESS) vk::DestroyRenderPass(device, render_pass, nullptr);


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2661

The spec says for `VkSubpassDependency2`

> If a [VkMemoryBarrier2](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkMemoryBarrier2) is included in the pNext chain, **srcStageMask**, **dstStageMask**, **srcAccessMask**, and **dstAccessMask** parameters are ignored. The synchronization and access scopes instead are defined by the parameters of [VkMemoryBarrier2](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#VkMemoryBarrier2).

We are already doing this in the Sync validation, but were not doing it in the parameter checking

some other notes about the PR/

- the `UNASSIGNED` were bogus, so removed
- `ConvertVkRenderPassCreateInfoToV2KHR` was not being used in the stateless code (but used 2 other places)
- the old `self.structMemberValidationConditions` was not being used anymore (the VU was updated awhile ago and code was never removed) so I just used that path to implement this "ignore" conditional logic