### PR TITLE
chassis: Cleanup ValidationObject creation

### DIFF
--- a/layers/generated/chassis.cpp
+++ b/layers/generated/chassis.cpp
@@ -278,41 +278,68 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     std::vector<ValidationObject*> local_object_dispatch;
 
     // Add VOs to dispatch vector. Order here will be the validation dispatch order!
-    auto thread_checker_obj = new ThreadSafety(nullptr);
-    thread_checker_obj->RegisterValidationObject(!local_disables[thread_safety], api_version, report_data, local_object_dispatch);
+    if (!local_disables[thread_safety]) {
+        local_object_dispatch.emplace_back(new ThreadSafety(nullptr));
+    }
 
-    auto parameter_validation_obj = new StatelessValidation;
-    parameter_validation_obj->RegisterValidationObject(!local_disables[stateless_checks], api_version, report_data, local_object_dispatch);
+    if (!local_disables[stateless_checks]) {
+        local_object_dispatch.emplace_back(new StatelessValidation);
+    }
 
-    auto object_tracker_obj = new ObjectLifetimes;
-    object_tracker_obj->RegisterValidationObject(!local_disables[object_tracking], api_version, report_data, local_object_dispatch);
+    if (!local_disables[object_tracking]) {
+        local_object_dispatch.emplace_back(new ObjectLifetimes);
+    }
 
-    auto core_checks_obj = new CoreChecks;
-    core_checks_obj->RegisterValidationObject(!local_disables[core_checks], api_version, report_data, local_object_dispatch);
+    if (!local_disables[core_checks]) {
+        local_object_dispatch.emplace_back(new CoreChecks);
+    }
 
-    auto best_practices_obj = new BestPractices;
-    best_practices_obj->RegisterValidationObject(local_enables[best_practices], api_version, report_data, local_object_dispatch);
+    if (local_enables[best_practices]) {
+        local_object_dispatch.emplace_back(new BestPractices);
+    }
 
-    auto gpu_assisted_obj = new GpuAssisted;
-    gpu_assisted_obj->RegisterValidationObject(local_enables[gpu_validation], api_version, report_data, local_object_dispatch);
+    if (local_enables[gpu_validation]) {
+        local_object_dispatch.emplace_back(new GpuAssisted);
+    }
 
-    auto debug_printf_obj = new DebugPrintf;
-    debug_printf_obj->RegisterValidationObject(local_enables[debug_printf], api_version, report_data, local_object_dispatch);
+    if (local_enables[debug_printf]) {
+        local_object_dispatch.emplace_back(new DebugPrintf);
+    }
 
-    auto sync_validation_obj = new SyncValidator;
-    sync_validation_obj->RegisterValidationObject(local_enables[sync_validation], api_version, report_data, local_object_dispatch);
+    if (local_enables[sync_validation]) {
+        local_object_dispatch.emplace_back(new SyncValidator);
+    }
 
     // If handle wrapping is disabled via the ValidationFeatures extension, override build flag
     if (local_disables[handle_wrapping]) {
         wrap_handles = false;
     }
 
+    // Initialize the validation objects
+    for (auto* intercept : local_object_dispatch) {
+        intercept->api_version = api_version;
+        intercept->report_data = report_data;
+    }
+
+    // Define logic to cleanup everything in case of an error
+    auto cleanup_allocations = [report_data, &local_object_dispatch](){
+        DeactivateInstanceDebugCallbacks(report_data);
+        FreePnextChain(report_data->instance_pnext_chain);
+        LayerDebugUtilsDestroyInstance(report_data);
+        for (ValidationObject* object : local_object_dispatch) {
+            delete object;
+        }
+    };
+
     // Init dispatch array and call registration functions
     bool skip = false;
     for (const ValidationObject* intercept : local_object_dispatch) {
         auto lock = intercept->ReadLock();
         skip |= intercept->PreCallValidateCreateInstance(pCreateInfo, pAllocator, pInstance);
-        if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
+        if (skip) {
+            cleanup_allocations();
+            return VK_ERROR_VALIDATION_FAILED_EXT;
+        }
     }
     for (ValidationObject* intercept : local_object_dispatch) {
         auto lock = intercept->WriteLock();
@@ -320,8 +347,10 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     }
 
     VkResult result = fpCreateInstance(pCreateInfo, pAllocator, pInstance);
