### PR TITLE
style: Use #pragma once everywhere

### DIFF
--- a/layers/android_ndk_types.h
+++ b/layers/android_ndk_types.h
@@ -32,8 +32,7 @@
 //     - r20 YCbCr was added
 //     - r23 (current) no differences from r20 being used
 
-#ifndef ANDROID_NDK_TYPES_H_
-#define ANDROID_NDK_TYPES_H_
+#pragma once
 
 // Everyone should be able to include this file and ignore it if not building for Android
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
@@ -73,5 +72,3 @@ constexpr uint64_t AHARDWAREBUFFER_USAGE_CAMERA_READ = 0x40000;
 #endif  // __ANDROID__
 
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
-
-#endif  // ANDROID_NDK_TYPES_H_

--- a/layers/best_practices/best_practices_error_enums.h
+++ b/layers/best_practices/best_practices_error_enums.h
@@ -18,8 +18,7 @@
  * limitations under the License.
  */
 
-#ifndef BEST_PRACTICES_ERROR_ENUMS_H_
-#define BEST_PRACTICES_ERROR_ENUMS_H_
+#pragma once
 
 // clang-format off
 
@@ -297,5 +296,3 @@
     "UNASSIGNED-BestPractices-ClearColor-NotCompressed";
 
 // clang-format on
-
-#endif

--- a/layers/cast_utils.h
+++ b/layers/cast_utils.h
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 #pragma once
-#ifndef CAST_UTILS_H_
-#define CAST_UTILS_H_
 
 #include <cassert>
 #include <cstddef>
@@ -105,5 +103,3 @@ ValueType CastFromHandle(HandleType handle) {
     CastFromHandle(handle, &value);
     return value;
 }
-
-#endif  // CAST_UTILS_H_

--- a/layers/core_checks/shader_validation.h
+++ b/layers/core_checks/shader_validation.h
@@ -17,8 +17,8 @@
  *
  * The Shader Validation file is in charge of taking the Shader Module data and validating it
  */
-#ifndef VULKAN_SHADER_VALIDATION_H
-#define VULKAN_SHADER_VALIDATION_H
+
+#pragma once
 
 #include <cstdlib>
 
@@ -150,4 +150,3 @@ spv_target_env PickSpirvEnv(uint32_t api_version, bool spirv_1_4);
 void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
                             spvtools::ValidatorOptions &options);
 
-#endif  // VULKAN_SHADER_VALIDATION_H

--- a/layers/core_validation_error_enums.h
+++ b/layers/core_validation_error_enums.h
@@ -15,8 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef CORE_VALIDATION_ERROR_ENUMS_H_
-#define CORE_VALIDATION_ERROR_ENUMS_H_
+#pragma once
 
 // clang-format off
 
@@ -77,5 +76,3 @@
 // clang-format on
 
 #undef DECORATE_UNUSED
-
-#endif  // CORE_VALIDATION_ERROR_ENUMS_H_

--- a/layers/generated/vk_extension_helper.h
+++ b/layers/generated/vk_extension_helper.h
@@ -22,9 +22,8 @@
  * limitations under the License.
  ****************************************************************************/
 
+#pragma once
 
-#ifndef VK_EXTENSION_HELPER_H_
-#define VK_EXTENSION_HELPER_H_
 #include <string>
 #include <utility>
 #include <set>
@@ -1733,6 +1732,3 @@ static const std::set<std::string> kDeviceExtensionNames = {
     VK_VALVE_DESCRIPTOR_SET_HOST_MAPPING_EXTENSION_NAME,
     VK_VALVE_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME,
 };
-
-
-#endif // VK_EXTENSION_HELPER_H_

--- a/layers/gpu_shaders/gpu_shaders_constants.h
+++ b/layers/gpu_shaders/gpu_shaders_constants.h
@@ -15,8 +15,7 @@
 // limitations under the License.
 // Values used between the GLSL shaders and the GPU-AV logic
 
-#ifndef GPU_SHADER_CONSTANTS
-#define GPU_SHADER_CONSTANTS
+#pragma once
 
 // values match those found in SPIRV-Tools instrument.hpp file.
 #define _kInstErrorMax 7
