### PR TITLE
layers: Print better error for interface match

### DIFF
--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -351,7 +351,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     }
 
     // Used to get human readable strings for error messages
-    void DescribeTypeInner(std::ostringstream &ss, uint32_t type) const;
+    void DescribeTypeInner(std::ostringstream &ss, uint32_t type, uint32_t indent) const;
     std::string DescribeType(uint32_t type) const;
 
     std::optional<VkPrimitiveTopology> GetTopology(const Instruction &entrypoint) const;
@@ -389,6 +389,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     uint32_t GetTypeBitsSize(const Instruction *insn) const;
     uint32_t GetTypeBytesSize(const Instruction *insn) const;
     uint32_t GetBaseType(const Instruction *insn) const;
+    const Instruction *GetBaseTypeInstruction(uint32_t type) const;
     uint32_t GetTypeId(uint32_t id) const;
     uint32_t GetTexelComponentCount(const Instruction &insn) const;
 


### PR DESCRIPTION
The error message for mismatch interfaces was not that helpful as it gets more complex

Vertex shader

```glsl
layout(buffer_reference) buffer T0 {
    int x[3];
};

layout(buffer_reference) buffer T1 {
    int y;
    float z[2];
    T0 w[2];
};

layout(set = 0, binding = 0) layout(buffer_reference) buffer dataBuffer {
    int a;
    int b;
    T1 c;
};
```

Error message before

> Validation Error: [ UNASSIGNED-CoreValidation-Shader-InterfaceTypeMismatch ] Object 0: handle = 0xee647e0000000009, type = VK_OBJECT_TYPE_SHADER_MODULE; | MessageID = 0xb6cf33fe | vkCreateGraphicsPipelines(): pCreateInfos[0] Type mismatch on location 0.0, between vertex shader and fragment shader: 'ptr to Output ptr to PhysicalStorageBuffer struct of (sint32, sint32, ptr to PhysicalStorageBuffer struct of (sint32, arr[2] of float32, ptr to PhysicalStorageBuffer struct of (arr[3] of sint32)))' vs 'ptr to Input ptr to PhysicalStorageBuffer struct of (sint32, sint32, ptr to PhysicalStorageBuffer struct of (sint32, arr[2] of float32, ptr to PhysicalStorageBuffer struct of (arr[2] of sint32)))'

new error message

```
Validation Error: [ UNASSIGNED-CoreValidation-Shader-InterfaceTypeMismatch ] Object 0: handle = 0xee647e0000000009, type = VK_OBJECT_TYPE_SHADER_MODULE; | MessageID = 0xb6cf33fe | vkCreateGraphicsPipelines(): pCreateInfos[0] Type mismatch on location 0.0, between
vertex shader stage:
pointer to Output ->
    pointer to PhysicalStorageBuffer ->
        struct of {
            sint32
            sint32
            pointer to PhysicalStorageBuffer ->
                struct of {
                    sint32
                    array[2] of float32
                    pointer to PhysicalStorageBuffer ->
                        struct of {
                            array[3] of sint32
                        }
                }
        }
fragment shader stage:
pointer to Input ->
    pointer to PhysicalStorageBuffer ->
        struct of {
            sint32
            sint32
            pointer to PhysicalStorageBuffer ->
                struct of {
                    sint32
                    array[2] of float32
                    pointer to PhysicalStorageBuffer ->
                        struct of {
                            array[2] of sint32
                        }
                }
        }
```