### PR TITLE
layers: Fix 00751 check

### DIFF
--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -277,10 +277,6 @@ TEST_F(VkPositiveLayerTest, DynamicRenderingPipeWithDiscard) {
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, bindStateFragShaderText, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    VkPipelineRasterizationStateCreateInfo rs_ci = LvlInitStruct<VkPipelineRasterizationStateCreateInfo>();
-    rs_ci.rasterizerDiscardEnable = VK_TRUE;
-    rs_ci.lineWidth = 1.0f;
-
     VkPipelineDepthStencilStateCreateInfo ds_ci = LvlInitStruct<VkPipelineDepthStencilStateCreateInfo>();
     ds_ci.depthTestEnable = VK_TRUE;
     ds_ci.depthWriteEnable = VK_TRUE;
@@ -290,7 +286,6 @@ TEST_F(VkPositiveLayerTest, DynamicRenderingPipeWithDiscard) {
     pipe.AddShader(&fs);
     pipe.AddDefaultColorAttachment();
     pipe.SetDepthStencil(&ds_ci);
-    pipe.SetRasterization(&rs_ci);
 
     VkDescriptorSetLayoutBinding dslb = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
     const VkDescriptorSetLayoutObj dsl(m_device, {dslb});

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -2725,6 +2725,7 @@ TEST_F(VkPositiveLayerTest, PositiveShaderModuleIdentifier) {
     pipe.gp_ci_.stageCount = 1;
     pipe.gp_ci_.pStages = &stage_ci;
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+    pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }

--- a/tests/vklayertests_debug_printf.cpp
+++ b/tests/vklayertests_debug_printf.cpp
@@ -157,6 +157,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintf) {
     VkPipelineObj pipe(m_device);
     pipe.AddShader(&vs);
     pipe.AddDefaultColorAttachment();
+    pipe.DisableRasterization();
     VkResult err = pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass());
     ASSERT_VK_SUCCESS(err);
 
@@ -286,6 +287,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintf) {
         VkPipelineObj pipe2(m_device);
         pipe2.AddShader(&vs_int64);
         pipe2.AddDefaultColorAttachment();
+        pipe2.DisableRasterization();
         err = pipe2.CreateVKPipeline(pipeline_layout.handle(), renderPass());
         ASSERT_VK_SUCCESS(err);
 
@@ -392,6 +394,7 @@ TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
     pipe.AddShader(&ts);
     pipe.AddShader(&ms);
     pipe.AddDefaultColorAttachment();
+    pipe.DisableRasterization();
     VkViewport viewport{};
     viewport.width = static_cast<float>(m_width);
     viewport.height = static_cast<float>(m_height);
@@ -543,6 +546,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPL) {
 
     CreatePipelineHelper pre_raster(*this);
     pre_raster.InitPreRasterLibInfo(1, &pre_raster_stage.stage_ci);
+    pre_raster.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pre_raster.InitState();
     pre_raster.gp_ci_.layout = pipeline_layout.handle();
     pre_raster.CreateGraphicsPipeline(true, false);
@@ -555,6 +559,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPL) {
     fragment.gp_ci_.layout = pipeline_layout.handle();
     fragment.gp_ci_.renderPass = render_pass;
     fragment.gp_ci_.subpass = subpass;
+    fragment.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     fragment.CreateGraphicsPipeline(true, false);
 
     CreatePipelineHelper frag_out(*this);

--- a/tests/vklayertests_gpu.cpp
+++ b/tests/vklayertests_gpu.cpp
@@ -584,6 +584,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuRobustBufferOOB) {
     VkPipelineObj robust_pipe(m_device);
     robust_pipe.AddShader(&vs);
     robust_pipe.AddDefaultColorAttachment();
+    robust_pipe.DisableRasterization();
     VkGraphicsPipelineCreateInfo gp_ci;
     robust_pipe.InitGraphicsPipelineCreateInfo(&gp_ci);
     gp_ci.pNext = &pipeline_robustness_ci;
@@ -717,6 +718,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
     VkPipelineObj pipe(m_device);
     pipe.AddShader(&vs);
     pipe.AddDefaultColorAttachment();
+    pipe.DisableRasterization();
     pipe.CreateVKPipeline(pipeline_layout.handle(), m_renderPass);
     VkCommandBufferBeginInfo begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
     m_commandBuffer->begin(&begin_info);
@@ -1112,6 +1114,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
         VkPipelineObj pipe(m_device);
         pipe.AddShader(&vs);
         pipe.AddDefaultColorAttachment();
+        pipe.DisableRasterization();
         err = pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass());
         ASSERT_VK_SUCCESS(err);
 
@@ -1180,6 +1183,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
         VkPipelineObj pipe(m_device);
         pipe.AddShader(&vs);
         pipe.AddDefaultColorAttachment();