@@ -37,5 +36,3 @@
 #define pre_dispatch_count_exceeds_limit_x_error 1
 #define pre_dispatch_count_exceeds_limit_y_error 2
 #define pre_dispatch_count_exceeds_limit_z_error 3
-
-#endif

--- a/layers/hash_util.h
+++ b/layers/hash_util.h
@@ -15,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef HASH_UTIL_H_
-#define HASH_UTIL_H_
+
+#pragma once
 
 #include <cstdint>
 #include <functional>
@@ -157,5 +157,3 @@ class Dictionary {
     Dict dict;
 };
 }  // namespace hash_util
-
-#endif  // HASH_UTILS_H_

--- a/layers/hash_vk_types.h
+++ b/layers/hash_vk_types.h
@@ -14,8 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef HASH_VK_TYPES_H_
-#define HASH_VK_TYPES_H_
+#pragma once
 
 // Includes everything needed for overloading std::hash
 #include "hash_util.h"
@@ -109,5 +108,3 @@ struct hash<const ExtEnabled DeviceExtensions::*> {
     }
 };
 }  // namespace std
-
-#endif  // HASH_VK_TYPES_H_

--- a/layers/sparse_containers.h
+++ b/layers/sparse_containers.h
@@ -18,8 +18,7 @@
  * John Zulauf <jzulauf@lunarg.com>
  *
  */
-#ifndef SPARSE_CONTAINERS_H_
-#define SPARSE_CONTAINERS_H_
+#pragma once
 #include <cassert>
 #include <memory>
 #include <vector>
@@ -399,4 +398,3 @@ class SparseVector {
 };
 
 }  // namespace sparse_container
-#endif

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -15,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef CORE_VALIDATION_DESCRIPTOR_SETS_H_
-#define CORE_VALIDATION_DESCRIPTOR_SETS_H_
+
+#pragma once
 
 #include "state_tracker/base_node.h"
 #include "state_tracker/buffer_state.h"
@@ -1093,4 +1093,3 @@ class PrefilterBindRequestMap {
     bool IsManyDescriptors() const { return descriptor_set_.GetTotalDescriptorCount() > kManyDescriptors_; }
 };
 }  // namespace cvdescriptorset
-#endif  // CORE_VALIDATION_DESCRIPTOR_SETS_H_

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -19,8 +19,6 @@
  *
  */
 #pragma once
-#ifndef IMAGE_LAYOUT_MAP_H_
-#define IMAGE_LAYOUT_MAP_H_
 
 #include <functional>
 #include <memory>
@@ -179,4 +177,3 @@ class ImageSubresourceLayoutMap {
     InitialLayoutStates initial_layout_states_;
 };
 }  // namespace image_layout_map
-#endif

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -14,8 +14,8 @@
  *
  * The Shader Module file is in charge of all things around creating and parsing an internal representation of a shader module
  */
-#ifndef VULKAN_SHADER_MODULE_H
-#define VULKAN_SHADER_MODULE_H
+
+#pragma once
 
 #include <cassert>
 #include <cstdlib>
@@ -440,5 +440,3 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     void SetUsedStructMember(const uint32_t variable_id, vvl::unordered_set<uint32_t> &accessible_ids,
                              const StructInfo &data) const;
 };
-
-#endif  // VULKAN_SHADER_MODULE_H

--- a/layers/stateless/parameter_name.h
+++ b/layers/stateless/parameter_name.h
@@ -15,8 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef PARAMETER_NAME_H
-#define PARAMETER_NAME_H
+#pragma once
 
 #include <cassert>
 #include <sstream>
@@ -126,5 +125,3 @@ class ParameterName {
     const size_t *args_;  ///< Array index values for formatting.
     size_t num_indices_;  ///< Number of array index values.
 };
-
-#endif  // PARAMETER_NAME_H

--- a/layers/subresource_adapter.h
+++ b/layers/subresource_adapter.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2022 The Khronos Group Inc.
- * Copyright (c) 2019-2022 Valve Corporation
- * Copyright (c) 2019-2022 LunarG, Inc.
+/* Copyright (c) 2019-2023 The Khronos Group Inc.
+ * Copyright (c) 2019-2023 Valve Corporation
+ * Copyright (c) 2019-2023 LunarG, Inc.
  * Copyright (C) 2019-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,9 +19,6 @@
  *
  */
 #pragma once
