### PR TITLE
Fix VK_EXT_pipeline_robustness to check if exposed

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -183,6 +183,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/framework/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/positive/other.cpp \
                    $(SRC_DIR)/tests/positive/pipeline.cpp \
                    $(SRC_DIR)/tests/positive/render_pass.cpp \
+                   $(SRC_DIR)/tests/positive/robustness.cpp \
                    $(SRC_DIR)/tests/positive/shaderval.cpp \
                    $(SRC_DIR)/tests/positive/sync.cpp \
                    $(SRC_DIR)/tests/positive/tooling.cpp \
@@ -267,6 +268,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/framework/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/positive/other.cpp \
                    $(SRC_DIR)/tests/positive/pipeline.cpp \
                    $(SRC_DIR)/tests/positive/render_pass.cpp \
+                   $(SRC_DIR)/tests/positive/robustness.cpp \
                    $(SRC_DIR)/tests/positive/shaderval.cpp \
                    $(SRC_DIR)/tests/positive/sync.cpp \
                    $(SRC_DIR)/tests/positive/tooling.cpp \

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -840,6 +840,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineFragmentShadingRateState(const PIPELINE_STATE& pipeline) const;
     bool ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE& pipeline) const;
     bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline) const;
+    bool ValidatePipelineRobustnessCreateInfo(const PIPELINE_STATE& pipeline, const char* parameter_name,
+                                              const VkPipelineRobustnessCreateInfoEXT& create_info) const;
     uint32_t CalcShaderStageCount(const PIPELINE_STATE& pipeline, VkShaderStageFlagBits stageBit) const;
     bool GroupHasValidIndex(const PIPELINE_STATE& pipeline, uint32_t group, uint32_t stage) const;
     bool ValidateRayTracingPipeline(const PIPELINE_STATE& pipeline, const safe_VkRayTracingPipelineCreateInfoCommon& create_info,

--- a/layers/core_checks/shader_cc_validation.cpp
+++ b/layers/core_checks/shader_cc_validation.cpp
@@ -2903,6 +2903,13 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE &pipeline, con
         }
     }
 
+    if (const auto *pipeline_robustness_info = LvlFindInChain<VkPipelineRobustnessCreateInfoEXT>(create_info->pNext);
+        pipeline_robustness_info) {
+        std::stringstream parameter_name;
+        parameter_name << "pCreateInfos[" << pipeline.create_index << "]";
+        skip |= ValidatePipelineRobustnessCreateInfo(pipeline, parameter_name.str().c_str(), *pipeline_robustness_info);
+    }
+
     // Validate Push Constants use
     skip |= ValidatePushConstantUsage(pipeline, module_state, create_info);
     // can dereference because entrypoint is validated by here

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -50,6 +50,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_pipeline_features;
     VkPhysicalDeviceAccelerationStructureFeaturesKHR ray_tracing_acceleration_structure_features;
     VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features;
+    VkPhysicalDevicePipelineRobustnessFeaturesEXT pipeline_robustness_features;
     VkPhysicalDeviceFragmentDensityMapFeaturesEXT fragment_density_map_features;
     VkPhysicalDeviceFragmentDensityMap2FeaturesEXT fragment_density_map2_features;
     VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM fragment_density_map_offset_features;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1099,6 +1099,12 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
             enabled_features.robustness2_features = *robustness2_features;
         }
 
