### PR TITLE
Add ExecutionModeSet

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -872,8 +872,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderSubgroupSizeControl(const SHADER_MODULE_STATE& module_state, VkPipelineShaderStageCreateFlags flags) const;
     bool ValidateComputeSharedMemory(const SHADER_MODULE_STATE& module_state, uint32_t total_shared_size) const;
     bool ValidateAtomicsTypes(const SHADER_MODULE_STATE& module_state) const;
-    bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint, VkShaderStageFlagBits stage,
-                                const PIPELINE_STATE& pipeline) const;
+    bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, const SHADER_MODULE_STATE::EntryPoint& entrypoint,
+                                VkShaderStageFlagBits stage, const PIPELINE_STATE& pipeline) const;
     bool ValidateViAgainstVsInputs(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
                                    const SHADER_MODULE_STATE::EntryPoint& entrypoint) const;
     bool ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state,
@@ -884,8 +884,8 @@ class CoreChecks : public ValidationStateTracker {
                                                             const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderInputAttachment(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline,
                                        const ResourceInterfaceVariable& variable) const;
-    bool ValidateConservativeRasterization(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
-                                           const PIPELINE_STATE& pipeline) const;
+    bool ValidateConservativeRasterization(const SHADER_MODULE_STATE& module_state,
+                                           const SHADER_MODULE_STATE::EntryPoint& entrypoint, const PIPELINE_STATE& pipeline) const;
     bool ValidatePushConstantUsage(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
                                    safe_VkPipelineShaderStageCreateInfo const* create_info) const;
     bool ValidateBuiltinLimits(const SHADER_MODULE_STATE& module_state, const SHADER_MODULE_STATE::EntryPoint& entrypoint,
@@ -1954,10 +1954,10 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore sempahore, uint64_t* pValue, const char* apiName) const;
     bool PreCallValidateGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore sempahore, uint64_t* pValue) const override;
     bool PreCallValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore sempahore, uint64_t* pValue) const override;
-    bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
+    bool ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE& module_state, const SHADER_MODULE_STATE::EntryPoint& entrypoint,
                                        const PipelineStageState& stage_state, uint32_t local_size_x, uint32_t local_size_y,
                                        uint32_t local_size_z) const;
-    bool ValidateTaskMeshWorkGroupSizes(const SHADER_MODULE_STATE& module_state, const Instruction& entrypoint,
+    bool ValidateTaskMeshWorkGroupSizes(const SHADER_MODULE_STATE& module_state, const SHADER_MODULE_STATE::EntryPoint& entrypoint,
                                         const PipelineStageState& stage_state, uint32_t local_size_x, uint32_t local_size_y,
                                         uint32_t local_size_z) const;
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -908,7 +908,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderDescriptorVariable(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                           const PIPELINE_STATE& pipeline,
                                           const std::vector<ResourceInterfaceVariable>& descriptor_variables) const;
-    bool ValidateTransformFeedback(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
+    bool ValidateTransformFeedback(const SHADER_MODULE_STATE& module_state, const SHADER_MODULE_STATE::EntryPoint& entrypoint,
+                                   const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderModuleId(const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
     bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -26,7 +26,7 @@ PipelineStageState::PipelineStageState(const safe_VkPipelineShaderStageCreateInf
                                        std::shared_ptr<const SHADER_MODULE_STATE::EntryPoint> &entrypoint)
     : module_state(module_state), create_info(create_info), entrypoint(entrypoint) {
     if (entrypoint) {
-        descriptor_variables = module_state->GetResourceInterfaceVariable((*entrypoint).entrypoint_insn);
+        descriptor_variables = &(*entrypoint).resource_interface_variables;
     }
 }
 
@@ -265,7 +265,7 @@ static VkPrimitiveTopology GetTopologyAtRasterizer(const PIPELINE_STATE &pipelin
         if (!stage.entrypoint) {
             continue;
         }
-        auto stage_topo = stage.module_state->GetTopology(stage.entrypoint->entrypoint_insn);
+        auto stage_topo = stage.module_state->GetTopology(*stage.entrypoint);
         if (stage_topo) {
             result = *stage_topo;
         }

--- a/tests/negative/pipeline_shader.cpp
+++ b/tests/negative/pipeline_shader.cpp
@@ -6811,6 +6811,13 @@ TEST_F(VkLayerTest, ShaderFloatControl) {
     auto properties2 = LvlInitStruct<VkPhysicalDeviceProperties2KHR>(&shader_float_control);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
 
+    if (shader_float_control.denormBehaviorIndependence == VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE) {
+        GTEST_SKIP() << "denormBehaviorIndependence is NONE";
+    }
+    if (shader_float_control.roundingModeIndependence == VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE) {
+        GTEST_SKIP() << "roundingModeIndependence is NONE";
+    }
+
     // Check for support of 32-bit properties, but only will test if they are not supported
     // in case all 16/32/64 version are not supported will set SetUnexpectedError for capability check
     bool signed_zero_inf_nan_preserve = (shader_float_control.shaderSignedZeroInfNanPreserveFloat32 == VK_TRUE);


### PR DESCRIPTION
Adds `ExecutionModeSet` to act like the `DecorationSet` we have

Instead of having to look up and re-find each `OpExecutionMode` value, this just stores them reducing many loops

While at it, I also moved all the `const Instruction& entrypoint` to `const EntryPoint& entrypoint` as it allows for grabbing more information as it is passed around

Also added a `transform_feedback_stream_inst` lookup for `ValidateTransformFeedback` instead of re-looping the module

Lastly, in attempt to make `SHADER_MODULE_STATE` simpler, I removed the getters in favor of just grabbing `static_data_` as it was not being done consistently and `StaticData` is const so can't write it anyway