### PR TITLE
tsan: Fix TSAN code/documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,12 +80,6 @@ if (VVL_ENABLE_ASAN)
     add_link_options(-fsanitize=address)
 endif()
 
-option(VVL_ENABLE_TSAN "Use thread sanitizer")
-if (VVL_ENABLE_TSAN)
-    add_compile_options(-fsanitize=thread)
-    add_link_options(-fsanitize=thread)
-endif()
-
 option(VVL_CLANG_TIDY "Use clang-tidy")
 if (VVL_CLANG_TIDY)
     find_program(CLANG_TIDY NAMES clang-tidy)

--- a/tests/README.md
+++ b/tests/README.md
@@ -176,7 +176,13 @@ to ensure high quality code.
 
 WIP (Not yet part of our CI process)
 
-`-D VVL_ENABLE_TSAN=ON` will enable TSAN in the build which is `OFF` by default.
+```bash
+# NOTE: ThreadSanitizer generally requires all code to be compiled with -fsanitize=thread to prevent false positives.
+# https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual#non-instrumented-code
+export CFLAGS=-fsanitize=thread
+export CXXFLAGS=-fsanitize=thread
+export LDFLAGS=-fsanitize=thread
+```
 
 - https://clang.llvm.org/docs/ThreadSanitizer.html
 - https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual


### PR DESCRIPTION
TSAN must be enabled for all code. Making the only viable option to enable the appropriate environment variables.