### PR TITLE
layers: Move Pipeline Derivatives to own function

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -380,7 +380,8 @@ class CoreChecks : public ValidationStateTracker {
                                       const VkPipelineLibraryCreateInfoKHR& link_info,
                                       const VkPipelineRenderingCreateInfo* rendering_struct, uint32_t pipe_index, int lib_index,
                                       const char* vuid) const;
-    bool ValidatePipeline(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipelines, uint32_t pipe_index) const;
+    bool ValidatePipelineDerivatives(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipelines, uint32_t pipe_index) const;
+    bool ValidatePipeline(const PIPELINE_STATE& pipeline) const;
     bool ValidImageBufferQueue(const CMD_BUFFER_STATE& cb_state, const VulkanTypedHandle& object, uint32_t queueFamilyIndex,
                                uint32_t count, const uint32_t* indices) const;
     bool ValidateFenceForSubmit(const FENCE_STATE* pFence, const char* inflight_vuid, const char* retired_vuid,


### PR DESCRIPTION
creates a `ValidatePipelineDerivatives` function to do all pipeline derivatives logic
