### PR TITLE
Shader validation cleanup

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -893,8 +893,8 @@ class CoreChecks : public ValidationStateTracker {
     bool RequireFeature(const SHADER_MODULE_STATE& module_state, VkBool32 feature, char const* feature_name,
                         const char* vuid) const;
     bool ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE& producer, const Instruction& producer_entrypoint,
-                                        shader_stage_attributes const* producer_stage, const SHADER_MODULE_STATE& consumer,
-                                        const Instruction& consumer_entrypoint, shader_stage_attributes const* consumer_stage,
+                                        VkShaderStageFlagBits producer_stage, const SHADER_MODULE_STATE& consumer,
+                                        const Instruction& consumer_entrypoint, VkShaderStageFlagBits consumer_stage,
                                         uint32_t pipe_index) const;
     bool ValidateDecorations(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
     bool ValidateVariables(const SHADER_MODULE_STATE& module_state) const;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -861,7 +861,7 @@ class CoreChecks : public ValidationStateTracker {
                                             const Instruction& insn) const;
     bool ValidateMemoryScope(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
     bool ValidateCooperativeMatrix(const SHADER_MODULE_STATE& module_state,
-                                   safe_VkPipelineShaderStageCreateInfo const* pStage) const;
+                                   safe_VkPipelineShaderStageCreateInfo const* create_info) const;
     bool ValidateShaderResolveQCOM(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                    const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderSubgroupSizeControl(const SHADER_MODULE_STATE& module_state, VkPipelineShaderStageCreateFlags flags) const;
@@ -880,7 +880,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateConservativeRasterization(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
                                            const PIPELINE_STATE& pipeline) const;
     bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
-                                   safe_VkPipelineShaderStageCreateInfo const* pStage, const std::string& vuid) const;
+                                   safe_VkPipelineShaderStageCreateInfo const* create_info, const std::string& vuid) const;
     bool ValidateBuiltinLimits(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
                                const PIPELINE_STATE& pipeline) const;
     PushConstantByteState ValidatePushConstantSetUpdate(const std::vector<uint8_t>& push_constant_data_update,
@@ -904,7 +904,7 @@ class CoreChecks : public ValidationStateTracker {
                                           const std::string& vuid_layout_mismatch) const;
     bool ValidateTransformFeedback(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderModuleId(const SHADER_MODULE_STATE& module_state, const PipelineStageState& stage_state,
-                                const safe_VkPipelineShaderStageCreateInfo* pStage, const VkPipelineCreateFlags flags) const;
+                                const safe_VkPipelineShaderStageCreateInfo* create_info, const VkPipelineCreateFlags flags) const;
     bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
     bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
 

--- a/layers/core_checks/descriptor_validation.cpp
+++ b/layers/core_checks/descriptor_validation.cpp
@@ -1099,7 +1099,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                 }
                 assert(set_index != std::numeric_limits<uint32_t>::max());
                 const auto pipeline = context.cb_state.GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS);
