### PR TITLE
layers: Fix and Label MaxFramebuffer extent

### DIFF
--- a/layers/core_checks/render_pass_validation.cpp
+++ b/layers/core_checks/render_pass_validation.cpp
@@ -2855,7 +2855,7 @@ bool CoreChecks::ValidateRenderingInfoAttachment(const std::shared_ptr<const IMA
         if (!device_group_render_pass_begin_info || device_group_render_pass_begin_info->deviceRenderAreaCount == 0) {
             if (!x_extent_valid) {
                 skip |= LogError(image_view->Handle(), "VUID-VkRenderingInfo-pNext-06079",
-                                 "%s(): %s width (%" PRIu32 ") is less than pRenderingInfo->renderArea.offset.x (%" PRIu32
+                                 "%s(): %s width (%" PRIu32 ") is less than pRenderingInfo->renderArea.offset.x (%" PRIi32
                                  ") + pRenderingInfo->renderArea.extent.width (%" PRIu32 ").",
                                  func_name, attachment, image_view->image_state->createInfo.extent.width,
                                  pRenderingInfo->renderArea.offset.x, pRenderingInfo->renderArea.extent.width);
@@ -2863,7 +2863,7 @@ bool CoreChecks::ValidateRenderingInfoAttachment(const std::shared_ptr<const IMA
 
             if (!y_extent_valid) {
                 skip |= LogError(image_view->Handle(), "VUID-VkRenderingInfo-pNext-06080",
-                                 "%s(): %s height (%" PRIu32 ") is less than pRenderingInfo->renderArea.offset.y (%" PRIu32
+                                 "%s(): %s height (%" PRIu32 ") is less than pRenderingInfo->renderArea.offset.y (%" PRIi32
                                  ") + pRenderingInfo->renderArea.extent.width (%" PRIu32 ").",
                                  func_name, attachment, image_view->image_state->createInfo.extent.height,
                                  pRenderingInfo->renderArea.offset.y, pRenderingInfo->renderArea.extent.height);
@@ -2872,14 +2872,14 @@ bool CoreChecks::ValidateRenderingInfoAttachment(const std::shared_ptr<const IMA
     } else {
         if (!x_extent_valid) {
             skip |= LogError(image_view->Handle(), "VUID-VkRenderingInfo-imageView-06075",
-                             "%s(): %s width (%" PRIu32 ") is less than pRenderingInfo->renderArea.offset.x (%" PRIu32
+                             "%s(): %s width (%" PRIu32 ") is less than pRenderingInfo->renderArea.offset.x (%" PRIi32
                              ") + pRenderingInfo->renderArea.extent.width (%" PRIu32 ").",
                              func_name, attachment, image_view->image_state->createInfo.extent.width,
                              pRenderingInfo->renderArea.offset.x, pRenderingInfo->renderArea.extent.width);
         }
         if (!y_extent_valid) {
             skip |= LogError(image_view->Handle(), "VUID-VkRenderingInfo-imageView-06076",
-                             "%s(): %s height (%" PRIu32 ") is less than pRenderingInfo->renderArea.offset.y (%" PRIu32
+                             "%s(): %s height (%" PRIu32 ") is less than pRenderingInfo->renderArea.offset.y (%" PRIi32
                              ") + pRenderingInfo->renderArea.extent.width (%" PRIu32 ").",
                              func_name, attachment, image_view->image_state->createInfo.extent.height,
                              pRenderingInfo->renderArea.offset.y, pRenderingInfo->renderArea.extent.height);
@@ -3131,7 +3131,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                                                                                        : "VUID-VkRenderingInfo-imageView-06117";
                 skip |= LogError(commandBuffer, vuid,
                                  "%s(): width of VkRenderingFragmentShadingRateAttachmentInfoKHR imageView (%" PRIu32
-                                 ") must not be less than (pRenderingInfo->renderArea.offset.x (%" PRIu32
+                                 ") must not be less than (pRenderingInfo->renderArea.offset.x (%" PRIi32
                                  ") + pRenderingInfo->renderArea.extent.width (%" PRIu32
                                  ") ) / shadingRateAttachmentTexelSize.width (%" PRIu32 ").",
                                  func_name, view_state->image_state->createInfo.extent.width, pRenderingInfo->renderArea.offset.x,
@@ -3147,7 +3147,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                                                                                        : "VUID-VkRenderingInfo-imageView-06118";
                 skip |= LogError(commandBuffer, vuid,
                                  "%s(): height of VkRenderingFragmentShadingRateAttachmentInfoKHR imageView (%" PRIu32
-                                 ") must not be less than (pRenderingInfo->renderArea.offset.y (%" PRIu32
+                                 ") must not be less than (pRenderingInfo->renderArea.offset.y (%" PRIi32
                                  ") + pRenderingInfo->renderArea.extent.height (%" PRIu32
                                  ") ) / shadingRateAttachmentTexelSize.height (%" PRIu32 ").",
                                  func_name, view_state->image_state->createInfo.extent.height, pRenderingInfo->renderArea.offset.y,
@@ -3342,9 +3342,9 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
             const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-07815"
                                                                                    : "VUID-VkRenderingInfo-renderArea-06073";
             skip |= LogError(commandBuffer, vuid,
-                             "%s(): pRenderingInfo->renderArea.offset.x (%" PRIu32
+                             "%s(): pRenderingInfo->renderArea.offset.x (%" PRIi32
                              ") + pRenderingInfo->renderArea.extent.width (%" PRIu32
-                             ") is not less than maxFramebufferWidth (%" PRIu32 ").",
+                             ") is not less than or equal to maxFramebufferWidth (%" PRIu32 ").",
                              func_name, pRenderingInfo->renderArea.offset.x, pRenderingInfo->renderArea.extent.width,
                              phys_dev_props.limits.maxFramebufferWidth);
         }
@@ -3354,7 +3354,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
             skip |= LogError(commandBuffer, vuid,
                              "%s(): pRenderingInfo->renderArea.offset.y (%" PRIi32
                              ") + pRenderingInfo->renderArea.extent.height (%" PRIu32
-                             ") is not less than maxFramebufferHeight (%" PRIu32 ").",
+                             ") is not less than or equal to maxFramebufferHeight (%" PRIu32 ").",
                              func_name, pRenderingInfo->renderArea.offset.y, pRenderingInfo->renderArea.extent.height,
                              phys_dev_props.limits.maxFramebufferHeight);
         }

--- a/layers/core_checks/render_pass_validation.cpp
+++ b/layers/core_checks/render_pass_validation.cpp
@@ -3087,9 +3087,9 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
     const auto rendering_fragment_shading_rate_attachment_info =
         LvlFindInChain<VkRenderingFragmentShadingRateAttachmentInfoKHR>(pRenderingInfo->pNext);
     // Upcasting to handle overflow
-    const auto x_adjusted_extent =
+    const int64_t x_adjusted_extent =
         static_cast<int64_t>(pRenderingInfo->renderArea.offset.x) + static_cast<int64_t>(pRenderingInfo->renderArea.extent.width);
-    const auto y_adjusted_extent =
+    const int64_t y_adjusted_extent =
         static_cast<int64_t>(pRenderingInfo->renderArea.offset.y) + static_cast<int64_t>(pRenderingInfo->renderArea.extent.height);
     if (rendering_fragment_shading_rate_attachment_info &&
         (rendering_fragment_shading_rate_attachment_info->imageView != VK_NULL_HANDLE)) {
@@ -3326,18 +3326,37 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
     }
 
     if (!non_zero_device_render_area) {
-        if (IsExtEnabled(device_extensions.vk_khr_device_group)) {
-            if (pRenderingInfo->renderArea.offset.x < 0) {
-                skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06077",
-                                 "%s(): renderArea.offset.x is %d and must be greater than 0.", func_name,
-                                 pRenderingInfo->renderArea.offset.x);
-            }
-
-            if (pRenderingInfo->renderArea.offset.y < 0) {
-                skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06078",
-                                 "%s(): renderArea.offset.y is %d and must be greater than 0.", func_name,
-                                 pRenderingInfo->renderArea.offset.y);
-            }
+        if (pRenderingInfo->renderArea.offset.x < 0) {
+            const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-06077"
+                                                                                   : "VUID-VkRenderingInfo-renderArea-06071";
+            skip |= LogError(commandBuffer, vuid, "%s(): pRenderingInfo->renderArea.offset.x (%" PRIu32 ") must not be negative.",
+                             func_name, pRenderingInfo->renderArea.offset.x);
+        }
+        if (pRenderingInfo->renderArea.offset.y < 0) {
+            const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-06078"
+                                                                                   : "VUID-VkRenderingInfo-renderArea-06072";
+            skip |= LogError(commandBuffer, vuid, "%s(): pRenderingInfo->renderArea.offset.y (%" PRIu32 ") must not be negative.",
+                             func_name, pRenderingInfo->renderArea.offset.y);
+        }
+        if (x_adjusted_extent > phys_dev_props.limits.maxFramebufferWidth) {
+            const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-07815"
+                                                                                   : "VUID-VkRenderingInfo-renderArea-06073";
+            skip |= LogError(commandBuffer, vuid,
+                             "%s(): pRenderingInfo->renderArea.offset.x (%" PRIu32
+                             ") + pRenderingInfo->renderArea.extent.width (%" PRIu32
+                             ") is not less than maxFramebufferWidth (%" PRIu32 ").",
+                             func_name, pRenderingInfo->renderArea.offset.x, pRenderingInfo->renderArea.extent.width,
+                             phys_dev_props.limits.maxFramebufferWidth);
+        }
+        if (y_adjusted_extent > phys_dev_props.limits.maxFramebufferHeight) {
+            const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-07816"
+                                                                                   : "VUID-VkRenderingInfo-renderArea-06074";
+            skip |= LogError(commandBuffer, vuid,
+                             "%s(): pRenderingInfo->renderArea.offset.y (%" PRIu32
+                             ") + pRenderingInfo->renderArea.extent.height (%" PRIu32
+                             ") is not less than maxFramebufferHeight (%" PRIu32 ").",
+                             func_name, pRenderingInfo->renderArea.offset.y, pRenderingInfo->renderArea.extent.height,
+                             phys_dev_props.limits.maxFramebufferHeight);
         }
 
         if (fragment_density_map_attachment_info && fragment_density_map_attachment_info->imageView != VK_NULL_HANDLE) {
@@ -3593,35 +3612,6 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                     "a stencil aspect.",
                     func_name, string_VkFormat(stencil_view_state->create_info.format));
             }
-        }
-    }
-
-    if (!IsExtEnabled(device_extensions.vk_khr_device_group)) {
-        if (pRenderingInfo->renderArea.offset.x < 0) {
-            skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-renderArea-06071",
-                             "%s(): pRenderingInfo->renderArea.offset.x (%" PRIu32 ") must not be negative.", func_name,
-                             pRenderingInfo->renderArea.offset.x);
-        }
-        if (pRenderingInfo->renderArea.offset.y < 0) {
-            skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-renderArea-06072",
-                             "%s(): pRenderingInfo->renderArea.offset.y (%" PRIu32 ") must not be negative.", func_name,
-                             pRenderingInfo->renderArea.offset.y);
-        }
-        if (x_adjusted_extent > phys_dev_props.limits.maxFramebufferWidth) {
-            skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-renderArea-06073",
-                             "%s(): pRenderingInfo->renderArea.offset.x (%" PRIu32
-                             ") + pRenderingInfo->renderArea.extent.width (%" PRIu32
-                             ") is not less than maxFramebufferWidth (%" PRIu32 ").",
-                             func_name, pRenderingInfo->renderArea.offset.x, pRenderingInfo->renderArea.extent.width,
-                             phys_dev_props.limits.maxFramebufferWidth);
-        }
-        if (y_adjusted_extent > phys_dev_props.limits.maxFramebufferHeight) {
-            skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-renderArea-06074",
-                             "%s(): pRenderingInfo->renderArea.offset.y (%" PRIu32
-                             ") + pRenderingInfo->renderArea.extent.height (%" PRIu32
-                             ") is not less than maxFramebufferHeight (%" PRIu32 ").",
-                             func_name, pRenderingInfo->renderArea.offset.y, pRenderingInfo->renderArea.extent.height,
-                             phys_dev_props.limits.maxFramebufferHeight);
         }
     }
 

