### PR TITLE
layers: Add 07999 08700 Remove 03600 03601

### DIFF
--- a/layers/stateless/parameter_validation_utils.cpp
+++ b/layers/stateless/parameter_validation_utils.cpp
@@ -7114,24 +7114,22 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
                              "pLibraryInfo and pLibraryInterface must be NULL.");
         }
         if (pCreateInfos[i].pLibraryInfo) {
-            if (pCreateInfos[i].pLibraryInfo->libraryCount == 0) {
-                if (pCreateInfos[i].stageCount == 0) {
-                    skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03600",
-                                     "vkCreateRayTracingPipelinesKHR(): If pLibraryInfo is not NULL and its libraryCount is 0, "
-                                     "stageCount must not be 0.");
-                }
-                if (pCreateInfos[i].groupCount == 0) {
-                    skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03601",
-                                     "vkCreateRayTracingPipelinesKHR(): If pLibraryInfo is not NULL and its libraryCount is 0, "
-                                     "groupCount must not be 0.");
-                }
-            } else {
-                if (pCreateInfos[i].pLibraryInterface == NULL) {
-                    skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03590",
-                                     "vkCreateRayTracingPipelinesKHR(): If pLibraryInfo is not NULL and its libraryCount member "
-                                     "is greater than 0, its "
-                                     "pLibraryInterface member must not be NULL.");
-                }
+            if ((pCreateInfos[i].pLibraryInfo->libraryCount > 0) && (pCreateInfos[i].pLibraryInterface == nullptr)) {
+                skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03590",
+                                 "vkCreateRayTracingPipelinesKHR(): If pLibraryInfo is not NULL and its libraryCount member "
+                                 "is greater than 0, its pLibraryInterface member must not be NULL.");
+            }
+        }
+        if ((pCreateInfos[i].pLibraryInfo == nullptr) || (pCreateInfos[i].pLibraryInfo->libraryCount == 0)) {
+            if (pCreateInfos[i].stageCount == 0) {
+                skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-07999",
+                                 "vkCreateRayTracingPipelinesKHR(): If pLibraryInfo is NULL or its libraryCount is 0, "
+                                 "stageCount must not be 0.");
+            }
+            if (((pCreateInfos[i].flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) && (pCreateInfos[i].groupCount == 0)) {
+                skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-flags-08700",
+                                 "vkCreateRayTracingPipelinesKHR(): VK_PIPELINE_CREATE_LIBRARY_BIT_KHR is not set, pLibraryInfo is "
+                                 "NULL or its libraryCount is 0, but groupCount is 0.");
             }
         }
         if (pCreateInfos[i].pLibraryInterface) {

--- a/tests/negative/ray_tracing.cpp
+++ b/tests/negative/ray_tracing.cpp
@@ -808,21 +808,31 @@ TEST_F(VkLayerTest, RayTracingValidateCmdTraceRaysKHR) {
 
         const VkPipelineLayoutObj pipeline_layout(m_device, {});
 
-        std::vector<VkPipelineShaderStageCreateInfo> shader_stages;
-        VkPipelineShaderStageCreateInfo stage_create_info = LvlInitStruct<VkPipelineShaderStageCreateInfo>();
-        stage_create_info.stage = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
-        stage_create_info.module = chit_shader.handle();
-        stage_create_info.pName = "main";
-        shader_stages.emplace_back(stage_create_info);
+        std::array<VkPipelineShaderStageCreateInfo, 2> shader_stages;
+        shader_stages[0] = LvlInitStruct<VkPipelineShaderStageCreateInfo>();
+        shader_stages[0].stage = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
+        shader_stages[0].module = chit_shader.handle();
+        shader_stages[0].pName = "main";
 
-        stage_create_info.stage = VK_SHADER_STAGE_RAYGEN_BIT_KHR;
-        stage_create_info.module = rgen_shader.handle();
-        shader_stages.emplace_back(stage_create_info);
+        shader_stages[1] = LvlInitStruct<VkPipelineShaderStageCreateInfo>();
+        shader_stages[1].stage = VK_SHADER_STAGE_RAYGEN_BIT_KHR;
+        shader_stages[1].module = rgen_shader.handle();
+        shader_stages[1].pName = "main";
+
+        std::array<VkRayTracingShaderGroupCreateInfoKHR, 1> shader_groups;
+        shader_groups[0] = LvlInitStruct<VkRayTracingShaderGroupCreateInfoKHR>();
+        shader_groups[0].type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR;
+        shader_groups[0].generalShader = 1;
+        shader_groups[0].closestHitShader = VK_SHADER_UNUSED_KHR;
+        shader_groups[0].anyHitShader = VK_SHADER_UNUSED_KHR;
+        shader_groups[0].intersectionShader = VK_SHADER_UNUSED_KHR;
 
         VkRayTracingPipelineCreateInfoKHR raytracing_pipeline_ci = LvlInitStruct<VkRayTracingPipelineCreateInfoKHR>();
         raytracing_pipeline_ci.flags = 0;
         raytracing_pipeline_ci.stageCount = static_cast<uint32_t>(shader_stages.size());
         raytracing_pipeline_ci.pStages = shader_stages.data();
+        raytracing_pipeline_ci.pGroups = shader_groups.data();
+        raytracing_pipeline_ci.groupCount = shader_groups.size();
         raytracing_pipeline_ci.layout = pipeline_layout.handle();
 
         const VkResult result = vkCreateRayTracingPipelinesKHR(m_device->handle(), VK_NULL_HANDLE, VK_NULL_HANDLE, 1,

--- a/tests/negative/ray_tracing_pipeline.cpp
+++ b/tests/negative/ray_tracing_pipeline.cpp
@@ -60,14 +60,12 @@ TEST_F(VkLayerTest, RayTracingPipelineCreateInfoKHR) {
         pipeline_ci.pGroups = &group_create_info;
         pipeline_ci.layout = empty_pipeline_layout.handle();
         pipeline_ci.stageCount = 0;
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                             "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03600");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-07999");
         vkCreateRayTracingPipelinesKHR(m_device->handle(), VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
         m_errorMonitor->VerifyFound();
         pipeline_ci.stageCount = 1;
         pipeline_ci.groupCount = 0;
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT,
-                                             "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03601");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRayTracingPipelineCreateInfoKHR-flags-08700");
         vkCreateRayTracingPipelinesKHR(m_device->handle(), VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
         m_errorMonitor->VerifyFound();
         pipeline_ci.groupCount = 1;
@@ -1100,10 +1098,19 @@ TEST_F(VkLayerTest, RayTracingPipelineMaxResources) {
     stage_create_info.module = rgen_shader.handle();
     stage_create_info.pName = "main";
 
+    auto shader_group = LvlInitStruct<VkRayTracingShaderGroupCreateInfoKHR>();
+    shader_group.type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR;
+    shader_group.generalShader = 0;
+    shader_group.closestHitShader = VK_SHADER_UNUSED_KHR;
+    shader_group.anyHitShader = VK_SHADER_UNUSED_KHR;
+    shader_group.intersectionShader = VK_SHADER_UNUSED_KHR;
+
     VkRayTracingPipelineCreateInfoKHR create_info = LvlInitStruct<VkRayTracingPipelineCreateInfoKHR>();
     create_info.layout = pipeline_layout.handle();
     create_info.stageCount = 1;
     create_info.pStages = &stage_create_info;
+    create_info.groupCount = 1;
+    create_info.pGroups = &shader_group;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRayTracingPipelineCreateInfoKHR-layout-03428");
     VkPipeline pipeline;
@@ -1144,11 +1151,20 @@ TEST_F(VkLayerTest, RayTracingInvalidPipelineFlags) {
     stage_create_info.module = rgen_shader.handle();
     stage_create_info.pName = "main";
 
+    auto shader_group = LvlInitStruct<VkRayTracingShaderGroupCreateInfoKHR>();
+    shader_group.type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_NV;
+    shader_group.generalShader = 0;
+    shader_group.closestHitShader = VK_SHADER_UNUSED_KHR;
+    shader_group.anyHitShader = VK_SHADER_UNUSED_KHR;
+    shader_group.intersectionShader = VK_SHADER_UNUSED_KHR;
+
     VkRayTracingPipelineCreateInfoKHR create_info = LvlInitStruct<VkRayTracingPipelineCreateInfoKHR>();
     create_info.flags = VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR | VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR;
     create_info.layout = empty_pipeline_layout.handle();
     create_info.stageCount = 1;
     create_info.pStages = &stage_create_info;
+    create_info.groupCount = 1;
+    create_info.pGroups = &shader_group;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRayTracingPipelineCreateInfoKHR-flags-06546");
     VkPipeline pipeline;


### PR DESCRIPTION
Fix up for Spencer's PR https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5499

Add:
`VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-07999`
>If pLibraryInfo is NULL or its libraryCount is 0, stageCount must not be 0

`VUID-VkRayTracingPipelineCreateInfoKHR-flags-08700`
>If flags does not include VK_PIPELINE_CREATE_LIBRARY_BIT_KHR and either pLibraryInfo is NULL or its libraryCount is 0, groupCount must not be 0

Remove `VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03600` and `VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03601`