### PR TITLE
sync: Call Destroy instead of Reset

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -4276,19 +4276,15 @@ syncval_state::CommandBuffer::CommandBuffer(SyncValidator *dev, VkCommandBuffer 
                                             const COMMAND_POOL_STATE *pool)
     : CMD_BUFFER_STATE(dev, cb, pCreateInfo, pool), access_context(*dev, this) {}
 
-syncval_state::CommandBuffer::~CommandBuffer() { Destroy(); }
-
 void syncval_state::CommandBuffer::Destroy() {
-    ResetCBState();  // must be first to clean up self references correctly.
+    access_context.Destroy();  // must be first to clean up self references correctly.
     CMD_BUFFER_STATE::Destroy();
 }
 
 void syncval_state::CommandBuffer::Reset() {
     CMD_BUFFER_STATE::Reset();
-    ResetCBState();
+    access_context.Reset();
 }
-
-void syncval_state::CommandBuffer::ResetCBState() { access_context.Reset(); }
 
 void syncval_state::CommandBuffer::NotifyInvalidate(const BASE_NODE::NodeList &invalid_nodes, bool unlink) {
     for (auto &obj : invalid_nodes) {

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -1588,15 +1588,12 @@ class CommandBuffer : public CMD_BUFFER_STATE {
 
     CommandBuffer(SyncValidator *dev, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
                   const COMMAND_POOL_STATE *pool);
-    ~CommandBuffer();
+    ~CommandBuffer() { Destroy(); }
 
     void NotifyInvalidate(const BASE_NODE::NodeList &invalid_nodes, bool unlink) override;
 
     void Destroy() override;
     void Reset() override;
-
-  private:
-    void ResetCBState();
 };
 }  // namespace syncval_state
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, syncval_state::CommandBuffer, CMD_BUFFER_STATE);


### PR DESCRIPTION
The Destroy call was calling ResetCBState() which results in Reset() being called. Reset adds in a self reference which causes a cycle in the shared_ptr's. Calling Destroy instead cleans everything up properly and doesn't leak any memory.

