### PR TITLE
Enable static C++ std library use for non-CI Android builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -378,6 +378,8 @@ tools.
     cd build-android
     ./build_all.sh
 
+> **NOTE:** To allow manual installation of Android layer libraries on development devices, `build_all.sh` will use the static version of the c++ library (libc++_static.so). For testing purposes and general usage including installation via APK the c++ shared library should be used (libc++_shared.so). See comments in [build_all.sh](build-android/build_all.sh) for details.
+
 > **NOTE:** By default, the `build_all.sh` script will build for all Android ABI variations. To **speed up the build time** if you know your target(s), set `APP_ABI` in both [build-android/jni/Application.mk](build-android/jni/Application.mk) and [build-android/jni/shaderc/Application.mk](build-android/jni/shaderc/Application.mk) to the desired [Android ABI](https://developer.android.com/ndk/guides/application_mk#app_abi)
 
 Resulting validation layer binaries will be in build-android/libs. Test and

--- a/build-android/build_all.sh
+++ b/build-android/build_all.sh
@@ -45,9 +45,7 @@ findtool apksigner
 set -ev
 
 LAYER_BUILD_DIR=$PWD
-DEMO_BUILD_DIR=$PWD/../demos/android
 echo LAYER_BUILD_DIR="${LAYER_BUILD_DIR}"
-echo DEMO_BUILD_DIR="${DEMO_BUILD_DIR}"
 
 #
 # Android builds and c++ libraries:

--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# To save time, modify the following line to exclude unnessary ABIs
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
-# APP_ABI := arm64-v8a   # just build for pixel2  (don't check in)
+
 APP_PLATFORM := android-26
 # if specified, build with static c++ library
 ifeq ($(ANDROID_STL_TYPE),STATIC)
@@ -23,5 +24,6 @@ ifeq ($(ANDROID_STL_TYPE),STATIC)
 else
   APP_STL := c++_shared
 endif
+
 NDK_TOOLCHAIN_VERSION := clang
 NDK_MODULE_PATH := .

--- a/build-android/jni/Application.mk
+++ b/build-android/jni/Application.mk
@@ -17,8 +17,11 @@
 APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 # APP_ABI := arm64-v8a   # just build for pixel2  (don't check in)
 APP_PLATFORM := android-26
-# Change back to using shared libs until the Android Tests issues
-# can be resolved
-APP_STL := c++_shared
+# if specified, build with static c++ library
+ifeq ($(ANDROID_STL_TYPE),STATIC)
+  APP_STL := c++_static
+else
+  APP_STL := c++_shared
+endif
 NDK_TOOLCHAIN_VERSION := clang
 NDK_MODULE_PATH := .

--- a/build-android/jni/shaderc/Application.mk
+++ b/build-android/jni/shaderc/Application.mk
@@ -1,9 +1,11 @@
 APP_ABI := all
 APP_BUILD_SCRIPT := Android.mk
+
 # if specified, build with static c++ library
 ifeq ($(ANDROID_STL_TYPE),STATIC)
   APP_STL := c++_static
 else
   APP_STL := c++_shared
 endif
+
 APP_PLATFORM := android-23

--- a/build-android/jni/shaderc/Application.mk
+++ b/build-android/jni/shaderc/Application.mk
@@ -1,5 +1,9 @@
 APP_ABI := all
 APP_BUILD_SCRIPT := Android.mk
-# Change back to shared lib until Android test crashes can be resolved
-APP_STL := c++_shared
+# if specified, build with static c++ library
+ifeq ($(ANDROID_STL_TYPE),STATIC)
+  APP_STL := c++_static
+else
+  APP_STL := c++_shared
+endif
 APP_PLATFORM := android-23


### PR DESCRIPTION
Android builds targeted at CI testing need to use the shared C++ standard library, but Android binary releases and manually built layers need to use the static C++ standard library.

This PR modifies the `build-android\build_all.sh` script to produce builds using the static library.  Github Actions and LunarG internal CI do not use this script and will continue to use the shared version of the library.

See tracking issue #5508 for background and related issues.

Also added some descriptive text in the Android build scripts to server as guidance when the Android build is converted to use CMake.

Fixes #5508.