### PR TITLE
layers: Label Shader Interface VU

### DIFF
--- a/layers/core_checks/shader_validation.cpp
+++ b/layers/core_checks/shader_validation.cpp
@@ -98,7 +98,7 @@ bool CoreChecks::ValidateViAgainstVsInputs(const PIPELINE_STATE &pipeline, const
                                           "] Vertex attribute at location %" PRIu32 " not consumed by vertex shader",
                                           pipeline.create_index, location);
         } else if (!attrib && input) {
-            skip |= LogError(module_state.vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
+            skip |= LogError(module_state.vk_shader_module(), "VUID-VkGraphicsPipelineCreateInfo-Input-07905",
                              "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
                              "] Vertex shader consumes input at location %" PRIu32 " but not provided",
                              pipeline.create_index, location);
@@ -3051,7 +3051,7 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE &produ
                     break;  // When going inbetween Tessellation or Geometry, array size can be different
                 }
                 const LogObjectList objlist(producer.vk_shader_module(), consumer.vk_shader_module());
-                skip |= LogError(objlist, kVUID_Core_Shader_InputNotProduced,
+                skip |= LogError(objlist, kVUID_Core_Shader_MissingOutput,
                                  "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] %s declared input at Location %" PRIu32
                                  " Comonent %" PRIu32 " but it is not an Output declared in %s",
                                  pipe_index, string_VkShaderStageFlagBits(consumer_stage), location, component,

--- a/layers/error_message/validation_error_enums.h
+++ b/layers/error_message/validation_error_enums.h
@@ -38,17 +38,18 @@
 [[maybe_unused]] static const char *kVUID_Core_DrawState_QueueForwardProgress = "UNASSIGNED-CoreValidation-DrawState-QueueForwardProgress";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidImageView = "UNASSIGNED-CoreValidation-DrawState-InvalidImageView";
 
-[[maybe_unused]] static const char *kVUID_Core_Shader_InputNotProduced = "UNASSIGNED-CoreValidation-Shader-InputNotProduced";
+[[maybe_unused]] static const char *kVUID_Core_Shader_MissingOutput = "UNASSIGNED-CoreValidation-Shader-MissingOutput";
 [[maybe_unused]] static const char *kVUID_Core_Shader_VertexInputMismatch = "UNASSIGNED-CoreValidation-Shader-VertexInputMismatch";
-[[maybe_unused]] static const char *kVUID_Core_Shader_FragmentOutputMismatch = "UNASSIGNED-CoreValidation-Shader-FragmentOutputMismatch";
 [[maybe_unused]] static const char *kVUID_Core_Shader_InterfacePatchVertex = "UNASSIGNED-CoreValidation-Shader-InterfacePatchVertex";
 [[maybe_unused]] static const char *kVUID_Core_Shader_AtomicFeature = "UNASSIGNED-CoreValidation-Shader-AtomicFeature";
-[[maybe_unused]] static const char *kVUID_Core_Shader_OutputNotConsumed = "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed";
 [[maybe_unused]] static const char *kVUID_Core_Shader_BuiltinMismatch = "UNASSIGNED-CoreValidation-Shader-BuiltinMismatch";
 
 [[maybe_unused]] static const char *kVUID_Core_BindImageMemory_Swapchain = "UNASSIGNED-CoreValidation-BindImageMemory-Swapchain";
 
 // TODO - Need to be moved to Best Practice
+[[maybe_unused]] static const char *kVUID_Core_Shader_InputNotProduced = "UNASSIGNED-CoreValidation-Shader-InputNotProduced";
+[[maybe_unused]] static const char *kVUID_Core_Shader_FragmentOutputMismatch = "UNASSIGNED-CoreValidation-Shader-FragmentOutputMismatch";
+[[maybe_unused]] static const char *kVUID_Core_Shader_OutputNotConsumed = "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed";
 [[maybe_unused]] static const char *kVUID_Core_Swapchain_PriorCount = "UNASSIGNED-CoreValidation-SwapchainPriorCount";
 [[maybe_unused]] static const char *kVUID_Core_Swapchain_PreTransform = "UNASSIGNED-CoreValidation-SwapchainPreTransform";
 [[maybe_unused]] static const char *kVUID_Core_Image_InvalidFormatLimitsViolation = "UNASSIGNED-CoreValidation-Image-InvalidFormatLimitsViolation";

--- a/tests/negative/geometry_tessellation.cpp
+++ b/tests/negative/geometry_tessellation.cpp
@@ -710,7 +710,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
 
         VkShaderObj gs(this, gsSourceStr.c_str(), VK_SHADER_STAGE_GEOMETRY_BIT);
 
-        m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+        m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-MissingOutput");
 
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), gs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};

--- a/tests/negative/pipeline_shader.cpp
+++ b/tests/negative/pipeline_shader.cpp
@@ -4143,7 +4143,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvided) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-MissingOutput");
 }
 
 TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvidedInBlock) {
@@ -4168,7 +4168,7 @@ TEST_F(VkLayerTest, CreatePipelineFragmentInputNotProvidedInBlock) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-MissingOutput");
 }
 
 TEST_F(VkLayerTest, CreatePipelineVsFsTypeMismatch) {
@@ -4268,7 +4268,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByLocation) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-MissingOutput");
 }
 
 TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByComponent) {
@@ -4302,7 +4302,7 @@ TEST_F(VkLayerTest, CreatePipelineVsFsMismatchByComponent) {
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-MissingOutput");
 }
 
 TEST_F(VkLayerTest, CreatePipelineDuplicateStage) {
@@ -4851,7 +4851,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxFragmentInputComponents) {
             "}\n";
         VkShaderObj fs(this, fsSourceStr.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+        m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-MissingOutput");
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
@@ -8896,7 +8896,7 @@ TEST_F(VkLayerTest, DISABLED_TestInvalidShaderInputAndOutputComponents) {
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
-        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-MissingOutput");
     }
 
     {
@@ -8959,7 +8959,7 @@ TEST_F(VkLayerTest, DISABLED_TestInvalidShaderInputAndOutputComponents) {
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
-        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
+        CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "UNASSIGNED-CoreValidation-Shader-MissingOutput");
     }
 
     {


### PR DESCRIPTION
- Adds `VUID-VkGraphicsPipelineCreateInfo-Input-07905`
- Some of the `UNASSIGNED-CoreValidation-Shader-*` are only for `LogWarning()` so need to moved to the Best Practice layer, but easier not to mix them with the `LogError` VUs