### PR TITLE
IWYU: add cstdio for snprintf in vk_mem_alloc.h

### DIFF
--- a/layers/external/vma/vk_mem_alloc.h
+++ b/layers/external/vma/vk_mem_alloc.h
@@ -2579,6 +2579,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(
 #undef VMA_IMPLEMENTATION
 
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <utility>


### PR DESCRIPTION
Discovered with GCC 13.