### PR TITLE
tests: Make GoogleTest assertions throw

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -3823,6 +3823,7 @@ void android_main(struct android_app *app) {
 }
 #endif
 
+#if !defined(ANDROID) && !defined(VALIDATION_APK)
 #if defined(_WIN32) && !defined(NDEBUG)
 #include <crtdbg.h>
 #endif
@@ -3852,3 +3853,4 @@ int main(int argc, char **argv) {
     VkTestFramework::Finish();
     return result;
 }
+#endif

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -3828,25 +3828,42 @@ void android_main(struct android_app *app) {
 #include <crtdbg.h>
 #endif
 
+// Makes any failed assertion throw, allowing for graceful cleanup of resources instead of hard aborts
+class ThrowListener : public testing::EmptyTestEventListener {
+    void OnTestPartResult(const testing::TestPartResult &result) override {
+        if (result.type() == testing::TestPartResult::kFatalFailure) {
+            // We need to make sure an exception wasn't already thrown so we dont throw another exception at the same time
+            std::exception_ptr ex = std::current_exception();
+            if (ex) {
+                return;
+            }
+            throw testing::AssertionException(result);
+        }
+    }
+};
+
 int main(int argc, char **argv) {
-    int result;
+    int result = -1;  // -1 indicates faliure, this is in case of an uncaught exception causing RUN_ALL_TESTS();
+                      // to not return 0
 
 #if defined(_WIN32)
-#if !defined(NDEBUG)
-    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
-#endif
     // Avoid "Abort, Retry, Ignore" dialog boxes
+    _set_error_mode(_OUT_TO_STDERR);
     _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
-    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
     _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
 #endif
 
     ::testing::InitGoogleTest(&argc, argv);
     VkTestFramework::InitArgs(&argc, argv);
 
     ::testing::AddGlobalTestEnvironment(new TestEnvironment);
+    ::testing::UnitTest::GetInstance()->listeners().Append(new ThrowListener);
 
     result = RUN_ALL_TESTS();
 


### PR DESCRIPTION
This change adds a TestEventListener which causes failed assertions to
throw, forcing a test to end early rather than continuing on. This is
beneficial due to making any assertions inside of constructors and
subroutines cause the test to stop execution rather than continue.

For example, if the test framework fails to create a device, subsequent
code is going to hard crash, potentially halting execution or worse
causing subsequent tests to fail in unpredictable ways. While it is
possible to halt execution with ASSERT_NO_FATAL_FAILURE in most cases,
it requires all tests to be rewritten using it, and doesn't work where
the failed assertion is inside of a constructor.

The tests on android use the android_main function to execute. Thus
we can platform-guard main to only exist on not-android. This is
helpful if there are constructs that can be used in not-android but
would cause compilation failure if they appeared anywhere in the
source, like exceptions.