+        pipe.DisableRasterization();
         auto subcase_err = pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass());
         ASSERT_VK_SUCCESS(subcase_err);
 
@@ -1260,6 +1264,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
         VkPipelineObj mesh_pipe(m_device);
         mesh_pipe.AddShader(&ms);
         mesh_pipe.AddDefaultColorAttachment();
+        mesh_pipe.DisableRasterization();
         err = mesh_pipe.CreateVKPipeline(mesh_pipeline_layout.handle(), renderPass());
         ASSERT_VK_SUCCESS(err);
         m_commandBuffer->begin(&begin_info);
@@ -1350,6 +1355,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
     VkPipelineObj pipe(m_device);
     pipe.AddShader(&vs);
     pipe.AddDefaultColorAttachment();
+    pipe.DisableRasterization();
     ASSERT_VK_SUCCESS(pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass()));
 
     VkCommandBufferBeginInfo begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
@@ -1375,6 +1381,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
         VkPipelineObj dr_pipe(m_device);
         dr_pipe.AddShader(&vs);
         dr_pipe.AddDefaultColorAttachment();
+        dr_pipe.DisableRasterization();
         ASSERT_VK_SUCCESS(dr_pipe.CreateVKPipeline(pipeline_layout.handle(), VK_NULL_HANDLE));
 
         m_commandBuffer->begin();
@@ -1458,6 +1465,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndexedIndirectCountDeviceLimitSubmit2) {
     VkPipelineObj pipe(m_device);
     pipe.AddShader(&vs);
     pipe.AddDefaultColorAttachment();
+    pipe.DisableRasterization();
     ASSERT_VK_SUCCESS(pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass()));
 
     VkCommandBufferBeginInfo begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
@@ -1533,6 +1541,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
     VkPipelineObj pipe(m_device);
     pipe.AddShader(&vs);
     pipe.AddDefaultColorAttachment();
+    pipe.DisableRasterization();
     err = pipe.CreateVKPipeline(pipeline_layout, renderPass());
     ASSERT_VK_SUCCESS(err);
 
@@ -1689,6 +1698,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
     VkPipelineObj pipe(m_device);
     pipe.AddShader(&vs);
     pipe.AddDefaultColorAttachment();
+    pipe.DisableRasterization();
     err = pipe.CreateVKPipeline(pipeline_layout, renderPass());
     ASSERT_VK_SUCCESS(err);
 
@@ -1980,6 +1990,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     VkPipelineObj pipe(m_device);
     pipe.AddShader(&vs);
     pipe.AddDefaultColorAttachment();
+    pipe.DisableRasterization();
     {
         const VkPipelineLayoutObj doomed_pipeline_layout(m_device);
         pipe.CreateVKPipeline(doomed_pipeline_layout.handle(), m_renderPass);

--- a/tests/vklayertests_graphics_library.cpp
+++ b/tests/vklayertests_graphics_library.cpp
@@ -1004,6 +1004,7 @@ TEST_F(VkGraphicsLibraryLayerTest, CreateGraphicsPipelineWithMissingMultisampleS
     pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pMultisampleState-06630");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-00751");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -15782,6 +15782,7 @@ TEST_F(VkLayerTest, ShaderModuleIdentifierFeatures) {
     pipe.gp_ci_.stageCount = 1;
     pipe.gp_ci_.pStages = &stage_ci;
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+    pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-stage-06846");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-module-parameter");
@@ -16390,6 +16391,9 @@ TEST_F(VkLayerTest, PipelineProtectedAccess) {
     VkPipelineObj featureless_pipe(&test_device);
     featureless_pipe.AddShader(&vs2);
     featureless_pipe.AddDefaultColorAttachment();
+    auto ms_state = *gp_ci.pRasterizationState;
+    ms_state.rasterizerDiscardEnable = VK_TRUE;
+    featureless_pipe.SetRasterization(&ms_state);
     featureless_pipe.InitGraphicsPipelineCreateInfo(&gp_ci);
     gp_ci.flags = VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT;
     const VkPipelineLayoutObj test_pipeline_layout(&test_device);

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -787,6 +787,7 @@ class VkPipelineObj : public vk_testing::Pipeline {
     void SetViewport(const std::vector<VkViewport> &viewports);
     void SetScissor(const std::vector<VkRect2D> &scissors);
     void SetLineState(const VkPipelineRasterizationLineStateCreateInfoEXT *line_state);
+    void DisableRasterization() { m_rs_state.rasterizerDiscardEnable = VK_TRUE; }
 
     void InitGraphicsPipelineCreateInfo(VkGraphicsPipelineCreateInfo *gp_ci);
 


### PR DESCRIPTION
This change also fixes GPL sub-state tracking where some sub-states are
allowed to be missing. Specifically:
- Vertex input state is not necessary if there is no vertex shader
  present
- Fragment shader/output state is not necessary if rasterizer discard
  enabled