### PR TITLE
chassis: Fix memory leak in vkCreateInstance if an error occured

### DIFF
--- a/layers/generated/best_practices.cpp
+++ b/layers/generated/best_practices.cpp
@@ -28,7 +28,7 @@ void BestPractices::PostCallRecordCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkInstance*                                 pInstance,
-    VkResult                                    result) {
+    VkResult&                                    result) {
     ValidationStateTracker::PostCallRecordCreateInstance(pCreateInfo, pAllocator, pInstance, result);
     if (result != VK_SUCCESS) {
         constexpr std::array error_codes = {VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_LAYER_NOT_PRESENT,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_INCOMPATIBLE_DRIVER};

--- a/layers/generated/best_practices.h
+++ b/layers/generated/best_practices.h
@@ -26,7 +26,7 @@ void PostCallRecordCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkInstance*                                 pInstance,
-    VkResult                                    result) override;
+    VkResult&                                    result) override;
 
 
 void PostCallRecordEnumeratePhysicalDevices(

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -4007,41 +4007,6 @@ class ValidationObject {
             return WriteLockGuard(validation_object_mutex);
         }
 
-        void RegisterValidationObject(bool vo_enabled, uint32_t instance_api_version,
-            debug_report_data* instance_report_data, std::vector<ValidationObject*> &dispatch_list) {
-            if (vo_enabled) {
-                api_version = instance_api_version;
-                report_data = instance_report_data;
-                dispatch_list.emplace_back(this);
-            }
-        }
-
-        void FinalizeInstanceValidationObject(ValidationObject *framework, VkInstance inst) {
-            instance_dispatch_table = framework->instance_dispatch_table;
-            enabled = framework->enabled;
-            disabled = framework->disabled;
-            fine_grained_locking = framework->fine_grained_locking;
-            instance = inst;
-        }
-
-        virtual void InitDeviceValidationObject(bool add_obj, ValidationObject *inst_obj, ValidationObject *dev_obj) {
-            if (add_obj) {
-                dev_obj->object_dispatch.emplace_back(this);
-                device = dev_obj->device;
-                physical_device = dev_obj->physical_device;
-                instance = inst_obj->instance;
-                report_data = inst_obj->report_data;
-                device_dispatch_table = dev_obj->device_dispatch_table;
-                api_version = dev_obj->api_version;
-                disabled = inst_obj->disabled;
-                enabled = inst_obj->enabled;
-                fine_grained_locking = inst_obj->fine_grained_locking;
-                instance_dispatch_table = inst_obj->instance_dispatch_table;
-                instance_extensions = inst_obj->instance_extensions;
-                device_extensions = dev_obj->device_extensions;
-            }
-        }
-
         ValidationObject* GetValidationObject(std::vector<ValidationObject*>& object_dispatch, LayerObjectTypeId object_type) {
             for (auto validation_object : object_dispatch) {
                 if (validation_object->container_type == object_type) {
@@ -4145,7 +4110,7 @@ class ValidationObject {
         // Pre/post hook point declarations
         virtual bool PreCallValidateCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) const { return false; };
         virtual void PreCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance) {};
-        virtual void PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance, VkResult result) {};
+        virtual void PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkInstance* pInstance, VkResult& result) {};
         virtual bool PreCallValidateDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator) const { return false; };
         virtual void PreCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator) {};
         virtual void PostCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator) {};

--- a/layers/generated/object_tracker.h
+++ b/layers/generated/object_tracker.h
@@ -30,7 +30,7 @@ void PostCallRecordCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkInstance*                                 pInstance,
-    VkResult                                    result) override;
+    VkResult&                                    result) override;
 bool PreCallValidateDestroyInstance(
     VkInstance                                  instance,
     const VkAllocationCallbacks*                pAllocator) const override;

