### PR TITLE
build: Remove unused include headers

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -257,6 +257,7 @@ target_sources(VkLayer_khronos_validation PRIVATE
     object_lifetime_validation.h
     object_tracker_utils.cpp
     range_vector.h
+    sparse_containers.h
     subresource_adapter.cpp
     subresource_adapter.h
     vk_layer_settings_ext.h

--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -22,9 +22,6 @@
 #include "best_practices/best_practices_error_enums.h"
 #include "core_checks/shader_validation.h"
 #include "sync/sync_utils.h"
-#include "state_tracker/cmd_buffer_state.h"
-#include "state_tracker/device_state.h"
-#include "state_tracker/render_pass_state.h"
 
 #include <string>
 #include <bitset>

--- a/layers/core_checks/android_validation.cpp
+++ b/layers/core_checks/android_validation.cpp
@@ -17,11 +17,8 @@
  * limitations under the License.
  */
 
-#include <vector>
-
 #include "vk_layer_utils.h"
 #include "vk_enum_string_helper.h"
-#include "chassis.h"
 #include "core_checks/core_validation.h"
 
 #ifdef AHB_VALIDATION_SUPPORT

--- a/layers/core_checks/buffer_validation.cpp
+++ b/layers/core_checks/buffer_validation.cpp
@@ -17,9 +17,6 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <assert.h>
-#include <sstream>
 #include <string>
 #include <vector>
 

--- a/layers/core_checks/image_validation.cpp
+++ b/layers/core_checks/image_validation.cpp
@@ -24,8 +24,6 @@
 #include "vk_enum_string_helper.h"
 #include "chassis.h"
 #include "core_checks/core_validation.h"
-#include "core_error_location.h"
-#include "sync/sync_vuid_maps.h"
 
 // There is a table in the Vulkan spec to list all formats that implicitly require YCbCr conversion,
 // but some features/extensions can explicitly turn that restriction off

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -21,15 +21,12 @@
 
 #include <cassert>
 #include <cinttypes>
-#include <cmath>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include <spirv/unified1/spirv.hpp>
 #include "vk_enum_string_helper.h"
-#include "vk_layer_data.h"
-#include "vk_layer_utils.h"
 #include "chassis.h"
 #include "core_checks/core_validation.h"
 #include "spirv_grammar_helper.h"

--- a/layers/generated/layer_chassis_dispatch.cpp
+++ b/layers/generated/layer_chassis_dispatch.cpp
@@ -20,11 +20,9 @@
  * limitations under the License.
  */
 
-#include <mutex>
 #include "cast_utils.h"
 #include "chassis.h"
 #include "layer_chassis_dispatch.h"
-#include "vk_layer_utils.h"
 #include "vk_safe_struct.h"
 
 std::shared_mutex dispatch_lock;

--- a/layers/generated/vk_format_utils.cpp
+++ b/layers/generated/vk_format_utils.cpp
@@ -23,7 +23,6 @@
 
 #include "vk_format_utils.h"
 #include "vk_layer_utils.h"
-#include <map>
 #include <vector>
 
 

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -20,7 +20,6 @@
 #include "spirv-tools/instrument.hpp"
 #include <iostream>
 #include "layer_chassis_dispatch.h"
-#include "state_tracker/cmd_buffer_state.h"
 
 // Perform initializations that can be done at Create Device time.
 void DebugPrintf::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {

--- a/layers/gpu_validation/gpu_utils.cpp
+++ b/layers/gpu_validation/gpu_utils.cpp
@@ -16,14 +16,12 @@
  */
 
 #include "gpu_validation/gpu_utils.h"
-#include "state_tracker/descriptor_sets.h"
 #include "sync/sync_utils.h"
 #include "spirv-tools/libspirv.h"
 #include "spirv-tools/optimizer.hpp"
 #include "spirv-tools/instrument.hpp"
 #include <spirv/unified1/spirv.hpp>
 #include <algorithm>
-#include <regex>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -1125,6 +1123,7 @@ bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::st
     return true;
 }
 #else
+#include <regex>
 bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::string &filename) {
     static const std::regex line_regex(  // matches #line directives
         "^"                              // beginning of line

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -23,10 +23,6 @@
 #include "spirv-tools/instrument.hpp"
 #include "layer_chassis_dispatch.h"
 #include "gpu_vuids.h"
-#include "state_tracker/buffer_state.h"
-#include "state_tracker/cmd_buffer_state.h"
-#include "state_tracker/render_pass_state.h"
-#include "vk_layer_config.h"
 // Generated shaders
 #include "gpu_shaders/gpu_shaders_constants.h"
 #include "gpu_pre_draw_vert.h"

--- a/layers/state_tracker/base_node.cpp
+++ b/layers/state_tracker/base_node.cpp
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 #include "state_tracker/base_node.h"
-#include "vk_layer_utils.h"
 
 BASE_NODE::~BASE_NODE() { Destroy(); }
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -18,10 +18,6 @@
  * limitations under the License.
  */
 #include "state_tracker/cmd_buffer_state.h"
-#include "state_tracker/render_pass_state.h"
-#include "state_tracker/video_session_state.h"
-#include "state_tracker/state_tracker.h"
-#include "state_tracker/image_state.h"
 
 COMMAND_POOL_STATE::COMMAND_POOL_STATE(ValidationStateTracker *dev, VkCommandPool cp, const VkCommandPoolCreateInfo *pCreateInfo,
                                        VkQueueFlags flags)

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -20,8 +20,6 @@
 #include "state_tracker/image_state.h"
 #include "state_tracker/pipeline_state.h"
 #include "state_tracker/descriptor_sets.h"
-#include "state_tracker/state_tracker.h"
-#include "vk_layer_utils.h"
 #include <limits>
 
 static VkImageSubresourceRange MakeImageFullRange(const VkImageCreateInfo &create_info) {

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -19,8 +19,6 @@
 #include "state_tracker/pipeline_state.h"
 #include "state_tracker/descriptor_sets.h"
 #include "state_tracker/cmd_buffer_state.h"
-#include "state_tracker/state_tracker.h"
-#include "state_tracker/shader_module.h"
 #include "enum_flag_bits.h"
 
 static bool WrotePrimitiveShadingRate(VkShaderStageFlagBits stage_flag, const Instruction &entrypoint,

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -17,8 +17,6 @@
 
 #include "state_tracker/pipeline_sub_state.h"
 
-#include "state_tracker/state_tracker.h"
-
 VertexInputState::VertexInputState(const PIPELINE_STATE &p, const safe_VkGraphicsPipelineCreateInfo &create_info)
     : parent(p), input_state(create_info.pVertexInputState), input_assembly_state(create_info.pInputAssemblyState) {
     if (create_info.pVertexInputState) {

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -18,7 +18,6 @@
  */
 #include "state_tracker/queue_state.h"
 #include "state_tracker/cmd_buffer_state.h"
-#include "state_tracker/state_tracker.h"
 
 using SemOp = SEMAPHORE_STATE::SemOp;
 

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -18,8 +18,6 @@
 #include <sstream>
 #include <string>
 
-#include "vk_layer_data.h"
-#include "vk_layer_utils.h"
 #include "state_tracker/pipeline_state.h"
 #include "state_tracker/descriptor_sets.h"
 #include "spirv_grammar_helper.h"

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -19,13 +19,10 @@
  */
 
 #include <algorithm>
-#include <cmath>
 
-#include "vk_enum_string_helper.h"
 #include "vk_format_utils.h"
 #include "vk_layer_data.h"
 #include "vk_layer_utils.h"
-#include "vk_layer_logging.h"
 #include "vk_typemap_helper.h"
 
 #include "chassis.h"
@@ -33,7 +30,6 @@
 #include "core_checks/shader_validation.h"
 #include "sync/sync_utils.h"
 #include "state_tracker/cmd_buffer_state.h"
-#include "state_tracker/render_pass_state.h"
 
 // NOTE:  Beware the lifespan of the rp_begin when holding  the return.  If the rp_begin isn't a "safe" copy, "IMAGELESS"
 //        attachments won't persist past the API entry point exit.

--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -17,10 +17,8 @@
  */
 #include "sync/sync_vuid_maps.h"
 #include "core_error_location.h"
-#include "state_tracker/device_state.h"
 #include "core_checks/core_validation.h"
 #include <cassert>
-#include <algorithm>
 #include <array>
 #include <vector>
 

--- a/scripts/format_utils_generator.py
+++ b/scripts/format_utils_generator.py
@@ -144,7 +144,6 @@ class FormatUtilsOutputGenerator(OutputGenerator):
         if self.sourceFile:
             write('#include "vk_format_utils.h"', file=self.outFile)
             write('#include "vk_layer_utils.h"', file=self.outFile)
-            write('#include <map>', file=self.outFile)
             write('#include <vector>', file=self.outFile)
         elif self.headerFile:
             write('#pragma once', file=self.outFile)

--- a/scripts/layer_chassis_dispatch_generator.py
+++ b/scripts/layer_chassis_dispatch_generator.py
@@ -1751,11 +1751,9 @@ void DispatchGetDescriptorEXT(
         if not self.header:
             write(self.inline_copyright_message, file=self.outFile)
             self.newline()
-            write('#include <mutex>', file=self.outFile)
             write('#include "cast_utils.h"', file=self.outFile)
             write('#include "chassis.h"', file=self.outFile)
             write('#include "layer_chassis_dispatch.h"', file=self.outFile)
-            write('#include "vk_layer_utils.h"', file=self.outFile)
             write('#include "vk_safe_struct.h"', file=self.outFile)
             self.newline()
             write('std::shared_mutex dispatch_lock;', file=self.outFile)

--- a/tests/layers/device_profile_api.cpp
+++ b/tests/layers/device_profile_api.cpp
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 #include <string.h>
-#include <stdlib.h>
 #include <cassert>
 #include <mutex>
 #include <unordered_map>

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -17,11 +17,8 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <memory>
 #include <mutex>
 #include <thread>
-
-#include "cast_utils.h"
 
 //
 // POSITIVE VALIDATION TESTS

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -17,11 +17,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <memory>
-#include <mutex>
 #include <thread>
-
-#include "cast_utils.h"
 
 //
 // POSITIVE VALIDATION TESTS

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -17,11 +17,6 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <memory>
-#include <mutex>
-#include <thread>
-
-#include "cast_utils.h"
 
 TEST_F(VkPositiveLayerTest, DynamicRenderingDraw) {
     TEST_DESCRIPTION("Draw with Dynamic Rendering.");

--- a/tests/positive/graphics_library.cpp
+++ b/tests/positive/graphics_library.cpp
@@ -17,11 +17,6 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <memory>
-#include <mutex>
-#include <thread>
-
-#include "cast_utils.h"
 
 class VkPositiveGraphicsLibraryLayerTest : public VkLayerTest {};
 

--- a/tests/positive/image_buffer.cpp
+++ b/tests/positive/image_buffer.cpp
@@ -17,11 +17,9 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <memory>
 #include <mutex>
 #include <thread>
 
-#include "cast_utils.h"
 #include "vk_layer_utils.h"
 
 //

--- a/tests/positive/instance.cpp
+++ b/tests/positive/instance.cpp
@@ -15,13 +15,8 @@
 #include "vk_extension_helper.h"
 
 #include <algorithm>
-#include <array>
 #include <chrono>
-#include <memory>
-#include <mutex>
 #include <thread>
-
-#include "cast_utils.h"
 
 //
 // POSITIVE VALIDATION TESTS

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -17,11 +17,6 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <memory>
-#include <mutex>
-#include <thread>
-
-#include "cast_utils.h"
 
 //
 // POSITIVE VALIDATION TESTS

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -15,13 +15,9 @@
 #include "vk_extension_helper.h"
 
 #include <algorithm>
-#include <array>
 #include <chrono>
-#include <memory>
 #include <mutex>
 #include <thread>
-
-#include "cast_utils.h"
 
 //
 // POSITIVE VALIDATION TESTS

--- a/tests/positive/sync.cpp
+++ b/tests/positive/sync.cpp
@@ -14,15 +14,10 @@
 #include "../layer_validation_tests.h"
 #include "vk_extension_helper.h"
 
-#include <algorithm>
 #include <array>
 #include <chrono>
 #include <deque>
-#include <memory>
-#include <mutex>
 #include <thread>
-
-#include "cast_utils.h"
 
 //
 // POSITIVE VALIDATION TESTS

--- a/tests/positive/tooling.cpp
+++ b/tests/positive/tooling.cpp
@@ -15,13 +15,7 @@
 #include "vk_extension_helper.h"
 
 #include <algorithm>
-#include <array>
 #include <chrono>
-#include <memory>
-#include <mutex>
-#include <thread>
-
-#include "cast_utils.h"
 
 //
 // POSITIVE VALIDATION TESTS

--- a/tests/positive/video.cpp
+++ b/tests/positive/video.cpp
@@ -13,13 +13,7 @@
 #include "vk_extension_helper.h"
 
 #include <algorithm>
-#include <array>
 #include <chrono>
-#include <memory>
-#include <mutex>
-#include <thread>
-
-#include "cast_utils.h"
 
 class VkPositiveVideoLayerTest : public VkVideoLayerTest {};
 

--- a/tests/vklayertests_arm_best_practices.cpp
+++ b/tests/vklayertests_arm_best_practices.cpp
@@ -13,7 +13,6 @@
 
 #include "cast_utils.h"
 #include "layer_validation_tests.h"
-#include "best_practices/best_practices_error_enums.h"
 
 const char *kEnableArmValidation = "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM";
 

--- a/tests/vklayertests_graphics_library.cpp
+++ b/tests/vklayertests_graphics_library.cpp
@@ -17,11 +17,6 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <memory>
-#include <mutex>
-#include <thread>
-
-#include "cast_utils.h"
 
 class VkGraphicsLibraryLayerTest : public VkLayerTest {};
 

--- a/tests/vklayertests_object_lifetime.cpp
+++ b/tests/vklayertests_object_lifetime.cpp
@@ -15,7 +15,6 @@
 #include "cast_utils.h"
 #include "enum_flag_bits.h"
 #include "layer_validation_tests.h"
-#include "vk_layer_utils.h"
 
 TEST_F(VkLayerTest, InvalidCmdBufferBufferDestroyed) {
     TEST_DESCRIPTION("Attempt to draw with a command buffer that is invalid due to a buffer dependency being destroyed.");

--- a/tests/vklayertests_others.cpp
+++ b/tests/vklayertests_others.cpp
@@ -18,7 +18,6 @@
 #include "layer_validation_tests.h"
 #include "vk_layer_utils.h"
 #include "generated/vk_validation_error_messages.h"
-#include "vk_layer_logging.h"
 
 class MessageIdFilter {
   public:

--- a/tests/vklayertests_portability_subset.cpp
+++ b/tests/vklayertests_portability_subset.cpp
@@ -12,7 +12,6 @@
 
 #include "cast_utils.h"
 #include "layer_validation_tests.h"
-#include "core_validation_error_enums.h"
 
 class VkPortabilitySubsetTest : public VkLayerTest {};
 

--- a/tests/vklayertests_query.cpp
+++ b/tests/vklayertests_query.cpp
@@ -13,12 +13,8 @@
  */
 
 #include "cast_utils.h"
-#include "core_validation_error_enums.h"
 #include "enum_flag_bits.h"
 #include "layer_validation_tests.h"
-#include "vk_layer_utils.h"
-#include "generated/vk_validation_error_messages.h"
-#include "vk_layer_logging.h"
 
 class VkLayerQueryTest : public VkLayerTest {};
 

--- a/tests/vklayertests_sparse.cpp
+++ b/tests/vklayertests_sparse.cpp
@@ -15,7 +15,6 @@
 #include "cast_utils.h"
 #include "enum_flag_bits.h"
 #include "layer_validation_tests.h"
-#include "vk_layer_utils.h"
 
 TEST_F(VkLayerTest, SparseBindingImageBufferCreate) {
     TEST_DESCRIPTION("Create buffer/image with sparse attributes but without the sparse_binding bit set");

--- a/tests/vklayertests_video.cpp
+++ b/tests/vklayertests_video.cpp
@@ -14,11 +14,6 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
-#include <memory>
-#include <mutex>
-#include <thread>
-
-#include "cast_utils.h"
 
 TEST_F(VkVideoLayerTest, VideoCodingScope) {
     TEST_DESCRIPTION("Tests calling functions inside/outside video coding scope");

--- a/tests/vktestbinding.cpp
+++ b/tests/vktestbinding.cpp
@@ -24,7 +24,6 @@
 #include <iostream>
 #include <vector>
 
-#include "test_common.h"
 #include "vk_typemap_helper.h"
 #include "vk_format_utils.h"
 

--- a/tests/vktestframework.cpp
+++ b/tests/vktestframework.cpp
@@ -21,7 +21,6 @@
 #include "glslang/SPIRV/GlslangToSpv.h"
 #include "glslang/SPIRV/SPVRemapper.h"
 #include <filesystem>
-#include <climits>
 #include <cmath>
 
 // Command-line options


### PR DESCRIPTION
Running code analysis, found many header are not used and can be removed from the build