### PR TITLE
Fix false positive VUID-vkResetCommandBuffer-commandBuffer-00045 error after exporting submitted fence handle

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3947,6 +3947,8 @@ void ValidationStateTracker::PostCallRecordImportFenceFdKHR(VkDevice device, con
 void ValidationStateTracker::RecordGetExternalFenceState(VkFence fence, VkExternalFenceHandleTypeFlagBits handle_type) {
     auto fence_state = Get<FENCE_STATE>(fence);
     if (fence_state) {
+        // We no longer can track inflight fence after the export - perform early retire.
+        fence_state->NotifyAndWait();
         fence_state->Export(handle_type);
     }
 }


### PR DESCRIPTION
This request fixes the issue: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5694