### PR TITLE
layers: Fix if InputAttachmentIndex is non-zero

### DIFF
--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -244,6 +244,7 @@ bool CoreChecks::ValidateShaderInputAttachment(const SHADER_MODULE_STATE &module
         const uint32_t subpass = pipeline.Subpass();
         const auto subpass_description = rpci->pSubpasses[subpass];
         const auto input_attachments = subpass_description.pInputAttachments;
+        // offsets by the InputAttachmentIndex decoration
         const uint32_t input_attachment_index = variable.decorations.input_attachment_index_start + i;
 
         // Same error, but provide more useful message 'how' VK_ATTACHMENT_UNUSED is derived

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1333,8 +1333,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const SHADER_MODULE_STATE& 
                     for (const Instruction* insn : image_read_loads) {
                         if (insn->Opcode() == spv::OpAccessChain) {
                             const uint32_t access_index = module_state.GetConstantValueById(insn->Word(4));
-                            const uint32_t index = access_index + decorations.input_attachment_index_start;
-                            input_attachment_index_read.at(index) = true;
+                            input_attachment_index_read[access_index] = true;
                         } else if (insn->Opcode() == spv::OpLoad) {
                             // if InputAttachment is accessed from load, just a single, non-array, index
                             input_attachment_index_read.resize(1);

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -112,6 +112,7 @@ struct ResourceInterfaceVariable {
 
     // A variable can have an array of indexes, need to track which are written to
     // can't use bitset because number of indexes isn't known until runtime
+    // This array will match the OpTypeArray and not consider the InputAttachmentIndex
     std::vector<bool> input_attachment_index_read;
 
     // Sampled Type width of the OpTypeImage the variable points to, 0 if doesn't use the image

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -619,12 +619,15 @@ TEST_F(VkPositiveLayerTest, CreatePipelineInputAttachmentArray) {
 
     // index 0 is unused
     // index 1 is is valid (for both color and input)
-    const VkAttachmentReference inputAttachmentReferences[2] = {{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_GENERAL},
+    // index 2 and 3 point to same image as index 1
+    const VkAttachmentReference inputAttachmentReferences[4] = {{VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_GENERAL},
+                                                                {0, VK_IMAGE_LAYOUT_GENERAL},
+                                                                {0, VK_IMAGE_LAYOUT_GENERAL},
                                                                 {0, VK_IMAGE_LAYOUT_GENERAL}};
 
     const VkSubpassDescription subpassDescription = {(VkSubpassDescriptionFlags)0,
                                                      VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                                     2,
+                                                     4,
                                                      inputAttachmentReferences,
                                                      1,
                                                      &inputAttachmentReferences[1],
@@ -700,6 +703,47 @@ TEST_F(VkPositiveLayerTest, CreatePipelineInputAttachmentArray) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                     {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
+            helper.gp_ci_.renderPass = renderPass.handle();
+        };
+        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+    }
+
+    // Array of size 1
+    // loads from index 0, but not the invalid index 0 since has offest of 3
+    {
+        const char *fs_source = R"(
+            #version 460
+            layout(input_attachment_index=3, set=0, binding=0) uniform subpassInput xs[1];
+            layout(location=0) out vec4 color;
+            void main() {
+                color = subpassLoad(xs[0]);
+            }
+        )";
+        VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL);
+
+        const auto set_info = [&](CreatePipelineHelper &helper) {
+            helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+            helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
+            helper.gp_ci_.renderPass = renderPass.handle();
+        };
+        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+    }
+
+    // Index from non-zero
+    {
+        const char *fs_source = R"(
+            #version 460
+            layout(input_attachment_index=2, set=0, binding=0) uniform subpassInput xs[2];
+            layout(location=0) out vec4 color;
+            void main() {
+                color = subpassLoad(xs[0]) + subpassLoad(xs[1]);
+            }
+        )";
+        VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL);
+
+        const auto set_info = [&](CreatePipelineHelper &helper) {
+            helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+            helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
             helper.gp_ci_.renderPass = renderPass.handle();
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5366 didn't have a test with `InputAttachmentIndex` set to a non-zero value. @Tony-LunarG pointed out from a CTS test there was a bug which was because I added the offset where not needed