+        const auto *pipeline_robustness_features =
+            LvlFindInChain<VkPhysicalDevicePipelineRobustnessFeaturesEXT>(pCreateInfo->pNext);
+        if (pipeline_robustness_features) {
+            enabled_features.pipeline_robustness_features = *pipeline_robustness_features;
+        }
+
         const auto *fragment_density_map_features =
             LvlFindInChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(pCreateInfo->pNext);
         if (fragment_density_map_features) {
@@ -1401,6 +1407,11 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
         has_format_feature2 =
             (api_version >= VK_API_VERSION_1_1 || IsExtEnabled(instance_extensions.vk_khr_get_physical_device_properties2)) &&
             phys_dev_extensions.find(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME) != phys_dev_extensions.end();
+
+        // feature is required if 1.3 or extension is supported
+        has_robust_image_access =
+            (api_version >= VK_API_VERSION_1_3 || IsExtEnabled(instance_extensions.vk_khr_get_physical_device_properties2)) &&
+            phys_dev_extensions.find(VK_EXT_IMAGE_ROBUSTNESS_EXTENSION_NAME) != phys_dev_extensions.end();
     }
 
     const auto &dev_ext = device_extensions;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1528,10 +1528,16 @@ class ValidationStateTracker : public ValidationObject {
     std::vector<VkExportMetalObjectTypeFlagBitsEXT> export_metal_flags;
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
-    // VK_KHR_format_feature_flags2 changes the behavior of the
-    // app/layers/spec if present. So it needs its own special boolean unlike
-    // the enabled_fatures.
-    bool has_format_feature2;
+    // Some extensions/features changes the behavior of the app/layers/spec if present.
+    // So it needs its own special boolean unlike the enabled_fatures.
+    bool has_format_feature2;  // VK_KHR_format_feature_flags2
+    // VK_EXT_pipeline_robustness was designed to be a subset of robustness extensions
+    // Enabling the other robustness features can reduce performance on GPU, so just the
+    // support is needed to check
+    bool has_robust_image_access;  // VK_EXT_image_robustness
+    // TODO - Issue 5657
+    // bool has_robust_image_access2;  // VK_EXT_robustness2
+    // bool has_robust_buffer_access2; // VK_EXT_robustness2
 
     // Device extension properties -- storing properties gathered from VkPhysicalDeviceProperties2::pNext chain
     struct DeviceExtensionProperties {

--- a/layers/stateless/pipeline_sl_validation.cpp
+++ b/layers/stateless/pipeline_sl_validation.cpp
@@ -101,103 +101,6 @@ bool StatelessValidation::manual_PreCallValidateCreatePipelineLayout(VkDevice de
     return skip;
 }
 
-bool StatelessValidation::ValidatePipelineRobustnessCreateInfo(const char *func_name, const char *parameter_name,
-                                                               const VkPipelineRobustnessCreateInfoEXT &create_info) const {
-    bool skip = false;
-
-    const auto *pipeline_robustness_features =
-        LvlFindInChain<VkPhysicalDevicePipelineRobustnessFeaturesEXT>(device_createinfo_pnext);
-    const auto *robustness2_features = LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
-    const auto *image_robustness_features = LvlFindInChain<VkPhysicalDeviceImageRobustnessFeaturesEXT>(device_createinfo_pnext);
-
-    const bool pipeline_robustness = (pipeline_robustness_features && pipeline_robustness_features->pipelineRobustness);
-    const bool robust_image_access = (image_robustness_features && image_robustness_features->robustImageAccess);
-    const bool robust_buffer_access2 = (robustness2_features && robustness2_features->robustBufferAccess2);
-    const bool robust_image_access2 = (robustness2_features && robustness2_features->robustImageAccess2);
-
-    if (pipeline_robustness) {
-        if (!robust_image_access) {
-            if (create_info.images == VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT) {
-                skip |= LogError(device, "VUID-VkPipelineRobustnessCreateInfoEXT-robustImageAccess-06930",
-                                 "%s(): %s "
-                                 "has VkPipelineRobustnessCreateInfoEXT::images == "
-                                 "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT "
-                                 "but robustImageAccess2 is not supported.",
-                                 func_name, parameter_name);
-            }
-        }
-
-        if (!robust_buffer_access2) {
-            if (create_info.storageBuffers == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT) {
-                skip |= LogError(device, "VUID-VkPipelineRobustnessCreateInfoEXT-robustBufferAccess2-06931",
-                                 "%s(): %s "
-                                 "has VkPipelineRobustnessCreateInfoEXT::storageBuffers == "
-                                 "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT "
-                                 "robustBufferAccess2 is not supported.",
-                                 func_name, parameter_name);
-            }
-            if (create_info.uniformBuffers == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT) {
-                skip |= LogError(device, "VUID-VkPipelineRobustnessCreateInfoEXT-robustBufferAccess2-06932",
-                                 "%s(): %s "
-                                 "has VkPipelineRobustnessCreateInfoEXT::uniformBuffers == "
-                                 "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT "
-                                 "robustBufferAccess2 is not supported.",
-                                 func_name, parameter_name);
-            }
-            if (create_info.vertexInputs == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT) {
-                skip |= LogError(device, "VUID-VkPipelineRobustnessCreateInfoEXT-robustBufferAccess2-06933",
-                                 "%s(): %s "
-                                 "has VkPipelineRobustnessCreateInfoEXT::vertexInputs == "
-                                 "VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT "
-                                 "but robustBufferAccess2 is not supported.",
-                                 func_name, parameter_name);
-            }
-        }
-
-        if (!robust_image_access2) {
-            if (create_info.images == VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT) {
-                skip |= LogError(device, "VUID-VkPipelineRobustnessCreateInfoEXT-robustImageAccess2-06934",
-                                 "%s(): %s "
-                                 "has VkPipelineRobustnessCreateInfoEXT::images == "
-                                 "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT "
-                                 "but robustImageAccess2 is not supported.",
-                                 func_name, parameter_name);
-            }
-        }
-    } else {
-        if (create_info.storageBuffers != VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT) {
-            skip |= LogError(device, "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06926",
-                             "%s(): %s "
-                             "has VkPipelineRobustnessCreateInfoEXT::storageBuffers == %s "
-                             "but the pipelineRobustness feature is not enabled.",
-                             func_name, parameter_name, string_VkPipelineRobustnessBufferBehaviorEXT(create_info.storageBuffers));
-        }
-        if (create_info.uniformBuffers != VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT) {
-            skip |= LogError(device, "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06927",
-                             "%s(): %s "
-                             "has VkPipelineRobustnessCreateInfoEXT::uniformBuffers == %s "
-                             "but the pipelineRobustness feature is not enabled.",
-                             func_name, parameter_name, string_VkPipelineRobustnessBufferBehaviorEXT(create_info.uniformBuffers));
-        }
-        if (create_info.vertexInputs != VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT) {
-            skip |= LogError(device, "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06928",
-                             "%s(): %s "
-                             "has VkPipelineRobustnessCreateInfoEXT::vertexInputs == %s "
-                             "but the pipelineRobustness feature is not enabled.",
-                             func_name, parameter_name, string_VkPipelineRobustnessBufferBehaviorEXT(create_info.vertexInputs));
-        }
-        if (create_info.images != VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT) {
-            skip |= LogError(device, "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06929",
-                             "%s(): %s "
-                             "has VkPipelineRobustnessCreateInfoEXT::images == %s "
-                             "but the pipelineRobustness feature is not enabled.",
-                             func_name, parameter_name, string_VkPipelineRobustnessImageBehaviorEXT(create_info.images));
-        }
-    }
-
-    return skip;
-}
-
 bool StatelessValidation::ValidatePipelineShaderStageCreateInfo(const char *func_name, const char *msg,
                                                                 const VkPipelineShaderStageCreateInfo *pCreateInfo) const {
     bool skip = false;
@@ -214,12 +117,6 @@ bool StatelessValidation::ValidatePipelineShaderStageCreateInfo(const char *func
                 func_name, msg, pCreateInfo->flags);
         }
     }
-
-    if (const auto *pipeline_robustness_info = LvlFindInChain<VkPipelineRobustnessCreateInfoEXT>(pCreateInfo->pNext);
-        pipeline_robustness_info) {
-        skip |= ValidatePipelineRobustnessCreateInfo(func_name, msg, *pipeline_robustness_info);
-    }
-
     return skip;
 }
 
