### PR TITLE
cmake: Only run update_deps.py during configure step

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -34,11 +34,6 @@ if (UPDATE_DEPS)
         set(_build_type ${CMAKE_BUILD_TYPE})
     endif()
 
-    message("********************************************************************************")
-    message("* NOTE: Adding target vvl_update_deps to run as needed for updating            *")
-    message("*       dependencies.                                                          *")
-    message("********************************************************************************")
-
     set(optional_args)
     if (NOT BUILD_TESTS)
         set(optional_args "--optional=tests")
@@ -65,46 +60,36 @@ if (UPDATE_DEPS)
         set(optional_args "${optional_args} ${cmake_var}")
     endif()
 
-    set(_update_deps_dir ${VVL_SOURCE_DIR}/external/${_build_type})
-    if (UPDATE_DEPS_DIR)
-        set(_update_deps_dir ${UPDATE_DEPS_DIR})
-    endif()
-    set(_helper_file "${_update_deps_dir}/helper.cmake")
-
     set(update_dep_py "${CMAKE_CURRENT_LIST_DIR}/update_deps.py")
     set(known_good_json "${CMAKE_CURRENT_LIST_DIR}/known_good.json")
 
-    # Add a target so that update_deps.py will run when necessary
-    # NOTE: This is triggered off of the timestamps of known_good.json and helper.cmake
-    add_custom_command(
-        OUTPUT ${_helper_file}
-        COMMAND ${PYTHON_EXECUTABLE} ${update_dep_py}
-            --dir ${_update_deps_dir} --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${optional_args}
-        DEPENDS ${known_good_json}
-    )
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${update_dep_py} ${known_good_json})
 
-    add_custom_target(vvl_update_deps ALL DEPENDS ${_helper_file})
+    file(TIMESTAMP ${update_dep_py} timestamp_1)
+    file(TIMESTAMP ${known_good_json} timestamp_2)
+    set(timestamp "${timestamp_1}-${timestamp_2}")
 
-    # Check if update_deps.py needs to be run on first cmake run
-    if (${known_good_json} IS_NEWER_THAN ${_helper_file})
+    set(UPDATE_DEPS_TIMESTAMP "0" CACHE STRING "Default value until we run update_deps.py")
+
+    if (timestamp STREQUAL $CACHE{UPDATE_DEPS_TIMESTAMP})
+        message(DEBUG "update_deps.py: no work to do.")
+    else()
+        set(UPDATE_DEPS_DIR "${PROJECT_SOURCE_DIR}/external/${_build_type}" CACHE PATH "Location where update_deps.py installs packages")
+        set(helper_file "${UPDATE_DEPS_DIR}/helper.cmake")
+
         execute_process(
             COMMAND ${PYTHON_EXECUTABLE} ${update_dep_py}
-                --dir ${_update_deps_dir} --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${optional_args}
-            WORKING_DIRECTORY ${VVL_SOURCE_DIR}
+                --dir ${UPDATE_DEPS_DIR} --arch ${_target_arch} --config ${_build_type} --generator "${CMAKE_GENERATOR}" ${optional_args}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             RESULT_VARIABLE _update_deps_result
         )
         if (NOT (${_update_deps_result} EQUAL 0))
             message(FATAL_ERROR "Could not run update_deps.py which is necessary to download dependencies.")
         endif()
+        set(UPDATE_DEPS_TIMESTAMP ${timestamp} CACHE STRING "Ensure we only run update_deps.py when we need to by caching time stamps" FORCE)
+        include(${helper_file})
     endif()
-    include(${_helper_file})
-else()
-    message("********************************************************************************")
-    message("* NOTE: Not adding target to run update_deps.py automatically.                 *")
-    message("********************************************************************************")
-    find_package(PythonInterp 3 QUIET)
 endif()
-# Dependencies can be installed in arbitrary locations. This is done by update_deps.py / users.
 if (ROBIN_HOOD_HASHING_INSTALL_DIR)
     list(APPEND CMAKE_PREFIX_PATH ${ROBIN_HOOD_HASHING_INSTALL_DIR})
 endif()


### PR DESCRIPTION
Remove need for `vvl_update_deps` custom target.

This fixes the bug where update_deps.py is run twice on CI for no reason. Which will help performance.

CMake will re-run the configure step when either known_good.json or update_deps.py are modified.