### PR TITLE
Add VUID 00758 (2nd PR)

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -2993,7 +2993,7 @@ void BestPractices::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
         IMAGE_VIEW_STATE* depth_image_view = nullptr;
 
-        const auto depth_attachment = rp->createInfo.pSubpasses[cmd_state->activeSubpass].pDepthStencilAttachment;
+        const auto depth_attachment = rp->createInfo.pSubpasses[cmd_state->GetActiveSubpass()].pDepthStencilAttachment;
         if (depth_attachment) {
             const uint32_t attachment_index = depth_attachment->attachment;
             if (attachment_index != VK_ATTACHMENT_UNUSED) {
@@ -3682,7 +3682,7 @@ void BestPractices::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuff
         // TODO: Implement other best practices for dynamic rendering
 
     } else {
-        auto& subpass = rp_state->createInfo.pSubpasses[cmd_state->activeSubpass];
+        auto& subpass = rp_state->createInfo.pSubpasses[cmd_state->GetActiveSubpass()];
         for (uint32_t i = 0; i < attachmentCount; i++) {
             auto& attachment = pClearAttachments[i];
             uint32_t fb_attachment = VK_ATTACHMENT_UNUSED;
@@ -4648,7 +4648,7 @@ bool BestPractices::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
             }
 
         } else {
-            const auto& subpass = rp->createInfo.pSubpasses[cb_node->activeSubpass];
+            const auto& subpass = rp->createInfo.pSubpasses[cb_node->GetActiveSubpass()];
 
             if (is_full_clear) {
                 for (uint32_t i = 0; i < attachmentCount; i++) {

--- a/layers/core_checks/cmd_buffer_validation.cpp
+++ b/layers/core_checks/cmd_buffer_validation.cpp
@@ -893,7 +893,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                     }
                 }
 
-                if (!cb_state->activeRenderPass->UsesDynamicRendering() && (cb_state->activeSubpass != inheritance_subpass)) {
+                if (!cb_state->activeRenderPass->UsesDynamicRendering() && (cb_state->GetActiveSubpass() != inheritance_subpass)) {
                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state->activeRenderPass->renderPass());
                     skip |= LogError(objlist, "VUID-vkCmdExecuteCommands-pCommandBuffers-06019",
                                      "vkCmdExecuteCommands(): pCommandBuffers[%" PRIu32
@@ -903,7 +903,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                      "match the current subpass (%u).",
                                      i, report_data->FormatHandle(pCommandBuffers[i]).c_str(),
                                      report_data->FormatHandle(cb_state->activeRenderPass->renderPass()).c_str(),
-                                     inheritance_subpass, cb_state->activeSubpass);
+                                     inheritance_subpass, cb_state->GetActiveSubpass());
                 } else if (cb_state->activeRenderPass->UsesDynamicRendering()) {
                     if (inheritance_render_pass != VK_NULL_HANDLE) {
                         const LogObjectList objlist(commandBuffer, pCommandBuffers[i]);
@@ -1639,11 +1639,11 @@ bool CoreChecks::PreCallValidateCmdEndConditionalRenderingEXT(VkCommandBuffer co
                              "pass instance, but a render pass instance is currently active in the command buffer.");
         }
         if (cb_state->conditional_rendering_inside_render_pass && cb_state->activeRenderPass != nullptr &&
-            cb_state->conditional_rendering_subpass != cb_state->activeSubpass) {
+            cb_state->conditional_rendering_subpass != cb_state->GetActiveSubpass()) {
             skip |= LogError(commandBuffer, "VUID-vkCmdEndConditionalRenderingEXT-None-01987",
                              "vkCmdBeginConditionalRenderingEXT(): Conditional rendering was begun in subpass %" PRIu32
                              ", but the current subpass is %" PRIu32 ".",
-                             cb_state->conditional_rendering_subpass, cb_state->activeSubpass);
+                             cb_state->conditional_rendering_subpass, cb_state->GetActiveSubpass());
         }
     }
 