@@ -1936,14 +1833,6 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                                  "VK_PIPELINE_CREATE_RAY_TRACING_ALLOW_MOTION_BIT_NV.",
                                  i, flags);
             }
-
-            if (const auto *pipeline_robustness_info = LvlFindInChain<VkPipelineRobustnessCreateInfoEXT>(create_info.pNext);
-                pipeline_robustness_info) {
-                std::stringstream parameter_name;
-                parameter_name << "pCreateInfos[" << i << "]";
-                skip |= ValidatePipelineRobustnessCreateInfo("vkCreateGraphicsPipelines", parameter_name.str().c_str(),
-                                                             *pipeline_robustness_info);
-            }
         }
     }
 
@@ -2067,14 +1956,6 @@ bool StatelessValidation::manual_PreCallValidateCreateComputePipelines(VkDevice 
                                      i, pCreateInfos[i].basePipelineIndex, createInfoCount);
                 }
             }
-        }
-
-        if (const auto *pipeline_robustness_info = LvlFindInChain<VkPipelineRobustnessCreateInfoEXT>(pCreateInfos[i].pNext);
-            pipeline_robustness_info) {
-            std::stringstream parameter_name;
-            parameter_name << "pCreateInfos[" << i << "]";
-            skip |= ValidatePipelineRobustnessCreateInfo("vkCreateComputePipelines", parameter_name.str().c_str(),
-                                                         *pipeline_robustness_info);
         }
 
         std::stringstream msg;