-                for (const auto &stage : pipeline->stage_state) {
+                for (const auto &stage : pipeline->stage_states) {
                     if (!stage.descriptor_variables) {
                         continue;
                     }

--- a/layers/core_checks/drawdispatch_validation.cpp
+++ b/layers/core_checks/drawdispatch_validation.cpp
@@ -2945,7 +2945,7 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE &cb_state, CMD_T
     //       "life times" of push constants are correct.
     //       Discussion on validity of these checks can be found at https://gitlab.khronos.org/vulkan/vulkan/-/issues/2602.
     if (!cb_state.push_constant_data_ranges || (pipeline_layout->push_constant_ranges == cb_state.push_constant_data_ranges)) {
-        for (const auto &stage : pipeline.stage_state) {
+        for (const auto &stage : pipeline.stage_states) {
             const auto *push_constants =
                 stage.module_state->FindEntrypointPushConstant(stage.create_info->pName, stage.create_info->stage);
             if (!push_constants || !push_constants->IsUsed()) {

--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -261,13 +261,13 @@ bool CoreChecks::ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> c
     const uint32_t active_shaders = pipeline.active_shaders;
     if (pipeline.pre_raster_state || pipeline.fragment_shader_state) {
         vvl::unordered_set<VkShaderStageFlags> unique_stage_set;
-        const auto stages = pipeline.GetShaderStages();
-        for (const auto &stage : stages) {
-            if (!unique_stage_set.insert(stage.stage).second) {
+        const auto stages_ci = pipeline.GetShaderStagesCreateInfo();
+        for (const auto &stage_ci : stages_ci) {
+            if (!unique_stage_set.insert(stage_ci.stage).second) {
                 skip |=
                     LogError(device, "VUID-VkGraphicsPipelineCreateInfo-stage-06897",
                              "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] State: Multiple shaders provided for stage %s",
-                             pipeline.create_index, string_VkShaderStageFlagBits(stage.stage));
+                             pipeline.create_index, string_VkShaderStageFlagBits(stage_ci.stage));
             }
         }
     }

--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -1109,7 +1109,7 @@ bool CoreChecks::ValidateRayTracingPipeline(const PIPELINE_STATE &pipeline,
     const auto *groups = create_info.ptr()->pGroups;
 
     for (uint32_t stage_index = 0; stage_index < create_info.stageCount; stage_index++) {
-        skip |= ValidatePipelineShaderStage(pipeline, pipeline.stage_state[stage_index]);
+        skip |= ValidatePipelineShaderStage(pipeline, pipeline.stage_states[stage_index]);
     }
 
     if ((create_info.flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) {
@@ -2958,7 +2958,7 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE &
             }
 
             if (pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass == VK_NULL_HANDLE && raster_state) {
-                for (const auto &stage : pipeline.stage_state) {
+                for (const auto &stage : pipeline.stage_states) {
                     if (stage.writes_to_gl_layer) {
                         skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06059",
                                          "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -3470,7 +3470,7 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE &pipel
     }
 
     const PipelineStageState *vertex_stage = nullptr, *fragment_stage = nullptr;
-    for (auto &stage : pipeline.stage_state) {
+    for (auto &stage : pipeline.stage_states) {
         // Only validate the shader state once when added, not again when linked
         if ((stage.stage_flag & pipeline.linking_shaders) == 0) {
             skip |= ValidatePipelineShaderStage(pipeline, stage);
@@ -3491,9 +3491,9 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE &pipel
         skip |= ValidateViAgainstVsInputs(pipeline, *vertex_stage->module_state.get(), *(vertex_stage->entrypoint));
     }
 
-    for (size_t i = 1; i < pipeline.stage_state.size(); i++) {
-        const auto &producer = pipeline.stage_state[i - 1];
-        const auto &consumer = pipeline.stage_state[i];
+    for (size_t i = 1; i < pipeline.stage_states.size(); i++) {
+        const auto &producer = pipeline.stage_states[i - 1];
+        const auto &consumer = pipeline.stage_states[i];
         assert(producer.module_state);
         if (&producer == fragment_stage) {
             break;
@@ -3526,7 +3526,7 @@ bool CoreChecks::ValidateGraphicsPipelineShaderDynamicState(const PIPELINE_STATE
                                                             const char *caller, const DrawDispatchVuid &vuid) const {
     bool skip = false;
 
-    for (auto &stage : pipeline.stage_state) {
+    for (auto &stage : pipeline.stage_states) {
         if (stage.stage_flag == VK_SHADER_STAGE_VERTEX_BIT || stage.stage_flag == VK_SHADER_STAGE_GEOMETRY_BIT ||
             stage.stage_flag == VK_SHADER_STAGE_MESH_BIT_EXT) {
             if (!phys_dev_ext_props.fragment_shading_rate_props.primitiveFragmentShadingRateWithMultipleViewports &&
@@ -3547,7 +3547,7 @@ bool CoreChecks::ValidateGraphicsPipelineShaderDynamicState(const PIPELINE_STATE
 }
 
 bool CoreChecks::ValidateComputePipelineShaderState(const PIPELINE_STATE &pipeline) const {
-    return ValidatePipelineShaderStage(pipeline, pipeline.stage_state[0]);
+    return ValidatePipelineShaderStage(pipeline, pipeline.stage_states[0]);
 }
 
 uint32_t CoreChecks::CalcShaderStageCount(const PIPELINE_STATE &pipeline, VkShaderStageFlagBits stageBit) const {

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -3552,9 +3552,9 @@ bool CoreChecks::ValidateComputePipelineShaderState(const PIPELINE_STATE &pipeli
 
 uint32_t CoreChecks::CalcShaderStageCount(const PIPELINE_STATE &pipeline, VkShaderStageFlagBits stageBit) const {
     uint32_t total = 0;
-    const auto stages = pipeline.GetShaderStages();
-    for (const auto &stage : stages) {
-        if (stage.stage == stageBit) {
+    const auto stages_ci = pipeline.GetShaderStagesCreateInfo();
+    for (const auto &stage_ci : stages_ci) {
+        if (stage_ci.stage == stageBit) {
             total++;
         }
     }
@@ -3575,11 +3575,11 @@ bool CoreChecks::GroupHasValidIndex(const PIPELINE_STATE &pipeline, uint32_t gro
         return true;
     }
 
-    const auto stages = pipeline.GetShaderStages();
+    const auto stages_ci = pipeline.GetShaderStagesCreateInfo();
 
-    const auto num_stages = static_cast<uint32_t>(stages.size());
+    const auto num_stages = static_cast<uint32_t>(stages_ci.size());
     if (group < num_stages) {
-        return (stages[group].stage & stage) != 0;
+        return (stages_ci[group].stage & stage) != 0;
     }
     group -= num_stages;
 
@@ -3588,10 +3588,10 @@ bool CoreChecks::GroupHasValidIndex(const PIPELINE_STATE &pipeline, uint32_t gro
     if (rt_lib_info) {
         for (uint32_t i = 0; i < rt_lib_info->libraryCount; ++i) {
             auto library_pipeline = Get<PIPELINE_STATE>(rt_lib_info->pLibraries[i]);
-            const auto lib_stages = library_pipeline->GetShaderStages();
-            const uint32_t stage_count = static_cast<uint32_t>(lib_stages.size());
+            const auto lib_stages_ci = library_pipeline->GetShaderStagesCreateInfo();
+            const uint32_t stage_count = static_cast<uint32_t>(lib_stages_ci.size());
             if (group < stage_count) {
-                return (lib_stages[group].stage & stage) != 0;
+                return (lib_stages_ci[group].stage & stage) != 0;
             }
             group -= stage_count;
         }

--- a/layers/core_checks/shader_validation.h
+++ b/layers/core_checks/shader_validation.h
@@ -30,13 +30,6 @@
 struct DeviceFeatures;
 struct DeviceExtensions;
 
-struct shader_stage_attributes {
-    char const *const name;
-    bool arrayed_input;
-    bool arrayed_output;
-    VkShaderStageFlags stage;
-};
-
 class ValidationCache {
   public:
     static VkValidationCacheEXT Create(VkValidationCacheCreateInfoEXT const *pCreateInfo) {

--- a/layers/gpu_validation/gpu_utils.cpp
+++ b/layers/gpu_validation/gpu_utils.cpp
@@ -833,8 +833,8 @@ void GpuAssistedBase::PreCallRecordPipelineCreations(uint32_t count, const Creat
         }
 
         if (replace_shaders) {
-            for (uint32_t i = 0; i < static_cast<uint32_t>(pipe->stage_state.size()); ++i) {
-                const auto &stage = pipe->stage_state[i];
+            for (uint32_t i = 0; i < static_cast<uint32_t>(pipe->stage_states.size()); ++i) {
+                const auto &stage = pipe->stage_states[i];
                 const auto &module_state = stage.module_state;
 
                 VkShaderModule shader_module;
@@ -854,7 +854,7 @@ void GpuAssistedBase::PreCallRecordPipelineCreations(uint32_t count, const Creat
             // !replace_shaders implies that the instrumented shaders should be used. However, if this is a non-executable pipeline
             // library created with pre-raster or fragment shader state, it contains shaders that have not yet been instrumented
             if (!pipe->HasFullState() && (pipe->pre_raster_state || pipe->fragment_shader_state)) {
-                for (const auto &stage : pipe->stage_state) {
+                for (const auto &stage : pipe->stage_states) {
                     auto module_state = std::const_pointer_cast<SHADER_MODULE_STATE>(stage.module_state);
                     if (!module_state->Handle()) {
                         // If the shader module's handle is non-null, then it was defined with CreateShaderModule and covered by the
@@ -906,10 +906,10 @@ void GpuAssistedBase::PostCallRecordPipelineCreations(const uint32_t count, cons
         auto pipeline_state = Get<PIPELINE_STATE>(pPipelines[pipeline]);
         if (!pipeline_state) continue;
 
-        if (!pipeline_state->stage_state.empty() &&
+        if (!pipeline_state->stage_states.empty() &&
             !(pipeline_state->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR)) {
             const auto pipeline_layout = pipeline_state->PipelineLayoutState();
-            for (auto &stage : pipeline_state->stage_state) {
+            for (auto &stage : pipeline_state->stage_states) {
                 auto &module_state = stage.module_state;
                 const auto shader_module = module_state->Handle();
 

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -469,7 +469,7 @@ class PIPELINE_STATE : public BASE_NODE {
         return create_info.graphics.pDynamicState;
     }
 
-    vvl::span<const safe_VkPipelineShaderStageCreateInfo> GetShaderStages() const {
+    vvl::span<const safe_VkPipelineShaderStageCreateInfo> GetShaderStagesCreateInfo() const {
         switch (create_info.graphics.sType) {
             case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO:
                 return vvl::span<const safe_VkPipelineShaderStageCreateInfo>{create_info.graphics.pStages,

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -179,7 +179,7 @@ class PIPELINE_STATE : public BASE_NODE {
 
     // Additional metadata needed by pipeline_state initialization and validation
     using StageStateVec = std::vector<PipelineStageState>;
-    const StageStateVec stage_state;
+    const StageStateVec stage_states;
     // Flag of which shader stages are active for this pipeline
     const uint32_t active_shaders = 0;
     // Shaders being linked in, don't need to be re-validated
@@ -456,7 +456,7 @@ class PIPELINE_STATE : public BASE_NODE {
     }
 
     std::shared_ptr<const SHADER_MODULE_STATE> GetShaderModuleState(VkShaderStageFlagBits stage) {
-        for (auto &s : stage_state) {
+        for (auto &s : stage_states) {
             if (s.stage_flag == stage) {
                 return s.module_state;
             }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2124,7 +2124,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
     using ImageDescriptor = cvdescriptorset::ImageDescriptor;
     using TexelDescriptor = cvdescriptorset::TexelDescriptor;
 
-    for (const auto &stage_state : pipe->stage_state) {
+    for (const auto &stage_state : pipe->stage_states) {
         const auto raster_state = pipe->RasterizationState();
         if (stage_state.stage_flag == VK_SHADER_STAGE_FRAGMENT_BIT && raster_state && raster_state->rasterizerDiscardEnable) {
             continue;
@@ -2258,7 +2258,7 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
     using ImageDescriptor = cvdescriptorset::ImageDescriptor;
     using TexelDescriptor = cvdescriptorset::TexelDescriptor;
 
-    for (const auto &stage_state : pipe->stage_state) {
+    for (const auto &stage_state : pipe->stage_states) {
         const auto raster_state = pipe->RasterizationState();
         if (stage_state.stage_flag == VK_SHADER_STAGE_FRAGMENT_BIT && raster_state && raster_state->rasterizerDiscardEnable) {
             continue;

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -4501,7 +4501,8 @@ TEST_F(VkLayerTest, CreatePipelineVertexOutputNotConsumed) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit, "not consumed by fragment shader");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit,
+                                      "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed");
 }
 
 TEST_F(VkLayerTest, CreatePipelineCheckShaderSpecializationApplied) {
@@ -4964,7 +4965,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvided) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "not written by vertex shader");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
 }
 
 TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvidedInBlock) {
@@ -4989,7 +4990,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvidedInBlock) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "not written by vertex shader");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
 }
 
 TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatch) {
@@ -5089,8 +5090,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByLocation) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                      "fragment shader consumes input location 0.0 which is not written by vertex shader");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
 }
 
 TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByComponent) {
@@ -5124,8 +5124,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByComponent) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                      std::vector<std::string>{"location 0.1 which is not written by vertex shader"});
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
 }
 
 TEST_F(VkLayerTest, CreatePipelineAttribNotConsumed) {
@@ -5362,9 +5361,7 @@ TEST_F(VkLayerTest, CreatePipelineTessPatchDecorationMismatch) {
         helper.shader_stages_.emplace_back(tcs.GetStageCreateInfo());
         helper.shader_stages_.emplace_back(tes.GetStageCreateInfo());
     };
-    CreatePipelineHelper::OneshotTest(
-        *this, set_info, kErrorBit,
-        "is per-vertex in tessellation control shader stage but per-patch in tessellation evaluation shader stage");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InterfaceTypeMismatch");
 }
 
 TEST_F(VkLayerTest, CreatePipelineTessErrors) {
@@ -5508,7 +5505,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputNotWritten) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.cb_attachments_[0].colorWriteMask = 1;
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "Attachment 0 not written by fragment shader");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
 }
 
 TEST_F(VkLayerTest, CreatePipelineFragmentOutputNotConsumed) {
@@ -5532,8 +5529,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputNotConsumed) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit,
-                                      "fragment shader writes to output location 1 with no matching attachment");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed");
 }
 
 TEST_F(VkLayerTest, CreatePipelineFragmentNoOutputLocation0ButAlphaToCoverageEnabled) {
@@ -5552,9 +5548,8 @@ TEST_F(VkLayerTest, CreatePipelineFragmentNoOutputLocation0ButAlphaToCoverageEna
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.pipe_ms_state_ci_ = ms_state_ci;
     };
-    CreatePipelineHelper::OneshotTest(
-        *this, set_info, kErrorBit,
-        "fragment shader doesn't declare alpha output at location 0 even though alpha to coverage is enabled.");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
+                                      "UNASSIGNED-CoreValidation-Shader-NoAlphaAtLocation0WithAlphaToCoverage");
 }
 
 TEST_F(VkLayerTest, CreatePipelineFragmentNoAlphaLocation0ButAlphaToCoverageEnabled) {
@@ -5581,9 +5576,8 @@ TEST_F(VkLayerTest, CreatePipelineFragmentNoAlphaLocation0ButAlphaToCoverageEnab
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.pipe_ms_state_ci_ = ms_state_ci;
     };
-    CreatePipelineHelper::OneshotTest(
-        *this, set_info, kErrorBit,
-        "fragment shader doesn't declare alpha output at location 0 even though alpha to coverage is enabled.");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
+                                      "UNASSIGNED-CoreValidation-Shader-NoAlphaAtLocation0WithAlphaToCoverage");
 }
 
 TEST_F(VkLayerTest, CreatePipelineFragmentOutputTypeMismatch) {
@@ -5607,7 +5601,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputTypeMismatch) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "does not match fragment shader output type");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-CoreValidation-Shader-InterfaceTypeMismatch");
 }
 
 TEST_F(VkLayerTest, CreatePipelineExceedVertexMaxComponentsWithBuiltins) {


### PR DESCRIPTION
This is in preparation for a much bigger change coming after

- Remove the `shader_stage_attributes`, it wasn't needed
- `shader_state` -> `shader_states` as it was hard to search or realize it was a vector
- Make it more clear what is a `VkPipelineShaderStageCreateInfo` struct, everything has the word `stage` in it so calling it `pStage` is not helpful for searching or code readability