### PR TITLE
Fix Ray Tracing action command

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1341,7 +1341,7 @@ class CoreChecks : public ValidationStateTracker {
                                               const char* vuid_single_device_memory, const char* vuid_binding_table_flag,
                                               const VkStridedDeviceAddressRegionKHR& binding_table,
                                               const char* binding_table_name) const;
-    bool ValidateCmdTraceRaysKHR(bool isIndirect, VkCommandBuffer commandBuffer,
+    bool ValidateCmdTraceRaysKHR(const CMD_TYPE cmd_type, const CMD_BUFFER_STATE& cb_state,
                                  const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
                                  const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
                                  const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -546,8 +546,7 @@ class CoreChecks : public ValidationStateTracker {
     const DrawDispatchVuid& GetDrawDispatchVuid(CMD_TYPE cmd_type) const;
     bool ValidateCmdDrawInstance(const CMD_BUFFER_STATE& cb_state, uint32_t instanceCount, uint32_t firstInstance,
                                  CMD_TYPE cmd_type) const;
-    bool ValidateCmdDrawType(const CMD_BUFFER_STATE& cb_state, bool indexed, VkPipelineBindPoint bind_point,
-                             CMD_TYPE cmd_type) const;
+    bool ValidateActionCmd(const CMD_BUFFER_STATE& cb_state, bool indexed, VkPipelineBindPoint bind_point, CMD_TYPE cmd_type) const;
     bool ValidateCmdNextSubpass(RenderPassCreateVersion rp_version, VkCommandBuffer commandBuffer, CMD_TYPE cmd_type) const;
     bool ValidateInsertMemoryRange(const VulkanTypedHandle& typed_handle, const DEVICE_MEMORY_STATE* mem_info,
                                    VkDeviceSize memoryOffset, const char* api_name) const;


### PR DESCRIPTION
This PR first renames `ValidateCmdDrawType` to `ValidateActionCmd` (there is no [direct name](https://github.com/KhronosGroup/Vulkan-Docs/issues/1908) for these, but confusing that `vkCmdTraceRays` is part of of "draw")

This PR also fixes that `VUID-vkCmdTraceRaysIndirectKHR-None-02700` was being called in two places, so removed the custom spot and have it use the one in `ValidateCmdBufDrawState`