### PR TITLE
Fix MINGW build and add MINGW to CI

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -218,6 +218,7 @@ jobs:
             external/${{ matrix.config }}/googletest/build/install
             external/${{ matrix.config }}/Vulkan-Headers/registry
             external/${{ matrix.config }}/SPIRV-Headers/include
+            external/${{ matrix.config }}/mimalloc/build/install
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.config }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$env:GITHUB_WORKSPACE\\external\\${{ matrix.config }}\\Vulkan-Headers\\registry;$env:PYTHONPATH" >> $env:GITHUB_ENV
@@ -309,3 +310,39 @@ jobs:
         run: cmake --build build --parallel $(sysctl -n hw.logicalcpu) --config ${{matrix.config}}
       - name: Install Vulkan-ValidationLayers
         run: cmake --install build --prefix build/install --config ${{matrix.config}}
+
+  mingw:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Cache dependent components
+        id: cache-deps
+        uses: actions/cache@v3
+        with:
+          path: |
+            external/Debug/glslang/build/install
+            external/Debug/Vulkan-Headers/build/install
+            external/Debug/SPIRV-Headers/build/install
+            external/Debug/SPIRV-Tools/build/install
+            external/Debug/robin-hood-hashing/build/install
+            external/Debug/googletest/build/install
+            external/Debug/Vulkan-Headers/registry
+            external/Debug/SPIRV-Headers/include
+            external/Debug/mimalloc/build/install
+          key: mingw-Debug-${{ hashfiles('scripts/known_good.json') }}
+      - uses: lukka/get-cmake@latest
+      - name: Set up MinGW
+        uses: egor-tensin/setup-mingw@v2
+      - name: Configure
+        run: cmake -S. -B build -D UPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Debug -D UPDATE_DEPS_SKIP_EXISTING_INSTALL=ON -G "Ninja"
+        env:
+          LDFLAGS: "-fuse-ld=lld" # MINGW linking is very slow. Use llvm linker instead.
+      - name: Build
+        run: cmake --build build
+      - name: Install
+        run: cmake --install build --prefix build/install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,11 +139,6 @@ elseif(MSVC)
     add_compile_options($<$<BOOL:${MSVC_IDE}>:/MP>) # Speed up Visual Studio builds
 endif()
 
-if(MINGW)
-    add_compile_definitions(_WIN32_WINNT=0x0600) # Must be declared before including Windows.h
-    add_compile_options("-Wa,-mbig-obj")
-endif()
-
 option(BUILD_LAYERS "Build VkLayer_khronos_validation" ON)
 option(BUILD_LAYER_SUPPORT_FILES "Install VkLayer_utils")
 

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -103,8 +103,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
 endif()
 
 if(MSVC)
-    # Avoid: fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
-    add_compile_options("/bigobj")
     add_compile_options("/we4189")
     add_compile_options("/we5038")
 endif()
@@ -276,8 +274,10 @@ target_sources(VkLayer_khronos_validation PRIVATE
 
 if(MSVC)
     target_link_options(VkLayer_khronos_validation PRIVATE /DEF:${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_khronos_validation.def)
+    target_compile_options(VkLayer_khronos_validation PRIVATE /bigobj)
 elseif(MINGW)
-    message(DEBUG "Functions are exported via VVL_EXPORT")
+    target_sources(VkLayer_khronos_validation PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/VkLayer_khronos_validation.def)
+    target_compile_options(VkLayer_khronos_validation PRIVATE -Wa,-mbig-obj)
 elseif(APPLE)
     message(DEBUG "Functions are exported via VVL_EXPORT")
     set_target_properties(VkLayer_khronos_validation PROPERTIES SUFFIX ".dylib")

--- a/layers/vk_layer_logging.cpp
+++ b/layers/vk_layer_logging.cpp
@@ -19,7 +19,6 @@
 #include <csignal>
 #include <cstring>
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-#include <winsock2.h>
 #include <debugapi.h>
 #endif
 

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -15,9 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef TEST_COMMON_H
-#define TEST_COMMON_H
+#pragma once
 
 #include <cassert>
 #include <cstdio>
@@ -26,11 +24,6 @@
 #include <thread>
 
 #include "vk_layer_logging.h"
-
-#ifdef _WIN32
-// WinSock2.h must be included *BEFORE* windows.h
-#include <winsock2.h>
-#endif
 
 #include <vulkan/vulkan.h>
 
@@ -145,5 +138,3 @@ static inline void test_error_callback(const char *expr, const char *file, unsig
             }                                                           \
         }                                                               \
     }
-
-#endif  // TEST_COMMON_H


### PR DESCRIPTION
Fixes regression caused by be666f39c462905ef245d88ff8f36bc8a8e7cf8e

In order to prevent further regressions to MinGW add it to CI.

- build: Fix MinGW winsock2.h warning
- cmake: Fix MINGW build regression
- ci: Add MinGW to github actions CI
