### PR TITLE
Fix WIN32 CI

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -25,7 +25,10 @@
             "sub_dir": "SPIRV-Headers",
             "build_dir": "SPIRV-Headers/build",
             "install_dir": "SPIRV-Headers/build/install",
-            "commit": "d13b52222c39a7e9a401b44646f0ca3a640fbd47"
+            "commit": "d13b52222c39a7e9a401b44646f0ca3a640fbd47",
+            "cmake_options": [
+                "-D SPIRV_HEADERS_SKIP_EXAMPLES=ON"
+            ]
         },
         {
             "name": "SPIRV-Tools",

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -457,10 +457,8 @@ class GoodRepo(object):
         for option in self.cmake_options:
             cmake_cmd.append(escape(option.format(**self.__dict__)))
 
-        # Set build config for single-configuration generators
-        if platform.system() == 'Linux' or platform.system() == 'Darwin':
-            cmake_cmd.append('-DCMAKE_BUILD_TYPE={config}'.format(
-                config=CONFIG_MAP[self._args.config]))
+        # Set build config for single-configuration generators (this is a no-op on multi-config generators)
+        cmake_cmd.append(f'-D CMAKE_BUILD_TYPE={CONFIG_MAP[self._args.config]}')
 
         # Use the CMake -A option to select the platform architecture
         # without needing a Visual Studio generator.


### PR DESCRIPTION
`update_deps.py` wouldn't specify `CMAKE_BUILD_TYPE` on Windows builds. Which breaks the new CI process, which uses Ninja for both Linux/Windows.

The fix is simple.

I made a change to `known_good.json` to ensure the ci cache is flushed, and it helps perf a little bit.
