### PR TITLE
Revert static lib changes to fix CI.

### DIFF
--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -17,6 +17,8 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 # APP_ABI := arm64-v8a   # just build for pixel2  (don't check in)
 APP_PLATFORM := android-26
-APP_STL := c++_static
+# Change back to using shared libs until the Android Tests issues
+# can be resolved
+APP_STL := c++_shared
 NDK_TOOLCHAIN_VERSION := clang
 NDK_MODULE_PATH := .

--- a/build-android/jni/shaderc/Application.mk
+++ b/build-android/jni/shaderc/Application.mk
@@ -1,4 +1,5 @@
 APP_ABI := all
 APP_BUILD_SCRIPT := Android.mk
-APP_STL := c++_static
+# Change back to shared lib until Android test crashes can be resolved
+APP_STL := c++_shared
 APP_PLATFORM := android-23


### PR DESCRIPTION
Need to temporarily replace static libs with shared libs to fix CI though static is preferred long-term.

Tracking issue for static/shared lib issue is here: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5508