### PR TITLE
tests: Remove more GetDeviceProcAddr

### DIFF
--- a/tests/positive/android_hardware_buffer.cpp
+++ b/tests/positive/android_hardware_buffer.cpp
@@ -283,10 +283,6 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExportImage) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    PFN_vkGetMemoryAndroidHardwareBufferANDROID vkGetMemoryAndroidHardwareBufferANDROID =
-        (PFN_vkGetMemoryAndroidHardwareBufferANDROID)vk::GetDeviceProcAddr(device(), "vkGetMemoryAndroidHardwareBufferANDROID");
-    ASSERT_TRUE(vkGetMemoryAndroidHardwareBufferANDROID != nullptr);
-
     // Create VkImage to be exported to an AHB
     VkExternalMemoryImageCreateInfo ext_image_info = LvlInitStruct<VkExternalMemoryImageCreateInfo>();
     ext_image_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -512,13 +512,6 @@ TEST_F(VkPositiveLayerTest, DrawIndirectCountWithoutFeature) {
         GTEST_SKIP() << "Tests requires Vulkan 1.1 exactly";
     }
 
-    auto vkCmdDrawIndirectCountKHR =
-        reinterpret_cast<PFN_vkCmdDrawIndirectCountKHR>(vk::GetDeviceProcAddr(device(), "vkCmdDrawIndirectCountKHR"));
-    ASSERT_TRUE(vkCmdDrawIndirectCountKHR != nullptr);
-    auto vkCmdDrawIndexedIndirectCountKHR =
-        reinterpret_cast<PFN_vkCmdDrawIndexedIndirectCountKHR>(vk::GetDeviceProcAddr(device(), "vkCmdDrawIndexedIndirectCountKHR"));
-    ASSERT_TRUE(vkCmdDrawIndexedIndirectCountKHR != nullptr);
-
     VkBufferObj indirect_buffer;
     indirect_buffer.init(*m_device, sizeof(VkDrawIndirectCommand), VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
                          VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT);
@@ -542,11 +535,11 @@ TEST_F(VkPositiveLayerTest, DrawIndirectCountWithoutFeature) {
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
-    vkCmdDrawIndirectCountKHR(m_commandBuffer->handle(), indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
-                              sizeof(VkDrawIndirectCommand));
+    vk::CmdDrawIndirectCountKHR(m_commandBuffer->handle(), indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
+                                sizeof(VkDrawIndirectCommand));
     vk::CmdBindIndexBuffer(m_commandBuffer->handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
-    vkCmdDrawIndexedIndirectCountKHR(m_commandBuffer->handle(), indexed_indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
-                                     sizeof(VkDrawIndexedIndirectCommand));
+    vk::CmdDrawIndexedIndirectCountKHR(m_commandBuffer->handle(), indexed_indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
+                                       sizeof(VkDrawIndexedIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 }
@@ -1143,9 +1136,6 @@ TEST_F(VkPositiveLayerTest, WriteTimestampNoneAndAll) {
         GTEST_SKIP() << "Device graphic queue has timestampValidBits of 0, skipping.\n";
     }
 
-    auto vkCmdWriteTimestamp2KHR =
-        reinterpret_cast<PFN_vkCmdWriteTimestamp2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdWriteTimestamp2KHR"));
-
     vk_testing::QueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_ci = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_ci.queryType = VK_QUERY_TYPE_TIMESTAMP;
@@ -1153,8 +1143,8 @@ TEST_F(VkPositiveLayerTest, WriteTimestampNoneAndAll) {
     query_pool.init(*m_device, query_pool_ci);
 
     m_commandBuffer->begin();
-    vkCmdWriteTimestamp2KHR(m_commandBuffer->handle(), VK_PIPELINE_STAGE_2_NONE_KHR, query_pool.handle(), 0);
-    vkCmdWriteTimestamp2KHR(m_commandBuffer->handle(), VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR, query_pool.handle(), 1);
+    vk::CmdWriteTimestamp2KHR(m_commandBuffer->handle(), VK_PIPELINE_STAGE_2_NONE_KHR, query_pool.handle(), 0);
+    vk::CmdWriteTimestamp2KHR(m_commandBuffer->handle(), VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR, query_pool.handle(), 1);
     m_commandBuffer->end();
 }
 

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -353,17 +353,12 @@ TEST_F(VkPositiveLayerTest, PushDescriptorNullDstSetTest) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_write.dstSet = 0;  // Should not cause a validation error
 
-    // Find address of extension call and make the call
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
-    assert(vkCmdPushDescriptorSetKHR != nullptr);
-
     m_commandBuffer->begin();
 
     // In Intel GPU, it needs to bind pipeline before push descriptor set.
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_);
-    vkCmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_.handle(), 0, 1,
-                              &descriptor_write);
+    vk::CmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_.handle(), 0, 1,
+                                &descriptor_write);
 }
 
 // This is a positive test. No failures are expected.
