### PR TITLE
layers: Add `VK_KHR_separate_depth_stencil_layouts` related VUIDs

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -936,6 +936,10 @@ class CoreChecks : public ValidationStateTracker {
                                                               const IMAGE_VIEW_STATE& image_view_state, VkFramebuffer framebuffer,
                                                               VkRenderPass renderpass, uint32_t attachment_index,
                                                               const char* variable_name) const;
+    bool ValidateRenderPassStencilLayoutAgainstFramebufferImageUsage(RenderPassCreateVersion rp_version, VkImageLayout layout,
+                                                                     const IMAGE_VIEW_STATE& image_view_state,
+                                                                     VkFramebuffer framebuffer, VkRenderPass renderpass,
+                                                                     uint32_t attachment_index, const char* variable_name) const;
     template <typename RegionType>
     bool ValidateBufferImageCopyData(const CMD_BUFFER_STATE& cb_state, uint32_t regionCount, const RegionType* pRegions,
                                      const IMAGE_STATE* image_state, const char* function, CMD_TYPE cmd_type,

--- a/layers/core_checks/image_layout_cc_validation.cpp
+++ b/layers/core_checks/image_layout_cc_validation.cpp
@@ -477,7 +477,6 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
     const auto &image_view = image_view_state.Handle();
     const auto *image_state = image_view_state.image_state.get();
     const auto &image = image_state->Handle();
-    const char *vuid;
     const bool use_rp2 = (rp_version == RENDER_PASS_VERSION_2);
     const char *function_name = use_rp2 ? "vkCmdBeginRenderPass2()" : "vkCmdBeginRenderPass()";
 
@@ -485,7 +484,7 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
         const LogObjectList objlist(image, renderpass, framebuffer, image_view);
         skip |=
             LogError(objlist, "VUID-VkRenderPassBeginInfo-framebuffer-parameter",
-                     "%s: RenderPass %s uses %s where pAttachments[%" PRIu32 "] = %s, which refers to an invalid image",
+                     "%s: RenderPass %s uses %s where pAttachments[%" PRIu32 "] = %s, which refers to an invalid image.",
                      function_name, report_data->FormatHandle(renderpass).c_str(), report_data->FormatHandle(framebuffer).c_str(),
                      attachment_index, report_data->FormatHandle(image_view).c_str());
         return skip;
@@ -499,13 +498,14 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
 
     // Check for layouts that mismatch image usages in the framebuffer
     if (layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL && !(image_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
-        vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03094" : "VUID-vkCmdBeginRenderPass-initialLayout-00895";
+        const char *vuid =
+            use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03094" : "VUID-vkCmdBeginRenderPass-initialLayout-00895";
         const LogObjectList objlist(image, renderpass, framebuffer, image_view);
         skip |= LogError(objlist, vuid,
                          "%s: Layout/usage mismatch for attachment %" PRIu32
                          " in %s"
                          " - the %s is %s but the image attached to %s via %s"
-                         " was not created with VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT",
+                         " was not created with VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT.",
                          function_name, attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
                          string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
                          report_data->FormatHandle(image_view).c_str());
@@ -513,39 +513,42 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
 
     if (layout == VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL &&
         !(image_usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT))) {
-        vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03097" : "VUID-vkCmdBeginRenderPass-initialLayout-00897";
+        const char *vuid =
+            use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03097" : "VUID-vkCmdBeginRenderPass-initialLayout-00897";
         const LogObjectList objlist(image, renderpass, framebuffer, image_view);
         skip |= LogError(objlist, vuid,
                          "%s: Layout/usage mismatch for attachment %" PRIu32
                          " in %s"
                          " - the %s is %s but the image attached to %s via %s"
-                         " was not created with VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT or VK_IMAGE_USAGE_SAMPLED_BIT",
+                         " was not created with VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT or VK_IMAGE_USAGE_SAMPLED_BIT.",
                          function_name, attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
                          string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
                          report_data->FormatHandle(image_view).c_str());
     }
 
     if (layout == VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL && !(image_usage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT)) {
-        vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03098" : "VUID-vkCmdBeginRenderPass-initialLayout-00898";
+        const char *vuid =
+            use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03098" : "VUID-vkCmdBeginRenderPass-initialLayout-00898";
         const LogObjectList objlist(image, renderpass, framebuffer, image_view);
         skip |= LogError(objlist, vuid,
                          "%s: Layout/usage mismatch for attachment %" PRIu32
                          " in %s"
                          " - the %s is %s but the image attached to %s via %s"
-                         " was not created with VK_IMAGE_USAGE_TRANSFER_SRC_BIT",
+                         " was not created with VK_IMAGE_USAGE_TRANSFER_SRC_BIT.",
                          function_name, attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
                          string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
                          report_data->FormatHandle(image_view).c_str());
     }
 
     if (layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL && !(image_usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT)) {
-        vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03099" : "VUID-vkCmdBeginRenderPass-initialLayout-00899";
+        const char *vuid =
+            use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03099" : "VUID-vkCmdBeginRenderPass-initialLayout-00899";
         const LogObjectList objlist(image, renderpass, framebuffer, image_view);
         skip |= LogError(objlist, vuid,
                          "%s: Layout/usage mismatch for attachment %" PRIu32
                          " in %s"
                          " - the %s is %s but the image attached to %s via %s"
-                         " was not created with VK_IMAGE_USAGE_TRANSFER_DST_BIT",
+                         " was not created with VK_IMAGE_USAGE_TRANSFER_DST_BIT.",
                          function_name, attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
                          string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
                          report_data->FormatHandle(image_view).c_str());
@@ -554,7 +557,8 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
     if (layout == VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT) {
         if (((image_usage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) == 0) ||
             ((image_usage & (VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) == 0)) {
-            vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-07002" : "VUID-vkCmdBeginRenderPass-initialLayout-07000";
+            const char *vuid =
+                use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-07002" : "VUID-vkCmdBeginRenderPass-initialLayout-07000";
             const LogObjectList objlist(image, renderpass, framebuffer, image_view);
             skip |=
                 LogError(objlist, vuid,
@@ -563,19 +567,20 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
                          " - the %s is %s but the image attached to %s via %s"
                          " was not created with either the VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT or "
                          "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT usage bits, and the VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT or "
-                         "VK_IMAGE_USAGE_SAMPLED_BIT usage bits",
+                         "VK_IMAGE_USAGE_SAMPLED_BIT usage bits.",
                          function_name, attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
                          string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
                          report_data->FormatHandle(image_view).c_str());
         }
         if (!(image_usage & VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT)) {
-            vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-07003" : "VUID-vkCmdBeginRenderPass-initialLayout-07001";
+            const char *vuid =
+                use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-07003" : "VUID-vkCmdBeginRenderPass-initialLayout-07001";
             const LogObjectList objlist(image, renderpass, framebuffer, image_view);
             skip |= LogError(objlist, vuid,
                              "%s: Layout/usage mismatch for attachment %" PRIu32
                              " in %s"
                              " - the %s is %s but the image attached to %s via %s"
-                             " was not created with the VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT usage bit",
+                             " was not created with the VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT usage bit.",
                              function_name, attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
                              string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
                              report_data->FormatHandle(image_view).c_str());
@@ -588,13 +593,14 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
              layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL ||
              layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL) &&
             !(image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-            vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03096" : "VUID-vkCmdBeginRenderPass-initialLayout-01758";
+            const char *vuid =
+                use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03096" : "VUID-vkCmdBeginRenderPass-initialLayout-01758";
             const LogObjectList objlist(image, renderpass, framebuffer, image_view);
             skip |= LogError(objlist, vuid,
                              "%s: Layout/usage mismatch for attachment %" PRIu32
                              " in %s"
                              " - the %s is %s but the image attached to %s via %s"
-                             " was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                             " was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.",
                              function_name, attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
                              string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
                              report_data->FormatHandle(image_view).c_str());
@@ -609,7 +615,7 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(RenderPass
                              "%s: Layout/usage mismatch for attachment %" PRIu32
                              " in %s"
                              " - the %s is %s but the image attached to %s via %s"
-                             " was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT",
+                             " was not created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.",
                              function_name, attachment_index, report_data->FormatHandle(renderpass).c_str(), variable_name,
                              string_VkImageLayout(layout), report_data->FormatHandle(framebuffer).c_str(),
                              report_data->FormatHandle(image_view).c_str());

--- a/layers/core_checks/render_pass_cc_validation.cpp
+++ b/layers/core_checks/render_pass_cc_validation.cpp
@@ -1764,6 +1764,29 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                             }
                         }
                     }
+
+                    if (IsImageLayoutDepthOnly(subpass.pDepthStencilAttachment->layout)) {
+                        if (LvlFindInChain<VkAttachmentReferenceStencilLayout>(subpass.pDepthStencilAttachment->pNext) == nullptr) {
+                            if (FormatIsDepthAndStencil(attachment_format)) {
+                                skip |= LogError(device, "VUID-VkRenderPassCreateInfo2-attachment-06244",
+                                                 "%s: pAttachments[%" PRIu32 "].format (%s) has both depth and stencil components.",
+                                                 function_name, attachment, string_VkFormat(attachment_format));
+                            }
+                        }
+                        if (FormatIsStencilOnly(attachment_format)) {
+                            skip |= LogError(device, "VUID-VkRenderPassCreateInfo2-attachment-06246",
+                                             "%s: pAttachments[%" PRIu32 "].format (%s) only has a stencil component.",
+                                             function_name, attachment, string_VkFormat(attachment_format));
+                        }
+                    }
+
+                    if (IsImageLayoutStencilOnly(subpass.pDepthStencilAttachment->layout)) {
+                        if (!FormatIsStencilOnly(attachment_format)) {
+                            skip |= LogError(device, "VUID-VkRenderPassCreateInfo2-attachment-06245",
+                                             "%s: pAttachments[%" PRIu32 "].format (%s) does not only have a stencil component.",
+                                             function_name, attachment, string_VkFormat(attachment_format));
+                        }
+                    }
                 }
             }
         }

