### PR TITLE
bp: Move Fragment Output checks to BP

### DIFF
--- a/layers/best_practices/best_practices_error_enums.h
+++ b/layers/best_practices/best_practices_error_enums.h
@@ -140,6 +140,9 @@
 [[maybe_unused]] static const char *kVUID_BestPractices_DrawState_SwapchainImagesNotFound = "UNASSIGNED-BestPractices-DrawState-SwapchainImagesNotFound";
 [[maybe_unused]] static const char *kVUID_BestPractices_DrawState_MismatchedImageType = "UNASSIGNED-BestPractices-DrawState-MismatchedImageType";
 [[maybe_unused]] static const char *kVUID_BestPractices_DrawState_InvalidExtents = "UNASSIGNED-BestPractices-DrawState-InvalidExtents";
+[[maybe_unused]] static const char *kVUID_BestPractices_Shader_InputNotProduced = "UNASSIGNED-BestPractices-Shader-InputNotProduced";
+[[maybe_unused]] static const char *kVUID_BestPractices_Shader_OutputNotConsumed = "UNASSIGNED-BestPractices-Shader-OutputNotConsumed";
+[[maybe_unused]] static const char *kVUID_BestPractices_Shader_FragmentOutputMismatch = "UNASSIGNED-BestPractices-Shader-FragmentOutputMismatch";
 
 // Arm-specific best practice
 [[maybe_unused]] static const char *kVUID_BestPractices_AllocateDescriptorSets_SuboptimalReuse =

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -895,6 +895,10 @@ class BestPractices : public ValidationStateTracker {
         VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
         const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos) const override;
 
