### PR TITLE
Add conservativeRasterizationPostDepthCoverage check

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -880,6 +880,8 @@ class CoreChecks : public ValidationStateTracker {
                                                             const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderInputAttachment(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
                                        const PIPELINE_STATE& pipeline) const;
+    bool ValidateConservativeRasterization(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
+                                           const PIPELINE_STATE& pipeline) const;
     bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
                                    safe_VkPipelineShaderStageCreateInfo const* pStage, const std::string& vuid) const;
     bool ValidateBuiltinLimits(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -1097,7 +1097,7 @@
                     "degenerateTrianglesRasterized": true,
                     "degenerateLinesRasterized": true,
                     "fullyCoveredFragmentShaderInputVariable": true,
-                    "conservativeRasterizationPostDepthCoverage": true
+                    "conservativeRasterizationPostDepthCoverage": false
                 },
                 "VkPhysicalDeviceShaderCorePropertiesAMD": {
                     "wavefrontSize": 4294967000,


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5323

Checks for `VUID-FullyCoveredEXT-conservativeRasterizationPostDepthCoverage-04235`