-    if (result != VK_SUCCESS) return result;
-
+    if (result != VK_SUCCESS) {
+        cleanup_allocations();
+        return result;
+    }
     auto framework = GetLayerDataPtr(get_dispatch_key(*pInstance), layer_data_map);
 
     framework->object_dispatch = local_object_dispatch;
@@ -342,30 +371,17 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
 
     OutputLayerStatusInfo(framework);
 
-    thread_checker_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    object_tracker_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    parameter_validation_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    core_checks_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    best_practices_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    gpu_assisted_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    debug_printf_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    sync_validation_obj->FinalizeInstanceValidationObject(framework, *pInstance);
+    for (auto* intercept : framework->object_dispatch) {
+        intercept->instance_dispatch_table = framework->instance_dispatch_table;
+        intercept->enabled = framework->enabled;
+        intercept->disabled = framework->disabled;
+        intercept->fine_grained_locking = framework->fine_grained_locking;
+        intercept->instance = *pInstance;
+    }
 
     for (ValidationObject* intercept : framework->object_dispatch) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordCreateInstance(pCreateInfo, pAllocator, pInstance, result);
-    }
-
-    // Delete unused validation objects to avoid memory leak.
-    std::vector<ValidationObject*> local_objs = {
-        thread_checker_obj, object_tracker_obj, parameter_validation_obj,
-        core_checks_obj, best_practices_obj, gpu_assisted_obj, debug_printf_obj,
-        sync_validation_obj,
-    };
-    for (auto obj : local_objs) {
-        if (std::find(local_object_dispatch.begin(), local_object_dispatch.end(), obj) == local_object_dispatch.end()) {
-            delete obj;
-        }
     }
 
     InstanceExtensionWhitelist(framework, pCreateInfo, *pInstance);
@@ -470,41 +486,53 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     auto disables = instance_interceptor->disabled;
     auto enables = instance_interceptor->enabled;
 
-    auto thread_safety_obj = new ThreadSafety(reinterpret_cast<ThreadSafety *>(instance_interceptor->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeThreading)));
-    thread_safety_obj->InitDeviceValidationObject(!disables[thread_safety], instance_interceptor, device_interceptor);
+    if (!disables[thread_safety]) {
+        device_interceptor->object_dispatch.emplace_back(new ThreadSafety(static_cast<ThreadSafety *>(
+            instance_interceptor->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeThreading))));
+    }
 
-    auto stateless_validation_obj = new StatelessValidation;
-    stateless_validation_obj->InitDeviceValidationObject(!disables[stateless_checks], instance_interceptor, device_interceptor);
+    if (!disables[stateless_checks]) {
+        device_interceptor->object_dispatch.emplace_back(new StatelessValidation);
+    }
 
-    auto object_tracker_obj = new ObjectLifetimes;
-    object_tracker_obj->InitDeviceValidationObject(!disables[object_tracking], instance_interceptor, device_interceptor);
+    if (!disables[object_tracking]) {
+        device_interceptor->object_dispatch.emplace_back(new ObjectLifetimes);
+    }
 
-    auto core_checks_obj = new CoreChecks;
-    core_checks_obj->InitDeviceValidationObject(!disables[core_checks], instance_interceptor, device_interceptor);
+    if (!disables[core_checks]) {
+        device_interceptor->object_dispatch.emplace_back(new CoreChecks);
+    }
 
-    auto best_practices_obj = new BestPractices;
-    best_practices_obj->InitDeviceValidationObject(enables[best_practices], instance_interceptor, device_interceptor);
+    if (enables[best_practices]) {
+        device_interceptor->object_dispatch.emplace_back(new BestPractices);
+    }
 
-    auto gpu_assisted_obj = new GpuAssisted;
-    gpu_assisted_obj->InitDeviceValidationObject(enables[gpu_validation], instance_interceptor, device_interceptor);
+    if (enables[gpu_validation]) {
+        device_interceptor->object_dispatch.emplace_back(new GpuAssisted);
+    }
 
