### PR TITLE
tests: Add regress for VU 03047

### DIFF
--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -1053,7 +1053,7 @@ void DescriptorSet::destroy() noexcept {
     // Only call vk::Free* on sets allocated from pool with usage *_DYNAMIC
     if (containing_pool_->getDynamicUsage()) {
         VkDescriptorSet sets[1] = {handle()};
-        EXPECT(vk::FreeDescriptorSets(device(), containing_pool_->GetObj(), 1, sets) == VK_SUCCESS);
+        EXPECT(vk::FreeDescriptorSets(device(), containing_pool_->handle(), 1, sets) == VK_SUCCESS);
     }
     handle_ = VK_NULL_HANDLE;
 }

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -866,10 +866,6 @@ class DescriptorPool : public internal::NonDispHandle<VkDescriptorPool> {
     ~DescriptorPool() noexcept;
     void destroy() noexcept;
 
-    // Descriptor sets allocated from this pool will need access to the original
-    // object
-    VkDescriptorPool GetObj() { return pool_; }
-
     // vkCreateDescriptorPool()
     void init(const Device &dev, const VkDescriptorPoolCreateInfo &info);
 
@@ -890,8 +886,6 @@ class DescriptorPool : public internal::NonDispHandle<VkDescriptorPool> {
                                                   const PoolSizes &pool_sizes);
 
   private:
-    VkDescriptorPool pool_;
-
     // Track whether this pool's usage is VK_DESCRIPTOR_POOL_USAGE_DYNAMIC
     bool dynamic_usage_;
 };


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5121

Please note that reverting https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4994 does not fail this test (@jeremyg-lunarg ). There are earlier checks in the code that ensure regression does not happen:
* `QueueWaitIdle` marks command buffer as not in use.
* Tried fence wait instance of `QueueWaitIdle` - also does not trigger the issue.
* When `vkBeginCommandBuffer` is called the second time (with the same command buffer), it resets the command buffer, and `CMD_BUFFER_STATE::ResetCBState` removes the bindings' command buffer reference.