### PR TITLE
layers: PointSize not needed if not emit vertex

### DIFF
--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -2290,7 +2290,8 @@ bool CoreChecks::ValidatePointSizeShaderState(const PIPELINE_STATE &pipeline, co
     }
 
     if (stage == VK_SHADER_STAGE_GEOMETRY_BIT && output_points) {
-        if (enabled_features.core.shaderTessellationAndGeometryPointSize && !entrypoint.written_builtin_point_size) {
+        if (enabled_features.core.shaderTessellationAndGeometryPointSize && !entrypoint.written_builtin_point_size &&
+            entrypoint.emit_vertex_geometry) {
             skip |= LogError(module_state.vk_shader_module(), "VUID-VkGraphicsPipelineCreateInfo-Geometry-07725",
                              "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
                              "] shaderTessellationAndGeometryPointSize is enabled, but PointSize is not "

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -208,6 +208,11 @@ SHADER_MODULE_STATE::EntryPoint::EntryPoint(const SHADER_MODULE_STATE& module_st
                                 }
                                 break;
 
+                            case spv::OpEmitVertex:
+                            case spv::OpEmitStreamVertex:
+                                emit_vertex_geometry = true;
+                                break;
+
                             default: {
                                 if (AtomicOperation(insn->Opcode())) {
                                     if (insn->Opcode() == spv::OpAtomicStore) {

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -227,6 +227,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
         StructInfo push_constant_used_in_shader;
 
+        bool emit_vertex_geometry{false};
+
         // Mark if a BuiltIn is written to
         bool written_builtin_point_size{false};
         bool written_builtin_primitive_shading_rate_khr{false};


### PR DESCRIPTION
Original issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4657

Fix for ` VUID-VkGraphicsPipelineCreateInfo-Geometry-07725`

New 245 spec clarify that when not emitting any vertex, Geometry shaders don't need a PointSize