--- a/layers/stateless/ray_tracing_sl_validation.cpp
+++ b/layers/stateless/ray_tracing_sl_validation.cpp
@@ -653,14 +653,6 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
                 }
             }
         }
-
-        if (const auto *pipeline_robustness_info = LvlFindInChain<VkPipelineRobustnessCreateInfoEXT>(pCreateInfos[i].pNext);
-            pipeline_robustness_info) {
-            std::stringstream parameter_name;
-            parameter_name << "pCreateInfos[" << i << "]";
-            skip |= ValidatePipelineRobustnessCreateInfo("vkCreateRayTracingPipelinesKHR", parameter_name.str().c_str(),
-                                                         *pipeline_robustness_info);
-        }
     }
 
     return skip;

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1067,8 +1067,6 @@ class StatelessValidation : public ValidationObject {
                                                     const VkAllocationCallbacks *pAllocator,
                                                     VkPipelineLayout *pPipelineLayout) const;
 
-    bool ValidatePipelineRobustnessCreateInfo(const char *func_name, const char *parameter_name,
-                                              const VkPipelineRobustnessCreateInfoEXT &create_info) const;
     bool ValidatePipelineShaderStageCreateInfo(const char *func_name, const char *msg,
                                                const VkPipelineShaderStageCreateInfo *pCreateInfo) const;
     bool ValidatePipelineTessellationStateCreateInfo(const VkPipelineTessellationStateCreateInfo &info, uint32_t index) const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     positive/ray_tracing.cpp
     positive/ray_tracing_pipeline.cpp
     positive/render_pass.cpp
+    positive/robustness.cpp
     positive/shaderval.cpp
     positive/sync.cpp
     positive/sync_val.cpp

