### PR TITLE
ci: Install Release loader/profiles/mockicd

### DIFF
--- a/scripts/github_ci_build_desktop.py
+++ b/scripts/github_ci_build_desktop.py
@@ -29,9 +29,11 @@ def main():
     parser = common_ci.GetArgParser()
     args = parser.parse_args()
 
+    config = args.configuration
+
     try:
-        common_ci.BuildVVL(args)
-        common_ci.CheckVVLCodegenConsistency(args)
+        common_ci.BuildVVL(config = config, cmake_args = args.cmake, build_tests = "OFF")
+        common_ci.CheckVVLCodegenConsistency(config = config)
 
     except subprocess.CalledProcessError as proc_error:
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))

--- a/scripts/github_ci_win_linux.py
+++ b/scripts/github_ci_win_linux.py
@@ -26,12 +26,14 @@ import common_ci
 #
 # Module Entrypoint
 def Build(args):
+    config = args.configuration
+
     try:
-        common_ci.BuildVVL(args, "ON")
-        common_ci.BuildLoader(args)
-        common_ci.BuildProfileLayer(args)
-        common_ci.BuildMockICD(args)
-        common_ci.CheckVVLCodegenConsistency(args)
+        common_ci.BuildVVL(config = config, cmake_args = args.cmake, build_tests = "ON")
+        common_ci.BuildLoader()
+        common_ci.BuildProfileLayer()
+        common_ci.BuildMockICD()
+        common_ci.CheckVVLCodegenConsistency(config = config)
 
     except subprocess.CalledProcessError as proc_error:
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))
@@ -43,8 +45,10 @@ def Build(args):
     sys.exit(0)
 
 def Test(args):
+    config = args.configuration
+
     try:
-        common_ci.RunVVLTests(args)
+        common_ci.RunVVLTests(config = config)
 
     except subprocess.CalledProcessError as proc_error:
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))


### PR DESCRIPTION
Have common_ci.py build/install release configs of the loader, profiles layer, and mock driver.

Installing them in 1 location simplifies the RunVVLTests function. Since all the shared libraries are all in 1 location.