### PR TITLE
tests: Unmap memory which was mapped

### DIFF
--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -1690,7 +1690,7 @@ TEST_F(VkPositiveLayerTest, TestMappingMemoryWithMultiInstanceHeapFlag) {
 
     uint32_t *pData;
     vk::MapMemory(device(), memory, 0, VK_WHOLE_SIZE, 0, (void **)&pData);
-
+    vk::UnmapMemory(device(), memory);
     vk::FreeMemory(m_device->device(), memory, nullptr);
 }
 

--- a/tests/vklayertests_memory.cpp
+++ b/tests/vklayertests_memory.cpp
@@ -175,6 +175,7 @@ TEST_F(VkLayerTest, InvalidMemoryMapping) {
 
     pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
                                            VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    vk::UnmapMemory(m_device->device(), mem);
     if (!pass) {
         vk::FreeMemory(m_device->device(), mem, NULL);
         vk::DestroyBuffer(m_device->device(), buffer, NULL);


### PR DESCRIPTION
While the spec does say that mapped memory is automatically unmapped when the allocation is freed, the MockICD will leak memory if we do not call unmap memory. Thus to allow tests to run cleanly with leak sanitizer, this test should unmap memory before exiting.