### PR TITLE
Fix DynamicRendering calling command cmd helper

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1478,6 +1478,7 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo) const override;
     bool ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
                                          const VkRenderingAttachmentInfo* pAttachments, const char* func_name) const;
+    bool ValidateCmdEndRendering(VkCommandBuffer commandBuffer, CMD_TYPE cmd_type) const;
     bool PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer) const override;
     bool PreCallValidateCmdEndRendering(VkCommandBuffer commandBuffer) const override;
     bool PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer) const override;

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -173,6 +173,14 @@ static char const bindStateFragSubpassLoadInputText[] = R"glsl(
     }
 )glsl";
 
+static char const bindStateFragColorOutputText[] = R"glsl(
+    #version 460
+    layout(location=0) out vec4 color;
+    void main() {
+        color = vec4(1.0f);
+    }
+)glsl";
+
 [[maybe_unused]] static const char *bindStateRTShaderText = R"glsl(
     #version 460
     #extension GL_EXT_ray_tracing : require // Requires SPIR-V 1.5 (Vulkan 1.2)

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -303,7 +303,6 @@ TEST_F(VkPositiveLayerTest, DynamicRenderingPipeWithDiscard) {
     pipe.CreateVKPipeline(pl.handle(), render_pass, &create_info);
 }
 
-
 TEST_F(VkPositiveLayerTest, UseStencilAttachmentWithIntegerFormatAndDepthStencilResolve) {
     TEST_DESCRIPTION("Use stencil attachment with integer format and depth stencil resolve extension");
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5492

We were not calling `ValidateCmd` for `vkCmdBeginRendering`/`vkCmdEndRendering` and missing the checks from it