### PR TITLE
android: Update BUILD.md for manual library installation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -391,6 +391,13 @@ demo APKs can be installed on production devices with:
 
     ./install_all.sh [-s <serial number>]
 
+> **NOTE:** Manual installation of Android layer libraries on development devices will require modifying [build-android/jni/Application.mk](build-android/jni/Application.mk) to use `libc++_static.so` instead of `libc++_shared.so`, like so:
+```patch
+-APP_STL := c++_shared
++APP_STL := c++_static
+```
+
+
 Note that there are no equivalent scripts on Windows yet, that work needs to
 be completed. The following per platform commands can be used for layer only
 builds:


### PR DESCRIPTION
It is not possible to manually copy/install layer libraries on a development device if they are built with c++_shared. As this remains common practice, added a note to enable installing layer binaries without using an APK.

Change-Id: I4e315204afd1541a4eb50e73784a0958725b46f1