### PR TITLE
Add InterfaceSlot for tracking Location/Components

### DIFF
--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -68,6 +68,7 @@ class Instruction {
 
     uint32_t GetConstantValue() const;
     uint32_t GetBitWidth() const;
+    uint32_t GetByteWidth() const { return (GetBitWidth() + 31) / 32; }
     AtomicInstructionInfo GetAtomicInfo(const SHADER_MODULE_STATE& module_state) const;
     spv::BuiltIn GetBuiltIn() const;
 

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -762,9 +762,7 @@ uint32_t SHADER_MODULE_STATE::GetLocationsConsumedByType(uint32_t type, bool str
             return insn->Word(3) * GetLocationsConsumedByType(insn->Word(2), false);
         case spv::OpTypeVector: {
             const Instruction* scalar_type = FindDef(insn->Word(2));
-            auto bit_width =
-                (scalar_type->Opcode() == spv::OpTypeInt || scalar_type->Opcode() == spv::OpTypeFloat) ? scalar_type->Word(2) : 32;
-
+            auto bit_width = scalar_type->GetByteWidth();
             // Locations are 128-bit wide; 3- and 4-component vectors of 64 bit types require two.
             return (bit_width * insn->Word(3) + 127) / 128;
         }
@@ -804,19 +802,13 @@ uint32_t SHADER_MODULE_STATE::GetComponentsConsumedByType(uint32_t type, bool st
             return insn->Word(3) * GetComponentsConsumedByType(insn->Word(2), false);
         case spv::OpTypeVector: {
             const Instruction* scalar_type = FindDef(insn->Word(2));
-            auto bit_width =
-                (scalar_type->Opcode() == spv::OpTypeInt || scalar_type->Opcode() == spv::OpTypeFloat) ? scalar_type->Word(2) : 32;
+            const uint32_t bit_width = scalar_type->GetByteWidth();
             // One component is 32-bit
             return (bit_width * insn->Word(3) + 31) / 32;
         }
-        case spv::OpTypeFloat: {
-            auto bit_width = insn->Word(2);
-            return (bit_width + 31) / 32;
-        }
-        case spv::OpTypeInt: {
-            auto bit_width = insn->Word(2);
-            return (bit_width + 31) / 32;
-        }
+        case spv::OpTypeFloat:
+        case spv::OpTypeInt:
+            return insn->GetByteWidth();
         case spv::OpConstant:
             return GetComponentsConsumedByType(insn->Word(1), false);
         default:

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1496,7 +1496,7 @@ vvl::unordered_set<uint32_t> SHADER_MODULE_STATE::CollectWritableOutputLocationi
     for (const auto& output : outputs) {
         auto store_it = store_pointer_ids.find(output.second.id);
         if (store_it != store_pointer_ids.end()) {
-            location_list.insert(output.first.first);
+            location_list.insert(output.first.Location());
             store_pointer_ids.erase(store_it);
             continue;
         }
@@ -1508,7 +1508,7 @@ vvl::unordered_set<uint32_t> SHADER_MODULE_STATE::CollectWritableOutputLocationi
                 continue;
             }
             if (accesschain_it->second == output.second.id) {
-                location_list.insert(output.first.first);
+                location_list.insert(output.first.Location());
                 store_pointer_ids.erase(store_it);
                 accesschain_members.erase(accesschain_it);
                 break;
@@ -1519,7 +1519,7 @@ vvl::unordered_set<uint32_t> SHADER_MODULE_STATE::CollectWritableOutputLocationi
     return location_list;
 }
 
-bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, UserDefinedInterfaceVariable>* out,
+bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<InterfaceSlot, UserDefinedInterfaceVariable>* out,
                                                        bool is_array_of_verts, bool is_patch,
                                                        const Instruction* variable_insn) const {
     // Walk down the type_id presented, trying to determine whether it's actually an interface block.
@@ -1570,7 +1570,7 @@ bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, User
                     variable.type_id = member_type_id;
                     variable.offset = offset;
                     variable.is_patch = member_is_patch;
-                    (*out)[std::make_pair(location + offset, component)] = variable;
+                    (*out)[InterfaceSlot(location + offset, component)] = variable;
                 }
             }
         }
@@ -1579,11 +1579,11 @@ bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, User
     return true;
 }
 
-std::map<location_t, UserDefinedInterfaceVariable> SHADER_MODULE_STATE::CollectInterfaceByLocation(
+std::map<InterfaceSlot, UserDefinedInterfaceVariable> SHADER_MODULE_STATE::CollectInterfaceByLocation(
     const Instruction& entrypoint, spv::StorageClass sinterface) const {
     // TODO: handle index=1 dual source outputs from FS -- two vars will have the same location, and we DON'T want to clobber.
 
-    std::map<location_t, UserDefinedInterfaceVariable> out;
+    std::map<InterfaceSlot, UserDefinedInterfaceVariable> out;
     // TODO - pass in the EntryPoint object so this can be found there
     const VkShaderStageFlagBits stage = static_cast<VkShaderStageFlagBits>(ExecutionModelToShaderStageFlagBits(entrypoint.Word(1)));
     const bool strip_output_array_level = (stage & (VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_MESH_BIT_EXT)) != 0;
@@ -1616,7 +1616,7 @@ std::map<location_t, UserDefinedInterfaceVariable> SHADER_MODULE_STATE::CollectI
                     UserDefinedInterfaceVariable variable(insn);
                     variable.offset = offset;
                     variable.is_patch = is_patch;
-                    out[std::make_pair(location + offset, component)] = variable;
+                    out[InterfaceSlot(location + offset, component)] = variable;
                 }
             }
         }


### PR DESCRIPTION
For future fixes to the Shader Interface Matching logic, we need a better system for tracking the `Location`/`Component` of a variable than the current `location_t` map

This was pulled out of my future change for easier reviewing