--- a/layers/core_checks/image_validation.cpp
+++ b/layers/core_checks/image_validation.cpp
@@ -954,7 +954,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                 view_mask = cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.viewMask;
             } else {
                 const auto *renderpass_create_info = cb_state.activeRenderPass->createInfo.ptr();
-                const auto *subpass_desc = &renderpass_create_info->pSubpasses[cb_state.activeSubpass];
+                const auto *subpass_desc = &renderpass_create_info->pSubpasses[cb_state.GetActiveSubpass()];
                 const auto *framebuffer = cb_state.activeFramebuffer.get();
 
                 is_valid_color_attachment_index = (clear_desc->colorAttachment == VK_ATTACHMENT_UNUSED);
@@ -988,7 +988,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                             skip |= LogError(objlist, vuid,
                                              "vkCmdClearAttachments() pAttachments[%" PRIu32 "] in pSubpasses[%" PRIu32
                                              "] has VK_IMAGE_ASPECT_DEPTH_BIT and is backed by an image view with format (%s).",
-                                             attachment_index, cb_state.activeSubpass, string_VkFormat(image_view_format));
+                                             attachment_index, cb_state.GetActiveSubpass(), string_VkFormat(image_view_format));
                         }
 
                         if ((aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) && !FormatHasStencil(image_view_format)) {
@@ -1000,7 +1000,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                             skip |= LogError(objlist, vuid,
                                              "vkCmdClearAttachments() pAttachments[%" PRIu32 "] in pSubpasses[%" PRIu32
                                              "] has VK_IMAGE_ASPECT_STENCIL_BIT and is backed by an image view with format (%s).",
-                                             attachment_index, cb_state.activeSubpass, string_VkFormat(image_view_format));
+                                             attachment_index, cb_state.GetActiveSubpass(), string_VkFormat(image_view_format));
                         }
                     }
 
@@ -1130,7 +1130,7 @@ void CoreChecks::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
             }
         } else if (cb_state.activeRenderPass->use_dynamic_rendering == false) {
             const VkRenderPassCreateInfo2 *renderpass_create_info = cb_state.activeRenderPass->createInfo.ptr();
-            const VkSubpassDescription2 *subpass_desc = &renderpass_create_info->pSubpasses[cb_state.activeSubpass];
+            const VkSubpassDescription2 *subpass_desc = &renderpass_create_info->pSubpasses[cb_state.GetActiveSubpass()];
 
             for (uint32_t attachment_index = 0; attachment_index < attachmentCount; attachment_index++) {
                 const auto clear_desc = &pAttachments[attachment_index];

--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -3197,7 +3197,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                     if (sample_locations_begin_info) {
                         for (uint32_t i = 0; i < sample_locations_begin_info->postSubpassSampleLocationsCount; ++i) {
                             if (sample_locations_begin_info->pPostSubpassSampleLocations[i].subpassIndex ==
-                                cb_state->activeSubpass) {
+                                cb_state->GetActiveSubpass()) {
                                 if (MatchSampleLocationsInfo(
                                         &sample_locations_begin_info->pPostSubpassSampleLocations[i].sampleLocationsInfo,
                                         &sample_locations->sampleLocationsInfo)) {
@@ -3218,7 +3218,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                                      "VkRenderPassSampleLocationsBeginInfoEXT::pPostSubpassSampleLocations subpassIndex "
                                      "matching the current subpass index and sampleLocationsInfo matching sampleLocationsInfo of "
                                      "VkPipelineSampleLocationsStateCreateInfoEXT the pipeline was created with.",
-                                     cb_state->activeSubpass);
+                                     cb_state->GetActiveSubpass());
                     }
                 }
             }
@@ -3668,7 +3668,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                 const auto dynamic_rendering_info = cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info;
             } else {
                 const auto render_pass_info = cb_state.activeRenderPass->createInfo.ptr();
-                const VkSubpassDescription2 *subpass_desc = &render_pass_info->pSubpasses[cb_state.activeSubpass];
+                const VkSubpassDescription2 *subpass_desc = &render_pass_info->pSubpasses[cb_state.GetActiveSubpass()];
                 uint32_t i;
                 unsigned subpass_num_samples = 0;
 
@@ -3798,13 +3798,13 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                                                     *rp_state.get(), caller, vuid.render_pass_compatible_02684);
         }
         const auto subpass = pipeline.Subpass();
-        if (subpass != cb_state.activeSubpass) {
+        if (subpass != cb_state.GetActiveSubpass()) {
             const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline(), cb_state.activeRenderPass->renderPass());
             skip |= LogError(objlist, vuid.subpass_index_02685, "%s: Pipeline was built for subpass %u but used in subpass %u.",
-                             caller, subpass, cb_state.activeSubpass);
+                             caller, subpass, cb_state.GetActiveSubpass());
         }
         const safe_VkAttachmentReference2 *ds_attachment =