--- a/layers/generated/thread_safety.cpp
+++ b/layers/generated/thread_safety.cpp
@@ -869,7 +869,7 @@ void ThreadSafety::PostCallRecordCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkInstance*                                 pInstance,
-    VkResult                                    result) {
+    VkResult&                                    result) {
     if (result == VK_SUCCESS) {
         CreateObjectParentInstance(*pInstance);
     }

--- a/layers/generated/thread_safety.h
+++ b/layers/generated/thread_safety.h
@@ -635,7 +635,7 @@ void PostCallRecordCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkInstance*                                 pInstance,
-    VkResult                                    result) override;
+    VkResult&                                    result) override;
 
 void PreCallRecordDestroyInstance(
     VkInstance                                  instance,

--- a/layers/object_tracker_utils.cpp
+++ b/layers/object_tracker_utils.cpp
@@ -615,7 +615,7 @@ void ObjectLifetimes::PostCallRecordGetPhysicalDeviceQueueFamilyProperties(VkPhy
                                                                            VkQueueFamilyProperties *pQueueFamilyProperties) {}
 
 void ObjectLifetimes::PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                                                   VkInstance *pInstance, VkResult result) {
+                                                   VkInstance *pInstance, VkResult& result) {
     if (result != VK_SUCCESS) return;
     CreateObject(*pInstance, kVulkanObjectTypeInstance, pAllocator);
 }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4030,7 +4030,7 @@ std::shared_ptr<PHYSICAL_DEVICE_STATE> ValidationStateTracker::CreatePhysicalDev
 
 void ValidationStateTracker::PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
                                                           const VkAllocationCallbacks *pAllocator, VkInstance *pInstance,
-                                                          VkResult result) {
+                                                          VkResult& result) {
     if (result != VK_SUCCESS) {
         return;
     }

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -492,7 +492,7 @@ class ValidationStateTracker : public ValidationObject {
     // Gets/Enumerations
     virtual std::shared_ptr<PHYSICAL_DEVICE_STATE> CreatePhysicalDeviceState(VkPhysicalDevice phys_dev);
     void PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
-                                      VkInstance* pInstance, VkResult result) override;
+                                      VkInstance* pInstance, VkResult& result) override;
     void PostCallRecordEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
         VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, uint32_t* pCounterCount, VkPerformanceCounterKHR* pCounters,
         VkPerformanceCounterDescriptionKHR* pCounterDescriptions, VkResult result) override;

--- a/layers/stateless/parameter_validation_utils.cpp
+++ b/layers/stateless/parameter_validation_utils.cpp
@@ -246,7 +246,7 @@ bool StatelessValidation::manual_PreCallValidateCreateInstance(const VkInstanceC
 
 void StatelessValidation::PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
                                                        const VkAllocationCallbacks *pAllocator, VkInstance *pInstance,
-                                                       VkResult result) {
+                                                       VkResult& result) {
     auto instance_data = GetLayerDataPtr(get_dispatch_key(*pInstance), layer_data_map);
     // Copy extension data into local object
     if (result != VK_SUCCESS) return;

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1010,7 +1010,7 @@ class StatelessValidation : public ValidationObject {
     void PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
                                     const VkAllocationCallbacks *pAllocator, VkDevice *pDevice, VkResult result) override;
     void PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo, const VkAllocationCallbacks *pAllocator,
-                                      VkInstance *pInstance, VkResult result) override;
+                                      VkInstance *pInstance, VkResult& result) override;
 
     void CommonPostCallRecordEnumeratePhysicalDevice(const VkPhysicalDevice *phys_devices, const int count);
     void PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t *pPhysicalDeviceCount,

--- a/scripts/best_practices_generator.py
+++ b/scripts/best_practices_generator.py
@@ -261,7 +261,10 @@ class BestPracticesOutputGenerator(OutputGenerator):
         typedef = typedef.split(')',1)[1]
         pre_decl = decls[0][:-1]
         pre_decl = pre_decl.split("VKAPI_CALL ")[1]
-        pre_decl = pre_decl.replace(')', ',\n    VkResult                                    result)')
+        if cmdname == 'vkCreateInstance':
+            pre_decl = pre_decl.replace(')', ',\n    VkResult&                                    result)')
+        else:
+            pre_decl = pre_decl.replace(')', ',\n    VkResult                                    result)')
         if cmdname in self.extra_parameter_list:
             pre_decl = pre_decl.replace(')', ',\n    void*                                       state_data)')
         pre_decl = pre_decl.replace(')', ') {\n')

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -401,41 +401,6 @@ class ValidationObject {
             return WriteLockGuard(validation_object_mutex);
         }
 
