### PR TITLE
layers: Remove unused debug_report_data

### DIFF
--- a/layers/core_checks/android_validation.cpp
+++ b/layers/core_checks/android_validation.cpp
@@ -475,7 +475,7 @@ bool CoreChecks::ValidateImageImportedHandleANDROID(const char *func_name, VkExt
 
 // Validate creating an image with an external format
 // This could be wrapped with VK_USE_PLATFORM_ANDROID_KHR instead of AHB_VALIDATION_SUPPORT, but this check is only for AHB
-bool CoreChecks::ValidateCreateImageANDROID(const debug_report_data *report_data, const VkImageCreateInfo *create_info) const {
+bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo *create_info) const {
     bool skip = false;
 
     const VkExternalFormatANDROID *ext_fmt_android = LvlFindInChain<VkExternalFormatANDROID>(create_info->pNext);
@@ -633,9 +633,7 @@ bool CoreChecks::ValidateImageImportedHandleANDROID(const char *func_name, VkExt
     return false;
 }
 
-bool CoreChecks::ValidateCreateImageANDROID(const debug_report_data *report_data, const VkImageCreateInfo *create_info) const {
-    return false;
-}
+bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo *create_info) const { return false; }
 
 bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *create_info) const { return false; }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1131,8 +1131,8 @@ class CoreChecks : public ValidationStateTracker {
     bool VerifyBoundMemoryIsValid(const DEVICE_MEMORY_STATE* mem_state, const LogObjectList& objlist,
                                   const VulkanTypedHandle& typed_handle, const LocType& location) const;
 
-    bool ValidateLayoutVsAttachmentDescription(const debug_report_data* report_data, RenderPassCreateVersion rp_version,
-                                               const VkImageLayout first_layout, const uint32_t attachment,
+    bool ValidateLayoutVsAttachmentDescription(RenderPassCreateVersion rp_version, const VkImageLayout first_layout,
+                                               const uint32_t attachment,
                                                const VkAttachmentDescription2& attachment_description) const;
 
     bool ValidateImageUsageFlags(VkCommandBuffer cb, IMAGE_STATE const& image_state, VkImageUsageFlags desired, bool strict,
@@ -1286,7 +1286,7 @@ class CoreChecks : public ValidationStateTracker {
     void PreCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
                                             const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo) override;
 
-    bool ValidateCreateImageANDROID(const debug_report_data* report_data, const VkImageCreateInfo* create_info) const;
+    bool ValidateCreateImageANDROID(const VkImageCreateInfo* create_info) const;
     bool ValidateCreateImageViewANDROID(const VkImageViewCreateInfo* create_info) const;
     bool ValidatePhysicalDeviceQueueFamilies(uint32_t queue_family_count, const uint32_t* queue_families, const char* cmd_name,
                                              const char* array_parameter_name, const char* vuid) const;

--- a/layers/core_checks/image_layout_validation.cpp
+++ b/layers/core_checks/image_layout_validation.cpp
@@ -383,8 +383,8 @@ void CoreChecks::UpdateCmdBufImageLayouts(const CMD_BUFFER_STATE *cb_state) {
 // ValidateLayoutVsAttachmentDescription is a general function where we can validate various state associated with the
 // VkAttachmentDescription structs that are used by the sub-passes of a renderpass. Initial check is to make sure that READ_ONLY
 // layout attachments don't have CLEAR as their loadOp.
-bool CoreChecks::ValidateLayoutVsAttachmentDescription(const debug_report_data *report_data, RenderPassCreateVersion rp_version,
-                                                       const VkImageLayout first_layout, const uint32_t attachment,
+bool CoreChecks::ValidateLayoutVsAttachmentDescription(RenderPassCreateVersion rp_version, const VkImageLayout first_layout,
+                                                       const uint32_t attachment,
                                                        const VkAttachmentDescription2 &attachment_description) const {
     bool skip = false;
     const bool use_rp2 = (rp_version == RENDER_PASS_VERSION_2);

--- a/layers/core_checks/image_validation.cpp
+++ b/layers/core_checks/image_validation.cpp
@@ -111,7 +111,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     bool skip = false;
 
     if (IsExtEnabled(device_extensions.vk_android_external_memory_android_hardware_buffer)) {
-        skip |= ValidateCreateImageANDROID(report_data, pCreateInfo);
+        skip |= ValidateCreateImageANDROID(pCreateInfo);
     } else {  // These checks are omitted or replaced when Android HW Buffer extension is active
         if (pCreateInfo->format == VK_FORMAT_UNDEFINED) {
             return LogError(device, "VUID-VkImageCreateInfo-format-00943",

--- a/layers/core_checks/render_pass_validation.cpp
+++ b/layers/core_checks/render_pass_validation.cpp
@@ -1451,8 +1451,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
 
                     if (attach_first_use[attachment_index]) {
                         skip |=
-                            ValidateLayoutVsAttachmentDescription(report_data, rp_version, subpass.pInputAttachments[j].layout,
-                                                                  attachment_index, pCreateInfo->pAttachments[attachment_index]);
+                            ValidateLayoutVsAttachmentDescription(rp_version, subpass.pInputAttachments[j].layout, attachment_index,
+                                                                  pCreateInfo->pAttachments[attachment_index]);
 
                         const bool used_as_depth = (subpass.pDepthStencilAttachment != NULL &&
                                                     subpass.pDepthStencilAttachment->attachment == attachment_index);
@@ -1621,7 +1621,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                                              image_layout);
 
                     if (attach_first_use[attachment]) {
-                        skip |= ValidateLayoutVsAttachmentDescription(report_data, rp_version, image_layout, attachment,
+                        skip |= ValidateLayoutVsAttachmentDescription(rp_version, image_layout, attachment,
                                                                       pCreateInfo->pAttachments[attachment]);
                     }
                     attach_first_use[attachment] = false;
@@ -1888,8 +1888,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
 
                     if (attach_first_use[attachment_index]) {
                         skip |=
-                            ValidateLayoutVsAttachmentDescription(report_data, rp_version, subpass.pColorAttachments[j].layout,
-                                                                  attachment_index, pCreateInfo->pAttachments[attachment_index]);
+                            ValidateLayoutVsAttachmentDescription(rp_version, subpass.pColorAttachments[j].layout, attachment_index,
+                                                                  pCreateInfo->pAttachments[attachment_index]);
                     }
                     attach_first_use[attachment_index] = false;
                 }


### PR DESCRIPTION
`debug_report_data` was not being used in `ValidateCreateImageANDROID` or `ValidateLayoutVsAttachmentDescription`