-
-#ifndef SUBRESOURCE_ADAPTER_H_
-#define SUBRESOURCE_ADAPTER_H_
 
 #include <algorithm>
 #include <array>
@@ -777,5 +774,3 @@ class BothRangeMap {
 };
 
 }  // namespace subresource_adapter
-
-#endif

--- a/scripts/helper_file_generator.py
+++ b/scripts/helper_file_generator.py
@@ -588,9 +588,8 @@ class HelperFileOutputGenerator(OutputGenerator):
         V_1_2_device_extensions_promoted_to_V_1_3_core = sorted([e.get('name') for e in promoted_1_3_exts if e.get('type') == 'device'])
 
         output = [
+            '#pragma once',
             '',
-            '#ifndef VK_EXTENSION_HELPER_H_',
-            '#define VK_EXTENSION_HELPER_H_',
             '#include <string>',
             '#include <utility>',
             '#include <set>',
@@ -809,7 +808,6 @@ class HelperFileOutputGenerator(OutputGenerator):
             struct.extend(['};', ''])
             output.extend(struct)
 
-        output.extend(['', '#endif // VK_EXTENSION_HELPER_H_'])
         return '\n'.join(output)
     #
     # Combine object types helper header file preamble with body text and return

--- a/tests/icd-spv.h
+++ b/tests/icd-spv.h
@@ -10,8 +10,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#ifndef ICD_SPV_H
-#define ICD_SPV_H
+#pragma once
 
 #include <stdint.h>
 
@@ -24,4 +23,3 @@ struct icd_spv_header {
     uint32_t gen_magic;  // Generator's magic number
 };
 
-#endif /* ICD_SPV_H */

--- a/tests/layer_validation_tests.h
+++ b/tests/layer_validation_tests.h
@@ -11,8 +11,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#ifndef VKLAYERTEST_H
-#define VKLAYERTEST_H
+#pragma once
 
 #include <vulkan/vulkan.h>
 
@@ -977,4 +976,3 @@ std::pair<VkBufferObj &&, VkAccelerationStructureGeometryKHR> GetSimpleAABB(cons
                                                                             uint32_t vk_api_version = VK_API_VERSION_1_2);
 
 void print_android(const char *c);
-#endif  // VKLAYERTEST_H

--- a/tests/layers/vk_lunarg_device_profile_api_layer.h
+++ b/tests/layers/vk_lunarg_device_profile_api_layer.h
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-#ifndef __VK_DEVICE_PROFILE_API_H__
-#define __VK_DEVICE_PROFILE_API_H__
+#pragma once
 
 #include "vulkan/vulkan.h"
 #ifdef __cplusplus
@@ -51,5 +50,3 @@ typedef void(VKAPI_PTR *PFN_VkSetPhysicalDeviceProperties2EXT)(VkPhysicalDevice 
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
-
-#endif  // __VK_DEVICE_PROFILE_API_H__

--- a/tests/vklayertests_video.h
+++ b/tests/vklayertests_video.h
@@ -9,8 +9,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#ifndef VKLAYERTESTS_VIDEO_H
-#define VKLAYERTESTS_VIDEO_H
+#pragma once
 
 #include "layer_validation_tests.h"
 #include "vk_extension_helper.h"
@@ -1521,5 +1520,3 @@ class VkVideoBestPracticesLayerTest : public VkVideoLayerTest {
         VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT, VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
     VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1, enables_, 4, disables_};
 };
-
-#endif  // VKLAYERTESTS_VIDEO_H

--- a/tests/vktestbinding.h
+++ b/tests/vktestbinding.h
@@ -16,8 +16,7 @@
  * limitations under the License.
  */
 
-#ifndef VKTESTBINDING_H
-#define VKTESTBINDING_H
+#pragma once
 
 #include <algorithm>
 #include <cassert>
@@ -1276,4 +1275,3 @@ struct GraphicsPipelineFromLibraries {
 
 }  // namespace vk_testing
 
-#endif  // VKTESTBINDING_H


### PR DESCRIPTION
The code is using #pragma once in most headers, but some still had include guards, and most perplexingly some had both.