### PR TITLE
Refactoring how Variables are handles in Shader Module

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -898,9 +898,8 @@ class CoreChecks : public ValidationStateTracker {
                         const char* vuid) const;
     bool ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE& producer,
                                         const SHADER_MODULE_STATE::EntryPoint& producer_entrypoint,
-                                        VkShaderStageFlagBits producer_stage, const SHADER_MODULE_STATE& consumer,
-                                        const SHADER_MODULE_STATE::EntryPoint& consumer_entrypoint,
-                                        VkShaderStageFlagBits consumer_stage, uint32_t pipe_index) const;
+                                        const SHADER_MODULE_STATE& consumer,
+                                        const SHADER_MODULE_STATE::EntryPoint& consumer_entrypoint, uint32_t pipe_index) const;
     bool ValidateDecorations(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
     bool ValidateVariables(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateShaderDescriptorVariable(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -885,7 +885,7 @@ class CoreChecks : public ValidationStateTracker {
                                            const PIPELINE_STATE& pipeline) const;
     bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
                                    safe_VkPipelineShaderStageCreateInfo const* create_info) const;
-    bool ValidateBuiltinLimits(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
+    bool ValidateBuiltinLimits(const SHADER_MODULE_STATE& module_state, const SHADER_MODULE_STATE::EntryPoint& entrypoint,
                                const PIPELINE_STATE& pipeline) const;
     PushConstantByteState ValidatePushConstantSetUpdate(const std::vector<uint8_t>& push_constant_data_update,
                                                         const SHADER_MODULE_STATE::StructInfo& push_constant_used_in_shader,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -853,8 +853,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderCapabilitiesAndExtensions(const Instruction& insn) const;
     VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) const;
 
-    bool ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage, const PIPELINE_STATE& pipeline,
-                                              const Instruction& entrypoint) const;
+    bool ValidateShaderStageInputOutputLimits(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
+                                              const PIPELINE_STATE& pipeline,
+                                              const SHADER_MODULE_STATE::EntryPoint& entrypoint) const;
     bool ValidateShaderStorageImageFormatsVariables(const SHADER_MODULE_STATE& module_state, const Instruction* insn) const;
     bool ValidateShaderStageMaxResources(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                          const PIPELINE_STATE& pipeline) const;
@@ -871,10 +872,12 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint, VkShaderStageFlagBits stage,
                                 const PIPELINE_STATE& pipeline) const;
     bool ValidateViAgainstVsInputs(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
-                                   const Instruction& entrypoint) const;
-    bool ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
-                                            const PIPELINE_STATE& pipeline, uint32_t subpass_index) const;
-    bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
+                                   const SHADER_MODULE_STATE::EntryPoint& entrypoint) const;
+    bool ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state,
+                                            const SHADER_MODULE_STATE::EntryPoint& entrypoint, const PIPELINE_STATE& pipeline,
+                                            uint32_t subpass_index) const;
+    bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE& module_state,
+                                                            const SHADER_MODULE_STATE::EntryPoint& entrypoint,
                                                             const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderInputAttachment(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline,
                                        const ResourceInterfaceVariable& variable) const;
@@ -893,10 +896,11 @@ class CoreChecks : public ValidationStateTracker {
                              const char* vuid) const;
     bool RequireFeature(const SHADER_MODULE_STATE& module_state, VkBool32 feature, char const* feature_name,
                         const char* vuid) const;
-    bool ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE& producer, const Instruction& producer_entrypoint,
+    bool ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE& producer,
+                                        const SHADER_MODULE_STATE::EntryPoint& producer_entrypoint,
                                         VkShaderStageFlagBits producer_stage, const SHADER_MODULE_STATE& consumer,