@@ -429,17 +424,13 @@ TEST_F(VkPositiveLayerTest, PushDescriptorUnboundSetTest) {
     descriptor_set.WriteDescriptorBufferInfo(2, buffer.handle(), 0, sizeof(bo_data));
     descriptor_set.UpdateDescriptorSets();
 
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
-    assert(vkCmdPushDescriptorSetKHR != nullptr);
-
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
     // Push descriptors and bind descriptor set
-    vkCmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
-                              descriptor_set.descriptor_writes.data());
+    vk::CmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
+                                descriptor_set.descriptor_writes.data());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 1, 1,
                               &descriptor_set.set_, 0, NULL);
 
@@ -587,10 +578,6 @@ TEST_F(VkPositiveLayerTest, PushDescriptorSetUpdatingSetNumber) {
 
     VkDescriptorBufferInfo buffer_info = {buffer_obj.handle(), 0, VK_WHOLE_SIZE};
 
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
-    ASSERT_TRUE(vkCmdPushDescriptorSetKHR != nullptr);
-
     const VkDescriptorSetLayoutBinding ds_binding_0 = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT,
                                                        nullptr};
     const VkDescriptorSetLayoutBinding ds_binding_1 = {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT,
@@ -639,8 +626,8 @@ TEST_F(VkPositiveLayerTest, PushDescriptorSetUpdatingSetNumber) {
             vk_testing::DescriptorSet(), 0, 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, &buffer_info);
 
         // Note: pushing to desciptor set number 2.
-        vkCmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 2, 1,
-                                  &descriptor_write);
+        vk::CmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 2, 1,
+                                    &descriptor_write);
         vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
     }
 
@@ -674,8 +661,8 @@ TEST_F(VkPositiveLayerTest, PushDescriptorSetUpdatingSetNumber) {
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
 
         // Note: now pushing to desciptor set number 3.
-        vkCmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 3, 1,
-                                  &descriptor_write);
+        vk::CmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 3, 1,
+                                    &descriptor_write);
         vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
     }
 
@@ -858,9 +845,6 @@ TEST_F(VkPositiveLayerTest, PushingDescriptorSetWithImmutableSampler) {
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
-
     std::vector<VkDescriptorSetLayoutBinding> ds_bindings = {
         {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, &sampler_handle}};
     OneOffDescriptorSet descriptor_set(m_device, ds_bindings);
@@ -884,8 +868,8 @@ TEST_F(VkPositiveLayerTest, PushingDescriptorSetWithImmutableSampler) {
     descriptor_write.dstSet = descriptor_set.set_;
 
     m_commandBuffer->begin();
-    vkCmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
-                              &descriptor_write);
+    vk::CmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
+                                &descriptor_write);
     m_commandBuffer->end();
 }
 

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -237,13 +237,6 @@ TEST_F(VkPositiveLayerTest, TestBeginQueryInDynamicRendering) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    PFN_vkCmdBeginRendering vkCmdBeginRendering =
-        reinterpret_cast<PFN_vkCmdBeginRendering>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginRendering"));
-    assert(vkCmdBeginRendering != nullptr);
-    PFN_vkCmdEndRendering vkCmdEndRendering =
-        reinterpret_cast<PFN_vkCmdEndRendering>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndRendering"));
-    assert(vkCmdEndRendering != nullptr);
-
     VkRenderingInfoKHR begin_rendering_info = LvlInitStruct<VkRenderingInfoKHR>();
     begin_rendering_info.layerCount = 1;
 
