### PR TITLE
tests: Fix WSI extension logic

### DIFF
--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -286,7 +286,7 @@ class ValidationSource:
 
 # Class to parse the validation layer test source and store testnames
 class ValidationTests:
-    def __init__(self, test_file_list, test_group_name=['VkLayerTest', 'VkPositiveLayerTest', 'VkWsiEnabledLayerTest', 'VkBestPracticesLayerTest']):
+    def __init__(self, test_file_list, test_group_name=['VkLayerTest', 'VkPositiveLayerTest', 'VkBestPracticesLayerTest']):
         self.test_files = test_file_list
         self.test_trigger_txt_list = []
         for tg in test_group_name:

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -1031,8 +1031,6 @@ void VkLayerTest::Init(VkPhysicalDeviceFeatures *features, VkPhysicalDeviceFeatu
 VkCommandBufferObj *VkLayerTest::CommandBuffer() { return m_commandBuffer; }
 
 VkLayerTest::VkLayerTest() {
-    m_enableWSI = false;
-
     // TODO: not quite sure why most of this is here instead of in super
 
     // Add default instance extensions to the list
@@ -1065,71 +1063,26 @@ VkLayerTest::VkLayerTest() {
     m_target_api_version = app_info_.apiVersion;
 }
 
-void VkLayerTest::AddSurfaceExtension([[maybe_unused]] const WsiPreference preference) {
-    m_enableWSI = true;
-
-    // Instance Extensions
+void VkLayerTest::AddSurfaceExtension() {
     AddRequiredExtensions(VK_KHR_SURFACE_EXTENSION_NAME);
-    // Device extensions
     AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    AddRequiredExtensions(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-    return;
+    AddWsiExtensions(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
 #endif
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR) && defined(VALIDATION_APK)
-    AddRequiredExtensions(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
-    return;
+    AddWsiExtensions(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
 #endif
 
-    switch (preference) {
-        case WsiPreference::Wayland: {
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-            AddRequiredExtensions(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
-#endif
-            return;
-        }
-        case WsiPreference::X11: {
-#if defined(VK_USE_PLATFORM_XLIB_KHR)
-            AddRequiredExtensions(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
-#endif
-            return;
-        }
-        case WsiPreference::XCB: {
-#if defined(VK_USE_PLATFORM_XCB_KHR)
-            AddRequiredExtensions(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
-#endif
-            return;
-        }
-        case WsiPreference::Default:
-            [[fallthrough]];
-        default:
-            break;
-    }
-
-    // User doesn't care which WSI backend they use. Pick the first one that works
-    assert(preference == WsiPreference::Default);
-#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-    if (auto temp_display = wl_display_connect(nullptr); temp_display) {
-        AddRequiredExtensions(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
-        wl_display_disconnect(temp_display);
-        return;
-    }
+    AddWsiExtensions(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
 #endif
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
-    if (auto temp_display = XOpenDisplay(nullptr); temp_display) {
-        AddRequiredExtensions(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
-        XCloseDisplay(temp_display);
-        return;
-    }
+    AddWsiExtensions(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
 #endif
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-    if (auto temp_xcb = xcb_connect(nullptr, nullptr); temp_xcb) {
-        AddRequiredExtensions(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
-        xcb_disconnect(temp_xcb);
-        return;
-    }
+    AddWsiExtensions(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
 #endif
 }
 

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -265,8 +265,7 @@ class VkLayerTest : public VkRenderFramework {
 
     void Init(VkPhysicalDeviceFeatures *features = nullptr, VkPhysicalDeviceFeatures2 *features2 = nullptr,
               const VkCommandPoolCreateFlags flags = 0, void *instance_pnext = nullptr);
-    enum class WsiPreference { Default, Wayland, X11, XCB };
-    void AddSurfaceExtension(const WsiPreference preference = WsiPreference::Default);
+    void AddSurfaceExtension();
     VkCommandBufferObj *CommandBuffer();
     void OOBRayTracingShadersTestBody(bool gpu_assisted);
 
@@ -309,7 +308,6 @@ class VkLayerTest : public VkRenderFramework {
   protected:
     uint32_t m_instance_api_version = 0;
     uint32_t m_target_api_version = 0;
-    bool m_enableWSI;
 
     void SetTargetApiVersion(uint32_t target_api_version);
     uint32_t DeviceValidationVersion() const;
@@ -364,11 +362,7 @@ class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {
 };
 class VkNvidiaBestPracticesLayerTest : public VkBestPracticesLayerTest {};
 
-class VkWsiEnabledLayerTest : public VkLayerTest {
-  public:
-  protected:
-    VkWsiEnabledLayerTest() { m_enableWSI = true; }
-};
+class VkWsiEnabledLayerTest : public VkLayerTest {};
 
 class VkGpuAssistedLayerTest : public VkLayerTest {
   public:

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -362,8 +362,6 @@ class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {
 };
 class VkNvidiaBestPracticesLayerTest : public VkBestPracticesLayerTest {};
 
-class VkWsiEnabledLayerTest : public VkLayerTest {};
-
 class VkGpuAssistedLayerTest : public VkLayerTest {
   public:
     VkValidationFeaturesEXT GetValidationFeatures();

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -234,6 +234,8 @@ class VkRenderFramework : public VkTestFramework {
     // Does not return anything as the caller should use AreRequiredExtensionsEnabled or AddOptionalExtensions then
     // `ext_name` can refer to a device or instance extension.
     void AddRequiredExtensions(const char *ext_name);
+    // Ensures at least 1 WSI instance extension is enabled
+    void AddWsiExtensions(const char *ext_name);
     // Same as AddRequiredExtensions but won't fail a check to AreRequiredExtensionsEnabled
     void AddOptionalExtensions(const char *ext_name);
     // After instance and physical device creation (e.g., after InitFramework), returns true if all required extensions are
@@ -326,6 +328,8 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<const char *> m_required_extensions;
     // Optional extensions to try and enable at device creation time
     std::vector<const char *> m_optional_extensions;
+    // wsi extensions to try and enable
+    std::vector<const char *> m_wsi_extensions;
     // Device extensions to enable
     std::vector<const char *> m_device_extension_names;
 

--- a/tests/negative/wsi.cpp
+++ b/tests/negative/wsi.cpp
@@ -2876,18 +2876,22 @@ TEST_F(VkLayerTest, TestCreatingWin32Surface) {
 #endif
 }
 
-TEST_F(VkLayerTest, TestCreatingWaylandSurface) {
+TEST_F(VkLayerTest, CreatingWaylandSurface) {
     TEST_DESCRIPTION("Test creating wayland surface with invalid display/surface");
 
 #ifndef VK_USE_PLATFORM_WAYLAND_KHR
     GTEST_SKIP() << "test not supported on platform";
 #else
-    AddSurfaceExtension(VkLayerTest::WsiPreference::Wayland);
+    AddSurfaceExtension();
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    if (!IsExtensionsEnabled(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME)) {
+        GTEST_SKIP() << VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME << " extension not supported.";
     }
 
     wl_display *display = nullptr;
@@ -2964,18 +2968,22 @@ TEST_F(VkLayerTest, TestCreatingWaylandSurface) {
 #endif
 }
 
-TEST_F(VkLayerTest, TestCreatingXcbSurface) {
+TEST_F(VkLayerTest, CreatingXcbSurface) {
     TEST_DESCRIPTION("Test creating xcb surface with invalid connection/window");
 
 #ifndef VK_USE_PLATFORM_XCB_KHR
     GTEST_SKIP() << "test not supported on platform";
 #else
-    AddSurfaceExtension(VkLayerTest::WsiPreference::XCB);
+    AddSurfaceExtension();
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    if (!IsExtensionsEnabled(VK_KHR_XCB_SURFACE_EXTENSION_NAME)) {
+        GTEST_SKIP() << VK_KHR_XCB_SURFACE_EXTENSION_NAME << " not supported.";
     }
 
     xcb_connection_t *xcb_connection = xcb_connect(nullptr, nullptr);
@@ -3016,18 +3024,22 @@ TEST_F(VkLayerTest, TestCreatingXcbSurface) {
 #endif
 }
 
-TEST_F(VkLayerTest, TestCreatingX11Surface) {
+TEST_F(VkLayerTest, CreatingX11Surface) {
     TEST_DESCRIPTION("Test creating invalid x11 surface");
 
 #ifndef VK_USE_PLATFORM_XLIB_KHR
     GTEST_SKIP() << "test not supported on platform";
 #else
-    AddSurfaceExtension(VkLayerTest::WsiPreference::X11);
+    AddSurfaceExtension();
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    if (!IsExtensionsEnabled(VK_KHR_XLIB_SURFACE_EXTENSION_NAME)) {
+        GTEST_SKIP() << VK_KHR_XLIB_SURFACE_EXTENSION_NAME << " not supported.";
     }
 
     if (std::getenv("DISPLAY") == nullptr) {

--- a/tests/positive/wsi.cpp
+++ b/tests/positive/wsi.cpp
@@ -23,12 +23,16 @@ TEST_F(VkPositiveWsiTest, CreateWaylandSurface) {
 #ifndef VK_USE_PLATFORM_WAYLAND_KHR
     GTEST_SKIP() << "test not supported on platform";
 #else
-    AddSurfaceExtension(VkLayerTest::WsiPreference::Wayland);
+    AddSurfaceExtension();
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    if (!IsExtensionsEnabled(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME)) {
+        GTEST_SKIP() << VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME << " extension not supported.";
     }
 
     wl_display *display = nullptr;
@@ -94,12 +98,16 @@ TEST_F(VkPositiveWsiTest, CreateXcbSurface) {
 #ifndef VK_USE_PLATFORM_XCB_KHR
     GTEST_SKIP() << "test not supported on platform";
 #else
-    AddSurfaceExtension(VkLayerTest::WsiPreference::XCB);
+    AddSurfaceExtension();
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    if (!IsExtensionsEnabled(VK_KHR_XCB_SURFACE_EXTENSION_NAME)) {
+        GTEST_SKIP() << VK_KHR_XCB_SURFACE_EXTENSION_NAME << " not supported.";
     }
 
     xcb_connection_t *xcb_connection = xcb_connect(nullptr, nullptr);
@@ -129,12 +137,16 @@ TEST_F(VkPositiveWsiTest, CreateX11Surface) {
 #ifndef VK_USE_PLATFORM_XLIB_KHR
     GTEST_SKIP() << "test not supported on platform";
 #else
-    AddSurfaceExtension(VkLayerTest::WsiPreference::X11);
+    AddSurfaceExtension();
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    if (!IsExtensionsEnabled(VK_KHR_XLIB_SURFACE_EXTENSION_NAME)) {
+        GTEST_SKIP() << VK_KHR_XLIB_SURFACE_EXTENSION_NAME << " not supported.";
     }
 
     if (std::getenv("DISPLAY") == nullptr) {


### PR DESCRIPTION
Currently WSI testing is a bit broken on linux since AddSurfaceExtension doesn't line up with CreateSurface.

In the new approach
- WSI extensions queried properly
- If AddSurfaceExtension is called at least 1 WSI will be required when calling AreRequiredExtensionsEnabled
- VkRenderFramework::CreateSurface checks if the extension is enabled
- Specific WSI tests now have to explicitly check for their desired WSI extension