--- a/layers/core_checks/render_pass_validation.cpp
+++ b/layers/core_checks/render_pass_validation.cpp
@@ -3158,10 +3158,10 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
             if (chained_device_group_struct) {
                 for (uint32_t deviceRenderAreaIndex = 0; deviceRenderAreaIndex < chained_device_group_struct->deviceRenderAreaCount;
                      ++deviceRenderAreaIndex) {
-                    auto offset_x = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].offset.x;
-                    auto width = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].extent.width;
-                    auto offset_y = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].offset.y;
-                    auto height = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].extent.height;
+                    const int32_t offset_x = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].offset.x;
+                    const uint32_t width = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].extent.width;
+                    const int32_t offset_y = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].offset.y;
+                    const uint32_t height = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].extent.height;
 
                     IMAGE_STATE *image_state = view_state->image_state.get();
                     if (image_state->createInfo.extent.width <
@@ -3171,7 +3171,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                         skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06120",
                                          "%s(): width of VkRenderingFragmentShadingRateAttachmentInfoKHR imageView (%" PRIu32
                                          ") must not be less than (VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
-                                         "].offset.x (%" PRIu32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
+                                         "].offset.x (%" PRIi32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
                                          "].extent.width (%" PRIu32 ") ) / shadingRateAttachmentTexelSize.width (%" PRIu32 ").",
                                          func_name, image_state->createInfo.extent.width, deviceRenderAreaIndex, offset_x,
                                          deviceRenderAreaIndex, width,
@@ -3184,7 +3184,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                         skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06122",
                                          "%s(): height of VkRenderingFragmentShadingRateAttachmentInfoKHR imageView (%" PRIu32
                                          ") must not be less than (VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
-                                         "].offset.y (%" PRIu32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
+                                         "].offset.y (%" PRIi32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
                                          "].extent.height (%" PRIu32
                                          ") ) / shadingRateAttachmentTexelSize.height "
                                          "(%" PRIu32 ").",
@@ -3329,13 +3329,13 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
         if (pRenderingInfo->renderArea.offset.x < 0) {
             const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-06077"
                                                                                    : "VUID-VkRenderingInfo-renderArea-06071";
-            skip |= LogError(commandBuffer, vuid, "%s(): pRenderingInfo->renderArea.offset.x (%" PRIu32 ") must not be negative.",
+            skip |= LogError(commandBuffer, vuid, "%s(): pRenderingInfo->renderArea.offset.x (%" PRIi32 ") must not be negative.",
                              func_name, pRenderingInfo->renderArea.offset.x);
         }
         if (pRenderingInfo->renderArea.offset.y < 0) {
             const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-06078"
                                                                                    : "VUID-VkRenderingInfo-renderArea-06072";
-            skip |= LogError(commandBuffer, vuid, "%s(): pRenderingInfo->renderArea.offset.y (%" PRIu32 ") must not be negative.",
+            skip |= LogError(commandBuffer, vuid, "%s(): pRenderingInfo->renderArea.offset.y (%" PRIi32 ") must not be negative.",
                              func_name, pRenderingInfo->renderArea.offset.y);
         }
         if (x_adjusted_extent > phys_dev_props.limits.maxFramebufferWidth) {
@@ -3352,7 +3352,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
             const char *vuid = IsExtEnabled(device_extensions.vk_khr_device_group) ? "VUID-VkRenderingInfo-pNext-07816"
                                                                                    : "VUID-VkRenderingInfo-renderArea-06074";
             skip |= LogError(commandBuffer, vuid,
-                             "%s(): pRenderingInfo->renderArea.offset.y (%" PRIu32
+                             "%s(): pRenderingInfo->renderArea.offset.y (%" PRIi32
                              ") + pRenderingInfo->renderArea.extent.height (%" PRIu32
                              ") is not less than maxFramebufferHeight (%" PRIu32 ").",
                              func_name, pRenderingInfo->renderArea.offset.y, pRenderingInfo->renderArea.extent.height,
@@ -3371,7 +3371,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                 skip |= LogError(
                     commandBuffer, vuid,
                     "%s(): width of VkRenderingFragmentDensityMapAttachmentInfoEXT imageView (%" PRIu32
-                    ") must not be less than (pRenderingInfo->renderArea.offset.x (%" PRIu32
+                    ") must not be less than (pRenderingInfo->renderArea.offset.x (%" PRIi32
                     ") + pRenderingInfo->renderArea.extent.width (%" PRIu32
                     ") ) / VkPhysicalDeviceFragmentDensityMapPropertiesEXT::maxFragmentDensityTexelSize.width (%" PRIu32 ").",
                     func_name, image_state->createInfo.extent.width, pRenderingInfo->renderArea.offset.x,
@@ -3387,7 +3387,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                 skip |= LogError(
                     commandBuffer, vuid,
                     "%s(): height of VkRenderingFragmentDensityMapAttachmentInfoEXT imageView (%" PRIu32
-                    ") must not be less than (pRenderingInfo->renderArea.offset.y (%" PRIu32
+                    ") must not be less than (pRenderingInfo->renderArea.offset.y (%" PRIi32
                     ") + pRenderingInfo->renderArea.extent.height (%" PRIu32
                     ") ) / VkPhysicalDeviceFragmentDensityMapPropertiesEXT::maxFragmentDensityTexelSize.height (%" PRIu32 ").",
                     func_name, image_state->createInfo.extent.height, pRenderingInfo->renderArea.offset.y,
@@ -3400,8 +3400,8 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
     if (chained_device_group_struct) {
         for (uint32_t deviceRenderAreaIndex = 0; deviceRenderAreaIndex < chained_device_group_struct->deviceRenderAreaCount;
              ++deviceRenderAreaIndex) {
-            auto offset_x = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].offset.x;
-            auto width = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].extent.width;
+            const int32_t offset_x = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].offset.x;
+            const uint32_t width = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].extent.width;
             if (offset_x < 0) {
                 skip |= LogError(commandBuffer, "VUID-VkDeviceGroupRenderPassBeginInfo-offset-06166",
                                  "%s(): pDeviceRenderAreas[%u].offset.x: %d must be greater than or equal to 0.", func_name,
@@ -3409,12 +3409,12 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
             }
             if ((offset_x + width) > phys_dev_props.limits.maxFramebufferWidth) {
                 skip |= LogError(commandBuffer, "VUID-VkDeviceGroupRenderPassBeginInfo-offset-06168",
-                                 "vkCmdBeginRenderingKHR(): pDeviceRenderAreas[%" PRIu32 "] sum of offset.x (%" PRId32
+                                 "vkCmdBeginRenderingKHR(): pDeviceRenderAreas[%" PRIu32 "] sum of offset.x (%" PRIi32
                                  ") and extent.width (%" PRIu32 ") is greater than maxFramebufferWidth (%" PRIu32 ").",
                                  deviceRenderAreaIndex, offset_x, width, phys_dev_props.limits.maxFramebufferWidth);
             }
-            auto offset_y = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].offset.y;
-            auto height = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].extent.height;
+            const int32_t offset_y = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].offset.y;
+            const uint32_t height = chained_device_group_struct->pDeviceRenderAreas[deviceRenderAreaIndex].extent.height;
             if (offset_y < 0) {
                 skip |= LogError(commandBuffer, "VUID-VkDeviceGroupRenderPassBeginInfo-offset-06167",
                                  "%s(): pDeviceRenderAreas[%u].offset.y: %d must be greater than or equal to 0.", func_name,
@@ -3422,7 +3422,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
             }
             if ((offset_y + height) > phys_dev_props.limits.maxFramebufferHeight) {
                 skip |= LogError(commandBuffer, "VUID-VkDeviceGroupRenderPassBeginInfo-offset-06169",
-                                 "vkCmdBeginRenderingKHR(): pDeviceRenderAreas[%" PRIu32 "] sum of offset.y (%" PRId32
+                                 "vkCmdBeginRenderingKHR(): pDeviceRenderAreas[%" PRIu32 "] sum of offset.y (%" PRIi32
                                  ") and extent.height (%" PRIu32 ") is greater than maxFramebufferHeight (%" PRIu32 ").",
                                  deviceRenderAreaIndex, offset_y, height, phys_dev_props.limits.maxFramebufferHeight);
             }
@@ -3435,14 +3435,14 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                         skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06083",
                                          "%s(): width of the pColorAttachments[%" PRIu32 "].imageView: %" PRIu32
                                          " must be greater than or equal to"
-                                         "renderArea.offset.x (%" PRIu32 ") + renderArea.extent.width (%" PRIu32 ").",
+                                         "renderArea.offset.x (%" PRIi32 ") + renderArea.extent.width (%" PRIu32 ").",
                                          func_name, j, image_state->createInfo.extent.width, offset_x, width);
                     }
                     if (image_state->createInfo.extent.height < offset_y + height) {
                         skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06084",
                                          "%s(): height of the pColorAttachments[%" PRIu32 "].imageView: %" PRIu32
                                          " must be greater than or equal to"
-                                         "renderArea.offset.y (%" PRIu32 ") + renderArea.extent.height (%" PRIu32 ").",
+                                         "renderArea.offset.y (%" PRIi32 ") + renderArea.extent.height (%" PRIu32 ").",
                                          func_name, j, image_state->createInfo.extent.height, offset_y, height);
                     }
                 }