@@ -256,10 +249,10 @@ TEST_F(VkPositiveLayerTest, TestBeginQueryInDynamicRendering) {
 
     m_commandBuffer->begin();
 
-    vkCmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
+    vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
     vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 0, 0);
     vk::CmdEndQuery(m_commandBuffer->handle(), query_pool.handle(), 0);
-    vkCmdEndRendering(m_commandBuffer->handle());
+    vk::CmdEndRendering(m_commandBuffer->handle());
 
     m_commandBuffer->end();
 }

--- a/tests/positive/dynamic_state.cpp
+++ b/tests/positive/dynamic_state.cpp
@@ -29,9 +29,6 @@ TEST_F(VkPositiveLayerTest, DiscardRectanglesVersion) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vkCmdSetDiscardRectangleEnableEXT =
-        GetDeviceProcAddr<PFN_vkCmdSetDiscardRectangleEnableEXT>("vkCmdSetDiscardRectangleEnableEXT");
-
     const VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT};
     VkPipelineDynamicStateCreateInfo dyn_state_ci = LvlInitStruct<VkPipelineDynamicStateCreateInfo>();
     dyn_state_ci.dynamicStateCount = size(dyn_states);
@@ -46,7 +43,7 @@ TEST_F(VkPositiveLayerTest, DiscardRectanglesVersion) {
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
-    vkCmdSetDiscardRectangleEnableEXT(m_commandBuffer->handle(), VK_TRUE);
+    vk::CmdSetDiscardRectangleEnableEXT(m_commandBuffer->handle(), VK_TRUE);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 }
@@ -148,9 +145,6 @@ TEST_F(VkPositiveLayerTest, TestCmdSetVertexInputEXT) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vkCmdSetVertexInputEXT =
-        reinterpret_cast<PFN_vkCmdSetVertexInputEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetVertexInputEXT"));
-
     CreatePipelineHelper pipe(*this);
     pipe.InitInfo();
     const VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VERTEX_INPUT_EXT};
@@ -175,7 +169,7 @@ TEST_F(VkPositiveLayerTest, TestCmdSetVertexInputEXT) {
 
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
-    vkCmdSetVertexInputEXT(m_commandBuffer->handle(), 1, &binding, 1, &attribute);
+    vk::CmdSetVertexInputEXT(m_commandBuffer->handle(), 1, &binding, 1, &attribute);
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdDraw(m_commandBuffer->handle(), 1, 0, 0, 0);
     m_commandBuffer->EndRenderPass();
@@ -211,10 +205,6 @@ TEST_F(VkPositiveLayerTest, TestCmdSetVertexInputEXTStride) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vkCmdSetVertexInputEXT =
-        reinterpret_cast<PFN_vkCmdSetVertexInputEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetVertexInputEXT"));
-    ASSERT_NE(vkCmdSetVertexInputEXT, nullptr);
-
     CreatePipelineHelper pipe(*this);
     pipe.InitInfo();
     const VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VERTEX_INPUT_EXT, VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT};
