### PR TITLE
bp: Add best practice for AMD workgroup size

### DIFF
--- a/layers/best_practices/best_practices_error_enums.h
+++ b/layers/best_practices/best_practices_error_enums.h
@@ -262,6 +262,8 @@
     "UNASSIGNED-BestPractices-SyncObjects-HighNumberOfSemaphores";
 [[maybe_unused]] static const char *kVUID_BestPractices_DynamicRendering_NotSupported =
     "UNASSIGNED-BestPractices-DynamicRendering-NotSupported";
+[[maybe_unused]] static const char *kVUID_BestPractices_LocalWorkgroup_Multiple64 =
+    "UNASSIGNED-BestPractices-LocalWorkgroup-Multiple64";
 
 // Imagination Technologies best practices
 [[maybe_unused]] static const char *kVUID_BestPractices_Texture_Format_PVRTC_Outdated =

--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -1368,10 +1368,12 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
     if (!entrypoint_optional) return false;
 
     const Instruction& entrypoint = *entrypoint_optional;
-    uint32_t x = 1, y = 1, z = 1;
-    module_state->FindLocalSize(entrypoint, x, y, z);
+    uint32_t x = {}, y = {}, z = {};
+    if (!module_state->FindLocalSize(entrypoint, x, y, z)) {
+        return false;
+    }
 
-    uint32_t thread_count = x * y * z;
+    const uint32_t thread_count = x * y * z;
 
     // Generate a priori warnings about work group sizes.
     if (thread_count > kMaxEfficientWorkGroupThreadCountArm) {

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -454,7 +454,10 @@ class BestPractices : public ValidationStateTracker {
                                                const VkComputePipelineCreateInfo* pCreateInfos,
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                void* pipe_state) const override;
+
     bool ValidateCreateComputePipelineArm(const VkComputePipelineCreateInfo& createInfo) const;
+
+    bool ValidateCreateComputePipelineAmd(const VkComputePipelineCreateInfo& createInfo) const;
 
     bool CheckPipelineStageFlags(const std::string& api_name, VkPipelineStageFlags flags) const;
     bool CheckPipelineStageFlags(const std::string& api_name, VkPipelineStageFlags2KHR flags) const;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -379,7 +379,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     const StructInfo *FindEntrypointPushConstant(char const *name, VkShaderStageFlagBits stageBits) const;
     const EntryPoint *FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
     std::optional<Instruction> FindEntrypointInstruction(char const *name, VkShaderStageFlagBits stageBits) const;
-    bool FindLocalSize(const Instruction &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y, uint32_t &local_size_z) const;
+    [[nodiscard]] bool FindLocalSize(const Instruction &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y,
+                                     uint32_t &local_size_z) const;
 
     const Instruction *GetConstantDef(uint32_t id) const;
     uint32_t GetConstantValueById(uint32_t id) const;


### PR DESCRIPTION
https://gpuopen.com/learn/rdna-performance-guide/#shaders
"Make the workgroup size a multiple of 64 to obtain best performance across all GPU generations."