### PR TITLE
Move more logic to Shader Module creation time

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -1343,16 +1343,13 @@ bool BestPractices::PreCallValidateCreateComputePipelines(VkDevice device, VkPip
 
         if (IsExtEnabled(device_extensions.vk_khr_maintenance4)) {
             auto module_state = Get<SHADER_MODULE_STATE>(createInfo.stage.module);
-            if (module_state) {  // No module if creating from module identifier
-                for (const Instruction* inst : module_state->GetBuiltinDecorationList()) {
-                    if (inst->GetBuiltIn() == spv::BuiltInWorkgroupSize) {
-                        skip |= LogWarning(device, kVUID_BestPractices_SpirvDeprecated_WorkgroupSize,
-                                           "vkCreateComputePipelines(): pCreateInfos[ %" PRIu32
-                                           "] is using the Workgroup built-in which SPIR-V 1.6 deprecated. The VK_KHR_maintenance4 "
-                                           "extension exposes a new LocalSizeId execution mode that should be used instead.",
-                                           i);
-                    }
-                }
+            if (module_state &&
+                module_state->static_data_.has_builtin_workgroup_size) {  // No module if creating from module identifier
+                skip |= LogWarning(device, kVUID_BestPractices_SpirvDeprecated_WorkgroupSize,
+                                   "vkCreateComputePipelines(): pCreateInfos[ %" PRIu32
+                                   "] is using the Workgroup built-in which SPIR-V 1.6 deprecated. The VK_KHR_maintenance4 "
+                                   "extension exposes a new LocalSizeId execution mode that should be used instead.",
+                                   i);
             }
         }
     }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -842,9 +842,9 @@ class CoreChecks : public ValidationStateTracker {
                                            const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule) const override;
     bool ValidatePipelineShaderStage(const PIPELINE_STATE& pipeline, const PipelineStageState& stage_state) const;
     bool ValidatePointSizeShaderState(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
-                                      const Instruction& entrypoint, VkShaderStageFlagBits stage) const;
+                                      const SHADER_MODULE_STATE::EntryPoint& entrypoint, VkShaderStageFlagBits stage) const;
     bool ValidatePrimitiveRateShaderState(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
-                                          const Instruction& entrypoint, VkShaderStageFlagBits stage) const;
+                                          const SHADER_MODULE_STATE::EntryPoint& entrypoint, VkShaderStageFlagBits stage) const;
     bool ValidateTexelOffsetLimits(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
 
     // Auto-generated helper functions

--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -2976,7 +2976,7 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE &
 
             if (pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass == VK_NULL_HANDLE && raster_state) {
                 for (const auto &stage : pipeline.stage_states) {
-                    if (stage.writes_to_gl_layer) {
+                    if (stage.module_state.static_data_.has_builtin_layer) {
                         skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06059",
                                          "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
                                          "] is being created with fragment shader state and renderPass != VK_NULL_HANDLE, but "

--- a/layers/core_checks/pipeline_validation.cpp
+++ b/layers/core_checks/pipeline_validation.cpp
@@ -2976,7 +2976,7 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE &
 
             if (pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass == VK_NULL_HANDLE && raster_state) {
                 for (const auto &stage : pipeline.stage_states) {
-                    if (stage.module_state.static_data_.has_builtin_layer) {
+                    if (stage.module_state->static_data_.has_builtin_layer) {
                         skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06059",
                                          "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
                                          "] is being created with fragment shader state and renderPass != VK_NULL_HANDLE, but "

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -302,7 +302,7 @@ bool CoreChecks::ValidateConservativeRasterization(const SHADER_MODULE_STATE &mo
     bool fully_covered = false;
     for (uint32_t id : FindEntrypointInterfaces(entrypoint)) {
         const Instruction *insn = module_state.FindDef(id);
-        const DecorationSet decorations = module_state.GetDecorationSet(insn->Word(2));
+        const auto decorations = module_state.GetDecorationSet(insn->Word(2));
         if (decorations.Has(DecorationSet::builtin_bit) && (decorations.builtin == spv::BuiltInFullyCoveredEXT)) {
             fully_covered = true;
             break;
@@ -519,7 +519,7 @@ bool CoreChecks::ValidateBuiltinLimits(const SHADER_MODULE_STATE &module_state, 
     for (uint32_t id : FindEntrypointInterfaces(entrypoint)) {
         const Instruction *insn = module_state.FindDef(id);
         assert(insn->Opcode() == spv::OpVariable);
-        const DecorationSet decorations = module_state.GetDecorationSet(insn->Word(2));
+        const auto decorations = module_state.GetDecorationSet(insn->Word(2));
 
         // Currently don't need to search in structs
         if (decorations.Has(DecorationSet::builtin_bit) && (decorations.builtin == spv::BuiltInSampleMask)) {
@@ -1216,7 +1216,7 @@ bool CoreChecks::ValidateShaderStorageImageFormatsVariables(const SHADER_MODULE_
         }
 
         const uint32_t var_id = insn->Word(2);
-        DecorationSet decorations = module_state.GetDecorationSet(var_id);
+        const auto decorations = module_state.GetDecorationSet(var_id);
 
         if (!enabled_features.core.shaderStorageImageReadWithoutFormat && !decorations.Has(DecorationSet::nonreadable_bit)) {
             skip |= LogError(module_state.vk_shader_module(), "VUID-RuntimeSpirv-OpTypeImage-06270",

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -105,7 +105,7 @@ bool CoreChecks::ValidateViAgainstVsInputs(const PIPELINE_STATE &pipeline, const
                                            const Instruction &entrypoint) const {
     bool skip = false;
     safe_VkPipelineVertexInputStateCreateInfo const *vi = pipeline.vertex_input_state->input_state;
-    const auto inputs = module_state.CollectInterfaceByLocation(entrypoint, spv::StorageClassInput, false);
+    const auto inputs = module_state.CollectInterfaceByLocation(entrypoint, spv::StorageClassInput);
 
     // Build index by location
     std::map<uint32_t, const VkVertexInputAttributeDescription *> attribs;
@@ -172,7 +172,7 @@ bool CoreChecks::ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER
     std::map<uint32_t, Attachment> location_map;
 
     // TODO: dual source blend index (spv::DecIndex, zero if not provided)
-    const auto outputs = module_state.CollectInterfaceByLocation(entrypoint, spv::StorageClassOutput, false);
+    const auto outputs = module_state.CollectInterfaceByLocation(entrypoint, spv::StorageClassOutput);
     for (const auto &output_it : outputs) {
         auto const location = output_it.first.first;
         location_map[location].output = &output_it.second;
@@ -348,7 +348,7 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE &m
 
     // TODO: dual source blend index (spv::DecIndex, zero if not provided)
 
-    const auto outputs = module_state.CollectInterfaceByLocation(entrypoint, spv::StorageClassOutput, false);
+    const auto outputs = module_state.CollectInterfaceByLocation(entrypoint, spv::StorageClassOutput);
     for (const auto &output_it : outputs) {
         auto const location = output_it.first.first;
         location_map[location].output = &output_it.second;
@@ -913,8 +913,8 @@ bool CoreChecks::ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE 
     uint32_t max_comp_in = 0;
     uint32_t max_comp_out = 0;
 
-    auto inputs = module_state.CollectInterfaceByLocation(entrypoint, spv::StorageClassInput, strip_input_array_level);
-    auto outputs = module_state.CollectInterfaceByLocation(entrypoint, spv::StorageClassOutput, strip_output_array_level);
+    auto inputs = module_state.CollectInterfaceByLocation(entrypoint, spv::StorageClassInput);
+    auto outputs = module_state.CollectInterfaceByLocation(entrypoint, spv::StorageClassOutput);
 
     // Find max component location used for input variables.
     for (auto &var : inputs) {
@@ -3310,12 +3310,8 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE &produ
                                                 uint32_t pipe_index) const {
     bool skip = false;
 
-    const bool arrayed_output = producer_stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
-    const bool arrayed_input = (consumer_stage & (VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT |
-                                                  VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT)) != 0;
-
-    auto outputs = producer.CollectInterfaceByLocation(producer_entrypoint, spv::StorageClassOutput, arrayed_output);
-    auto inputs = consumer.CollectInterfaceByLocation(consumer_entrypoint, spv::StorageClassInput, arrayed_input);
+    auto outputs = producer.CollectInterfaceByLocation(producer_entrypoint, spv::StorageClassOutput);
+    auto inputs = consumer.CollectInterfaceByLocation(consumer_entrypoint, spv::StorageClassInput);
 
     auto output_it = outputs.begin();
     auto input_it = inputs.begin();

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -41,10 +41,7 @@ static bool WrotePrimitiveShadingRate(VkShaderStageFlagBits stage_flag, const In
 PipelineStageState::PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
                                        std::shared_ptr<const SHADER_MODULE_STATE> &module_state,
                                        const SHADER_MODULE_STATE::EntryPoint *entrypoint)
-    : module_state(module_state),
-      create_info(create_info),
-      entrypoint(entrypoint),
-      writes_to_gl_layer(module_state->WritesToGlLayer()) {
+    : module_state(module_state), create_info(create_info), entrypoint(entrypoint) {
     if (entrypoint) {
         descriptor_variables = module_state->GetResourceInterfaceVariable((*entrypoint).entrypoint_insn);
         wrote_primitive_shading_rate =

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -21,31 +21,12 @@
 #include "state_tracker/cmd_buffer_state.h"
 #include "enum_flag_bits.h"
 
-static bool WrotePrimitiveShadingRate(VkShaderStageFlagBits stage_flag, const Instruction &entrypoint,
-                                      const SHADER_MODULE_STATE *module_state) {
-    bool primitive_rate_written = false;
-    if (stage_flag == VK_SHADER_STAGE_VERTEX_BIT || stage_flag == VK_SHADER_STAGE_GEOMETRY_BIT ||
-        stage_flag == VK_SHADER_STAGE_MESH_BIT_EXT) {
-        for (const Instruction *inst : module_state->GetBuiltinDecorationList()) {
-            if (inst->GetBuiltIn() == spv::BuiltInPrimitiveShadingRateKHR) {
-                primitive_rate_written = module_state->IsBuiltInWritten(inst, entrypoint);
-            }
-            if (primitive_rate_written) {
-                break;
-            }
-        }
-    }
-    return primitive_rate_written;
-}
-
 PipelineStageState::PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
                                        std::shared_ptr<const SHADER_MODULE_STATE> &module_state,
                                        const SHADER_MODULE_STATE::EntryPoint *entrypoint)
     : module_state(module_state), create_info(create_info), entrypoint(entrypoint) {
     if (entrypoint) {
         descriptor_variables = module_state->GetResourceInterfaceVariable((*entrypoint).entrypoint_insn);
-        wrote_primitive_shading_rate =
-            WrotePrimitiveShadingRate(create_info->stage, (*entrypoint).entrypoint_insn, module_state.get());
     }
 }
 

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -100,7 +100,6 @@ struct PipelineStageState {
     const SHADER_MODULE_STATE::EntryPoint *entrypoint;
     const std::vector<ResourceInterfaceVariable> *descriptor_variables = {};
     bool wrote_primitive_shading_rate;
-    bool writes_to_gl_layer;
 
     PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
                        std::shared_ptr<const SHADER_MODULE_STATE> &module_state, const SHADER_MODULE_STATE::EntryPoint *entrypoint);

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -99,7 +99,6 @@ struct PipelineStageState {
     const safe_VkPipelineShaderStageCreateInfo *create_info;
     const SHADER_MODULE_STATE::EntryPoint *entrypoint;
     const std::vector<ResourceInterfaceVariable> *descriptor_variables = {};
-    bool wrote_primitive_shading_rate;
 
     PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
                        std::shared_ptr<const SHADER_MODULE_STATE> &module_state, const SHADER_MODULE_STATE::EntryPoint *entrypoint);

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -336,6 +336,8 @@ SHADER_MODULE_STATE::StaticData::StaticData(const SHADER_MODULE_STATE& module_st
                 decoration_inst.push_back(&insn);
                 if (insn.Word(2) == spv::DecorationBuiltIn) {
                     builtin_decoration_inst.push_back(&insn);
+                    has_builtin_layer |= (insn.Word(3) == spv::BuiltInLayer);
+                    has_builtin_workgroup_size |= (insn.Word(3) == spv::BuiltInWorkgroupSize);
                 } else if (insn.Word(2) == spv::DecorationSpecId) {
                     spec_const_map[insn.Word(3)] = target_id;
                 }

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -771,7 +771,7 @@ uint32_t SHADER_MODULE_STATE::GetComponentsConsumedByType(uint32_t type, bool st
             return sum;
         }
         case spv::OpTypeArray: {
-            uint32_t locations = GetComponentsConsumedByType(insn->Word(2), false);
+            uint32_t components = GetComponentsConsumedByType(insn->Word(2), false);
             if (!strip_array_level) {
                 components *= GetConstantValueById(insn->Word(3));
             }
@@ -1397,7 +1397,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const SHADER_MODULE_STATE& 
                         sampler_id = const_def->Word(const_def->ResultId());
                         sampler_index = const_def->GetConstantValue();
                     }
-                    auto sampler_dec = module_state.GetDecorationSet(sampler_id);
+                    const auto sampler_dec = module_state.GetDecorationSet(sampler_id);
                     if (image_index >= samplers_used_by_image.size()) {
                         samplers_used_by_image.resize(image_index + 1);
                     }

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -258,6 +258,10 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         vvl::unordered_map<uint32_t, std::vector<const Instruction *>> execution_mode_inst;
         // both OpDecorate and OpMemberDecorate builtin instructions
         std::vector<const Instruction *> builtin_decoration_inst;
+        // BuiltIn we just care about existing or not, don't have to be written to
+        bool has_builtin_layer{false};
+        bool has_builtin_workgroup_size{false};
+
         std::vector<const Instruction *> atomic_inst;
         std::vector<spv::Capability> capability_list;
 
@@ -395,11 +399,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     const Instruction *GetBaseTypeInstruction(uint32_t type) const;
     uint32_t GetTypeId(uint32_t id) const;
     uint32_t GetTexelComponentCount(const Instruction &insn) const;
-
-    bool WritesToGlLayer() const {
-        return std::any_of(static_data_.builtin_decoration_inst.begin(), static_data_.builtin_decoration_inst.end(),
-                           [](const Instruction *insn) { return insn->GetBuiltIn() == spv::BuiltInLayer; });
-    }
 
     bool HasCapability(spv::Capability find_capability) const {
         return std::any_of(static_data_.capability_list.begin(), static_data_.capability_list.end(),

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -217,6 +217,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         // There is no single unique item for a single entry point
         const Instruction &entrypoint_insn;  // OpEntryPoint instruction
         const VkShaderStageFlagBits stage;
+        const uint32_t id;
         const std::string name;
         // All ids that can be accessed from the entry point
         vvl::unordered_set<uint32_t> accessible_ids;
@@ -225,6 +226,12 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         std::vector<ResourceInterfaceVariable> resource_interface_variables;
 
         StructInfo push_constant_used_in_shader;
+
+        // Mark if a BuiltIn is written to
+        bool written_builtin_point_size{false};
+        bool written_builtin_primitive_shading_rate_khr{false};
+        bool written_builtin_viewport_index{false};
+        bool written_builtin_viewport_mask_nv{false};
 
         EntryPoint(const SHADER_MODULE_STATE &module_state, const Instruction &entrypoint);
     };
@@ -261,6 +268,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         // BuiltIn we just care about existing or not, don't have to be written to
         bool has_builtin_layer{false};
         bool has_builtin_workgroup_size{false};
+        uint32_t builtin_workgroup_size_id = 0;
 
         std::vector<const Instruction *> atomic_inst;
         std::vector<spv::Capability> capability_list;
@@ -325,7 +333,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     const std::vector<Instruction> &GetInstructions() const { return static_data_.instructions; }
     const std::vector<const Instruction *> &GetDecorationInstructions() const { return static_data_.decoration_inst; }
-    const std::vector<const Instruction *> &GetMemberDecorationInstructions() const { return static_data_.member_decoration_inst; }
     const std::vector<const Instruction *> &GetAtomicInstructions() const { return static_data_.atomic_inst; }
     const std::vector<const Instruction *> &GetVariableInstructions() const { return static_data_.variable_inst; }
     const std::vector<ResourceInterfaceVariable> *GetResourceInterfaceVariable(const Instruction &entrypoint) const {
@@ -418,8 +425,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     // point functions and which offset in the structs are used
     uint32_t UpdateOffset(uint32_t offset, const std::vector<uint32_t> &array_indices, const StructInfo &data) const;
     void SetUsedBytes(uint32_t offset, const std::vector<uint32_t> &array_indices, const StructInfo &data) const;
-    void DefineStructMember(const Instruction *insn, std::vector<const Instruction *> &member_decorate_insn,
-                            StructInfo &data) const;
+    void DefineStructMember(const Instruction *insn, StructInfo &data) const;
     void RunUsedArray(uint32_t offset, std::vector<uint32_t> array_indices, uint32_t access_chain_word_index,
                       const Instruction *access_chain, const StructInfo &data) const;
     void RunUsedStruct(uint32_t offset, uint32_t access_chain_word_index, const Instruction *access_chain,

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -98,7 +98,7 @@ struct ResourceInterfaceVariable {
     spv::StorageClass storage_class;
 
     VkShaderStageFlagBits stage;
-    DecorationSet decorations;
+    const DecorationSet &decorations;
 
     // If the type is a OpTypeArray save the length
     uint32_t array_length = 0;
@@ -245,6 +245,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         vvl::unordered_map<uint32_t, const Instruction *> definitions;
 
         vvl::unordered_map<uint32_t, DecorationSet> decorations;
+        DecorationSet empty_decoration;  // all zero values, allows use to return a reference and not a copy each time
         // <Specialization constant ID -> target ID> mapping
         vvl::unordered_map<uint32_t, uint32_t> spec_const_map;
         // Find all decoration instructions to prevent relooping module later - many checks need this info
@@ -350,11 +351,10 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     VkShaderModule vk_shader_module() const { return handle_.Cast<VkShaderModule>(); }
 
-    DecorationSet GetDecorationSet(uint32_t id) const {
-        // return the actual decorations for this id, or a default set.
-        auto it = static_data_.decorations.find(id);
-        if (it != static_data_.decorations.end()) return it->second;
-        return DecorationSet();
+    const DecorationSet &GetDecorationSet(uint32_t id) const {
+        // return the actual decorations for this id, or a default empty set.
+        const auto it = static_data_.decorations.find(id);
+        return (it != static_data_.decorations.end()) ? it->second : static_data_.empty_decoration;
     }
 
     // Used to get human readable strings for error messages

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -385,8 +385,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     bool CollectInterfaceBlockMembers(std::map<location_t, UserDefinedInterfaceVariable> *out, bool is_array_of_verts,
                                       bool is_patch, const Instruction *variable_insn) const;
     std::map<location_t, UserDefinedInterfaceVariable> CollectInterfaceByLocation(const Instruction &entrypoint,
-                                                                                  spv::StorageClass sinterface,
-                                                                                  bool is_array_of_verts) const;
+                                                                                  spv::StorageClass sinterface) const;
     std::vector<uint32_t> CollectBuiltinBlockMembers(const Instruction &entrypoint, uint32_t storageClass) const;
 
     uint32_t GetNumComponentsInBaseType(const Instruction *insn) const;


### PR DESCRIPTION
This change does

- Lower where "strip array" interface check is done
- Make `DecorationSet` a const ref
- Move `BuiltIn` checks to creation time when it is known