@@ -3455,14 +3455,14 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                     skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06083",
                                      "%s(): width of the pDepthAttachment->imageView: %" PRIu32
                                      " must be greater than or equal to"
-                                     "renderArea.offset.x (%" PRIu32 ") + renderArea.extent.width (%" PRIu32 ").",
+                                     "renderArea.offset.x (%" PRIi32 ") + renderArea.extent.width (%" PRIu32 ").",
                                      func_name, image_state->createInfo.extent.width, offset_x, width);
                 }
                 if (image_state->createInfo.extent.height < offset_y + height) {
                     skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06084",
                                      "%s(): height of the pDepthAttachment->imageView: %" PRIu32
                                      " must be greater than or equal to"
-                                     "renderArea.offset.y (%" PRIu32 ") + renderArea.extent.height (%" PRIu32 ").",
+                                     "renderArea.offset.y (%" PRIi32 ") + renderArea.extent.height (%" PRIu32 ").",
                                      func_name, image_state->createInfo.extent.height, offset_y, height);
                 }
             }
@@ -3474,14 +3474,14 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                     skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06083",
                                      "%s(): width of the pStencilAttachment->imageView: %" PRIu32
                                      " must be greater than or equal to"
-                                     "renderArea.offset.x (%" PRIu32 ") +  renderArea.extent.width (%" PRIu32 ").",
+                                     "renderArea.offset.x (%" PRIi32 ") +  renderArea.extent.width (%" PRIu32 ").",
                                      func_name, image_state->createInfo.extent.width, offset_x, width);
                 }
                 if (image_state->createInfo.extent.height < offset_y + height) {
                     skip |= LogError(commandBuffer, "VUID-VkRenderingInfo-pNext-06084",
                                      "%s(): height of the pStencilAttachment->imageView: %" PRIu32
                                      " must be greater than or equal to"
-                                     "renderArea.offset.y (%" PRIu32 ") +  renderArea.extent.height(%" PRIu32 ").",
+                                     "renderArea.offset.y (%" PRIi32 ") +  renderArea.extent.height(%" PRIu32 ").",
                                      func_name, image_state->createInfo.extent.height, offset_y, height);
                 }
             }