@@ -239,7 +229,7 @@ TEST_F(VkPositiveLayerTest, TestCmdSetVertexInputEXTStride) {
 
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
-    vkCmdSetVertexInputEXT(m_commandBuffer->handle(), 1, &binding, 1, &attribute);
+    vk::CmdSetVertexInputEXT(m_commandBuffer->handle(), 1, &binding, 1, &attribute);
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdDraw(m_commandBuffer->handle(), 1, 0, 0, 0);
     m_commandBuffer->EndRenderPass();
@@ -297,10 +287,6 @@ TEST_F(VkPositiveLayerTest, DynamicColorWriteNoColorAttachments) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto vkCmdSetColorWriteEnableEXT =
-        reinterpret_cast<PFN_vkCmdSetColorWriteEnableEXT>(vk::GetDeviceProcAddr(m_device->handle(), "vkCmdSetColorWriteEnableEXT"));
-    ASSERT_NE(vkCmdSetColorWriteEnableEXT, nullptr);
-
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
     m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
@@ -357,7 +343,7 @@ TEST_F(VkPositiveLayerTest, DynamicColorWriteNoColorAttachments) {
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     VkBool32 color_write_enable = VK_TRUE;
-    vkCmdSetColorWriteEnableEXT(m_commandBuffer->handle(), 1, &color_write_enable);
+    vk::CmdSetColorWriteEnableEXT(m_commandBuffer->handle(), 1, &color_write_enable);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);

--- a/tests/positive/gpu_av.cpp
+++ b/tests/positive/gpu_av.cpp
@@ -40,8 +40,6 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOPushDescriptor) {
         GTEST_SKIP() << "maxBoundDescriptorSets is too low";
     }
 
-    auto vkCmdPushDescriptorSetKHR = GetDeviceProcAddr<PFN_vkCmdPushDescriptorSetKHR>("vkCmdPushDescriptorSetKHR");
-
     char const *csSource = R"glsl(
         #version 450
         layout(constant_id=0) const uint _const_2_0 = 1;
@@ -112,8 +110,8 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOPushDescriptor) {
 
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
-    vkCmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 2,
-                              descriptor_writes);
+    vk::CmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 2,
+                                descriptor_writes);
 
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 3, 1,
                               &descriptor_set_2.set_, 0, nullptr);

