### PR TITLE
test: Remove static from Video function pointers

### DIFF
--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -2333,7 +2333,7 @@ void VkCommandBufferObj::EndRendering() {
 }
 
 void VkCommandBufferObj::BeginVideoCoding(const VkVideoBeginCodingInfoKHR &beginInfo) {
-    static PFN_vkCmdBeginVideoCodingKHR vkCmdBeginVideoCodingKHR =
+    PFN_vkCmdBeginVideoCodingKHR vkCmdBeginVideoCodingKHR =
         (PFN_vkCmdBeginVideoCodingKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginVideoCodingKHR");
     ASSERT_NE(vkCmdBeginVideoCodingKHR, nullptr);
 
@@ -2341,7 +2341,7 @@ void VkCommandBufferObj::BeginVideoCoding(const VkVideoBeginCodingInfoKHR &begin
 }
 
 void VkCommandBufferObj::ControlVideoCoding(const VkVideoCodingControlInfoKHR &controlInfo) {
-    static PFN_vkCmdControlVideoCodingKHR vkCmdControlVideoCodingKHR =
+    PFN_vkCmdControlVideoCodingKHR vkCmdControlVideoCodingKHR =
         (PFN_vkCmdControlVideoCodingKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdControlVideoCodingKHR");
     ASSERT_NE(vkCmdControlVideoCodingKHR, nullptr);
 
@@ -2349,7 +2349,7 @@ void VkCommandBufferObj::ControlVideoCoding(const VkVideoCodingControlInfoKHR &c
 }
 
 void VkCommandBufferObj::DecodeVideo(const VkVideoDecodeInfoKHR &decodeInfo) {
-    static PFN_vkCmdDecodeVideoKHR vkCmdDecodeVideoKHR =
+    PFN_vkCmdDecodeVideoKHR vkCmdDecodeVideoKHR =
         (PFN_vkCmdDecodeVideoKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdDecodeVideoKHR");
     ASSERT_NE(vkCmdDecodeVideoKHR, nullptr);
 
@@ -2357,7 +2357,7 @@ void VkCommandBufferObj::DecodeVideo(const VkVideoDecodeInfoKHR &decodeInfo) {
 }
 
 void VkCommandBufferObj::EndVideoCoding(const VkVideoEndCodingInfoKHR &endInfo) {
-    static PFN_vkCmdEndVideoCodingKHR vkCmdEndVideoCodingKHR =
+    PFN_vkCmdEndVideoCodingKHR vkCmdEndVideoCodingKHR =
         (PFN_vkCmdEndVideoCodingKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndVideoCodingKHR");
     ASSERT_NE(vkCmdEndVideoCodingKHR, nullptr);
 


### PR DESCRIPTION
Various functions are being loaded using vkGetDeviceProcAddr then stored inside a static local variable. This means subsequent tests that use those functions will contain a *stale* function pointer, since the device is different and the dynamic libraries would have been unloaded.