### PR TITLE
More improvements to Pipeline Validation

### DIFF
--- a/docs/shader_validation.md
+++ b/docs/shader_validation.md
@@ -33,22 +33,22 @@ The code is currently split up into the following main sections
 
 ### Design details
 
-When dealing with shader validation there a few concepts to understand and not confuse
+When dealing with shader validation there are a few concepts to understand and not confuse
 
 - `EntryPoints`
   - Tied to a shader stage (fragment, vertex, etc)
   - Knows which variables and instructions are touched in stage
-    - There might be things in a `ShaderModule` not related the the shader stage checking
+    - There might be things in a `ShaderModule` not related to shader stage validation
 - `Shader Module`
   - a `VkShaderModule` object
   - contains all information about the SPIR-V module
-  - contains SPIR-V instructs (in array of `uint32_t` words)
+  - contains SPIR-V instructions (in an array of `uint32_t` words)
   - knows the relationship between instructions
   - can contain multiple `EntryPoints`
     - [For more details](https://github.com/KhronosGroup/SPIRV-Guide/blob/master/chapters/entry_execution.md#instructions-with-multiple-execution-modes)
 - `Pipeline`
   - contains 1 or more shader object
-  - dcecides both which `Shader Module` and `EntryPoint` is used
+  - decides both which `Shader Module` and `EntryPoint` are used
   - has other state not known if validating just the shader object
 - `Pipeline Library` (GPL) (`VK_EXT_graphics_pipeline_library`)
   - part of a pipeline that can be reused
@@ -56,12 +56,12 @@ When dealing with shader validation there a few concepts to understand and not c
   - lets app use a hash instead of having the driver re-create the `ShaderModule`
   - not possible to validate as the VVL don't know what the `ShaderModule` is
 
-When dealing with validation, it is important to know what should be validated when.
+When dealing with validation, it is important to know what should be validated, and when.
 
 If validation only cares about... :
 
-- the SPIR-V itself, should be mapped to the `Shader Module`
-- if how two stages interface, needs to be done when all stages are there
+- the SPIR-V itself, is mapped to the `Shader Module`
+- if two stages interface, needs to be done when all stages are there
   -For `Pipeline Library` it might need to wait until linking
-- descriptors variables, should use `EntryPoint`
+- descriptors variables, use `EntryPoint`
 - the stage of a shader module is always known, regardless of even using `ShaderModuleIdentifier`

--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -1367,7 +1367,7 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
         return false;
     }
     // Generate warnings about work group sizes based on active resources.
-    auto entrypoint_optional = module_state->FindEntrypoint(createInfo.stage.pName, createInfo.stage.stage);
+    auto entrypoint_optional = module_state->FindEntrypointInstruction(createInfo.stage.pName, createInfo.stage.stage);
     if (!entrypoint_optional) return false;
 
     const Instruction& entrypoint = *entrypoint_optional;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -818,6 +818,7 @@ class CoreChecks : public ValidationStateTracker {
                                                     const char* caller, const DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE& pipeline) const;
     bool ValidateGraphicsPipelinePreRasterState(const PIPELINE_STATE& pipeline) const;
