### PR TITLE
ci: Enable Address Sanitizer

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build Vulkan-ValidationLayers
         run: |
           echo "PYTHONPATH = $PYTHONPATH"
-          python3 scripts/github_ci_win_linux.py --build --config ${{ matrix.config }}
+          python3 scripts/github_ci_win_linux.py --build --config ${{ matrix.config }} --cmake='-DVVL_ENABLE_ASAN=ON'
         env:
           CC: ${{ matrix.cc }}
           CXX: ${{ matrix.cxx }}
@@ -121,7 +121,7 @@ jobs:
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$GITHUB_WORKSPACE/external/release/Vulkan-Headers/build/install/share/vulkan/registry:$PYTHONPATH" >> $GITHUB_ENV
       - name: Build Vulkan-ValidationLayers
-        run: python3 scripts/github_ci_win_linux.py --build --config release --cmake='-DVVL_CPP_STANDARD=20'
+        run: python3 scripts/github_ci_win_linux.py --build --config release --cmake='-DVVL_CPP_STANDARD=20 -DVVL_ENABLE_ASAN=ON'
         env:
           CC: clang
           CXX: clang++

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -125,6 +125,8 @@ def BuildLoader(args):
     make_dirs(LOADER_BUILD_DIR)
     cmake_cmd = f'cmake -C ../external/helper.cmake -DCMAKE_BUILD_TYPE={args.configuration} {args.cmake} ..'
     if IsWindows(): cmake_cmd = cmake_cmd + f' -A {args.arch}'
+    # This enables better stack traces from leak sanitizer by using the loader feature which prevents unloading of libraries at shutdown.
+    if not IsWindows(): cmake_cmd = cmake_cmd + ' -D LOADER_ENABLE_ADDRESS_SANITIZER=ON -D LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING=ON'
     RunShellCmd(cmake_cmd, LOADER_BUILD_DIR)
 
     print("Build Loader")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,10 @@ target_sources(vk_layer_validation_tests PRIVATE
     ray_tracing_objects.cpp
 )
 
+if (VVL_ENABLE_ASAN)
+    target_compile_definitions(vk_layer_validation_tests PRIVATE VVL_ENABLE_ASAN=1)
+endif()
+
 # gtest_discover_tests has problem with cross-compiling, but it is faster and more robust
 if (CMAKE_CROSSCOMPILING)
     gtest_add_tests(TARGET vk_layer_validation_tests)

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -47,6 +47,14 @@
 using std::string;
 using std::vector;
 
+#if defined(VVL_ENABLE_ASAN)
+#if __has_include(<sanitizer/lsan_interface.h>)
+#include <sanitizer/lsan_interface.h>
+#else
+#error The lsan_interface.h header was not found!
+#endif
+#endif
+
 //--------------------------------------------------------------------------------------
 // Mesh and VertexFormat Data
 //--------------------------------------------------------------------------------------

--- a/tests/vklayertests_wsi.cpp
+++ b/tests/vklayertests_wsi.cpp
@@ -1728,6 +1728,11 @@ TEST_F(VkLayerTest, DisplayPresentInfoSrcRect) {
 
 TEST_F(VkLayerTest, LeakASwapchain) {
     TEST_DESCRIPTION("Leak a VkSwapchainKHR.");
+    // Because this test intentionally leaks swapchains & surfaces, we need to disable leak checking because drivers may leak memory
+    // that cannot be cleaned up from this test.
+#if defined(VVL_ENABLE_ASAN)
+    auto leak_sanitizer_disabler = __lsan::ScopedDisabler();
+#endif
 
     AddSurfaceExtension();
     ASSERT_NO_FATAL_FAILURE(InitFramework());

--- a/tests/vksyncvaltests.cpp
+++ b/tests/vksyncvaltests.cpp
@@ -4895,6 +4895,9 @@ TEST_F(VkSyncValTest, SyncQSRenderPass) {
 
 TEST_F(VkSyncValTest, SyncQSPresentAcquire) {
     TEST_DESCRIPTION("Try destroying a swapchain presentable image with vkDestroyImage");
+#if defined(VVL_ENABLE_ASAN)
+    auto leak_sanitizer_disabler = __lsan::ScopedDisabler();
+#endif
 
     AddSurfaceExtension();
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation


### PR DESCRIPTION
This commit enabled Address Sanitizer in github actions CI runs. 
Currently, only Linux will have ASAN enabled with the MockICD.
ASAN requires enabling it in the loader with the option to disable unloading of dynamic libraries which enables useful stack traces.

Because leaks are unavoidable in certain circumstances, a mechanism has been setup to allow tests to disable leak detection if need be. The current tests which require this are:
* VkSyncValTest.SyncQSPresentAcquire - known leak with fix incoming
* VkLayerTest.LeakASwapchain - intentionally leaks memory to trigger test case

To disable leak checking in a test, add the following to the start of a test.

```
#if defined(VVL_ENABLE_ASAN)
    auto leak_sanitizer_disabler = __lsan::ScopedDisabler();
#endif
```

__lsan::ScopedDisabler() is a RAII type which calls the necessary leak sanitizer interface functions to prevent leaks that occur during the execution of the test from failing the test.