### PR TITLE
scripts: Remove the need to set PYTHONPATH everywhere

### DIFF
--- a/docs/generated_code.md
+++ b/docs/generated_code.md
@@ -7,23 +7,21 @@ How to generate the code:
 
 - Linux:
 ```bash
-PYTHONPATH=$PYTHONPATH:$PWD/external/Vulkan-Headers/registry python3 scripts/generate_source.py external/Vulkan-Headers/registry/ external/SPIRV-Headers/include/spirv/unified1/
+scripts/generate_source.py external/Vulkan-Headers/registry/ external/SPIRV-Headers/include/spirv/unified1/
 ```
 
 - Windows Powershell:
 ```powershell
-pwsh -Command { $env:PYTHONPATH+=";$PWD/external/Vulkan-Headers/registry"; python3 scripts/generate_source.py external/Vulkan-Headers/registry/ external/SPIRV-Headers/include/spirv/unified1/ }
+pwsh -Command { python3 scripts/generate_source.py external/Vulkan-Headers/registry/ external/SPIRV-Headers/include/spirv/unified1/ }
 ```
 
 - Windows Command:
 ```cmd
-cmd /C "set PYTHONPATH=%PYTHONPATH%;%cd%/external/Vulkan-Headers/registry && python3 scripts/generate_source.py external/Vulkan-Headers/registry/ external/SPIRV-Headers/include/spirv/unified1/"
+cmd /C "python3 scripts/generate_source.py external/Vulkan-Headers/registry/ external/SPIRV-Headers/include/spirv/unified1/"
 ```
 
 When making change to the `scripts/` folder, make sure to run `generate_source.py` and check in both the changes to
 `scripts/` and `layers/generated/` in any PR.
-
-Note the addition of the Vulkan registry directory to `PYTHONPATH`. This is because the generation scripts depend on modules within the Vulkan registry.
 
 ## CMake helper
 
@@ -33,8 +31,6 @@ A helper CMake target `vvl_codegen` is also provided to simplify the invocation 
 cmake -S . -B build -D VVL_CODEGEN=ON
 cmake --build build --target vvl_codegen
 ```
-
-Using the CMake target will also set `PYTHONPATH` properly, assuming a standard cmake invokation was made.
 
 NOTE: `VVL_CODEGEN` is `OFF` by default to allow users to build `VVL` via `add_subdirectory` and to avoid potential issues for system/language package managers.
 

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -140,7 +140,7 @@ option(VVL_CODEGEN "Enable vulkan validation layer code generation")
 if (VVL_CODEGEN)
     find_package(PythonInterp 3 REQUIRED)
     add_custom_target(vvl_codegen
-        COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${VULKAN_HEADERS_REGISTRY_DIRECTORY} ${PYTHON_EXECUTABLE} "${VVL_SOURCE_DIR}/scripts/generate_source.py"
+        COMMAND ${CMAKE_COMMAND} -E env ${PYTHON_EXECUTABLE} "${VVL_SOURCE_DIR}/scripts/generate_source.py"
             ${VULKAN_HEADERS_REGISTRY_DIRECTORY} "${SPIRV_HEADERS_INSTALL_DIR}/include/spirv/unified1"
             --incremental --generated-version ${VulkanHeaders_VERSION}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/generated

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -86,12 +86,6 @@ def CheckVVL(config):
     vulkan_registry = ext_dir + "/Vulkan-Headers/registry"
     spirv_unified = ext_dir + "/SPIRV-Headers/include/spirv/unified1/"
 
-    # Scripts depend on modules within the Vulkan registry.
-    if "PYTHONPATH" in os.environ:
-        print(f"Using provided PYTHONPATH {os.environ['PYTHONPATH']}")
-    else:
-        os.environ['PYTHONPATH'] = vulkan_registry
-
     # Verify consistency of generated source code
     print("Check Generated Source Code Consistency")
     gen_check_cmd = f'python3 scripts/generate_source.py --verify {vulkan_registry} {spirv_unified}'

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -26,7 +26,6 @@ import tempfile
 import difflib
 import json
 
-import common_codegen
 
 # files to exclude from --verify check
 verify_exclude = ['.clang-format']
@@ -40,6 +39,10 @@ def main(argv):
     group.add_argument('-i', '--incremental', action='store_true', help='only update repo files that change')
     group.add_argument('-v', '--verify', action='store_true', help='verify repo files match generator output')
     args = parser.parse_args(argv)
+
+    # We need modules from the registry directory, add it here so no one has to set it in PYTHONPATH
+    sys.path.insert(0, args.registry)
+    import common_codegen
 
     gen_cmds = [*[[common_codegen.repo_relative('scripts/lvl_genvk.py'),
                    '-registry', os.path.abspath(os.path.join(args.registry,  'vk.xml')),


### PR DESCRIPTION
The scripts all need to know the registry directory already, so they can update sys.path to include it.