-            cb_state.activeRenderPass->createInfo.pSubpasses[cb_state.activeSubpass].pDepthStencilAttachment;
+            cb_state.activeRenderPass->createInfo.pSubpasses[cb_state.GetActiveSubpass()].pDepthStencilAttachment;
         if (ds_attachment != nullptr) {
             // Check if depth stencil attachment was created with sample location compatible bit
             if (pipeline.SampleLocationEnabled() == VK_TRUE) {
@@ -3821,7 +3821,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
                                                  "%s: sampleLocationsEnable is true for the pipeline, but the subpass (%u) depth "
                                                  "stencil attachment's VkImage was not created with "
                                                  "VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT.",
-                                                 caller, cb_state.activeSubpass);
+                                                 caller, cb_state.GetActiveSubpass());
                             }
                         }
                     }
@@ -3884,7 +3884,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &state, co
     if (pipeline.fragment_output_state && pipeline.fragment_output_state->dual_source_blending && cb_state.activeRenderPass) {
         uint32_t count = cb_state.activeRenderPass->UsesDynamicRendering()
                              ? cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.colorAttachmentCount
-                             : cb_state.activeRenderPass->createInfo.pSubpasses[cb_state.activeSubpass].colorAttachmentCount;
+                             : cb_state.activeRenderPass->createInfo.pSubpasses[cb_state.GetActiveSubpass()].colorAttachmentCount;
         if (count > phys_dev_props.limits.maxFragmentDualSrcAttachments) {
             const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
             skip |=

--- a/layers/core_checks/query_validation.cpp
+++ b/layers/core_checks/query_validation.cpp
@@ -452,7 +452,7 @@ bool CoreChecks::ValidateBeginQuery(const CMD_BUFFER_STATE &cb_state, const Quer
     if (cb_state.activeRenderPass) {
         const auto *render_pass_info = cb_state.activeRenderPass->createInfo.ptr();
         if (!cb_state.activeRenderPass->UsesDynamicRendering()) {
-            const auto *subpass_desc = &render_pass_info->pSubpasses[cb_state.activeSubpass];
+            const auto *subpass_desc = &render_pass_info->pSubpasses[cb_state.GetActiveSubpass()];
             if (subpass_desc) {
                 uint32_t bits = GetBitSetCount(subpass_desc->viewMask);
                 if (query_obj.query + bits > query_pool_state->createInfo.queryCount) {

--- a/layers/core_checks/render_pass_validation.cpp
+++ b/layers/core_checks/render_pass_validation.cpp
@@ -556,7 +556,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(RenderPassCreateVersion rp_version, Vk
     RENDER_PASS_STATE *rp_state = cb_state->activeRenderPass.get();
     if (rp_state) {
         const VkRenderPassCreateInfo2 *rpci = rp_state->createInfo.ptr();
-        if (!rp_state->UsesDynamicRendering() && (cb_state->activeSubpass != rp_state->createInfo.subpassCount - 1)) {
+        if (!rp_state->UsesDynamicRendering() && (cb_state->GetActiveSubpass() != rp_state->createInfo.subpassCount - 1)) {
             vuid = use_rp2 ? "VUID-vkCmdEndRenderPass2-None-03103" : "VUID-vkCmdEndRenderPass-None-00910";
             skip |= LogError(commandBuffer, vuid, "%s: Called before reaching final subpass.", function_name);
         }
@@ -626,7 +626,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(RenderPassCreateVersion rp_version, Vk
 
                         // fdm attachment
                         const auto *fdm_attachment = LvlFindInChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci->pNext);
-                        const VkSubpassDescription2 &subpass = rpci->pSubpasses[cb_state->activeSubpass];
+                        const VkSubpassDescription2 &subpass = rpci->pSubpasses[cb_state->GetActiveSubpass()];
                         if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED) {
                             if (fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
                                 if ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0) {
@@ -3815,7 +3815,7 @@ bool CoreChecks::ValidateCmdNextSubpass(RenderPassCreateVersion rp_version, VkCo
     skip |= ValidateCmd(*cb_state, cmd_type);
 
     auto subpass_count = cb_state->activeRenderPass->createInfo.subpassCount;
-    if (cb_state->activeSubpass == subpass_count - 1) {
+    if (cb_state->GetActiveSubpass() == subpass_count - 1) {
         vuid = use_rp2 ? "VUID-vkCmdNextSubpass2-None-03102" : "VUID-vkCmdNextSubpass-None-00909";
         skip |= LogError(commandBuffer, vuid, "%s: Attempted to advance beyond final subpass.", function_name);
     }
@@ -3843,7 +3843,7 @@ bool CoreChecks::PreCallValidateCmdNextSubpass2(VkCommandBuffer commandBuffer, c
 void CoreChecks::RecordCmdNextSubpassLayouts(VkCommandBuffer commandBuffer, VkSubpassContents contents) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     auto framebuffer = Get<FRAMEBUFFER_STATE>(cb_state->activeRenderPassBeginInfo.framebuffer);
-    TransitionSubpassLayouts(cb_state.get(), cb_state->activeRenderPass.get(), cb_state->activeSubpass, framebuffer.get());
+    TransitionSubpassLayouts(cb_state.get(), cb_state->activeRenderPass.get(), cb_state->GetActiveSubpass(), framebuffer.get());
 }
 
 void CoreChecks::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents) {

--- a/layers/core_checks/synchronization_validation.cpp
+++ b/layers/core_checks/synchronization_validation.cpp
@@ -792,8 +792,8 @@ bool CoreChecks::ValidateRenderPassPipelineBarriers(const Location &outer_loc, c
     bool skip = false;
     const auto &rp_state = cb_state->activeRenderPass;
     RenderPassDepState state(this, outer_loc.StringFunc().c_str(), "VUID-vkCmdPipelineBarrier-pDependencies-02285",
-                             cb_state->activeSubpass, rp_state->renderPass(), enabled_features,
-                             rp_state->self_dependencies[cb_state->activeSubpass], rp_state->createInfo.pDependencies);
+                             cb_state->GetActiveSubpass(), rp_state->renderPass(), enabled_features,
+                             rp_state->self_dependencies[cb_state->GetActiveSubpass()], rp_state->createInfo.pDependencies);
     if (state.self_dependencies.size() == 0) {
         skip |= LogError(state.rp_handle, "VUID-vkCmdPipelineBarrier-pDependencies-02285",
                          "%s Barriers cannot be set during subpass %d of %s with no self-dependency specified.",
@@ -845,8 +845,8 @@ bool CoreChecks::ValidateRenderPassPipelineBarriers(const Location &outer_loc, c
         return skip;
     }
     RenderPassDepState state(this, outer_loc.StringFunc().c_str(), "VUID-vkCmdPipelineBarrier2-pDependencies-02285",
-                             cb_state->activeSubpass, rp_state->renderPass(), enabled_features,
-                             rp_state->self_dependencies[cb_state->activeSubpass], rp_state->createInfo.pDependencies);
+                             cb_state->GetActiveSubpass(), rp_state->renderPass(), enabled_features,
+                             rp_state->self_dependencies[cb_state->GetActiveSubpass()], rp_state->createInfo.pDependencies);
 
     if (state.self_dependencies.size() == 0) {
         skip |= LogError(state.rp_handle, state.vuid,
@@ -1798,7 +1798,7 @@ void CoreChecks::EnqueueSubmitTimeValidateImageBarrierAttachment(const Location 
     // Secondary CBs can have null framebuffer so queue up validation in that case 'til FB is known
     if ((cb_state->activeRenderPass) && (VK_NULL_HANDLE == cb_state->activeFramebuffer) &&
         (VK_COMMAND_BUFFER_LEVEL_SECONDARY == cb_state->createInfo.level)) {
-        const auto active_subpass = cb_state->activeSubpass;
+        const auto active_subpass = cb_state->GetActiveSubpass();
         const auto rp_state = cb_state->activeRenderPass;
         const auto &sub_desc = rp_state->createInfo.pSubpasses[active_subpass];
         // Secondary CB case w/o FB specified delay validation

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -68,6 +68,8 @@ const char *CommandTypeString(CMD_TYPE type) {
 
 void CMD_BUFFER_STATE::SetActiveSubpass(uint32_t subpass) {
     active_subpass_ = subpass;
+    // Always reset stored rasterization samples count
+    active_subpass_sample_count_ = std::nullopt;
 }
 
 CMD_BUFFER_STATE::CMD_BUFFER_STATE(ValidationStateTracker *dev, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -296,6 +296,10 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     uint32_t active_render_pass_device_mask;
     uint32_t GetActiveSubpass() const { return active_subpass_; }
     void SetActiveSubpass(uint32_t subpass);
+    std::optional<VkSampleCountFlagBits> GetActiveSubpassRasterizationSampleCount() const { return active_subpass_sample_count_; }
+    void SetActiveSubpassRasterizationSampleCount(VkSampleCountFlagBits rasterization_sample_count) {
+        active_subpass_sample_count_ = rasterization_sample_count;
+    }
     std::shared_ptr<FRAMEBUFFER_STATE> activeFramebuffer;
     // Unified data structs to track objects bound to this command buffer as well as object
     //  dependencies that have been broken : either destroyed objects, or updated descriptor sets
@@ -599,6 +603,9 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     int label_stack_depth_ = 0;
 
     uint32_t active_subpass_;
+    // Stores rasterization samples count obtained from the first pipeline with a pMultisampleState in the active subpass,
+    // or std::nullopt
+    std::optional<VkSampleCountFlagBits> active_subpass_sample_count_;
 
   protected:
     void NotifyInvalidate(const BASE_NODE::NodeList &invalid_nodes, bool unlink) override;

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -294,7 +294,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
 
     VkSubpassContents activeSubpassContents;
     uint32_t active_render_pass_device_mask;
-    uint32_t activeSubpass;
+    uint32_t GetActiveSubpass() const { return active_subpass_; }
+    void SetActiveSubpass(uint32_t subpass);
     std::shared_ptr<FRAMEBUFFER_STATE> activeFramebuffer;
     // Unified data structs to track objects bound to this command buffer as well as object
     //  dependencies that have been broken : either destroyed objects, or updated descriptor sets
@@ -596,6 +597,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
 
     // Keep track of how many CmdBeginDebugUtilsLabelEXT calls have been made without a matching CmdEndDebugUtilsLabelEXT
     int label_stack_depth_ = 0;
+
+    uint32_t active_subpass_;
 
   protected:
     void NotifyInvalidate(const BASE_NODE::NodeList &invalid_nodes, bool unlink) override;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3345,7 +3345,7 @@ void ValidationStateTracker::PostCallRecordCmdBeginQuery(VkCommandBuffer command
     uint32_t num_queries = 1;
     // If render pass instance has multiview enabled, query uses N consecutive query indices
     if (cb_state->activeRenderPass) {
-        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(cb_state->activeSubpass);
+        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(cb_state->GetActiveSubpass());
         num_queries = std::max(num_queries, bits);
     }
     for (uint32_t i = 0; i < num_queries; ++i) {
@@ -3367,7 +3367,7 @@ void ValidationStateTracker::PostCallRecordCmdEndQuery(VkCommandBuffer commandBu
     uint32_t num_queries = 1;
     // If render pass instance has multiview enabled, query uses N consecutive query indices
     if (cb_state->activeRenderPass) {
-        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(cb_state->activeSubpass);
+        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(cb_state->GetActiveSubpass());
         num_queries = std::max(num_queries, bits);
     }
 
@@ -3603,7 +3603,7 @@ void ValidationStateTracker::PostCallRecordCmdBeginConditionalRenderingEXT(
     cb_state->RecordCmd(CMD_BEGINCONDITIONALRENDERINGEXT);
     cb_state->conditional_rendering_active = true;
     cb_state->conditional_rendering_inside_render_pass = cb_state->activeRenderPass != nullptr;
-    cb_state->conditional_rendering_subpass = cb_state->activeSubpass;
+    cb_state->conditional_rendering_subpass = cb_state->GetActiveSubpass();
 }
 
 void ValidationStateTracker::PostCallRecordCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer) {
@@ -4506,7 +4506,7 @@ void ValidationStateTracker::PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuff
     uint32_t num_queries = 1;
     // If render pass instance has multiview enabled, query uses N consecutive query indices
     if (cb_state->activeRenderPass) {
-        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(cb_state->activeSubpass);
+        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(cb_state->GetActiveSubpass());
         num_queries = std::max(num_queries, bits);
     }
 
@@ -4523,7 +4523,7 @@ void ValidationStateTracker::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer
     uint32_t num_queries = 1;
     // If render pass instance has multiview enabled, query uses N consecutive query indices
     if (cb_state->activeRenderPass) {
-        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(cb_state->activeSubpass);
+        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(cb_state->GetActiveSubpass());
         num_queries = std::max(num_queries, bits);
     }
 

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -941,6 +941,8 @@ class ValidationStateTracker : public ValidationObject {
                                          VkIndexType indexType) override;
     void PreCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                       VkPipeline pipeline) override;
+    void PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
+                                       VkPipeline pipeline) override;
     void PreCallRecordCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
                                                 VkImageLayout imageLayout) override;
     void PreCallRecordCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2703,7 +2703,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandExecuti
                                             caller_name, string_SyncHazard(hazard.hazard),
                                             sync_state.report_data->FormatHandle(view_handle).c_str(),
                                             sync_state.report_data->FormatHandle(cmd_buffer.commandBuffer()).c_str(),
-                                            cmd_buffer.activeSubpass, location, exec_context.FormatHazard(hazard).c_str());
+                                            cmd_buffer.GetActiveSubpass(), location, exec_context.FormatHazard(hazard).c_str());
             }
         }
     }
@@ -2753,7 +2753,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandExecuti
                     "%s: Hazard %s for %s in %s, Subpass #%d, and depth part of pDepthStencilAttachment. Access info %s.",
                     caller_name, string_SyncHazard(hazard.hazard),
                     sync_state.report_data->FormatHandle(view_state.image_view()).c_str(),
-                    sync_state.report_data->FormatHandle(cmd_buffer.commandBuffer()).c_str(), cmd_buffer.activeSubpass,
+                    sync_state.report_data->FormatHandle(cmd_buffer.commandBuffer()).c_str(), cmd_buffer.GetActiveSubpass(),
                     exec_context.FormatHazard(hazard).c_str());
             }
         }
@@ -2767,7 +2767,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandExecuti
                     "%s: Hazard %s for %s in %s, Subpass #%d, and stencil part of pDepthStencilAttachment. Access info %s.",
                     caller_name, string_SyncHazard(hazard.hazard),
                     sync_state.report_data->FormatHandle(view_state.image_view()).c_str(),
-                    sync_state.report_data->FormatHandle(cmd_buffer.commandBuffer()).c_str(), cmd_buffer.activeSubpass,
+                    sync_state.report_data->FormatHandle(cmd_buffer.commandBuffer()).c_str(), cmd_buffer.GetActiveSubpass(),
                     exec_context.FormatHazard(hazard).c_str());
             }
         }


### PR DESCRIPTION
Add VUID-VkGraphicsPipelineCreateInfo-subpass-00758 after request in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4075

## Previous PR

https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5377
In the previous PR, validation was performed at pipeline creation time, using state stored in the supplied render pass. This is incorrect, as the supplied render pass only serves as a template in this context.
Validation is now done at pipeline bind time, using a new attribute `active_subpass_sample_count_` stored in `CMD_BUFFER_STATE`

## Some context for 00758 

VUID-VkGraphicsPipelineCreateInfo-subpass-00758
> If the pipeline is being created with fragment output interface state, and subpass does not use any color and/or depth/stencil attachments, then the rasterizationSamples member of pMultisampleState must follow the rules for a zero-attachment subpass

zero-attachment subpass definition:
> It is legal for a subpass to use no color or depth/stencil attachments, either because it has no attachment references or because all of them are VK_ATTACHMENT_UNUSED. This kind of subpass can use shader side effects such as image stores and atomics to produce an output. In this case, the subpass continues to use the width, height, and layers of the framebuffer to define the dimensions of the rendering area, and the rasterizationSamples from each pipeline’s VkPipelineMultisampleStateCreateInfo to define the number of samples used in rasterization; however, **if VkPhysicalDeviceFeatures::variableMultisampleRate is VK_FALSE, then all pipelines to be bound with the subpass must have the same value for VkPipelineMultisampleStateCreateInfo::rasterizationSamples**.

VkPhysicalDeviceFeatures::variableMultisampleRate definition:
> VkPhysicalDeviceFeatures::variableMultisampleRate specifies whether all pipelines that will be bound to a command buffer during a subpass which uses no attachments must have the same value for VkPipelineMultisampleStateCreateInfo::rasterizationSamples. If set to VK_TRUE, the implementation supports variable multisample rates in a subpass which uses no attachments. **If set to VK_FALSE, then all pipelines bound in such a subpass must have the same multisample rate**. This has no effect in situations where a subpass uses any attachments.