--- a/tests/negative/robustness.cpp
+++ b/tests/negative/robustness.cpp
@@ -72,7 +72,9 @@ TEST_F(VkLayerTest, PipelineRobustnessDisabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, PipelineRobustnessRobustBufferAccess2Unsupported) {
+// Need to fix check to check if feature is exposed
+// TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5657
+TEST_F(VkLayerTest, DISABLED_PipelineRobustnessRobustBufferAccess2Unsupported) {
     TEST_DESCRIPTION("Create a pipeline using VK_EXT_pipeline_robustness with robustBufferAccess2 being unsupported");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -140,7 +142,9 @@ TEST_F(VkLayerTest, PipelineRobustnessRobustBufferAccess2Unsupported) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, PipelineRobustnessRobustImageAccess2Unsupported) {
+// Need to fix check to check if feature is exposed
+// TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5657
+TEST_F(VkLayerTest, DISABLED_PipelineRobustnessRobustImageAccess2Unsupported) {
     TEST_DESCRIPTION("Create a pipeline using VK_EXT_pipeline_robustness with robustImageAccess2 being unsupported");
 
     AddRequiredExtensions(VK_EXT_PIPELINE_ROBUSTNESS_EXTENSION_NAME);
@@ -188,46 +192,32 @@ TEST_F(VkLayerTest, PipelineRobustnessRobustImageAccess2Unsupported) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, PipelineRobustnessRobustImageAccessUnsupported) {
-    TEST_DESCRIPTION("Create a pipeline using VK_EXT_pipeline_robustness with robustImageAccess being unsupported");
+TEST_F(VkLayerTest, PipelineRobustnessRobustImageAccessNotExposed) {
+    TEST_DESCRIPTION("Check if VK_EXT_image_robustness is not exposed");
 
+    SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_PIPELINE_ROBUSTNESS_EXTENSION_NAME);
-    AddOptionalExtensions(VK_EXT_IMAGE_ROBUSTNESS_EXTENSION_NAME);
-
-    SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
-        GTEST_SKIP() << "At least Vulkan version 1.1 is required";
+    if (DeviceValidationVersion() > VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "version 1.3 enables extensions which we don't want";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-
-    if (IsExtensionsEnabled(VK_EXT_IMAGE_ROBUSTNESS_EXTENSION_NAME)) {
-        auto robust_image_features = LvlInitStruct<VkPhysicalDeviceImageRobustnessFeatures>();
-        GetPhysicalDeviceFeatures2(robust_image_features);
-
-        if (robust_image_features.robustImageAccess) {
-            GTEST_SKIP() << "robustImageAccess is supported";
-        }
-    }
-
     auto pipeline_robustness_features = LvlInitStruct<VkPhysicalDevicePipelineRobustnessFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(pipeline_robustness_features);
-
+    GetPhysicalDeviceFeatures2(pipeline_robustness_features);
     if (!pipeline_robustness_features.pipelineRobustness) {
         GTEST_SKIP() << "pipelineRobustness is not supported";
     }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pipeline_robustness_features));
+    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_IMAGE_ROBUSTNESS_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_EXT_image_robustness is supported";
+    }
 
     CreateComputePipelineHelper pipe(*this);
-
-    VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info;
-
     pipe.InitInfo();
     pipe.InitState();
-    pipeline_robustness_info = LvlInitStruct<VkPipelineRobustnessCreateInfoEXT>();
+    auto pipeline_robustness_info = LvlInitStruct<VkPipelineRobustnessCreateInfoEXT>();
     pipeline_robustness_info.images = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT;
     pipe.cp_ci_.pNext = &pipeline_robustness_info;
 

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -889,53 +889,6 @@ TEST_F(VkPositiveLayerTest, PushingDescriptorSetWithImmutableSampler) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkPositiveLayerTest, BindVertexBuffers2EXTNullDescriptors) {
-    TEST_DESCRIPTION("Test nullDescriptor works wih CmdBindVertexBuffers variants");
-
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-    AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
-    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-    ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (!AreRequiredExtensionsEnabled()) {
-        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
-    }
-
-    auto robustness2_features = LvlInitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(robustness2_features);
-    if (!robustness2_features.nullDescriptor) {
-        GTEST_SKIP() << "nullDescriptor feature not supported";
-    }
-
-    PFN_vkCmdBindVertexBuffers2EXT vkCmdBindVertexBuffers2EXT =
-        (PFN_vkCmdBindVertexBuffers2EXT)vk::GetInstanceProcAddr(instance(), "vkCmdBindVertexBuffers2EXT");
-    ASSERT_TRUE(vkCmdBindVertexBuffers2EXT != nullptr);
-
-    VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
-    ASSERT_NO_FATAL_FAILURE(InitViewport());
-    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    OneOffDescriptorSet descriptor_set(m_device, {
-                                                     {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
-                                                     {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
-                                                     {2, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
-                                                 });
-
-    descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
-    descriptor_set.WriteDescriptorBufferInfo(1, VK_NULL_HANDLE, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    VkBufferView buffer_view = VK_NULL_HANDLE;
-    descriptor_set.WriteDescriptorBufferView(2, buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
-    descriptor_set.UpdateDescriptorSets();
-    descriptor_set.descriptor_writes.clear();
-
-    m_commandBuffer->begin();
-    VkBuffer buffer = VK_NULL_HANDLE;
-    VkDeviceSize offset = 0;
-    vk::CmdBindVertexBuffers(m_commandBuffer->handle(), 0, 1, &buffer, &offset);
-    vkCmdBindVertexBuffers2EXT(m_commandBuffer->handle(), 0, 1, &buffer, &offset, nullptr, nullptr);
-    m_commandBuffer->end();
-}
-
 TEST_F(VkPositiveLayerTest, CopyMutableDescriptors) {
     TEST_DESCRIPTION("Copy mutable descriptors.");
 

--- a/tests/positive/robustness.cpp
+++ b/tests/positive/robustness.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+#include "generated/vk_extension_helper.h"
+
+TEST_F(VkPositiveLayerTest, WriteDescriptorSetAccelerationStructureNVNullDescriptor) {
+    TEST_DESCRIPTION("Validate using NV acceleration structure descriptor writing with null descriptor.");
+
+    AddRequiredExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    auto robustness2_features = LvlInitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
+    auto features2 = GetPhysicalDeviceFeatures2(robustness2_features);
+    if (robustness2_features.nullDescriptor != VK_TRUE) {
+        GTEST_SKIP() << "nullDescriptor feature not supported";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+
+    OneOffDescriptorSet ds(m_device, {
+                                         {0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV, 1, VK_SHADER_STAGE_MISS_BIT_NV, nullptr},
+                                     });
+
+    VkAccelerationStructureNV top_level_as = VK_NULL_HANDLE;
+
+    VkWriteDescriptorSetAccelerationStructureNV acc = LvlInitStruct<VkWriteDescriptorSetAccelerationStructureNV>();
+    acc.accelerationStructureCount = 1;
+    acc.pAccelerationStructures = &top_level_as;
+
+    VkWriteDescriptorSet descriptor_write = LvlInitStruct<VkWriteDescriptorSet>(&acc);
+    descriptor_write.dstSet = ds.set_;
+    descriptor_write.dstBinding = 0;
+    descriptor_write.descriptorCount = 1;
+    descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV;
+
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
+}
+
+TEST_F(VkPositiveLayerTest, BindVertexBuffers2EXTNullDescriptors) {
+    TEST_DESCRIPTION("Test nullDescriptor works wih CmdBindVertexBuffers variants");
+
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    auto robustness2_features = LvlInitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
+    auto features2 = GetPhysicalDeviceFeatures2(robustness2_features);
+    if (!robustness2_features.nullDescriptor) {
+        GTEST_SKIP() << "nullDescriptor feature not supported";
+    }
+
+    PFN_vkCmdBindVertexBuffers2EXT vkCmdBindVertexBuffers2EXT =
+        (PFN_vkCmdBindVertexBuffers2EXT)vk::GetInstanceProcAddr(instance(), "vkCmdBindVertexBuffers2EXT");
+    ASSERT_TRUE(vkCmdBindVertexBuffers2EXT != nullptr);
+
+    VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
+    ASSERT_NO_FATAL_FAILURE(InitViewport());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    OneOffDescriptorSet descriptor_set(m_device, {
+                                                     {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                     {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                     {2, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                 });
+
+    descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    descriptor_set.WriteDescriptorBufferInfo(1, VK_NULL_HANDLE, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    VkBufferView buffer_view = VK_NULL_HANDLE;
+    descriptor_set.WriteDescriptorBufferView(2, buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
+    descriptor_set.UpdateDescriptorSets();
+    descriptor_set.descriptor_writes.clear();
+
+    m_commandBuffer->begin();
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkDeviceSize offset = 0;
+    vk::CmdBindVertexBuffers(m_commandBuffer->handle(), 0, 1, &buffer, &offset);
+    vkCmdBindVertexBuffers2EXT(m_commandBuffer->handle(), 0, 1, &buffer, &offset, nullptr, nullptr);
+    m_commandBuffer->end();
+}

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -2520,42 +2520,6 @@ TEST_F(VkPositiveLayerTest, SpecializationWordBoundryOffset) {
     vk::UnmapMemory(m_device->device(), buffer.memory().handle());
 }
 
-TEST_F(VkPositiveLayerTest, WriteDescriptorSetAccelerationStructureNVNullDescriptor) {
-    TEST_DESCRIPTION("Validate using NV acceleration structure descriptor writing with null descriptor.");
-
-    AddRequiredExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);
-    AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
-    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!AreRequiredExtensionsEnabled()) {
-        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
-    }
-
-    auto robustness2_features = LvlInitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(robustness2_features);
-    if (robustness2_features.nullDescriptor != VK_TRUE) {
-        GTEST_SKIP() << "nullDescriptor feature not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
-
-    OneOffDescriptorSet ds(m_device, {
-                                         {0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV, 1, VK_SHADER_STAGE_MISS_BIT_NV, nullptr},
-                                     });
-
-    VkAccelerationStructureNV top_level_as = VK_NULL_HANDLE;
-
-    VkWriteDescriptorSetAccelerationStructureNV acc = LvlInitStruct<VkWriteDescriptorSetAccelerationStructureNV>();
-    acc.accelerationStructureCount = 1;
-    acc.pAccelerationStructures = &top_level_as;
-
-    VkWriteDescriptorSet descriptor_write = LvlInitStruct<VkWriteDescriptorSet>(&acc);
-    descriptor_write.dstSet = ds.set_;
-    descriptor_write.dstBinding = 0;
-    descriptor_write.descriptorCount = 1;
-    descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV;
-
-    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
-}
-
 TEST_F(VkPositiveLayerTest, Spirv16Vulkan13) {
     TEST_DESCRIPTION("Create a shader using 1.3 spirv environment");
     SetTargetApiVersion(VK_API_VERSION_1_3);


### PR DESCRIPTION
To help, but not fix yet, https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5657

Enabling robustness features can cause performance on GPUs to go down, the `VK_EXT_pipeline_robustness` extension was added so people could just use that extension, but it took advantage of the other robustness features

This change

- Moves logic from Stateless to CoreCheck
- creates a `has_robust_image_access` to check if extension is expose
- Disables the 4 `VK_EXT_robustness2` VUs
  - We will need to write up a way to query the device features if they are not provided, currently we just assumed the features were passed into CreateDevice