### PR TITLE
layers: Account for `VkSurfaceFullScreenExclusiveInfoEXT` when validating swapchain creation

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -495,7 +495,7 @@ class CoreChecks : public ValidationStateTracker {
                                                  VkSwapchainCreateInfoKHR const* create_info,
                                                  const SURFACE_STATE* surface_state) const;
     bool ValidateSwapchainPresentScalingCreateInfo(VkPresentModeKHR present_mode, const char* func_name,
-                                                   VkSurfaceCapabilitiesKHR* capabilities,
+                                                   const VkSurfaceCapabilitiesKHR* capabilities,
                                                    VkSwapchainCreateInfoKHR const* create_info,
                                                    const SURFACE_STATE* surface_state) const;
     bool ValidateCreateSwapchain(const char* func_name, VkSwapchainCreateInfoKHR const* pCreateInfo,

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -381,9 +381,9 @@ VKAPI_ATTR bool LogMsg(const debug_report_data *debug_data, VkFlags msg_flags, c
         str_plus_spec_text.resize(result);
     }
 
-    // Append the spec error text to the error message, unless it's an UNASSIGNED or UNDEFINED vuid
+    // Append the spec error text to the error message, unless it contains a word treated as special
     if ((vuid_text.find("UNASSIGNED-") == std::string::npos) && (vuid_text.find(kVUIDUndefined) == std::string::npos) &&
-        (vuid_text.rfind("SYNC-", 0) == std::string::npos)) {
+        (vuid_text.rfind("SYNC-", 0) == std::string::npos) && (vuid_text.find("INTERNAL-ERROR-") == std::string::npos)) {
         // Linear search makes no assumptions about the layout of the string table. This is not fast, but it does not need to be at
         // this point in the error reporting path
         uint32_t num_vuids = sizeof(vuid_spec_text) / sizeof(vuid_spec_text_pair);

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <algorithm>
 #include <memory>
+#include <string_view>
 
 #include "vulkan/vulkan.h"
 #include "utils/cast_utils.h"
@@ -4089,6 +4090,15 @@ class ValidationObject {
             const bool result = LogMsg(report_data, kInformationBit, objlist, vuid_text, format, argptr);
             va_end(argptr);
             return result;
+        }
+
+        void LogInternalError(std::string_view failure_location, const LogObjectList &obj_list,
+                              std::string_view entrypoint, VkResult err) const {
+            const std::string_view err_string = string_VkResult(err);
+            std::string vuid = "INTERNAL-ERROR-";
+            vuid += entrypoint;
+            LogError(obj_list, vuid, "In %s: %s() was called in the Validation Layer state tracking and failed with result = %s.",
+                     failure_location.data(), entrypoint.data(), err_string.data());
         }
 
         // Handle Wrapping Data

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -19,6 +19,7 @@
 #pragma once
 #include "state_tracker/base_node.h"
 #include "generated/layer_chassis_dispatch.h"
+#include "generated/vk_safe_struct.h"
 #include <vector>
 
 struct DeviceFeatures {
@@ -111,9 +112,9 @@ class QUEUE_FAMILY_PERF_COUNTERS {
 
 class SURFACELESS_QUERY_STATE {
   public:
-    std::vector<VkSurfaceFormatKHR> formats;
+    std::vector<safe_VkSurfaceFormat2KHR> formats;
     std::vector<VkPresentModeKHR> present_modes;
-    VkSurfaceCapabilitiesKHR capabilities;
+    safe_VkSurfaceCapabilities2KHR capabilities;
 };
 
 class PHYSICAL_DEVICE_STATE : public BASE_NODE {

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -480,6 +480,21 @@ constexpr uint32_t ResolveRemainingLayers(const VkImageCreateInfo &ci, VkImageSu
     return (range.layerCount == VK_REMAINING_ARRAY_LAYERS) ? (ci.arrayLayers - range.baseArrayLayer) : range.layerCount;
 }
 
+// Find whether or not an element is in list
+// Two definitions, to be able to do the following calls:
+// IsIn(1, {1, 2, 3});
+// std::array arr {1, 2, 3};
+// IsIn(1, arr);
+template <typename T, typename RANGE>
+bool IsValueIn(const T &v, const RANGE &range) {
+    return std::find(std::begin(range), std::end(range), v) != std::end(range);
+}
+
+template <typename T>
+bool IsValueIn(const T &v, const std::initializer_list<T> &list) {
+    return IsValueIn<T, decltype(list)>(v, list);
+}
+
 extern "C" {
 #endif
 

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -40,6 +40,9 @@
 #define STRINGIFY_HELPER(s) #s
 
 #ifdef __cplusplus
+template <typename... Types>
+void UNUSED(Types...) {}
+
 static inline VkExtent3D CastTo3D(const VkExtent2D &d2) {
     VkExtent3D d3 = {d2.width, d2.height, 1};
     return d3;

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -39,9 +39,18 @@
 #define STRINGIFY(s) STRINGIFY_HELPER(s)
 #define STRINGIFY_HELPER(s) #s
 
+#if defined __PRETTY_FUNCTION__
+#define VVL_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#else
+// For MSVC
+#if defined(__FUNCSIG__)
+#define VVL_PRETTY_FUNCTION __FUNCSIG__
+#else
+#define VVL_PRETTY_FUNCTION __FILE__ ":" STRINGIFY(__LINE__)
+#endif
+#endif
+
 #ifdef __cplusplus
-template <typename... Types>
-void UNUSED(Types...) {}
 
 static inline VkExtent3D CastTo3D(const VkExtent2D &d2) {
     VkExtent3D d3 = {d2.width, d2.height, 1};

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -220,6 +220,7 @@ class LayerChassisOutputGenerator(OutputGenerator):
 #include <string.h>
 #include <algorithm>
 #include <memory>
+#include <string_view>
 
 #include "vulkan/vulkan.h"
 #include "utils/cast_utils.h"
@@ -443,6 +444,15 @@ class ValidationObject {
             const bool result = LogMsg(report_data, kInformationBit, objlist, vuid_text, format, argptr);
             va_end(argptr);
             return result;
+        }
+
+        void LogInternalError(std::string_view failure_location, const LogObjectList &obj_list,
+                              std::string_view entrypoint, VkResult err) const {
+            const std::string_view err_string = string_VkResult(err);
+            std::string vuid = "INTERNAL-ERROR-";
+            vuid += entrypoint;
+            LogError(obj_list, vuid, "In %s: %s() was called in the Validation Layer state tracking and failed with result = %s.",
+                     failure_location.data(), entrypoint.data(), err_string.data());
         }
 
         // Handle Wrapping Data

--- a/tests/negative/wsi.cpp
+++ b/tests/negative/wsi.cpp
@@ -2763,7 +2763,7 @@ TEST_F(VkLayerTest, TestvkAcquireFullScreenExclusiveModeEXT) {
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
 #ifndef VK_USE_PLATFORM_WIN32_KHR
-    GTEST_SKIP() << "Test not supported on platform, skipping".
+    GTEST_SKIP() << "Test not supported on platform, skipping.";
 #else
     AddSurfaceExtension();
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -2775,10 +2775,6 @@ TEST_F(VkLayerTest, TestvkAcquireFullScreenExclusiveModeEXT) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
-    if (!InitSurface()) {
-        GTEST_SKIP() << "Cannot create surface";
-    }
-    InitSwapchainInfo();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     if (!InitSwapchain()) {
         GTEST_SKIP() << "Cannot create surface or swapchain";


### PR DESCRIPTION
Originally was https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4703, but since rebasing this old PR lead to terrible merge issues, I'd rather leave the old one untouched just in case.

- Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4594

The main thing about the fix is an update to `SURFACE_STATE` to use `VkSurfaceFormat2KHR`, `VkSurfaceCapabilities2KHR` and `VkPhysicalDeviceSurfaceInfo2KHR`. It now relies on `DispatchGetPhysicalDeviceSurfaceFormats2KHR` and `DispatchGetPhysicalDeviceSurfaceCapabilities2KHR` when `vk_khr_get_surface_capabilities2` is enabled. Otherwise it fall backs to the original functions.

This PR defines a `LogInternalError` used to log errors we get from our internal `DispatchVkFoo` calls.