+    bool ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state, const EntryPoint& entrypoint,
+                                            const PIPELINE_STATE& pipeline, uint32_t subpass_index) const;
+    bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE& module_state, const EntryPoint& entrypoint,
+                                                            const PIPELINE_STATE& pipeline) const;
 // Include code-generated functions
 #include "generated/best_practices.h"
   protected:

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -106,8 +106,9 @@ bool BestPractices::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
 
     for (uint32_t i = 0; i < createInfoCount; i++) {
         const auto& create_info = pCreateInfos[i];
+        const auto& pipeline = *cgpl_state->pipe_state[i].get();
 
-        if (!(cgpl_state->pipe_state[i]->active_shaders & VK_SHADER_STAGE_MESH_BIT_EXT) && create_info.pVertexInputState) {
+        if (!(pipeline.active_shaders & VK_SHADER_STAGE_MESH_BIT_EXT) && create_info.pVertexInputState) {
             const auto& vertex_input = *create_info.pVertexInputState;
             uint32_t count = 0;
             for (uint32_t j = 0; j < vertex_input.vertexBindingDescriptionCount; j++) {
@@ -136,6 +137,27 @@ bool BestPractices::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                 VendorSpecificTag(kBPVendorArm));
         }
 
+        const PipelineStageState* fragment_stage = nullptr;
+        for (auto& stage_state : pipeline.stage_states) {
+            if (stage_state.create_info->stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
+                fragment_stage = &stage_state;
+                break;
+            }
+        }
+
+        // Only validate pipelines that contain shader stages
+        if (pipeline.pre_raster_state && pipeline.fragment_shader_state) {
+            if (fragment_stage && fragment_stage->entrypoint && fragment_stage->module_state->has_valid_spirv) {
+                const auto& rp_state = pipeline.RenderPassState();
+                if (rp_state && rp_state->UsesDynamicRendering()) {
+                    skip |= ValidateFsOutputsAgainstDynamicRenderingRenderPass(*fragment_stage->module_state.get(),
+                                                                               *fragment_stage->entrypoint, pipeline);
+                } else {
+                    skip |= ValidateFsOutputsAgainstRenderPass(*fragment_stage->module_state.get(), *fragment_stage->entrypoint,
+                                                               pipeline, pipeline.Subpass());
+                }
+            }
+        }
         skip |= VendorCheckEnabled(kBPVendorArm) && ValidateMultisampledBlendingArm(createInfoCount, pCreateInfos);
     }
     if (VendorCheckEnabled(kBPVendorAMD) || VendorCheckEnabled(kBPVendorNVIDIA)) {
@@ -627,6 +649,143 @@ bool BestPractices::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer
                                   "and/or mesh shaders. Group draw calls using these shader stages together.",
                                   VendorSpecificTag(kBPVendorNVIDIA));
             // Do not set 'skip' so the number of switches gets properly counted after the message.
+        }
+    }
+
+    return skip;
+}
+
+bool BestPractices::ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state, const EntryPoint& entrypoint,
+                                                       const PIPELINE_STATE& pipeline, uint32_t subpass_index) const {
+    bool skip = false;
+
+    struct Attachment {
+        const VkAttachmentReference2* reference = nullptr;
+        const VkAttachmentDescription2* attachment = nullptr;
+        const StageInteraceVariable* output = nullptr;
+    };
+    std::map<uint32_t, Attachment> location_map;
+
+    const auto& rp_state = pipeline.RenderPassState();
+    if (rp_state && !rp_state->UsesDynamicRendering()) {
+        const auto rpci = rp_state->createInfo.ptr();
+        const auto subpass = rpci->pSubpasses[subpass_index];
+        for (uint32_t i = 0; i < subpass.colorAttachmentCount; ++i) {
+            auto const& reference = subpass.pColorAttachments[i];
+            location_map[i].reference = &reference;
+            if (reference.attachment != VK_ATTACHMENT_UNUSED &&
+                rpci->pAttachments[reference.attachment].format != VK_FORMAT_UNDEFINED) {
+                location_map[i].attachment = &rpci->pAttachments[reference.attachment];
+            }
+        }
+    }
+
+    // TODO: dual source blend index (spv::DecIndex, zero if not provided)
+    for (const auto* variable : entrypoint.user_defined_interface_variables) {
+        if ((variable->storage_class != spv::StorageClassOutput) || variable->interface_slots.empty()) {
+            continue;  // not an output interface
+        }
+        // It is not allowed to have Block Fragment or 64-bit vectors output in Frag shader
+        // This means all Locations in slots will be the same
+        location_map[variable->interface_slots[0].Location()].output = variable;
+    }
+
+    const auto* ms_state = pipeline.MultisampleState();
+    const bool alpha_to_coverage_enabled = ms_state && (ms_state->alphaToCoverageEnable == VK_TRUE);
+
+    // Don't check any color attachments if rasterization is disabled
+    const auto raster_state = pipeline.RasterizationState();
+    if (raster_state && !raster_state->rasterizerDiscardEnable) {
+        for (const auto& location_it : location_map) {
+            const auto reference = location_it.second.reference;
+            if (reference != nullptr && reference->attachment == VK_ATTACHMENT_UNUSED) {
+                continue;
+            }
+
+            const auto location = location_it.first;
+            const auto attachment = location_it.second.attachment;
+            const auto output = location_it.second.output;
+            if (attachment && !output) {
+                const auto& attachments = pipeline.Attachments();
+                if (location < attachments.size() && attachments[location].colorWriteMask != 0) {
+                    skip |= LogWarning(module_state.vk_shader_module(), kVUID_BestPractices_Shader_InputNotProduced,
+                                       "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attachment %" PRIu32
+                                       " not written by fragment shader; undefined values will be written to attachment",
+                                       pipeline.create_index, location);
+                }
+            } else if (!attachment && output) {
+                if (!(alpha_to_coverage_enabled && location == 0)) {
+                    skip |= LogWarning(module_state.vk_shader_module(), kVUID_BestPractices_Shader_OutputNotConsumed,
+                                       "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
+                                       "] fragment shader writes to output location %" PRIu32 " with no matching attachment",
+                                       pipeline.create_index, location);
+                }
+            } else if (attachment && output) {
+                const auto attachment_type = GetFormatType(attachment->format);
+                const auto output_type = module_state.GetNumericType(output->type_id);
+
+                // Type checking
+                if (!(output_type & attachment_type)) {
+                    skip |= LogWarning(
+                        module_state.vk_shader_module(), kVUID_BestPractices_Shader_FragmentOutputMismatch,
+                        "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attachment %" PRIu32
+                        " of type `%s` does not match fragment shader output type of `%s`; resulting values are undefined",
+                        pipeline.create_index, location, string_VkFormat(attachment->format),
+                        module_state.DescribeType(output->type_id).c_str());
+                }
+            } else {            // !attachment && !output
+                assert(false);  // at least one exists in the map
+            }
+        }
+    }
+
+    return skip;
+}
+
+bool BestPractices::ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE& module_state,
+                                                                       const EntryPoint& entrypoint,
+                                                                       const PIPELINE_STATE& pipeline) const {
+    bool skip = false;
+
+    struct Attachment {
+        const StageInteraceVariable* output = nullptr;
+    };
+    std::map<uint32_t, Attachment> location_map;
+
+    // TODO: dual source blend index (spv::DecIndex, zero if not provided)
+    for (const auto* variable : entrypoint.user_defined_interface_variables) {
+        if ((variable->storage_class != spv::StorageClassOutput) || variable->interface_slots.empty()) {
+            continue;  // not an output interface
+        }
+        // It is not allowed to have Block Fragment or 64-bit vectors output in Frag shader
+        // This means all Locations in slots will be the same
+        location_map[variable->interface_slots[0].Location()].output = variable;
+    }
+
+    for (uint32_t location = 0; location < location_map.size(); ++location) {
+        const auto output = location_map[location].output;
+
+        const auto& rp_state = pipeline.RenderPassState();
+        const auto& attachments = pipeline.Attachments();
+        if (!output && location < attachments.size() && attachments[location].colorWriteMask != 0) {
+            skip |= LogWarning(module_state.vk_shader_module(), kVUID_BestPractices_Shader_InputNotProduced,
+                               "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attachment %" PRIu32
+                               " not written by fragment shader; undefined values will be written to attachment",
+                               pipeline.create_index, location);
+        } else if (pipeline.fragment_output_state && output &&
+                   (location < rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount)) {
+            auto format = rp_state->dynamic_rendering_pipeline_create_info.pColorAttachmentFormats[location];
+            const auto attachment_type = GetFormatType(format);
+            const auto output_type = module_state.GetNumericType(output->type_id);
+
+            // Type checking
+            if (!(output_type & attachment_type)) {
+                skip |= LogWarning(
+                    module_state.vk_shader_module(), kVUID_BestPractices_Shader_FragmentOutputMismatch,
+                    "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attachment %" PRIu32
+                    " of type `%s` does not match fragment shader output type of `%s`; resulting values are undefined",
+                    pipeline.create_index, location, string_VkFormat(format), module_state.DescribeType(output->type_id).c_str());
+            }
         }
     }
 

--- a/layers/core_checks/cc_shader.cpp
+++ b/layers/core_checks/cc_shader.cpp
@@ -112,56 +112,6 @@ bool CoreChecks::ValidateViAgainstVsInputs(const PIPELINE_STATE &pipeline, const
     return skip;
 }
 
-bool CoreChecks::ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE &module_state,
-                                                                    const EntryPoint &entrypoint,
-                                                                    const PIPELINE_STATE &pipeline) const {
-    bool skip = false;
-
-    struct Attachment {
-        const StageInteraceVariable *output = nullptr;
-    };
-    std::map<uint32_t, Attachment> location_map;
-
-    // TODO: dual source blend index (spv::DecIndex, zero if not provided)
-    for (const auto *variable : entrypoint.user_defined_interface_variables) {
-        if ((variable->storage_class != spv::StorageClassOutput) || variable->interface_slots.empty()) {
-            continue;  // not an output interface
-        }
-        // It is not allowed to have Block Fragment or 64-bit vectors output in Frag shader
-        // This means all Locations in slots will be the same
-        location_map[variable->interface_slots[0].Location()].output = variable;
-    }
-
-    for (uint32_t location = 0; location < location_map.size(); ++location) {
-        const auto output = location_map[location].output;
-
-        const auto &rp_state = pipeline.RenderPassState();
-        const auto &attachments = pipeline.Attachments();
-        if (!output && location < attachments.size() && attachments[location].colorWriteMask != 0) {
-            skip |= LogWarning(module_state.vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
-                               "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attachment %" PRIu32
-                               " not written by fragment shader; undefined values will be written to attachment",
-                               pipeline.create_index, location);
-        } else if (pipeline.fragment_output_state && output &&
-                   (location < rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount)) {
-            auto format = rp_state->dynamic_rendering_pipeline_create_info.pColorAttachmentFormats[location];
-            const auto attachment_type = GetFormatType(format);
-            const auto output_type = module_state.GetNumericType(output->type_id);
-
-            // Type checking
-            if (!(output_type & attachment_type)) {
-                skip |= LogWarning(
-                    module_state.vk_shader_module(), kVUID_Core_Shader_FragmentOutputMismatch,
-                    "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attachment %" PRIu32
-                    " of type `%s` does not match fragment shader output type of `%s`; resulting values are undefined",
-                    pipeline.create_index, location, string_VkFormat(format), module_state.DescribeType(output->type_id).c_str());
-            }
-        }
-    }
-
-    return skip;
-}
-
 // Validate use of input attachments against subpass structure
 bool CoreChecks::ValidateShaderInputAttachment(const SHADER_MODULE_STATE &module_state, const PIPELINE_STATE &pipeline,
                                                const ResourceInterfaceVariable &variable) const {
@@ -235,93 +185,6 @@ bool CoreChecks::ValidateConservativeRasterization(const SHADER_MODULE_STATE &mo
                          "] has a fragment shader with a\nOpExecutionMode EarlyFragmentTests\nOpDecorate BuiltIn "
                          "FullyCoveredEXT\nbut conservativeRasterizationPostDepthCoverage is not enabled",
                          pipeline.create_index);
-    }
-
-    return skip;
-}
-
-bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE &module_state, const EntryPoint &entrypoint,
-                                                    const PIPELINE_STATE &pipeline, uint32_t subpass_index) const {
-    bool skip = false;
-
-    struct Attachment {
-        const VkAttachmentReference2 *reference = nullptr;
-        const VkAttachmentDescription2 *attachment = nullptr;
-        const StageInteraceVariable *output = nullptr;
-    };
-    std::map<uint32_t, Attachment> location_map;
-
-    const auto &rp_state = pipeline.RenderPassState();
-    if (rp_state && !rp_state->UsesDynamicRendering()) {
-        const auto rpci = rp_state->createInfo.ptr();
-        const auto subpass = rpci->pSubpasses[subpass_index];
-        for (uint32_t i = 0; i < subpass.colorAttachmentCount; ++i) {
-            auto const &reference = subpass.pColorAttachments[i];
-            location_map[i].reference = &reference;
-            if (reference.attachment != VK_ATTACHMENT_UNUSED &&
-                rpci->pAttachments[reference.attachment].format != VK_FORMAT_UNDEFINED) {
-                location_map[i].attachment = &rpci->pAttachments[reference.attachment];
-            }
-        }
-    }
-
-    // TODO: dual source blend index (spv::DecIndex, zero if not provided)
-    for (const auto *variable : entrypoint.user_defined_interface_variables) {
-        if ((variable->storage_class != spv::StorageClassOutput) || variable->interface_slots.empty()) {
-            continue;  // not an output interface
-        }
-        // It is not allowed to have Block Fragment or 64-bit vectors output in Frag shader
-        // This means all Locations in slots will be the same
-        location_map[variable->interface_slots[0].Location()].output = variable;
-    }
-
-    const auto *ms_state = pipeline.MultisampleState();
-    const bool alpha_to_coverage_enabled = ms_state && (ms_state->alphaToCoverageEnable == VK_TRUE);
-
-    // Don't check any color attachments if rasterization is disabled
-    const auto raster_state = pipeline.RasterizationState();
-    if (raster_state && !raster_state->rasterizerDiscardEnable) {
-        for (const auto &location_it : location_map) {
-            const auto reference = location_it.second.reference;
-            if (reference != nullptr && reference->attachment == VK_ATTACHMENT_UNUSED) {
-                continue;
-            }
-
-            const auto location = location_it.first;
-            const auto attachment = location_it.second.attachment;
-            const auto output = location_it.second.output;
-            if (attachment && !output) {
-                const auto &attachments = pipeline.Attachments();
-                if (location < attachments.size() && attachments[location].colorWriteMask != 0) {
-                    skip |= LogWarning(module_state.vk_shader_module(), kVUID_Core_Shader_InputNotProduced,
-                                       "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attachment %" PRIu32
-                                       " not written by fragment shader; undefined values will be written to attachment",
-                                       pipeline.create_index, location);
-                }
-            } else if (!attachment && output) {
-                if (!(alpha_to_coverage_enabled && location == 0)) {
-                    skip |= LogWarning(module_state.vk_shader_module(), kVUID_Core_Shader_OutputNotConsumed,
-                                       "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-                                       "] fragment shader writes to output location %" PRIu32 " with no matching attachment",
-                                       pipeline.create_index, location);
-                }
-            } else if (attachment && output) {
-                const auto attachment_type = GetFormatType(attachment->format);
-                const auto output_type = module_state.GetNumericType(output->type_id);
-
-                // Type checking
-                if (!(output_type & attachment_type)) {
-                    skip |= LogWarning(
-                        module_state.vk_shader_module(), kVUID_Core_Shader_FragmentOutputMismatch,
-                        "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attachment %" PRIu32
-                        " of type `%s` does not match fragment shader output type of `%s`; resulting values are undefined",
-                        pipeline.create_index, location, string_VkFormat(attachment->format),
-                        module_state.DescribeType(output->type_id).c_str());
-                }
-            } else {            // !attachment && !output
-                assert(false);  // at least one exists in the map
-            }
-        }
     }
 
     return skip;
