### PR TITLE
syncval: Clean up and correct bound size code.

### DIFF
--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -40,6 +40,17 @@ class BUFFER_STATE : public BINDABLE {
     BUFFER_STATE(BUFFER_STATE const &rh_obj) = delete;
 
     VkBuffer buffer() const { return handle_.Cast<VkBuffer>(); }
+    std::optional<VkDeviceSize> ComputeValidSize(VkDeviceSize offset, VkDeviceSize size) const {
+        return ::ComputeValidSize(offset, size, createInfo.size);
+    }
+    VkDeviceSize ComputeSize(VkDeviceSize offset, VkDeviceSize size) const {
+        std::optional<VkDeviceSize> valid_size = ComputeValidSize(offset, size);
+        return valid_size.has_value() ? *valid_size : VkDeviceSize(0);
+    }
+    static VkDeviceSize ComputeSize(const std::shared_ptr<const BUFFER_STATE> &buffer_state, VkDeviceSize offset,
+                                    VkDeviceSize size) {
+        return buffer_state ? buffer_state->ComputeSize(offset, size) : VkDeviceSize(0);
+    }
 
     sparse_container::range<VkDeviceAddress> DeviceAddressRange() const { return {deviceAddress, deviceAddress + createInfo.size}; }
 };

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -122,6 +122,11 @@ struct BufferBinding {
     VkDeviceSize stride;
 
     BufferBinding() : buffer_state(), size(0), offset(0), stride(0) {}
+    BufferBinding(const std::shared_ptr<BUFFER_STATE> &buffer_state_, VkDeviceSize size_, VkDeviceSize offset_,
+                  VkDeviceSize stride_)
+        : buffer_state(buffer_state_), size(size_), offset(offset_), stride(stride_) {}
+    BufferBinding(const std::shared_ptr<BUFFER_STATE> &buffer_state_, VkDeviceSize offset_)
+        : BufferBinding(buffer_state_, BUFFER_STATE::ComputeSize(buffer_state_, offset_, VK_WHOLE_SIZE), offset_, 0U) {}
     virtual ~BufferBinding() {}
 
     virtual void reset() { *this = BufferBinding(); }
@@ -132,6 +137,8 @@ struct IndexBufferBinding : BufferBinding {
     VkIndexType index_type;
 
     IndexBufferBinding() : BufferBinding(), index_type(static_cast<VkIndexType>(0)) {}
+    IndexBufferBinding(const std::shared_ptr<BUFFER_STATE> &buffer_state_, VkDeviceSize offset_, VkIndexType index_type_)
+        : BufferBinding(buffer_state_, offset_), index_type(index_type_) {}
     virtual ~IndexBufferBinding() {}
 
     virtual void reset() override { *this = IndexBufferBinding(); }

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -1489,10 +1489,10 @@ class CommandBufferAccessContext : public CommandExecutionContext {
 
     bool ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, CMD_TYPE cmd_type) const;
     void RecordDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, ResourceUsageTag tag);
-    bool ValidateDrawVertex(uint32_t vertexCount, uint32_t firstVertex, CMD_TYPE cmd_type) const;
-    void RecordDrawVertex(uint32_t vertexCount, uint32_t firstVertex, ResourceUsageTag tag);
-    bool ValidateDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, CMD_TYPE cmd_type) const;
-    void RecordDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, ResourceUsageTag tag);
+    bool ValidateDrawVertex(const std::optional<uint32_t> &vertexCount, uint32_t firstVertex, CMD_TYPE cmd_type) const;
+    void RecordDrawVertex(const std::optional<uint32_t> &vertexCount, uint32_t firstVertex, ResourceUsageTag tag);
+    bool ValidateDrawVertexIndex(const std::optional<uint32_t> &indexCount, uint32_t firstIndex, CMD_TYPE cmd_type) const;
+    void RecordDrawVertexIndex(const std::optional<uint32_t> &indexCount, uint32_t firstIndex, ResourceUsageTag tag);
     bool ValidateDrawSubpassAttachment(CMD_TYPE cmd_type) const;
     void RecordDrawSubpassAttachment(ResourceUsageTag tag);
     ResourceUsageTag RecordNextSubpass(CMD_TYPE cmd_type);

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -389,6 +389,18 @@ static inline VkDeviceSize SafeDivision(VkDeviceSize dividend, VkDeviceSize divi
     return result;
 }
 
+inline std::optional<VkDeviceSize> ComputeValidSize(VkDeviceSize offset, VkDeviceSize size, VkDeviceSize whole_size) {
+    std::optional<VkDeviceSize> valid_size;
+    if (offset < whole_size) {
+        if (size == VK_WHOLE_SIZE) {
+            valid_size.emplace(whole_size - offset);
+        } else if ((offset + size) <= whole_size) {
+            valid_size.emplace(size);
+        }
+    }
+    return valid_size;
+}
+
 // Only 32 bit fields should need a bit count
 static inline uint32_t GetBitSetCount(uint32_t field) {
     std::bitset<32> view_bits(field);


### PR DESCRIPTION
Get rid of magic UINT32 max usage, and correctly set size for bind vertex buffer2