-        void RegisterValidationObject(bool vo_enabled, uint32_t instance_api_version,
-            debug_report_data* instance_report_data, std::vector<ValidationObject*> &dispatch_list) {
-            if (vo_enabled) {
-                api_version = instance_api_version;
-                report_data = instance_report_data;
-                dispatch_list.emplace_back(this);
-            }
-        }
-
-        void FinalizeInstanceValidationObject(ValidationObject *framework, VkInstance inst) {
-            instance_dispatch_table = framework->instance_dispatch_table;
-            enabled = framework->enabled;
-            disabled = framework->disabled;
-            fine_grained_locking = framework->fine_grained_locking;
-            instance = inst;
-        }
-
-        virtual void InitDeviceValidationObject(bool add_obj, ValidationObject *inst_obj, ValidationObject *dev_obj) {
-            if (add_obj) {
-                dev_obj->object_dispatch.emplace_back(this);
-                device = dev_obj->device;
-                physical_device = dev_obj->physical_device;
-                instance = inst_obj->instance;
-                report_data = inst_obj->report_data;
-                device_dispatch_table = dev_obj->device_dispatch_table;
-                api_version = dev_obj->api_version;
-                disabled = inst_obj->disabled;
-                enabled = inst_obj->enabled;
-                fine_grained_locking = inst_obj->fine_grained_locking;
-                instance_dispatch_table = inst_obj->instance_dispatch_table;
-                instance_extensions = inst_obj->instance_extensions;
-                device_extensions = dev_obj->device_extensions;
-            }
-        }
-
         ValidationObject* GetValidationObject(std::vector<ValidationObject*>& object_dispatch, LayerObjectTypeId object_type) {
             for (auto validation_object : object_dispatch) {
                 if (validation_object->container_type == object_type) {
@@ -821,29 +786,43 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     std::vector<ValidationObject*> local_object_dispatch;
 
     // Add VOs to dispatch vector. Order here will be the validation dispatch order!
-    auto thread_checker_obj = new ThreadSafety(nullptr);
-    thread_checker_obj->RegisterValidationObject(!local_disables[thread_safety], api_version, report_data, local_object_dispatch);
+    if (!local_disables[thread_safety]) {
+        local_object_dispatch.emplace_back(new ThreadSafety(nullptr));
+    }
 
-    auto parameter_validation_obj = new StatelessValidation;
-    parameter_validation_obj->RegisterValidationObject(!local_disables[stateless_checks], api_version, report_data, local_object_dispatch);
+    if (!local_disables[stateless_checks]) {
+        local_object_dispatch.emplace_back(new StatelessValidation);
+    }
 
-    auto object_tracker_obj = new ObjectLifetimes;
-    object_tracker_obj->RegisterValidationObject(!local_disables[object_tracking], api_version, report_data, local_object_dispatch);
+    if (!local_disables[object_tracking]) {
+        local_object_dispatch.emplace_back(new ObjectLifetimes);
+    }
 
-    auto core_checks_obj = new CoreChecks;
-    core_checks_obj->RegisterValidationObject(!local_disables[core_checks], api_version, report_data, local_object_dispatch);
+    if (!local_disables[core_checks]) {
+        local_object_dispatch.emplace_back(new CoreChecks);
+    }
 
-    auto best_practices_obj = new BestPractices;
-    best_practices_obj->RegisterValidationObject(local_enables[best_practices], api_version, report_data, local_object_dispatch);
+    if (local_enables[best_practices]) {
+        local_object_dispatch.emplace_back(new BestPractices);
+    }
 
-    auto gpu_assisted_obj = new GpuAssisted;
-    gpu_assisted_obj->RegisterValidationObject(local_enables[gpu_validation], api_version, report_data, local_object_dispatch);
+    if (local_enables[gpu_validation]) {
+        local_object_dispatch.emplace_back(new GpuAssisted);
+    }
 
-    auto debug_printf_obj = new DebugPrintf;
-    debug_printf_obj->RegisterValidationObject(local_enables[debug_printf], api_version, report_data, local_object_dispatch);
+    if (local_enables[debug_printf]) {
+        local_object_dispatch.emplace_back(new DebugPrintf);
+    }
 
-    auto sync_validation_obj = new SyncValidator;
-    sync_validation_obj->RegisterValidationObject(local_enables[sync_validation], api_version, report_data, local_object_dispatch);
+    if (local_enables[sync_validation]) {
+        local_object_dispatch.emplace_back(new SyncValidator);
+    }
+
+    // Initialize the validation objects
+    for (ValidationObject* intercept : local_object_dispatch) {
+        intercept->api_version = api_version;
+        intercept->report_data = report_data;
+    }
 
     // If handle wrapping is disabled via the ValidationFeatures extension, override build flag
     if (local_disables[handle_wrapping]) {
@@ -855,7 +834,15 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     for (const ValidationObject* intercept : local_object_dispatch) {
         auto lock = intercept->ReadLock();
         skip |= intercept->PreCallValidateCreateInstance(pCreateInfo, pAllocator, pInstance);
-        if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
+        if (skip) {
+            for (ValidationObject* object : local_object_dispatch) {
+                delete object;
+            }
+            DeactivateInstanceDebugCallbacks(report_data);
+            FreePnextChain(report_data->instance_pnext_chain);
+            LayerDebugUtilsDestroyInstance(report_data);
+            return VK_ERROR_VALIDATION_FAILED_EXT;
+        }
     }
     for (ValidationObject* intercept : local_object_dispatch) {
         auto lock = intercept->WriteLock();
@@ -863,8 +850,16 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     }
 
     VkResult result = fpCreateInstance(pCreateInfo, pAllocator, pInstance);
-    if (result != VK_SUCCESS) return result;
-
+    if (result != VK_SUCCESS) {
+        // Destroy all of the created validation objects if there is an error
+        DeactivateInstanceDebugCallbacks(report_data);
+        FreePnextChain(report_data->instance_pnext_chain);
+        LayerDebugUtilsDestroyInstance(report_data);
+        for (ValidationObject* object : local_object_dispatch) {
+            delete object;
+        }
+        return result;
+    }
     auto framework = GetLayerDataPtr(get_dispatch_key(*pInstance), layer_data_map);
 
     framework->object_dispatch = local_object_dispatch;
@@ -885,29 +880,27 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
 
     OutputLayerStatusInfo(framework);
 
-    thread_checker_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    object_tracker_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    parameter_validation_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    core_checks_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    best_practices_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    gpu_assisted_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    debug_printf_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    sync_validation_obj->FinalizeInstanceValidationObject(framework, *pInstance);
+    for (ValidationObject* intercept : framework->object_dispatch) {
+        intercept->instance_dispatch_table = framework->instance_dispatch_table;
+        intercept->enabled = framework->enabled;
+        intercept->disabled = framework->disabled;
+        intercept->fine_grained_locking = framework->fine_grained_locking;
+        intercept->instance = *pInstance;
+    }
 
     for (ValidationObject* intercept : framework->object_dispatch) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordCreateInstance(pCreateInfo, pAllocator, pInstance, result);
-    }
-
-    // Delete unused validation objects to avoid memory leak.
-    std::vector<ValidationObject*> local_objs = {
-        thread_checker_obj, object_tracker_obj, parameter_validation_obj,
-        core_checks_obj, best_practices_obj, gpu_assisted_obj, debug_printf_obj,
-        sync_validation_obj,
-    };
-    for (auto obj : local_objs) {
-        if (std::find(local_object_dispatch.begin(), local_object_dispatch.end(), obj) == local_object_dispatch.end()) {
-            delete obj;
+        // If an error occured then we need to clean up any allocated memory.
+        if (result != VK_SUCCESS) {
+            DeactivateInstanceDebugCallbacks(report_data);
+            FreePnextChain(report_data->instance_pnext_chain);
+            LayerDebugUtilsDestroyInstance(report_data);
+            for (ValidationObject* object : local_object_dispatch) {
+                delete object;
+            }
+            FreeLayerDataPtr(get_dispatch_key(*pInstance), layer_data_map);
+            return result;
         }
     }
 
@@ -942,8 +935,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(VkInstance instance, const VkAllocati
 
     LayerDebugUtilsDestroyInstance(layer_data->report_data);
 
-    for (auto item = layer_data->object_dispatch.begin(); item != layer_data->object_dispatch.end(); item++) {
-        delete *item;
+    for (ValidationObject* object : layer_data->object_dispatch) {
+        delete object;
     }
     FreeLayerDataPtr(key, layer_data_map);
 }
@@ -1013,41 +1006,53 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     auto disables = instance_interceptor->disabled;
     auto enables = instance_interceptor->enabled;
 
-    auto thread_safety_obj = new ThreadSafety(reinterpret_cast<ThreadSafety *>(instance_interceptor->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeThreading)));
-    thread_safety_obj->InitDeviceValidationObject(!disables[thread_safety], instance_interceptor, device_interceptor);
+    if (!disables[thread_safety]) {
+        device_interceptor->object_dispatch.emplace_back(new ThreadSafety(reinterpret_cast<ThreadSafety *>(
+            instance_interceptor->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeThreading))));
+    }
 
-    auto stateless_validation_obj = new StatelessValidation;
-    stateless_validation_obj->InitDeviceValidationObject(!disables[stateless_checks], instance_interceptor, device_interceptor);
+    if (!disables[stateless_checks]) {
+        device_interceptor->object_dispatch.emplace_back(new StatelessValidation);
+    }
 
-    auto object_tracker_obj = new ObjectLifetimes;
-    object_tracker_obj->InitDeviceValidationObject(!disables[object_tracking], instance_interceptor, device_interceptor);
+    if (!disables[object_tracking]) {
+        device_interceptor->object_dispatch.emplace_back(new ObjectLifetimes);
+    }
 
-    auto core_checks_obj = new CoreChecks;
-    core_checks_obj->InitDeviceValidationObject(!disables[core_checks], instance_interceptor, device_interceptor);
+    if (!disables[core_checks]) {
+        device_interceptor->object_dispatch.emplace_back(new CoreChecks);
+    }
 
-    auto best_practices_obj = new BestPractices;
-    best_practices_obj->InitDeviceValidationObject(enables[best_practices], instance_interceptor, device_interceptor);
+    if (enables[best_practices]) {
+        device_interceptor->object_dispatch.emplace_back(new BestPractices);
+    }
 
-    auto gpu_assisted_obj = new GpuAssisted;
-    gpu_assisted_obj->InitDeviceValidationObject(enables[gpu_validation], instance_interceptor, device_interceptor);
+    if (enables[gpu_validation]) {
+        device_interceptor->object_dispatch.emplace_back(new GpuAssisted);
+    }
 
-    auto debug_printf_obj = new DebugPrintf;
-    debug_printf_obj->InitDeviceValidationObject(enables[debug_printf], instance_interceptor, device_interceptor);
+    if (enables[debug_printf]) {
+        device_interceptor->object_dispatch.emplace_back(new DebugPrintf);
+    }
 
-    auto sync_validation_obj = new SyncValidator;
-    sync_validation_obj->InitDeviceValidationObject(enables[sync_validation], instance_interceptor, device_interceptor);
+    if (enables[sync_validation]) {
+        device_interceptor->object_dispatch.emplace_back(new SyncValidator);
+    }
 
-    // Delete unused validation objects to avoid memory leak.
-    std::vector<ValidationObject *> local_objs = {
-        thread_safety_obj, stateless_validation_obj, object_tracker_obj,
-        core_checks_obj, best_practices_obj, gpu_assisted_obj, debug_printf_obj,
-        sync_validation_obj,
-    };
-    for (auto obj : local_objs) {
-        if (std::find(device_interceptor->object_dispatch.begin(), device_interceptor->object_dispatch.end(), obj) ==
-            device_interceptor->object_dispatch.end()) {
-            delete obj;
-        }
+    // Initialize all of the objects with the appropriate data
+    for(ValidationObject* object : device_interceptor->object_dispatch) {
+        object->device = device_interceptor->device;
+        object->physical_device = device_interceptor->physical_device;
+        object->instance = instance_interceptor->instance;
+        object->report_data = instance_interceptor->report_data;
+        object->device_dispatch_table = device_interceptor->device_dispatch_table;
+        object->api_version = device_interceptor->api_version;
+        object->disabled = instance_interceptor->disabled;
+        object->enabled = instance_interceptor->enabled;
+        object->fine_grained_locking = instance_interceptor->fine_grained_locking;
+        object->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
+        object->instance_extensions = instance_interceptor->instance_extensions;
+        object->device_extensions = device_interceptor->device_extensions;
     }
 
     for (ValidationObject* intercept : instance_interceptor->object_dispatch) {
@@ -1086,8 +1091,8 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(VkDevice device, const VkAllocationCall
         intercept->PostCallRecordDestroyDevice(device, pAllocator);
     }
 
-    for (auto item = layer_data->object_dispatch.begin(); item != layer_data->object_dispatch.end(); item++) {
-        delete *item;
+    for (ValidationObject* object : layer_data->object_dispatch) {
+        delete object;
     }
     FreeLayerDataPtr(key, layer_data_map);
 }
@@ -1874,7 +1879,10 @@ VVL_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(V
         post_call_record = 'virtual void PostCallRecord' + prototype
         resulttype = elem.find('proto/type')
         if resulttype.text == 'VkResult':
-            post_call_record = post_call_record.replace(')', ', VkResult result)')
+            if 'CreateInstance' in prototype:
+                post_call_record = post_call_record.replace(')', ', VkResult& result)')
+            else:
+                post_call_record = post_call_record.replace(')', ', VkResult result)')
         elif resulttype.text == 'VkDeviceAddress':
             post_call_record = post_call_record.replace(')', ', VkDeviceAddress result)')
         return '        %s\n        %s\n        %s\n' % (pre_call_validate, pre_call_record, post_call_record)

--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -1060,7 +1060,10 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
                 if post_call_record:
                     post_cr_func_decl = 'void PostCallRecord' + func_decl_template + decl_terminator
                     if result_type.text == 'VkResult':
-                        post_cr_func_decl = post_cr_func_decl.replace(')', ',\n    VkResult                                    result)')
+                        if 'CreateInstance' in func_decl_template:
+                            post_cr_func_decl = post_cr_func_decl.replace(')', ',\n    VkResult&                                    result)')
+                        else:
+                            post_cr_func_decl = post_cr_func_decl.replace(')', ',\n    VkResult                                    result)')
                     elif result_type.text == 'VkDeviceAddress':
                         post_cr_func_decl = post_cr_func_decl.replace(')', ',\n    VkDeviceAddress                             result)')
                     self.appendSection('command', post_cr_func_decl)
@@ -1090,7 +1093,10 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
                     self.appendSection('command', '')
 
                     if result_type.text == 'VkResult':
-                        post_cr_func_decl = post_cr_func_decl.replace(')', ',\n    VkResult                                    result)')
+                        if 'CreateInstance' in func_decl_template:
+                            post_cr_func_decl = post_cr_func_decl.replace(')', ',\n    VkResult&                                    result)')
+                        else:
+                            post_cr_func_decl = post_cr_func_decl.replace(')', ',\n    VkResult                                    result)')
                         failure_condition = 'result != VK_SUCCESS'
                         # VK_INCOMPLETE is considered a success
                         if 'EnumeratePhysicalDeviceGroups' in cmdname:

--- a/scripts/thread_safety_generator.py
+++ b/scripts/thread_safety_generator.py
@@ -1846,7 +1846,10 @@ void ThreadSafety::PostCallRecordCreateRayTracingPipelinesKHR(
             # PostCallRecord
             post_decl = pre_decl.replace('PreCallRecord', 'PostCallRecord')
             if result_type.text == 'VkResult':
-                post_decl = post_decl.replace(')', ',\n    VkResult                                    result)')
+                if 'CreateInstance' in pre_decl:
+                    post_decl = post_decl.replace(')', ',\n    VkResult&                                    result)')
+                else:
+                    post_decl = post_decl.replace(')', ',\n    VkResult                                    result)')
             elif result_type.text == 'VkDeviceAddress':
                 post_decl = post_decl.replace(')', ',\n    VkDeviceAddress                             result)')
             self.appendSection('command', '')
@@ -1869,7 +1872,10 @@ void ThreadSafety::PostCallRecordCreateRayTracingPipelinesKHR(
             # PostCallRecord
             post_decl = pre_decl.replace('PreCallRecord', 'PostCallRecord')
             if result_type.text == 'VkResult':
-                post_decl = post_decl.replace(')', ',\n    VkResult                                    result)')
+                if 'CreateInstance' in pre_decl:
+                    post_decl = post_decl.replace(')', ',\n    VkResult&                                    result)')
+                else:
+                    post_decl = post_decl.replace(')', ',\n    VkResult                                    result)')
             elif result_type.text == 'VkDeviceAddress':
                 post_decl = post_decl.replace(')', ',\n    VkDeviceAddress                             result)')
             self.appendSection('command', '')

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -767,8 +767,9 @@ TEST_F(VkLayerTest, PnextOnlyStructValidation) {
 
     uint32_t queue_node_count;
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, NULL);
-    VkQueueFamilyProperties *queue_props = new VkQueueFamilyProperties[queue_node_count];
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, queue_props);
+    std::vector<VkQueueFamilyProperties> queue_props;
+    queue_props.resize(queue_node_count);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, queue_props.data());
     float priorities[] = {1.0f};
     VkDeviceQueueCreateInfo queue_info = LvlInitStruct<VkDeviceQueueCreateInfo>();
     queue_info.flags = 0;
@@ -1805,16 +1806,17 @@ TEST_F(VkLayerTest, InvalidQueueFamilyIndex) {
     // with SHARING_MODE_CONCURRENT that uses a non-device PDEV queue family.
     uint32_t queue_count;
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
-    VkQueueFamilyProperties *queue_props = new VkQueueFamilyProperties[queue_count];
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props);
+    std::vector<VkQueueFamilyProperties> queue_props;
+    queue_props.resize(queue_count);
+    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
 
     if (queue_count < 3) {
         GTEST_SKIP() << "Multiple queue families are required to run this test.";
     }
-    std::vector<float> priorities(queue_props->queueCount, 1.0f);
+    std::vector<float> priorities(queue_props.at(0).queueCount, 1.0f);
     VkDeviceQueueCreateInfo queue_info = LvlInitStruct<VkDeviceQueueCreateInfo>();
     queue_info.queueFamilyIndex = 0;
-    queue_info.queueCount = queue_props->queueCount;
+    queue_info.queueCount = static_cast<uint32_t>(queue_props.at(0).queueCount);
     queue_info.pQueuePriorities = priorities.data();
     VkDeviceCreateInfo dev_info = LvlInitStruct<VkDeviceCreateInfo>();
     dev_info.queueCreateInfoCount = 1;
@@ -9179,6 +9181,7 @@ TEST_F(VkLayerTest, InstanceCreateEnumeratePortability) {
         ici.ppEnabledExtensionNames = enabled_extensions.data();
 
         vk::CreateInstance(&ici, nullptr, &local_instance);
+        vk::DestroyInstance(local_instance, nullptr);
     }
 }
 


### PR DESCRIPTION
If an error occurs duing the call down the CreateInstance chain, VVL must
clean up any allocated objects. This is made easier by only allocating
Validation Objects for which the filters allow, rather than the previous
method of allocating everything and removing the unused ones. While from a
first glance std::unique_ptr<> seems like the obvious choice, because of
how intrusive such a change would be it was not chosen.

The second place an error can occur is during PostCallRecordCreateInstance.
This results in faileding a vulkan function call after a successful call
down the vkCreateInstance chain, leaving Vulkan in a weird state. The
previous commit would not pass the error code upwards, so to the application
everything appeared correct since the return value was VK_SUCCESS. However,
this causes CTS Out Of Memory tests to fail due to OOM not being returned.
The fix for this is to make the PostCallRecordCreateInstance pass the
VkResult value by reference instead of value, allowing the error code to
propagate upwards. This did require special casing the PostCallRecord
in the various code generators.

Lastly, the commit does a general cleanup of the ValidationObject code by
removing the functions only used during initialization. Since they are used
only during vkCreateInstance and vkCreateDevice, moving them into those
functions cleans up the overal interface of the functions.

This commit makes the following tests have clean output when run with a
leak sanitizer:
* VkLayerTest.InstanceExtensionDependencies
* VkLayerTest.InstanceBadStype
* VkLayerTest.InstanceDuplicatePnextStype
* VkLayerTest.InstanceAppInfoBadStype
* VkLayerTest.InstanceValidationFeaturesBadFlags
* VkLayerTest.InstanceBadValidationFlags

Note that to get the clean output, the loader must have been updated to
contain the commit 3db19f3 (or just run with a loader built against
1.3.243 or higher).

Fixes #5076 