### PR TITLE
tests: Fix external memory tests for swiftshader

### DIFF
--- a/tests/vklayertests_external_memory_sync.cpp
+++ b/tests/vklayertests_external_memory_sync.cpp
@@ -255,8 +255,18 @@ TEST_F(VkLayerTest, BufferMemoryWithUnsupportedExternalHandleType) {
     auto export_memory_info = LvlInitStruct<VkExportMemoryAllocateInfo>();
     export_memory_info.handleTypes = handle_type | not_supported_type;
 
+    vk_testing::Buffer buffer;
+    buffer.init_no_mem(*m_device, buffer_info);
+    auto alloc_info = vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, buffer.memory_requirements(),
+                                                                        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &export_memory_info);
+    VkResult result = buffer.memory().try_init(*m_device, alloc_info);
+    if (result != VK_SUCCESS) {
+        GTEST_SKIP() << "vkAllocateMemory failed (probably due to unsupported handle type). Unable to reach vkBindBufferMemory to "
+                        "run valdiation";
+    }
+
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportMemoryAllocateInfo-handleTypes-00656");
-    vk_testing::Buffer buffer(*m_device, buffer_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &export_memory_info);
+    buffer.bind_memory(buffer.memory(), 0);
     m_errorMonitor->VerifyFound();
 }
 
@@ -332,8 +342,18 @@ TEST_F(VkLayerTest, ImageMemoryWithUnsupportedExternalHandleType) {
     auto export_memory_info = LvlInitStruct<VkExportMemoryAllocateInfo>();
     export_memory_info.handleTypes = handle_type | not_supported_type;
 
+    vk_testing::Image image;
+    image.init_no_mem(*m_device, image_info);
+    auto alloc_info = vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, image.memory_requirements(),
+                                                                        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &export_memory_info);
+    VkResult result = image.memory().try_init(*m_device, alloc_info);
+    if (result != VK_SUCCESS) {
+        GTEST_SKIP() << "vkAllocateMemory failed (probably due to unsupported handle type). Unable to reach vkBindImageMemory to "
+                        "run valdiation";
+    }
+
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportMemoryAllocateInfo-handleTypes-00656");
-    vk_testing::Image image(*m_device, image_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &export_memory_info);
+    image.bind_memory(image.memory(), 0);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -470,6 +470,16 @@ void DeviceMemory::init(const Device &dev, const VkMemoryAllocateInfo &info) {
     memory_allocate_info_ = info;
 }
 
+VkResult DeviceMemory::try_init(const Device &dev, const VkMemoryAllocateInfo &info) {
+    assert(!initialized());
+    VkDeviceMemory handle = VK_NULL_HANDLE;
+    auto result = vk::AllocateMemory(dev.handle(), &info, nullptr, &handle);
+    if (result == VK_SUCCESS) {
+        NonDispHandle::init(dev.handle(), handle);
+    }
+    return result;
+}
+
 const void *DeviceMemory::map(VkFlags flags) const {
     void *data;
     if (!EXPECT(vk::MapMemory(device(), handle(), 0, VK_WHOLE_SIZE, flags, &data) == VK_SUCCESS)) data = NULL;

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -313,7 +313,10 @@ class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
     DeviceMemory &operator=(DeviceMemory &&) = default;
 
     // vkAllocateMemory()
+    // Fails the test when allocation is unsuccessful
     void init(const Device &dev, const VkMemoryAllocateInfo &info);
+    // Does not fail the test when allocation is unsuccessful and instead returns error code
+    VkResult try_init(const Device &dev, const VkMemoryAllocateInfo &info);
 
     // vkMapMemory()
     const void *map(VkFlags flags) const;


### PR DESCRIPTION
With current spec (1.3.242) the validation of VU 00656 can be done only in vkBindMemory. With invalid input (e.g. handle type is not supported for any resource) vkAllocateMemory can legally fail. This does not give a chance for validation to run. This fix detects vkAllocateMemory failure and skips the test since validation is not possible.