### PR TITLE
Ensure pipeline layout is always present

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -746,6 +746,9 @@ class CoreChecks : public ValidationStateTracker {
                                       const PIPELINE_LAYOUT_STATE& pipeline_layout, const uint32_t layoutIndex,
                                       std::string& errorMsg) const;
 
+    bool VerifySetLayoutCompatibility(const PIPELINE_LAYOUT_STATE& layout_a, const PIPELINE_LAYOUT_STATE& layout_b,
+                                      std::string& errorMsg) const;
+
     struct DescriptorContext {
         const char* caller;
         const DrawDispatchVuid& vuids;

--- a/layers/core_checks/descriptor_validation.cpp
+++ b/layers/core_checks/descriptor_validation.cpp
@@ -172,6 +172,21 @@ bool CoreChecks::VerifySetLayoutCompatibility(const cvdescriptorset::DescriptorS
     }
 }
 
+bool CoreChecks::VerifySetLayoutCompatibility(const PIPELINE_LAYOUT_STATE &layout_a, const PIPELINE_LAYOUT_STATE &layout_b,
+                                              std::string &error_msg) const {
+    const uint32_t num_sets = static_cast<uint32_t>(std::min(layout_a.set_layouts.size(), layout_b.set_layouts.size()));
+    for (uint32_t i = 0; i < num_sets; ++i) {
+        const auto ds_a = layout_a.set_layouts[i];
+        const auto ds_b = layout_b.set_layouts[i];
+        if (ds_a && ds_b) {
+            if (!VerifySetLayoutCompatibility(*ds_a, *ds_b, error_msg)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                       VkPipelineLayout layout, uint32_t firstSet, uint32_t setCount,
                                                       const VkDescriptorSet *pDescriptorSets, uint32_t dynamicOffsetCount,

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -16,6 +16,12 @@
  */
 
 #include "state_tracker/pipeline_sub_state.h"
+#include "state_tracker/pipeline_state.h"
+
+VkPipelineLayoutCreateFlags PipelineSubState::PipelineLayoutCreateFlags() const {
+    const auto layout_state = parent.PipelineLayoutState();
+    return (layout_state) ? layout_state->CreateFlags() : static_cast<VkPipelineLayoutCreateFlags>(0);
+}
 
 VertexInputState::VertexInputState(const PIPELINE_STATE &p, const safe_VkGraphicsPipelineCreateInfo &create_info)
     : PipelineSubState(p), input_state(create_info.pVertexInputState), input_assembly_state(create_info.pInputAssemblyState) {

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -38,6 +38,8 @@ static inline VkGraphicsPipelineLibraryFlagsEXT GetGraphicsLibType(const CreateI
 struct PipelineSubState {
     PipelineSubState(const PIPELINE_STATE &p) : parent(p) {}
     const PIPELINE_STATE &parent;
+
+    VkPipelineLayoutCreateFlags PipelineLayoutCreateFlags() const;
 };
 
 struct VertexInputState : public PipelineSubState {

--- a/tests/negative/graphics_library.cpp
+++ b/tests/negative/graphics_library.cpp
@@ -1672,6 +1672,7 @@ TEST_F(VkGraphicsLibraryLayerTest, CreatePipelineTessErrors) {
         libs[0] = vi_patch_lib.pipeline_;
         libs[1] = pre_raster_lib.pipeline_;
         auto exe_pipe_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+        exe_pipe_ci.layout = fs_lib.gp_ci_.layout;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-topology-00737");
         vk_testing::Pipeline exe_pipe(*m_device, exe_pipe_ci);
         m_errorMonitor->VerifyFound();
@@ -1748,6 +1749,7 @@ TEST_F(VkGraphicsLibraryLayerTest, CreatePipelineTessErrors) {
         libs[0] = vi_lib.pipeline_;
         libs[1] = pre_raster_lib.pipeline_;
         auto exe_pipe_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+        exe_pipe_ci.layout = fs_lib.gp_ci_.layout;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-00736");
         vk_testing::Pipeline exe_pipe(*m_device, exe_pipe_ci);
         m_errorMonitor->VerifyFound();

--- a/tests/positive/graphics_library.cpp
+++ b/tests/positive/graphics_library.cpp
@@ -286,6 +286,7 @@ TEST_F(VkPositiveGraphicsLibraryLayerTest, ExeLibrary) {
     link_info.pLibraries = libraries;
 
     auto exe_pipe_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
     vk_testing::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 }
@@ -708,6 +709,7 @@ TEST_F(VkPositiveGraphicsLibraryLayerTest, DynamicPrimitiveTopolgy) {
     auto exe_pipe_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
     exe_pipe_ci.pInputAssemblyState = &ia_state;
     exe_pipe_ci.pDynamicState = &dynamic_create_info;
+    exe_pipe_ci.layout = layout;
     vk_testing::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
@@ -825,6 +827,7 @@ TEST_F(VkPositiveGraphicsLibraryLayerTest, LinkingInputAttachment) {
     link_info.pLibraries = libraries;
 
     auto exe_pipe_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    exe_pipe_ci.layout = layout;
     vk_testing::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 }

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -6346,6 +6346,7 @@ TEST_F(VkPositiveLayerTest, ShaderModuleIdentifierGPL) {
 
     auto pipe_ci = LvlInitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
     pipe_ci.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+    pipe_ci.layout = pipe.gp_ci_.layout;
     vk_testing::Pipeline exe_pipe(*m_device, pipe_ci);
 }
 


### PR DESCRIPTION
- Move 07826 check to pipeline creation time
- Add 07827

Marking as a draft for now as there may be other missing VUIDs that should be added as part of this change.