### PR TITLE
docs: Add VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL to json

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1368,6 +1368,16 @@
                                 "LINUX",
                                 "ANDROID"
                             ]
+                        },
+                        {
+                            "key": "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL",
+                            "label": "Hardware specific best practices",
+                            "description": "Activating this feature enables all vendor specific best practices.",
+                            "platforms": [
+                                "WINDOWS",
+                                "LINUX",
+                                "ANDROID"
+                            ]
                         }
                     ],
                     "default": []


### PR DESCRIPTION
Adding this to the json ensures it's properly added to the generated documentation on vulkan.lunarg.com

closes #5573