### PR TITLE
layers: Add LogDebug

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -820,8 +820,7 @@ void BestPractices::ValidateReturnCodes(const char* api_name, VkResult result) c
 
     // While the result is successful, users may still want this information. Since it may be unexpected.
     if (result > VK_SUCCESS) {
-        LogInfo(instance, kVUID_BestPractices_NonSuccess_Result, "%s(): Returned non-success return code %s.", api_name,
-                result_string);
+        LogDebug(instance, kVUID_BestPractices_NonSuccess_Result, "%s(): Returned successful value %s.", api_name, result_string);
         return;
     }
 
@@ -1533,12 +1532,12 @@ bool BestPractices::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCou
         }
         if (pSubmits[submit].signalSemaphoreCount == 0 && pSubmits[submit].pSignalSemaphores != nullptr) {
             skip |=
-                LogWarning(device, kVUID_BestPractices_SemaphoreCount,
+                LogDebug(device, kVUID_BestPractices_SemaphoreCount,
                            "pSubmits[%" PRIu32 "].pSignalSemaphores is set, but pSubmits[%" PRIu32 "].signalSemaphoreCount is 0.",
                            submit, submit);
         }
         if (pSubmits[submit].waitSemaphoreCount == 0 && pSubmits[submit].pWaitSemaphores != nullptr) {
-            skip |= LogWarning(device, kVUID_BestPractices_SemaphoreCount,
+            skip |= LogDebug(device, kVUID_BestPractices_SemaphoreCount,
                                "pSubmits[%" PRIu32 "].pWaitSemaphores is set, but pSubmits[%" PRIu32 "].waitSemaphoreCount is 0.",
                                submit, submit);
         }

--- a/layers/generated/chassis.h
+++ b/layers/generated/chassis.h
@@ -4092,6 +4092,14 @@ class ValidationObject {
             return result;
         }
 
+        bool DECORATE_PRINTF(4, 5) LogDebug(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
+            va_list argptr;
+            va_start(argptr, format);
+            const bool result = LogMsg(report_data, kDebugBit, objlist, vuid_text, format, argptr);
+            va_end(argptr);
+            return result;
+        }
+
         void LogInternalError(std::string_view failure_location, const LogObjectList &obj_list,
                               std::string_view entrypoint, VkResult err) const {
             const std::string_view err_string = string_VkResult(err);

--- a/scripts/layer_chassis_generator.py
+++ b/scripts/layer_chassis_generator.py
@@ -446,6 +446,14 @@ class ValidationObject {
             return result;
         }
 
+        bool DECORATE_PRINTF(4, 5) LogDebug(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
+            va_list argptr;
+            va_start(argptr, format);
+            const bool result = LogMsg(report_data, kDebugBit, objlist, vuid_text, format, argptr);
+            va_end(argptr);
+            return result;
+        }
+
         void LogInternalError(std::string_view failure_location, const LogObjectList &obj_list,
                               std::string_view entrypoint, VkResult err) const {
             const std::string_view err_string = string_VkResult(err);

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -91,11 +91,11 @@ struct DebugReporter {
                                                         size_t, int32_t, const char *, const char *msg, void *user_data);
 
     const char *debug_extension_name = VK_EXT_DEBUG_REPORT_EXTENSION_NAME;
-    VkDebugReportCallbackCreateInfoEXT debug_create_info_ = {VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT, nullptr,
-                                                             VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT |
-                                                                 VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT |
-                                                                 VK_DEBUG_REPORT_INFORMATION_BIT_EXT,
-                                                             &DebugCallback, &error_monitor_};
+    VkDebugReportCallbackCreateInfoEXT debug_create_info_ = {
+        VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT, nullptr,
+        VK_DEBUG_REPORT_ERROR_BIT_EXT | VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT |
+            VK_DEBUG_REPORT_INFORMATION_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT,
+        &DebugCallback, &error_monitor_};
     using DebugCreateFnType = PFN_vkCreateDebugReportCallbackEXT;
     const char *debug_create_fn_name_ = "vkCreateDebugReportCallbackEXT";
     using DebugDestroyFnType = PFN_vkDestroyDebugReportCallbackEXT;
@@ -112,7 +112,7 @@ struct DebugReporter {
         nullptr,
         0,
         VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
-            VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT,
+            VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT,
         VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT,
         &DebugCallback,
         &error_monitor_};

--- a/tests/negative/best_practices.cpp
+++ b/tests/negative/best_practices.cpp
@@ -1501,7 +1501,7 @@ TEST_F(VkBestPracticesLayerTest, SemaphoreSetWhenCountIsZero) {
     signal_submit_info.signalSemaphoreCount = 0;
     signal_submit_info.pSignalSemaphores = &semaphore_handle;
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-SemaphoreCount");
+    m_errorMonitor->SetDesiredFailureMsg(kDebugBit, "UNASSIGNED-BestPractices-SemaphoreCount");
     vk::QueueSubmit(m_device->m_queue, 1, &signal_submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
 
@@ -1512,7 +1512,7 @@ TEST_F(VkBestPracticesLayerTest, SemaphoreSetWhenCountIsZero) {
     wait_submit_info.waitSemaphoreCount = 0;
     wait_submit_info.pWaitSemaphores = &semaphore_handle;
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-SemaphoreCount");
+    m_errorMonitor->SetDesiredFailureMsg(kDebugBit, "UNASSIGNED-BestPractices-SemaphoreCount");
     vk::QueueSubmit(m_device->m_queue, 1, &wait_submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
The intent is to address concerns of #4654 and #5604

VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT (LogDebug):
`Diagnostic message`

VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT (LogInfo):
`Informational message like the creation of a resource`