### PR TITLE
layers: Fix shader module tracking of NonWritable

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -852,10 +852,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderCapabilitiesAndExtensions(const Instruction& insn) const;
     VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) const;
 
-    bool ValidateShaderStageWritableOrAtomicDescriptor(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
-                                                       bool has_descriptor_written_to, bool has_atomic_descriptor) const;
-    bool ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
-                                              const PIPELINE_STATE& pipeline, const Instruction& entrypoint) const;
+    bool ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage, const PIPELINE_STATE& pipeline,
+                                              const Instruction& entrypoint) const;
     bool ValidateShaderStorageImageFormatsVariables(const SHADER_MODULE_STATE& module_state, const Instruction* insn) const;
     bool ValidateShaderStageMaxResources(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                          const PIPELINE_STATE& pipeline) const;
@@ -900,6 +898,10 @@ class CoreChecks : public ValidationStateTracker {
                                         uint32_t pipe_index) const;
     bool ValidateDecorations(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
     bool ValidateVariables(const SHADER_MODULE_STATE& module_state) const;
+    bool ValidateShaderDescriptorVariable(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
+                                          const PIPELINE_STATE& pipeline,
+                                          const std::vector<ResourceInterfaceVariable>& descriptor_variables,
+                                          const std::string& vuid_layout_mismatch) const;
     bool ValidateTransformFeedback(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderModuleId(const SHADER_MODULE_STATE& module_state, const PipelineStageState& stage_state,
                                 const safe_VkPipelineShaderStageCreateInfo* pStage, const VkPipelineCreateFlags flags) const;

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -49,13 +49,6 @@ PipelineStageState::PipelineStageState(const safe_VkPipelineShaderStageCreateInf
       writes_to_gl_layer(module_state->WritesToGlLayer()) {
     if (entrypoint) {
         descriptor_variables = module_state->GetResourceInterfaceVariable(*entrypoint);
-        if (descriptor_variables) {
-            has_descriptor_written_to = std::any_of(descriptor_variables->begin(), descriptor_variables->end(),
-                                                    [](const auto &variable) { return variable.is_written_to; });
-
-            has_atomic_descriptor = std::any_of(descriptor_variables->begin(), descriptor_variables->end(),
-                                                [](const auto &variable) { return variable.is_atomic_operation; });
-        }
         wrote_primitive_shading_rate = WrotePrimitiveShadingRate(stage_flag, *entrypoint, module_state.get());
     }
 }

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -100,8 +100,6 @@ struct PipelineStageState {
     VkShaderStageFlagBits stage_flag;
     std::optional<Instruction> entrypoint;
     const std::vector<ResourceInterfaceVariable> *descriptor_variables = {};
-    bool has_descriptor_written_to;
-    bool has_atomic_descriptor;
     bool wrote_primitive_shading_rate;
     bool writes_to_gl_layer;
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -105,8 +105,15 @@ struct ResourceInterfaceVariable {
     // Sampled Type width of the OpTypeImage the variable points to, 0 if doesn't use the image
     uint32_t image_sampled_type_width = 0;
 
-    bool is_read_from{false};
-    bool is_written_to{false};
+    bool is_read_from{false};   // has operation to reads from the variable
+    bool is_written_to{false};  // has operation to writes to the variable
+
+    // Type of resource type (vkspec.html#interfaces-resources-storage-class-correspondence)
+    bool is_storage_image{false};
+    bool is_storage_texel_buffer{false};
+    bool is_storage_buffer{false};
+    bool is_input_attachment{false};
+
     bool is_atomic_operation{false};
     bool is_sampler_sampled{false};
     bool is_sampler_implicitLod_dref_proj{false};


### PR DESCRIPTION
(related https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5302 / https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5310#discussion_r1111734088)

The logic for `VUID-RuntimeSpirv-NonWritable-06340` and `VUID-RuntimeSpirv-NonWritable-06341` was not fully complete

This PR does a few cleanup 

1. creates a dedicated `ValidateShaderDescriptorVariable` function 
2. add proper tracking for the type of resource (ex `is_storage_image`) needed for the moment (will add rest in future PR)
3. Fix the above 2 VUID logic

