### PR TITLE
Fix External Format Android tests

### DIFF
--- a/tests/positive/android_hardware_buffer.cpp
+++ b/tests/positive/android_hardware_buffer.cpp
@@ -349,6 +349,10 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExternalImage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
+    if (IsPlatform(kGalaxyS10)) {
+        GTEST_SKIP() << "This test should not run on Galaxy S10 - fails in gralloc";
+    }
+
     ASSERT_NO_FATAL_FAILURE(InitState());
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required.";
@@ -450,6 +454,10 @@ TEST_F(VkPositiveLayerTest, AndroidHardwareBufferExternalCameraFormat) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    if (IsPlatform(kGalaxyS10)) {
+        GTEST_SKIP() << "This test should not run on Galaxy S10 - fails in gralloc";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());


### PR DESCRIPTION
1. Fixes External Format tests to query before creating the image otherwise it was failing with `VUID-VkImageCreateInfo-pNext-00990`

2. Add 2 Null-AHB test to make sure we fail early