### PR TITLE
layers: Add LogObjectList to copy blit resolve

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -956,8 +956,8 @@ class CoreChecks : public ValidationStateTracker {
                                        uint32_t render_pass_layer_count, uint32_t rect_count, const VkClearRect* clear_rects) const;
 
     template <typename RegionType>
-    bool ValidateImageCopyData(const uint32_t regionCount, const RegionType* pRegions, const IMAGE_STATE* src_state,
-                               const IMAGE_STATE* dst_state, CMD_TYPE cmd_type) const;
+    bool ValidateImageCopyData(VkCommandBuffer cb, const uint32_t regionCount, const RegionType* pRegions,
+                               const IMAGE_STATE* src_state, const IMAGE_STATE* dst_state, CMD_TYPE cmd_type) const;
 
     bool VerifyClearImageLayout(const CMD_BUFFER_STATE& cb_state, const IMAGE_STATE* image_state,
                                 const VkImageSubresourceRange& range, VkImageLayout dest_image_layout, const char* func_name) const;


### PR DESCRIPTION
went trough `copy_blit_resolve_validation.cpp` and added `LogObjectList` wherever it was missing objects that would be valuable to print out