+    bool ValidateGraphicsPipelineInputAssemblyState(const PIPELINE_STATE& pipeline) const;
     bool ValidateGraphicsPipelineColorBlendState(const PIPELINE_STATE& pipeline,
                                                  const safe_VkSubpassDescription2* subpass_desc) const;
     bool ValidateGraphicsPipelineRasterizationState(const PIPELINE_STATE& pipeline,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -901,8 +901,8 @@ class CoreChecks : public ValidationStateTracker {
                                           const std::vector<ResourceInterfaceVariable>& descriptor_variables,
                                           const std::string& vuid_layout_mismatch) const;
     bool ValidateTransformFeedback(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
-    bool ValidateShaderModuleId(const SHADER_MODULE_STATE& module_state, const PipelineStageState& stage_state,
-                                const safe_VkPipelineShaderStageCreateInfo* create_info, const VkPipelineCreateFlags flags) const;
+    bool ValidateShaderModuleId(const SHADER_MODULE_STATE& module_state, const safe_VkPipelineShaderStageCreateInfo* create_info,
+                                const VkPipelineCreateFlags flags) const;
     bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
     bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -902,8 +902,7 @@ class CoreChecks : public ValidationStateTracker {
                                           const std::vector<ResourceInterfaceVariable>& descriptor_variables,
                                           const std::string& vuid_layout_mismatch) const;
     bool ValidateTransformFeedback(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
-    bool ValidateShaderModuleId(const SHADER_MODULE_STATE& module_state, const safe_VkPipelineShaderStageCreateInfo* create_info,
-                                const VkPipelineCreateFlags flags) const;
+    bool ValidateShaderModuleId(const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
     bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
 

--- a/layers/core_checks/drawdispatch_validation.cpp
+++ b/layers/core_checks/drawdispatch_validation.cpp
@@ -2958,11 +2958,11 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE &cb_state, CMD_T
                 result |= LogError(objlist, vuid.push_constants_set_06425,
                                    "%s(): Shader in %s uses push-constant statically but vkCmdPushConstants was not called yet for "
                                    "pipeline layout %s.",
-                                   function, string_VkShaderStageFlags(stage.stage_flag).c_str(),
+                                   function, string_VkShaderStageFlags(stage.create_info->stage).c_str(),
                                    report_data->FormatHandle(pipeline_layout->layout()).c_str());
             }
 
-            const auto it = cb_state.push_constant_data_update.find(stage.stage_flag);
+            const auto it = cb_state.push_constant_data_update.find(stage.create_info->stage);
             if (it == cb_state.push_constant_data_update.end()) {
                 // This error has been printed in ValidatePushConstantUsage.
                 break;

--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -284,6 +284,7 @@ bool CoreChecks::ValidatePipeline(const PIPELINE_STATE &pipeline) const {
         }
     }
 
+    skip |= ValidateShaderModuleId(pipeline);
     skip |= ValidatePipelineCacheControlFlags(pipeline.create_flags, pipeline.create_index, "vkCreateGraphicsPipelines",
                                               "VUID-VkGraphicsPipelineCreateInfo-pipelineCreationCacheControl-02878");
     skip |= ValidatePipelineProtectedAccessFlags(pipeline.create_flags, pipeline.create_index);
@@ -973,6 +974,7 @@ bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipeli
             continue;
         }
         skip |= ValidateComputePipelineShaderState(*pipeline);
+        skip |= ValidateShaderModuleId(*pipeline);
         skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, i, "vkCreateComputePipelines",
                                                   "VUID-VkComputePipelineCreateInfo-pipelineCreationCacheControl-02875");
     }
@@ -1041,8 +1043,8 @@ bool CoreChecks::ValidateRayTracingPipeline(const PIPELINE_STATE &pipeline,
     }
     const auto *groups = create_info.ptr()->pGroups;
 
-    for (uint32_t stage_index = 0; stage_index < create_info.stageCount; stage_index++) {
-        skip |= ValidatePipelineShaderStage(pipeline, pipeline.stage_states[stage_index]);
+    for (auto &stage_state : pipeline.stage_states) {
+        skip |= ValidatePipelineShaderStage(pipeline, stage_state);
     }
 
     if ((create_info.flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) {
@@ -1159,6 +1161,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkP
             }
         }
         skip |= ValidateRayTracingPipeline(*pipeline, pipeline->GetCreateInfo<CIType>(), pCreateInfos[i].flags, /*isKHR*/ false);
+        skip |= ValidateShaderModuleId(*pipeline);
         skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, i, "vkCreateRayTracingPipelinesNV",
                                                   "VUID-VkRayTracingPipelineCreateInfoNV-pipelineCreationCacheControl-02905");
     }
@@ -1200,6 +1203,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
             }
         }
         skip |= ValidateRayTracingPipeline(*pipeline, pipeline->GetCreateInfo<CIType>(), pCreateInfos[i].flags, /*isKHR*/ true);
