### PR TITLE
tests: Clean up instance extension names

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -1036,7 +1036,7 @@ VkLayerTest::VkLayerTest() {
     // TODO: not quite sure why most of this is here instead of in super
 
     // Add default instance extensions to the list
-    instance_extensions_.push_back(debug_reporter_.debug_extension_name);
+    m_instance_extension_names.push_back(debug_reporter_.debug_extension_name);
 
     instance_layers_.push_back(kValidationLayerName);
 

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -1079,7 +1079,7 @@ TEST_F(VkBestPracticesLayerTest, ExpectedQueryDetails) {
     // Vulkan 1.1 required to test vkGetPhysicalDeviceQueueFamilyProperties2
     app_info_.apiVersion = VK_API_VERSION_1_1;
     // VK_KHR_get_physical_device_properties2 required to test vkGetPhysicalDeviceQueueFamilyProperties2KHR
-    instance_extensions_.emplace_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    m_instance_extension_names.emplace_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
     const vk_testing::PhysicalDevice phys_device_obj(gpu_);
 

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -2912,8 +2912,8 @@ TEST_F(VkLayerTest, CopyImageCompressedBlockAlignment) {
     m_commandBuffer->CopyImage(image_1.image(), VK_IMAGE_LAYOUT_GENERAL, image_2.image(), VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
 
     std::string vuid;
-    bool ycbcr = (DeviceExtensionEnabled(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME) ||
-                  (DeviceValidationVersion() >= VK_API_VERSION_1_1));
+    bool ycbcr =
+        (IsExtensionsEnabled(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME) || (DeviceValidationVersion() >= VK_API_VERSION_1_1));
 
     // Src, Dest offsets must be multiples of compressed block sizes {4, 4, 1}
     // Image transfer granularity gets set to compressed block size, so an ITG error is also (unavoidably) triggered.

--- a/tests/vklayertests_image.cpp
+++ b/tests/vklayertests_image.cpp
@@ -1773,8 +1773,8 @@ TEST_F(VkLayerTest, CopyInvalidImageMemory) {
     copy_region.extent.depth = 1;
 
     std::string vuid;
-    bool ycbcr = (DeviceExtensionEnabled(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME) ||
-                  (DeviceValidationVersion() >= VK_API_VERSION_1_1));
+    bool ycbcr =
+        (IsExtensionsEnabled(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME) || (DeviceValidationVersion() >= VK_API_VERSION_1_1));
 
     m_commandBuffer->begin();
     vuid = ycbcr ? "VUID-vkCmdCopyImage-srcImage-01546" : "VUID-vkCmdCopyImage-srcImage-00127";
@@ -2736,10 +2736,10 @@ TEST_F(VkLayerTest, CreateImageViewDifferentClass) {
     imgViewInfo.image = mutImage.handle();
 
     // Create mutable format image that is not compatiable
-    bool ycbcr_support = (DeviceExtensionEnabled(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME) ||
-                          (DeviceValidationVersion() >= VK_API_VERSION_1_1));
+    bool ycbcr_support =
+        (IsExtensionsEnabled(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME) || (DeviceValidationVersion() >= VK_API_VERSION_1_1));
     bool maintenance2_support =
-        (DeviceExtensionEnabled(VK_KHR_MAINTENANCE_2_EXTENSION_NAME) || (DeviceValidationVersion() >= VK_API_VERSION_1_1));
+        (IsExtensionsEnabled(VK_KHR_MAINTENANCE_2_EXTENSION_NAME) || (DeviceValidationVersion() >= VK_API_VERSION_1_1));
     const char *error_vuid;
     if ((!maintenance2_support) && (!ycbcr_support)) {
         error_vuid = "VUID-VkImageViewCreateInfo-image-01018";

--- a/tests/vklayertests_instanceless.cpp
+++ b/tests/vklayertests_instanceless.cpp
@@ -44,7 +44,7 @@ TEST_F(VkLayerTest, InstanceExtensionDependencies) {
     ASSERT_TRUE(InstanceExtensionSupported(VK_KHR_SURFACE_EXTENSION_NAME));  // Driver should always provide dependencies
 
     Monitor().SetDesiredFailureMsg(kErrorBit, "VUID-vkCreateInstance-ppEnabledExtensionNames-01388");
-    instance_extensions_.push_back(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
+    m_instance_extension_names.push_back(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
     const auto ici = GetInstanceCreateInfo();
     vk::CreateInstance(&ici, nullptr, &dummy_instance);
     Monitor().VerifyFound();
@@ -67,7 +67,7 @@ TEST_F(VkLayerTest, InstanceDuplicatePnextStype) {
     if (!InstanceExtensionSupported(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME)) {
         GTEST_SKIP() << "Did not find required instance extension";
     }
-    instance_extensions_.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+    m_instance_extension_names.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
 
     auto ici = GetInstanceCreateInfo();
 
@@ -100,7 +100,7 @@ TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
     if (!InstanceExtensionSupported(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME)) {
         GTEST_SKIP() << "Did not find required instance extension";
     }
-    instance_extensions_.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+    m_instance_extension_names.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
 
     auto ici = GetInstanceCreateInfo();
 
@@ -147,7 +147,7 @@ TEST_F(VkLayerTest, InstanceBadValidationFlags) {
     if (!InstanceExtensionSupported(VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME)) {
         GTEST_SKIP() << "Did not find required instance extension";
     }
-    instance_extensions_.push_back(VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME);
+    m_instance_extension_names.push_back(VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME);
 
     auto ici = GetInstanceCreateInfo();
 

--- a/tests/vklayertests_memory.cpp
+++ b/tests/vklayertests_memory.cpp
@@ -2064,10 +2064,10 @@ TEST_F(VkLayerTest, DedicatedAllocation) {
     dedicated_allocate_info.buffer = VK_NULL_HANDLE;
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-    const char *image_vuid = DeviceExtensionEnabled(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME)
+    const char *image_vuid = IsExtensionsEnabled(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME)
                                  ? "VUID-VkMemoryDedicatedAllocateInfo-image-02964"
                                  : "VUID-VkMemoryDedicatedAllocateInfo-image-01433";
-    const char *buffer_vuid = DeviceExtensionEnabled(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME)
+    const char *buffer_vuid = IsExtensionsEnabled(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME)
                                   ? "VUID-VkMemoryDedicatedAllocateInfo-buffer-02965"
                                   : "VUID-VkMemoryDedicatedAllocateInfo-buffer-01435";
 #else

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -3962,7 +3962,7 @@ TEST_F(VkLayerTest, QueueSubmitBinarySemaphoreNotSignaled) {
 
     auto semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
     // VUIDs reported change if the extension is enabled, even if the timelineSemaphore feature isn't supported.
-    const bool has_timeline_sem_ext = DeviceExtensionEnabled(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
+    const bool has_timeline_sem_ext = IsExtensionsEnabled(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
 
     {
         vk_testing::Semaphore semaphore[3];

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -3227,7 +3227,7 @@ TEST_F(VkLayerTest, QueuePresentBinarySemaphoreNotSignaled) {
     present.pWaitSemaphores = &semaphore.handle();
 
     // VUIDs reported change if the extension is enabled, even if the timelineSemaphore feature isn't supported.
-    const bool has_timeline_sem_ext = DeviceExtensionEnabled(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
+    const bool has_timeline_sem_ext = IsExtensionsEnabled(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     const char *expected_vuid =
         has_timeline_sem_ext ? "VUID-vkQueuePresentKHR-pWaitSemaphores-03268" : "VUID-vkQueuePresentKHR-pWaitSemaphores-01295";
 

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -737,8 +737,8 @@ TEST_F(VkLayerTest, SwapchainNotSupported) {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     // in "issue" section of VK_KHR_android_surface it talks how querying support is not needed on Android
     // The validation layers currently don't validate this VUID for Android surfaces
-    if (std::find(instance_extensions_.begin(), instance_extensions_.end(), VK_KHR_ANDROID_SURFACE_EXTENSION_NAME) !=
-        instance_extensions_.end()) {
+    if (std::find(m_instance_extension_names.begin(), m_instance_extension_names.end(), VK_KHR_ANDROID_SURFACE_EXTENSION_NAME) !=
+        m_instance_extension_names.end()) {
         GTEST_SKIP() << "Test does not run on Android Surface";
     }
 #endif

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -197,21 +197,6 @@ bool VkRenderFramework::DeviceExtensionSupported(const char *extension_name, con
     return std::any_of(extensions.begin(), extensions.end(), IsTheQueriedExtension);
 }
 
-// Return true if device is created and extension name is found in the list
-bool VkRenderFramework::DeviceExtensionEnabled(const char *ext_name) {
-    if (NULL == m_device) return false;
-
-    bool ext_found = false;
-    for (auto ext : m_device_extension_names) {
-        if (!strncmp(ext, ext_name, VK_MAX_EXTENSION_NAME_SIZE)) {
-            ext_found = true;
-            break;
-        }
-    }
-    return ext_found;
-}
-
-
 VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
 #ifdef VK_USE_PLATFORM_METAL_EXT
     return {

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -171,13 +171,6 @@ bool VkRenderFramework::InstanceExtensionSupported(const char *const extension_n
     return std::any_of(available_extensions_.begin(), available_extensions_.end(), IsTheQueriedExtension);
 }
 
-// Return true if instance exists and extension name is in the list
-bool VkRenderFramework::InstanceExtensionEnabled(const char *ext_name) {
-    if (!instance_) return false;
-
-    return std::any_of(instance_extensions_.begin(), instance_extensions_.end(),
-                       [ext_name](const char *e) { return 0 == strncmp(ext_name, e, VK_MAX_EXTENSION_NAME_SIZE); });
-}
 // Return true if extension name is found and spec value is >= requested spec value
 bool VkRenderFramework::DeviceExtensionSupported(const char *extension_name, const uint32_t spec_version) const {
     if (!instance_ || !gpu_) {
@@ -228,8 +221,8 @@ VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
         &app_info_,
         static_cast<uint32_t>(instance_layers_.size()),
         instance_layers_.data(),
-        static_cast<uint32_t>(instance_extensions_.size()),
-        instance_extensions_.data(),
+        static_cast<uint32_t>(m_instance_extension_names.size()),
+        m_instance_extension_names.data(),
     };
 #else
     return {
@@ -239,8 +232,8 @@ VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
         &app_info_,
         static_cast<uint32_t>(instance_layers_.size()),
         instance_layers_.data(),
-        static_cast<uint32_t>(instance_extensions_.size()),
-        instance_extensions_.data(),
+        static_cast<uint32_t>(m_instance_extension_names.size()),
+        m_instance_extension_names.data(),
     };
 #endif
 }
@@ -308,7 +301,7 @@ void VkRenderFramework::InitFramework(void * /*unused compatibility parameter*/,
     static bool print_driver_info = GetEnvironment("VK_LAYER_TESTS_PRINT_DRIVER") != "";
     if (print_driver_info && !driver_printed &&
         InstanceExtensionSupported(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
-        instance_extensions_.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+        m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     }
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
@@ -318,7 +311,7 @@ void VkRenderFramework::InitFramework(void * /*unused compatibility parameter*/,
 #endif
 
     RemoveIf(instance_layers_, LayerNotSupportedWithReporting);
-    RemoveIf(instance_extensions_, ExtensionNotSupportedWithReporting);
+    RemoveIf(m_instance_extension_names, ExtensionNotSupportedWithReporting);
 
     auto ici = GetInstanceCreateInfo();
 

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -203,7 +203,6 @@ class VkRenderFramework : public VkTestFramework {
                                   uint32_t spec_version = 0) const {  // deprecated
         return DeviceExtensionSupported(name, spec_version);
     }
-    bool DeviceExtensionEnabled(const char *name);
 
     // Tracks ext_name to be enabled at device creation time and attempts to enable any required instance extensions.
     // Does not return anything as the caller should use AreRequiredExtensionsEnabled or AddOptionalExtensions then

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -198,7 +198,6 @@ class VkRenderFramework : public VkTestFramework {
 
     const VkRenderPassBeginInfo &renderPassBeginInfo() const { return m_renderPassBeginInfo; }
 
-    bool InstanceExtensionEnabled(const char *name);
     bool DeviceExtensionSupported(const char *extension_name, uint32_t spec_version = 0) const;
     bool DeviceExtensionSupported(VkPhysicalDevice, const char *, const char *name,
                                   uint32_t spec_version = 0) const {  // deprecated
@@ -243,8 +242,7 @@ class VkRenderFramework : public VkTestFramework {
 
     VkApplicationInfo app_info_;
     std::vector<const char *> instance_layers_;
-    std::vector<const char *> instance_extensions_;
-    std::vector<const char *> &m_instance_extension_names = instance_extensions_;  // compatibility alias name
+    std::vector<const char *> m_instance_extension_names;
     VkInstance instance_;
     VkPhysicalDevice gpu_ = VK_NULL_HANDLE;
     VkPhysicalDeviceProperties physDevProps_;


### PR DESCRIPTION
`std::vector<const char *> &m_instance_extension_names = instance_extensions_;  // compatibility alias name` seems like a useless thing to keep around

there are more instances of `m_instance_extension_names` so decided to keep it (also it matches `m_device_extension_names`)

Happy to rename the member variable to be consistent with each other later, but having 2 variables alias make it hard to search for anything

(also `InstanceExtensionEnabled` is not used so removed)