--- a/tests/positive/memory.cpp
+++ b/tests/positive/memory.cpp
@@ -24,9 +24,6 @@ TEST_F(VkPositiveLayerTest, MapMemory2) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto fpvkMapMemory2KHR = (PFN_vkMapMemory2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkMapMemory2KHR");
-    auto fpvkUnmapMemory2KHR = (PFN_vkUnmapMemory2KHR)vk::GetDeviceProcAddr(m_device->device(), "vkUnmapMemory2KHR");
-
     /* Vulkan doesn't have any requirements on what allocationSize can be
      * other than that it must be non-zero.  Pick 64KB because that should
      * work out to an even number of pages on basically any GPU.
@@ -52,21 +49,21 @@ TEST_F(VkPositiveLayerTest, MapMemory2) {
     unmap_info.memory = memory;
 
     uint32_t *pData = NULL;
-    err = fpvkMapMemory2KHR(m_device->device(), &map_info, (void **)&pData);
+    err = vk::MapMemory2KHR(m_device->device(), &map_info, (void **)&pData);
     ASSERT_VK_SUCCESS(err);
     ASSERT_TRUE(pData != NULL);
 
-    err = fpvkUnmapMemory2KHR(m_device->device(), &unmap_info);
+    err = vk::UnmapMemory2KHR(m_device->device(), &unmap_info);
     ASSERT_VK_SUCCESS(err);
 
     map_info.size = VK_WHOLE_SIZE;
 
     pData = NULL;
-    err = fpvkMapMemory2KHR(m_device->device(), &map_info, (void **)&pData);
+    err = vk::MapMemory2KHR(m_device->device(), &map_info, (void **)&pData);
     ASSERT_VK_SUCCESS(err);
     ASSERT_TRUE(pData != NULL);
 
-    err = fpvkUnmapMemory2KHR(m_device->device(), &unmap_info);
+    err = vk::UnmapMemory2KHR(m_device->device(), &unmap_info);
     ASSERT_VK_SUCCESS(err);
 
     vk::FreeMemory(m_device->device(), memory, NULL);

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -357,13 +357,11 @@ TEST_F(VkPositiveLayerTest, HostQueryResetSuccess) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
 
-    auto fpvkResetQueryPoolEXT = (PFN_vkResetQueryPoolEXT)vk::GetDeviceProcAddr(m_device->device(), "vkResetQueryPoolEXT");
-
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
     vk_testing::QueryPool query_pool(*m_device, query_pool_create_info);
-    fpvkResetQueryPoolEXT(m_device->device(), query_pool.handle(), 0, 1);
+    vk::ResetQueryPoolEXT(m_device->device(), query_pool.handle(), 0, 1);
 }
 
 TEST_F(VkPositiveLayerTest, UseFirstQueueUnqueried) {
@@ -779,10 +777,6 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
         ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     }
 
-    auto vkExportMetalObjectsEXT =
-        reinterpret_cast<PFN_vkExportMetalObjectsEXT>(vk::GetDeviceProcAddr(m_device->device(), "vkExportMetalObjectsEXT"));
-    ASSERT_TRUE(vkExportMetalObjectsEXT != nullptr);
-
     const VkDevice device = m_device->device();
 
     // Get Metal Device and Metal Command Queue in 1 call
@@ -795,7 +789,7 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
         auto objectsInfo = LvlInitStruct<VkExportMetalObjectsInfoEXT>(&deviceInfo);
 
         // This tests both device, queue, and pNext chaining
-        vkExportMetalObjectsEXT(device, &objectsInfo);
+        vk::ExportMetalObjectsEXT(device, &objectsInfo);
 
         ASSERT_TRUE(deviceInfo.mtlDevice != nullptr);
         ASSERT_TRUE(queueInfo.mtlCommandQueue != nullptr);
@@ -818,7 +812,7 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
         bufferInfo.memory = memory;
         auto objectsInfo = LvlInitStruct<VkExportMetalObjectsInfoEXT>(&bufferInfo);
 
-        vkExportMetalObjectsEXT(device, &objectsInfo);
+        vk::ExportMetalObjectsEXT(device, &objectsInfo);
 
         ASSERT_TRUE(bufferInfo.mtlBuffer != nullptr);
 
@@ -854,7 +848,7 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
         auto objectsInfo = LvlInitStruct<VkExportMetalObjectsInfoEXT>(&textureInfo);
 
         // This tests both texture, surface, and pNext chaining
-        vkExportMetalObjectsEXT(device, &objectsInfo);
+        vk::ExportMetalObjectsEXT(device, &objectsInfo);
 
         ASSERT_TRUE(textureInfo.mtlTexture != nullptr);
         ASSERT_TRUE(surfaceInfo.ioSurface != nullptr);
@@ -873,7 +867,7 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
         eventInfo.event = event.handle();
         auto objectsInfo = LvlInitStruct<VkExportMetalObjectsInfoEXT>(&eventInfo);
 
-        vkExportMetalObjectsEXT(device, &objectsInfo);
+        vk::ExportMetalObjectsEXT(device, &objectsInfo);
 
         ASSERT_TRUE(eventInfo.mtlSharedEvent != nullptr);
     }

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -3066,19 +3066,16 @@ TEST_F(VkPositiveLayerTest, ProtectedAndUnprotectedQueue) {
     VkQueue test_queue_protected = VK_NULL_HANDLE;
     VkQueue test_queue_unprotected = VK_NULL_HANDLE;
 
-    PFN_vkGetDeviceQueue2 vkGetDeviceQueue2 = (PFN_vkGetDeviceQueue2)vk::GetDeviceProcAddr(test_device, "vkGetDeviceQueue2");
-    ASSERT_TRUE(vkGetDeviceQueue2 != nullptr);
-
     VkDeviceQueueInfo2 queue_info_2 = LvlInitStruct<VkDeviceQueueInfo2>();
 
     queue_info_2.flags = VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT;
     queue_info_2.queueFamilyIndex = queue_family_index;
     queue_info_2.queueIndex = 0;
-    vkGetDeviceQueue2(test_device, &queue_info_2, &test_queue_protected);
+    vk::GetDeviceQueue2(test_device, &queue_info_2, &test_queue_protected);
 
     queue_info_2.flags = 0;
     queue_info_2.queueIndex = 0;
-    vkGetDeviceQueue2(test_device, &queue_info_2, &test_queue_unprotected);
+    vk::GetDeviceQueue2(test_device, &queue_info_2, &test_queue_unprotected);
 
     vk::DestroyDevice(test_device, nullptr);
 }
@@ -3798,9 +3795,6 @@ TEST_F(VkPositiveLayerTest, DestroySwapchainWithBoundImages) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
-    auto vkBindImageMemory2KHR =
-        reinterpret_cast<PFN_vkBindImageMemory2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkBindImageMemory2KHR"));
-
     auto image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = m_surface_formats[0].format;
@@ -3833,7 +3827,7 @@ TEST_F(VkPositiveLayerTest, DestroySwapchainWithBoundImages) {
         bind_info.memory = VK_NULL_HANDLE;
         bind_info.memoryOffset = 0;
 
-        vkBindImageMemory2KHR(m_device->device(), 1, &bind_info);
+        vk::BindImageMemory2KHR(m_device->device(), 1, &bind_info);
     }
 }
 
@@ -3908,14 +3902,11 @@ TEST_F(VkPositiveLayerTest, ProtectedSwapchainImageColorAttachment) {
     ASSERT_VK_SUCCESS(vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain));
 
     // Get VkImage from swapchain which should be protected
-    PFN_vkGetSwapchainImagesKHR vkGetSwapchainImagesKHR =
-        (PFN_vkGetSwapchainImagesKHR)vk::GetDeviceProcAddr(m_device->handle(), "vkGetSwapchainImagesKHR");
-    ASSERT_TRUE(vkGetSwapchainImagesKHR != nullptr);
     uint32_t image_count;
     std::vector<VkImage> swapchain_images;
-    vkGetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr);
+    vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr);
     swapchain_images.resize(image_count, VK_NULL_HANDLE);
-    vkGetSwapchainImagesKHR(device(), m_swapchain, &image_count, swapchain_images.data());
+    vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, swapchain_images.data());
     VkImage protected_image = swapchain_images.at(0);  // only need 1 image to test
 
     // Create a protected image view
@@ -4922,10 +4913,6 @@ TEST_F(VkPositiveLayerTest, LineTopologyClasses) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
-
-    auto vkCmdSetPrimitiveTopologyEXT = reinterpret_cast<PFN_vkCmdSetPrimitiveTopologyEXT>(
-        vk::GetDeviceProcAddr(m_device->device(), "vkCmdSetPrimitiveTopologyEXT"));
-
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const VkDynamicState dyn_states[1] = {
@@ -4959,7 +4946,7 @@ TEST_F(VkPositiveLayerTest, LineTopologyClasses) {
 
     vk::CmdBindPipeline(cb.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     cb.BindVertexBuffer(&vb, 0, 0);
-    vkCmdSetPrimitiveTopologyEXT(cb.handle(), VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY);
+    vk::CmdSetPrimitiveTopologyEXT(cb.handle(), VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY);
     vk::CmdDraw(cb.handle(), 1, 1, 0, 0);
 
     cb.EndRenderPass();
@@ -5525,10 +5512,6 @@ TEST_F(VkPositiveLayerTest, TestUpdateAfterBind) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vkQueueSubmit2KHR =
-        reinterpret_cast<PFN_vkQueueSubmit2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR"));
-    assert(vkQueueSubmit2KHR != nullptr);
-
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
@@ -5622,7 +5605,7 @@ TEST_F(VkPositiveLayerTest, TestUpdateAfterBind) {
     submit_info.commandBufferInfoCount = 1;
     submit_info.pCommandBufferInfos = &cb_info;
 
-    vkQueueSubmit2KHR(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+    vk::QueueSubmit2KHR(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     vk::QueueWaitIdle(m_device->m_queue);
 
     vk::DestroyBuffer(device(), buffer2, nullptr);
@@ -5660,10 +5643,6 @@ TEST_F(VkPositiveLayerTest, TestPartiallyBoundDescriptors) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    auto vkQueueSubmit2KHR =
-        reinterpret_cast<PFN_vkQueueSubmit2KHR>(vk::GetDeviceProcAddr(m_device->device(), "vkQueueSubmit2KHR"));
-    assert(vkQueueSubmit2KHR != nullptr);
 
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = 4096;
@@ -5753,7 +5732,7 @@ TEST_F(VkPositiveLayerTest, TestPartiallyBoundDescriptors) {
     submit_info.commandBufferInfoCount = 1;
     submit_info.pCommandBufferInfos = &cb_info;
 
-    vkQueueSubmit2KHR(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+    vk::QueueSubmit2KHR(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     vk::QueueWaitIdle(m_device->m_queue);
 
     vk::DestroyBuffer(device(), buffer3, nullptr);
@@ -5867,12 +5846,8 @@ TEST_F(VkPositiveLayerTest, ShaderModuleIdentifierGPL) {
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
     ASSERT_TRUE(vs.initialized());
 
-    auto vkGetShaderModuleIdentifierEXT = reinterpret_cast<PFN_vkGetShaderModuleIdentifierEXT>(
-        vk::GetDeviceProcAddr(m_device->device(), "vkGetShaderModuleIdentifierEXT"));
-    ASSERT_NE(vkGetShaderModuleIdentifierEXT, nullptr);
-
     auto vs_identifier = LvlInitStruct<VkShaderModuleIdentifierEXT>();
-    vkGetShaderModuleIdentifierEXT(device(), vs.handle(), &vs_identifier);
+    vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &vs_identifier);
 
     auto sm_id_create_info = LvlInitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
     sm_id_create_info.identifierSize = vs_identifier.identifierSize;
@@ -5895,12 +5870,8 @@ TEST_F(VkPositiveLayerTest, ShaderModuleIdentifierGPL) {
     fs_ci.codeSize = fs_spv.size() * sizeof(decltype(fs_spv)::value_type);
     fs_ci.pCode = fs_spv.data();
 
-    auto vkGetShaderModuleCreateInfoIdentifierEXT = reinterpret_cast<PFN_vkGetShaderModuleCreateInfoIdentifierEXT>(
-        vk::GetDeviceProcAddr(m_device->device(), "vkGetShaderModuleCreateInfoIdentifierEXT"));
-    ASSERT_NE(vkGetShaderModuleCreateInfoIdentifierEXT, nullptr);
-
     auto fs_identifier = LvlInitStruct<VkShaderModuleIdentifierEXT>();
-    vkGetShaderModuleCreateInfoIdentifierEXT(device(), &fs_ci, &fs_identifier);
+    vk::GetShaderModuleCreateInfoIdentifierEXT(device(), &fs_ci, &fs_identifier);
 
     sm_id_create_info.identifierSize = fs_identifier.identifierSize;
     sm_id_create_info.pIdentifier = fs_identifier.identifier;

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -1019,14 +1019,10 @@ TEST_F(VkPositiveLayerTest, BeginRenderPassWithViewMask) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_write.dstSet = 0;  // Should not cause a validation error
 
-    PFN_vkCmdPushDescriptorSetKHR vkCmdPushDescriptorSetKHR =
-        (PFN_vkCmdPushDescriptorSetKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdPushDescriptorSetKHR");
-    assert(vkCmdPushDescriptorSetKHR != nullptr);
-
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_);
-    vkCmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_.handle(), 0, 1,
-                              &descriptor_write);
+    vk::CmdPushDescriptorSetKHR(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_.handle(), 0, 1,
+                                &descriptor_write);
     vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdNextSubpass(m_commandBuffer->handle(), VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdEndRenderPass(m_commandBuffer->handle());

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -1860,9 +1860,8 @@ TEST_F(VkPositiveLayerTest, PositiveShaderModuleIdentifier) {
     auto sm_id_create_info = LvlInitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto vkGetShaderModuleIdentifierEXT = (PFN_vkGetShaderModuleIdentifierEXT)vk::GetDeviceProcAddr(m_device->device(), "vkGetShaderModuleIdentifierEXT");
     auto get_identifier = LvlInitStruct<VkShaderModuleIdentifierEXT>();
-    vkGetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
+    vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
 


### PR DESCRIPTION
Should remove rest of the `GetDeviceProcAddr` outside the few that are dedicated for testing that function