--- a/layers/core_checks/render_pass_cc_validation.cpp
+++ b/layers/core_checks/render_pass_cc_validation.cpp
@@ -1370,7 +1370,6 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                                                    const char *function_name) const {
     bool skip = false;
     const bool use_rp2 = (rp_version == RENDER_PASS_VERSION_2);
-    const char *vuid;
 
     // Track when we're observing the first use of an attachment
     std::vector<bool> attach_first_use(pCreateInfo->attachmentCount, true);
@@ -1387,8 +1386,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
 
         if (!IsExtEnabled(device_extensions.vk_huawei_subpass_shading)) {
             if (subpass.pipelineBindPoint != VK_PIPELINE_BIND_POINT_GRAPHICS) {
-                vuid = use_rp2 ? "VUID-VkSubpassDescription2-pipelineBindPoint-03062"
-                               : "VUID-VkSubpassDescription-pipelineBindPoint-00844";
+                const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pipelineBindPoint-03062"
+                                           : "VUID-VkSubpassDescription-pipelineBindPoint-00844";
                 skip |= LogError(device, vuid,
                                  "%s: Pipeline bind point for pSubpasses[%" PRIu32 "] must be VK_PIPELINE_BIND_POINT_GRAPHICS.",
                                  function_name, i);
@@ -1396,8 +1395,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
         } else {
             if (subpass.pipelineBindPoint != VK_PIPELINE_BIND_POINT_GRAPHICS &&
                 subpass.pipelineBindPoint != VK_PIPELINE_BIND_POINT_SUBPASS_SHADING_HUAWEI) {
-                vuid = use_rp2 ? "VUID-VkSubpassDescription2-pipelineBindPoint-04953"
-                               : "VUID-VkSubpassDescription-pipelineBindPoint-04952";
+                const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pipelineBindPoint-04953"
+                                           : "VUID-VkSubpassDescription-pipelineBindPoint-04952";
                 skip |= LogError(device, vuid,
                                  "%s: Pipeline bind point for pSubpasses[%" PRIu32
                                  "] must be VK_PIPELINE_BIND_POINT_GRAPHICS or "
@@ -1420,16 +1419,16 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                                                 function_name);
 
                 if (aspect_mask & VK_IMAGE_ASPECT_METADATA_BIT) {
-                    vuid = use_rp2 ? "VUID-VkSubpassDescription2-attachment-02801"
-                                   : "VUID-VkInputAttachmentAspectReference-aspectMask-01964";
+                    const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-attachment-02801"
+                                               : "VUID-VkInputAttachmentAspectReference-aspectMask-01964";
                     skip |= LogError(
                         device, vuid,
                         "%s: Aspect mask for input attachment reference %d in subpass %d includes VK_IMAGE_ASPECT_METADATA_BIT.",
                         function_name, j, i);
                 } else if (aspect_mask & (VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT | VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT |
                                           VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT | VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT)) {
-                    vuid = use_rp2 ? "VUID-VkSubpassDescription2-attachment-04563"
-                                   : "VUID-VkInputAttachmentAspectReference-aspectMask-02250";
+                    const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-attachment-04563"
+                                               : "VUID-VkInputAttachmentAspectReference-aspectMask-02250";
                     skip |= LogError(device, vuid,
                                      "%s: Aspect mask for input attachment reference %d in subpass %d includes "
                                      "VK_IMAGE_ASPECT_MEMORY_PLANE_*_BIT_EXT bit.",
@@ -1445,9 +1444,12 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                     skip |= AddAttachmentUse(rp_version, i, attachment_uses, attachment_layouts, attachment_index, ATTACHMENT_INPUT,
                                              attachment_ref.layout);
 
-                    vuid = use_rp2 ? "VUID-VkRenderPassCreateInfo2-attachment-02525" : "VUID-VkRenderPassCreateInfo-pNext-01963";
-                    // Assuming no disjoint image since there's no handle
-                    skip |= ValidateImageAspectMask(VK_NULL_HANDLE, attachment_format, aspect_mask, false, function_name, vuid);
+                    {
+                        const char *vuid =
+                            use_rp2 ? "VUID-VkRenderPassCreateInfo2-attachment-02525" : "VUID-VkRenderPassCreateInfo-pNext-01963";
+                        // Assuming no disjoint image since there's no handle
+                        skip |= ValidateImageAspectMask(VK_NULL_HANDLE, attachment_format, aspect_mask, false, function_name, vuid);
+                    }
 
                     if (attach_first_use[attachment_index]) {
                         skip |=
@@ -1462,7 +1464,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                         }
                         if (!used_as_depth && !used_as_color &&
                             pCreateInfo->pAttachments[attachment_index].loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
-                            vuid = use_rp2 ? "VUID-VkSubpassDescription2-loadOp-03064" : "VUID-VkSubpassDescription-loadOp-00846";
+                            const char *vuid =
+                                use_rp2 ? "VUID-VkSubpassDescription2-loadOp-03064" : "VUID-VkSubpassDescription-loadOp-00846";
                             skip |= LogError(device, vuid,
                                              "%s: attachment %u is first used as an input attachment in %s with loadOp set to "
                                              "VK_ATTACHMENT_LOAD_OP_CLEAR.",
@@ -1476,16 +1479,16 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                     const VkFormatFeatureFlags2KHR format_features = GetPotentialFormatFeatures(attachment_format);
                     if ((format_features & valid_flags) == 0) {
                         if (!enabled_features.linear_color_attachment_features.linearColorAttachment) {
-                            vuid = use_rp2 ? "VUID-VkSubpassDescription2-pInputAttachments-02897"
-                                           : "VUID-VkSubpassDescription-pInputAttachments-02647";
+                            const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pInputAttachments-02897"
+                                                       : "VUID-VkSubpassDescription-pInputAttachments-02647";
                             skip |= LogError(
                                 device, vuid,
                                 "%s: Input attachment %s format (%s) does not contain VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT "
                                 "| VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.",
                                 function_name, error_type.c_str(), string_VkFormat(attachment_format));
                         } else if ((format_features & VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV) == 0) {
-                            vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06499"
-                                           : "VUID-VkSubpassDescription-linearColorAttachment-06496";
+                            const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06499"
+                                                       : "VUID-VkSubpassDescription-linearColorAttachment-06496";
                             skip |= LogError(
                                 device, vuid,
                                 "%s: Input attachment %s format (%s) does not contain VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT "
@@ -1527,7 +1530,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
             std::string error_type = "pSubpasses[" + std::to_string(i) + "].pPreserveAttachments[" + std::to_string(j) + "]";
             uint32_t attachment = subpass.pPreserveAttachments[j];
             if (attachment == VK_ATTACHMENT_UNUSED) {
-                vuid = use_rp2 ? "VUID-VkSubpassDescription2-attachment-03073" : "VUID-VkSubpassDescription-attachment-00853";
+                const char *vuid =
+                    use_rp2 ? "VUID-VkSubpassDescription2-attachment-03073" : "VUID-VkSubpassDescription-attachment-00853";
                 skip |= LogError(device, vuid, "%s:  Preserve attachment (%d) must not be VK_ATTACHMENT_UNUSED.", function_name, j);
             } else {
                 skip |= ValidateAttachmentIndex(rp_version, attachment, pCreateInfo->attachmentCount, error_type.c_str(),
@@ -1560,8 +1564,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                         subpass_performs_resolve = true;
 
                         if (pCreateInfo->pAttachments[attachment_ref.attachment].samples != VK_SAMPLE_COUNT_1_BIT) {
-                            vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03067"
-                                           : "VUID-VkSubpassDescription-pResolveAttachments-00849";
+                            const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03067"
+                                                       : "VUID-VkSubpassDescription-pResolveAttachments-00849";
                             skip |= LogError(
                                 device, vuid,
                                 "%s: Subpass %u requests multisample resolve into attachment %u, which must "
@@ -1573,15 +1577,15 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                         const VkFormatFeatureFlags2KHR format_features = GetPotentialFormatFeatures(attachment_format);
                         if ((format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR) == 0) {
                             if (!enabled_features.linear_color_attachment_features.linearColorAttachment) {
-                                vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-02899"
-                                               : "VUID-VkSubpassDescription-pResolveAttachments-02649";
+                                const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-02899"
+                                                           : "VUID-VkSubpassDescription-pResolveAttachments-02649";
                                 skip |= LogError(device, vuid,
                                                  "%s: Resolve attachment %s format (%s) does not contain "
                                                  "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT.",
                                                  function_name, error_type.c_str(), string_VkFormat(attachment_format));
                             } else if ((format_features & VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV) == 0) {
-                                vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06501"
-                                               : "VUID-VkSubpassDescription-linearColorAttachment-06498";
+                                const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06501"
+                                                           : "VUID-VkSubpassDescription-linearColorAttachment-06498";
                                 skip |= LogError(
                                     device, vuid,
                                     "%s: Resolve attachment %s format (%s) does not contain "
@@ -1592,7 +1596,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
 
                         //  VK_QCOM_render_pass_shader_resolve check of resolve attachmnents
                         if ((subpass.flags & VK_SUBPASS_DESCRIPTION_SHADER_RESOLVE_BIT_QCOM) != 0) {
-                            vuid = use_rp2 ? "VUID-VkRenderPassCreateInfo2-flags-04907" : "VUID-VkSubpassDescription-flags-03341";
+                            const char *vuid =
+                                use_rp2 ? "VUID-VkRenderPassCreateInfo2-flags-04907" : "VUID-VkSubpassDescription-flags-03341";
                             skip |= LogError(
                                 device, vuid,
                                 "%s: Subpass %u enables shader resolve, which requires every element of pResolve attachments"
@@ -1628,8 +1633,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
 
                     const VkFormatFeatureFlags2KHR format_features = GetPotentialFormatFeatures(attachment_format);
                     if ((format_features & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT_KHR) == 0) {
-                        vuid = use_rp2 ? "VUID-VkSubpassDescription2-pDepthStencilAttachment-02900"
-                                       : "VUID-VkSubpassDescription-pDepthStencilAttachment-02650";
+                        const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pDepthStencilAttachment-02900"
+                                                   : "VUID-VkSubpassDescription-pDepthStencilAttachment-02650";
                         skip |= LogError(device, vuid,
                                          "%s: Depth Stencil %s format (%s) does not contain "
                                          "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.",
@@ -1807,8 +1812,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                                     .samples;
                             if (current_sample_count != last_sample_count) {
                                 // Also VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06869
-                                vuid = use_rp2 ? "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872"
-                                               : "VUID-VkSubpassDescription-pColorAttachments-06868";
+                                const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872"
+                                                           : "VUID-VkSubpassDescription-pColorAttachments-06868";
                                 skip |= LogError(
                                     device, vuid,
                                     "%s: Subpass %u attempts to render to color attachments with inconsistent sample counts."
@@ -1822,8 +1827,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                     last_sample_count_attachment = j;
 
                     if (subpass_performs_resolve && current_sample_count == VK_SAMPLE_COUNT_1_BIT) {
-                        vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03066"
-                                       : "VUID-VkSubpassDescription-pResolveAttachments-00848";
+                        const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03066"
+                                                   : "VUID-VkSubpassDescription-pResolveAttachments-00848";
                         skip |= LogError(device, vuid,
                                          "%s: Subpass %u requests multisample resolve from attachment %u which has "
                                          "VK_SAMPLE_COUNT_1_BIT.",
@@ -1837,8 +1842,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
 
                         if (IsExtEnabled(device_extensions.vk_amd_mixed_attachment_samples)) {
                             if (current_sample_count > depth_stencil_sample_count) {
-                                vuid = use_rp2 ? "VUID-VkSubpassDescription2-pColorAttachments-03070"
-                                               : "VUID-VkSubpassDescription-pColorAttachments-01506";
+                                const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pColorAttachments-03070"
+                                                           : "VUID-VkSubpassDescription-pColorAttachments-01506";
                                 skip |=
                                     LogError(device, vuid, "%s: %s has %s which is larger than depth/stencil attachment %s.",
                                              function_name, error_type.c_str(), string_VkSampleCountFlagBits(current_sample_count),
@@ -1852,8 +1857,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                             !(use_rp2 &&
                               enabled_features.multisampled_render_to_single_sampled_features.multisampledRenderToSingleSampled) &&
                             current_sample_count != depth_stencil_sample_count) {
-                            vuid = use_rp2 ? "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872"
-                                           : "VUID-VkSubpassDescription-pDepthStencilAttachment-01418";
+                            const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872"
+                                                       : "VUID-VkSubpassDescription-pDepthStencilAttachment-01418";
                             skip |= LogError(device, vuid,
                                              "%s:  Subpass %u attempts to render to use a depth/stencil attachment with sample "
                                              "count that differs "
@@ -1869,15 +1874,15 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                     const VkFormatFeatureFlags2KHR format_features = GetPotentialFormatFeatures(attachment_format);
                     if ((format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT_KHR) == 0) {
                         if (!enabled_features.linear_color_attachment_features.linearColorAttachment) {
-                            vuid = use_rp2 ? "VUID-VkSubpassDescription2-pColorAttachments-02898"
-                                           : "VUID-VkSubpassDescription-pColorAttachments-02648";
+                            const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pColorAttachments-02898"
+                                                       : "VUID-VkSubpassDescription-pColorAttachments-02648";
                             skip |= LogError(device, vuid,
                                              "%s: Color attachment %s format (%s) does not contain "
                                              "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT.",
                                              function_name, error_type.c_str(), string_VkFormat(attachment_format));
                         } else if ((format_features & VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV) == 0) {
-                            vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06500"
-                                           : "VUID-VkSubpassDescription-linearColorAttachment-06497";
+                            const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-linearColorAttachment-06500"
+                                                       : "VUID-VkSubpassDescription-linearColorAttachment-06497";
                             skip |= LogError(
                                 device, vuid,
                                 "%s: Color attachment %s format (%s) does not contain "
@@ -1898,8 +1903,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
             if (subpass_performs_resolve && subpass.pResolveAttachments[j].attachment != VK_ATTACHMENT_UNUSED &&
                 subpass.pResolveAttachments[j].attachment < pCreateInfo->attachmentCount) {
                 if (attachment_index == VK_ATTACHMENT_UNUSED) {
-                    vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03065"
-                                   : "VUID-VkSubpassDescription-pResolveAttachments-00847";
+                    const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03065"
+                                               : "VUID-VkSubpassDescription-pResolveAttachments-00847";
                     skip |= LogError(device, vuid,
                                      "%s: Subpass %u requests multisample resolve from attachment %u which has "
                                      "attachment=VK_ATTACHMENT_UNUSED.",
@@ -1908,8 +1913,8 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                     const auto &color_desc = pCreateInfo->pAttachments[attachment_index];
                     const auto &resolve_desc = pCreateInfo->pAttachments[subpass.pResolveAttachments[j].attachment];
                     if (color_desc.format != resolve_desc.format) {
-                        vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03068"
-                                       : "VUID-VkSubpassDescription-pResolveAttachments-00850";
+                        const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-pResolveAttachments-03068"
+                                                   : "VUID-VkSubpassDescription-pResolveAttachments-00850";
                         skip |= LogError(device, vuid,
                                          "%s: %s resolves to an attachment with a "
                                          "different format. color format: %u, resolve format: %u.",

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -503,9 +503,9 @@ constexpr uint32_t ResolveRemainingLayers(const VkImageCreateInfo &ci, VkImageSu
 
 // Find whether or not an element is in list
 // Two definitions, to be able to do the following calls:
-// IsIn(1, {1, 2, 3});
+// IsValueIn(1, {1, 2, 3});
 // std::array arr {1, 2, 3};
-// IsIn(1, arr);
+// IsValueIn(1, arr);
 template <typename T, typename RANGE>
 bool IsValueIn(const T &v, const RANGE &range) {
     return std::find(std::begin(range), std::end(range), v) != std::end(range);

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -282,6 +282,12 @@ static inline bool IsImageLayoutReadOnly(VkImageLayout layout) {
                        [layout](const VkImageLayout read_only_layout) { return layout == read_only_layout; });
 }
 
+static inline bool IsImageLayoutDepthOnly(VkImageLayout layout) {
+    constexpr std::array depth_only_layouts = {VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL};
+    return std::any_of(depth_only_layouts.begin(), depth_only_layouts.end(),
+                       [layout](const VkImageLayout read_only_layout) { return layout == read_only_layout; });
+}
+
 static inline bool IsImageLayoutDepthReadOnly(VkImageLayout layout) {
     constexpr std::array read_only_layouts = {
         VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
@@ -290,6 +296,13 @@ static inline bool IsImageLayoutDepthReadOnly(VkImageLayout layout) {
         VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL,
     };
     return std::any_of(read_only_layouts.begin(), read_only_layouts.end(),
+                       [layout](const VkImageLayout read_only_layout) { return layout == read_only_layout; });
+}
+
+static inline bool IsImageLayoutStencilOnly(VkImageLayout layout) {
+    constexpr std::array depth_only_layouts = {VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL,
+                                               VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL};
+    return std::any_of(depth_only_layouts.begin(), depth_only_layouts.end(),
                        [layout](const VkImageLayout read_only_layout) { return layout == read_only_layout; });
 }
 

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -270,28 +270,17 @@ void PositiveTestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice de
     }
 }
 
-void PositiveTestRenderPass2KHRCreate(ErrorMonitor *error_monitor, const VkDevice device,
-                                      const VkRenderPassCreateInfo2KHR *create_info) {
-    VkRenderPass render_pass = VK_NULL_HANDLE;
-    VkResult err;
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR");
-
-    err = vkCreateRenderPass2KHR(device, create_info, nullptr, &render_pass);
-    if (err == VK_SUCCESS) vk::DestroyRenderPass(device, render_pass, nullptr);
+void PositiveTestRenderPass2KHRCreate(const vk_testing::Device &device, const VkRenderPassCreateInfo2KHR &create_info) {
+    vk_testing::RenderPass rp(device, create_info, true);
 }
 
-void TestRenderPass2KHRCreate(ErrorMonitor *error_monitor, const VkDevice device, const VkRenderPassCreateInfo2KHR *create_info,
-                              const char *rp2_vuid) {
-    VkRenderPass render_pass = VK_NULL_HANDLE;
-    VkResult err;
-    PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR =
-        (PFN_vkCreateRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR");
-
-    error_monitor->SetDesiredFailureMsg(kErrorBit, rp2_vuid);
-    err = vkCreateRenderPass2KHR(device, create_info, nullptr, &render_pass);
-    if (err == VK_SUCCESS) vk::DestroyRenderPass(device, render_pass, nullptr);
-    error_monitor->VerifyFound();
+void TestRenderPass2KHRCreate(ErrorMonitor &error_monitor, const vk_testing::Device &device,
+                              const VkRenderPassCreateInfo2KHR &create_info, const std::initializer_list<const char *> &vuids) {
+    for (auto vuid : vuids) {
+        error_monitor.SetDesiredFailureMsg(kErrorBit, vuid);
+    }
+    vk_testing::RenderPass rp(device, create_info, true);
+    error_monitor.VerifyFound();
 }
 
 void TestRenderPassBegin(ErrorMonitor *error_monitor, const VkDevice device, const VkCommandBuffer command_buffer,
@@ -307,12 +296,10 @@ void TestRenderPassBegin(ErrorMonitor *error_monitor, const VkDevice device, con
         vk::ResetCommandBuffer(command_buffer, 0);
     }
     if (rp2Supported && rp2_vuid) {
-        PFN_vkCmdBeginRenderPass2KHR vkCmdBeginRenderPass2KHR =
-            (PFN_vkCmdBeginRenderPass2KHR)vk::GetDeviceProcAddr(device, "vkCmdBeginRenderPass2KHR");
         VkSubpassBeginInfoKHR subpass_begin_info = {VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO_KHR, nullptr, VK_SUBPASS_CONTENTS_INLINE};
         vk::BeginCommandBuffer(command_buffer, &cmd_begin_info);
         error_monitor->SetDesiredFailureMsg(kErrorBit, rp2_vuid);
-        vkCmdBeginRenderPass2KHR(command_buffer, begin_info, &subpass_begin_info);
+        vk::CmdBeginRenderPass2KHR(command_buffer, begin_info, &subpass_begin_info);
         error_monitor->VerifyFound();
         vk::ResetCommandBuffer(command_buffer, 0);
 

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -898,10 +898,9 @@ void TestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice device, co
                           bool rp2_supported, const char *rp1_vuid, const char *rp2_vuid);
 void PositiveTestRenderPassCreate(ErrorMonitor *error_monitor, const VkDevice device, const VkRenderPassCreateInfo *create_info,
                                   bool rp2_supported);
-void PositiveTestRenderPass2KHRCreate(ErrorMonitor *error_monitor, const VkDevice device,
-                                      const VkRenderPassCreateInfo2KHR *create_info);
-void TestRenderPass2KHRCreate(ErrorMonitor *error_monitor, const VkDevice device, const VkRenderPassCreateInfo2KHR *create_info,
-                              const char *rp2_vuid);
+void PositiveTestRenderPass2KHRCreate(const vk_testing::Device &device, const VkRenderPassCreateInfo2KHR &create_info);
+void TestRenderPass2KHRCreate(ErrorMonitor &error_monitor, const vk_testing::Device &device,
+                              const VkRenderPassCreateInfo2KHR &create_info, const std::initializer_list<const char *> &vuids);
 void TestRenderPassBegin(ErrorMonitor *error_monitor, const VkDevice device, const VkCommandBuffer command_buffer,
                          const VkRenderPassBeginInfo *begin_info, bool rp2Supported, const char *rp1_vuid, const char *rp2_vuid);
 

--- a/tests/negative/renderpass.cpp
+++ b/tests/negative/renderpass.cpp
@@ -283,21 +283,21 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentDescriptionInvalidFinalLayout) {
 
             for (size_t i = 0; i < forbidden_layouts_array_size; ++i) {
                 attachment_description_stencil_layout.stencilInitialLayout = forbidden_layouts[i];
-                TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
-                                         "VUID-VkAttachmentDescriptionStencilLayout-stencilInitialLayout-03308");
+                TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(),
+                                         {"VUID-VkAttachmentDescriptionStencilLayout-stencilInitialLayout-03308"});
             }
             attachment_description_stencil_layout.stencilInitialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
             for (size_t i = 0; i < forbidden_layouts_array_size; ++i) {
                 attachment_description_stencil_layout.stencilFinalLayout = forbidden_layouts[i];
-                TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
-                                         "VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03309");
+                TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(),
+                                         {"VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03309"});
             }
             attachment_description_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
-                                     "VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03310");
+            TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(),
+                                     {"VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03310"});
             attachment_description_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
-                                     "VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03310");
+            TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(),
+                                     {"VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03310"});
 
             rpci2.pAttachments[0].pNext = nullptr;
         }
@@ -615,8 +615,8 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentsMisc) {
         if (rp2Supported) {
             safe_VkRenderPassCreateInfo2 create_info2 = ConvertVkRenderPassCreateInfoToV2KHR(rpci_same);
             m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pColorAttachments-02898");
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), create_info2.ptr(),
-                                     "VUID-VkSubpassDescription2-pDepthStencilAttachment-04440");
+            TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *create_info2.ptr(),
+                                     {"VUID-VkSubpassDescription2-pDepthStencilAttachment-04440"});
         }
 
         // Same test but use 2 different VkAttachmentReference to point to same attachment
@@ -629,8 +629,8 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentsMisc) {
         if (rp2Supported) {
             safe_VkRenderPassCreateInfo2 create_info2 = ConvertVkRenderPassCreateInfoToV2KHR(rpci_same);
             m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pColorAttachments-02898");
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), create_info2.ptr(),
-                                     "VUID-VkSubpassDescription2-pDepthStencilAttachment-04440");
+            TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *create_info2.ptr(),
+                                     {"VUID-VkSubpassDescription2-pDepthStencilAttachment-04440"});
         }
     }
 }
@@ -735,30 +735,28 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidLayout) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
-    auto features2 = GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
-    separate_depth_stencil_layouts_features.separateDepthStencilLayouts = VK_FALSE;
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState());
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
 
-    VkAttachmentDescription attach[] = {
-        {0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
-         VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_UNDEFINED,
-         VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
-        {0, ds_format, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
-         VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_UNDEFINED,
-         VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL},
+    const std::array attachments = {
+        VkAttachmentDescription{0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
+        VkAttachmentDescription{0, ds_format, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL},
     };
-    VkAttachmentReference refs[] = {
-        {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},          // color
-        {1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL},  // depth stencil
+    std::array refs = {
+        VkAttachmentReference{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},          // color
+        VkAttachmentReference{1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL},  // depth stencil
     };
-    VkSubpassDescription subpasses[] = {
-        {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, &refs[0], nullptr, &refs[1], 0, nullptr},
+    const std::array subpasses = {
+        VkSubpassDescription{0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, &refs[0], nullptr, &refs[1], 0, nullptr},
     };
 
-    auto rpci = LvlInitStruct<VkRenderPassCreateInfo>(nullptr, 0u, 2u, attach, 1u, subpasses, 0u, nullptr);
+    auto rpci = LvlInitStruct<VkRenderPassCreateInfo>(nullptr, 0u, static_cast<uint32_t>(attachments.size()), attachments.data(),
+                                                      static_cast<uint32_t>(subpasses.size()), subpasses.data(), 0u, nullptr);
 
     // Use UNDEFINED layout
     refs[0].layout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -779,105 +777,179 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidLayout) {
         rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
         rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
 
-        if (separate_depth_stencil_layouts_features.separateDepthStencilLayouts) {
-            // Set a valid VkAttachmentReferenceStencilLayout since the feature bit is set
-            auto attachment_reference_stencil_layout = LvlInitStruct<VkAttachmentReferenceStencilLayout>();
-            attachment_reference_stencil_layout.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR;
-            rpci2.pSubpasses[0].pDepthStencilAttachment->pNext = &attachment_reference_stencil_layout;
+        rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+        rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
+        TestRenderPass2KHRCreate(
+            *m_errorMonitor, *m_device, *rpci2.ptr(),
+            {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313", "VUID-VkRenderPassCreateInfo2-attachment-06244"});
+        rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR;
+        TestRenderPass2KHRCreate(
+            *m_errorMonitor, *m_device, *rpci2.ptr(),
+            {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313", "VUID-VkRenderPassCreateInfo2-attachment-06244"});
 
-            // reset to valid layout
-            // The following tests originally were negative tests until it was noticed that the aspectMask only matters for input
-            // attachments. These tests were converted into positive tests to catch regression
-            rpci2.pSubpasses[0].pColorAttachments[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-            {
-                rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+        rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+        rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+        TestRenderPass2KHRCreate(
+            *m_errorMonitor, *m_device, *rpci2.ptr(),
+            {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313", "VUID-VkRenderPassCreateInfo2-attachment-06245"});
+        rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR;
+        TestRenderPass2KHRCreate(
+            *m_errorMonitor, *m_device, *rpci2.ptr(),
+            {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313", "VUID-VkRenderPassCreateInfo2-attachment-06245"});
+    }
+}
 
-                rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
-                PositiveTestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr());
-                rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR;
-                PositiveTestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr());
-            }
-            {
-                rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidLayoutSeparateDepthStencilLayoutsFeature) {
+    TEST_DESCRIPTION("Attachment reference uses PREINITIALIZED or UNDEFINED layouts");
 
-                rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
-                PositiveTestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr());
-                rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR;
-                PositiveTestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr());
-            }
-            {
-                rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+    AddRequiredExtensions(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddOptionalExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
 
-                rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
-                PositiveTestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr());
-                rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR;
-                PositiveTestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr());
-            }
+    auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
+    auto features2 = GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
 
-            rpci2.pAttachments[1].format = ds_format;                                                                // reset
-            rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;  // reset
+    if (!separate_depth_stencil_layouts_features.separateDepthStencilLayouts) {
+        GTEST_SKIP() << "separateDepthStencilLayouts feature not supported, skipping test.";
+    }
 
-            VkImageLayout forbidden_layouts[] = {VK_IMAGE_LAYOUT_PREINITIALIZED,
-                                                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-                                                 VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR,
-                                                 VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR,
-                                                 VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
-                                                 VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
-                                                 VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
-                                                 VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
-                                                 VK_IMAGE_LAYOUT_PRESENT_SRC_KHR};
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat stencil_format = VK_FORMAT_S8_UINT;
+
+    const std::array attachments = {
+        VkAttachmentDescription{0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
+        VkAttachmentDescription{0, ds_format, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL},
+        VkAttachmentDescription{0, stencil_format, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL}};
+    std::array refs = {
+        VkAttachmentReference{0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},          // color
+        VkAttachmentReference{1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL},  // depth stencil
+    };
+    const std::array subpasses = {
+        VkSubpassDescription{0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, &refs[0], nullptr, &refs[1], 0, nullptr},
+    };
+
+    auto rpci = LvlInitStruct<VkRenderPassCreateInfo>(nullptr, 0u, static_cast<uint32_t>(attachments.size()), attachments.data(),
+                                                      static_cast<uint32_t>(subpasses.size()), subpasses.data(), 0u, nullptr);
+
+    // Use UNDEFINED layout
+    refs[0].layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    TestRenderPassCreate(m_errorMonitor, m_device->device(), &rpci, rp2Supported, "VUID-VkAttachmentReference-layout-03077",
+                         "VUID-VkAttachmentReference2-layout-03077");
+
+    // Use PREINITIALIZED layout
+    refs[0].layout = VK_IMAGE_LAYOUT_PREINITIALIZED;
+    TestRenderPassCreate(m_errorMonitor, m_device->device(), &rpci, rp2Supported, "VUID-VkAttachmentReference-layout-03077",
+                         "VUID-VkAttachmentReference2-layout-03077");
+
+    if (rp2Supported) {
+        safe_VkRenderPassCreateInfo2 rpci2 = ConvertVkRenderPassCreateInfoToV2KHR(rpci);
+
+        // set valid values to start
+        rpci2.pSubpasses[0].pColorAttachments[0].aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        rpci2.pSubpasses[0].pColorAttachments[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+        rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
+
+        // Set a valid VkAttachmentReferenceStencilLayout since the feature bit is set
+        auto attachment_reference_stencil_layout = LvlInitStruct<VkAttachmentReferenceStencilLayout>();
+        attachment_reference_stencil_layout.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR;
+        rpci2.pSubpasses[0].pDepthStencilAttachment->pNext = &attachment_reference_stencil_layout;
+
+        // reset to valid layout
+        // The following tests originally were negative tests until it was noticed that the aspectMask only matters for input
+        // attachments. These tests were converted into positive tests to catch regression
+        rpci2.pSubpasses[0].pColorAttachments[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        {
             rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+
             rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
-            for (size_t i = 0; i < (sizeof(forbidden_layouts) / sizeof(forbidden_layouts[0])); ++i) {
-                attachment_reference_stencil_layout.stencilLayout = forbidden_layouts[i];
-                TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
-                                         "VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318");
-            }
-
-            attachment_reference_stencil_layout.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
-
-            auto attachment_description_stencil_layout = LvlInitStruct<VkAttachmentDescriptionStencilLayoutKHR>();
-            attachment_description_stencil_layout.stencilInitialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
-            attachment_description_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
-
-            rpci2.pAttachments[1].pNext = &attachment_description_stencil_layout;
-
-            rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
-            rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(), "VUID-VkAttachmentDescription2-format-06906");
-
-            rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-            rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(), "VUID-VkAttachmentDescription2-format-06907");
-
-            rpci2.pAttachments[1].pNext = nullptr;
-
-            rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-            rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(), "VUID-VkAttachmentDescription2-format-06249");
-
-            rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-            rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(), "VUID-VkAttachmentDescription2-format-06250");
-
-            rpci2.pSubpasses[0].pDepthStencilAttachment->pNext = nullptr;
-        } else {
-            rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-            rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
-                                     "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313");
+            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
             rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR;
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
-                                     "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313");
-
-            rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
-            rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
-                                     "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313");
-            rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR;
-            TestRenderPass2KHRCreate(m_errorMonitor, m_device->device(), rpci2.ptr(),
-                                     "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313");
+            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
         }
+        {
+            rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+            const auto original_attachment = rpci2.pSubpasses[0].pDepthStencilAttachment->attachment;
+            rpci2.pSubpasses[0].pDepthStencilAttachment->attachment = 2;
+
+            rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
+            rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR;
+            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
+
+            rpci2.pSubpasses[0].pDepthStencilAttachment->attachment = original_attachment;
+        }
+        {
+            rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+
+            rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
+            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
+            rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR;
+            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
+        }
+
+        rpci2.pAttachments[1].format = ds_format;                                                                // reset
+        rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;  // reset
+
+        std::array forbidden_layouts = {
+            VK_IMAGE_LAYOUT_PREINITIALIZED,
+            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+            VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR,
+            VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL_KHR,
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+            VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+            VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
+            VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
+            // VK_IMAGE_LAYOUT_PRESENT_SRC_KHR // Would need VK_KHR_swapchain
+        };
+        rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+        rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
+        for (size_t i = 0; i < forbidden_layouts.size(); ++i) {
+            attachment_reference_stencil_layout.stencilLayout = forbidden_layouts[i];
+            TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(),
+                                     {"VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318"});
+        }
+
+        attachment_reference_stencil_layout.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+
+        auto attachment_description_stencil_layout = LvlInitStruct<VkAttachmentDescriptionStencilLayoutKHR>();
+        attachment_description_stencil_layout.stencilInitialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+        attachment_description_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+
+        rpci2.pAttachments[1].pNext = &attachment_description_stencil_layout;
+
+        rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+        rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06906"});
+
+        rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+        rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
+        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06907"});
+
+        rpci2.pAttachments[1].pNext = nullptr;
+
+        rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+        rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06249"});
+
+        rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
+        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06250"});
+
+        rpci2.pSubpasses[0].pDepthStencilAttachment->pNext = nullptr;
     }
 }
 
@@ -1318,6 +1390,161 @@ TEST_F(VkLayerTest, RenderPassBeginLayoutsFramebufferImageUsageMismatches) {
         views[1] = image_view_no_usage_sampled.handle();
         test_layout_helper("VUID-vkCmdBeginRenderPass-initialLayout-07000", "VUID-vkCmdBeginRenderPass2-initialLayout-07002");
     }
+}
+
+TEST_F(VkLayerTest, RenderPassBeginLayoutsStencilBufferImageUsageMismatches) {
+    TEST_DESCRIPTION("Test that separate stencil initial/final layouts match up with the usage bits in framebuffer attachment");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);  // Because TestRenderPassBegin relies on it
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required";
+    }
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported, skipping test.";
+    }
+
+    auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
+    auto features2 = GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
+    if (!separate_depth_stencil_layouts_features.separateDepthStencilLayouts) {
+        GTEST_SKIP() << "separateDepthStencilLayouts not supported, skipping test.";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+
+    // Closure to create a render pass with just a depth/stencil image used as an input attachment (not a depth attachment!).
+    // This image purposely has not VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.
+    // The layout of the depth and stencil aspects of this image can be defined separately, allowing to trigger different errors.
+    auto test = [this](VkImageLayout depth_initial_layout, VkImageLayout stencil_initial_layout, const char *rp1_vuid,
+                       const char *rp2_vuid) {
+        // Create an input attachment with a depth stencil format, without VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
+        VkImageObj input_image(m_device);
+
+        VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+        input_image.InitNoLayout(128, 128, 1, depth_stencil_format, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
+        ASSERT_TRUE(input_image.initialized());
+
+        VkImageView input_view =
+            input_image.targetView(depth_stencil_format, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0, 1, 0, 1);
+
+        // Create the render pass attachment...
+        auto stencil_layout = LvlInitStruct<VkAttachmentDescriptionStencilLayout>();
+        stencil_layout.stencilInitialLayout = stencil_initial_layout;
+        stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_GENERAL;
+        auto depth_stencil_attachment_desc = LvlInitStruct<VkAttachmentDescription2>(&stencil_layout);
+        depth_stencil_attachment_desc.format = depth_stencil_format;
+        depth_stencil_attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        depth_stencil_attachment_desc.initialLayout = depth_initial_layout;  // This will trigger errors
+        depth_stencil_attachment_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+        // ... and a reference to it...
+        auto stencil_ref = LvlInitStruct<VkAttachmentReferenceStencilLayoutKHR>();
+        stencil_ref.stencilLayout = VK_IMAGE_LAYOUT_GENERAL;
+        auto input_attachment_ref = LvlInitStruct<VkAttachmentReference2>(&stencil_ref);
+        input_attachment_ref.attachment = 0;
+        input_attachment_ref.layout = VK_IMAGE_LAYOUT_GENERAL;
+        input_attachment_ref.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+
+        // ... which is used in the one subpass.
+        auto subpass_desc = LvlInitStruct<VkSubpassDescription2>();
+        subpass_desc.inputAttachmentCount = 1;
+        subpass_desc.pInputAttachments = &input_attachment_ref;
+
+        // Create render pass and framebuffer
+        auto rpci = LvlInitStruct<VkRenderPassCreateInfo2>();
+        rpci.attachmentCount = 1;
+        rpci.pAttachments = &depth_stencil_attachment_desc;
+        rpci.subpassCount = 1;
+        rpci.pSubpasses = &subpass_desc;
+        vk_testing::RenderPass rp(*m_device, rpci);
+
+        auto fbci = LvlInitStruct<VkFramebufferCreateInfo>();
+        fbci.renderPass = rp;
+        fbci.attachmentCount = 1;
+        fbci.pAttachments = &input_view;
+        fbci.width = input_image.width();
+        fbci.height = input_image.height();
+        fbci.layers = 1;
+
+        vk_testing::Framebuffer fb(*m_device, fbci);
+
+        // Begin render pass and trigger errors
+        auto rp_begin = LvlInitStruct<VkRenderPassBeginInfo>();
+        rp_begin.renderPass = rp;
+        rp_begin.framebuffer = fb;
+        rp_begin.renderArea.extent = {fbci.width, fbci.height};
+
+        TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &rp_begin, true, rp1_vuid, rp2_vuid);
+    };
+
+    test(VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL, "VUID-vkCmdBeginRenderPass-initialLayout-02842",
+         "VUID-vkCmdBeginRenderPass2-initialLayout-02844");
+
+    test(VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL, "VUID-vkCmdBeginRenderPass-stencilInitialLayout-02843",
+         "VUID-vkCmdBeginRenderPass2-stencilInitialLayout-02845");
+}
+
+TEST_F(VkLayerTest, RenderPassBeginInvalidStencilFormat) {
+    TEST_DESCRIPTION("Test that separate stencil initial/final layouts match up with the usage bits in framebuffer attachment");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required";
+    }
+    auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
+    auto features2 = GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
+    if (!separate_depth_stencil_layouts_features.separateDepthStencilLayouts) {
+        GTEST_SKIP() << "separateDepthStencilLayouts not supported, skipping test.";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+
+    // Closure to create a render pass with just a depth/stencil image with specified format.
+    // The layout is set to have more or less components than what this format has, triggering an error.
+    auto test = [this](VkFormat depth_stencil_format, VkImageLayout depth_stencil_attachment_ref_layout, const char *vuid) {
+        // Create an input attachment with a depth stencil format, without VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
+        VkImageObj depth_stencil_image(m_device);
+
+        depth_stencil_image.InitNoLayout(128, 128, 1, depth_stencil_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+                                         VK_IMAGE_TILING_OPTIMAL);
+        ASSERT_TRUE(depth_stencil_image.initialized());
+
+        // Create the render pass attachment...
+        auto depth_stencil_attachment_desc = LvlInitStruct<VkAttachmentDescription2>();
+        depth_stencil_attachment_desc.format = depth_stencil_format;
+        depth_stencil_attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        depth_stencil_attachment_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;  // This will trigger errors
+        depth_stencil_attachment_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+        // ... and a reference to it...
+        auto depth_stencil_attachment_ref = LvlInitStruct<VkAttachmentReference2>();
+        depth_stencil_attachment_ref.attachment = 0;
+        depth_stencil_attachment_ref.layout = depth_stencil_attachment_ref_layout;
+        depth_stencil_attachment_ref.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+
+        // ... which is used in the one subpass.
+        auto subpass_desc = LvlInitStruct<VkSubpassDescription2>();
+        subpass_desc.pDepthStencilAttachment = &depth_stencil_attachment_ref;
+
+        // Create render pass
+        auto rpci = LvlInitStruct<VkRenderPassCreateInfo2>();
+        rpci.attachmentCount = 1;
+        rpci.pAttachments = &depth_stencil_attachment_desc;
+        rpci.subpassCount = 1;
+        rpci.pSubpasses = &subpass_desc;
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
+        vk_testing::RenderPass rp(*m_device, rpci);
+        m_errorMonitor->VerifyFound();
+    };
+
+    test(FindSupportedDepthStencilFormat(gpu()), VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
+         "VUID-VkRenderPassCreateInfo2-attachment-06244");
+    test(FindSupportedDepthStencilFormat(gpu()), VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL,
+         "VUID-VkRenderPassCreateInfo2-attachment-06245");
+    test(VK_FORMAT_S8_UINT, VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, "VUID-VkRenderPassCreateInfo2-attachment-06246");
 }
 
 TEST_F(VkLayerTest, RenderPassBeginClearOpMismatch) {


### PR DESCRIPTION
- Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5624

Add:
VUID-VkRenderPassCreateInfo2-attachment-06244
VUID-VkRenderPassCreateInfo2-attachment-06245
VUID-VkRenderPassCreateInfo2-attachment-06246
VUID-vkCmdBeginRenderPass-stencilInitialLayout-02843
VUID-vkCmdBeginRenderPass2-stencilInitialLayout-02845
VUID-vkCmdBeginRenderPass-initialLayout-02842
VUID-vkCmdBeginRenderPass2-initialLayout-02844

Two new tests: `RenderPassBeginLayoutsStencilBufferImageUsageMismatches` and `RenderPassBeginInvalidStencilFormat`
Split up `RenderPassCreateAttachmentReferenceInvalidLayout` into two tests because the `if (separate_depth_stencil_layouts_features.separateDepthStencilLayouts) { ... }` logic was not working as intended anymore, and one branch was dead. There is now one test for each of the previous branches.