### PR TITLE
layers: Fix which GPL shader stages are checked

### DIFF
--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -898,7 +898,8 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE 
         }
     }
 
-    if (is_xfb_execution_mode && ((pipeline.active_shaders & (VK_SHADER_STAGE_MESH_BIT_EXT | VK_SHADER_STAGE_TASK_BIT_EXT)) != 0)) {
+    if (is_xfb_execution_mode &&
+        ((pipeline.create_info_shaders & (VK_SHADER_STAGE_MESH_BIT_EXT | VK_SHADER_STAGE_TASK_BIT_EXT)) != 0)) {
         skip |= LogError(pipeline.pipeline(), "VUID-VkGraphicsPipelineCreateInfo-None-02322",
                          "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
                          "] If the pipeline is being created with pre-rasterization shader state, and there are any mesh shader "
@@ -2281,7 +2282,7 @@ bool CoreChecks::ValidatePointSizeShaderState(const PIPELINE_STATE &pipeline, co
                          pipeline.create_index);
         }
     } else if (stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT &&
-               ((pipeline.active_shaders & VK_SHADER_STAGE_GEOMETRY_BIT) == 0) && point_mode) {
+               ((pipeline.create_info_shaders & VK_SHADER_STAGE_GEOMETRY_BIT) == 0) && point_mode) {
         if (enabled_features.core.shaderTessellationAndGeometryPointSize && !pointsize_written) {
             skip |= LogError(module_state.vk_shader_module(), "VUID-VkGraphicsPipelineCreateInfo-TessellationEvaluation-07723",
                              "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
@@ -2297,7 +2298,8 @@ bool CoreChecks::ValidatePointSizeShaderState(const PIPELINE_STATE &pipeline, co
                 pipeline.create_index);
         }
     } else if (stage == VK_SHADER_STAGE_VERTEX_BIT &&
-               ((pipeline.active_shaders & (VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT)) == 0) &&
+               ((pipeline.create_info_shaders & (VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT)) ==
+                0) &&
                pipeline.topology_at_rasterizer == VK_PRIMITIVE_TOPOLOGY_POINT_LIST) {
         if (!pointsize_written) {
             skip |= LogError(module_state.vk_shader_module(), "VUID-VkGraphicsPipelineCreateInfo-Vertex-07722",

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -194,10 +194,10 @@ static uint32_t GetMaxActiveSlot(const PIPELINE_STATE::ActiveSlotMap &active_slo
     return max_active_slot;
 }
 
-static uint32_t GetActiveShaders(const PIPELINE_STATE::StageStateVec &stage_states) {
+static uint32_t GetCreateInfoShaders(const PIPELINE_STATE &pipe_state) {
     uint32_t result = 0;
-    for (const auto &stage : stage_states) {
-        result |= stage.stage_flag;
+    for (const auto &stage_ci : pipe_state.shader_stages_ci) {
+        result |= stage_ci.stage;
     }
     return result;
 }
@@ -565,8 +565,9 @@ PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const V
       fragment_shader_state(CreateFragmentShaderState(*this, *state_data, *pCreateInfo, create_info.graphics, rpstate)),
       fragment_output_state(CreateFragmentOutputState(*this, *state_data, *pCreateInfo, create_info.graphics, rpstate)),
       stage_states(GetStageStates(*state_data, *this, csm_states)),
-      active_shaders(GetActiveShaders(stage_states)),
+      create_info_shaders(GetCreateInfoShaders(*this)),
       linking_shaders(GetLinkingShaders(library_create_info, *state_data)),
+      active_shaders(create_info_shaders | linking_shaders),
       fragmentShader_writable_output_location_list(GetFSOutputLocations(stage_states)),
       active_slots(GetActiveSlots(stage_states)),
       max_active_slot(GetMaxActiveSlot(active_slots)),
@@ -643,7 +644,8 @@ PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const V
       create_flags(create_info.compute.flags),
       shader_stages_ci(&create_info.compute.stage, 1),
       stage_states(GetStageStates(*state_data, *this, csm_states)),
-      active_shaders(GetActiveShaders(stage_states)),
+      create_info_shaders(GetCreateInfoShaders(*this)),
+      active_shaders(create_info_shaders),  // compute has no linking shaders
       active_slots(GetActiveSlots(stage_states)),
       uses_shader_module_id(UsesShaderModuleId(*this)),
       descriptor_buffer_mode((create_info.compute.flags & VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) != 0),
@@ -664,7 +666,8 @@ PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const V
       shader_stages_ci(create_info.raytracing.pStages, create_info.raytracing.stageCount),
       ray_tracing_library_ci(create_info.raytracing.pLibraryInfo),
       stage_states(GetStageStates(*state_data, *this, csm_states)),
-      active_shaders(GetActiveShaders(stage_states)),
+      create_info_shaders(GetCreateInfoShaders(*this)),
+      active_shaders(create_info_shaders),  // RTX has no linking shaders
       active_slots(GetActiveSlots(stage_states)),
       uses_shader_module_id(UsesShaderModuleId(*this)),
       descriptor_buffer_mode((create_info.raytracing.flags & VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) != 0),
@@ -687,7 +690,8 @@ PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const V
       shader_stages_ci(create_info.raytracing.pStages, create_info.raytracing.stageCount),
       ray_tracing_library_ci(create_info.raytracing.pLibraryInfo),
       stage_states(GetStageStates(*state_data, *this, csm_states)),
-      active_shaders(GetActiveShaders(stage_states)),
+      create_info_shaders(GetCreateInfoShaders(*this)),
+      active_shaders(create_info_shaders),  // RTX has no linking shaders
       active_slots(GetActiveSlots(stage_states)),
       uses_shader_module_id(UsesShaderModuleId(*this)),
       descriptor_buffer_mode((create_info.graphics.flags & VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) != 0),

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -187,10 +187,15 @@ class PIPELINE_STATE : public BASE_NODE {
     // Additional metadata needed by pipeline_state initialization and validation
     using StageStateVec = std::vector<PipelineStageState>;
     const StageStateVec stage_states;
-    // Flag of which shader stages are active for this pipeline
-    const uint32_t active_shaders = 0;
+
+    // Shaders from the pipeline create info
+    // Normally used for validating pipeline creation, if stages are linked, they will already have been validated
+    const VkShaderStageFlags create_info_shaders = 0;
     // Shaders being linked in, don't need to be re-validated
-    const uint32_t linking_shaders = 0;
+    const VkShaderStageFlags linking_shaders = 0;
+    // Flag of which shader stages are active for this pipeline
+    // create_info_shaders + linking_shaders
+    const VkShaderStageFlags active_shaders = 0;
 
     const vvl::unordered_set<uint32_t> fragmentShader_writable_output_location_list;
 
@@ -288,6 +293,10 @@ class PIPELINE_STATE : public BASE_NODE {
         }
         return {};
     }
+
+    // Used to know if the pipeline substate is being created (as opposed to being linked)
+    // Important as some pipeline checks need pipeline state that won't be there if the substate is from linking
+    bool OwnsSubState(const std::shared_ptr<PipelineSubState> sub_state) const { return sub_state && (&sub_state->parent == this); }
 
     const std::shared_ptr<const RENDER_PASS_STATE> RenderPassState() const {
         // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -20,7 +20,7 @@
 #include "state_tracker/state_tracker.h"
 
 VertexInputState::VertexInputState(const PIPELINE_STATE &p, const safe_VkGraphicsPipelineCreateInfo &create_info)
-    : parent(p), input_state(create_info.pVertexInputState), input_assembly_state(create_info.pInputAssemblyState) {
+    : PipelineSubState(p), input_state(create_info.pVertexInputState), input_assembly_state(create_info.pInputAssemblyState) {
     if (create_info.pVertexInputState) {
         const auto *vici = create_info.pVertexInputState;
         if (vici->vertexBindingDescriptionCount) {
@@ -54,7 +54,7 @@ VertexInputState::VertexInputState(const PIPELINE_STATE &p, const safe_VkGraphic
 
 PreRasterState::PreRasterState(const PIPELINE_STATE &p, const ValidationStateTracker &dev_data,
                                const safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const RENDER_PASS_STATE> rp)
-    : parent(p), rp_state(rp), subpass(create_info.subpass) {
+    : PipelineSubState(p), rp_state(rp), subpass(create_info.subpass) {
     pipeline_layout = dev_data.Get<PIPELINE_LAYOUT_STATE>(create_info.layout);
 
     viewport_state = create_info.pViewportState;
@@ -188,10 +188,10 @@ void FragmentShaderState::SetFragmentShaderInfo(FragmentShaderState &fs_state, c
 
 FragmentShaderState::FragmentShaderState(const PIPELINE_STATE &p, const ValidationStateTracker &dev_data,
                                          std::shared_ptr<const RENDER_PASS_STATE> rp, uint32_t subp, VkPipelineLayout layout)
-    : parent(p), rp_state(rp), subpass(subp), pipeline_layout(dev_data.Get<PIPELINE_LAYOUT_STATE>(layout)) {}
+    : PipelineSubState(p), rp_state(rp), subpass(subp), pipeline_layout(dev_data.Get<PIPELINE_LAYOUT_STATE>(layout)) {}
 
 FragmentOutputState::FragmentOutputState(const PIPELINE_STATE &p, std::shared_ptr<const RENDER_PASS_STATE> rp, uint32_t sp)
-    : parent(p), rp_state(rp), subpass(sp) {}
+    : PipelineSubState(p), rp_state(rp), subpass(sp) {}
 
 // static
 bool FragmentOutputState::IsBlendConstantsEnabled(const AttachmentVector &attachments) {

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -34,10 +34,14 @@ static inline VkGraphicsPipelineLibraryFlagsEXT GetGraphicsLibType(const CreateI
     return static_cast<VkGraphicsPipelineLibraryFlagsEXT>(0);
 }
 
-struct VertexInputState {
-    VertexInputState(const PIPELINE_STATE &p, const safe_VkGraphicsPipelineCreateInfo &create_info);
-
+// Common amoung all pipeline sub state
+struct PipelineSubState {
+    PipelineSubState(const PIPELINE_STATE &p) : parent(p) {}
     const PIPELINE_STATE &parent;
+};
+
+struct VertexInputState : public PipelineSubState {
+    VertexInputState(const PIPELINE_STATE &p, const safe_VkGraphicsPipelineCreateInfo &create_info);
 
     safe_VkPipelineVertexInputStateCreateInfo *input_state = nullptr;
     safe_VkPipelineInputAssemblyStateCreateInfo *input_assembly_state = nullptr;
@@ -58,7 +62,7 @@ struct VertexInputState {
                                                      const safe_VkGraphicsPipelineCreateInfo &create_info);
 };
 
-struct PreRasterState {
+struct PreRasterState : public PipelineSubState {
     PreRasterState(const PIPELINE_STATE &p, const ValidationStateTracker &dev_data,
                    const safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const RENDER_PASS_STATE> rp);
 
@@ -66,8 +70,6 @@ struct PreRasterState {
         return VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT |
                VK_SHADER_STAGE_GEOMETRY_BIT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
     }
-
-    const PIPELINE_STATE &parent;
 
     std::shared_ptr<const PIPELINE_LAYOUT_STATE> pipeline_layout;
     safe_VkPipelineViewportStateCreateInfo *viewport_state = nullptr;
@@ -101,7 +103,7 @@ std::unique_ptr<const safe_VkPipelineDepthStencilStateCreateInfo> ToSafeDepthSte
 std::unique_ptr<const safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(const safe_VkPipelineShaderStageCreateInfo &cbs);
 std::unique_ptr<const safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(const VkPipelineShaderStageCreateInfo &cbs);
 
-struct FragmentShaderState {
+struct FragmentShaderState : public PipelineSubState {
     FragmentShaderState(const PIPELINE_STATE &p, const ValidationStateTracker &dev_data,
                         std::shared_ptr<const RENDER_PASS_STATE> rp, uint32_t subpass, VkPipelineLayout layout);
 
@@ -119,8 +121,6 @@ struct FragmentShaderState {
     }
 
     static inline VkShaderStageFlags ValidShaderStages() { return VK_SHADER_STAGE_FRAGMENT_BIT; }
-
-    const PIPELINE_STATE &parent;
 
     std::shared_ptr<const RENDER_PASS_STATE> rp_state;
     uint32_t subpass = 0;
@@ -152,7 +152,7 @@ static bool IsSampleLocationEnabled(const CreateInfo &create_info) {
     return result;
 }
 
-struct FragmentOutputState {
+struct FragmentOutputState : public PipelineSubState {
     using AttachmentVector = std::vector<VkPipelineColorBlendAttachmentState>;
 
     FragmentOutputState(const PIPELINE_STATE &p, std::shared_ptr<const RENDER_PASS_STATE> rp, uint32_t sp);
@@ -189,8 +189,6 @@ struct FragmentOutputState {
 
     static bool IsBlendConstantsEnabled(const AttachmentVector &attachments);
     static bool GetDualSourceBlending(const safe_VkPipelineColorBlendStateCreateInfo *color_blend_state);
-
-    const PIPELINE_STATE &parent;
 
     std::shared_ptr<const RENDER_PASS_STATE> rp_state;
     uint32_t subpass = 0;

--- a/tests/vklayertests_graphics_library.cpp
+++ b/tests/vklayertests_graphics_library.cpp
@@ -1660,13 +1660,14 @@ TEST_F(VkGraphicsLibraryLayerTest, CreatePipelineTessErrors) {
         m_errorMonitor->VerifyFound();
     }
 
-    // Pass patch topology without tessellation shaders
-    CreatePipelineHelper vi_patch_lib(*this);
-    vi_patch_lib.InitVertexInputLibInfo();
-    vi_patch_lib.InitState();
-    vi_patch_lib.gp_ci_.pInputAssemblyState = &iasci;
-    vi_patch_lib.CreateGraphicsPipeline(true, false);
     {
+        // Pass patch topology without tessellation shaders
+        CreatePipelineHelper vi_patch_lib(*this);
+        vi_patch_lib.InitVertexInputLibInfo();
+        vi_patch_lib.InitState();
+        vi_patch_lib.gp_ci_.pInputAssemblyState = &iasci;
+        vi_patch_lib.CreateGraphicsPipeline(true, false);
+
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfo(1, &vs_stage.stage_ci);
         pre_raster_lib.InitState();


### PR DESCRIPTION
There are VUs that say

> If the pipeline is being created with [pre-rasterization shader state](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#pipelines-graphics-subsets-pre-rasterization)

But currently we were checking all stages, including those being linked in

Adding the `HasSameParent` function allows us to know only to check if the pipeline was created with the state (for GPL)