### PR TITLE
Use new Shader Module info in Shader Validation

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -905,8 +905,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDecorations(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
     bool ValidateVariables(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateShaderDescriptorVariable(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
-                                          const PIPELINE_STATE& pipeline,
-                                          const std::vector<ResourceInterfaceVariable>& descriptor_variables) const;
+                                          const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE::EntryPoint& entrypoint) const;
     bool ValidateTransformFeedback(const SHADER_MODULE_STATE& module_state, const SHADER_MODULE_STATE::EntryPoint& entrypoint,
                                    const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderModuleId(const PIPELINE_STATE& pipeline) const;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -862,8 +862,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderStorageImageFormatsVariables(const SHADER_MODULE_STATE& module_state, const Instruction* insn) const;
     bool ValidateShaderStageMaxResources(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                          const PIPELINE_STATE& pipeline) const;
-    bool ValidateShaderStageGroupNonUniform(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
-                                            const Instruction& insn) const;
+    bool ValidateShaderStageGroupNonUniform(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage) const;
     bool ValidateMemoryScope(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
     bool ValidateCooperativeMatrix(const SHADER_MODULE_STATE& module_state,
                                    safe_VkPipelineShaderStageCreateInfo const* create_info) const;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -910,7 +910,7 @@ class CoreChecks : public ValidationStateTracker {
                                    const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderModuleId(const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state) const;
-    bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
+    bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state) const;
 
     template <typename RegionType>
     bool ValidateCopyImageTransferGranularityRequirements(const CMD_BUFFER_STATE& cb_state, const IMAGE_STATE* src_img,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -909,7 +909,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateTransformFeedback(const SHADER_MODULE_STATE& module_state, const SHADER_MODULE_STATE::EntryPoint& entrypoint,
                                    const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderModuleId(const PIPELINE_STATE& pipeline) const;
-    bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
+    bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state, const Instruction& insn) const;
 
     template <typename RegionType>

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -902,12 +902,12 @@ class CoreChecks : public ValidationStateTracker {
                                         const SHADER_MODULE_STATE::EntryPoint& producer_entrypoint,
                                         const SHADER_MODULE_STATE& consumer,
                                         const SHADER_MODULE_STATE::EntryPoint& consumer_entrypoint, uint32_t pipe_index) const;
-    bool ValidateDecorations(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
     bool ValidateVariables(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateShaderDescriptorVariable(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                           const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE::EntryPoint& entrypoint) const;
     bool ValidateTransformFeedback(const SHADER_MODULE_STATE& module_state, const SHADER_MODULE_STATE::EntryPoint& entrypoint,
                                    const PIPELINE_STATE& pipeline) const;
+    bool ValidateTransformFeedbackDecorations(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderModuleId(const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderClock(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateImageWrite(const SHADER_MODULE_STATE& module_state) const;

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -964,6 +964,8 @@ bool CoreChecks::ValidateShaderStorageImageFormatsVariables(const SHADER_MODULE_
                                                             const Instruction *insn) const {
     bool skip = false;
     // Go through all variables for images and check decorations
+    // Note: Tried to move to ResourceInterfaceVariable but the issue is the variables don't need to be accessed in the entrypoint
+    // to trigger the error.
     assert(insn->Opcode() == spv::OpVariable);
     // spirv-val validates this is an OpTypePointer
     const Instruction *pointer_def = module_state.FindDef(insn->Word(1));

--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -2329,7 +2329,7 @@ bool CoreChecks::ValidateVariables(const SHADER_MODULE_STATE &module_state) cons
 
 bool CoreChecks::ValidateShaderDescriptorVariable(const SHADER_MODULE_STATE &module_state, VkShaderStageFlagBits stage,
                                                   const PIPELINE_STATE &pipeline,
-                                                  const std::vector<ResourceInterfaceVariable> &descriptor_variables) const {
+                                                  const SHADER_MODULE_STATE::EntryPoint &entrypoint) const {
     bool skip = false;
 
     std::string vuid_07988;
@@ -2366,7 +2366,7 @@ bool CoreChecks::ValidateShaderDescriptorVariable(const SHADER_MODULE_STATE &mod
             break;
     }
 
-    for (const auto &variable : descriptor_variables) {
+    for (const auto &variable : entrypoint.resource_interface_variables) {
         const auto &binding =
             GetDescriptorBinding(pipeline.PipelineLayoutState().get(), variable.decorations.set, variable.decorations.binding);
         uint32_t required_descriptor_count;
@@ -2905,7 +2905,7 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE &pipeline, con
     // Validate Push Constants use
     skip |= ValidatePushConstantUsage(pipeline, module_state, create_info);
     // can dereference because entrypoint is validated by here
-    skip |= ValidateShaderDescriptorVariable(module_state, stage, pipeline, *stage_state.descriptor_variables);
+    skip |= ValidateShaderDescriptorVariable(module_state, stage, pipeline, entrypoint);
 
     if (stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
         skip |= ValidateConservativeRasterization(module_state, entrypoint, pipeline);

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -696,6 +696,10 @@ SHADER_MODULE_STATE::StaticData::StaticData(const SHADER_MODULE_STATE& module_st
                 type_struct_instructions.push_back(&insn);
                 break;
             }
+            case spv::OpReadClockKHR: {
+                read_clock_inst.push_back(&insn);
+                break;
+            }
 
             default:
                 if (AtomicOperation(insn.Opcode())) {

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -698,7 +698,7 @@ SHADER_MODULE_STATE::StaticData::StaticData(const SHADER_MODULE_STATE& module_st
             }
 
             default:
-                if (AtomicOperation(insn.Opcode()) == true) {
+                if (AtomicOperation(insn.Opcode())) {
                     atomic_inst.push_back(&insn);
                     if (insn.Opcode() == spv::OpAtomicStore) {
                         atomic_store_pointer_ids.emplace_back(insn.Word(1));
@@ -706,6 +706,9 @@ SHADER_MODULE_STATE::StaticData::StaticData(const SHADER_MODULE_STATE& module_st
                     } else {
                         atomic_pointer_ids.emplace_back(insn.Word(3));
                     }
+                }
+                if (GroupOperation(insn.Opcode())) {
+                    group_inst.push_back(&insn);
                 }
                 // We don't care about any other defs for now.
                 break;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -427,6 +427,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
         std::vector<const Instruction *> atomic_inst;
         std::vector<const Instruction *> group_inst;
+        std::vector<const Instruction *> read_clock_inst;
         std::vector<spv::Capability> capability_list;
 
         bool has_specialization_constants{false};

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -247,7 +247,7 @@ struct ResourceInterfaceVariable : public VariableBase {
 
     // Type once array/pointer are stripped
     // most likly will be OpTypeImage, OpTypeStruct, OpTypeSampler, or OpTypeAccelerationStructureKHR
-    spv::Op base_type;
+    const Instruction &base_type;
 
     bool is_read_from{false};   // has operation to reads from the variable
     bool is_written_to{false};  // has operation to writes to the variable
@@ -255,7 +255,7 @@ struct ResourceInterfaceVariable : public VariableBase {
     // Type of resource type (vkspec.html#interfaces-resources-storage-class-correspondence)
     bool is_storage_image{false};
     bool is_storage_texel_buffer{false};
-    bool is_storage_buffer{false};
+    const bool is_storage_buffer;
     bool is_input_attachment{false};
 
     bool is_atomic_operation{false};
@@ -267,6 +267,10 @@ struct ResourceInterfaceVariable : public VariableBase {
     bool is_dref_operation{false};
 
     ResourceInterfaceVariable(const SHADER_MODULE_STATE &module_state, const Instruction &insn, VkShaderStageFlagBits stage);
+
+  protected:
+    static const Instruction &FindBaseType(ResourceInterfaceVariable &variable, const SHADER_MODULE_STATE &module_state);
+    static bool IsStorageBuffer(const ResourceInterfaceVariable &variable);
 };
 
 enum FORMAT_TYPE {

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -422,6 +422,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
         uint32_t builtin_workgroup_size_id = 0;
 
         std::vector<const Instruction *> atomic_inst;
+        std::vector<const Instruction *> group_inst;
         std::vector<spv::Capability> capability_list;
 
         bool has_specialization_constants{false};


### PR DESCRIPTION
With all the refactoring in Shader Module state tracking, this tries to reduce the runtime logic that was being done in Shader Validation