### PR TITLE
Descriptors use ShaderModule Variable object

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -1409,8 +1409,7 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
     // or we may have a linearly tiled image, but these cases are quite unlikely in practice.
     bool accesses_2d = false;
     for (const auto& variable : entrypoint->resource_interface_variables) {
-        auto dim = module_state->GetShaderResourceDimensionality(variable);
-        if (dim != spv::Dim1D && dim != spv::DimBuffer) {
+        if (variable.image_dim != spv::Dim1D && variable.image_dim != spv::DimBuffer) {
             accesses_2d = true;
             break;
         }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -739,7 +739,7 @@ class CoreChecks : public ValidationStateTracker {
     VkResult CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize,
                                                 void* pData) override;
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
-    bool ValidateDrawState(const cvdescriptorset::DescriptorSet& descriptor_set, const BindingReqMap& bindings,
+    bool ValidateDrawState(const cvdescriptorset::DescriptorSet& descriptor_set, const BindingVariableMap& bindings,
                            const std::vector<uint32_t>& dynamic_offsets, const CMD_BUFFER_STATE& cb_state, const char* caller,
                            const DrawDispatchVuid& vuids) const;
 
@@ -762,7 +762,7 @@ class CoreChecks : public ValidationStateTracker {
         bool record_time_validate;
         std::optional<vvl::unordered_map<VkImageView, VkImageLayout>>& checked_layouts;
     };
-    using DescriptorBindingInfo = std::pair<const uint32_t, DescriptorRequirement>;
+    using DescriptorBindingInfo = std::pair<const uint32_t, const ResourceInterfaceVariable*>;
 
     bool ValidateDescriptorSetBindingData(const DescriptorContext& context, const DescriptorBindingInfo& binding_info,
                                           const cvdescriptorset::DescriptorBinding& binding) const;

--- a/layers/core_checks/descriptor_cc_validation.cpp
+++ b/layers/core_checks/descriptor_cc_validation.cpp
@@ -1112,10 +1112,10 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                 assert(set_index != std::numeric_limits<uint32_t>::max());
                 const auto pipeline = context.cb_state.GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS);
                 for (const auto &stage : pipeline->stage_states) {
-                    if (!stage.descriptor_variables) {
+                    if (!stage.entrypoint) {
                         continue;
                     }
-                    for (const auto &variable : *stage.descriptor_variables) {
+                    for (const auto &variable : stage.entrypoint->resource_interface_variables) {
                         if (variable.decorations.set == set_index && variable.decorations.binding == binding) {
                             descriptor_written_to |= variable.is_written_to;
                             descriptor_read_from |= variable.is_read_from | variable.is_sampler_implicitLod_dref_proj;

--- a/layers/core_checks/drawdispatch_cc_validation.cpp
+++ b/layers/core_checks/drawdispatch_cc_validation.cpp
@@ -2934,11 +2934,11 @@ bool CoreChecks::ValidateCmdBufDrawState(const CMD_BUFFER_STATE &cb_state, CMD_T
                     if (need_validate) {
                         if (!descriptor_set_changed && reduced_map.IsManyDescriptors()) {
                             // Only validate the bindings that haven't already been validated
-                            BindingReqMap delta_reqs;
+                            BindingVariableMap delta_reqs;
                             std::set_difference(binding_req_map.begin(), binding_req_map.end(),
                                                 set_info.validated_set_binding_req_map.begin(),
                                                 set_info.validated_set_binding_req_map.end(),
-                                                vvl::insert_iterator<BindingReqMap>(delta_reqs, delta_reqs.begin()));
+                                                vvl::insert_iterator<BindingVariableMap>(delta_reqs, delta_reqs.begin()));
                             skip |=
                                 ValidateDrawState(*descriptor_set, delta_reqs, set_info.dynamicOffsets, cb_state, function, vuid);
                         } else {

--- a/layers/core_checks/shader_cc_validation.cpp
+++ b/layers/core_checks/shader_cc_validation.cpp
@@ -46,16 +46,6 @@ static uint32_t GetLocationsConsumedByFormat(VkFormat format) {
     }
 }
 
-static uint32_t GetFormatType(VkFormat fmt) {
-    if (FormatIsSINT(fmt)) return FORMAT_TYPE_SINT;
-    if (FormatIsUINT(fmt)) return FORMAT_TYPE_UINT;
-    // Formats such as VK_FORMAT_D16_UNORM_S8_UINT are both
-    if (FormatIsDepthAndStencil(fmt)) return FORMAT_TYPE_FLOAT | FORMAT_TYPE_UINT;
-    if (fmt == VK_FORMAT_UNDEFINED) return 0;
-    // everything else -- UNORM/SNORM/FLOAT/USCALED/SSCALED is all float in the shader.
-    return FORMAT_TYPE_FLOAT;
-}
-
 bool CoreChecks::ValidateViAgainstVsInputs(const PIPELINE_STATE &pipeline, const SHADER_MODULE_STATE &module_state,
                                            const SHADER_MODULE_STATE::EntryPoint &entrypoint) const {
     bool skip = false;
@@ -104,7 +94,7 @@ bool CoreChecks::ValidateViAgainstVsInputs(const PIPELINE_STATE &pipeline, const
                              pipeline.create_index, location);
         } else if (attrib && input) {
             const auto attrib_type = GetFormatType(attrib->format);
-            const auto input_type = module_state.GetFundamentalType(input->type_id);
+            const auto input_type = module_state.GetNumericType(input->type_id);
 
             // Type checking
             if (!(attrib_type & input_type)) {
@@ -156,7 +146,7 @@ bool CoreChecks::ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER
                    (location < rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount)) {
             auto format = rp_state->dynamic_rendering_pipeline_create_info.pColorAttachmentFormats[location];
             const auto attachment_type = GetFormatType(format);
-            const auto output_type = module_state.GetFundamentalType(output->type_id);
+            const auto output_type = module_state.GetNumericType(output->type_id);
 
             // Type checking
             if (!(output_type & attachment_type)) {
@@ -319,7 +309,7 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE &m
                 }
             } else if (attachment && output) {
                 const auto attachment_type = GetFormatType(attachment->format);
-                const auto output_type = module_state.GetFundamentalType(output->type_id);
+                const auto output_type = module_state.GetNumericType(output->type_id);
 
                 // Type checking
                 if (!(output_type & attachment_type)) {

--- a/layers/generated/spirv_grammar_helper.cpp
+++ b/layers/generated/spirv_grammar_helper.cpp
@@ -1101,3 +1101,24 @@ const char* string_SpvDecoration(uint32_t decoration) {
     }
 };
 
+const char* string_SpvDim(uint32_t dim) {
+    switch(dim) {
+        case spv::Dim1D:
+            return "1D";
+        case spv::Dim2D:
+            return "2D";
+        case spv::Dim3D:
+            return "3D";
+        case spv::DimCube:
+            return "Cube";
+        case spv::DimRect:
+            return "Rect";
+        case spv::DimBuffer:
+            return "Buffer";
+        case spv::DimSubpassData:
+            return "SubpassData";
+        default:
+            return "Unknown Dim";
+    }
+};
+

--- a/layers/generated/spirv_grammar_helper.h
+++ b/layers/generated/spirv_grammar_helper.h
@@ -50,4 +50,5 @@ const char* string_SpvOpcode(uint32_t opcode);
 const char* string_SpvStorageClass(uint32_t storage_class);
 const char* string_SpvExecutionModel(uint32_t execution_model);
 const char* string_SpvDecoration(uint32_t decoration);
+const char* string_SpvDim(uint32_t dim);
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1125,11 +1125,11 @@ void CMD_BUFFER_STATE::UpdatePipelineState(CMD_TYPE cmd_type, const VkPipelineBi
                 // Bind this set and its active descriptor resources to the command buffer
                 if (!descriptor_set_changed && reduced_map.IsManyDescriptors()) {
                     // Only record the bindings that haven't already been recorded
-                    BindingReqMap delta_reqs;
+                    BindingVariableMap delta_reqs;
                     std::set_difference(binding_req_map.begin(), binding_req_map.end(),
                                         set_info.validated_set_binding_req_map.begin(),
                                         set_info.validated_set_binding_req_map.end(),
-                                        vvl::insert_iterator<BindingReqMap>(delta_reqs, delta_reqs.begin()));
+                                        vvl::insert_iterator<BindingVariableMap>(delta_reqs, delta_reqs.begin()));
                     descriptor_set->UpdateDrawState(dev_data, this, cmd_type, pipe, delta_reqs);
                 } else {
                     descriptor_set->UpdateDrawState(dev_data, this, cmd_type, pipe, binding_req_map);
@@ -1145,7 +1145,7 @@ void CMD_BUFFER_STATE::UpdatePipelineState(CMD_TYPE cmd_type, const VkPipelineBi
                         set_info.validated_set_binding_req_map = set_binding_pair.second;
                     }
                 } else {
-                    set_info.validated_set_binding_req_map = BindingReqMap();
+                    set_info.validated_set_binding_req_map = BindingVariableMap();
                 }
             }
         }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -242,7 +242,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     std::shared_ptr<const CMD_BUFFER_STATE> shared_from_this() const { return SharedFromThisImpl(this); }
     std::shared_ptr<CMD_BUFFER_STATE> shared_from_this() { return SharedFromThisImpl(this); }
 
-    using DescriptorBindingInfo = std::pair<const uint32_t, DescriptorRequirement>;
+    using DescriptorBindingInfo = std::pair<const uint32_t, const ResourceInterfaceVariable *>;
     struct CmdDrawDispatchInfo {
         CMD_TYPE cmd_type;
         std::vector<DescriptorBindingInfo> binding_infos;

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -557,7 +557,7 @@ void cvdescriptorset::DescriptorSet::PerformCopyUpdate(ValidationStateTracker *d
 //   to be used in a draw by the given cb_state
 void cvdescriptorset::DescriptorSet::UpdateDrawState(ValidationStateTracker *device_data, CMD_BUFFER_STATE *cb_state,
                                                      CMD_TYPE cmd_type, const PIPELINE_STATE *pipe,
-                                                     const BindingReqMap &binding_req_map) {
+                                                     const BindingVariableMap &binding_req_map) {
     // Descriptor UpdateDrawState only call image layout validation callbacks. If it is disabled, skip the entire loop.
     if (device_data->disabled[image_layout_validation]) {
         return;
@@ -615,8 +615,9 @@ void cvdescriptorset::DescriptorSet::UpdateDrawState(ValidationStateTracker *dev
     }
 }
 
-void cvdescriptorset::DescriptorSet::FilterOneBindingReq(const BindingReqMap::value_type &binding_req_pair, BindingReqMap *out_req,
-                                                         const TrackedBindings &bindings, uint32_t limit) {
+void cvdescriptorset::DescriptorSet::FilterOneBindingReq(const BindingVariableMap::value_type &binding_req_pair,
+                                                         BindingVariableMap *out_req, const TrackedBindings &bindings,
+                                                         uint32_t limit) {
     if (bindings.size() < limit) {
         const auto it = bindings.find(binding_req_pair.first);
         if (it == bindings.cend()) out_req->emplace(binding_req_pair);
@@ -624,7 +625,7 @@ void cvdescriptorset::DescriptorSet::FilterOneBindingReq(const BindingReqMap::va
 }
 
 void cvdescriptorset::DescriptorSet::FilterBindingReqs(const CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &pipeline,
-                                                       const BindingReqMap &in_req, BindingReqMap *out_req) const {
+                                                       const BindingVariableMap &in_req, BindingVariableMap *out_req) const {
     // For const cleanliness we have to find in the maps...
     const auto validated_it = cb_state.descriptorset_cache.find(this);
     if (validated_it == cb_state.descriptorset_cache.end()) {
@@ -676,7 +677,7 @@ void cvdescriptorset::DescriptorSet::FilterBindingReqs(const CMD_BUFFER_STATE &c
 }
 
 void cvdescriptorset::DescriptorSet::UpdateValidationCache(CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &pipeline,
-                                                           const BindingReqMap &updated_bindings) {
+                                                           const BindingVariableMap &updated_bindings) {
     auto &validated = cb_state.descriptorset_cache[this];
 
     auto &image_sample_version = validated.image_samplers[&pipeline];
@@ -1183,10 +1184,10 @@ void cvdescriptorset::PerformUpdateDescriptorSets(ValidationStateTracker *dev_da
         }
     }
 }
-const BindingReqMap &cvdescriptorset::PrefilterBindRequestMap::FilteredMap(const CMD_BUFFER_STATE &cb_state,
-                                                                           const PIPELINE_STATE &pipeline) {
+const BindingVariableMap &cvdescriptorset::PrefilterBindRequestMap::FilteredMap(const CMD_BUFFER_STATE &cb_state,
+                                                                                const PIPELINE_STATE &pipeline) {
     if (IsManyDescriptors()) {
-        filtered_map_.reset(new BindingReqMap);
+        filtered_map_.reset(new BindingVariableMap);
         descriptor_set_.FilterBindingReqs(cb_state, pipeline, orig_map_, filtered_map_.get());
         return *filtered_map_;
     }

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -869,16 +869,17 @@ class DescriptorSet : public BASE_NODE {
     // Bind given cmd_buffer to this descriptor set and
     // update CB image layout map with image/imagesampler descriptor image layouts
     void UpdateDrawState(ValidationStateTracker *, CMD_BUFFER_STATE *cb_state, CMD_TYPE cmd_type, const PIPELINE_STATE *,
-                         const BindingReqMap &);
+                         const BindingVariableMap &);
 
     // Track work that has been bound or validated to avoid duplicate work, important when large descriptor arrays
     // are present
     typedef vvl::unordered_set<uint32_t> TrackedBindings;
-    static void FilterOneBindingReq(const BindingReqMap::value_type &binding_req_pair, BindingReqMap *out_req,
+    static void FilterOneBindingReq(const BindingVariableMap::value_type &binding_req_pair, BindingVariableMap *out_req,
                                     const TrackedBindings &set, uint32_t limit);
-    void FilterBindingReqs(const CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &, const BindingReqMap &in_req,
-                           BindingReqMap *out_req) const;
-    void UpdateValidationCache(CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &pipeline, const BindingReqMap &updated_bindings);
+    void FilterBindingReqs(const CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &, const BindingVariableMap &in_req,
+                           BindingVariableMap *out_req) const;
+    void UpdateValidationCache(CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &pipeline,
+                               const BindingVariableMap &updated_bindings);
 
     // For a particular binding, get the global index
     const IndexRange GetGlobalIndexRangeFromBinding(const uint32_t binding, bool actual_length = false) const {
@@ -1079,13 +1080,13 @@ class DescriptorSet : public BASE_NODE {
 class PrefilterBindRequestMap {
   public:
     static const uint32_t kManyDescriptors_ = 64;  // TODO base this number on measured data
-    std::unique_ptr<BindingReqMap> filtered_map_;
-    const BindingReqMap &orig_map_;
+    std::unique_ptr<BindingVariableMap> filtered_map_;
+    const BindingVariableMap &orig_map_;
     const DescriptorSet &descriptor_set_;
 
-    PrefilterBindRequestMap(const DescriptorSet &ds, const BindingReqMap &in_map)
+    PrefilterBindRequestMap(const DescriptorSet &ds, const BindingVariableMap &in_map)
         : filtered_map_(), orig_map_(in_map), descriptor_set_(ds) {}
-    const BindingReqMap &FilteredMap(const CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &);
+    const BindingVariableMap &FilteredMap(const CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &);
     bool IsManyDescriptors() const { return descriptor_set_.GetTotalDescriptorCount() > kManyDescriptors_; }
 };
 }  // namespace cvdescriptorset

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -434,8 +434,7 @@ IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &im, VkIma
       // When the image has a external format the views format must be VK_FORMAT_UNDEFINED and it is required to use a sampler
       // Ycbcr conversion. Thus we can't extract any meaningful information from the format parameter. As a Sampler Ycbcr
       // conversion must be used the shader type is always float.
-      descriptor_format_bits(im->HasAHBFormat() ? static_cast<unsigned>(DESCRIPTOR_REQ_COMPONENT_TYPE_FLOAT)
-                                                : DescriptorRequirementsBitsFromFormat(ci->format)),
+      descriptor_format_bits(im->HasAHBFormat() ? static_cast<unsigned>(NumericTypeFloat) : GetFormatType(ci->format)),
       samplerConversion(GetSamplerConversion(ci)),
       filter_cubic_props(cubic_props),
       min_lod(GetImageViewMinLod(ci)),

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -135,33 +135,7 @@ PIPELINE_STATE::ActiveSlotMap PIPELINE_STATE::GetActiveSlots(const StageStateVec
         // Capture descriptor uses for the pipeline
         for (const auto &variable : stage.entrypoint->resource_interface_variables) {
             // While validating shaders capture which slots are used by the pipeline
-            auto &entry = active_slots[variable.decorations.set][variable.decorations.binding];
-            entry.is_written_to |= variable.is_written_to;
-
-            auto &reqs = entry.reqs;
-            reqs |= stage.module_state->DescriptorTypeToReqs(variable.type_id);
-            if (variable.is_atomic_operation) reqs |= DESCRIPTOR_REQ_VIEW_ATOMIC_OPERATION;
-            if (variable.is_sampler_sampled) reqs |= DESCRIPTOR_REQ_SAMPLER_SAMPLED;
-            if (variable.is_sampler_implicitLod_dref_proj) reqs |= DESCRIPTOR_REQ_SAMPLER_IMPLICITLOD_DREF_PROJ;
-            if (variable.is_sampler_bias_offset) reqs |= DESCRIPTOR_REQ_SAMPLER_BIAS_OFFSET;
-            if (variable.is_read_without_format) reqs |= DESCRIPTOR_REQ_IMAGE_READ_WITHOUT_FORMAT;
-            if (variable.is_write_without_format) reqs |= DESCRIPTOR_REQ_IMAGE_WRITE_WITHOUT_FORMAT;
-            if (variable.is_dref_operation) reqs |= DESCRIPTOR_REQ_IMAGE_DREF;
-
-            if (!variable.samplers_used_by_image.empty()) {
-                if (variable.samplers_used_by_image.size() > entry.samplers_used_by_image.size()) {
-                    entry.samplers_used_by_image.resize(variable.samplers_used_by_image.size());
-                }
-                uint32_t image_index = 0;
-                for (const auto &samplers : variable.samplers_used_by_image) {
-                    for (const auto &sampler : samplers) {
-                        entry.samplers_used_by_image[image_index].emplace(sampler);
-                    }
-                    ++image_index;
-                }
-            }
-            entry.write_without_formats_component_count_list = variable.write_without_formats_component_count_list;
-            entry.image_sampled_type_width = variable.image_sampled_type_width;
+            active_slots[variable.decorations.set][variable.decorations.binding] = &variable;
         }
     }
     return active_slots;

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -24,11 +24,7 @@
 PipelineStageState::PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
                                        std::shared_ptr<const SHADER_MODULE_STATE> &module_state,
                                        std::shared_ptr<const SHADER_MODULE_STATE::EntryPoint> &entrypoint)
-    : module_state(module_state), create_info(create_info), entrypoint(entrypoint) {
-    if (entrypoint) {
-        descriptor_variables = &(*entrypoint).resource_interface_variables;
-    }
-}
+    : module_state(module_state), create_info(create_info), entrypoint(entrypoint) {}
 
 // static
 PIPELINE_STATE::StageStateVec PIPELINE_STATE::GetStageStates(const ValidationStateTracker &state_data,
@@ -133,11 +129,11 @@ PIPELINE_STATE::StageStateVec PIPELINE_STATE::GetStageStates(const ValidationSta
 PIPELINE_STATE::ActiveSlotMap PIPELINE_STATE::GetActiveSlots(const StageStateVec &stage_states) {
     PIPELINE_STATE::ActiveSlotMap active_slots;
     for (const auto &stage : stage_states) {
-        if (!stage.entrypoint || !stage.descriptor_variables) {
+        if (!stage.entrypoint) {
             continue;
         }
         // Capture descriptor uses for the pipeline
-        for (const auto &variable : *stage.descriptor_variables) {
+        for (const auto &variable : stage.entrypoint->resource_interface_variables) {
             // While validating shaders capture which slots are used by the pipeline
             auto &entry = active_slots[variable.decorations.set][variable.decorations.binding];
             entry.is_written_to |= variable.is_written_to;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -98,7 +98,6 @@ struct PipelineStageState {
     std::shared_ptr<const SHADER_MODULE_STATE> module_state;
     const safe_VkPipelineShaderStageCreateInfo *create_info;
     std::shared_ptr<const SHADER_MODULE_STATE::EntryPoint> entrypoint;
-    const std::vector<ResourceInterfaceVariable> *descriptor_variables = {};
 
     PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
                        std::shared_ptr<const SHADER_MODULE_STATE> &module_state,

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -128,3 +128,12 @@ spv::BuiltIn Instruction::GetBuiltIn() const {
         return spv::BuiltInMax;
     }
 }
+
+spv::Dim Instruction::FindImageDim() const { return (Opcode() == spv::OpTypeImage) ? (spv::Dim(Word(3))) : spv::DimMax; }
+
+bool Instruction::IsArrayed() const { return (Opcode() == spv::OpTypeImage) && (Word(5) != 0); }
+
+bool Instruction::IsMultisampled() const {
+    // spirv-val makes sure that the MS operand is only non-zero when possible to be Multisampled
+    return (Opcode() == spv::OpTypeImage) && (Word(6) != 0);
+}

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -72,6 +72,11 @@ class Instruction {
     AtomicInstructionInfo GetAtomicInfo(const SHADER_MODULE_STATE& module_state) const;
     spv::BuiltIn GetBuiltIn() const;
 
+    // Helpers for OpTypeImage
+    spv::Dim FindImageDim() const;
+    bool IsArrayed() const;
+    bool IsMultisampled() const;
+
     // Auto-generated helper functions
     spv::StorageClass StorageClass() const;
 

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2043,10 +2043,10 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
         if (stage_state.create_info->stage == VK_SHADER_STAGE_FRAGMENT_BIT && raster_state &&
             raster_state->rasterizerDiscardEnable) {
             continue;
-        } else if (!stage_state.descriptor_variables) {
+        } else if (!stage_state.entrypoint) {
             continue;
         }
-        for (const auto &variable : *stage_state.descriptor_variables) {
+        for (const auto &variable : stage_state.entrypoint->resource_interface_variables) {
             const auto *descriptor_set = (*per_sets)[variable.decorations.set].bound_descriptor_set.get();
             if (!descriptor_set) continue;
             auto binding = descriptor_set->GetBinding(variable.decorations.binding);
@@ -2181,10 +2181,10 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
         if (stage_state.create_info->stage == VK_SHADER_STAGE_FRAGMENT_BIT && raster_state &&
             raster_state->rasterizerDiscardEnable) {
             continue;
-        } else if (!stage_state.descriptor_variables) {
+        } else if (!stage_state.entrypoint) {
             continue;
         }
-        for (const auto &variable : *stage_state.descriptor_variables) {
+        for (const auto &variable : stage_state.entrypoint->resource_interface_variables) {
             const auto *descriptor_set = (*per_sets)[variable.decorations.set].bound_descriptor_set.get();
             if (!descriptor_set) continue;
             auto binding = descriptor_set->GetBinding(variable.decorations.binding);

--- a/scripts/spirv_grammar_generator.py
+++ b/scripts/spirv_grammar_generator.py
@@ -97,6 +97,7 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
         self.storageClassList = [] # list of storage classes
         self.executionModelList = []
         self.decorationList = []
+        self.dimList = []
         # Need range to be large as largest possible operand index
         self.imageOperandsParamCount = [[] for i in range(3)]
 
@@ -219,6 +220,7 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
                 self.addToStingList(operandKind, 'StorageClass', self.storageClassList)
                 self.addToStingList(operandKind, 'ExecutionModel', self.executionModelList)
                 self.addToStingList(operandKind, 'Decoration', self.decorationList)
+                self.addToStingList(operandKind, 'Dim', self.dimList)
 
             for instruction in instructions:
                 opname = instruction['opname']
@@ -476,6 +478,7 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
             output +=  'const char* string_SpvStorageClass(uint32_t storage_class);\n'
             output +=  'const char* string_SpvExecutionModel(uint32_t execution_model);\n'
             output +=  'const char* string_SpvDecoration(uint32_t decoration);\n'
+            output +=  'const char* string_SpvDim(uint32_t dim);\n'
         elif self.sourceFile:
             output =  'const char* string_SpvOpcode(uint32_t opcode) {\n'
             output += '    auto format_info = kInstructionTable.find(opcode);\n'
@@ -513,6 +516,16 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
                 output += '            return \"{}\";\n'.format(decoration)
             output += '        default:\n'
             output += '            return \"Unknown Decoration\";\n'
+            output += '    }\n'
+            output += '};\n'
+
+            output += '\nconst char* string_SpvDim(uint32_t dim) {\n'
+            output += '    switch(dim) {\n'
+            for dim in self.dimList:
+                output += '        case spv::Dim{}:\n'.format(dim)
+                output += '            return \"{}\";\n'.format(dim)
+            output += '        default:\n'
+            output += '            return \"Unknown Dim\";\n'
             output += '    }\n'
             output += '};\n'
         return output


### PR DESCRIPTION
Before we were going:

1. Parse shader object
2. Copy info about the Shader to the Pipeline object
3. Have the Descriptors us the Pipeline object

This just skips the step 2

This can be seen in `PIPELINE_STATE::GetActiveSlots` where we not just give it the `ResourceInterfaceVariable` and not do all the "re-copy what found"

I also redefined `NUMERIC_TYPE` - There is an internal spec PR I have that will properly spec that

>  "Numeric Type" == Float vs SInt vs UInt