### PR TITLE
git: Ignore PR 949

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -144,3 +144,18 @@ e19e20dacd199de47c9f29a05a992e560b5bf5e4
 
 # Fix clang-format errors in core_validation.cpp
 7256b55653e99b31feb465e5d00566249ec57bc3
+
+# Refactor validation layer tests
+20c80f8d76e17ea705f5e258322979a24427bbeb
+
+# Refactor validation layer tests
+11b2e80ae1ca5eec3c60fd199a79eb28d687bf34
+
+# Refactor validation layer tests
+088160a6f470598c62f9c708d4f85215dab7c481
+
+# Refactor validation layer tests
+ef74b1167d16187042028893328f87ee6f884e1d
+
+# Refactor validation layer tests
+aae202333dda8a6ca1422a773d02c4d7853f71b7


### PR DESCRIPTION
Using git blame, found https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/949 produced a lot of churn moving things around