### PR TITLE
layers: Suppress incorrect validation error for buffer_reference

### DIFF
--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -90,6 +90,8 @@ static bool TypesMatch(const SHADER_MODULE_STATE &a, const SHADER_MODULE_STATE &
     const Instruction *a_base_insn = GetBaseTypeInstruction(a, a_type);
     const Instruction *b_base_insn = GetBaseTypeInstruction(b, b_type);
 
+    if (nullptr == a_base_insn && nullptr == b_base_insn) return true;
+
     return BaseTypesMatch(a, b, a_base_insn, b_base_insn);
 }
 


### PR DESCRIPTION
SHADER_MODULE_STATE::GetBaseType returns zero when passed a physical storage buffer to a struct, which later results in a validation error, despite no check whether structs passed between shader stages are compatible. This change suppresses the validation error.

Conceptually, this change addresses a wider spectrum of cases, where in the `TypesMatch` function we failed to identify both of the compared types, and would return `false` (types don't match). Currently the only clear path for this to happen is dealing with a physical storage buffer to a struct, in which case a potentially unhelpful validation error is produced:

```
Validation Error: [ UNASSIGNED-CoreValidation-Shader-InterfaceTypeMismatch ] Object 0: handle = 0x9294aa0000036c76, type = VK_OBJECT_TYPE_SHADER_MODULE; | MessageID = 0xb6cf33fe | Type mismatch on location 0.0, between vertex shader and fragment shader: 'ptr to Output ptr to PhysicalStorageBuffer struct of (sint32, sint32)' vs 'ptr to Input ptr to PhysicalStorageBuffer struct of (sint32, sint32)'
```

This logic seems to hold for a general case, where both types are unknown - since we failed to identify parameter types, we cannot validate their compatibility.

Returning `true` in this case leads to some counter-intuitive logic, where `true` doesn't mean we verified the types match, rather, that we're not certain that they don't match. If this is not acceptable, I can refactor this to also be able to express the case where we were unable to compare the types.

Otherwise, `TypesMatch` is only used in one place, and is static within the `shader_validation.cpp` file, so this workaround doesn't introduce issues elsewhere.

Conceptually, failing to identify types in `TypesMatch` likely warrants its own validation warnings, but handling this is beyond the scope of this pull request.

An ideal solution would be to implement a mechanism to compare this type of parameters being passed between shader stages, at least for cases where they can be resolved, and validate struct compatibility. The above validation error shows the types are known, and [BaseTypesMatch](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/v1.3.235/layers/shader_validation.cpp#L57) already contains the code for comparing structs. This is also beyond the scope of this pull request.