### PR TITLE
Remove crash caused by use of VK_EXT_image_2d_view_of_3d

### DIFF
--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -173,16 +173,17 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
     void Update(uint32_t subpass, const uint32_t *preserved, uint32_t count) {
         // for preserved attachment, preserve the layout from the most recent (max subpass) dependency
         // or initial, if none
-        for (const auto attachment : vvl::make_span(preserved, count)) {
-            uint32_t max_prev = VK_SUBPASS_EXTERNAL;
-            for (const auto &prev : rp->subpass_dependencies[subpass].prev) {
-                const auto prev_pass = prev.first->pass;
-                max_prev = (max_prev == VK_SUBPASS_EXTERNAL) ? prev_pass : std::max(prev_pass, max_prev);
-            }
 
+        // max_prev is invariant across attachments
+        uint32_t max_prev = VK_SUBPASS_EXTERNAL;
+        for (const auto &prev : rp->subpass_dependencies[subpass].prev) {
+            const auto prev_pass = prev.first->pass;
+            max_prev = (max_prev == VK_SUBPASS_EXTERNAL) ? prev_pass : std::max(prev_pass, max_prev);
+        }
+
+        for (const auto attachment : vvl::make_span(preserved, count)) {
             if (max_prev == VK_SUBPASS_EXTERNAL) {
                 subpass_attachment_layout[subpass][attachment] = rp->createInfo.pAttachments[attachment].initialLayout;
-
             } else {
                 subpass_attachment_layout[subpass][attachment] = subpass_attachment_layout[max_prev][attachment];
             }

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -1190,8 +1190,6 @@ class AccessContext {
       public:
         AsyncReference(const AccessContext &async_context, ResourceUsageTag async_tag)
             : context_(&async_context), tag_(async_tag) {}
-        // AsyncReference(const AsyncReference &) = default;
-        // AsyncReference &operator =(const AsyncReference &) = default;
         const AccessContext &Context() const { return *context_; }
         // For RenderPass time validation this is "start tag", for QueueSubmit, this is the earliest
         // unsynchronized tag for the Queue being tested against (max synchrononous + 1, perhaps)


### PR DESCRIPTION
VK_EXT_image_2d_view_of_3d is not supported by syncval at this time, but this changed causes depth sliced views to be ignored inside of asserting on their presence.  Fixes #4536.