-    auto debug_printf_obj = new DebugPrintf;
-    debug_printf_obj->InitDeviceValidationObject(enables[debug_printf], instance_interceptor, device_interceptor);
+    if (enables[debug_printf]) {
+        device_interceptor->object_dispatch.emplace_back(new DebugPrintf);
+    }
 
-    auto sync_validation_obj = new SyncValidator;
-    sync_validation_obj->InitDeviceValidationObject(enables[sync_validation], instance_interceptor, device_interceptor);
+    if (enables[sync_validation]) {
+        device_interceptor->object_dispatch.emplace_back(new SyncValidator);
+    }
 
-    // Delete unused validation objects to avoid memory leak.
-    std::vector<ValidationObject *> local_objs = {
-        thread_safety_obj, stateless_validation_obj, object_tracker_obj,
-        core_checks_obj, best_practices_obj, gpu_assisted_obj, debug_printf_obj,
-        sync_validation_obj,
-    };
-    for (auto obj : local_objs) {
-        if (std::find(device_interceptor->object_dispatch.begin(), device_interceptor->object_dispatch.end(), obj) ==
-            device_interceptor->object_dispatch.end()) {
-            delete obj;
-        }
+    // Initialize all of the objects with the appropriate data
+    for(auto* object : device_interceptor->object_dispatch) {
+        object->device = device_interceptor->device;
+        object->physical_device = device_interceptor->physical_device;
+        object->instance = instance_interceptor->instance;
+        object->report_data = instance_interceptor->report_data;
+        object->device_dispatch_table = device_interceptor->device_dispatch_table;
+        object->api_version = device_interceptor->api_version;
+        object->disabled = instance_interceptor->disabled;
+        object->enabled = instance_interceptor->enabled;
+        object->fine_grained_locking = instance_interceptor->fine_grained_locking;
+        object->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
+        object->instance_extensions = instance_interceptor->instance_extensions;
+        object->device_extensions = device_interceptor->device_extensions;
     }
 
     for (ValidationObject* intercept : instance_interceptor->object_dispatch) {

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -4008,41 +4008,6 @@ class ValidationObject {
             return WriteLockGuard(validation_object_mutex);
         }
 
-        void RegisterValidationObject(bool vo_enabled, uint32_t instance_api_version,
-            debug_report_data* instance_report_data, std::vector<ValidationObject*> &dispatch_list) {
-            if (vo_enabled) {
-                api_version = instance_api_version;
-                report_data = instance_report_data;
-                dispatch_list.emplace_back(this);
-            }
-        }
-
-        void FinalizeInstanceValidationObject(ValidationObject *framework, VkInstance inst) {
-            instance_dispatch_table = framework->instance_dispatch_table;
-            enabled = framework->enabled;
-            disabled = framework->disabled;
-            fine_grained_locking = framework->fine_grained_locking;
-            instance = inst;
-        }
-
-        virtual void InitDeviceValidationObject(bool add_obj, ValidationObject *inst_obj, ValidationObject *dev_obj) {
-            if (add_obj) {
-                dev_obj->object_dispatch.emplace_back(this);
-                device = dev_obj->device;
-                physical_device = dev_obj->physical_device;
-                instance = inst_obj->instance;
-                report_data = inst_obj->report_data;
-                device_dispatch_table = dev_obj->device_dispatch_table;
-                api_version = dev_obj->api_version;
-                disabled = inst_obj->disabled;
-                enabled = inst_obj->enabled;
-                fine_grained_locking = inst_obj->fine_grained_locking;
-                instance_dispatch_table = inst_obj->instance_dispatch_table;
-                instance_extensions = inst_obj->instance_extensions;
-                device_extensions = dev_obj->device_extensions;
-            }
-        }
-
         ValidationObject* GetValidationObject(std::vector<ValidationObject*>& object_dispatch, LayerObjectTypeId object_type) {
             for (auto validation_object : object_dispatch) {
                 if (validation_object->container_type == object_type) {

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -401,41 +401,6 @@ class ValidationObject {
             return WriteLockGuard(validation_object_mutex);
         }
 
-        void RegisterValidationObject(bool vo_enabled, uint32_t instance_api_version,
-            debug_report_data* instance_report_data, std::vector<ValidationObject*> &dispatch_list) {
-            if (vo_enabled) {
-                api_version = instance_api_version;
-                report_data = instance_report_data;
-                dispatch_list.emplace_back(this);
-            }
-        }
-
-        void FinalizeInstanceValidationObject(ValidationObject *framework, VkInstance inst) {
-            instance_dispatch_table = framework->instance_dispatch_table;
-            enabled = framework->enabled;
-            disabled = framework->disabled;
-            fine_grained_locking = framework->fine_grained_locking;
-            instance = inst;
-        }
-
-        virtual void InitDeviceValidationObject(bool add_obj, ValidationObject *inst_obj, ValidationObject *dev_obj) {
-            if (add_obj) {
-                dev_obj->object_dispatch.emplace_back(this);
-                device = dev_obj->device;
-                physical_device = dev_obj->physical_device;
-                instance = inst_obj->instance;
-                report_data = inst_obj->report_data;
-                device_dispatch_table = dev_obj->device_dispatch_table;
-                api_version = dev_obj->api_version;
-                disabled = inst_obj->disabled;
-                enabled = inst_obj->enabled;
-                fine_grained_locking = inst_obj->fine_grained_locking;
-                instance_dispatch_table = inst_obj->instance_dispatch_table;
-                instance_extensions = inst_obj->instance_extensions;
-                device_extensions = dev_obj->device_extensions;
-            }
-        }
-
         ValidationObject* GetValidationObject(std::vector<ValidationObject*>& object_dispatch, LayerObjectTypeId object_type) {
             for (auto validation_object : object_dispatch) {
                 if (validation_object->container_type == object_type) {
@@ -821,41 +786,68 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     std::vector<ValidationObject*> local_object_dispatch;
 
     // Add VOs to dispatch vector. Order here will be the validation dispatch order!
-    auto thread_checker_obj = new ThreadSafety(nullptr);
-    thread_checker_obj->RegisterValidationObject(!local_disables[thread_safety], api_version, report_data, local_object_dispatch);
+    if (!local_disables[thread_safety]) {
+        local_object_dispatch.emplace_back(new ThreadSafety(nullptr));
+    }
 
-    auto parameter_validation_obj = new StatelessValidation;
-    parameter_validation_obj->RegisterValidationObject(!local_disables[stateless_checks], api_version, report_data, local_object_dispatch);
+    if (!local_disables[stateless_checks]) {
+        local_object_dispatch.emplace_back(new StatelessValidation);
+    }
 
-    auto object_tracker_obj = new ObjectLifetimes;
-    object_tracker_obj->RegisterValidationObject(!local_disables[object_tracking], api_version, report_data, local_object_dispatch);
+    if (!local_disables[object_tracking]) {
+        local_object_dispatch.emplace_back(new ObjectLifetimes);
+    }
 
-    auto core_checks_obj = new CoreChecks;
-    core_checks_obj->RegisterValidationObject(!local_disables[core_checks], api_version, report_data, local_object_dispatch);
+    if (!local_disables[core_checks]) {
+        local_object_dispatch.emplace_back(new CoreChecks);
+    }
 
-    auto best_practices_obj = new BestPractices;
-    best_practices_obj->RegisterValidationObject(local_enables[best_practices], api_version, report_data, local_object_dispatch);
+    if (local_enables[best_practices]) {
+        local_object_dispatch.emplace_back(new BestPractices);
+    }
 
-    auto gpu_assisted_obj = new GpuAssisted;
-    gpu_assisted_obj->RegisterValidationObject(local_enables[gpu_validation], api_version, report_data, local_object_dispatch);
+    if (local_enables[gpu_validation]) {
+        local_object_dispatch.emplace_back(new GpuAssisted);
+    }
 
-    auto debug_printf_obj = new DebugPrintf;
-    debug_printf_obj->RegisterValidationObject(local_enables[debug_printf], api_version, report_data, local_object_dispatch);
+    if (local_enables[debug_printf]) {
+        local_object_dispatch.emplace_back(new DebugPrintf);
+    }
 
-    auto sync_validation_obj = new SyncValidator;
-    sync_validation_obj->RegisterValidationObject(local_enables[sync_validation], api_version, report_data, local_object_dispatch);
+    if (local_enables[sync_validation]) {
+        local_object_dispatch.emplace_back(new SyncValidator);
+    }
 
     // If handle wrapping is disabled via the ValidationFeatures extension, override build flag
     if (local_disables[handle_wrapping]) {
         wrap_handles = false;
     }
 
+    // Initialize the validation objects
+    for (auto* intercept : local_object_dispatch) {
+        intercept->api_version = api_version;
+        intercept->report_data = report_data;
+    }
+
+    // Define logic to cleanup everything in case of an error
+    auto cleanup_allocations = [report_data, &local_object_dispatch](){
+        DeactivateInstanceDebugCallbacks(report_data);
+        FreePnextChain(report_data->instance_pnext_chain);
+        LayerDebugUtilsDestroyInstance(report_data);
+        for (ValidationObject* object : local_object_dispatch) {
+            delete object;
+        }
+    };
+
     // Init dispatch array and call registration functions
     bool skip = false;
     for (const ValidationObject* intercept : local_object_dispatch) {
         auto lock = intercept->ReadLock();
         skip |= intercept->PreCallValidateCreateInstance(pCreateInfo, pAllocator, pInstance);
-        if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
+        if (skip) {
+            cleanup_allocations();
+            return VK_ERROR_VALIDATION_FAILED_EXT;
+        }
     }
     for (ValidationObject* intercept : local_object_dispatch) {
         auto lock = intercept->WriteLock();
@@ -863,8 +855,10 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
     }
 
     VkResult result = fpCreateInstance(pCreateInfo, pAllocator, pInstance);
-    if (result != VK_SUCCESS) return result;
-
+    if (result != VK_SUCCESS) {
+        cleanup_allocations();
+        return result;
+    }
     auto framework = GetLayerDataPtr(get_dispatch_key(*pInstance), layer_data_map);
 
     framework->object_dispatch = local_object_dispatch;
@@ -885,30 +879,17 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo *pCreat
 
     OutputLayerStatusInfo(framework);
 
-    thread_checker_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    object_tracker_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    parameter_validation_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    core_checks_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    best_practices_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    gpu_assisted_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    debug_printf_obj->FinalizeInstanceValidationObject(framework, *pInstance);
-    sync_validation_obj->FinalizeInstanceValidationObject(framework, *pInstance);
+    for (auto* intercept : framework->object_dispatch) {
+        intercept->instance_dispatch_table = framework->instance_dispatch_table;
+        intercept->enabled = framework->enabled;
+        intercept->disabled = framework->disabled;
+        intercept->fine_grained_locking = framework->fine_grained_locking;
+        intercept->instance = *pInstance;
+    }
 
     for (ValidationObject* intercept : framework->object_dispatch) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordCreateInstance(pCreateInfo, pAllocator, pInstance, result);
-    }
-
-    // Delete unused validation objects to avoid memory leak.
-    std::vector<ValidationObject*> local_objs = {
-        thread_checker_obj, object_tracker_obj, parameter_validation_obj,
-        core_checks_obj, best_practices_obj, gpu_assisted_obj, debug_printf_obj,
-        sync_validation_obj,
-    };
-    for (auto obj : local_objs) {
-        if (std::find(local_object_dispatch.begin(), local_object_dispatch.end(), obj) == local_object_dispatch.end()) {
-            delete obj;
-        }
     }
 
     InstanceExtensionWhitelist(framework, pCreateInfo, *pInstance);
@@ -1013,41 +994,53 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     auto disables = instance_interceptor->disabled;
     auto enables = instance_interceptor->enabled;
 
-    auto thread_safety_obj = new ThreadSafety(reinterpret_cast<ThreadSafety *>(instance_interceptor->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeThreading)));
-    thread_safety_obj->InitDeviceValidationObject(!disables[thread_safety], instance_interceptor, device_interceptor);
+    if (!disables[thread_safety]) {
+        device_interceptor->object_dispatch.emplace_back(new ThreadSafety(static_cast<ThreadSafety *>(
+            instance_interceptor->GetValidationObject(instance_interceptor->object_dispatch, LayerObjectTypeThreading))));
+    }
 
-    auto stateless_validation_obj = new StatelessValidation;
-    stateless_validation_obj->InitDeviceValidationObject(!disables[stateless_checks], instance_interceptor, device_interceptor);
+    if (!disables[stateless_checks]) {
+        device_interceptor->object_dispatch.emplace_back(new StatelessValidation);
+    }
 
-    auto object_tracker_obj = new ObjectLifetimes;
-    object_tracker_obj->InitDeviceValidationObject(!disables[object_tracking], instance_interceptor, device_interceptor);
+    if (!disables[object_tracking]) {
+        device_interceptor->object_dispatch.emplace_back(new ObjectLifetimes);
+    }
 
-    auto core_checks_obj = new CoreChecks;
-    core_checks_obj->InitDeviceValidationObject(!disables[core_checks], instance_interceptor, device_interceptor);
+    if (!disables[core_checks]) {
+        device_interceptor->object_dispatch.emplace_back(new CoreChecks);
+    }
 
-    auto best_practices_obj = new BestPractices;
-    best_practices_obj->InitDeviceValidationObject(enables[best_practices], instance_interceptor, device_interceptor);
+    if (enables[best_practices]) {
+        device_interceptor->object_dispatch.emplace_back(new BestPractices);
+    }
 
-    auto gpu_assisted_obj = new GpuAssisted;
-    gpu_assisted_obj->InitDeviceValidationObject(enables[gpu_validation], instance_interceptor, device_interceptor);
+    if (enables[gpu_validation]) {
+        device_interceptor->object_dispatch.emplace_back(new GpuAssisted);
+    }
 
-    auto debug_printf_obj = new DebugPrintf;
-    debug_printf_obj->InitDeviceValidationObject(enables[debug_printf], instance_interceptor, device_interceptor);
+    if (enables[debug_printf]) {
+        device_interceptor->object_dispatch.emplace_back(new DebugPrintf);
+    }
 
-    auto sync_validation_obj = new SyncValidator;
-    sync_validation_obj->InitDeviceValidationObject(enables[sync_validation], instance_interceptor, device_interceptor);
+    if (enables[sync_validation]) {
+        device_interceptor->object_dispatch.emplace_back(new SyncValidator);
+    }
 
-    // Delete unused validation objects to avoid memory leak.
-    std::vector<ValidationObject *> local_objs = {
-        thread_safety_obj, stateless_validation_obj, object_tracker_obj,
-        core_checks_obj, best_practices_obj, gpu_assisted_obj, debug_printf_obj,
-        sync_validation_obj,
-    };
-    for (auto obj : local_objs) {
-        if (std::find(device_interceptor->object_dispatch.begin(), device_interceptor->object_dispatch.end(), obj) ==
-            device_interceptor->object_dispatch.end()) {
-            delete obj;
-        }
+    // Initialize all of the objects with the appropriate data
+    for(auto* object : device_interceptor->object_dispatch) {
+        object->device = device_interceptor->device;
+        object->physical_device = device_interceptor->physical_device;
+        object->instance = instance_interceptor->instance;
+        object->report_data = instance_interceptor->report_data;
+        object->device_dispatch_table = device_interceptor->device_dispatch_table;
+        object->api_version = device_interceptor->api_version;
+        object->disabled = instance_interceptor->disabled;
+        object->enabled = instance_interceptor->enabled;
+        object->fine_grained_locking = instance_interceptor->fine_grained_locking;
+        object->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
+        object->instance_extensions = instance_interceptor->instance_extensions;
+        object->device_extensions = device_interceptor->device_extensions;
     }
 
     for (ValidationObject* intercept : instance_interceptor->object_dispatch) {


### PR DESCRIPTION
This commit makes it so that only validation objects that will be used will be created. This prevents the need of manually removing unused objects.

In addition, cleanup code was added when an error is detected, thus preventing the leaking of ValidationObjects, debug_report_data, and copied pNext chains.

Lastly, the various 'init' functions of the ValidationObject have been deleted by having their contents moved into the vkCreateInstance/vkCreateDevice functions instead of having a separate function.