### PR TITLE
layers: Move more to PIPELINE_STATE init

### DIFF
--- a/layers/core_checks/drawdispatch_validation.cpp
+++ b/layers/core_checks/drawdispatch_validation.cpp
@@ -2327,7 +2327,7 @@ bool CoreChecks::ValidateBaseGroups(const CMD_BUFFER_STATE &cb_state, uint32_t b
     if (baseGroupX || baseGroupY || baseGroupZ) {
         const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_COMPUTE);
         const auto *pipeline_state = cb_state.lastBound[lv_bind_point].pipeline_state;
-        if (pipeline_state && !(pipeline_state->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_DISPATCH_BASE)) {
+        if (pipeline_state && !(pipeline_state->create_flags & VK_PIPELINE_CREATE_DISPATCH_BASE)) {
             skip |= LogError(cb_state.Handle(), "VUID-vkCmdDispatchBase-baseGroupX-00427",
                              "%s(): If any of baseGroupX, baseGroupY, or baseGroupZ are not zero, then the bound compute pipeline "
                              "must have been created with the VK_PIPELINE_CREATE_DISPATCH_BASE flag",
@@ -2545,7 +2545,7 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(bool isIndirect, VkCommandBuffer comman
                          "vkCmdTraceRaysKHR: A valid pipeline must be bound to the pipeline bind point used by this command.");
     } else {  // bound to valid RT pipeline
         if (pHitShaderBindingTable) {
-            if (pipeline_state->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR) {
+            if (pipeline_state->create_flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR) {
                 if (pHitShaderBindingTable->deviceAddress == 0) {
                     const char *vuid =
                         isIndirect ? "VUID-vkCmdTraceRaysIndirectKHR-flags-03697" : "VUID-vkCmdTraceRaysKHR-flags-03697";
@@ -2560,7 +2560,7 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(bool isIndirect, VkCommandBuffer comman
                                  rt_func_name, pHitShaderBindingTable->size, pHitShaderBindingTable->stride);
                 }
             }
-            if (pipeline_state->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR) {
+            if (pipeline_state->create_flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR) {
                 if (pHitShaderBindingTable->deviceAddress == 0) {
                     const char *vuid =
                         isIndirect ? "VUID-vkCmdTraceRaysIndirectKHR-flags-03696" : "VUID-vkCmdTraceRaysKHR-flags-03696";
@@ -2575,7 +2575,7 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(bool isIndirect, VkCommandBuffer comman
                                  rt_func_name, pHitShaderBindingTable->size, pHitShaderBindingTable->stride);
                 }
             }
-            if (pipeline_state->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR) {
+            if (pipeline_state->create_flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR) {
                 // No vuid to check for pHitShaderBindingTable->deviceAddress == 0 with this flag
 
                 if (pHitShaderBindingTable->size == 0 || pHitShaderBindingTable->stride == 0) {

--- a/layers/core_checks/ray_tracing_validation.cpp
+++ b/layers/core_checks/ray_tracing_validation.cpp
@@ -982,7 +982,7 @@ bool CoreChecks::PreCallValidateGetRayTracingShaderGroupHandlesKHR(VkDevice devi
         return skip;
     }
     const PIPELINE_STATE &pipeline_state = *pPipeline;
-    if (pipeline_state.GetPipelineCreateFlags() & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) {
+    if (pipeline_state.create_flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) {
         if (!enabled_features.pipeline_library_group_handles_features.pipelineLibraryGroupHandles) {
             const char *vuid = IsExtEnabled(device_extensions.vk_ext_pipeline_library_group_handles)
                                    ? "VUID-vkGetRayTracingShaderGroupHandlesKHR-pipeline-07828"
@@ -1072,11 +1072,11 @@ bool CoreChecks::PreCallValidateGetRayTracingShaderGroupStackSizeKHR(VkDevice de
     bool skip = false;
     auto pipeline_state = Get<PIPELINE_STATE>(pipeline);
     if (pipeline_state) {
-        if (pipeline_state->GetPipelineType() != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
+        if (pipeline_state->pipeline_type != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
             skip |=
                 LogError(device, "VUID-vkGetRayTracingShaderGroupStackSizeKHR-pipeline-04622",
                          "vkGetRayTracingShaderGroupStackSizeKHR: Pipeline must be a ray-tracing pipeline, but is a %s pipeline.",
-                         string_VkPipelineBindPoint(pipeline_state->GetPipelineType()));
+                         string_VkPipelineBindPoint(pipeline_state->pipeline_type));
         } else if (group >= pipeline_state->GetCreateInfo<VkRayTracingPipelineCreateInfoKHR>().groupCount) {
             skip |=
                 LogError(device, "VUID-vkGetRayTracingShaderGroupStackSizeKHR-group-03608",

--- a/layers/gpu_validation/gpu_utils.cpp
+++ b/layers/gpu_validation/gpu_utils.cpp
@@ -906,8 +906,7 @@ void GpuAssistedBase::PostCallRecordPipelineCreations(const uint32_t count, cons
         auto pipeline_state = Get<PIPELINE_STATE>(pPipelines[pipeline]);
         if (!pipeline_state) continue;
 
-        if (!pipeline_state->stage_states.empty() &&
-            !(pipeline_state->GetPipelineCreateFlags() & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR)) {
+        if (!pipeline_state->stage_states.empty() && !(pipeline_state->create_flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR)) {
             const auto pipeline_layout = pipeline_state->PipelineLayoutState();
             for (auto &stage : pipeline_state->stage_states) {
                 auto &module_state = stage.module_state;


### PR DESCRIPTION
This change does 2 main things

1. Moves logic to member variables of `PIPELINE_STATE` that are part of the Create Info struct. These are constantly being queried and checking which sType, but we know this information at init time
2. Moves more away from using `stage_states` to indirectly get the information already known in create info (main idea is `stage_states` is re-doing a lot of work and future goal is to trim it down more)