### PR TITLE
tests: Forbid copy/move of timeout guard

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -194,6 +194,7 @@ void ThreadTimeoutHelper::OnThreadDone() {
     {
         std::lock_guard lock(mutex_);
         active_threads_--;
+        assert(active_threads_ >= 0);
         if (!active_threads_) last_worker = true;
     }
     if (last_worker) cv_.notify_one();

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -860,9 +860,16 @@ class ThreadTimeoutHelper {
 
     struct Guard {
         Guard(ThreadTimeoutHelper &timeout_helper) : timeout_helper_(timeout_helper) {}
+        Guard(const Guard &) = delete;
+        Guard &operator=(const Guard &) = delete;
+
         ~Guard() { timeout_helper_.OnThreadDone(); }
+
         ThreadTimeoutHelper &timeout_helper_;
     };
+    // Mandatory elision of copy/move operations guarantees the destructor is not called
+    // (even in the presence of copy/move constructor) and the object is constructed directly
+    // into the destination storage: https://en.cppreference.com/w/cpp/language/copy_elision
     Guard ThreadGuard() { return Guard(*this); }
 
   private:


### PR DESCRIPTION
Based on this comment: https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/0f6867787052243586afeadeb9c3b6b8cff6638a#r106221779

Plus added a comment why original code does not cause issues when returning local object with non-trivial destructor.