@@ -3496,7 +3496,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                         commandBuffer, "VUID-VkRenderingInfo-pNext-06113",
                         "%s(): width of VkRenderingFragmentDensityMapAttachmentInfoEXT imageView (%" PRIu32
                         ") must not be less than (VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
-                        "].offset.x (%" PRIu32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
+                        "].offset.x (%" PRIi32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
                         "].extent.width (%" PRIu32
                         ") ) / VkPhysicalDeviceFragmentDensityMapPropertiesEXT::maxFragmentDensityTexelSize.width (%" PRIu32 ").",
                         func_name, image_state->createInfo.extent.width, deviceRenderAreaIndex, offset_x, deviceRenderAreaIndex,
@@ -3509,7 +3509,7 @@ bool CoreChecks::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const 
                         commandBuffer, "VUID-VkRenderingInfo-pNext-06115",
                         "%s(): height of VkRenderingFragmentDensityMapAttachmentInfoEXT imageView (%" PRIu32
                         ") must not be less than (VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
-                        "].offset.y (%" PRIu32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
+                        "].offset.y (%" PRIi32 ") + VkDeviceGroupRenderPassBeginInfo::pDeviceRenderAreas[%" PRIu32
                         "].extent.height (%" PRIu32
                         ") ) / VkPhysicalDeviceFragmentDensityMapPropertiesEXT::maxFragmentDensityTexelSize.height (%" PRIu32 ").",
                         func_name, image_state->createInfo.extent.height, deviceRenderAreaIndex, offset_y, deviceRenderAreaIndex,

