### PR TITLE
layers: Mask fragment shader state with rasterizerDiscard

### DIFF
--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -326,6 +326,7 @@ void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
             pipeline_handle = it->second.pipeline;
             pgm = it->second.pgm;
         }
+        assert(pgm.size() != 0);
         // Search through the shader source for the printf format string for this invocation
         const auto format_string = FindFormatString(pgm, debug_record->format_string_id);
         // Break the format string into strings with 1 or 0 value

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -514,6 +514,8 @@ class PIPELINE_STATE : public BASE_NODE {
                                                                           const safe_VkGraphicsPipelineCreateInfo &safe_create_info,
                                                                           const std::shared_ptr<const RENDER_PASS_STATE> &rp);
 
+    static bool EnablesRasterizationStates(const safe_VkGraphicsPipelineCreateInfo &create_info);
+
     // Merged layouts
     std::shared_ptr<const PIPELINE_LAYOUT_STATE> merged_graphics_layout;
 };

--- a/tests/negative/debug_printf.cpp
+++ b/tests/negative/debug_printf.cpp
@@ -574,7 +574,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPL) {
         fragment.pipeline_,
         frag_out.pipeline_,
     };
-    vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries);
+    vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries, pipeline_layout.handle());
     ASSERT_TRUE(pipe);
 
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
@@ -710,6 +710,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPL) {
 
         CreatePipelineHelper pre_raster_i64(*this);
         pre_raster_i64.InitPreRasterLibInfo(1, &pre_raster_i64_stage.stage_ci);
+        pre_raster_i64.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
         pre_raster_i64.gp_ci_.layout = pipeline_layout.handle();
         pre_raster_i64.gp_ci_.renderPass = render_pass;
         pre_raster_i64.gp_ci_.subpass = subpass;
@@ -722,7 +723,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPL) {
             frag_out.pipeline_,
         };
 
-        vk_testing::GraphicsPipelineFromLibraries pipe2(*m_device, libraries_i64);
+        vk_testing::GraphicsPipelineFromLibraries pipe2(*m_device, libraries_i64, pipeline_layout.handle());
         ASSERT_TRUE(pipe2);
 
         m_commandBuffer->begin(&begin_info);
@@ -893,7 +894,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragment) {
         fragment.pipeline_,
         frag_out.pipeline_,
     };
-    vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries);
+    vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries, layout);
     ASSERT_TRUE(pipe);
 
     m_commandBuffer->begin();
@@ -1052,7 +1053,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragmentIndependentSets) {
         fragment.pipeline_,
         frag_out.pipeline_,
     };
-    vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries);
+    vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries, layout);
     ASSERT_TRUE(pipe);
 
     m_commandBuffer->begin();

--- a/tests/negative/gpu_av.cpp
+++ b/tests/negative/gpu_av.cpp
@@ -2365,7 +2365,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPL) {
         fragment.pipeline_,
         frag_out.pipeline_,
     };
-    vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries);
+    vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries, pipeline_layout.handle());
     ASSERT_TRUE(pipe);
 
     VkCommandBufferBeginInfo begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
@@ -2571,7 +2571,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPLIndependentSets) {
         fragment.pipeline_,
         frag_out.pipeline_,
     };
-    vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries);
+    vk_testing::GraphicsPipelineFromLibraries pipe(*m_device, libraries, pipeline_layout.handle());
     ASSERT_TRUE(pipe);
 
     VkCommandBufferBeginInfo begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();

--- a/tests/negative/portability_subset.cpp
+++ b/tests/negative/portability_subset.cpp
@@ -231,6 +231,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesTriangleFans) {
     pipe.ia_ci_ = VkPipelineInputAssemblyStateCreateInfo{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO, nullptr, 0,
                                                          VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN, VK_FALSE};
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
+    pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
     pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineInputAssemblyStateCreateInfo-triangleFans-04452");
@@ -277,6 +278,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexInputStride) {
     pipe.ia_ci_ = VkPipelineInputAssemblyStateCreateInfo{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO, nullptr, 0,
                                                          VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, VK_FALSE};
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
+    pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
     pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkVertexInputBindingDescription-stride-04456");
@@ -317,6 +319,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexAttributes) {
     pipe.vi_ci_ = VkPipelineVertexInputStateCreateInfo{
         VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO, nullptr, 0, 1, &vertex_desc, 1, &vertex_attrib};
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
+    pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
     pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
@@ -401,6 +404,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesDepthStencilState) {
     pipe.InitInfo();
     pipe.gp_ci_.pDepthStencilState = &depth_stencil_ci;
     pipe.rs_state_ci_.cullMode = VK_CULL_MODE_NONE;
+    pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
     pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineDepthStencilStateCreateInfo-separateStencilMaskRef-04453");

--- a/tests/positive/graphics_library.cpp
+++ b/tests/positive/graphics_library.cpp
@@ -186,6 +186,8 @@ TEST_F(VkPositiveGraphicsLibraryLayerTest, FragmentMixedAttachmentSamplesAMD) {
     pipe.InitState();
     pipe.gp_ci_.pRasterizationState = nullptr;
 
+    pipe.gp_ci_.pRasterizationState = nullptr;
+
     // Ensure validation runs with pRasterizationState being nullptr.
     // It's legal for this fragment library to not have a raster state defined.
     ASSERT_TRUE(pipe.gp_ci_.pRasterizationState == nullptr);


### PR DESCRIPTION
It is possible to encounter VUID 06590 as a false positive if rasterizer discard is used. Fragment output state was masked out (incorrectly, since it did not consider dynamic state), and fragment shader state was not masked at all.

Ran into this in vkd3d-proton test suite.