### PR TITLE
VkDeviceImageMemoryRequirementsKHR plane aspect

### DIFF
--- a/layers/stateless/sl_device_memory.cpp
+++ b/layers/stateless/sl_device_memory.cpp
@@ -180,24 +180,26 @@ bool StatelessValidation::ValidateDeviceImageMemoryRequirements(VkDevice device,
     bool skip = false;
 
     if (pInfo && pInfo->pCreateInfo) {
-        const auto *image_swapchain_create_info = LvlFindInChain<VkImageSwapchainCreateInfoKHR>(pInfo->pCreateInfo);
-        if (image_swapchain_create_info) {
+        const auto &create_info = *(pInfo->pCreateInfo);
+        if (LvlFindInChain<VkImageSwapchainCreateInfoKHR>(create_info.pNext)) {
             skip |= LogError(device, "VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06416",
-                             "%s(): pInfo->pCreateInfo->pNext chain contains VkImageSwapchainCreateInfoKHR.", func_name);
+                             "%s(): pCreateInfo->pNext chain contains VkImageSwapchainCreateInfoKHR.", func_name);
         }
-        const auto *drm_format_modifier_create_info =
-            LvlFindInChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pInfo->pCreateInfo);
-        if (drm_format_modifier_create_info) {
+        if (LvlFindInChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(create_info.pNext)) {
             skip |= LogError(device, "VUID-VkDeviceImageMemoryRequirements-pCreateInfo-06776",
-                             "%s(): pInfo->pCreateInfo->pNext chain contains VkImageDrmFormatModifierExplicitCreateInfoEXT.",
-                             func_name);
+                             "%s(): pCreateInfo->pNext chain contains VkImageDrmFormatModifierExplicitCreateInfoEXT.", func_name);
         }
 
-        if ((pInfo->pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT) != 0) {
-            if (FormatIsMultiplane(pInfo->pCreateInfo->format) && (pInfo->planeAspect == VK_IMAGE_ASPECT_NONE_KHR)) {
+        if (FormatIsMultiplane(create_info.format) && (create_info.flags & VK_IMAGE_CREATE_DISJOINT_BIT) != 0) {
+            if (pInfo->planeAspect == VK_IMAGE_ASPECT_NONE_KHR) {
                 skip |= LogError(device, "VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06417",
                                  "%s(): Must not specify VK_IMAGE_ASPECT_NONE_KHR with a multi-planar format and disjoint flag.",
                                  func_name);
+            } else if ((create_info.tiling == VK_IMAGE_TILING_LINEAR || create_info.tiling == VK_IMAGE_TILING_OPTIMAL) &&
+                       !IsOnlyOneValidPlaneAspect(create_info.format, pInfo->planeAspect)) {
+                skip |= LogError(device, "VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06419",
+                                 "%s(): planeAspect is %s but is invalid for %s.", func_name,
+                                 string_VkImageAspectFlags(pInfo->planeAspect).c_str(), string_VkFormat(create_info.format));
             }
         }
     }

--- a/tests/negative/memory.cpp
+++ b/tests/negative/memory.cpp
@@ -2452,11 +2452,6 @@ TEST_F(VkLayerTest, DeviceImageMemoryRequirementsDisjoint) {
         GTEST_SKIP() << "Test requires disjoint support extensions";
     }
 
-    PFN_vkGetDeviceImageMemoryRequirementsKHR vkGetDeviceImageMemoryRequirementsKHR =
-        reinterpret_cast<PFN_vkGetDeviceImageMemoryRequirementsKHR>(
-            vk::GetInstanceProcAddr(instance(), "vkGetDeviceImageMemoryRequirementsKHR"));
-    assert(vkGetDeviceImageMemoryRequirementsKHR != nullptr);
-
     auto image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
@@ -2475,8 +2470,17 @@ TEST_F(VkLayerTest, DeviceImageMemoryRequirementsDisjoint) {
     VkMemoryRequirements2 memory_requirements = LvlInitStruct<VkMemoryRequirements2>();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06417");
-    vkGetDeviceImageMemoryRequirementsKHR(device(), &device_image_memory_requirements, &memory_requirements);
+    vk::GetDeviceImageMemoryRequirementsKHR(device(), &device_image_memory_requirements, &memory_requirements);
     m_errorMonitor->VerifyFound();
+
+    device_image_memory_requirements.planeAspect = VK_IMAGE_ASPECT_PLANE_2_BIT;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06419");
+    vk::GetDeviceImageMemoryRequirementsKHR(device(), &device_image_memory_requirements, &memory_requirements);
+    m_errorMonitor->VerifyFound();
+
+    // valid
+    device_image_memory_requirements.planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
+    vk::GetDeviceImageMemoryRequirementsKHR(device(), &device_image_memory_requirements, &memory_requirements);
 }
 
 TEST_F(VkLayerTest, TestBindBufferMemoryDeviceGroup) {


### PR DESCRIPTION
Adds VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06419 using new `IsOnlyOneValidPlaneAspect` helper