--- a/tests/negative/dynamic_rendering.cpp
+++ b/tests/negative/dynamic_rendering.cpp
@@ -2412,12 +2412,14 @@ TEST_F(VkLayerTest, DynamicRenderingTestFragmentDensityMapRenderArea) {
 
     begin_rendering_info.renderArea.offset.x = 1;
     begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06112");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
     begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06112");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -2432,12 +2434,14 @@ TEST_F(VkLayerTest, DynamicRenderingTestFragmentDensityMapRenderArea) {
 
     begin_rendering_info.renderArea.offset.y = 1;
     begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07816");  // if over max
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06114");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
     begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07816");  // if over max
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06114");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -2913,12 +2917,14 @@ TEST_F(VkLayerTest, DynamicRenderingDeviceGroupAreaGreaterThanAttachmentExtent) 
 
     begin_rendering_info.renderArea.offset.x = 1;
     begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06079");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
     begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06079");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -2933,12 +2939,14 @@ TEST_F(VkLayerTest, DynamicRenderingDeviceGroupAreaGreaterThanAttachmentExtent) 
 
     begin_rendering_info.renderArea.offset.y = 1;
     begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07816");  // if over max
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06080");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
     begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07816");  // if over max
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06080");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -5454,12 +5462,14 @@ TEST_F(VkLayerTest, DynamicRenderingFragmentShadingRateAttachmentSizeWithDeviceG
 
     begin_rendering_info.renderArea.offset.x = 1;
     begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06119");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
     begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-pNext-06119");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
When using `VK_KHR_dynamic_rendering` the `VUID-VkRenderingInfo-pNext-07815` and `VUID-VkRenderingInfo-pNext-07816` VUs were missing

Fixed logic as the VUs were gated by the `VK_KHR_device_group` being enabled which is wrong, only the VUID changes