### PR TITLE
layers: Hash ResourceInterfaceVariable descriptor members

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -1409,7 +1409,7 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
     // or we may have a linearly tiled image, but these cases are quite unlikely in practice.
     bool accesses_2d = false;
     for (const auto& variable : entrypoint->resource_interface_variables) {
-        if (variable.image_dim != spv::Dim1D && variable.image_dim != spv::DimBuffer) {
+        if (variable.info.image_dim != spv::Dim1D && variable.info.image_dim != spv::DimBuffer) {
             accesses_2d = true;
             break;
         }

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -899,30 +899,30 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
 
         // if combined sampler, this variable might not be a OpTypeImage
         // SubpassData gets validated elsewhere
-        if (variable.IsImage() && variable.image_dim != spv::DimSubpassData) {
+        if (variable.IsImage() && variable.info.image_dim != spv::DimSubpassData) {
             bool valid_dim = true;
             // From vkspec.html#textures-operation-validation
             switch (image_view_ci.viewType) {
                 case VK_IMAGE_VIEW_TYPE_1D:
-                    valid_dim = (variable.image_dim == spv::Dim1D) && !variable.is_image_array;
+                    valid_dim = (variable.info.image_dim == spv::Dim1D) && !variable.info.is_image_array;
                     break;
                 case VK_IMAGE_VIEW_TYPE_2D:
-                    valid_dim = (variable.image_dim == spv::Dim2D) && !variable.is_image_array;
+                    valid_dim = (variable.info.image_dim == spv::Dim2D) && !variable.info.is_image_array;
                     break;
                 case VK_IMAGE_VIEW_TYPE_3D:
-                    valid_dim = (variable.image_dim == spv::Dim3D) && !variable.is_image_array;
+                    valid_dim = (variable.info.image_dim == spv::Dim3D) && !variable.info.is_image_array;
                     break;
                 case VK_IMAGE_VIEW_TYPE_CUBE:
-                    valid_dim = (variable.image_dim == spv::DimCube) && !variable.is_image_array;
+                    valid_dim = (variable.info.image_dim == spv::DimCube) && !variable.info.is_image_array;
                     break;
                 case VK_IMAGE_VIEW_TYPE_1D_ARRAY:
-                    valid_dim = (variable.image_dim == spv::Dim1D) && variable.is_image_array;
+                    valid_dim = (variable.info.image_dim == spv::Dim1D) && variable.info.is_image_array;
                     break;
                 case VK_IMAGE_VIEW_TYPE_2D_ARRAY:
-                    valid_dim = (variable.image_dim == spv::Dim2D) && variable.is_image_array;
+                    valid_dim = (variable.info.image_dim == spv::Dim2D) && variable.info.is_image_array;
                     break;
                 case VK_IMAGE_VIEW_TYPE_CUBE_ARRAY:
-                    valid_dim = (variable.image_dim == spv::DimCube) && variable.is_image_array;
+                    valid_dim = (variable.info.image_dim == spv::DimCube) && variable.info.is_image_array;
                     break;
                 default:
                     break;  // incase a new VkImageViewType is added, let it be valid by default
@@ -934,11 +934,11 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                                 "%s: Descriptor set %s in binding #%" PRIu32 " index %" PRIu32
                                 " ImageView type is %s but the OpTypeImage has (Dim = %s) and (Arrrayed = %d).",
                                 context.caller, report_data->FormatHandle(set).c_str(), binding, index,
-                                string_VkImageViewType(image_view_ci.viewType), string_SpvDim(variable.image_dim),
-                                variable.is_image_array);
+                                string_VkImageViewType(image_view_ci.viewType), string_SpvDim(variable.info.image_dim),
+                                variable.info.is_image_array);
             }
 
-            if (!(variable.image_format_type & image_view_state->descriptor_format_bits)) {
+            if (!(variable.info.image_format_type & image_view_state->descriptor_format_bits)) {
                 // bad component type
                 auto set = context.descriptor_set.GetSet();
                 const LogObjectList objlist(set, image_view);
@@ -946,7 +946,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                                 "%s: Descriptor set %s in binding #%" PRIu32 " index %" PRIu32
                                 " requires %s component type, but bound descriptor format is %s.",
                                 context.caller, report_data->FormatHandle(set).c_str(), binding, index,
-                                string_NumericType(variable.image_format_type), string_VkFormat(image_view_ci.format));
+                                string_NumericType(variable.info.image_format_type), string_VkFormat(image_view_ci.format));
             }
 
             const bool image_format_width_64 = FormatHasComponentSize(image_view_ci.format, 64);
@@ -1008,7 +1008,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
         }
 
         // Verify Sample counts