+        skip |= ValidateShaderModuleId(*pipeline);
         skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, i, "vkCreateRayTracingPipelinesKHR",
                                                   "VUID-VkRayTracingPipelineCreateInfoKHR-pipelineCreationCacheControl-02905");
         const auto create_info = pipeline->GetCreateInfo<VkRayTracingPipelineCreateInfoKHR>();

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -196,7 +196,6 @@ static uint32_t GetCreateInfoShaders(const PIPELINE_STATE &pipe_state) {
     for (const auto &stage_ci : pipe_state.shader_stages_ci) {
         result |= stage_ci.stage;
     }
-    result |= pipe_state.linking_shaders;
     return result;
 }
 

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -97,13 +97,13 @@ typedef std::map<uint32_t, DescriptorRequirement> BindingReqMap;
 struct PipelineStageState {
     std::shared_ptr<const SHADER_MODULE_STATE> module_state;
     const safe_VkPipelineShaderStageCreateInfo *create_info;
-    VkShaderStageFlagBits stage_flag;
     std::optional<Instruction> entrypoint;
     const std::vector<ResourceInterfaceVariable> *descriptor_variables = {};
     bool wrote_primitive_shading_rate;
     bool writes_to_gl_layer;
 
-    PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *stage, std::shared_ptr<const SHADER_MODULE_STATE> &module_state);
+    PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
+                       std::shared_ptr<const SHADER_MODULE_STATE> &module_state);
 };
 
 class PIPELINE_STATE : public BASE_NODE {
@@ -176,6 +176,8 @@ class PIPELINE_STATE : public BASE_NODE {
     VkPipelineCreateFlags create_flags;
     vvl::span<const safe_VkPipelineShaderStageCreateInfo> shader_stages_ci;
     const safe_VkPipelineLibraryCreateInfoKHR *ray_tracing_library_ci = nullptr;
+    // If using a shader module identifier, the module itself is not validated, but the shader stage is still known
+    const bool uses_shader_module_id;
 
     // State split up based on library types
     const std::shared_ptr<VertexInputState> vertex_input_state;  // VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT
@@ -208,7 +210,6 @@ class PIPELINE_STATE : public BASE_NODE {
     const uint32_t max_active_slot = 0;  // the highest set number in active_slots for pipeline layout compatibility checks
 
     const VkPrimitiveTopology topology_at_rasterizer = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
-    const bool uses_shader_module_id;
     const bool descriptor_buffer_mode = false;
     const bool uses_pipeline_robustness;
 
@@ -455,15 +456,6 @@ class PIPELINE_STATE : public BASE_NODE {
     VkShaderModule GetShaderModuleByCIIndex(uint32_t i) {
         // TODO this _should_ be a static_assert, but that only works on MSVC currently
         assert(false && "Not implemented");
-        return {};
-    }
-
-    std::shared_ptr<const SHADER_MODULE_STATE> GetShaderModuleState(VkShaderStageFlagBits stage) {
-        for (auto &s : stage_states) {
-            if (s.stage_flag == stage) {
-                return s.module_state;
-            }
-        }
         return {};
     }
 

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -97,13 +97,13 @@ typedef std::map<uint32_t, DescriptorRequirement> BindingReqMap;
 struct PipelineStageState {
     std::shared_ptr<const SHADER_MODULE_STATE> module_state;
     const safe_VkPipelineShaderStageCreateInfo *create_info;
-    std::optional<Instruction> entrypoint;
+    const SHADER_MODULE_STATE::EntryPoint *entrypoint;
     const std::vector<ResourceInterfaceVariable> *descriptor_variables = {};
     bool wrote_primitive_shading_rate;
     bool writes_to_gl_layer;
 
     PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
-                       std::shared_ptr<const SHADER_MODULE_STATE> &module_state);
+                       std::shared_ptr<const SHADER_MODULE_STATE> &module_state, const SHADER_MODULE_STATE::EntryPoint *entrypoint);
 };
 
 class PIPELINE_STATE : public BASE_NODE {

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -608,7 +608,17 @@ const SHADER_MODULE_STATE::StructInfo* SHADER_MODULE_STATE::FindEntrypointPushCo
     return nullptr;
 }
 
-std::optional<Instruction> SHADER_MODULE_STATE::FindEntrypoint(char const* name, VkShaderStageFlagBits stageBits) const {
+const SHADER_MODULE_STATE::EntryPoint* SHADER_MODULE_STATE::FindEntrypoint(char const* name,
+                                                                           VkShaderStageFlagBits stageBits) const {
+    for (const auto& entry_point : static_data_.entry_points) {
+        if (entry_point.name.compare(name) == 0 && entry_point.stage == stageBits) {
+            return &entry_point;
+        }
+    }
+    return nullptr;
+}
+
+std::optional<Instruction> SHADER_MODULE_STATE::FindEntrypointInstruction(char const* name, VkShaderStageFlagBits stageBits) const {
     std::optional<Instruction> result;
     for (const auto& entry_point : static_data_.entry_points) {
         if (entry_point.name.compare(name) == 0 && entry_point.stage == stageBits) {

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -364,7 +364,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     std::optional<VkPrimitiveTopology> GetTopology(const Instruction &entrypoint) const;
 
     const StructInfo *FindEntrypointPushConstant(char const *name, VkShaderStageFlagBits stageBits) const;
-    std::optional<Instruction> FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
+    const EntryPoint *FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
+    std::optional<Instruction> FindEntrypointInstruction(char const *name, VkShaderStageFlagBits stageBits) const;
     bool FindLocalSize(const Instruction &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y, uint32_t &local_size_z) const;
 
     const Instruction *GetConstantDef(uint32_t id) const;

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2049,7 +2049,8 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
 
     for (const auto &stage_state : pipe->stage_states) {
         const auto raster_state = pipe->RasterizationState();
-        if (stage_state.stage_flag == VK_SHADER_STAGE_FRAGMENT_BIT && raster_state && raster_state->rasterizerDiscardEnable) {
+        if (stage_state.create_info->stage == VK_SHADER_STAGE_FRAGMENT_BIT && raster_state &&
+            raster_state->rasterizerDiscardEnable) {
             continue;
         } else if (!stage_state.descriptor_variables) {
             continue;
@@ -2060,7 +2061,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
             auto binding = descriptor_set->GetBinding(variable.decorations.binding);
             const auto descriptor_type = binding->type;
             SyncStageAccessIndex sync_index =
-                GetSyncStageAccessIndexsByDescriptorSet(descriptor_type, variable, stage_state.stage_flag);
+                GetSyncStageAccessIndexsByDescriptorSet(descriptor_type, variable, stage_state.create_info->stage);
 
             for (uint32_t index = 0; index < binding->count; index++) {
                 const auto *descriptor = binding->GetDescriptor(index);
@@ -2186,7 +2187,8 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
 
     for (const auto &stage_state : pipe->stage_states) {
         const auto raster_state = pipe->RasterizationState();
-        if (stage_state.stage_flag == VK_SHADER_STAGE_FRAGMENT_BIT && raster_state && raster_state->rasterizerDiscardEnable) {
+        if (stage_state.create_info->stage == VK_SHADER_STAGE_FRAGMENT_BIT && raster_state &&
+            raster_state->rasterizerDiscardEnable) {
             continue;
         } else if (!stage_state.descriptor_variables) {
             continue;
@@ -2197,7 +2199,7 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
             auto binding = descriptor_set->GetBinding(variable.decorations.binding);
             const auto descriptor_type = binding->type;
             SyncStageAccessIndex sync_index =
-                GetSyncStageAccessIndexsByDescriptorSet(descriptor_type, variable, stage_state.stage_flag);
+                GetSyncStageAccessIndexsByDescriptorSet(descriptor_type, variable, stage_state.create_info->stage);
 
             for (uint32_t i = 0; i < binding->count; i++) {
                 const auto *descriptor = binding->GetDescriptor(i);

--- a/tests/negative/dynamic_rendering.cpp
+++ b/tests/negative/dynamic_rendering.cpp
@@ -3339,6 +3339,7 @@ TEST_F(VkLayerTest, DynamicRenderingInvalidLibraryViewMask) {
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.shader_stages_ = {pipe.fs_->GetStageCreateInfo()};
     pipe.InitState();
+    m_errorMonitor->SetUnexpectedError("VUID-VkGraphicsPipelineCreateInfo-pStages-06895");  // spec bug
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06626");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();

--- a/tests/negative/pipeline_shader.cpp
+++ b/tests/negative/pipeline_shader.cpp
@@ -15832,7 +15832,6 @@ TEST_F(VkLayerTest, ShaderModuleIdentifier) {
     stage_ci.pNext = nullptr;
     // No shader module ci and no shader module id ci in pNext and invalid module
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-stage-06845");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-module-parameter");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
@@ -15930,7 +15929,6 @@ TEST_F(VkLayerTest, ShaderModuleIdentifierFeatures) {
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-stage-06846");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-module-parameter");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 

--- a/tests/negative/pipeline_shader.cpp
+++ b/tests/negative/pipeline_shader.cpp
@@ -7363,10 +7363,6 @@ TEST_F(VkLayerTest, CooperativeMatrixNV) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
-
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
     auto cooperative_matrix_features = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesNV>(&float16_features);
     auto memory_model_features = LvlInitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
@@ -7422,13 +7418,9 @@ TEST_F(VkLayerTest, CooperativeMatrixNV) {
     pipe.cs_.reset(new VkShaderObj(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, &specInfo));
     pipe.InitState();
     pipe.pipeline_layout_ = VkPipelineLayoutObj(m_device, {});
+    m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-CooperativeMatrixType");
+    m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-CooperativeMatrixMulAdd");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-pSpecializationInfo-06719");
-    pipe.CreateComputePipeline();
-    m_errorMonitor->VerifyFound();
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-Shader-CooperativeMatrixType");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-Shader-CooperativeMatrixMulAdd");
-    m_errorMonitor->SetUnexpectedError("VUID-VkPipelineShaderStageCreateInfo-pSpecializationInfo-06719");
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
This is pulled out of a large change I have been working on in the Shader validation code. (to help make managing `VK_EXT_graphics_pipeline_library` and  `VK_EXT_shader_module_identifier` better) 

This PR does

- Adds some documentation about shader val
- Makes dedicated function for `VkPipelineInputAssemblyStateCreateInfo`
- Move `ValidateShaderModuleId` out from "shader val" to "pipeline val" (there is no shader module to validate in `VK_EXT_shader_module_identifier`)
- Try to reduce more of `PipelineStageState` 

The future goal is to basically remove `PipelineStageState` and make use of the `EntryPoint` where ever possible