### PR TITLE
Fix issues related to pipeline library sub state and shader module identifiers

### DIFF
--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -253,6 +253,15 @@ class PIPELINE_STATE : public BASE_NODE {
 
     bool IsGraphicsLibrary() const { return !HasFullState(); }
     bool HasFullState() const {
+        // First make sure that this pipeline is a "classic" pipeline, or is linked together with the appropriate sub-state
+        // libraries
+        if (graphics_lib_type && (graphics_lib_type != (VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT |
+                                                        VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT |
+                                                        VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT |
+                                                        VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT))) {
+            return false;
+        }
+
         // If Pre-raster state does contain a vertex shader, vertex input state is not required
         const bool vi_satisfied = [this]() -> bool {
             if (pre_raster_state && pre_raster_state->vertex_shader) {

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -77,9 +77,14 @@ PreRasterState::PreRasterState(const PIPELINE_STATE &p, const ValidationStateTra
                 }
             }
 
-            // TODO (ncesario) Need to check if a shader module identifier is used to reference the shader module.
-            //                 This requires adding identifier -> module state tracking similar to buffer device
-            //                 address.
+            // Check if a shader module identifier is used to reference the shader module.
+            if (!module_state) {
+                if (const auto shader_stage_id =
+                        LvlFindInChain<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>(create_info.pStages[i].pNext);
+                    shader_stage_id) {
+                    module_state = dev_data.GetShaderModuleStateFromIdentifier(*shader_stage_id);
+                }
+            }
 
             if (module_state) {
                 const auto *stage_ci = &create_info.pStages[i];
@@ -165,6 +170,15 @@ void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const Validatio
                 if (shader_ci) {
                     const uint32_t unique_shader_id = 0;  // TODO GPU-AV rework required to get this value properly
                     module_state = state_data.CreateShaderModuleState(*shader_ci, unique_shader_id);
+                }
+            }
+
+            // Check if a shader module identifier is used to reference the shader module.
+            if (!module_state) {
+                if (const auto shader_stage_id =
+                        LvlFindInChain<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>(create_info.pStages[i].pNext);
+                    shader_stage_id) {
+                    module_state = state_data.GetShaderModuleStateFromIdentifier(*shader_stage_id);
                 }
             }
 

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -77,6 +77,10 @@ PreRasterState::PreRasterState(const PIPELINE_STATE &p, const ValidationStateTra
                 }
             }
 
+            // TODO (ncesario) Need to check if a shader module identifier is used to reference the shader module.
+            //                 This requires adding identifier -> module state tracking similar to buffer device
+            //                 address.
+
             if (module_state) {
                 const auto *stage_ci = &create_info.pStages[i];
                 switch (create_info.pStages[i].stage) {

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5602,6 +5602,21 @@ void ValidationStateTracker::RecordGetBufferDeviceAddress(const VkBufferDeviceAd
     }
 }
 
+void ValidationStateTracker::PostCallRecordGetShaderModuleIdentifierEXT(VkDevice, const VkShaderModule shaderModule,
+                                                                        VkShaderModuleIdentifierEXT *pIdentifier) {
+    if (const auto shader_state = Get<SHADER_MODULE_STATE>(shaderModule); shader_state) {
+        WriteLockGuard guard(shader_identifier_map_lock_);
+        shader_identifier_map_.emplace(*pIdentifier, std::move(shader_state));
+    }
+}
+
+void ValidationStateTracker::PostCallRecordGetShaderModuleCreateInfoIdentifierEXT(VkDevice,
+                                                                                  const VkShaderModuleCreateInfo *pCreateInfo,
+                                                                                  VkShaderModuleIdentifierEXT *pIdentifier) {
+    WriteLockGuard guard(shader_identifier_map_lock_);
+    shader_identifier_map_.emplace(*pIdentifier, CreateShaderModuleState(*pCreateInfo, 0, VK_NULL_HANDLE));
+}
+
 void ValidationStateTracker::PostCallRecordGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfo *pInfo,
                                                                   VkDeviceAddress address) {
     RecordGetBufferDeviceAddress(pInfo, address);

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1455,6 +1455,29 @@ class ValidationStateTracker : public ValidationObject {
         }
     }
 
+    inline std::shared_ptr<SHADER_MODULE_STATE> GetShaderModuleStateFromIdentifier(const VkShaderModuleIdentifierEXT& ident) {
+        ReadLockGuard guard(shader_identifier_map_lock_);
+        if (const auto itr = shader_identifier_map_.find(ident); itr != shader_identifier_map_.cend()) {
+            return itr->second;
+        }
+        return {};
+    }
+
+    inline std::shared_ptr<SHADER_MODULE_STATE> GetShaderModuleStateFromIdentifier(
+        const VkPipelineShaderStageModuleIdentifierCreateInfoEXT& shader_stage_id) const {
+        if (shader_stage_id.pIdentifier) {
+            auto shader_id = LvlInitStruct<VkShaderModuleIdentifierEXT>();
+            shader_id.identifierSize = shader_stage_id.identifierSize;
+            const uint32_t copy_size = std::min(VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT, shader_stage_id.identifierSize);
+            std::copy(shader_stage_id.pIdentifier, shader_stage_id.pIdentifier + copy_size, shader_id.identifier);
+            ReadLockGuard guard(shader_identifier_map_lock_);
+            if (const auto itr = shader_identifier_map_.find(shader_id); itr != shader_identifier_map_.cend()) {
+                return itr->second;
+            }
+        }
+        return {};
+    }
+
     // Link to the device's physical-device data
     PHYSICAL_DEVICE_STATE* physical_device_state;
 

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1421,6 +1421,12 @@ class ValidationStateTracker : public ValidationObject {
                                                  VkDeviceAddress address) override;
     void PostCallRecordGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                  VkDeviceAddress address) override;
+
+    void PostCallRecordGetShaderModuleIdentifierEXT(VkDevice device, VkShaderModule shaderModule,
+                                                    VkShaderModuleIdentifierEXT* pIdentifier) override;
+    void PostCallRecordGetShaderModuleCreateInfoIdentifierEXT(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
+                                                              VkShaderModuleIdentifierEXT* pIdentifier) override;
+
     template <typename ExtProp>
     void GetPhysicalDeviceExtProperties(VkPhysicalDevice gpu, ExtEnabled enabled, ExtProp* ext_prop) {
         assert(ext_prop);
@@ -1545,6 +1551,10 @@ class ValidationStateTracker : public ValidationObject {
     std::atomic<VkDeviceSize> descriptorBufferAddressSpaceSize = {0u};
     std::atomic<VkDeviceSize> resourceDescriptorBufferAddressSpaceSize = {0u};
     std::atomic<VkDeviceSize> samplerDescriptorBufferAddressSpaceSize = {0u};
+
+    // Keep track of identifier -> state
+    vvl::unordered_map<VkShaderModuleIdentifierEXT, std::shared_ptr<SHADER_MODULE_STATE>> shader_identifier_map_;
+    mutable std::shared_mutex shader_identifier_map_lock_;
 
   private:
     VALSTATETRACK_MAP_AND_TRAITS(VkQueue, QUEUE_STATE, queue_map_)

--- a/layers/utils/hash_vk_types.h
+++ b/layers/utils/hash_vk_types.h
@@ -108,3 +108,23 @@ struct hash<const ExtEnabled DeviceExtensions::*> {
     }
 };
 }  // namespace std
+
+static inline bool operator==(const VkShaderModuleIdentifierEXT &a, const VkShaderModuleIdentifierEXT &b) {
+    if (a.identifierSize != b.identifierSize) {
+        return false;
+    }
+    for (uint32_t i = 0u; i < a.identifierSize; ++i) {
+        if (a.identifier[i] != b.identifier[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+namespace std {
+template <>
+struct hash<VkShaderModuleIdentifierEXT> {
+    size_t operator()(const VkShaderModuleIdentifierEXT &value) const {
+        return hash_util::HashCombiner().Combine(value.identifier, value.identifier + value.identifierSize).Value();
+    }
+};
+}  // namespace std

--- a/layers/utils/hash_vk_types.h
+++ b/layers/utils/hash_vk_types.h
@@ -113,7 +113,8 @@ static inline bool operator==(const VkShaderModuleIdentifierEXT &a, const VkShad
     if (a.identifierSize != b.identifierSize) {
         return false;
     }
-    for (uint32_t i = 0u; i < a.identifierSize; ++i) {
+    const uint32_t copy_size = std::min(VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT, a.identifierSize);
+    for (uint32_t i = 0u; i < copy_size; ++i) {
         if (a.identifier[i] != b.identifier[i]) {
             return false;
         }

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -54,7 +54,7 @@ if (UPDATE_DEPS)
     endif()
 
     set(_update_deps_dir ${VVL_SOURCE_DIR}/external/${_build_type})
-    if (UPDATE_DEPS_DIR AND EXISTS "${UPDATE_DEPS_DIR}")
+    if (UPDATE_DEPS_DIR)
         set(_update_deps_dir ${UPDATE_DEPS_DIR})
     endif()
     set(_helper_file "${_update_deps_dir}/helper.cmake")

--- a/tests/negative/ray_tracing.cpp
+++ b/tests/negative/ray_tracing.cpp
@@ -616,7 +616,7 @@ TEST_F(VkLayerTest, RayTracingTestWriteAccelerationStructureMemory) {
     vkBuildAccelerationStructuresKHR(device(), VK_NULL_HANDLE, 1, &build_info_khr, &pBuildRangeInfos);
     m_errorMonitor->VerifyFound();
 
-    std::vector<uint32_t> data(buffer.create_info().size);
+    std::vector<uint32_t> data(static_cast<size_t>(buffer.create_info().size));
     VkAccelerationStructureKHR acceleration_structure_handle = acceleration_structure.handle();
     // .dstAccelerationStructure buffer is not bound to host visible memory
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkWriteAccelerationStructuresPropertiesKHR-buffer-03733");

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -6305,3 +6305,106 @@ TEST_F(VkPositiveLayerTest, DISABLED_GraphicsPipelineStageCreationFeedbackCount0
 
     CreatePipelineHelper::OneshotTest(*this, set_feedback, kErrorBit);
 }
+
+TEST_F(VkPositiveLayerTest, ShaderModuleIdentifierGPL) {
+    TEST_DESCRIPTION("Create pipeline sub-state that references shader module identifiers");
+    AddRequiredExtensions(VK_EXT_SHADER_MODULE_IDENTIFIER_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    auto gpl_features = LvlInitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>();
+    auto pipeline_cache_control_features = LvlInitStruct<VkPhysicalDevicePipelineCreationCacheControlFeatures>(&gpl_features);
+    auto shader_module_id_features =
+        LvlInitStruct<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(&pipeline_cache_control_features);
+    GetPhysicalDeviceFeatures2(shader_module_id_features);
+
+    if (!gpl_features.graphicsPipelineLibrary) {
+        GTEST_SKIP() << "graphicsPipelineLibrary feature not supported";
+    }
+    if (!shader_module_id_features.shaderModuleIdentifier) {
+        GTEST_SKIP() << "shaderModuleIdentifier feature not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &shader_module_id_features));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    // Create a pre-raster pipeline referencing a VS via identifier, with the VS identifier queried from a shader module
+    VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
+    ASSERT_TRUE(vs.initialized());
+
+    auto vkGetShaderModuleIdentifierEXT = reinterpret_cast<PFN_vkGetShaderModuleIdentifierEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetShaderModuleIdentifierEXT"));
+    ASSERT_NE(vkGetShaderModuleIdentifierEXT, nullptr);
+
+    auto vs_identifier = LvlInitStruct<VkShaderModuleIdentifierEXT>();
+    vkGetShaderModuleIdentifierEXT(device(), vs.handle(), &vs_identifier);
+
+    auto sm_id_create_info = LvlInitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
+    sm_id_create_info.identifierSize = vs_identifier.identifierSize;
+    sm_id_create_info.pIdentifier = vs_identifier.identifier;
+
+    auto stage_ci = LvlInitStruct<VkPipelineShaderStageCreateInfo>(&sm_id_create_info);
+    stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
+    stage_ci.module = VK_NULL_HANDLE;
+    stage_ci.pName = "main";
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitPreRasterLibInfo(1, &stage_ci);
+    pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+    pipe.InitState();
+    ASSERT_VK_SUCCESS(pipe.CreateGraphicsPipeline());
+
+    // Create a fragment shader library with FS referencing an identifier queried from VkShaderModuleCreateInfo
+    const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, bindStateFragShaderText);
+    auto fs_ci = LvlInitStruct<VkShaderModuleCreateInfo>();
+    fs_ci.codeSize = fs_spv.size() * sizeof(decltype(fs_spv)::value_type);
+    fs_ci.pCode = fs_spv.data();
+
+    auto vkGetShaderModuleCreateInfoIdentifierEXT = reinterpret_cast<PFN_vkGetShaderModuleCreateInfoIdentifierEXT>(
+        vk::GetDeviceProcAddr(m_device->device(), "vkGetShaderModuleCreateInfoIdentifierEXT"));
+    ASSERT_NE(vkGetShaderModuleCreateInfoIdentifierEXT, nullptr);
+
+    auto fs_identifier = LvlInitStruct<VkShaderModuleIdentifierEXT>();
+    vkGetShaderModuleCreateInfoIdentifierEXT(device(), &fs_ci, &fs_identifier);
+
+    sm_id_create_info.identifierSize = fs_identifier.identifierSize;
+    sm_id_create_info.pIdentifier = fs_identifier.identifier;
+
+    auto fs_stage_ci = LvlInitStruct<VkPipelineShaderStageCreateInfo>(&sm_id_create_info);
+    fs_stage_ci.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    fs_stage_ci.module = VK_NULL_HANDLE;
+    fs_stage_ci.pName = "main";
+
+    CreatePipelineHelper fs_pipe(*this);
+    fs_pipe.InitFragmentLibInfo(1, &fs_stage_ci);
+    fs_pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+    fs_pipe.gp_ci_.layout = pipe.gp_ci_.layout;
+    fs_pipe.InitState();
+    ASSERT_VK_SUCCESS(fs_pipe.CreateGraphicsPipeline(true, false));
+
+    // Create a complete pipeline with the above pre-raster fs libraries
+    CreatePipelineHelper vi_pipe(*this);
+    vi_pipe.InitVertexInputLibInfo();
+    vi_pipe.CreateGraphicsPipeline();
+
+    CreatePipelineHelper fo_pipe(*this);
+    fo_pipe.InitFragmentOutputLibInfo();
+    fo_pipe.CreateGraphicsPipeline();
+
+    VkPipeline libraries[4] = {
+        vi_pipe.pipeline_,
+        pipe.pipeline_,
+        fs_pipe.pipeline_,
+        fo_pipe.pipeline_,
+    };
+    auto link_info = LvlInitStruct<VkPipelineLibraryCreateInfoKHR>();
+    link_info.libraryCount = size(libraries);
+    link_info.pLibraries = libraries;
+
+    auto pipe_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    pipe_ci.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+    vk_testing::Pipeline exe_pipe(*m_device, pipe_ci);
+}


### PR DESCRIPTION
This PR does the following:
- `layers: Fix HasFullState`: Fixes issues where HasFullState() was incorrectly returning true
- `layers: Add shader identifier tracking`, `layers: User shader identifiers`: Adds state tracking for associating shader identifiers with shader state objects