### PR TITLE
layers: Add VkMemoryAllocateInfo import VUs

### DIFF
--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -367,6 +367,7 @@ typedef vk_testing::Fence VkFenceObj;
 typedef vk_testing::Semaphore VkSemaphoreObj;
 typedef vk_testing::Buffer VkBufferObj;
 typedef vk_testing::AccelerationStructure VkAccelerationStructureObj;
+using VkDeviceMemoryObj = vk_testing::DeviceMemory;
 class VkCommandPoolObj : public vk_testing::CommandPool {
   public:
     VkCommandPoolObj() : vk_testing::CommandPool(){};


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5431

This PR validates `VkMemoryAllocateInfo`'s allocation size and memory type index during memory import operation:
`VUID-VkMemoryAllocateInfo-allocationSize-01742`
`VUID-VkMemoryAllocateInfo-allocationSize-01743`

Updated `ValidateImportMemoryHandleType` to skip the test if there is no memory type that supports import and export that use different handle types. This happens on AMD drivers and is a valid situation. There is no guarantee the same memory type is supported by different handle types.

One lesson from this PR is that in some cases external memory requires dedicated allocation. It's the case on Android Pixel 3. 
We have scheduled work for dedicated memory VUs to improve detection of such cases.

