### PR TITLE
scripts: Remove vk.xml workaround

### DIFF
--- a/scripts/object_tracker_generator.py
+++ b/scripts/object_tracker_generator.py
@@ -396,9 +396,6 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
         self.type_categories = GetTypeCategories(self.registry.tree)
         self.is_aliased_type = GetHandleAliased(self.registry.tree)
 
-        # Fix the parent of VkSwapchainKHR
-        self.handle_parents['VkSwapchainKHR'] = 'VkDevice'
-
         header_file = (genOpts.filename == 'object_tracker.h')
         source_file = (genOpts.filename == 'object_tracker.cpp')
 


### PR DESCRIPTION
vk.xml now properly sets the Device as the parent of the Swapchain