### PR TITLE
layers: Fix message for non-queue operation

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -290,7 +290,7 @@ struct SemaphoreSubmitState {
     bool ValidateWaitSemaphore(const core_error::Location& loc, VkSemaphore semaphore, uint64_t value);
     bool ValidateSignalSemaphore(const core_error::Location& loc, VkSemaphore semaphore, uint64_t value);
 
-    bool CannotSignal(const SEMAPHORE_STATE& semaphore_state, VkQueue& other_queue) const {
+    bool CannotSignal(const SEMAPHORE_STATE& semaphore_state, VkQueue& other_queue, const char*& other_func) const {
         const auto semaphore = semaphore_state.semaphore();
         if (signaled_semaphores.count(semaphore)) {
             other_queue = queue;
@@ -299,7 +299,8 @@ struct SemaphoreSubmitState {
         if (!unsignaled_semaphores.count(semaphore)) {
             const auto last_op = semaphore_state.LastOp();
             if (last_op && !last_op->CanBeSignaled()) {
-                other_queue = last_op && last_op->queue ? last_op->queue->Queue() : VK_NULL_HANDLE;
+                other_queue = last_op->queue ? last_op->queue->Queue() : VK_NULL_HANDLE;
+                other_func = last_op->func_name;
                 return true;
             }
         }

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -349,11 +349,11 @@ void SEMAPHORE_STATE::EnqueueWait(QUEUE_STATE *queue, uint64_t queue_seq, uint64
     }
 }
 
-void SEMAPHORE_STATE::EnqueueAcquire() {
+void SEMAPHORE_STATE::EnqueueAcquire(const char *func_name) {
     auto guard = WriteLock();
     assert(type == VK_SEMAPHORE_TYPE_BINARY);
     auto payload = next_payload_++;
-    SemOp acquire(kBinaryAcquire, nullptr, 0, payload);
+    SemOp acquire(kBinaryAcquire, nullptr, 0, payload, func_name);
     timeline_.emplace(payload, acquire);
 }
 

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -115,13 +115,14 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     }
 
     struct SemOp {
-        SemOp(OpType ot, QUEUE_STATE *q, uint64_t queue_seq, uint64_t timeline_payload)
-            : op_type(ot), queue(q), seq(queue_seq), payload(timeline_payload) {}
+        SemOp(OpType ot, QUEUE_STATE *q, uint64_t queue_seq, uint64_t timeline_payload, const char *func_name = nullptr)
+            : op_type(ot), queue(q), seq(queue_seq), payload(timeline_payload), func_name(func_name) {}
 
         OpType op_type;
         QUEUE_STATE *queue;
         uint64_t seq;
         uint64_t payload;
+        const char *func_name;  // has to be initialized with a string literal
 
         bool operator<(const SemOp &rhs) const { return payload < rhs.payload; }
 
@@ -209,7 +210,7 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     void EnqueueWait(QUEUE_STATE *queue, uint64_t queue_seq, uint64_t &payload);
 
     // Binary only special cases enqueue functions
-    void EnqueueAcquire();
+    void EnqueueAcquire(const char *func_name);
 
     // Signal queue(s) that need to retire because a wait on this payload has finished
     void Notify(uint64_t payload);

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4079,7 +4079,8 @@ void ValidationStateTracker::PostCallRecordCreateSharedSwapchainsKHR(VkDevice de
 }
 
 void ValidationStateTracker::RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
-                                                         VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex) {
+                                                         VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex,
+                                                         const char *func_name) {
     auto fence_state = Get<FENCE_STATE>(fence);
     if (fence_state) {
         // Treat as inflight since it is valid to wait on this fence, even in cases where it is technically a temporary
@@ -4091,7 +4092,7 @@ void ValidationStateTracker::RecordAcquireNextImageState(VkDevice device, VkSwap
     if (semaphore_state) {
         // Treat as signaled since it is valid to wait on this semaphore, even in cases where it is technically a
         // temporary import
-        semaphore_state->EnqueueAcquire();
+        semaphore_state->EnqueueAcquire(func_name);
     }
 
     // Mark the image as acquired.
@@ -4105,14 +4106,14 @@ void ValidationStateTracker::PostCallRecordAcquireNextImageKHR(VkDevice device, 
                                                                VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex,
                                                                VkResult result) {
     if ((VK_SUCCESS != result) && (VK_SUBOPTIMAL_KHR != result)) return;
-    RecordAcquireNextImageState(device, swapchain, timeout, semaphore, fence, pImageIndex);
+    RecordAcquireNextImageState(device, swapchain, timeout, semaphore, fence, pImageIndex, "vkAcquireNextImageKHR");
 }
 
 void ValidationStateTracker::PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo,
                                                                 uint32_t *pImageIndex, VkResult result) {
     if ((VK_SUCCESS != result) && (VK_SUBOPTIMAL_KHR != result)) return;
     RecordAcquireNextImageState(device, pAcquireInfo->swapchain, pAcquireInfo->timeout, pAcquireInfo->semaphore,
-                                pAcquireInfo->fence, pImageIndex);
+                                pAcquireInfo->fence, pImageIndex, "vkAcquireNextImage2KHR");
 }
 
 std::shared_ptr<PHYSICAL_DEVICE_STATE> ValidationStateTracker::CreatePhysicalDeviceState(VkPhysicalDevice phys_dev) {

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1272,7 +1272,7 @@ class ValidationStateTracker : public ValidationObject {
     void PerformUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet, const UPDATE_TEMPLATE_STATE* template_state,
                                                     const void* pData);
     void RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
-                                     VkFence fence, uint32_t* pImageIndex);
+                                     VkFence fence, uint32_t* pImageIndex, const char* func_name);
     void RecordCreateSamplerYcbcrConversionState(const VkSamplerYcbcrConversionCreateInfo* create_info,
                                                  VkSamplerYcbcrConversion ycbcr_conversion);
     virtual std::shared_ptr<SWAPCHAIN_NODE> CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info,


### PR DESCRIPTION
`vkAcquireNextImageKHR` and `vkAcquireNextImage2KHR` are not initiated on specific queue.
New functionality can also be used to update other places to include operation name in the output.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5589