-        if (variable.IsImage() && !variable.is_multisampled && image_view_state->samples != VK_SAMPLE_COUNT_1_BIT) {
+        if (variable.IsImage() && !variable.info.is_multisampled && image_view_state->samples != VK_SAMPLE_COUNT_1_BIT) {
             auto set = context.descriptor_set.GetSet();
             return LogError(set, " VUID-RuntimeSpirv-samples-08725",
                             "%s: Descriptor set %s in binding #%" PRIu32 " index %" PRIu32
@@ -1016,7 +1016,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                             context.caller, report_data->FormatHandle(set).c_str(), binding, index,
                             string_VkSampleCountFlagBits(image_view_state->samples));
         }
-        if (variable.IsImage() && variable.is_multisampled && image_view_state->samples == VK_SAMPLE_COUNT_1_BIT) {
+        if (variable.IsImage() && variable.info.is_multisampled && image_view_state->samples == VK_SAMPLE_COUNT_1_BIT) {
             auto set = context.descriptor_set.GetSet();
             return LogError(set, "VUID-RuntimeSpirv-samples-08726",
                             "%s: Descriptor set %s in binding #%" PRIu32 " index %" PRIu32
@@ -1025,7 +1025,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
         }
 
         // Verify VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT
-        if (variable.is_atomic_operation && (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) &&
+        if (variable.info.is_atomic_operation && (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) &&
             !(image_view_state->format_features & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
             auto set = context.descriptor_set.GetSet();
             const LogObjectList objlist(set, image_view);
@@ -1043,7 +1043,8 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
             const VkFormatFeatureFlags2 format_features = image_view_state->format_features;
 
             if (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
-                if ((variable.is_read_without_format) && !(format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT)) {
+                if ((variable.info.is_read_without_format) &&
+                    !(format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT)) {
                     auto set = context.descriptor_set.GetSet();
                     const LogObjectList objlist(set, image_view);
                     return LogError(objlist, context.vuids.storage_image_read_without_format_07028,
@@ -1055,7 +1056,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                                     string_VkFormatFeatureFlags2(format_features).c_str());
                 }
 
-                if ((variable.is_write_without_format) &&
+                if ((variable.info.is_write_without_format) &&
                     !(format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT)) {
                     auto set = context.descriptor_set.GetSet();
                     const LogObjectList objlist(set, image_view);
@@ -1069,7 +1070,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                 }
             }
 
-            if ((variable.is_dref_operation) && !(format_features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT)) {
+            if ((variable.info.is_dref_operation) && !(format_features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT)) {
                 auto set = context.descriptor_set.GetSet();
                 const LogObjectList objlist(set, image_view);
                 return LogError(objlist, context.vuids.depth_compare_sample_06479,
@@ -1118,7 +1119,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                         if (inteface_variable.decorations.set == set_index && inteface_variable.decorations.binding == binding) {
                             descriptor_written_to |= inteface_variable.is_written_to;
                             descriptor_read_from |=
-                                inteface_variable.is_read_from | inteface_variable.is_sampler_implicitLod_dref_proj;
+                                inteface_variable.is_read_from | inteface_variable.info.is_sampler_implicitLod_dref_proj;
                             break;
                         }
                     }
@@ -1357,7 +1358,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
 
             // UnnormalizedCoordinates sampler validations
             // only check if sampled as could have a texelFetch on a combined image sampler
-            if (sampler_state->createInfo.unnormalizedCoordinates && variable.is_sampler_sampled) {
+            if (sampler_state->createInfo.unnormalizedCoordinates && variable.info.is_sampler_sampled) {
                 // If ImageView is used by a unnormalizedCoordinates sampler, it needs to check ImageView type
                 if (image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_3D || image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_CUBE ||
                     image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_1D_ARRAY ||
@@ -1375,7 +1376,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
 
                 // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample*
                 // instructions with ImplicitLod, Dref or Proj in their name
-                if (variable.is_sampler_implicitLod_dref_proj) {
+                if (variable.info.is_sampler_implicitLod_dref_proj) {
                     auto set = context.descriptor_set.GetSet();
                     const LogObjectList objlist(set, image_view, sampler_state->sampler());
                     return LogError(objlist, context.vuids.sampler_implicitLod_dref_proj_02703,
@@ -1388,7 +1389,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
 
                 // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample*
                 // instructions that includes a LOD bias or any offset values
-                if (variable.is_sampler_bias_offset) {
+                if (variable.info.is_sampler_bias_offset) {
                     auto set = context.descriptor_set.GetSet();
                     const LogObjectList objlist(set, image_view, sampler_state->sampler());
                     return LogError(objlist, context.vuids.sampler_bias_offset_02704,
@@ -1467,7 +1468,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
         }
         const auto format_bits = GetFormatType(buffer_view_format);
 
-        if (!(variable.image_format_type & format_bits)) {
+        if (!(variable.info.image_format_type & format_bits)) {
             // bad component type
             auto set = context.descriptor_set.GetSet();
             auto vuid_text = enabled_features.descriptor_buffer_features.descriptorBuffer
@@ -1477,7 +1478,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                             "Descriptor set %s encountered the following validation error at %s time: Descriptor in "
                             "binding #%" PRIu32 " index %" PRIu32 " requires %s component type, but bound descriptor format is %s.",
                             report_data->FormatHandle(set).c_str(), context.caller, binding, index,
-                            string_NumericType(variable.image_format_type), string_VkFormat(buffer_view_format));
+                            string_NumericType(variable.info.image_format_type), string_VkFormat(buffer_view_format));
         }
 
         const bool buffer_format_width_64 = FormatHasComponentSize(buffer_view_format, 64);
@@ -1505,7 +1506,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
         const VkDescriptorType descriptor_type = context.descriptor_set.GetBinding(binding)->type;
 
         // Verify VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT
-        if ((variable.is_atomic_operation) && (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) &&
+        if ((variable.info.is_atomic_operation) && (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) &&
             !(buf_format_features & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)) {
             auto set = context.descriptor_set.GetSet();
             const LogObjectList objlist(set, buffer_view);
@@ -1523,7 +1524,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
         // device feature.
         if (has_format_feature2) {
             if (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
-                if ((variable.is_read_without_format) &&
+                if ((variable.info.is_read_without_format) &&
                     !(buf_format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR)) {
                     auto set = context.descriptor_set.GetSet();
 
@@ -1538,7 +1539,7 @@ bool CoreChecks::ValidateDescriptor(const DescriptorContext &context, const Desc
                                     string_VkFormatFeatureFlags2KHR(buf_format_features).c_str());
                 }
 
-                if ((variable.is_write_without_format) &&
+                if ((variable.info.is_write_without_format) &&
                     !(buf_format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR)) {
                     auto set = context.descriptor_set.GetSet();
                     const LogObjectList objlist(set, buffer_view);

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -254,18 +254,33 @@ struct ResourceInterfaceVariable : public VariableBase {
     // This array will match the OpTypeArray and not consider the InputAttachmentIndex
     std::vector<bool> input_attachment_index_read;
 
-    // Sampled Type width of the OpTypeImage the variable points to, 0 if doesn't use the image
-    uint32_t image_sampled_type_width = 0;
-
     // Type once array/pointer are stripped
     // most likly will be OpTypeImage, OpTypeStruct, OpTypeSampler, or OpTypeAccelerationStructureKHR
     const Instruction &base_type;
 
-    const NumericType image_format_type;
-    bool IsImage() const { return image_format_type != NumericTypeUnknown; }
-    const spv::Dim image_dim;
-    const bool is_image_array;
-    const bool is_multisampled;
+    // Sampled Type width of the OpTypeImage the variable points to, 0 if doesn't use the image
+    const uint32_t image_sampled_type_width;
+
+    // All info regarding what will be validated from requirements imposed by the pipeline on a descriptor. These
+    // can't be checked at pipeline creation time as they depend on the Image or ImageView bound.
+    // That is perf-critical code and hashing if 2 variables have same info provides a 20%
+    // perf bonus
+    struct Info {
+        NumericType image_format_type;
+        spv::Dim image_dim;
+        bool is_image_array;
+        bool is_multisampled;
+        bool is_atomic_operation;
+
+        bool is_sampler_sampled{false};
+        bool is_sampler_implicitLod_dref_proj{false};
+        bool is_sampler_bias_offset{false};
+        bool is_read_without_format{false};   // For storage images
+        bool is_write_without_format{false};  // For storage images
+        bool is_dref_operation{false};
+    } info;
+    uint32_t descriptor_hash = 0;
+    bool IsImage() const { return info.image_format_type != NumericTypeUnknown; }
 
     bool is_read_from{false};   // has operation to reads from the variable
     bool is_written_to{false};  // has operation to writes to the variable
@@ -276,25 +291,23 @@ struct ResourceInterfaceVariable : public VariableBase {
     const bool is_storage_buffer;
     bool is_input_attachment{false};
 
-    bool is_atomic_operation{false};
-    bool is_sampler_sampled{false};
-    bool is_sampler_implicitLod_dref_proj{false};
-    bool is_sampler_bias_offset{false};
-    bool is_read_without_format{false};   // For storage images
-    bool is_write_without_format{false};  // For storage images
-    bool is_dref_operation{false};
-
     ResourceInterfaceVariable(const SHADER_MODULE_STATE &module_state, const Instruction &insn, VkShaderStageFlagBits stage);
 
   protected:
     static const Instruction &FindBaseType(ResourceInterfaceVariable &variable, const SHADER_MODULE_STATE &module_state);
+    static uint32_t FindImageSampledTypeWidth(const SHADER_MODULE_STATE &module_state, const Instruction &base_type);
     static NumericType FindImageFormatType(const SHADER_MODULE_STATE &module_state, const Instruction &base_type);
     static bool IsStorageBuffer(const ResourceInterfaceVariable &variable);
+    static bool IsAtomicOperation(const SHADER_MODULE_STATE &module_state, const ResourceInterfaceVariable &variable);
 };
 
-// Used to help detect if different variable is being used
-inline bool operator==(const ResourceInterfaceVariable &a, const ResourceInterfaceVariable &b) noexcept { return a.id == b.id; }
-inline bool operator<(const ResourceInterfaceVariable &a, const ResourceInterfaceVariable &b) noexcept { return a.id < b.id; }
+// Used to help detect if two different variables are checking the same things for descriptors
+inline bool operator==(const ResourceInterfaceVariable &a, const ResourceInterfaceVariable &b) noexcept {
+    return a.descriptor_hash == b.descriptor_hash;
+}
+inline bool operator<(const ResourceInterfaceVariable &a, const ResourceInterfaceVariable &b) noexcept {
+    return a.descriptor_hash < b.descriptor_hash;
+}
 
 struct SHADER_MODULE_STATE : public BASE_NODE {
     // Contains all the details for a OpTypeStruct


### PR DESCRIPTION
@Tony-LunarG pointed out https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/898721a7a9e98689e0b8ec75ebc77896a295cdf4 gave Doom a 20% decrease. At first I thought it might be of doing a `copy` instead of a `move` but then realize we use to check if descriptors were different from the `DescriptorReqFlags` we had. In that commit I used the Variable ID instead. I think what is happening is a lot of variables have the same properties (Image type, is_atomic, sampled operation type), and so I created a hash to check if worth re-validating

Will wait for Tony to confirm this was the issue for the performance regression before debating how to possibly improve the design