### PR TITLE
layers: Ensure hex output is in lowercase

### DIFF
--- a/layers/core_checks/cmd_buffer_validation.cpp
+++ b/layers/core_checks/cmd_buffer_validation.cpp
@@ -1268,7 +1268,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                         const auto subresource = image_state->subresource_encoder.Decode(index);
                         skip |=
                             LogError(pCommandBuffers[i], "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001",
-                                     "%s: Executed secondary command buffer using %s (subresource: aspectMask 0x%X array layer %u, "
+                                     "%s: Executed secondary command buffer using %s (subresource: aspectMask 0x%x array layer %u, "
                                      "mip level %u) which expects layout %s--instead, image %s layout is %s.",
                                      "vkCmdExecuteCommands():", report_data->FormatHandle(image).c_str(), subresource.aspectMask,
                                      subresource.arrayLayer, subresource.mipLevel, string_VkImageLayout(sub_layout), layout_type,

--- a/layers/core_checks/device_memory_validation.cpp
+++ b/layers/core_checks/device_memory_validation.cpp
@@ -420,11 +420,11 @@ bool CoreChecks::ValidateMemoryTypes(const DEVICE_MEMORY_STATE *mem_info, const 
                                      const char *msgCode) const {
     bool skip = false;
     if (((1 << mem_info->alloc_info.memoryTypeIndex) & memory_type_bits) == 0) {
-        skip = LogError(mem_info->mem(), msgCode,
-                        "%s(): MemoryRequirements->memoryTypeBits (0x%X) for this object type are not compatible with the memory "
-                        "type (0x%X) of %s.",
-                        funcName, memory_type_bits, mem_info->alloc_info.memoryTypeIndex,
-                        report_data->FormatHandle(mem_info->mem()).c_str());
+        skip = LogError(
+            mem_info->mem(), msgCode,
+            "%s(): MemoryRequirements->memoryTypeBits (0x%x) for this object type are not compatible with the memory type (%" PRIu32
+            ") of %s.",
+            funcName, memory_type_bits, mem_info->alloc_info.memoryTypeIndex, report_data->FormatHandle(mem_info->mem()).c_str());
     }
     return skip;
 }

--- a/layers/core_checks/image_layout_validation.cpp
+++ b/layers/core_checks/image_layout_validation.cpp
@@ -344,7 +344,7 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location &loc, const CMD_BUFFE
                     for (auto index : sparse_container::range_view<decltype(intersected_range)>(intersected_range)) {
                         const auto subresource = image_state->subresource_encoder.Decode(index);
                         skip |= LogError(cb_state.commandBuffer(), kVUID_Core_DrawState_InvalidImageLayout,
-                                         "%s command buffer %s expects %s (subresource: aspectMask 0x%X array layer %" PRIu32
+                                         "%s command buffer %s expects %s (subresource: aspectMask 0x%x array layer %" PRIu32
                                          ", mip level %" PRIu32
                                          ") "
                                          "to be in layout %s--instead, current layout is %s.",

--- a/layers/core_checks/ray_tracing_validation.cpp
+++ b/layers/core_checks/ray_tracing_validation.cpp
@@ -456,7 +456,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructureNV(VkCommandBuffer 
         if (dst_as_state->create_infoNV.info.flags != pInfo->flags) {
             skip |= LogError(commandBuffer, "VUID-vkCmdBuildAccelerationStructureNV-dst-02488",
                              "vkCmdBuildAccelerationStructureNV(): create info VkAccelerationStructureInfoNV::flags"
-                             "[0x%X] must be identical to build info VkAccelerationStructureInfoNV::flags [0x%X].",
+                             "[0x%x] must be identical to build info VkAccelerationStructureInfoNV::flags [0x%x].",
                              dst_as_state->create_infoNV.info.flags, pInfo->flags);
         }
         if (dst_as_state->create_infoNV.info.instanceCount < pInfo->instanceCount) {

--- a/layers/core_checks/render_pass_validation.cpp
+++ b/layers/core_checks/render_pass_validation.cpp
@@ -952,8 +952,8 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
 
                     if (framebuffer_attachment_image_info->flags != image_create_info->flags) {
                         skip |= LogError(pRenderPassBeginInfo->renderPass, "VUID-VkRenderPassBeginInfo-framebuffer-03209",
-                                         "%s: Image view #%u created from an image with flags set as 0x%X, "
-                                         "but image info #%u used to create the framebuffer had flags set as 0x%X",
+                                         "%s: Image view #%u created from an image with flags set as 0x%x, "
+                                         "but image info #%u used to create the framebuffer had flags set as 0x%x",
                                          func_name, i, image_create_info->flags, i, framebuffer_attachment_image_info->flags);
                     }
 

--- a/layers/core_checks/synchronization_validation.cpp
+++ b/layers/core_checks/synchronization_validation.cpp
@@ -771,7 +771,7 @@ struct RenderPassDepState {
             std::stringstream self_dep_ss;
             stream_join(self_dep_ss, ", ", self_dependencies);
             core->LogError(rp_handle, vuid,
-                           "%s: dependencyFlags param (0x%X) does not equal VkSubpassDependency dependencyFlags value for any "
+                           "%s: dependencyFlags param (0x%x) does not equal VkSubpassDependency dependencyFlags value for any "
                            "self-dependency of subpass %d of %s. Candidate VkSubpassDependency are pDependencies entries [%s].",
                            func_name.c_str(), dependency_flags, active_subpass, core->report_data->FormatHandle(rp_handle).c_str(),
                            self_dep_ss.str().c_str());

--- a/layers/core_checks/video_validation.cpp
+++ b/layers/core_checks/video_validation.cpp
@@ -929,7 +929,7 @@ bool CoreChecks::PreCallValidateBindVideoSessionMemoryKHR(VkDevice device, VkVid
                         LogObjectList objlist(videoSession);
                         objlist.add(mem_state->Handle());
                         skip |= LogError(objlist, "VUID-vkBindVideoSessionMemoryKHR-pBindSessionMemoryInfos-07198",
-                                         "vkBindVideoSessionMemoryKHR(): memoryTypeBits (0x%X) for memory binding "
+                                         "vkBindVideoSessionMemoryKHR(): memoryTypeBits (0x%x) for memory binding "
                                          "with index %u of %s are not compatible with the memory type index (%u) of "
                                          "%s specified in pBindSessionMemoryInfos[%u].memory",
                                          mem_binding_info->requirements.memoryTypeBits, bind_info.memoryBindIndex,


### PR DESCRIPTION
According to LunarG coding guidelines: "Use lowercase for all hex output".