-                                        const Instruction& consumer_entrypoint, VkShaderStageFlagBits consumer_stage,
-                                        uint32_t pipe_index) const;
+                                        const SHADER_MODULE_STATE::EntryPoint& consumer_entrypoint,
+                                        VkShaderStageFlagBits consumer_stage, uint32_t pipe_index) const;
     bool ValidateDecorations(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
     bool ValidateVariables(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateShaderDescriptorVariable(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -286,17 +286,7 @@ bool CoreChecks::ValidateConservativeRasterization(const SHADER_MODULE_STATE &mo
         return skip;
     }
 
-    bool fully_covered = false;
-    for (uint32_t id : FindEntrypointInterfaces(entrypoint)) {
-        const Instruction *insn = module_state.FindDef(id);
-        const auto decorations = module_state.GetDecorationSet(insn->Word(2));
-        if (decorations.builtin == spv::BuiltInFullyCoveredEXT) {
-            fully_covered = true;
-            break;
-        }
-    }
-
-    if (fully_covered) {
+    if (module_state.static_data_.has_builtin_fully_covered) {
         const LogObjectList objlist(module_state.vk_shader_module(), pipeline.PipelineLayoutState()->layout());
         skip |= LogError(objlist, "VUID-FullyCoveredEXT-conservativeRasterizationPostDepthCoverage-04235",
                          "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -290,7 +290,7 @@ bool CoreChecks::ValidateConservativeRasterization(const SHADER_MODULE_STATE &mo
     for (uint32_t id : FindEntrypointInterfaces(entrypoint)) {
         const Instruction *insn = module_state.FindDef(id);
         const auto decorations = module_state.GetDecorationSet(insn->Word(2));
-        if (decorations.Has(DecorationSet::builtin_bit) && (decorations.builtin == spv::BuiltInFullyCoveredEXT)) {
+        if (decorations.builtin == spv::BuiltInFullyCoveredEXT) {
             fully_covered = true;
             break;
         }
@@ -518,7 +518,7 @@ bool CoreChecks::ValidateBuiltinLimits(const SHADER_MODULE_STATE &module_state, 
         const auto decorations = module_state.GetDecorationSet(insn->Word(2));
 
         // Currently don't need to search in structs
-        if (decorations.Has(DecorationSet::builtin_bit) && (decorations.builtin == spv::BuiltInSampleMask)) {
+        if (decorations.builtin == spv::BuiltInSampleMask) {
             const Instruction *type_pointer = module_state.FindDef(insn->Word(1));
             assert(type_pointer->Opcode() == spv::OpTypePointer);
 

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -108,7 +108,7 @@ bool CoreChecks::ValidateViAgainstVsInputs(const PIPELINE_STATE &pipeline, const
 
             // Type checking
             if (!(attrib_type & input_type)) {
-                skip |= LogError(module_state.vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
+                skip |= LogError(module_state.vk_shader_module(), kVUID_Core_Shader_VertexInputMismatch,
                                  "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
                                  "] Attribute type of `%s` at location %" PRIu32 " does not match vertex shader input type of `%s`",
                                  pipeline.create_index, string_VkFormat(attrib->format), location,
@@ -160,7 +160,7 @@ bool CoreChecks::ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER
             // Type checking
             if (!(output_type & attachment_type)) {
                 skip |= LogWarning(
-                    module_state.vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
+                    module_state.vk_shader_module(), kVUID_Core_Shader_FragmentOutputMismatch,
                     "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attachment %" PRIu32
                     " of type `%s` does not match fragment shader output type of `%s`; resulting values are undefined",
                     pipeline.create_index, location, string_VkFormat(format), module_state.DescribeType(output->type_id).c_str());
@@ -335,7 +335,7 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE &m
                 // Type checking
                 if (!(output_type & attachment_type)) {
                     skip |= LogWarning(
-                        module_state.vk_shader_module(), kVUID_Core_Shader_InterfaceTypeMismatch,
+                        module_state.vk_shader_module(), kVUID_Core_Shader_FragmentOutputMismatch,
                         "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attachment %" PRIu32
                         " of type `%s` does not match fragment shader output type of `%s`; resulting values are undefined",
                         pipeline.create_index, location, string_VkFormat(attachment->format),

--- a/layers/error_message/validation_error_enums.h
+++ b/layers/error_message/validation_error_enums.h
@@ -39,9 +39,12 @@
 [[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidImageView = "UNASSIGNED-CoreValidation-DrawState-InvalidImageView";
 
 [[maybe_unused]] static const char *kVUID_Core_Shader_InputNotProduced = "UNASSIGNED-CoreValidation-Shader-InputNotProduced";
-[[maybe_unused]] static const char *kVUID_Core_Shader_InterfaceTypeMismatch = "UNASSIGNED-CoreValidation-Shader-InterfaceTypeMismatch";
+[[maybe_unused]] static const char *kVUID_Core_Shader_VertexInputMismatch = "UNASSIGNED-CoreValidation-Shader-VertexInputMismatch";
+[[maybe_unused]] static const char *kVUID_Core_Shader_FragmentOutputMismatch = "UNASSIGNED-CoreValidation-Shader-FragmentOutputMismatch";
+[[maybe_unused]] static const char *kVUID_Core_Shader_InterfacePatchVertex = "UNASSIGNED-CoreValidation-Shader-InterfacePatchVertex";
 [[maybe_unused]] static const char *kVUID_Core_Shader_AtomicFeature = "UNASSIGNED-CoreValidation-Shader-AtomicFeature";
 [[maybe_unused]] static const char *kVUID_Core_Shader_OutputNotConsumed = "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed";
+[[maybe_unused]] static const char *kVUID_Core_Shader_BuiltinMismatch = "UNASSIGNED-CoreValidation-Shader-BuiltinMismatch";
 
 [[maybe_unused]] static const char *kVUID_Core_BindImageMemory_Swapchain = "UNASSIGNED-CoreValidation-BindImageMemory-Swapchain";
 

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -23,7 +23,7 @@
 
 PipelineStageState::PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
                                        std::shared_ptr<const SHADER_MODULE_STATE> &module_state,
-                                       const SHADER_MODULE_STATE::EntryPoint *entrypoint)
+                                       std::shared_ptr<const SHADER_MODULE_STATE::EntryPoint> &entrypoint)
     : module_state(module_state), create_info(create_info), entrypoint(entrypoint) {
     if (entrypoint) {
         descriptor_variables = module_state->GetResourceInterfaceVariable((*entrypoint).entrypoint_insn);
@@ -63,7 +63,7 @@ PIPELINE_STATE::StageStateVec PIPELINE_STATE::GetStageStates(const ValidationSta
                     }
                 }
 
-                const auto *entrypoint = module->FindEntrypoint(stage_ci.pName, stage_ci.stage);
+                auto entrypoint = module->FindEntrypoint(stage_ci.pName, stage_ci.stage);
                 stage_states.emplace_back(&stage_ci, module, entrypoint);
                 stage_found = true;
             }
@@ -122,7 +122,7 @@ PIPELINE_STATE::StageStateVec PIPELINE_STATE::GetStageStates(const ValidationSta
             if (!stage_ci) {
                 continue;
             }
-            const auto *entrypoint = module_state->FindEntrypoint(stage_ci->pName, stage_ci->stage);
+            auto entrypoint = module_state->FindEntrypoint(stage_ci->pName, stage_ci->stage);
             stage_states.emplace_back(stage_ci, module_state, entrypoint);
         }
     }

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -243,8 +243,15 @@ static vvl::unordered_set<uint32_t> GetFSOutputLocations(const PIPELINE_STATE::S
             continue;
         }
         if (stage_state.create_info->stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
-            result = stage_state.module_state->CollectWritableOutputLocationinFS(stage_state.entrypoint->entrypoint_insn);
-            break;
+            for (const auto *variable : stage_state.entrypoint->user_defined_interface_variables) {
+                if ((variable->storage_class != spv::StorageClassOutput) || variable->interface_slots.empty()) {
+                    continue;  // not an output interface
+                }
+                // It is not allowed to have Block Fragment or 64-bit vectors output in Frag shader
+                // This means all Locations in slots will be the same
+                result.insert(variable->interface_slots[0].Location());
+            }
+            break;  // found
         }
     }
     return result;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -97,11 +97,12 @@ typedef std::map<uint32_t, DescriptorRequirement> BindingReqMap;
 struct PipelineStageState {
     std::shared_ptr<const SHADER_MODULE_STATE> module_state;
     const safe_VkPipelineShaderStageCreateInfo *create_info;
-    const SHADER_MODULE_STATE::EntryPoint *entrypoint;
+    std::shared_ptr<const SHADER_MODULE_STATE::EntryPoint> entrypoint;
     const std::vector<ResourceInterfaceVariable> *descriptor_variables = {};
 
     PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
-                       std::shared_ptr<const SHADER_MODULE_STATE> &module_state, const SHADER_MODULE_STATE::EntryPoint *entrypoint);
+                       std::shared_ptr<const SHADER_MODULE_STATE> &module_state,
+                       std::shared_ptr<const SHADER_MODULE_STATE::EntryPoint> &entrypoint);
 };
 
 class PIPELINE_STATE : public BASE_NODE {

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -68,6 +68,7 @@ class Instruction {
 
     uint32_t GetConstantValue() const;
     uint32_t GetBitWidth() const;
+    uint32_t GetByteWidth() const { return (GetBitWidth() + 31) / 32; }
     AtomicInstructionInfo GetAtomicInfo(const SHADER_MODULE_STATE& module_state) const;
     spv::BuiltIn GetBuiltIn() const;
 

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -883,11 +883,11 @@ uint32_t SHADER_MODULE_STATE::GetFundamentalType(uint32_t type) const {
     }
 }
 
-const Instruction* SHADER_MODULE_STATE::GetStructType(const Instruction* insn, bool is_array_of_verts) const {
+const Instruction* SHADER_MODULE_STATE::GetStructType(const Instruction* insn) const {
     while (true) {
         if (insn->Opcode() == spv::OpTypePointer) {
             insn = FindDef(insn->Word(3));
-        } else if (insn->Opcode() == spv::OpTypeArray && is_array_of_verts) {
+        } else if (insn->Opcode() == spv::OpTypeArray) {
             insn = FindDef(insn->Word(2));
         } else if (insn->Opcode() == spv::OpTypeStruct) {
             return insn;
@@ -898,7 +898,7 @@ const Instruction* SHADER_MODULE_STATE::GetStructType(const Instruction* insn, b
 }
 
 void SHADER_MODULE_STATE::DefineStructMember(const Instruction* insn, StructInfo& data) const {
-    const Instruction* struct_type = GetStructType(insn, false);
+    const Instruction* struct_type = GetStructType(insn);
     data.size = 0;
 
     StructInfo data1;
@@ -1562,7 +1562,7 @@ bool SHADER_MODULE_STATE::CollectInterfaceBlockMembers(std::map<location_t, User
                                                        bool is_array_of_verts, bool is_patch,
                                                        const Instruction* variable_insn) const {
     // Walk down the type_id presented, trying to determine whether it's actually an interface block.
-    const Instruction* struct_type = GetStructType(FindDef(variable_insn->Word(1)), is_array_of_verts && !is_patch);
+    const Instruction* struct_type = GetStructType(FindDef(variable_insn->Word(1)));
     if (!struct_type || !(GetDecorationSet(struct_type->Word(1)).Has(DecorationSet::block_bit))) {
         // This isn't an interface block.
         return false;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -282,6 +282,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         std::vector<const Instruction *> builtin_decoration_inst;
         // BuiltIn we just care about existing or not, don't have to be written to
         bool has_builtin_layer{false};
+        bool has_builtin_fully_covered{false};
         bool has_builtin_workgroup_size{false};
         uint32_t builtin_workgroup_size_id = 0;
 
@@ -365,8 +366,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     const vvl::unordered_map<uint32_t, std::vector<const Instruction *>> &GetExecutionModeInstructions() const {
         return static_data_.execution_mode_inst;
     }
-
-    const std::vector<const Instruction *> &GetBuiltinDecorationList() const { return static_data_.builtin_decoration_inst; }
 
     const vvl::unordered_map<uint32_t, uint32_t> &GetSpecConstMap() const { return static_data_.spec_const_map; }
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -401,7 +401,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     uint32_t GetLocationsConsumedByType(uint32_t type) const;
     uint32_t GetComponentsConsumedByType(uint32_t type) const;
     uint32_t GetFundamentalType(uint32_t type) const;
-    const Instruction *GetStructType(const Instruction *insn, bool is_array_of_verts) const;
+    const Instruction *GetStructType(const Instruction *insn) const;
 
     uint32_t DescriptorTypeToReqs(uint32_t type_id) const;
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -385,8 +385,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     const Instruction *GetConstantDef(uint32_t id) const;
     uint32_t GetConstantValueById(uint32_t id) const;
     spv::Dim GetShaderResourceDimensionality(const ResourceInterfaceVariable &resource) const;
-    uint32_t GetLocationsConsumedByType(uint32_t type, bool strip_array_level) const;
-    uint32_t GetComponentsConsumedByType(uint32_t type, bool strip_array_level) const;
+    uint32_t GetLocationsConsumedByType(uint32_t type) const;
+    uint32_t GetComponentsConsumedByType(uint32_t type) const;
     uint32_t GetFundamentalType(uint32_t type) const;
     const Instruction *GetStructType(const Instruction *insn, bool is_array_of_verts) const;
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -322,22 +322,17 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     uint32_t gpu_validation_shader_id{std::numeric_limits<uint32_t>::max()};
 
-    explicit SHADER_MODULE_STATE(vvl::span<const uint32_t> code, spv_target_env env = SPV_ENV_VULKAN_1_0)
+    explicit SHADER_MODULE_STATE(vvl::span<const uint32_t> code)
         : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule),
           words_(code.begin(), code.end()),
-          static_data_(*this) {
-        PreprocessShaderBinary(env);
-    }
+          static_data_(*this) {}
 
-    SHADER_MODULE_STATE(const VkShaderModuleCreateInfo &create_info, VkShaderModule shaderModule, spv_target_env env,
-                        uint32_t unique_shader_id)
+    SHADER_MODULE_STATE(const VkShaderModuleCreateInfo &create_info, VkShaderModule shaderModule, uint32_t unique_shader_id)
         : BASE_NODE(shaderModule, kVulkanObjectTypeShaderModule),
           words_(create_info.pCode, create_info.pCode + create_info.codeSize / sizeof(uint32_t)),
           has_valid_spirv(true),
           static_data_(*this),
-          gpu_validation_shader_id(unique_shader_id) {
-        PreprocessShaderBinary(env);
-    }
+          gpu_validation_shader_id(unique_shader_id) {}
 
     SHADER_MODULE_STATE() : BASE_NODE(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule) {}
 
@@ -432,10 +427,6 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
                                             std::vector<SHADER_MODULE_STATE::EntryPoint> &entry_points);
 
   private:
-    // Functions used for initialization only
-    // Used to populate the shader module object
-    void PreprocessShaderBinary(spv_target_env env);
-
     // The following are all helper functions to set the push constants values by tracking if the values are accessed in the entry
     // point functions and which offset in the structs are used
     uint32_t UpdateOffset(uint32_t offset, const std::vector<uint32_t> &array_indices, const StructInfo &data) const;

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -117,6 +117,10 @@ static char const bindStateGeomPointSizeShaderText[] = R"glsl(
     layout (points) in;
     layout (points) out;
     layout (max_vertices = 1) out;
+    in gl_PerVertex {
+        vec4 gl_Position;
+        float gl_PointSize;
+    };
     void main() {
        gl_Position = vec4(1);
        gl_PointSize = 1.0;

--- a/tests/negative/geometry_tessellation.cpp
+++ b/tests/negative/geometry_tessellation.cpp
@@ -347,7 +347,7 @@ TEST_F(VkLayerTest, BuiltinBlockOrderMismatchVsGs) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "Builtin variable inside block doesn't match between");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-BuiltinMismatch");
 }
 
 TEST_F(VkLayerTest, BuiltinBlockSizeMismatchVsGs) {
@@ -388,7 +388,7 @@ TEST_F(VkLayerTest, BuiltinBlockSizeMismatchVsGs) {
         helper.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
         helper.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "Number of elements inside builtin block differ between stages");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-BuiltinMismatch");
 }
 
 TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationControlInputOutputComponents) {
@@ -492,9 +492,8 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationControlInputOutputCompone
                 break;
             }
             case 1: {
-                // (in and out component limit) and (in and out location limit)
-                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
-                                              "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                // in and out component limit
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
             }
@@ -614,9 +613,8 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationEvaluationInputOutputComp
                 break;
             }
             case 1: {
-                // (in and out component limit) and (in and out location limit)
-                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
-                                              "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                // in and out component limit
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
             }
@@ -724,10 +722,8 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
                 break;
             }
             case 1: {
-                // (in and out component limit) and (in and out location limit) and maxGeometryTotalOutputComponents
-                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
-                                              "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
-                                              "VUID-RuntimeSpirv-Location-06272"};
+                // in and out component limit
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
             }
@@ -848,7 +844,7 @@ TEST_F(VkLayerTest, CreatePipelineTessPatchDecorationMismatch) {
         helper.shader_stages_.emplace_back(tcs.GetStageCreateInfo());
         helper.shader_stages_.emplace_back(tes.GetStageCreateInfo());
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InterfaceTypeMismatch");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InterfacePatchVertex");
 }
 
 TEST_F(VkLayerTest, CreatePipelineTessErrors) {

--- a/tests/negative/pipeline_shader.cpp
+++ b/tests/negative/pipeline_shader.cpp
@@ -4200,7 +4200,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatch) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "Type mismatch on location 0");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
 }
 
 TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatchInBlock) {
@@ -4234,7 +4234,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatchInBlock) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "Type mismatch on location 0");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
 }
 
 TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByLocation) {
@@ -4530,7 +4530,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentOutputTypeMismatch) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-CoreValidation-Shader-InterfaceTypeMismatch");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-CoreValidation-Shader-FragmentOutputMismatch");
 }
 
 TEST_F(VkLayerTest, CreatePipelineExceedVertexMaxComponentsWithBuiltins) {
@@ -4738,8 +4738,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxVertexOutputComponents) {
             }
             case 1: {
                 // component and location limit (maxVertexOutputComponents)
-                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
-                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-Location-06272");
                 break;
             }
             case 2: {
@@ -4808,8 +4807,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxComponentsBlocks) {
 
     // 1 for maxVertexOutputComponents and 1 for maxFragmentInputComponents
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                      vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
-                                                     "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
+                                      vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
 }
 
 TEST_F(VkLayerTest, CreatePipelineExceedMaxFragmentInputComponents) {
@@ -4863,13 +4861,12 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxFragmentInputComponents) {
                 break;
             }
             case 1: {
-                // component and location limit (maxFragmentInputComponents)
-                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
-                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
+                // (maxFragmentInputComponents)
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-Location-06272");
                 break;
             }
             case 2:
-                // just component limit (maxFragmentInputComponents)
+                // (maxFragmentInputComponents)
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-Location-06272");
                 break;
             default: {
@@ -8854,7 +8851,9 @@ TEST_F(VkLayerTest, ComputeSharedMemorySpecConstantSet) {
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-Workgroup-06530");
 }
 
-TEST_F(VkLayerTest, TestInvalidShaderInputAndOutputComponents) {
+// Spec doesn't clarify if this is valid or not
+// https://gitlab.khronos.org/vulkan/vulkan/-/issues/3293
+TEST_F(VkLayerTest, DISABLED_TestInvalidShaderInputAndOutputComponents) {
     TEST_DESCRIPTION("Test invalid shader layout in and out with different components.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -10697,7 +10696,7 @@ TEST_F(VkLayerTest, TestShaderInputOutputMismatch) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.InitState();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-Shader-InterfaceTypeMismatch");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -10986,7 +10985,7 @@ TEST_F(VkLayerTest, StorageTexelBufferWriteLessComponent) {
 }
 
 TEST_F(VkLayerTest, StorageImageUnknownWriteLessComponent) {
-    TEST_DESCRIPTION("Test writing to image unknown format with less compoents.");
+    TEST_DESCRIPTION("Test writing to image unknown format with less components.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -11071,7 +11070,7 @@ TEST_F(VkLayerTest, StorageImageUnknownWriteLessComponent) {
 }
 
 TEST_F(VkLayerTest, StorageTexelBufferUnkownWriteLessComponent) {
-    TEST_DESCRIPTION("Test writing to texel buffer unknown format with less compoents.");
+    TEST_DESCRIPTION("Test writing to texel buffer unknown format with less components.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME);

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -5691,7 +5691,9 @@ TEST_F(VkPositiveLayerTest, TestShaderInputOutputMatch) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkPositiveLayerTest, TestShaderInputOutputMatch2) {
+// Spec doesn't clarify if this is valid or not
+// https://gitlab.khronos.org/vulkan/vulkan/-/issues/3445
+TEST_F(VkPositiveLayerTest, DISABLED_TestShaderInputOutputMatch2) {
     TEST_DESCRIPTION("Test matching vertex shader output with fragment shader input.");
 
     ASSERT_NO_FATAL_FAILURE(Init());

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -1982,8 +1982,7 @@ TEST_F(VkPositiveLayerTest, TestShaderInputAndOutputComponents) {
                 layout(location = 4, component = 0) in vec2 xy;
                 layout(location = 4, component = 2) in vec2 zw;
 
-                layout(location = 5, component = 0) in vec2 st;
-                layout(location = 5, component = 2) in vec2 pq;
+                layout(location = 5, component = 0) in vec4 st;
 
                 layout(location = 6, component = 0) in vec4 cdef;
 
@@ -1999,7 +1998,7 @@ TEST_F(VkPositiveLayerTest, TestShaderInputAndOutputComponents) {
                             vec4(r1, g1, 1.0f, a1) *
                             vec4(inBlock.zero_red, inBlock.zero_green, inBlock.zero_blue, inBlock.zero_alpha) *
                             vec4(inBlock.one_red, inBlock.one_green, inBlock.one_blue, inBlock.one_alpha) *
-                            vec4(xy, zw) * vec4(st, pq) * cdef * vec4(ar1, ar2, ar3, ar4);
+                            vec4(xy, zw) * st * cdef * vec4(ar1, ar2, ar3, ar4);
                 }
             )glsl";
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);


### PR DESCRIPTION
Main goal - Group `OpVariable` into 3 types

- Stage interface (input/output)
  - Built Ins
  - User Defined
- Resource Variables

From here the goal is to do as much as possible during the init prasing of the shader