### PR TITLE
layers: Fix vkCmdClearAttachment aspect mask VU

### DIFF
--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -1306,3 +1306,35 @@ TEST_F(VkPositiveLayerTest, ThreadedCommandBuffersWithLabels) {
         ADD_FAILURE() << "The waiting time for the worker threads exceeded the maximum limit: " << wait_time << " seconds.";
     for (auto &worker : workers) worker.join();
 }
+
+TEST_F(VkPositiveLayerTest, ClearAttachmentsDepthStencil) {
+    TEST_DESCRIPTION("Call CmdClearAttachments with no depth/stencil attachment.");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on this device";
+    }
+
+    m_commandBuffer->begin();
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+
+    VkClearAttachment attachment;
+    attachment.colorAttachment = 0;
+    VkClearRect clear_rect = {};
+    clear_rect.rect.offset = {0, 0};
+    clear_rect.rect.extent = {1, 1};
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &attachment, 1, &clear_rect);
+
+    attachment.clearValue.depthStencil.depth = 0.0f;
+    // Aspect Mask can be non-color because pDepthStencilAttachment is null
+    attachment.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &attachment, 1, &clear_rect);
+    attachment.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+    vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &attachment, 1, &clear_rect);
+}

--- a/tests/vklayertests_dynamic_rendering.cpp
+++ b/tests/vklayertests_dynamic_rendering.cpp
@@ -468,8 +468,9 @@ TEST_F(VkLayerTest, DynamicRenderingClearAttachments) {
         m_commandBuffer->begin();
 
         // Try to clear stencil, but image view does not have stencil aspect
+        // This is a valid clear because the ImageView aspect are ignored
+        // https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5733#note_398961
         {
-            // setup incorrect image views and begin rendering
             if (use_dynamic_rendering) {
                 depth_attachment_info.imageView = depth_image_view.handle();
                 stencil_attachment_info.imageView = depth_image_view.handle();
@@ -484,16 +485,13 @@ TEST_F(VkLayerTest, DynamicRenderingClearAttachments) {
                 m_commandBuffer->BeginRenderPass(renderpass_bi);
             }
 
-            // issue clear cmd
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-pAttachments-07270");
             VkClearAttachment clear_stencil_attachment;
             clear_stencil_attachment.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+            clear_stencil_attachment.clearValue.depthStencil.depth = 1.0f;
             clear_stencil_attachment.clearValue.depthStencil.stencil = 0;
             VkClearRect clear_rect{rect, 0, 1};
             vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &clear_stencil_attachment, 1, &clear_rect);
-            m_errorMonitor->VerifyFound();
 
-            // end rendering and setup default, correct, image views
             if (use_dynamic_rendering) {
                 m_commandBuffer->EndRendering();
 
@@ -507,9 +505,8 @@ TEST_F(VkLayerTest, DynamicRenderingClearAttachments) {
             }
         }
 
-        // Try to clear depth, but image view does not have depth aspect
+        // Try to clear depth, but image view does not have depth aspect (valid, see stencil above)
         {
-            // setup incorrect image views and begin rendering
             if (use_dynamic_rendering) {
                 depth_attachment_info.imageView = stencil_image_view.handle();
                 stencil_attachment_info.imageView = stencil_image_view.handle();
@@ -524,16 +521,12 @@ TEST_F(VkLayerTest, DynamicRenderingClearAttachments) {
                 m_commandBuffer->BeginRenderPass(renderpass_bi);
             }
 
-            // issue clear cmd
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-pAttachments-07270");
             VkClearAttachment clear_depth_attachment;
             clear_depth_attachment.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
             clear_depth_attachment.clearValue.depthStencil.depth = 1.0f;
             VkClearRect clear_rect{rect, 0, 1};
             vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &clear_depth_attachment, 1, &clear_rect);
-            m_errorMonitor->VerifyFound();
 
-            // end rendering and setup default, correct, image views
             if (use_dynamic_rendering) {
                 m_commandBuffer->EndRendering();
 

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -946,7 +946,6 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
     if (dsBinding) {
         att.format = m_depth_stencil_fmt;
         att.loadOp = (m_clear_via_load_op) ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
-        ;
         att.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         att.stencilLoadOp = (m_clear_via_load_op) ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
         att.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;


### PR DESCRIPTION
The [1.3.242 spec update](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5348) removed `VUID-vkCmdClearAttachments-pAttachments-07270` and split it up as

- VUID-vkCmdClearAttachments-aspectMask-07884
- VUID-vkCmdClearAttachments-aspectMask-07885
- VUID-vkCmdClearAttachments-aspectMask-07886
- VUID-vkCmdClearAttachments-aspectMask-07887

The main change is

- The aspect mask is ignore, the image view format is what is important
- Color attachments don't have the restriction (allows to clear a plan of a multi-planar image)
- Dynamic rendering never gets to this situation because it will be cause before since it has a dedicated depth and stencil attachment instead of a shared `pDepthStencilAttachment`