### PR TITLE
ci: Speed up Android CI for Android.mk build

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -210,20 +210,17 @@ jobs:
         - name: Build
           run: cmake --build build/
 
-  android:
-      runs-on: ubuntu-20.04
+  android_mk:
+      runs-on: ubuntu-22.04
       strategy:
         fail-fast: false
-        matrix:
-          abi: [ arm64-v8a, armeabi-v7a ]
-
       steps:
         - uses: actions/checkout@v3
         - uses: actions/setup-python@v4
           with:
             python-version: '3.8'
-        - name: Build ValidationLayers
-          run: python3 scripts/github_ci_android.py --abi ${{ matrix.abi }}
+        - name: Build
+          run: python3 scripts/github_ci_android.py --abi arm64-v8a
 
   macos-12:
     runs-on: macos-12

--- a/scripts/github_ci_android.py
+++ b/scripts/github_ci_android.py
@@ -30,15 +30,19 @@ DEFAULT_ABI = SUPPORTED_ABIS[0]
 #
 # Fetch Android components, build Android VVL
 def BuildAndroid(target_abi):
-    print("Fetching NDK\n")
-    wget_cmd = 'wget http://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip'
-    common_ci.RunShellCmd(wget_cmd)
+    # GitHub actions already comes with NDK pre-installed. We should avoid downloading unless we have to.
+    # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#environment-variables-2
+    if "ANDROID_NDK_HOME" not in os.environ:
+        print("Fetching NDK\n")
+        wget_cmd = 'wget http://dl.google.com/android/repository/android-ndk-r21d-linux-x86_64.zip'
+        common_ci.RunShellCmd(wget_cmd)
 
-    print("Extracting NDK components\n")
-    unzip_cmd = 'unzip -u -q android-ndk-r21d-linux-x86_64.zip'
-    common_ci.RunShellCmd(unzip_cmd)
-    # Add NDK to path
-    os.environ['ANDROID_NDK_HOME'] = common_ci.RepoRelative('android-ndk-r21d')
+        print("Extracting NDK components\n")
+        unzip_cmd = 'unzip -u -q android-ndk-r21d-linux-x86_64.zip'
+        common_ci.RunShellCmd(unzip_cmd)
+
+        os.environ['ANDROID_NDK_HOME'] = common_ci.RepoRelative('android-ndk-r21d')
+
     os.environ['PATH'] = os.environ.get('ANDROID_NDK_HOME') + os.pathsep + os.environ.get('PATH')
 
     print("Preparing Android Dependencies\n")


### PR DESCRIPTION
- Don't download the NDK unless we need to.
- Only test 1 ABI. New android_cmake tests both.