### PR TITLE
Change back to using libc++_static.so for Android

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -391,13 +391,6 @@ demo APKs can be installed on production devices with:
 
     ./install_all.sh [-s <serial number>]
 
-> **NOTE:** Manual installation of Android layer libraries on development devices will require modifying [build-android/jni/Application.mk](build-android/jni/Application.mk) to use `libc++_static.so` instead of `libc++_shared.so`, like so:
-```patch
--APP_STL := c++_shared
-+APP_STL := c++_static
-```
-
-
 Note that there are no equivalent scripts on Windows yet, that work needs to
 be completed. The following per platform commands can be used for layer only
 builds:

--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -1,5 +1,6 @@
-# Copyright 2015 The Android Open Source Project
-# Copyright (C) 2015 Valve Corporation
+# Copyright 2023 The Android Open Source Project
+# Copyright (C) 2023 Valve Corporation
+# Copyright (C) 2023 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +17,6 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 # APP_ABI := arm64-v8a   # just build for pixel2  (don't check in)
 APP_PLATFORM := android-26
-APP_STL := c++_shared
+APP_STL := c++_static
 NDK_TOOLCHAIN_VERSION := clang
 NDK_MODULE_PATH := .

--- a/build-android/jni/shaderc/Application.mk
+++ b/build-android/jni/shaderc/Application.mk
@@ -1,4 +1,4 @@
 APP_ABI := all
 APP_BUILD_SCRIPT := Android.mk
-APP_STL := c++_shared
+APP_STL := c++_static
 APP_PLATFORM := android-23


### PR DESCRIPTION
Using the c++ shared library (libc++_shared.so) causes non-trivial install complications on Android, so changing back to using libc++_static.so.

Fixes #5491.