### PR TITLE
layers: Move input attachment to ResourceInterfaceVariable

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -875,8 +875,8 @@ class CoreChecks : public ValidationStateTracker {
                                             const PIPELINE_STATE& pipeline, uint32_t subpass_index) const;
     bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
                                                             const PIPELINE_STATE& pipeline) const;
-    bool ValidateShaderInputAttachment(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
-                                       const PIPELINE_STATE& pipeline) const;
+    bool ValidateShaderInputAttachment(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline,
+                                       const ResourceInterfaceVariable& variable) const;
     bool ValidateConservativeRasterization(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
                                            const PIPELINE_STATE& pipeline) const;
     bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -43,6 +43,7 @@ struct DecorationSet {
         per_vertex_bit = 1 << 6,
         passthrough_bit = 1 << 7,
         aliased_bit = 1 << 8,
+        input_attachment_bit = 1 << 9,
     };
     static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
 
@@ -58,6 +59,7 @@ struct DecorationSet {
     uint32_t binding = 0;
 
     uint32_t builtin = kInvalidValue;
+    uint32_t input_attachment_index = kInvalidValue;
 
     void Add(uint32_t decoration, uint32_t value);
     bool Has(FlagBit flag_bit) const { return (flags & flag_bit) != 0; }
@@ -206,7 +208,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
         std::vector<UserDefinedInterfaceVariable> user_defined_interface_variables;
         std::vector<ResourceInterfaceVariable> resource_interface_variables;
-        vvl::unordered_set<uint32_t> input_attachment_indexes;
 
         StructInfo push_constant_used_in_shader;
 
@@ -314,14 +315,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         for (const auto &entry_point : static_data_.entry_points) {
             if (entry_point.entrypoint_insn == entrypoint) {
                 return &entry_point.accessible_ids;
-            }
-        }
-        return nullptr;
-    }
-    const vvl::unordered_set<uint32_t> *GetAttachmentIndexes(const Instruction &entrypoint) const {
-        for (const auto &entry_point : static_data_.entry_points) {
-            if (entry_point.entrypoint_insn == entrypoint) {
-                return &entry_point.input_attachment_indexes;
             }
         }
         return nullptr;


### PR DESCRIPTION
Instead of keeping a list of Input attachments per Entrypoint, this just moves it to the Interface Variable itself. This is nice because future change needs to be able to map which index is which variable, and currently this was an extra step 