### PR TITLE
layers: More fixes for 243 header

### DIFF
--- a/layers/core_checks/copy_blit_resolve_validation.cpp
+++ b/layers/core_checks/copy_blit_resolve_validation.cpp
@@ -2003,7 +2003,7 @@ bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkI
     vuid = is_2 ? "VUID-VkCopyImageToBufferInfo2-pRegions-00183" : "VUID-vkCmdCopyImageToBuffer-pRegions-00183";
     skip |= ValidateBufferBounds(commandBuffer, *src_image_state, *dst_buffer_state, regionCount, pRegions, func_name, vuid);
 
-    vuid = is_2 ? "VUID-VkCopyImageToBufferInfo2-srcImage-07930" : "VUID-vkCmdCopyImageToBuffer-srcImage-07930";
+    vuid = is_2 ? "VUID-VkCopyImageToBufferInfo2-None-07930" : "VUID-vkCmdCopyImageToBuffer-None-07930";
     std::string location = func_name;
     location.append("() : srcImage");
     skip |= ValidateImageSampleCount(commandBuffer, *src_image_state, VK_SAMPLE_COUNT_1_BIT, location.c_str(), vuid);
@@ -2162,7 +2162,7 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
     vuid = is_2 ? "VUID-VkCopyBufferToImageInfo2-pRegions-00171" : "VUID-vkCmdCopyBufferToImage-pRegions-00171";
     skip |= ValidateBufferBounds(commandBuffer, *dst_image_state, *src_buffer_state, regionCount, pRegions, func_name, vuid);
 
-    vuid = is_2 ? "VUID-VkCopyBufferToImageInfo2-dstImage-07930" : "VUID-vkCmdCopyBufferToImage-dstImage-07930";
+    vuid = is_2 ? "VUID-VkCopyBufferToImageInfo2-None-07930" : "VUID-vkCmdCopyBufferToImage-None-07930";
     std::string location = func_name;
     location.append("() : dstImage");
     skip |= ValidateImageSampleCount(commandBuffer, *dst_image_state, VK_SAMPLE_COUNT_1_BIT, location.c_str(), vuid);

--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -3230,23 +3230,6 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
             const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
             skip |= LogError(objlist, "VUID-vkCmdBindPipeline-None-02323", "vkCmdBindPipeline(): transform feedback is active.");
         }
-        if (cb_state->activeRenderPass && cb_state->activeRenderPass->UsesDynamicRendering()) {
-            const auto rendering_info = cb_state->activeRenderPass->dynamic_rendering_begin_rendering_info;
-            const auto msrtss_info = LvlFindInChain<VkMultisampledRenderToSingleSampledInfoEXT>(rendering_info.pNext);
-            // If no color attachment exists, this can be nullptr.
-            const auto multisample_state = pipeline_state.MultisampleState();
-            const auto pipeline_rasterization_samples = multisample_state ? multisample_state->rasterizationSamples : 0;
-            if (msrtss_info && msrtss_info->multisampledRenderToSingleSampledEnable &&
-                (msrtss_info->rasterizationSamples != pipeline_rasterization_samples)) {
-                const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
-                skip |= LogError(objlist, "VUID-vkCmdBindPipeline-pipeline-06856",
-                                 "vkCmdBindPipeline(): A VkMultisampledRenderToSingleSampledInfoEXT struct in the pNext chain of "
-                                 "VkRenderingInfo passed to vkCmdBeginRendering has a rasterizationSamples of (%" PRIu32
-                                 ") which is not equal to pMultisampleState.rasterizationSamples used to create the pipeline, "
-                                 "which is (%" PRIu32 ").",
-                                 msrtss_info->rasterizationSamples, pipeline_rasterization_samples);
-            }
-        }
         if (enabled_features.pipeline_protected_access_features.pipelineProtectedAccess) {
             if (cb_state->unprotected) {
                 const LogObjectList objlist(cb_state->commandBuffer(), pipeline);

--- a/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
+++ b/tests/vklayertests_descriptor_renderpass_framebuffer.cpp
@@ -11752,9 +11752,8 @@ TEST_F(VkLayerTest, MultisampledRenderToSingleSampled) {
     m_commandBuffer->begin();
     m_commandBuffer->BeginRendering(begin_rendering_info);
     // ms_render_to_ss.rasterizationSamples != ms_state.rasterizationSamples
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindPipeline-pipeline-06856");
+    // Valid because never hit draw time
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_helper.pipeline_);
-    m_errorMonitor->VerifyFound();
     m_commandBuffer->EndRendering();
     m_commandBuffer->end();
 


### PR DESCRIPTION
- `VUID-VkCopyImageToBufferInfo2-None-07930` was label wrong (and VUID like it)
- `VUID-vkCmdBindPipeline-pipeline-06856` was moved to a draw time error now (adding back in future PR)