### PR TITLE
tests: Make width and height uint32

### DIFF
--- a/tests/layer_validation_tests.cpp
+++ b/tests/layer_validation_tests.cpp
@@ -931,7 +931,7 @@ void VkLayerTest::VKTriangleTest(BsoFailSelect failCase) {
     if (failcase_needs_depth) {
         m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
-        m_depthStencil->Init(m_device, static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), m_depth_stencil_fmt,
+        m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt,
                              VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
         depth_attachment = m_depthStencil->BindInfo();
     }
@@ -971,7 +971,7 @@ void VkLayerTest::VKTriangleTest(BsoFailSelect failCase) {
         VkClearAttachment color_attachment = {};
         color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         color_attachment.colorAttachment = 2000000000;  // Someone who knew what they were doing would use 0 for the index;
-        VkClearRect clear_rect = {{{0, 0}, {static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height)}}, 0, 1};
+        VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
         vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
     }

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -338,7 +338,7 @@ TEST_F(VkPositiveLayerTest, ConfirmNoVLErrorWhenVkCmdClearAttachmentsCalledInSec
     color_attachment.clearValue.color.float32[2] = 0.0;
     color_attachment.clearValue.color.float32[3] = 0.0;
     color_attachment.colorAttachment = 0;
-    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
     vk::CmdClearAttachments(secondary.handle(), 1, &color_attachment, 1, &clear_rect);
     secondary.end();
     // Modify clear rect here to verify that it doesn't cause validation error

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -797,7 +797,7 @@ TEST_F(VkPositiveLayerTest, CreateGraphicsPipelineWithIgnoredPointers) {
     }
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
@@ -911,7 +911,7 @@ TEST_F(VkPositiveLayerTest, CreateGraphicsPipelineWithIgnoredPointers) {
         pipeline_rasterization_state_create_info.rasterizerDiscardEnable = VK_FALSE;
 
         VkViewport viewport = {0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f};
-        VkRect2D scissor = {{0, 0}, {static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height)}};
+        VkRect2D scissor = {{0, 0}, {m_width, m_height}};
 
         const VkPipelineViewportStateCreateInfo pipeline_viewport_state_create_info{
             VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
@@ -1140,10 +1140,12 @@ TEST_F(VkPositiveLayerTest, ViewportArray2NV) {
     VkShaderObj tcs(this, tcs_src, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT);
     VkShaderObj fs(this, bindStateFragShaderText, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    std::vector<VkViewport> vps = {{0.0f, 0.0f, m_width / 2.0f, m_height}, {m_width / 2.0f, 0.0f, m_width / 2.0f, m_height}};
-    std::vector<VkRect2D> scs = {
-        {{0, 0}, {static_cast<uint32_t>(m_width) / 2, static_cast<uint32_t>(m_height)}},
-        {{static_cast<int32_t>(m_width) / 2, 0}, {static_cast<uint32_t>(m_width) / 2, static_cast<uint32_t>(m_height)}}};
+    const float fp_width = static_cast<float>(m_width);
+    const float fp_height = static_cast<float>(m_height);
+
+    std::vector<VkViewport> vps = {{0.0f, 0.0f, fp_width / 2.0f, fp_height}, {fp_width / 2.0f, 0.0f, fp_width / 2.0f, fp_height}};
+    std::vector<VkRect2D> scs = {{{0, 0}, {m_width / 2, m_height}},
+                                 {{static_cast<int32_t>(m_width) / 2, 0}, {m_width / 2, m_height}}};
 
     enum class TestStage { VERTEX = 0, TESSELLATION_EVAL = 1, GEOMETRY = 2 };
     std::array<TestStage, 3> vertex_stages = {{TestStage::VERTEX, TestStage::TESSELLATION_EVAL, TestStage::GEOMETRY}};
@@ -5940,7 +5942,7 @@ TEST_F(VkPositiveLayerTest, DynamicColorWriteNoColorAttachments) {
     ASSERT_NE(vkCmdSetColorWriteEnableEXT, nullptr);
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
     CreatePipelineHelper pipe(*this);

--- a/tests/vklayertests_amd_best_practices.cpp
+++ b/tests/vklayertests_amd_best_practices.cpp
@@ -773,7 +773,7 @@ TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {
     color_attachment.clearValue.color.float32[2] = 1.0;
     color_attachment.clearValue.color.float32[3] = 1.0;
     color_attachment.colorAttachment = 0;
-    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
     vk::CmdClearAttachments(secondary_cmd_buf.handle(), 1, &color_attachment, 1, &clear_rect);
 

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -635,7 +635,7 @@ TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {
     }
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     InitRenderTarget(m_depthStencil->BindInfo());
 
     // set up pipelines
@@ -1513,7 +1513,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantAttachment) {
         ASSERT_TRUE((format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0);
     }
 
-    auto ds = CreateImage(ds_format, (uint32_t)m_width, (uint32_t)m_height, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    auto ds = CreateImage(ds_format, m_width, m_height, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
     m_clear_via_load_op = true;
     m_depth_stencil_fmt = ds_format;

--- a/tests/vklayertests_best_practices.cpp
+++ b/tests/vklayertests_best_practices.cpp
@@ -230,7 +230,7 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTest) {
     color_attachment.clearValue.color.float32[2] = 1.0;
     color_attachment.clearValue.color.float32[3] = 1.0;
     color_attachment.colorAttachment = 0;
-    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
     // Call for full-sized FB Color attachment prior to issuing a Draw
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
@@ -273,8 +273,8 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTestSecondary) {
     color_attachment.clearValue.color.float32[2] = 1.0;
     color_attachment.clearValue.color.float32[3] = 1.0;
     color_attachment.colorAttachment = 0;
-    VkClearRect clear_rect_small = {{{0, 0}, {(uint32_t)m_width - 1u, (uint32_t)m_height - 1u}}, 0, 1};
-    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+    VkClearRect clear_rect_small = {{{0, 0}, {m_width - 1u, m_height - 1u}}, 0, 1};
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     {
@@ -810,7 +810,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     color_attachment.clearValue.color.float32[2] = 1.0;
     color_attachment.clearValue.color.float32[3] = 1.0;
     color_attachment.colorAttachment = 0;
-    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
     vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
 
@@ -857,7 +857,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     color_attachment.clearValue.color.float32[2] = 1.0;
     color_attachment.clearValue.color.float32[3] = 1.0;
     color_attachment.colorAttachment = 0;
-    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
     // Plain clear after load.
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);

--- a/tests/vklayertests_command.cpp
+++ b/tests/vklayertests_command.cpp
@@ -909,7 +909,7 @@ TEST_F(VkLayerTest, ClearAttachmentsDepth) {
         GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
 
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
     m_commandBuffer->begin();
@@ -938,7 +938,7 @@ TEST_F(VkLayerTest, ClearAttachmentsStencil) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     m_depth_stencil_fmt = FindSupportedDepthOnlyFormat(gpu());
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
     m_commandBuffer->begin();
@@ -9353,8 +9353,8 @@ TEST_F(VkLayerTest, ValidateMultiviewUnboundResourcesAfterBeginRenderPassAndNext
     auto image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = static_cast<uint32_t>(m_width);
-    image_create_info.extent.height = static_cast<uint32_t>(m_height);
+    image_create_info.extent.width = m_width;
+    image_create_info.extent.height = m_height;
     image_create_info.extent.depth = 1;
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = multiview_count;
@@ -9370,8 +9370,8 @@ TEST_F(VkLayerTest, ValidateMultiviewUnboundResourcesAfterBeginRenderPassAndNext
                                              VK_REMAINING_ARRAY_LAYERS, VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
     auto framebufferCreateInfo = LvlInitStruct<VkFramebufferCreateInfo>();
-    framebufferCreateInfo.width = static_cast<uint32_t>(m_width);
-    framebufferCreateInfo.height = static_cast<uint32_t>(m_height);
+    framebufferCreateInfo.width = m_width;
+    framebufferCreateInfo.height = m_height;
     framebufferCreateInfo.layers = 1;
     framebufferCreateInfo.renderPass = m_renderPass;
     framebufferCreateInfo.attachmentCount = 1;
@@ -9384,8 +9384,8 @@ TEST_F(VkLayerTest, ValidateMultiviewUnboundResourcesAfterBeginRenderPassAndNext
     m_renderPassClearValues.emplace_back(clear);
     m_renderPassBeginInfo.renderPass = m_renderPass;
     m_renderPassBeginInfo.framebuffer = m_framebuffer;
-    m_renderPassBeginInfo.renderArea.extent.width = static_cast<uint32_t>(m_width);
-    m_renderPassBeginInfo.renderArea.extent.height = static_cast<uint32_t>(m_height);
+    m_renderPassBeginInfo.renderArea.extent.width = m_width;
+    m_renderPassBeginInfo.renderArea.extent.height = m_height;
     m_renderPassBeginInfo.clearValueCount = m_renderPassClearValues.size();
     m_renderPassBeginInfo.pClearValues = m_renderPassClearValues.data();
 
@@ -11176,7 +11176,7 @@ TEST_F(VkLayerTest, ClearDepthRangeUnrestricted) {
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
     int depth_attachment_index = 1;
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt,
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 

--- a/tests/vklayertests_debug_printf.cpp
+++ b/tests/vklayertests_debug_printf.cpp
@@ -393,12 +393,12 @@ TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
     pipe.AddShader(&ms);
     pipe.AddDefaultColorAttachment();
     VkViewport viewport{};
-    viewport.width = m_width;
-    viewport.height = m_height;
+    viewport.width = static_cast<float>(m_width);
+    viewport.height = static_cast<float>(m_height);
     pipe.SetViewport({viewport});
     VkRect2D rect{};
-    rect.extent.width = (uint32_t)m_width;
-    rect.extent.height = (uint32_t)m_height;
+    rect.extent.width = m_width;
+    rect.extent.height = m_height;
     pipe.SetScissor({rect});
     VkResult err = pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass());
     ASSERT_VK_SUCCESS(err);

--- a/tests/vklayertests_dynamic_rendering.cpp
+++ b/tests/vklayertests_dynamic_rendering.cpp
@@ -305,7 +305,7 @@ TEST_F(VkLayerTest, DynamicRenderingCmdClearAttachmentTests) {
     color_attachment.clearValue.color.float32[2] = 1.0;
     color_attachment.clearValue.color.float32[3] = 1.0;
     color_attachment.colorAttachment = 0;
-    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
     auto clear_cmds = [this, &color_attachment](VkCommandBuffer cmd_buffer, VkClearRect clear_rect) {
         // extent too wide
@@ -2557,7 +2557,7 @@ TEST_F(VkLayerTest, DynamicRenderingWithBarrier) {
     m_commandBuffer->begin();
 
     VkRenderingInfoKHR begin_rendering_info = LvlInitStruct<VkRenderingInfoKHR>();
-    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
     begin_rendering_info.renderArea = clear_rect.rect;
     begin_rendering_info.layerCount = 1;
 

--- a/tests/vklayertests_nvidia_best_practices.cpp
+++ b/tests/vklayertests_nvidia_best_practices.cpp
@@ -1163,8 +1163,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, ClearColor_NotCompressed)
     };
 
     VkImageObj image(m_device);
-    image.Init((uint32_t)m_width, (uint32_t)m_height, 1, VK_FORMAT_B8G8R8A8_UNORM,
-               VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
+    image.Init(m_width, m_height, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
     VkImageViewCreateInfo image_view_ci = LvlInitStruct<VkImageViewCreateInfo>();
@@ -1183,7 +1182,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, ClearColor_NotCompressed)
     color_attachment.clearValue = {};
 
     VkRenderingInfo begin_rendering_info = LvlInitStruct<VkRenderingInfo>();
-    begin_rendering_info.renderArea.extent = {(uint32_t)m_width, (uint32_t)m_height};
+    begin_rendering_info.renderArea.extent = {m_width, m_height};
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
@@ -1202,7 +1201,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, ClearColor_NotCompressed)
         }
     };
 
-    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
     m_commandBuffer->begin();
     vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);

--- a/tests/vklayertests_pipeline_shader.cpp
+++ b/tests/vklayertests_pipeline_shader.cpp
@@ -3016,7 +3016,7 @@ TEST_F(VkLayerTest, CreateGraphicsPipelineWithBadBasePointer) {
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
@@ -3104,7 +3104,7 @@ TEST_F(VkLayerTest, SetDepthRangeUnrestricted) {
     // Need to set format framework uses for InitRenderTarget
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt,
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
@@ -4205,7 +4205,7 @@ TEST_F(VkLayerTest, CmdClearAttachmentTests) {
     color_attachment.clearValue.color.float32[2] = 1.0;
     color_attachment.clearValue.color.float32[3] = 1.0;
     color_attachment.colorAttachment = 0;
-    VkClearRect clear_rect = {{{0, 0}, {(uint32_t)m_width, (uint32_t)m_height}}, 0, 1};
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
     auto clear_cmds = [this, &color_attachment](VkCommandBuffer cmd_buffer, VkClearRect clear_rect) {
         // extent too wide

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -224,7 +224,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesTriangleFans) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
     CreatePipelineHelper pipe(*this);
@@ -263,7 +263,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexInputStride) {
     auto vertex_stride = portability_properties.minVertexInputBindingStrideAlignment - 1;
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
     CreatePipelineHelper pipe(*this);
@@ -299,7 +299,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexAttributes) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
     CreatePipelineHelper pipe(*this);
@@ -388,7 +388,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesDepthStencilState) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
     auto depth_stencil_ci = LvlInitStruct<VkPipelineDepthStencilStateCreateInfo>();
@@ -429,7 +429,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesColorBlendAttachmentState
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_device, static_cast<int32_t>(m_width), static_cast<int32_t>(m_height), m_depth_stencil_fmt);
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
     CreatePipelineHelper pipe(*this);

--- a/tests/vkrenderframework.cpp
+++ b/tests/vkrenderframework.cpp
@@ -89,8 +89,8 @@ VkRenderFramework::VkRenderFramework()
       m_renderPass(VK_NULL_HANDLE),
       m_framebuffer(VK_NULL_HANDLE),
       m_addRenderPassSelfDependency(false),
-      m_width(256.0),   // default window width
-      m_height(256.0),  // default window height
+      m_width(256),   // default window width
+      m_height(256),  // default window height
       m_render_target_fmt(VK_FORMAT_R8G8B8A8_UNORM),
       m_depth_stencil_fmt(VK_FORMAT_UNDEFINED),
       m_clear_via_load_op(true),
@@ -608,19 +608,19 @@ void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *crea
     m_commandBuffer = new VkCommandBufferObj(m_device, m_commandPool);
 }
 
-void VkRenderFramework::InitViewport(float width, float height) {
+void VkRenderFramework::InitViewport(uint32_t width, uint32_t height) {
     VkViewport viewport;
     VkRect2D scissor;
     viewport.x = 0;
     viewport.y = 0;
-    viewport.width = 1.f * width;
-    viewport.height = 1.f * height;
+    viewport.width = static_cast<float>(width);
+    viewport.height = static_cast<float>(height);
     viewport.minDepth = 0.f;
     viewport.maxDepth = 1.f;
     m_viewports.push_back(viewport);
 
-    scissor.extent.width = (int32_t)width;
-    scissor.extent.height = (int32_t)height;
+    scissor.extent.width = width;
+    scissor.extent.height = height;
     scissor.offset.x = 0;
     scissor.offset.y = 0;
     m_scissors.push_back(scissor);
@@ -909,11 +909,11 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
         vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), m_render_target_fmt, &props);
 
         if (props.linearTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) {
-            img->Init((uint32_t)m_width, (uint32_t)m_height, 1, m_render_target_fmt,
+            img->Init(m_width, m_height, 1, m_render_target_fmt,
                       VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
                       VK_IMAGE_TILING_LINEAR);
         } else if (props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) {
-            img->Init((uint32_t)m_width, (uint32_t)m_height, 1, m_render_target_fmt,
+            img->Init(m_width, m_height, 1, m_render_target_fmt,
                       VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
                       VK_IMAGE_TILING_OPTIMAL);
         } else {
@@ -1017,16 +1017,16 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
     fb_info.renderPass = m_renderPass;
     fb_info.attachmentCount = bindings.size();
     fb_info.pAttachments = bindings.data();
-    fb_info.width = (uint32_t)m_width;
-    fb_info.height = (uint32_t)m_height;
+    fb_info.width = m_width;
+    fb_info.height = m_height;
     fb_info.layers = 1;
 
     vk::CreateFramebuffer(device(), &fb_info, NULL, &m_framebuffer);
 
     m_renderPassBeginInfo.renderPass = m_renderPass;
     m_renderPassBeginInfo.framebuffer = m_framebuffer;
-    m_renderPassBeginInfo.renderArea.extent.width = (int32_t)m_width;
-    m_renderPassBeginInfo.renderArea.extent.height = (int32_t)m_height;
+    m_renderPassBeginInfo.renderArea.extent.width = m_width;
+    m_renderPassBeginInfo.renderArea.extent.height = m_height;
     m_renderPassBeginInfo.clearValueCount = m_renderPassClearValues.size();
     m_renderPassBeginInfo.pClearValues = m_renderPassClearValues.data();
 }
@@ -2419,7 +2419,7 @@ VkImageView *VkDepthStencilObj::BindInfo() { return &m_attachmentBindInfo; }
 
 VkFormat VkDepthStencilObj::Format() const { return this->m_depth_stencil_fmt; }
 
-void VkDepthStencilObj::Init(VkDeviceObj *device, int32_t width, int32_t height, VkFormat format, VkImageUsageFlags usage,
+void VkDepthStencilObj::Init(VkDeviceObj *device, uint32_t width, uint32_t height, VkFormat format, VkImageUsageFlags usage,
                              VkImageAspectFlags aspect) {
     VkImageViewCreateInfo view_info = LvlInitStruct<VkImageViewCreateInfo>();
 

--- a/tests/vkrenderframework.h
+++ b/tests/vkrenderframework.h
@@ -191,7 +191,7 @@ class VkRenderFramework : public VkTestFramework {
     void InitFramework(void * /*unused compatibility parameter*/ = NULL, void *instance_pnext = NULL);
     void ShutdownFramework();
 
-    void InitViewport(float width, float height);
+    void InitViewport(uint32_t width, uint32_t height);
     void InitViewport();
      // Functions to modify the VkRenderFramework surface & swapchain variables
     bool InitSurface();
@@ -313,7 +313,7 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<VkClearValue> m_renderPassClearValues;
     VkRenderPassBeginInfo m_renderPassBeginInfo;
     std::vector<std::unique_ptr<VkImageObj>> m_renderTargets;
-    float m_width, m_height;
+    uint32_t m_width, m_height;
     VkFormat m_render_target_fmt;
     VkFormat m_depth_stencil_fmt;
     VkClearColorValue m_clear_color;
@@ -577,7 +577,7 @@ class VkTextureObj : public VkImageObj {
 class VkDepthStencilObj : public VkImageObj {
   public:
     VkDepthStencilObj(VkDeviceObj *device);
-    void Init(VkDeviceObj *device, int32_t width, int32_t height, VkFormat format,
+    void Init(VkDeviceObj *device, uint32_t width, uint32_t height, VkFormat format,
               VkImageUsageFlags usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VkImageAspectFlags aspect = 0);
     bool Initialized();
     VkImageView *BindInfo();

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -1118,8 +1118,6 @@ TEST_F(VkSyncValTest, SyncRenderPassBeginTransitionHazard) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(2));
 
     // Render Target Information
-    auto width = static_cast<uint32_t>(m_width);
-    auto height = static_cast<uint32_t>(m_height);
     auto *rt_0 = m_renderTargets[0].get();
     auto *rt_1 = m_renderTargets[1].get();
 
@@ -1127,12 +1125,12 @@ TEST_F(VkSyncValTest, SyncRenderPassBeginTransitionHazard) {
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     VkImageObj image_a(m_device), image_b(m_device);
-    const auto image_ci = VkImageObj::ImageCreateInfo2D(width, height, 1, 1, format, usage, VK_IMAGE_TILING_OPTIMAL);
+    const auto image_ci = VkImageObj::ImageCreateInfo2D(m_width, m_height, 1, 1, format, usage, VK_IMAGE_TILING_OPTIMAL);
     image_a.Init(image_ci);
     image_b.Init(image_ci);
 
     VkOffset3D zero_offset{0, 0, 0};
-    VkExtent3D full_extent{width, height, 1};  // <-- image type is 2D
+    VkExtent3D full_extent{m_width, m_height, 1};  // <-- image type is 2D
     VkImageSubresourceLayers layer_color{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     VkImageCopy region_to_copy = {layer_color, zero_offset, layer_color, zero_offset, full_extent};
 


### PR DESCRIPTION
In most places the code works with uint32_t width and height. This change replaces many float->uint32 casts with only a few uint32->float casts.