### PR TITLE
layers: Label new MS runtime VUID

### DIFF
--- a/layers/core_checks/descriptor_validation.cpp
+++ b/layers/core_checks/descriptor_validation.cpp
@@ -1010,10 +1010,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
         // Verify Sample counts
         if ((reqs & DESCRIPTOR_REQ_SINGLE_SAMPLE) && image_view_state->samples != VK_SAMPLE_COUNT_1_BIT) {
             auto set = context.descriptor_set.GetSet();
-            auto vuid_text = enabled_features.descriptor_buffer_features.descriptorBuffer
-                                 ? context.vuids.descriptor_buffer_bit_set_08114
-                                 : context.vuids.descriptor_valid_02699;
-            return LogError(set, vuid_text,
+            return LogError(set, " VUID-RuntimeSpirv-samples-08725",
                             "%s: Descriptor set %s in binding #%" PRIu32 " index %" PRIu32
                             " requires bound image to have VK_SAMPLE_COUNT_1_BIT but got %s.",
                             context.caller, report_data->FormatHandle(set).c_str(), binding, index,
@@ -1021,10 +1018,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
         }
         if ((reqs & DESCRIPTOR_REQ_MULTI_SAMPLE) && image_view_state->samples == VK_SAMPLE_COUNT_1_BIT) {
             auto set = context.descriptor_set.GetSet();
-            auto vuid_text = enabled_features.descriptor_buffer_features.descriptorBuffer
-                                 ? context.vuids.descriptor_buffer_bit_set_08114
-                                 : context.vuids.descriptor_valid_02699;
-            return LogError(set, vuid_text,
+            return LogError(set, "VUID-RuntimeSpirv-samples-08726",
                             "%s: Descriptor set %s in binding #%" PRIu32 " index %" PRIu32
                             " requires bound image to have multiple samples, but got VK_SAMPLE_COUNT_1_BIT.",
                             context.caller, report_data->FormatHandle(set).c_str(), binding, index);

--- a/tests/negative/command.cpp
+++ b/tests/negative/command.cpp
@@ -1031,8 +1031,6 @@ TEST_F(VkLayerTest, DrawTimeImageMultisampleMismatchWithPipeline) {
         "Test that an error is produced when a multisampled images are consumed via singlesample images types in the shader, or "
         "vice versa.");
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "requires bound image to have multiple samples");
-
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -1073,9 +1071,8 @@ TEST_F(VkLayerTest, DrawTimeImageMultisampleMismatchWithPipeline) {
     VkRect2D scissor = {{0, 0}, {16, 16}};
     vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
 
-    // error produced here.
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-samples-08726");
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
-
     m_errorMonitor->VerifyFound();
 
     m_commandBuffer->EndRenderPass();


### PR DESCRIPTION
` VUID-RuntimeSpirv-samples-08725` and `VUID-RuntimeSpirv-samples-08726` were added recently to help breakup that massive "if descriptors don't match pipeline" VU