### PR TITLE
layers: Add vkGetMemoryFdKHR VUs

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1802,6 +1802,7 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                HANDLE* pHandle) const override;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
+    bool PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR* pGetFdInfo, int* pFd) const override;
     bool PreCallValidateImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo) const override;
     bool PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd) const override;
 

--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -12215,6 +12215,7 @@ bool StatelessValidation::PreCallValidateGetMemoryFdKHR(
         skip |= ValidateFlags("vkGetMemoryFdKHR", "pGetFdInfo->handleType", "VkExternalMemoryHandleTypeFlagBits", AllVkExternalMemoryHandleTypeFlagBits, pGetFdInfo->handleType, kRequiredSingleBit, "VUID-VkMemoryGetFdInfoKHR-handleType-parameter", "VUID-VkMemoryGetFdInfoKHR-handleType-parameter");
     }
     skip |= ValidateRequiredPointer("vkGetMemoryFdKHR", "pFd", pFd, "VUID-vkGetMemoryFdKHR-pFd-parameter");
+    if (!skip) skip |= manual_PreCallValidateGetMemoryFdKHR(device, pGetFdInfo, pFd);
     return skip;
 }
 

--- a/layers/stateless/parameter_validation_utils.cpp
+++ b/layers/stateless/parameter_validation_utils.cpp
@@ -7621,6 +7621,18 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversionKHR(
                                                 "vkCreateSamplerYcbcrConversionKHR");
 }
 
+bool StatelessValidation::manual_PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR *pGetFdInfo,
+                                                               int *pFd) const {
+    constexpr auto allowed_types = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT | VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+    bool skip = false;
+    if (0 == (pGetFdInfo->handleType & allowed_types)) {
+        skip |= LogError(pGetFdInfo->memory, "VUID-VkMemoryGetFdInfoKHR-handleType-00672",
+                         "vkGetMemoryFdKHR(): handle type %s is not one of the supported handle types.",
+                         string_VkExternalMemoryHandleTypeFlagBits(pGetFdInfo->handleType));
+    }
+    return skip;
+}
+
 bool StatelessValidation::ValidateExternalSemaphoreHandleType(VkSemaphore semaphore, const char *vuid, const char *caller,
                                                               VkExternalSemaphoreHandleTypeFlagBits handle_type,
                                                               VkExternalSemaphoreHandleTypeFlags allowed_types) const {

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1369,6 +1369,7 @@ class StatelessValidation : public ValidationObject {
                                                                const VkAllocationCallbacks *pAllocator,
                                                                VkSamplerYcbcrConversion *pYcbcrConversion) const;
 
+    bool manual_PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR *pGetFdInfo, int *pFd) const;
     bool ValidateExternalSemaphoreHandleType(VkSemaphore semaphore, const char *vuid, const char *caller,
                                              VkExternalSemaphoreHandleTypeFlagBits handle_type,
                                              VkExternalSemaphoreHandleTypeFlags allowed_types) const;

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -234,6 +234,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkCmdDrawIndirectByteCountEXT',
             'vkCreateSamplerYcbcrConversion',
             'vkCreateSamplerYcbcrConversionKHR',
+            'vkGetMemoryFdKHR',
             'vkImportSemaphoreFdKHR',
             'vkGetSemaphoreFdKHR',
             'vkImportFenceFdKHR',

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     positive/command.cpp
     positive/descriptors.cpp
     positive/dynamic_rendering.cpp
+    positive/external_memory_sync.cpp
     positive/gpu_av.cpp
     positive/graphics_library.cpp
     positive/image_buffer.cpp

--- a/tests/positive/external_memory_sync.cpp
+++ b/tests/positive/external_memory_sync.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+
+TEST_F(VkPositiveLayerTest, GetMemoryFdHandle) {
+    TEST_DESCRIPTION("Get POXIS handle for memory allocation");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "At least Vulkan version 1.1 is required";
+    }
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    auto vkGetMemoryFdKHR = GetInstanceProcAddr<PFN_vkGetMemoryFdKHR>("vkGetMemoryFdKHR");
+
+    auto export_info = LvlInitStruct<VkExportMemoryAllocateInfo>();
+    export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+    auto alloc_info = LvlInitStruct<VkMemoryAllocateInfo>(&export_info);
+    alloc_info.allocationSize = 1024;
+    alloc_info.memoryTypeIndex = 0;
+
+    vk_testing::DeviceMemory memory;
+    memory.init(*m_device, alloc_info);
+    auto get_handle_info = LvlInitStruct<VkMemoryGetFdInfoKHR>();
+    get_handle_info.memory = memory;
+    get_handle_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+    int fd = -1;
+    vkGetMemoryFdKHR(*m_device, &get_handle_info, &fd);
+}


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5431

This PR validates `VkMemoryGetFdInfoKHR` passed to `vkGetMemoryFdKHR`:
`VUID-VkMemoryGetFdInfoKHR-handleType-00671`
`VUID-VkMemoryGetFdInfoKHR-handleType-00672`