### PR TITLE
cmake: Add VVL_CODEGEN

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,6 +15,7 @@
         "BUILD_TESTS": "ON",
         "BUILD_WERROR": "ON",
         "UPDATE_DEPS": "ON",
+        "VVL_CODEGEN": "ON",
         "CMAKE_BUILD_TYPE": "Debug"
       }
     }

--- a/docs/generated_code.md
+++ b/docs/generated_code.md
@@ -14,16 +14,18 @@ When making change to the `scripts/` folder, make sure to run `generate_source.p
 
 Note the addition of the Vulkan registry directory to `PYTHONPATH`. This is because the generation scripts depend on modules within the Vulkan registry.
 
-## Cmake helper
+## CMake helper
 
-A helper CMake target `VulkanVL_generated_source` is also provided to simplify
-the invocation of `scripts/generate_source.py` from the build directory:
+A helper CMake target `vvl_codegen` is also provided to simplify the invocation of `scripts/generate_source.py` from the build directory:
 
 ```bash
-cmake --build . --target VulkanVL_generated_source
+cmake -S . -B build -D VVL_CODEGEN=ON
+cmake --build build --target vvl_codegen
 ```
 
-Using the cmake target will also set `PYTHONPATH` properly, assuming a standard cmake invokation was made.
+Using the CMake target will also set `PYTHONPATH` properly, assuming a standard cmake invokation was made.
+
+NOTE: `VVL_CODEGEN` is `OFF` by default to allow users to build `VVL` via `add_subdirectory` and to avoid potential issues for system/language package managers.
 
 ## How it works
 

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -114,29 +114,17 @@ else()
     message(FATAL_ERROR "Cannot determine SPIRV-Tools target name")
 endif()
 
-find_package(PythonInterp 3 QUIET)
-
-if (PYTHONINTERP_FOUND)
-    # Get the include directory of the SPIRV-Headers
-    get_target_property(SPIRV_HEADERS_INCLUDE_DIR SPIRV-Headers::SPIRV-Headers INTERFACE_INCLUDE_DIRECTORIES)
-
-    set(spirv_unified_include_dir "${SPIRV_HEADERS_INCLUDE_DIR}/spirv/unified1/")
-    if (NOT IS_DIRECTORY ${spirv_unified_include_dir})
-        message(FATAL_ERROR "Unable to find spirv/unified1")
-    endif()
-
-    set(generate_source_py "${VVL_SOURCE_DIR}/scripts/generate_source.py")
-    if (NOT EXISTS ${generate_source_py})
-        message(FATAL_ERROR "Unable to find generate_source.py!")
-    endif()
-
-    add_custom_target(VulkanVL_generated_source
-        COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${VULKAN_HEADERS_REGISTRY_DIRECTORY} ${PYTHON_EXECUTABLE} ${generate_source_py} ${VULKAN_HEADERS_REGISTRY_DIRECTORY} ${spirv_unified_include_dir}
+# NOTE: Our custom code generation target isn't desirable for system package managers or add_subdirectory users.
+# So this target needs to be off by default to avoid obtuse build errors or patches.
+option(VVL_CODEGEN "Enable vulkan validation layer code generation")
+if (VVL_CODEGEN)
+    find_package(PythonInterp 3 REQUIRED)
+    add_custom_target(vvl_codegen
+        COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${VULKAN_HEADERS_REGISTRY_DIRECTORY} ${PYTHON_EXECUTABLE} "${VVL_SOURCE_DIR}/scripts/generate_source.py"
+            ${VULKAN_HEADERS_REGISTRY_DIRECTORY} "${SPIRV_HEADERS_INSTALL_DIR}/include/spirv/unified1"
             --incremental --generated-version ${VulkanHeaders_VERSION}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/generated
     )
-else()
-    message(NOTICE "VulkanVL_generated_source target requires python 3")
 endif()
 
 add_library(VkLayer_khronos_validation MODULE)

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -106,7 +106,7 @@ def main(argv):
     # get directory where generators will run
     if args.verify or args.incremental:
         # generate in temp directory so we can compare or copy later
-        temp_obj = tempfile.TemporaryDirectory(prefix='VulkanVL_generated_source_')
+        temp_obj = tempfile.TemporaryDirectory(prefix='vvl_codegen_')
         temp_dir = temp_obj.name
         gen_dir = temp_dir
     else:


### PR DESCRIPTION
Code generation should be OFF by default. It's not needed to build the vulkan validation layers.

- It's causing issues for add_subdirectory users.
- Package managers have no good way to disable this aside from patching.