### PR TITLE
layers: Fix AccelerationStructureDescriptor::is_khr_ initialisation

### DIFF
--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -859,8 +859,9 @@ void cvdescriptorset::AccelerationStructureDescriptor::CopyUpdate(DescriptorSet 
                                                                   const Descriptor *src, bool is_bindless) {
     if (src->GetClass() == Mutable) {
         auto acc_desc = static_cast<const MutableDescriptor *>(src);
+        is_khr_ = acc_desc->IsAccelerationStructureKHR();
         if (is_khr_) {
-            acc_ = acc_desc->GetAccelerationStructure();
+            acc_ = acc_desc->GetAccelerationStructureKHR();
             ReplaceStatePtr(set_state, acc_state_, dev_data->GetConstCastShared<ACCELERATION_STRUCTURE_STATE_KHR>(acc_),
                             is_bindless);
         } else {
@@ -1031,7 +1032,7 @@ void cvdescriptorset::MutableDescriptor::CopyUpdate(DescriptorSet *set_state, co
             } break;
             case AccelerationStructure: {
                 if (is_khr_) {
-                    acc_ = mutable_src->GetAccelerationStructure();
+                    acc_ = mutable_src->GetAccelerationStructureKHR();
                     ReplaceStatePtr(set_state, acc_state_, dev_data->GetConstCastShared<ACCELERATION_STRUCTURE_STATE_KHR>(acc_),
                                     is_bindless);
                 } else {

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -656,12 +656,19 @@ class MutableDescriptor : public Descriptor {
     VkDeviceSize GetOffset() const { return offset_; }
     VkDeviceSize GetRange() const { return range_; }
     std::shared_ptr<BUFFER_VIEW_STATE> GetSharedBufferViewState() const { return buffer_view_state_; }
-    VkAccelerationStructureKHR GetAccelerationStructure() const { return acc_; }
+    VkAccelerationStructureKHR GetAccelerationStructureKHR() const { return acc_; }
     const ACCELERATION_STRUCTURE_STATE_KHR *GetAccelerationStructureStateKHR() const { return acc_state_.get(); }
     ACCELERATION_STRUCTURE_STATE_KHR *GetAccelerationStructureStateKHR() { return acc_state_.get(); }
     VkAccelerationStructureNV GetAccelerationStructureNV() const { return acc_nv_; }
     const ACCELERATION_STRUCTURE_STATE *GetAccelerationStructureStateNV() const { return acc_state_nv_.get(); }
     ACCELERATION_STRUCTURE_STATE *GetAccelerationStructureStateNV() { return acc_state_nv_.get(); }
+    // Returns true if there is a stored KHR acceleration structure and false if there is a stored NV acceleration structure.
+    // Asserts that there is only one of the two.
+    bool IsAccelerationStructureKHR() const {
+        auto acc_khr = GetAccelerationStructureKHR();
+        assert((acc_khr != VK_NULL_HANDLE) ^ (GetAccelerationStructureNV() != VK_NULL_HANDLE));
+        return acc_khr != VK_NULL_HANDLE;
+    }
 
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *cb_state);
 

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -743,6 +743,18 @@ std::shared_ptr<rt::as::AccelerationStructureKHR> AccelStructSimpleOnHostBottomL
     return as;
 }
 
+std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnDeviceTopLevel(uint32_t vk_api_version, VkDeviceSize size) {
+    auto as = std::make_shared<AccelerationStructureKHR>(vk_api_version);
+    as->SetSize(size);
+    as->SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
+    as->SetDeviceBufferMemoryAllocateFlags(VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR);
+    as->SetDeviceBufferMemoryPropertyFlags(VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    as->SetBufferUsageFlags(VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+                            VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
+    as->SetDeviceBufferInitNoMem(false);
+    return as;
+}
+
 BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceBottomLevel(uint32_t vk_api_version, const vk_testing::Device &device,
                                                                 GeometryKHR::Type geometry_type /*= GeometryKHR::Type::Triangle*/) {
     BuildGeometryInfoKHR out_build_info(vk_api_version);

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -224,6 +224,7 @@ GeometryKHR GeometrySimpleHostInstance(uint32_t vk_api_version, VkAccelerationSt
 std::shared_ptr<AccelerationStructureKHR> AccelStructNull(uint32_t vk_api_version);
 std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnDeviceBottomLevel(uint32_t vk_api_version, VkDeviceSize size);
 std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnHostBottomLevel(uint32_t vk_api_version, VkDeviceSize size);
+std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnDeviceTopLevel(uint32_t vk_api_version, VkDeviceSize size);
 
 BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceBottomLevel(uint32_t vk_api_version, const vk_testing::Device& device,
                                                                 GeometryKHR::Type geometry_type = GeometryKHR::Type::Triangle);


### PR DESCRIPTION
- Fix for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5300

AccelerationStructureDescriptor::is_khr_ was not initialised

Locally, I now have no validation error in this test, but it still fails:
```
Writing test log into TestResults.qpa
dEQP Core vulkan-cts-1.3.5.0-238-ge873c6862 (0xe873c686) starting..
  target implementation = 'Default'
loader_get_json: Failed to open JSON file C:\Program Files (x86)\Epic Games\Epic Online Services\managedArtifacts\98bc04bc842e4906993fd6d6644ffb8d\EOSOverlayVkLayer-Win64.json

Test case 'dEQP-VK.binding_model.mutable_descriptor.single_nonmutable.acceleration_structure_khr.update_copy.mutable_source.normal_source.pool_same_types.pre_update.no_array.comp'..
  InternalError (1 API usage errors found)

DONE!

Test run totals:
  Passed:        0/1 (0.0%)
  Failed:        1/1 (100.0%)
  Not supported: 0/1 (0.0%)
  Warnings:      0/1 (0.0%)
  Waived:        0/1 (0.0%)
```

I run with the following command line options:
--deqp-validation=enable --deqp-print-validation-errors --deqp-caselist=dEQP-VK.binding_model.mutable_descriptor.single_nonmutable.acceleration_structure_khr.update_copy.mutable_source.normal_source.pool_same_types.pre_update.no_array.comp