@@ -3147,18 +3010,6 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE &pipel
             }
         }
     }
-
-    if (fragment_stage && fragment_stage->entrypoint && fragment_stage->module_state->has_valid_spirv) {
-        const auto &rp_state = pipeline.RenderPassState();
-        if (rp_state && rp_state->UsesDynamicRendering()) {
-            skip |= ValidateFsOutputsAgainstDynamicRenderingRenderPass(*fragment_stage->module_state.get(),
-                                                                       *fragment_stage->entrypoint, pipeline);
-        } else {
-            skip |= ValidateFsOutputsAgainstRenderPass(*fragment_stage->module_state.get(), *fragment_stage->entrypoint, pipeline,
-                                                       pipeline.Subpass());
-        }
-    }
-
     return skip;
 }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -882,10 +882,6 @@ class CoreChecks : public ValidationStateTracker {
                                 const PIPELINE_STATE& pipeline) const;
     bool ValidateViAgainstVsInputs(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
                                    const EntryPoint& entrypoint) const;
-    bool ValidateFsOutputsAgainstRenderPass(const SHADER_MODULE_STATE& module_state, const EntryPoint& entrypoint,
-                                            const PIPELINE_STATE& pipeline, uint32_t subpass_index) const;
-    bool ValidateFsOutputsAgainstDynamicRenderingRenderPass(const SHADER_MODULE_STATE& module_state, const EntryPoint& entrypoint,
-                                                            const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderInputAttachment(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline,
                                        const ResourceInterfaceVariable& variable) const;
     bool ValidateConservativeRasterization(const SHADER_MODULE_STATE& module_state, const EntryPoint& entrypoint,

--- a/layers/error_message/validation_error_enums.h
+++ b/layers/error_message/validation_error_enums.h
@@ -44,8 +44,6 @@
 [[maybe_unused]] static const char *kVUID_Core_BindImageMemory_Swapchain = "UNASSIGNED-CoreValidation-BindImageMemory-Swapchain";
 
 // TODO - Need to be moved to Best Practice
-[[maybe_unused]] static const char *kVUID_Core_Shader_InputNotProduced = "UNASSIGNED-CoreValidation-Shader-InputNotProduced";
-[[maybe_unused]] static const char *kVUID_Core_Shader_FragmentOutputMismatch = "UNASSIGNED-CoreValidation-Shader-FragmentOutputMismatch";
 [[maybe_unused]] static const char *kVUID_Core_Shader_OutputNotConsumed = "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed";
 [[maybe_unused]] static const char *kVUID_Core_Swapchain_PriorCount = "UNASSIGNED-CoreValidation-SwapchainPriorCount";
 [[maybe_unused]] static const char *kVUID_Core_Swapchain_PreTransform = "UNASSIGNED-CoreValidation-SwapchainPreTransform";

--- a/tests/negative/best_practices.cpp
+++ b/tests/negative/best_practices.cpp
@@ -732,7 +732,7 @@ TEST_F(VkBestPracticesLayerTest, TooManyInstancedVertexBuffers) {
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers");
 
     // This test does not need for the shader to consume the vertex input
-    m_errorMonitor->SetAllowedFailureMsg(kVUID_Core_Shader_OutputNotConsumed);
+    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-Shader-OutputNotConsumed");
 
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -770,6 +770,74 @@ TEST_F(VkBestPracticesLayerTest, TooManyInstancedVertexBuffers) {
     pipe.CreateGraphicsPipeline();
 
     m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkBestPracticesLayerTest, CreatePipelineFragmentOutputNotWritten) {
+    TEST_DESCRIPTION(
+        "Test that an error is produced for a fragment shader which does not provide an output for one of the pipeline's color "
+        "attachments");
+
+    ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    VkShaderObj fs(this, bindStateMinimalShaderText, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+        helper.cb_attachments_[0].colorWriteMask = 1;
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-BestPractices-Shader-InputNotProduced");
+}
+
+TEST_F(VkBestPracticesLayerTest, CreatePipelineFragmentOutputTypeMismatch) {
+    TEST_DESCRIPTION(
+        "Test that an error is produced for a mismatch between the fundamental type of an fragment shader output variable, and the "
+        "format of the corresponding attachment");
+
+    ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    char const *fsSource = R"glsl(
+        #version 450
+        layout(location=0) out ivec4 x; /* not UNORM */
+        void main(){
+           x = ivec4(1);
+        }
+    )glsl";
+
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-BestPractices-Shader-FragmentOutputMismatch");
+}
+
+TEST_F(VkBestPracticesLayerTest, CreatePipelineFragmentOutputNotConsumed) {
+    TEST_DESCRIPTION(
+        "Test that a warning is produced for a fragment shader which provides a spurious output with no matching attachment");
+
+    ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    char const *fsSource = R"glsl(
+        #version 450
+        layout(location=0) out vec4 x;
+        layout(location=1) out vec4 y; /* no matching attachment for this */
+        void main(){
+           x = vec4(1);
+           y = vec4(1);
+        }
+    )glsl";
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-BestPractices-Shader-OutputNotConsumed");
 }
 
 TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {

--- a/tests/negative/geometry_tessellation.cpp
+++ b/tests/negative/geometry_tessellation.cpp
@@ -477,8 +477,6 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationControlInputOutputCompone
         tessInfo.flags = 0;
         tessInfo.patchControlPoints = 3;
 
-        m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-InputNotProduced");
-
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(),
                                      helper.fs_->GetStageCreateInfo()};
@@ -596,8 +594,6 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationEvaluationInputOutputComp
         VkPipelineTessellationStateCreateInfo tessInfo = LvlInitStruct<VkPipelineTessellationStateCreateInfo>();
         tessInfo.flags = 0;
         tessInfo.patchControlPoints = 3;
-
-        m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-Shader-InputNotProduced");
 
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(),

--- a/tests/negative/pipeline_shader.cpp
+++ b/tests/negative/pipeline_shader.cpp
@@ -4470,47 +4470,6 @@ TEST_F(VkLayerTest, CreatePipelineDepthStencilRequired) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CreatePipelineFragmentOutputNotWritten) {
-    TEST_DESCRIPTION(
-        "Test that an error is produced for a fragment shader which does not provide an output for one of the pipeline's color "
-        "attachments");
-
-    ASSERT_NO_FATAL_FAILURE(Init());
-    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    VkShaderObj fs(this, bindStateMinimalShaderText, VK_SHADER_STAGE_FRAGMENT_BIT);
-
-    const auto set_info = [&](CreatePipelineHelper &helper) {
-        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        helper.cb_attachments_[0].colorWriteMask = 1;
-    };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-CoreValidation-Shader-InputNotProduced");
-}
-
-TEST_F(VkLayerTest, CreatePipelineFragmentOutputNotConsumed) {
-    TEST_DESCRIPTION(
-        "Test that a warning is produced for a fragment shader which provides a spurious output with no matching attachment");
-
-    ASSERT_NO_FATAL_FAILURE(Init());
-    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    char const *fsSource = R"glsl(
-        #version 450
-        layout(location=0) out vec4 x;
-        layout(location=1) out vec4 y; /* no matching attachment for this */
-        void main(){
-           x = vec4(1);
-           y = vec4(1);
-        }
-    )glsl";
-    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
-
-    const auto set_info = [&](CreatePipelineHelper &helper) {
-        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed");
-}
-
 // Currently need to clarify the VU - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5520
 TEST_F(VkLayerTest, DISABLED_CreatePipelineFragmentNoOutputLocation0ButAlphaToCoverageEnabled) {
     TEST_DESCRIPTION("Test that an error is produced when alpha to coverage is enabled but no output at location 0 is declared.");
@@ -4559,30 +4518,6 @@ TEST_F(VkLayerTest, DISABLED_CreatePipelineFragmentNoAlphaLocation0ButAlphaToCov
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
                                       "UNASSIGNED-CoreValidation-Shader-NoAlphaAtLocation0WithAlphaToCoverage");
-}
-
-TEST_F(VkLayerTest, CreatePipelineFragmentOutputTypeMismatch) {
-    TEST_DESCRIPTION(
-        "Test that an error is produced for a mismatch between the fundamental type of an fragment shader output variable, and the "
-        "format of the corresponding attachment");
-
-    ASSERT_NO_FATAL_FAILURE(Init());
-    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    char const *fsSource = R"glsl(
-        #version 450
-        layout(location=0) out ivec4 x; /* not UNORM */
-        void main(){
-           x = ivec4(1);
-        }
-    )glsl";
-
-    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
-
-    const auto set_info = [&](CreatePipelineHelper &helper) {
-        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    };
-    CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "UNASSIGNED-CoreValidation-Shader-FragmentOutputMismatch");
 }
 
 TEST_F(VkLayerTest, CreatePipelineExceedVertexMaxComponentsWithBuiltins) {


### PR DESCRIPTION
Moves the Fragment shader output interface checks to Best Practice

They were before just reporting `LogWarning` in the `CoreChecks`