### PR TITLE
cmake: Enable MSVC warnings 4189 and 5038 consistently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,17 +110,14 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
         )
     endif()
 elseif(MSVC)
-    # TODO: Update to /W4
-    add_compile_options("/W3")
-    # Warn about nested declarations
-    add_compile_options("/w34456")
-    # Warn about potentially uninitialized variables
-    add_compile_options("/w34701")
-    add_compile_options("/w34703")
-    # Warn about different indirection types.
-    add_compile_options("/w34057")
-    # Warn about signed/unsigned mismatch.
-    add_compile_options("/w34245")
+    add_compile_options("/W3") # TODO: Update to /W4   
+    add_compile_options("/w34456") # Warn about nested declarations
+    add_compile_options("/w34701") # Warn about potentially uninitialized variables
+    add_compile_options("/w34703") # Warn about potentially uninitialized variables    
+    add_compile_options("/w34057") # Warn about different indirection types.
+    add_compile_options("/w34245") # Warn about signed/unsigned mismatch.
+    add_compile_options("/we4189") # Warn about unused variables
+    add_compile_options("/we5038") # Warn about MIL ordering in constructors
 
     # PDBs aren't generated on Release builds by default.
     add_compile_options("$<$<CONFIG:Release>:/Zi>")

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -102,11 +102,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
     endif()
 endif()
 
-if(MSVC)
-    add_compile_options("/we4189")
-    add_compile_options("/we5038")
-endif()
-
 # NOTE: LunarG/VulkanTools disables BUILD_LAYERS and BUILD_TESTS to minimize dependencies.
 if (NOT BUILD_LAYERS)
     return()


### PR DESCRIPTION
4189 and 5038 are pretty valuable warnings to also have for the testing code.