### PR TITLE
bp: Simplify generated/best_practices.cpp

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -101,30 +101,6 @@ const char* BestPractices::VendorSpecificTag(BPVendorFlags vendors) const {
     return res->second.c_str();
 }
 
-// Despite the return code being successful this can be a useful utility for some developers in niche debugging situation.
-void BestPractices::LogSuccess(const char* api_name, VkResult result) const {
-    assert(result > VK_SUCCESS);
-
-    LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", api_name, string_VkResult(result));
-}
-
-void BestPractices::LogError(const char* api_name, VkResult result) const {
-    assert(result < VK_SUCCESS);  // Anything less than VK_SUCCESS is an error.
-
-    // Despite being error codes log these results as informational.
-    // That is because they are returned frequently during window resizing.
-    // They are expected to occur during the normal application lifecycle.
-    constexpr std::array common_failure_codes = {VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT};
-    const auto result_string = string_VkResult(result);
-
-    if (const auto it = std::find(common_failure_codes.begin(), common_failure_codes.end(), result);
-        it != common_failure_codes.end()) {
-        LogInfo(instance, kVUID_BestPractices_Failure_Result, "%s(): Returned error %s.", api_name, result_string);
-    } else {
-        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", api_name, result_string);
-    }
-}
-
 void BestPractices::RecordSetDepthTestState(bp_state::CommandBuffer& cmd_state, VkCompareOp new_depth_compare_op,
                                             bool new_depth_test_enable) {
     assert(VendorCheckEnabled(kBPVendorNVIDIA));

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -377,9 +377,6 @@ class BestPractices : public ValidationStateTracker {
 
     std::string GetAPIVersionName(uint32_t version) const;
 
-    void LogSuccess(const char* api_name, VkResult result) const;
-    void LogError(const char* api_name, VkResult result) const;
-
     bool ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const char* caller) const;
 
     void RecordCmdDrawType(VkCommandBuffer cmd_buffer, uint32_t draw_count, const char* caller);

--- a/layers/generated/best_practices.cpp
+++ b/layers/generated/best_practices.cpp
@@ -24,6 +24,12 @@
 
 #include "chassis.h"
 #include "best_practices/best_practices_validation.h"
+#include "best_practices/best_practices_error_enums.h"
+
+constexpr std::array kCommonErrorCodes = {
+    VK_ERROR_OUT_OF_DATE_KHR, VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+};
+
 void BestPractices::PostCallRecordCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
@@ -31,7 +37,8 @@ void BestPractices::PostCallRecordCreateInstance(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateInstance(pCreateInfo, pAllocator, pInstance, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateInstance", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_LAYER_NOT_PRESENT,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_INCOMPATIBLE_DRIVER
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_LAYER_NOT_PRESENT,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_INCOMPATIBLE_DRIVER
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateInstance", string_VkResult(result));
     }
 }
 
@@ -42,11 +49,13 @@ void BestPractices::PostCallRecordEnumeratePhysicalDevices(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkEnumeratePhysicalDevices", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkEnumeratePhysicalDevices", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkEnumeratePhysicalDevices", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkEnumeratePhysicalDevices", string_VkResult(result));
     }
 }
 
@@ -61,7 +70,8 @@ void BestPractices::PostCallRecordGetPhysicalDeviceImageFormatProperties(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags, pImageFormatProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceImageFormatProperties", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceImageFormatProperties", string_VkResult(result));
     }
 }
 
@@ -73,7 +83,8 @@ void BestPractices::PostCallRecordCreateDevice(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDevice", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_FEATURE_NOT_PRESENT,VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_FEATURE_NOT_PRESENT,VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDevice", string_VkResult(result));
     }
 }
 
@@ -84,11 +95,13 @@ void BestPractices::PostCallRecordEnumerateInstanceExtensionProperties(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkEnumerateInstanceExtensionProperties", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkEnumerateInstanceExtensionProperties", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkEnumerateInstanceExtensionProperties", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_LAYER_NOT_PRESENT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_LAYER_NOT_PRESENT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkEnumerateInstanceExtensionProperties", string_VkResult(result));
     }
 }
 
@@ -100,11 +113,13 @@ void BestPractices::PostCallRecordEnumerateDeviceExtensionProperties(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkEnumerateDeviceExtensionProperties", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkEnumerateDeviceExtensionProperties", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkEnumerateDeviceExtensionProperties", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_LAYER_NOT_PRESENT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_LAYER_NOT_PRESENT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkEnumerateDeviceExtensionProperties", string_VkResult(result));
     }
 }
 
@@ -114,11 +129,13 @@ void BestPractices::PostCallRecordEnumerateInstanceLayerProperties(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordEnumerateInstanceLayerProperties(pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkEnumerateInstanceLayerProperties", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkEnumerateInstanceLayerProperties", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkEnumerateInstanceLayerProperties", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkEnumerateInstanceLayerProperties", string_VkResult(result));
     }
 }
 
@@ -129,11 +146,13 @@ void BestPractices::PostCallRecordEnumerateDeviceLayerProperties(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkEnumerateDeviceLayerProperties", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkEnumerateDeviceLayerProperties", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkEnumerateDeviceLayerProperties", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkEnumerateDeviceLayerProperties", string_VkResult(result));
     }
 }
 
@@ -146,7 +165,8 @@ void BestPractices::PostCallRecordQueueSubmit(
     ValidationStateTracker::PostCallRecordQueueSubmit(queue, submitCount, pSubmits, fence, result);
     ManualPostCallRecordQueueSubmit(queue, submitCount, pSubmits, fence, result);
     if (result < VK_SUCCESS) {
-        LogError("vkQueueSubmit", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkQueueSubmit", string_VkResult(result));
     }
 }
 
@@ -155,7 +175,8 @@ void BestPractices::PostCallRecordQueueWaitIdle(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordQueueWaitIdle(queue, result);
     if (result < VK_SUCCESS) {
-        LogError("vkQueueWaitIdle", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkQueueWaitIdle", string_VkResult(result));
     }
 }
 
@@ -164,7 +185,8 @@ void BestPractices::PostCallRecordDeviceWaitIdle(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordDeviceWaitIdle(device, result);
     if (result < VK_SUCCESS) {
-        LogError("vkDeviceWaitIdle", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkDeviceWaitIdle", string_VkResult(result));
     }
 }
 
@@ -176,7 +198,8 @@ void BestPractices::PostCallRecordAllocateMemory(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, result);
     if (result < VK_SUCCESS) {
-        LogError("vkAllocateMemory", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAllocateMemory", string_VkResult(result));
     }
 }
 
@@ -190,7 +213,8 @@ void BestPractices::PostCallRecordMapMemory(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordMapMemory(device, memory, offset, size, flags, ppData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkMapMemory", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_MEMORY_MAP_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_MEMORY_MAP_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkMapMemory", string_VkResult(result));
     }
 }
 
@@ -201,7 +225,8 @@ void BestPractices::PostCallRecordFlushMappedMemoryRanges(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, result);
     if (result < VK_SUCCESS) {
-        LogError("vkFlushMappedMemoryRanges", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkFlushMappedMemoryRanges", string_VkResult(result));
     }
 }
 
@@ -212,7 +237,8 @@ void BestPractices::PostCallRecordInvalidateMappedMemoryRanges(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, result);
     if (result < VK_SUCCESS) {
-        LogError("vkInvalidateMappedMemoryRanges", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkInvalidateMappedMemoryRanges", string_VkResult(result));
     }
 }
 
@@ -224,7 +250,8 @@ void BestPractices::PostCallRecordBindBufferMemory(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBindBufferMemory(device, buffer, memory, memoryOffset, result);
     if (result < VK_SUCCESS) {
-        LogError("vkBindBufferMemory", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBindBufferMemory", string_VkResult(result));
     }
 }
 
@@ -236,7 +263,8 @@ void BestPractices::PostCallRecordBindImageMemory(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBindImageMemory(device, image, memory, memoryOffset, result);
     if (result < VK_SUCCESS) {
-        LogError("vkBindImageMemory", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBindImageMemory", string_VkResult(result));
     }
 }
 
@@ -249,7 +277,8 @@ void BestPractices::PostCallRecordQueueBindSparse(
     ValidationStateTracker::PostCallRecordQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, result);
     ManualPostCallRecordQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, result);
     if (result < VK_SUCCESS) {
-        LogError("vkQueueBindSparse", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkQueueBindSparse", string_VkResult(result));
     }
 }
 
@@ -261,7 +290,8 @@ void BestPractices::PostCallRecordCreateFence(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateFence(device, pCreateInfo, pAllocator, pFence, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateFence", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateFence", string_VkResult(result));
     }
 }
 
@@ -272,7 +302,8 @@ void BestPractices::PostCallRecordResetFences(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordResetFences(device, fenceCount, pFences, result);
     if (result < VK_SUCCESS) {
-        LogError("vkResetFences", result); // VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkResetFences", string_VkResult(result));
     }
 }
 
@@ -282,11 +313,13 @@ void BestPractices::PostCallRecordGetFenceStatus(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetFenceStatus(device, fence, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetFenceStatus", result); // VK_NOT_READY
+        // VK_NOT_READY
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetFenceStatus", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetFenceStatus", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetFenceStatus", string_VkResult(result));
     }
 }
 
@@ -299,11 +332,13 @@ void BestPractices::PostCallRecordWaitForFences(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordWaitForFences(device, fenceCount, pFences, waitAll, timeout, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkWaitForFences", result); // VK_TIMEOUT
+        // VK_TIMEOUT
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkWaitForFences", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkWaitForFences", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkWaitForFences", string_VkResult(result));
     }
 }
 
@@ -315,7 +350,8 @@ void BestPractices::PostCallRecordCreateSemaphore(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateSemaphore", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateSemaphore", string_VkResult(result));
     }
 }
 
@@ -327,7 +363,8 @@ void BestPractices::PostCallRecordCreateEvent(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateEvent(device, pCreateInfo, pAllocator, pEvent, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateEvent", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateEvent", string_VkResult(result));
     }
 }
 
@@ -337,11 +374,13 @@ void BestPractices::PostCallRecordGetEventStatus(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetEventStatus(device, event, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetEventStatus", result); // VK_EVENT_SET,VK_EVENT_RESET
+        // VK_EVENT_SET,VK_EVENT_RESET
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetEventStatus", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetEventStatus", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetEventStatus", string_VkResult(result));
     }
 }
 
@@ -351,7 +390,8 @@ void BestPractices::PostCallRecordSetEvent(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordSetEvent(device, event, result);
     if (result < VK_SUCCESS) {
-        LogError("vkSetEvent", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkSetEvent", string_VkResult(result));
     }
 }
 
@@ -361,7 +401,8 @@ void BestPractices::PostCallRecordResetEvent(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordResetEvent(device, event, result);
     if (result < VK_SUCCESS) {
-        LogError("vkResetEvent", result); // VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkResetEvent", string_VkResult(result));
     }
 }
 
@@ -373,7 +414,8 @@ void BestPractices::PostCallRecordCreateQueryPool(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateQueryPool", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateQueryPool", string_VkResult(result));
     }
 }
 
@@ -389,11 +431,13 @@ void BestPractices::PostCallRecordGetQueryPoolResults(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetQueryPoolResults", result); // VK_NOT_READY
+        // VK_NOT_READY
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetQueryPoolResults", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetQueryPoolResults", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetQueryPoolResults", string_VkResult(result));
     }
 }
 
@@ -405,7 +449,8 @@ void BestPractices::PostCallRecordCreateBuffer(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateBuffer", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateBuffer", string_VkResult(result));
     }
 }
 
@@ -417,7 +462,8 @@ void BestPractices::PostCallRecordCreateBufferView(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateBufferView(device, pCreateInfo, pAllocator, pView, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateBufferView", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateBufferView", string_VkResult(result));
     }
 }
 
@@ -429,7 +475,8 @@ void BestPractices::PostCallRecordCreateImage(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateImage(device, pCreateInfo, pAllocator, pImage, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateImage", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_COMPRESSION_EXHAUSTED_EXT,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_COMPRESSION_EXHAUSTED_EXT,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateImage", string_VkResult(result));
     }
 }
 
@@ -441,7 +488,8 @@ void BestPractices::PostCallRecordCreateImageView(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateImageView(device, pCreateInfo, pAllocator, pView, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateImageView", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateImageView", string_VkResult(result));
     }
 }
 
@@ -454,7 +502,8 @@ void BestPractices::PostCallRecordCreateShaderModule(
     void*                                       state_data) {
     ValidationStateTracker::PostCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, result, state_data);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateShaderModule", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateShaderModule", string_VkResult(result));
     }
 }
 
@@ -466,7 +515,8 @@ void BestPractices::PostCallRecordCreatePipelineCache(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreatePipelineCache", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreatePipelineCache", string_VkResult(result));
     }
 }
 
@@ -478,11 +528,13 @@ void BestPractices::PostCallRecordGetPipelineCacheData(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPipelineCacheData(device, pipelineCache, pDataSize, pData, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPipelineCacheData", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPipelineCacheData", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPipelineCacheData", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPipelineCacheData", string_VkResult(result));
     }
 }
 
@@ -494,7 +546,8 @@ void BestPractices::PostCallRecordMergePipelineCaches(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, result);
     if (result < VK_SUCCESS) {
-        LogError("vkMergePipelineCaches", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkMergePipelineCaches", string_VkResult(result));
     }
 }
 
@@ -510,11 +563,13 @@ void BestPractices::PostCallRecordCreateGraphicsPipelines(
     ValidationStateTracker::PostCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, state_data);
     ManualPostCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, state_data);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkCreateGraphicsPipelines", result); // VK_PIPELINE_COMPILE_REQUIRED_EXT
+        // VK_PIPELINE_COMPILE_REQUIRED_EXT
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkCreateGraphicsPipelines", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkCreateGraphicsPipelines", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateGraphicsPipelines", string_VkResult(result));
     }
 }
 
@@ -530,11 +585,13 @@ void BestPractices::PostCallRecordCreateComputePipelines(
     ValidationStateTracker::PostCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, state_data);
     ManualPostCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, state_data);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkCreateComputePipelines", result); // VK_PIPELINE_COMPILE_REQUIRED_EXT
+        // VK_PIPELINE_COMPILE_REQUIRED_EXT
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkCreateComputePipelines", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkCreateComputePipelines", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateComputePipelines", string_VkResult(result));
     }
 }
 
@@ -546,7 +603,8 @@ void BestPractices::PostCallRecordCreatePipelineLayout(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreatePipelineLayout", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreatePipelineLayout", string_VkResult(result));
     }
 }
 
@@ -558,7 +616,8 @@ void BestPractices::PostCallRecordCreateSampler(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateSampler(device, pCreateInfo, pAllocator, pSampler, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateSampler", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateSampler", string_VkResult(result));
     }
 }
 
@@ -570,7 +629,8 @@ void BestPractices::PostCallRecordCreateDescriptorSetLayout(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDescriptorSetLayout", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDescriptorSetLayout", string_VkResult(result));
     }
 }
 
@@ -582,7 +642,8 @@ void BestPractices::PostCallRecordCreateDescriptorPool(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDescriptorPool", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FRAGMENTATION_EXT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FRAGMENTATION_EXT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDescriptorPool", string_VkResult(result));
     }
 }
 
@@ -595,7 +656,8 @@ void BestPractices::PostCallRecordAllocateDescriptorSets(
     ValidationStateTracker::PostCallRecordAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, result, state_data);
     ManualPostCallRecordAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, result, state_data);
     if (result < VK_SUCCESS) {
-        LogError("vkAllocateDescriptorSets", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FRAGMENTED_POOL,VK_ERROR_OUT_OF_POOL_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FRAGMENTED_POOL,VK_ERROR_OUT_OF_POOL_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAllocateDescriptorSets", string_VkResult(result));
     }
 }
 
@@ -607,7 +669,8 @@ void BestPractices::PostCallRecordCreateFramebuffer(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateFramebuffer", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateFramebuffer", string_VkResult(result));
     }
 }
 
@@ -619,7 +682,8 @@ void BestPractices::PostCallRecordCreateRenderPass(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateRenderPass", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateRenderPass", string_VkResult(result));
     }
 }
 
@@ -631,7 +695,8 @@ void BestPractices::PostCallRecordCreateCommandPool(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateCommandPool", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateCommandPool", string_VkResult(result));
     }
 }
 
@@ -642,7 +707,8 @@ void BestPractices::PostCallRecordResetCommandPool(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordResetCommandPool(device, commandPool, flags, result);
     if (result < VK_SUCCESS) {
-        LogError("vkResetCommandPool", result); // VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkResetCommandPool", string_VkResult(result));
     }
 }
 
@@ -653,7 +719,8 @@ void BestPractices::PostCallRecordAllocateCommandBuffers(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, result);
     if (result < VK_SUCCESS) {
-        LogError("vkAllocateCommandBuffers", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAllocateCommandBuffers", string_VkResult(result));
     }
 }
 
@@ -663,7 +730,8 @@ void BestPractices::PostCallRecordBeginCommandBuffer(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBeginCommandBuffer(commandBuffer, pBeginInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkBeginCommandBuffer", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBeginCommandBuffer", string_VkResult(result));
     }
 }
 
@@ -672,7 +740,8 @@ void BestPractices::PostCallRecordEndCommandBuffer(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordEndCommandBuffer(commandBuffer, result);
     if (result < VK_SUCCESS) {
-        LogError("vkEndCommandBuffer", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkEndCommandBuffer", string_VkResult(result));
     }
 }
 
@@ -682,7 +751,8 @@ void BestPractices::PostCallRecordResetCommandBuffer(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordResetCommandBuffer(commandBuffer, flags, result);
     if (result < VK_SUCCESS) {
-        LogError("vkResetCommandBuffer", result); // VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkResetCommandBuffer", string_VkResult(result));
     }
 }
 
@@ -695,7 +765,8 @@ void BestPractices::PostCallRecordBindBufferMemory2(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBindBufferMemory2(device, bindInfoCount, pBindInfos, result);
     if (result < VK_SUCCESS) {
-        LogError("vkBindBufferMemory2", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBindBufferMemory2", string_VkResult(result));
     }
 }
 
@@ -706,7 +777,8 @@ void BestPractices::PostCallRecordBindImageMemory2(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, result);
     if (result < VK_SUCCESS) {
-        LogError("vkBindImageMemory2", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBindImageMemory2", string_VkResult(result));
     }
 }
 
@@ -717,11 +789,13 @@ void BestPractices::PostCallRecordEnumeratePhysicalDeviceGroups(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkEnumeratePhysicalDeviceGroups", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkEnumeratePhysicalDeviceGroups", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkEnumeratePhysicalDeviceGroups", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkEnumeratePhysicalDeviceGroups", string_VkResult(result));
     }
 }
 
@@ -732,7 +806,8 @@ void BestPractices::PostCallRecordGetPhysicalDeviceImageFormatProperties2(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceImageFormatProperties2", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED,VK_ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED,VK_ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceImageFormatProperties2", string_VkResult(result));
     }
 }
 
@@ -744,7 +819,8 @@ void BestPractices::PostCallRecordCreateSamplerYcbcrConversion(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateSamplerYcbcrConversion", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateSamplerYcbcrConversion", string_VkResult(result));
     }
 }
 
@@ -756,7 +832,8 @@ void BestPractices::PostCallRecordCreateDescriptorUpdateTemplate(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDescriptorUpdateTemplate", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDescriptorUpdateTemplate", string_VkResult(result));
     }
 }
 
@@ -768,7 +845,8 @@ void BestPractices::PostCallRecordCreateRenderPass2(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateRenderPass2", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateRenderPass2", string_VkResult(result));
     }
 }
 
@@ -779,7 +857,8 @@ void BestPractices::PostCallRecordGetSemaphoreCounterValue(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetSemaphoreCounterValue(device, semaphore, pValue, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetSemaphoreCounterValue", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetSemaphoreCounterValue", string_VkResult(result));
     }
 }
 
@@ -790,11 +869,13 @@ void BestPractices::PostCallRecordWaitSemaphores(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordWaitSemaphores(device, pWaitInfo, timeout, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkWaitSemaphores", result); // VK_TIMEOUT
+        // VK_TIMEOUT
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkWaitSemaphores", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkWaitSemaphores", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkWaitSemaphores", string_VkResult(result));
     }
 }
 
@@ -804,7 +885,8 @@ void BestPractices::PostCallRecordSignalSemaphore(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordSignalSemaphore(device, pSignalInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkSignalSemaphore", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkSignalSemaphore", string_VkResult(result));
     }
 }
 
@@ -815,11 +897,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceToolProperties(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceToolProperties(physicalDevice, pToolCount, pToolProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceToolProperties", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceToolProperties", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceToolProperties", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceToolProperties", string_VkResult(result));
     }
 }
 
@@ -831,7 +915,8 @@ void BestPractices::PostCallRecordCreatePrivateDataSlot(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreatePrivateDataSlot(device, pCreateInfo, pAllocator, pPrivateDataSlot, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreatePrivateDataSlot", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreatePrivateDataSlot", string_VkResult(result));
     }
 }
 
@@ -844,7 +929,8 @@ void BestPractices::PostCallRecordSetPrivateData(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordSetPrivateData(device, objectType, objectHandle, privateDataSlot, data, result);
     if (result < VK_SUCCESS) {
-        LogError("vkSetPrivateData", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkSetPrivateData", string_VkResult(result));
     }
 }
 
@@ -856,7 +942,8 @@ void BestPractices::PostCallRecordQueueSubmit2(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, result);
     if (result < VK_SUCCESS) {
-        LogError("vkQueueSubmit2", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkQueueSubmit2", string_VkResult(result));
     }
 }
 
@@ -868,7 +955,8 @@ void BestPractices::PostCallRecordGetPhysicalDeviceSurfaceSupportKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceSurfaceSupportKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceSurfaceSupportKHR", string_VkResult(result));
     }
 }
 
@@ -880,7 +968,8 @@ void BestPractices::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, result);
     ManualPostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceSurfaceCapabilitiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceSurfaceCapabilitiesKHR", string_VkResult(result));
     }
 }
 
@@ -893,11 +982,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceSurfaceFormatsKHR(
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, result);
     ManualPostCallRecordGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceSurfaceFormatsKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceSurfaceFormatsKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceSurfaceFormatsKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceSurfaceFormatsKHR", string_VkResult(result));
     }
 }
 
@@ -910,11 +1001,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceSurfacePresentModesKHR(
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, result);
     ManualPostCallRecordGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceSurfacePresentModesKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceSurfacePresentModesKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceSurfacePresentModesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceSurfacePresentModesKHR", string_VkResult(result));
     }
 }
 
@@ -926,7 +1019,8 @@ void BestPractices::PostCallRecordCreateSwapchainKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateSwapchainKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_COMPRESSION_EXHAUSTED_EXT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_COMPRESSION_EXHAUSTED_EXT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateSwapchainKHR", string_VkResult(result));
     }
 }
 
@@ -939,11 +1033,13 @@ void BestPractices::PostCallRecordGetSwapchainImagesKHR(
     ValidationStateTracker::PostCallRecordGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, result);
     ManualPostCallRecordGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetSwapchainImagesKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetSwapchainImagesKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetSwapchainImagesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetSwapchainImagesKHR", string_VkResult(result));
     }
 }
 
@@ -957,11 +1053,17 @@ void BestPractices::PostCallRecordAcquireNextImageKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkAcquireNextImageKHR", result); // VK_TIMEOUT,VK_NOT_READY,VK_SUBOPTIMAL_KHR
+        // VK_TIMEOUT,VK_NOT_READY,VK_SUBOPTIMAL_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkAcquireNextImageKHR", string_VkResult(result));
+        return;
+    }
+    if (IsValueIn(result, kCommonErrorCodes)) {
+        LogInfo(instance, kVUID_BestPractices_Error_Result, "%s(): Returned common error %s.", "vkAcquireNextImageKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkAcquireNextImageKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAcquireNextImageKHR", string_VkResult(result));
     }
 }
 
@@ -972,11 +1074,17 @@ void BestPractices::PostCallRecordQueuePresentKHR(
     ValidationStateTracker::PostCallRecordQueuePresentKHR(queue, pPresentInfo, result);
     ManualPostCallRecordQueuePresentKHR(queue, pPresentInfo, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkQueuePresentKHR", result); // VK_SUBOPTIMAL_KHR
+        // VK_SUBOPTIMAL_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkQueuePresentKHR", string_VkResult(result));
+        return;
+    }
+    if (IsValueIn(result, kCommonErrorCodes)) {
+        LogInfo(instance, kVUID_BestPractices_Error_Result, "%s(): Returned common error %s.", "vkQueuePresentKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkQueuePresentKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkQueuePresentKHR", string_VkResult(result));
     }
 }
 
@@ -986,7 +1094,8 @@ void BestPractices::PostCallRecordGetDeviceGroupPresentCapabilitiesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetDeviceGroupPresentCapabilitiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDeviceGroupPresentCapabilitiesKHR", string_VkResult(result));
     }
 }
 
@@ -997,7 +1106,8 @@ void BestPractices::PostCallRecordGetDeviceGroupSurfacePresentModesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetDeviceGroupSurfacePresentModesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDeviceGroupSurfacePresentModesKHR", string_VkResult(result));
     }
 }
 
@@ -1009,11 +1119,13 @@ void BestPractices::PostCallRecordGetPhysicalDevicePresentRectanglesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDevicePresentRectanglesKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDevicePresentRectanglesKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDevicePresentRectanglesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDevicePresentRectanglesKHR", string_VkResult(result));
     }
 }
 
@@ -1024,11 +1136,17 @@ void BestPractices::PostCallRecordAcquireNextImage2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkAcquireNextImage2KHR", result); // VK_TIMEOUT,VK_NOT_READY,VK_SUBOPTIMAL_KHR
+        // VK_TIMEOUT,VK_NOT_READY,VK_SUBOPTIMAL_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkAcquireNextImage2KHR", string_VkResult(result));
+        return;
+    }
+    if (IsValueIn(result, kCommonErrorCodes)) {
+        LogInfo(instance, kVUID_BestPractices_Error_Result, "%s(): Returned common error %s.", "vkAcquireNextImage2KHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkAcquireNextImage2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAcquireNextImage2KHR", string_VkResult(result));
     }
 }
 
@@ -1039,11 +1157,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceDisplayPropertiesKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceDisplayPropertiesKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceDisplayPropertiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceDisplayPropertiesKHR", string_VkResult(result));
     }
 }
 
@@ -1055,11 +1175,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceDisplayPlanePropertiesKHR(
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, result);
     ManualPostCallRecordGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceDisplayPlanePropertiesKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceDisplayPlanePropertiesKHR", string_VkResult(result));
     }
 }
 
@@ -1071,11 +1193,13 @@ void BestPractices::PostCallRecordGetDisplayPlaneSupportedDisplaysKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetDisplayPlaneSupportedDisplaysKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetDisplayPlaneSupportedDisplaysKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetDisplayPlaneSupportedDisplaysKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDisplayPlaneSupportedDisplaysKHR", string_VkResult(result));
     }
 }
 
@@ -1087,11 +1211,13 @@ void BestPractices::PostCallRecordGetDisplayModePropertiesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetDisplayModePropertiesKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetDisplayModePropertiesKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetDisplayModePropertiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDisplayModePropertiesKHR", string_VkResult(result));
     }
 }
 
@@ -1104,7 +1230,8 @@ void BestPractices::PostCallRecordCreateDisplayModeKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDisplayModeKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDisplayModeKHR", string_VkResult(result));
     }
 }
 
@@ -1116,7 +1243,8 @@ void BestPractices::PostCallRecordGetDisplayPlaneCapabilitiesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetDisplayPlaneCapabilitiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDisplayPlaneCapabilitiesKHR", string_VkResult(result));
     }
 }
 
@@ -1128,7 +1256,8 @@ void BestPractices::PostCallRecordCreateDisplayPlaneSurfaceKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDisplayPlaneSurfaceKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDisplayPlaneSurfaceKHR", string_VkResult(result));
     }
 }
 
@@ -1141,7 +1270,8 @@ void BestPractices::PostCallRecordCreateSharedSwapchainsKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateSharedSwapchainsKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INCOMPATIBLE_DISPLAY_KHR,VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INCOMPATIBLE_DISPLAY_KHR,VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateSharedSwapchainsKHR", string_VkResult(result));
     }
 }
 
@@ -1155,7 +1285,8 @@ void BestPractices::PostCallRecordCreateXlibSurfaceKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateXlibSurfaceKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateXlibSurfaceKHR", string_VkResult(result));
     }
 }
 
@@ -1171,7 +1302,8 @@ void BestPractices::PostCallRecordCreateXcbSurfaceKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateXcbSurfaceKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateXcbSurfaceKHR", string_VkResult(result));
     }
 }
 
@@ -1187,7 +1319,8 @@ void BestPractices::PostCallRecordCreateWaylandSurfaceKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateWaylandSurfaceKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateWaylandSurfaceKHR", string_VkResult(result));
     }
 }
 
@@ -1203,7 +1336,8 @@ void BestPractices::PostCallRecordCreateAndroidSurfaceKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateAndroidSurfaceKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateAndroidSurfaceKHR", string_VkResult(result));
     }
 }
 
@@ -1219,7 +1353,8 @@ void BestPractices::PostCallRecordCreateWin32SurfaceKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateWin32SurfaceKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateWin32SurfaceKHR", string_VkResult(result));
     }
 }
 
@@ -1232,7 +1367,8 @@ void BestPractices::PostCallRecordGetPhysicalDeviceVideoCapabilitiesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceVideoCapabilitiesKHR(physicalDevice, pVideoProfile, pCapabilities, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceVideoCapabilitiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceVideoCapabilitiesKHR", string_VkResult(result));
     }
 }
 
@@ -1244,11 +1380,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceVideoFormatPropertiesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceVideoFormatPropertiesKHR(physicalDevice, pVideoFormatInfo, pVideoFormatPropertyCount, pVideoFormatProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceVideoFormatPropertiesKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceVideoFormatPropertiesKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceVideoFormatPropertiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceVideoFormatPropertiesKHR", string_VkResult(result));
     }
 }
 
@@ -1260,7 +1398,8 @@ void BestPractices::PostCallRecordCreateVideoSessionKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateVideoSessionKHR(device, pCreateInfo, pAllocator, pVideoSession, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateVideoSessionKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_VIDEO_STD_VERSION_NOT_SUPPORTED_KHR,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateVideoSessionKHR", string_VkResult(result));
     }
 }
 
@@ -1272,7 +1411,8 @@ void BestPractices::PostCallRecordGetVideoSessionMemoryRequirementsKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetVideoSessionMemoryRequirementsKHR(device, videoSession, pMemoryRequirementsCount, pMemoryRequirements, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetVideoSessionMemoryRequirementsKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetVideoSessionMemoryRequirementsKHR", string_VkResult(result));
         return;
     }
 }
@@ -1285,7 +1425,8 @@ void BestPractices::PostCallRecordBindVideoSessionMemoryKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBindVideoSessionMemoryKHR(device, videoSession, bindSessionMemoryInfoCount, pBindSessionMemoryInfos, result);
     if (result < VK_SUCCESS) {
-        LogError("vkBindVideoSessionMemoryKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBindVideoSessionMemoryKHR", string_VkResult(result));
     }
 }
 
@@ -1297,7 +1438,8 @@ void BestPractices::PostCallRecordCreateVideoSessionParametersKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateVideoSessionParametersKHR(device, pCreateInfo, pAllocator, pVideoSessionParameters, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateVideoSessionParametersKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateVideoSessionParametersKHR", string_VkResult(result));
     }
 }
 
@@ -1308,7 +1450,8 @@ void BestPractices::PostCallRecordUpdateVideoSessionParametersKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordUpdateVideoSessionParametersKHR(device, videoSessionParameters, pUpdateInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkUpdateVideoSessionParametersKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_VIDEO_STD_PARAMETERS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkUpdateVideoSessionParametersKHR", string_VkResult(result));
     }
 }
 
@@ -1319,7 +1462,8 @@ void BestPractices::PostCallRecordGetPhysicalDeviceImageFormatProperties2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceImageFormatProperties2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED,VK_ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED,VK_ERROR_IMAGE_USAGE_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_OPERATION_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_FORMAT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PICTURE_LAYOUT_NOT_SUPPORTED_KHR,VK_ERROR_VIDEO_PROFILE_CODEC_NOT_SUPPORTED_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceImageFormatProperties2KHR", string_VkResult(result));
     }
 }
 
@@ -1330,11 +1474,13 @@ void BestPractices::PostCallRecordEnumeratePhysicalDeviceGroupsKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordEnumeratePhysicalDeviceGroupsKHR(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkEnumeratePhysicalDeviceGroupsKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkEnumeratePhysicalDeviceGroupsKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkEnumeratePhysicalDeviceGroupsKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkEnumeratePhysicalDeviceGroupsKHR", string_VkResult(result));
     }
 }
 
@@ -1347,7 +1493,8 @@ void BestPractices::PostCallRecordGetMemoryWin32HandleKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetMemoryWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetMemoryWin32HandleKHR", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetMemoryWin32HandleKHR", string_VkResult(result));
     }
 }
 
@@ -1363,7 +1510,8 @@ void BestPractices::PostCallRecordGetMemoryWin32HandlePropertiesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetMemoryWin32HandlePropertiesKHR(device, handleType, handle, pMemoryWin32HandleProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetMemoryWin32HandlePropertiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetMemoryWin32HandlePropertiesKHR", string_VkResult(result));
     }
 }
 
@@ -1376,7 +1524,8 @@ void BestPractices::PostCallRecordGetMemoryFdKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetMemoryFdKHR(device, pGetFdInfo, pFd, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetMemoryFdKHR", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetMemoryFdKHR", string_VkResult(result));
     }
 }
 
@@ -1388,7 +1537,8 @@ void BestPractices::PostCallRecordGetMemoryFdPropertiesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetMemoryFdPropertiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetMemoryFdPropertiesKHR", string_VkResult(result));
     }
 }
 
@@ -1400,7 +1550,8 @@ void BestPractices::PostCallRecordImportSemaphoreWin32HandleKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkImportSemaphoreWin32HandleKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkImportSemaphoreWin32HandleKHR", string_VkResult(result));
     }
 }
 
@@ -1415,7 +1566,8 @@ void BestPractices::PostCallRecordGetSemaphoreWin32HandleKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetSemaphoreWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetSemaphoreWin32HandleKHR", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetSemaphoreWin32HandleKHR", string_VkResult(result));
     }
 }
 
@@ -1427,7 +1579,8 @@ void BestPractices::PostCallRecordImportSemaphoreFdKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkImportSemaphoreFdKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkImportSemaphoreFdKHR", string_VkResult(result));
     }
 }
 
@@ -1438,7 +1591,8 @@ void BestPractices::PostCallRecordGetSemaphoreFdKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetSemaphoreFdKHR(device, pGetFdInfo, pFd, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetSemaphoreFdKHR", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetSemaphoreFdKHR", string_VkResult(result));
     }
 }
 
@@ -1450,7 +1604,8 @@ void BestPractices::PostCallRecordCreateDescriptorUpdateTemplateKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDescriptorUpdateTemplateKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDescriptorUpdateTemplateKHR", string_VkResult(result));
     }
 }
 
@@ -1462,7 +1617,8 @@ void BestPractices::PostCallRecordCreateRenderPass2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateRenderPass2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateRenderPass2KHR", string_VkResult(result));
     }
 }
 
@@ -1472,11 +1628,17 @@ void BestPractices::PostCallRecordGetSwapchainStatusKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetSwapchainStatusKHR(device, swapchain, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetSwapchainStatusKHR", result); // VK_SUBOPTIMAL_KHR
+        // VK_SUBOPTIMAL_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetSwapchainStatusKHR", string_VkResult(result));
+        return;
+    }
+    if (IsValueIn(result, kCommonErrorCodes)) {
+        LogInfo(instance, kVUID_BestPractices_Error_Result, "%s(): Returned common error %s.", "vkGetSwapchainStatusKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetSwapchainStatusKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetSwapchainStatusKHR", string_VkResult(result));
     }
 }
 
@@ -1488,7 +1650,8 @@ void BestPractices::PostCallRecordImportFenceWin32HandleKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkImportFenceWin32HandleKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkImportFenceWin32HandleKHR", string_VkResult(result));
     }
 }
 
@@ -1503,7 +1666,8 @@ void BestPractices::PostCallRecordGetFenceWin32HandleKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetFenceWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetFenceWin32HandleKHR", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetFenceWin32HandleKHR", string_VkResult(result));
     }
 }
 
@@ -1515,7 +1679,8 @@ void BestPractices::PostCallRecordImportFenceFdKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordImportFenceFdKHR(device, pImportFenceFdInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkImportFenceFdKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkImportFenceFdKHR", string_VkResult(result));
     }
 }
 
@@ -1526,7 +1691,8 @@ void BestPractices::PostCallRecordGetFenceFdKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetFenceFdKHR(device, pGetFdInfo, pFd, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetFenceFdKHR", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetFenceFdKHR", string_VkResult(result));
     }
 }
 
@@ -1539,11 +1705,13 @@ void BestPractices::PostCallRecordEnumeratePhysicalDeviceQueueFamilyPerformanceQ
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", string_VkResult(result));
     }
 }
 
@@ -1553,7 +1721,8 @@ void BestPractices::PostCallRecordAcquireProfilingLockKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordAcquireProfilingLockKHR(device, pInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkAcquireProfilingLockKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_TIMEOUT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_TIMEOUT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAcquireProfilingLockKHR", string_VkResult(result));
     }
 }
 
@@ -1565,7 +1734,8 @@ void BestPractices::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2KHR(
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, result);
     ManualPostCallRecordGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceSurfaceCapabilities2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceSurfaceCapabilities2KHR", string_VkResult(result));
     }
 }
 
@@ -1578,11 +1748,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, result);
     ManualPostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceSurfaceFormats2KHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceSurfaceFormats2KHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceSurfaceFormats2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceSurfaceFormats2KHR", string_VkResult(result));
     }
 }
 
@@ -1593,11 +1765,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceDisplayProperties2KHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceDisplayProperties2KHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceDisplayProperties2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceDisplayProperties2KHR", string_VkResult(result));
     }
 }
 
@@ -1608,11 +1782,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceDisplayPlaneProperties2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceDisplayPlaneProperties2KHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceDisplayPlaneProperties2KHR", string_VkResult(result));
     }
 }
 
@@ -1624,11 +1800,13 @@ void BestPractices::PostCallRecordGetDisplayModeProperties2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetDisplayModeProperties2KHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetDisplayModeProperties2KHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetDisplayModeProperties2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDisplayModeProperties2KHR", string_VkResult(result));
     }
 }
 
@@ -1639,7 +1817,8 @@ void BestPractices::PostCallRecordGetDisplayPlaneCapabilities2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetDisplayPlaneCapabilities2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDisplayPlaneCapabilities2KHR", string_VkResult(result));
     }
 }
 
@@ -1651,7 +1830,8 @@ void BestPractices::PostCallRecordCreateSamplerYcbcrConversionKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateSamplerYcbcrConversionKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateSamplerYcbcrConversionKHR", string_VkResult(result));
     }
 }
 
@@ -1662,7 +1842,8 @@ void BestPractices::PostCallRecordBindBufferMemory2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBindBufferMemory2KHR(device, bindInfoCount, pBindInfos, result);
     if (result < VK_SUCCESS) {
-        LogError("vkBindBufferMemory2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBindBufferMemory2KHR", string_VkResult(result));
     }
 }
 
@@ -1673,7 +1854,8 @@ void BestPractices::PostCallRecordBindImageMemory2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBindImageMemory2KHR(device, bindInfoCount, pBindInfos, result);
     if (result < VK_SUCCESS) {
-        LogError("vkBindImageMemory2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBindImageMemory2KHR", string_VkResult(result));
     }
 }
 
@@ -1684,7 +1866,8 @@ void BestPractices::PostCallRecordGetSemaphoreCounterValueKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetSemaphoreCounterValueKHR(device, semaphore, pValue, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetSemaphoreCounterValueKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetSemaphoreCounterValueKHR", string_VkResult(result));
     }
 }
 
@@ -1695,11 +1878,13 @@ void BestPractices::PostCallRecordWaitSemaphoresKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordWaitSemaphoresKHR(device, pWaitInfo, timeout, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkWaitSemaphoresKHR", result); // VK_TIMEOUT
+        // VK_TIMEOUT
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkWaitSemaphoresKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkWaitSemaphoresKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkWaitSemaphoresKHR", string_VkResult(result));
     }
 }
 
@@ -1709,7 +1894,8 @@ void BestPractices::PostCallRecordSignalSemaphoreKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordSignalSemaphoreKHR(device, pSignalInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkSignalSemaphoreKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkSignalSemaphoreKHR", string_VkResult(result));
     }
 }
 
@@ -1720,11 +1906,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceFragmentShadingRatesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount, pFragmentShadingRates, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceFragmentShadingRatesKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceFragmentShadingRatesKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceFragmentShadingRatesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceFragmentShadingRatesKHR", string_VkResult(result));
     }
 }
 
@@ -1736,11 +1924,17 @@ void BestPractices::PostCallRecordWaitForPresentKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordWaitForPresentKHR(device, swapchain, presentId, timeout, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkWaitForPresentKHR", result); // VK_TIMEOUT,VK_SUBOPTIMAL_KHR
+        // VK_TIMEOUT,VK_SUBOPTIMAL_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkWaitForPresentKHR", string_VkResult(result));
+        return;
+    }
+    if (IsValueIn(result, kCommonErrorCodes)) {
+        LogInfo(instance, kVUID_BestPractices_Error_Result, "%s(): Returned common error %s.", "vkWaitForPresentKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkWaitForPresentKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR,VK_ERROR_FULL_SCREEN_EXCLUSIVE_MODE_LOST_EXT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkWaitForPresentKHR", string_VkResult(result));
     }
 }
 
@@ -1751,7 +1945,8 @@ void BestPractices::PostCallRecordCreateDeferredOperationKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDeferredOperationKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDeferredOperationKHR", string_VkResult(result));
     }
 }
 
@@ -1761,7 +1956,8 @@ void BestPractices::PostCallRecordGetDeferredOperationResultKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDeferredOperationResultKHR(device, operation, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetDeferredOperationResultKHR", result); // VK_NOT_READY
+        // VK_NOT_READY
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetDeferredOperationResultKHR", string_VkResult(result));
         return;
     }
 }
@@ -1772,11 +1968,13 @@ void BestPractices::PostCallRecordDeferredOperationJoinKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordDeferredOperationJoinKHR(device, operation, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkDeferredOperationJoinKHR", result); // VK_THREAD_DONE_KHR,VK_THREAD_IDLE_KHR
+        // VK_THREAD_DONE_KHR,VK_THREAD_IDLE_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkDeferredOperationJoinKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkDeferredOperationJoinKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkDeferredOperationJoinKHR", string_VkResult(result));
     }
 }
 
@@ -1788,11 +1986,13 @@ void BestPractices::PostCallRecordGetPipelineExecutablePropertiesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPipelineExecutablePropertiesKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPipelineExecutablePropertiesKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPipelineExecutablePropertiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPipelineExecutablePropertiesKHR", string_VkResult(result));
     }
 }
 
@@ -1804,11 +2004,13 @@ void BestPractices::PostCallRecordGetPipelineExecutableStatisticsKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPipelineExecutableStatisticsKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPipelineExecutableStatisticsKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPipelineExecutableStatisticsKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPipelineExecutableStatisticsKHR", string_VkResult(result));
     }
 }
 
@@ -1820,11 +2022,13 @@ void BestPractices::PostCallRecordGetPipelineExecutableInternalRepresentationsKH
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount, pInternalRepresentations, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPipelineExecutableInternalRepresentationsKHR", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPipelineExecutableInternalRepresentationsKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPipelineExecutableInternalRepresentationsKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPipelineExecutableInternalRepresentationsKHR", string_VkResult(result));
     }
 }
 
@@ -1835,7 +2039,8 @@ void BestPractices::PostCallRecordMapMemory2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordMapMemory2KHR(device, pMemoryMapInfo, ppData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkMapMemory2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_MEMORY_MAP_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_MEMORY_MAP_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkMapMemory2KHR", string_VkResult(result));
     }
 }
 
@@ -1847,7 +2052,8 @@ void BestPractices::PostCallRecordQueueSubmit2KHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordQueueSubmit2KHR(queue, submitCount, pSubmits, fence, result);
     if (result < VK_SUCCESS) {
-        LogError("vkQueueSubmit2KHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_DEVICE_LOST
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkQueueSubmit2KHR", string_VkResult(result));
     }
 }
 
@@ -1859,7 +2065,8 @@ void BestPractices::PostCallRecordCreateDebugReportCallbackEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDebugReportCallbackEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDebugReportCallbackEXT", string_VkResult(result));
     }
 }
 
@@ -1869,7 +2076,8 @@ void BestPractices::PostCallRecordDebugMarkerSetObjectTagEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordDebugMarkerSetObjectTagEXT(device, pTagInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkDebugMarkerSetObjectTagEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkDebugMarkerSetObjectTagEXT", string_VkResult(result));
     }
 }
 
@@ -1879,7 +2087,8 @@ void BestPractices::PostCallRecordDebugMarkerSetObjectNameEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordDebugMarkerSetObjectNameEXT(device, pNameInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkDebugMarkerSetObjectNameEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkDebugMarkerSetObjectNameEXT", string_VkResult(result));
     }
 }
 
@@ -1891,7 +2100,8 @@ void BestPractices::PostCallRecordCreateCuModuleNVX(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateCuModuleNVX(device, pCreateInfo, pAllocator, pModule, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateCuModuleNVX", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateCuModuleNVX", string_VkResult(result));
     }
 }
 
@@ -1903,7 +2113,8 @@ void BestPractices::PostCallRecordCreateCuFunctionNVX(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateCuFunctionNVX(device, pCreateInfo, pAllocator, pFunction, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateCuFunctionNVX", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateCuFunctionNVX", string_VkResult(result));
     }
 }
 
@@ -1914,7 +2125,8 @@ void BestPractices::PostCallRecordGetImageViewAddressNVX(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetImageViewAddressNVX(device, imageView, pProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetImageViewAddressNVX", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_UNKNOWN
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_UNKNOWN
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetImageViewAddressNVX", string_VkResult(result));
     }
 }
 
@@ -1928,11 +2140,13 @@ void BestPractices::PostCallRecordGetShaderInfoAMD(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetShaderInfoAMD", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetShaderInfoAMD", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetShaderInfoAMD", result); // VK_ERROR_FEATURE_NOT_PRESENT,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_FEATURE_NOT_PRESENT,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetShaderInfoAMD", string_VkResult(result));
     }
 }
 
@@ -1946,7 +2160,8 @@ void BestPractices::PostCallRecordCreateStreamDescriptorSurfaceGGP(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateStreamDescriptorSurfaceGGP(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateStreamDescriptorSurfaceGGP", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateStreamDescriptorSurfaceGGP", string_VkResult(result));
     }
 }
 
@@ -1964,7 +2179,8 @@ void BestPractices::PostCallRecordGetPhysicalDeviceExternalImageFormatProperties
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceExternalImageFormatPropertiesNV(physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceExternalImageFormatPropertiesNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceExternalImageFormatPropertiesNV", string_VkResult(result));
     }
 }
 
@@ -1978,7 +2194,8 @@ void BestPractices::PostCallRecordGetMemoryWin32HandleNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetMemoryWin32HandleNV(device, memory, handleType, pHandle, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetMemoryWin32HandleNV", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetMemoryWin32HandleNV", string_VkResult(result));
     }
 }
 
@@ -1994,7 +2211,8 @@ void BestPractices::PostCallRecordCreateViSurfaceNN(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateViSurfaceNN(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateViSurfaceNN", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateViSurfaceNN", string_VkResult(result));
     }
 }
 
@@ -2009,7 +2227,8 @@ void BestPractices::PostCallRecordAcquireXlibDisplayEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordAcquireXlibDisplayEXT(physicalDevice, dpy, display, result);
     if (result < VK_SUCCESS) {
-        LogError("vkAcquireXlibDisplayEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAcquireXlibDisplayEXT", string_VkResult(result));
     }
 }
 
@@ -2025,7 +2244,8 @@ void BestPractices::PostCallRecordGetRandROutputDisplayEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetRandROutputDisplayEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetRandROutputDisplayEXT", string_VkResult(result));
     }
 }
 
@@ -2039,7 +2259,8 @@ void BestPractices::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2EXT(
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, result);
     ManualPostCallRecordGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceSurfaceCapabilities2EXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceSurfaceCapabilities2EXT", string_VkResult(result));
     }
 }
 
@@ -2050,7 +2271,8 @@ void BestPractices::PostCallRecordDisplayPowerControlEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordDisplayPowerControlEXT(device, display, pDisplayPowerInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkDisplayPowerControlEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkDisplayPowerControlEXT", string_VkResult(result));
     }
 }
 
@@ -2062,7 +2284,8 @@ void BestPractices::PostCallRecordRegisterDeviceEventEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, result);
     if (result < VK_SUCCESS) {
-        LogError("vkRegisterDeviceEventEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkRegisterDeviceEventEXT", string_VkResult(result));
     }
 }
 
@@ -2075,7 +2298,8 @@ void BestPractices::PostCallRecordRegisterDisplayEventEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, result);
     if (result < VK_SUCCESS) {
-        LogError("vkRegisterDisplayEventEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkRegisterDisplayEventEXT", string_VkResult(result));
     }
 }
 
@@ -2086,8 +2310,13 @@ void BestPractices::PostCallRecordGetSwapchainCounterEXT(
     uint64_t*                                   pCounterValue,
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, result);
+    if (IsValueIn(result, kCommonErrorCodes)) {
+        LogInfo(instance, kVUID_BestPractices_Error_Result, "%s(): Returned common error %s.", "vkGetSwapchainCounterEXT", string_VkResult(result));
+        return;
+    }
     if (result < VK_SUCCESS) {
-        LogError("vkGetSwapchainCounterEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetSwapchainCounterEXT", string_VkResult(result));
     }
 }
 
@@ -2098,7 +2327,8 @@ void BestPractices::PostCallRecordGetRefreshCycleDurationGOOGLE(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetRefreshCycleDurationGOOGLE", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetRefreshCycleDurationGOOGLE", string_VkResult(result));
     }
 }
 
@@ -2110,11 +2340,17 @@ void BestPractices::PostCallRecordGetPastPresentationTimingGOOGLE(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPastPresentationTimingGOOGLE", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPastPresentationTimingGOOGLE", string_VkResult(result));
+        return;
+    }
+    if (IsValueIn(result, kCommonErrorCodes)) {
+        LogInfo(instance, kVUID_BestPractices_Error_Result, "%s(): Returned common error %s.", "vkGetPastPresentationTimingGOOGLE", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPastPresentationTimingGOOGLE", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_OUT_OF_DATE_KHR,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPastPresentationTimingGOOGLE", string_VkResult(result));
     }
 }
 
@@ -2128,7 +2364,8 @@ void BestPractices::PostCallRecordCreateIOSSurfaceMVK(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateIOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateIOSSurfaceMVK", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateIOSSurfaceMVK", string_VkResult(result));
     }
 }
 
@@ -2144,7 +2381,8 @@ void BestPractices::PostCallRecordCreateMacOSSurfaceMVK(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateMacOSSurfaceMVK", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateMacOSSurfaceMVK", string_VkResult(result));
     }
 }
 
@@ -2156,7 +2394,8 @@ void BestPractices::PostCallRecordSetDebugUtilsObjectNameEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordSetDebugUtilsObjectNameEXT(device, pNameInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkSetDebugUtilsObjectNameEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkSetDebugUtilsObjectNameEXT", string_VkResult(result));
     }
 }
 
@@ -2166,7 +2405,8 @@ void BestPractices::PostCallRecordSetDebugUtilsObjectTagEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordSetDebugUtilsObjectTagEXT(device, pTagInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkSetDebugUtilsObjectTagEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkSetDebugUtilsObjectTagEXT", string_VkResult(result));
     }
 }
 
@@ -2178,7 +2418,8 @@ void BestPractices::PostCallRecordCreateDebugUtilsMessengerEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDebugUtilsMessengerEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDebugUtilsMessengerEXT", string_VkResult(result));
     }
 }
 
@@ -2191,7 +2432,8 @@ void BestPractices::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(device, buffer, pProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetAndroidHardwareBufferPropertiesANDROID", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetAndroidHardwareBufferPropertiesANDROID", string_VkResult(result));
     }
 }
 
@@ -2206,7 +2448,8 @@ void BestPractices::PostCallRecordGetMemoryAndroidHardwareBufferANDROID(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetMemoryAndroidHardwareBufferANDROID(device, pInfo, pBuffer, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetMemoryAndroidHardwareBufferANDROID", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetMemoryAndroidHardwareBufferANDROID", string_VkResult(result));
     }
 }
 
@@ -2219,7 +2462,8 @@ void BestPractices::PostCallRecordGetImageDrmFormatModifierPropertiesEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetImageDrmFormatModifierPropertiesEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetImageDrmFormatModifierPropertiesEXT", string_VkResult(result));
     }
 }
 
@@ -2239,7 +2483,8 @@ void BestPractices::PostCallRecordCreateAccelerationStructureNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateAccelerationStructureNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateAccelerationStructureNV", string_VkResult(result));
     }
 }
 
@@ -2250,7 +2495,8 @@ void BestPractices::PostCallRecordBindAccelerationStructureMemoryNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, result);
     if (result < VK_SUCCESS) {
-        LogError("vkBindAccelerationStructureMemoryNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBindAccelerationStructureMemoryNV", string_VkResult(result));
     }
 }
 
@@ -2265,11 +2511,13 @@ void BestPractices::PostCallRecordCreateRayTracingPipelinesNV(
     void*                                       state_data) {
     ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, state_data);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkCreateRayTracingPipelinesNV", result); // VK_PIPELINE_COMPILE_REQUIRED_EXT
+        // VK_PIPELINE_COMPILE_REQUIRED_EXT
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkCreateRayTracingPipelinesNV", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkCreateRayTracingPipelinesNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_SHADER_NV
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateRayTracingPipelinesNV", string_VkResult(result));
     }
 }
 
@@ -2283,7 +2531,8 @@ void BestPractices::PostCallRecordGetRayTracingShaderGroupHandlesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetRayTracingShaderGroupHandlesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetRayTracingShaderGroupHandlesKHR", string_VkResult(result));
     }
 }
 
@@ -2297,7 +2546,8 @@ void BestPractices::PostCallRecordGetRayTracingShaderGroupHandlesNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetRayTracingShaderGroupHandlesNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetRayTracingShaderGroupHandlesNV", string_VkResult(result));
     }
 }
 
@@ -2309,7 +2559,8 @@ void BestPractices::PostCallRecordGetAccelerationStructureHandleNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetAccelerationStructureHandleNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetAccelerationStructureHandleNV", string_VkResult(result));
     }
 }
 
@@ -2320,7 +2571,8 @@ void BestPractices::PostCallRecordCompileDeferredNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCompileDeferredNV(device, pipeline, shader, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCompileDeferredNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCompileDeferredNV", string_VkResult(result));
     }
 }
 
@@ -2332,7 +2584,8 @@ void BestPractices::PostCallRecordGetMemoryHostPointerPropertiesEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetMemoryHostPointerPropertiesEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetMemoryHostPointerPropertiesEXT", string_VkResult(result));
     }
 }
 
@@ -2343,11 +2596,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceCalibrateableTimeDomainsEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceCalibrateableTimeDomainsEXT(physicalDevice, pTimeDomainCount, pTimeDomains, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", string_VkResult(result));
     }
 }
 
@@ -2360,7 +2615,8 @@ void BestPractices::PostCallRecordGetCalibratedTimestampsEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetCalibratedTimestampsEXT(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetCalibratedTimestampsEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetCalibratedTimestampsEXT", string_VkResult(result));
     }
 }
 
@@ -2370,7 +2626,8 @@ void BestPractices::PostCallRecordInitializePerformanceApiINTEL(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordInitializePerformanceApiINTEL(device, pInitializeInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkInitializePerformanceApiINTEL", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkInitializePerformanceApiINTEL", string_VkResult(result));
     }
 }
 
@@ -2380,7 +2637,8 @@ void BestPractices::PostCallRecordCmdSetPerformanceMarkerINTEL(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCmdSetPerformanceMarkerINTEL", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCmdSetPerformanceMarkerINTEL", string_VkResult(result));
     }
 }
 
@@ -2390,7 +2648,8 @@ void BestPractices::PostCallRecordCmdSetPerformanceStreamMarkerINTEL(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCmdSetPerformanceStreamMarkerINTEL", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCmdSetPerformanceStreamMarkerINTEL", string_VkResult(result));
     }
 }
 
@@ -2400,7 +2659,8 @@ void BestPractices::PostCallRecordCmdSetPerformanceOverrideINTEL(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCmdSetPerformanceOverrideINTEL", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCmdSetPerformanceOverrideINTEL", string_VkResult(result));
     }
 }
 
@@ -2411,7 +2671,8 @@ void BestPractices::PostCallRecordAcquirePerformanceConfigurationINTEL(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, result);
     if (result < VK_SUCCESS) {
-        LogError("vkAcquirePerformanceConfigurationINTEL", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAcquirePerformanceConfigurationINTEL", string_VkResult(result));
     }
 }
 
@@ -2421,7 +2682,8 @@ void BestPractices::PostCallRecordReleasePerformanceConfigurationINTEL(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordReleasePerformanceConfigurationINTEL(device, configuration, result);
     if (result < VK_SUCCESS) {
-        LogError("vkReleasePerformanceConfigurationINTEL", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkReleasePerformanceConfigurationINTEL", string_VkResult(result));
     }
 }
 
@@ -2431,7 +2693,8 @@ void BestPractices::PostCallRecordQueueSetPerformanceConfigurationINTEL(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordQueueSetPerformanceConfigurationINTEL(queue, configuration, result);
     if (result < VK_SUCCESS) {
-        LogError("vkQueueSetPerformanceConfigurationINTEL", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkQueueSetPerformanceConfigurationINTEL", string_VkResult(result));
     }
 }
 
@@ -2442,7 +2705,8 @@ void BestPractices::PostCallRecordGetPerformanceParameterINTEL(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPerformanceParameterINTEL(device, parameter, pValue, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPerformanceParameterINTEL", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPerformanceParameterINTEL", string_VkResult(result));
     }
 }
 
@@ -2456,7 +2720,8 @@ void BestPractices::PostCallRecordCreateImagePipeSurfaceFUCHSIA(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateImagePipeSurfaceFUCHSIA(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateImagePipeSurfaceFUCHSIA", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateImagePipeSurfaceFUCHSIA", string_VkResult(result));
     }
 }
 
@@ -2472,7 +2737,8 @@ void BestPractices::PostCallRecordCreateMetalSurfaceEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateMetalSurfaceEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_NATIVE_WINDOW_IN_USE_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateMetalSurfaceEXT", string_VkResult(result));
     }
 }
 
@@ -2485,11 +2751,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceToolPropertiesEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceToolPropertiesEXT", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceToolPropertiesEXT", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceToolPropertiesEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceToolPropertiesEXT", string_VkResult(result));
     }
 }
 
@@ -2500,11 +2768,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceCooperativeMatrixPropertiesNV
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", string_VkResult(result));
     }
 }
 
@@ -2515,11 +2785,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceSupportedFramebufferMixedSamp
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount, pCombinations, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", string_VkResult(result));
     }
 }
 
@@ -2533,11 +2805,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceSurfacePresentModes2EXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfacePresentModes2EXT(physicalDevice, pSurfaceInfo, pPresentModeCount, pPresentModes, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceSurfacePresentModes2EXT", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceSurfacePresentModes2EXT", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceSurfacePresentModes2EXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceSurfacePresentModes2EXT", string_VkResult(result));
     }
 }
 
@@ -2551,7 +2825,8 @@ void BestPractices::PostCallRecordAcquireFullScreenExclusiveModeEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordAcquireFullScreenExclusiveModeEXT(device, swapchain, result);
     if (result < VK_SUCCESS) {
-        LogError("vkAcquireFullScreenExclusiveModeEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAcquireFullScreenExclusiveModeEXT", string_VkResult(result));
     }
 }
 
@@ -2565,7 +2840,8 @@ void BestPractices::PostCallRecordReleaseFullScreenExclusiveModeEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordReleaseFullScreenExclusiveModeEXT(device, swapchain, result);
     if (result < VK_SUCCESS) {
-        LogError("vkReleaseFullScreenExclusiveModeEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkReleaseFullScreenExclusiveModeEXT", string_VkResult(result));
     }
 }
 
@@ -2580,7 +2856,8 @@ void BestPractices::PostCallRecordGetDeviceGroupSurfacePresentModes2EXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDeviceGroupSurfacePresentModes2EXT(device, pSurfaceInfo, pModes, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetDeviceGroupSurfacePresentModes2EXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDeviceGroupSurfacePresentModes2EXT", string_VkResult(result));
     }
 }
 
@@ -2594,7 +2871,8 @@ void BestPractices::PostCallRecordCreateHeadlessSurfaceEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateHeadlessSurfaceEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateHeadlessSurfaceEXT", string_VkResult(result));
     }
 }
 
@@ -2604,7 +2882,8 @@ void BestPractices::PostCallRecordReleaseSwapchainImagesEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordReleaseSwapchainImagesEXT(device, pReleaseInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkReleaseSwapchainImagesEXT", result); // VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkReleaseSwapchainImagesEXT", string_VkResult(result));
     }
 }
 
@@ -2616,7 +2895,8 @@ void BestPractices::PostCallRecordCreateIndirectCommandsLayoutNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateIndirectCommandsLayoutNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateIndirectCommandsLayoutNV", string_VkResult(result));
     }
 }
 
@@ -2627,7 +2907,8 @@ void BestPractices::PostCallRecordAcquireDrmDisplayEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordAcquireDrmDisplayEXT(physicalDevice, drmFd, display, result);
     if (result < VK_SUCCESS) {
-        LogError("vkAcquireDrmDisplayEXT", result); // VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAcquireDrmDisplayEXT", string_VkResult(result));
     }
 }
 
@@ -2639,7 +2920,8 @@ void BestPractices::PostCallRecordGetDrmDisplayEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetDrmDisplayEXT", result); // VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDrmDisplayEXT", string_VkResult(result));
     }
 }
 
@@ -2651,7 +2933,8 @@ void BestPractices::PostCallRecordCreatePrivateDataSlotEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreatePrivateDataSlotEXT(device, pCreateInfo, pAllocator, pPrivateDataSlot, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreatePrivateDataSlotEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreatePrivateDataSlotEXT", string_VkResult(result));
     }
 }
 
@@ -2664,7 +2947,8 @@ void BestPractices::PostCallRecordSetPrivateDataEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordSetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, data, result);
     if (result < VK_SUCCESS) {
-        LogError("vkSetPrivateDataEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkSetPrivateDataEXT", string_VkResult(result));
     }
 }
 
@@ -2675,7 +2959,8 @@ void BestPractices::PostCallRecordGetBufferOpaqueCaptureDescriptorDataEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetBufferOpaqueCaptureDescriptorDataEXT(device, pInfo, pData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetBufferOpaqueCaptureDescriptorDataEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetBufferOpaqueCaptureDescriptorDataEXT", string_VkResult(result));
     }
 }
 
@@ -2686,7 +2971,8 @@ void BestPractices::PostCallRecordGetImageOpaqueCaptureDescriptorDataEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetImageOpaqueCaptureDescriptorDataEXT(device, pInfo, pData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetImageOpaqueCaptureDescriptorDataEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetImageOpaqueCaptureDescriptorDataEXT", string_VkResult(result));
     }
 }
 
@@ -2697,7 +2983,8 @@ void BestPractices::PostCallRecordGetImageViewOpaqueCaptureDescriptorDataEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetImageViewOpaqueCaptureDescriptorDataEXT(device, pInfo, pData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetImageViewOpaqueCaptureDescriptorDataEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetImageViewOpaqueCaptureDescriptorDataEXT", string_VkResult(result));
     }
 }
 
@@ -2708,7 +2995,8 @@ void BestPractices::PostCallRecordGetSamplerOpaqueCaptureDescriptorDataEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetSamplerOpaqueCaptureDescriptorDataEXT(device, pInfo, pData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetSamplerOpaqueCaptureDescriptorDataEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetSamplerOpaqueCaptureDescriptorDataEXT", string_VkResult(result));
     }
 }
 
@@ -2719,7 +3007,8 @@ void BestPractices::PostCallRecordGetAccelerationStructureOpaqueCaptureDescripto
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetAccelerationStructureOpaqueCaptureDescriptorDataEXT(device, pInfo, pData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT", string_VkResult(result));
     }
 }
 
@@ -2730,11 +3019,13 @@ void BestPractices::PostCallRecordGetDeviceFaultInfoEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDeviceFaultInfoEXT(device, pFaultCounts, pFaultInfo, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetDeviceFaultInfoEXT", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetDeviceFaultInfoEXT", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetDeviceFaultInfoEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDeviceFaultInfoEXT", string_VkResult(result));
     }
 }
 
@@ -2746,7 +3037,8 @@ void BestPractices::PostCallRecordAcquireWinrtDisplayNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordAcquireWinrtDisplayNV(physicalDevice, display, result);
     if (result < VK_SUCCESS) {
-        LogError("vkAcquireWinrtDisplayNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkAcquireWinrtDisplayNV", string_VkResult(result));
     }
 }
 
@@ -2761,7 +3053,8 @@ void BestPractices::PostCallRecordGetWinrtDisplayNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetWinrtDisplayNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_DEVICE_LOST,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetWinrtDisplayNV", string_VkResult(result));
     }
 }
 
@@ -2777,7 +3070,8 @@ void BestPractices::PostCallRecordCreateDirectFBSurfaceEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateDirectFBSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateDirectFBSurfaceEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateDirectFBSurfaceEXT", string_VkResult(result));
     }
 }
 
@@ -2792,7 +3086,8 @@ void BestPractices::PostCallRecordGetMemoryZirconHandleFUCHSIA(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetMemoryZirconHandleFUCHSIA(device, pGetZirconHandleInfo, pZirconHandle, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetMemoryZirconHandleFUCHSIA", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetMemoryZirconHandleFUCHSIA", string_VkResult(result));
     }
 }
 
@@ -2808,7 +3103,8 @@ void BestPractices::PostCallRecordGetMemoryZirconHandlePropertiesFUCHSIA(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetMemoryZirconHandlePropertiesFUCHSIA(device, handleType, zirconHandle, pMemoryZirconHandleProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetMemoryZirconHandlePropertiesFUCHSIA", result); // VK_ERROR_INVALID_EXTERNAL_HANDLE
+        // VK_ERROR_INVALID_EXTERNAL_HANDLE
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetMemoryZirconHandlePropertiesFUCHSIA", string_VkResult(result));
     }
 }
 
@@ -2822,7 +3118,8 @@ void BestPractices::PostCallRecordImportSemaphoreZirconHandleFUCHSIA(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordImportSemaphoreZirconHandleFUCHSIA(device, pImportSemaphoreZirconHandleInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkImportSemaphoreZirconHandleFUCHSIA", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkImportSemaphoreZirconHandleFUCHSIA", string_VkResult(result));
     }
 }
 
@@ -2837,7 +3134,8 @@ void BestPractices::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(device, pGetZirconHandleInfo, pZirconHandle, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetSemaphoreZirconHandleFUCHSIA", result); // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetSemaphoreZirconHandleFUCHSIA", string_VkResult(result));
     }
 }
 
@@ -2853,7 +3151,8 @@ void BestPractices::PostCallRecordCreateBufferCollectionFUCHSIA(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateBufferCollectionFUCHSIA(device, pCreateInfo, pAllocator, pCollection, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateBufferCollectionFUCHSIA", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_EXTERNAL_HANDLE,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateBufferCollectionFUCHSIA", string_VkResult(result));
     }
 }
 
@@ -2868,7 +3167,8 @@ void BestPractices::PostCallRecordSetBufferCollectionImageConstraintsFUCHSIA(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordSetBufferCollectionImageConstraintsFUCHSIA(device, collection, pImageConstraintsInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkSetBufferCollectionImageConstraintsFUCHSIA", result); // VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED
+        // VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkSetBufferCollectionImageConstraintsFUCHSIA", string_VkResult(result));
     }
 }
 
@@ -2883,7 +3183,8 @@ void BestPractices::PostCallRecordSetBufferCollectionBufferConstraintsFUCHSIA(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordSetBufferCollectionBufferConstraintsFUCHSIA(device, collection, pBufferConstraintsInfo, result);
     if (result < VK_SUCCESS) {
-        LogError("vkSetBufferCollectionBufferConstraintsFUCHSIA", result); // VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED
+        // VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_FORMAT_NOT_SUPPORTED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkSetBufferCollectionBufferConstraintsFUCHSIA", string_VkResult(result));
     }
 }
 
@@ -2898,7 +3199,8 @@ void BestPractices::PostCallRecordGetBufferCollectionPropertiesFUCHSIA(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetBufferCollectionPropertiesFUCHSIA(device, collection, pProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetBufferCollectionPropertiesFUCHSIA", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetBufferCollectionPropertiesFUCHSIA", string_VkResult(result));
     }
 }
 
@@ -2911,11 +3213,13 @@ void BestPractices::PostCallRecordGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(device, renderpass, pMaxWorkgroupSize, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_SURFACE_LOST_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI", string_VkResult(result));
     }
 }
 
@@ -2926,7 +3230,8 @@ void BestPractices::PostCallRecordGetMemoryRemoteAddressNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetMemoryRemoteAddressNV(device, pMemoryGetRemoteAddressInfo, pAddress, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetMemoryRemoteAddressNV", result); // VK_ERROR_INVALID_EXTERNAL_HANDLE
+        // VK_ERROR_INVALID_EXTERNAL_HANDLE
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetMemoryRemoteAddressNV", string_VkResult(result));
     }
 }
 
@@ -2937,7 +3242,8 @@ void BestPractices::PostCallRecordGetPipelinePropertiesEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPipelinePropertiesEXT(device, pPipelineInfo, pPipelineProperties, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetPipelinePropertiesEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPipelinePropertiesEXT", string_VkResult(result));
     }
 }
 
@@ -2951,7 +3257,8 @@ void BestPractices::PostCallRecordCreateScreenSurfaceQNX(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateScreenSurfaceQNX(instance, pCreateInfo, pAllocator, pSurface, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateScreenSurfaceQNX", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateScreenSurfaceQNX", string_VkResult(result));
     }
 }
 
@@ -2965,7 +3272,8 @@ void BestPractices::PostCallRecordCreateMicromapEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateMicromapEXT(device, pCreateInfo, pAllocator, pMicromap, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateMicromapEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateMicromapEXT", string_VkResult(result));
     }
 }
 
@@ -2977,11 +3285,13 @@ void BestPractices::PostCallRecordBuildMicromapsEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBuildMicromapsEXT(device, deferredOperation, infoCount, pInfos, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkBuildMicromapsEXT", result); // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkBuildMicromapsEXT", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkBuildMicromapsEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBuildMicromapsEXT", string_VkResult(result));
     }
 }
 
@@ -2992,11 +3302,13 @@ void BestPractices::PostCallRecordCopyMicromapEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCopyMicromapEXT(device, deferredOperation, pInfo, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkCopyMicromapEXT", result); // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkCopyMicromapEXT", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkCopyMicromapEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCopyMicromapEXT", string_VkResult(result));
     }
 }
 
@@ -3007,11 +3319,13 @@ void BestPractices::PostCallRecordCopyMicromapToMemoryEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCopyMicromapToMemoryEXT(device, deferredOperation, pInfo, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkCopyMicromapToMemoryEXT", result); // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkCopyMicromapToMemoryEXT", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkCopyMicromapToMemoryEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCopyMicromapToMemoryEXT", string_VkResult(result));
     }
 }
 
@@ -3022,11 +3336,13 @@ void BestPractices::PostCallRecordCopyMemoryToMicromapEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCopyMemoryToMicromapEXT(device, deferredOperation, pInfo, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkCopyMemoryToMicromapEXT", result); // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkCopyMemoryToMicromapEXT", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkCopyMemoryToMicromapEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCopyMemoryToMicromapEXT", string_VkResult(result));
     }
 }
 
@@ -3041,7 +3357,8 @@ void BestPractices::PostCallRecordWriteMicromapsPropertiesEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordWriteMicromapsPropertiesEXT(device, micromapCount, pMicromaps, queryType, dataSize, pData, stride, result);
     if (result < VK_SUCCESS) {
-        LogError("vkWriteMicromapsPropertiesEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkWriteMicromapsPropertiesEXT", string_VkResult(result));
     }
 }
 
@@ -3053,11 +3370,13 @@ void BestPractices::PostCallRecordGetPhysicalDeviceOpticalFlowImageFormatsNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetPhysicalDeviceOpticalFlowImageFormatsNV(physicalDevice, pOpticalFlowImageFormatInfo, pFormatCount, pImageFormatProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetPhysicalDeviceOpticalFlowImageFormatsNV", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetPhysicalDeviceOpticalFlowImageFormatsNV", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetPhysicalDeviceOpticalFlowImageFormatsNV", result); // VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_FORMAT_NOT_SUPPORTED
+        // VK_ERROR_EXTENSION_NOT_PRESENT,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_FORMAT_NOT_SUPPORTED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetPhysicalDeviceOpticalFlowImageFormatsNV", string_VkResult(result));
     }
 }
 
@@ -3069,7 +3388,8 @@ void BestPractices::PostCallRecordCreateOpticalFlowSessionNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateOpticalFlowSessionNV(device, pCreateInfo, pAllocator, pSession, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateOpticalFlowSessionNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateOpticalFlowSessionNV", string_VkResult(result));
     }
 }
 
@@ -3082,7 +3402,8 @@ void BestPractices::PostCallRecordBindOpticalFlowSessionImageNV(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBindOpticalFlowSessionImageNV(device, session, bindingPoint, view, layout, result);
     if (result < VK_SUCCESS) {
-        LogError("vkBindOpticalFlowSessionImageNV", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INITIALIZATION_FAILED
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBindOpticalFlowSessionImageNV", string_VkResult(result));
     }
 }
 
@@ -3095,7 +3416,8 @@ void BestPractices::PostCallRecordCreateShadersEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateShadersEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INITIALIZATION_FAILED,VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateShadersEXT", string_VkResult(result));
     }
 }
 
@@ -3107,11 +3429,13 @@ void BestPractices::PostCallRecordGetShaderBinaryDataEXT(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetShaderBinaryDataEXT(device, shader, pDataSize, pData, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetShaderBinaryDataEXT", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetShaderBinaryDataEXT", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkGetShaderBinaryDataEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetShaderBinaryDataEXT", string_VkResult(result));
     }
 }
 
@@ -3123,7 +3447,8 @@ void BestPractices::PostCallRecordGetFramebufferTilePropertiesQCOM(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetFramebufferTilePropertiesQCOM(device, framebuffer, pPropertiesCount, pProperties, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkGetFramebufferTilePropertiesQCOM", result); // VK_INCOMPLETE
+        // VK_INCOMPLETE
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkGetFramebufferTilePropertiesQCOM", string_VkResult(result));
         return;
     }
 }
@@ -3136,7 +3461,8 @@ void BestPractices::PostCallRecordCreateAccelerationStructureKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, result);
     if (result < VK_SUCCESS) {
-        LogError("vkCreateAccelerationStructureKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS_KHR
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateAccelerationStructureKHR", string_VkResult(result));
     }
 }
 
@@ -3149,11 +3475,13 @@ void BestPractices::PostCallRecordBuildAccelerationStructuresKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkBuildAccelerationStructuresKHR", result); // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkBuildAccelerationStructuresKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkBuildAccelerationStructuresKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkBuildAccelerationStructuresKHR", string_VkResult(result));
     }
 }
 
@@ -3164,11 +3492,13 @@ void BestPractices::PostCallRecordCopyAccelerationStructureKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCopyAccelerationStructureKHR(device, deferredOperation, pInfo, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkCopyAccelerationStructureKHR", result); // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkCopyAccelerationStructureKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkCopyAccelerationStructureKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCopyAccelerationStructureKHR", string_VkResult(result));
     }
 }
 
@@ -3179,11 +3509,13 @@ void BestPractices::PostCallRecordCopyAccelerationStructureToMemoryKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkCopyAccelerationStructureToMemoryKHR", result); // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkCopyAccelerationStructureToMemoryKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkCopyAccelerationStructureToMemoryKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCopyAccelerationStructureToMemoryKHR", string_VkResult(result));
     }
 }
 
@@ -3194,11 +3526,13 @@ void BestPractices::PostCallRecordCopyMemoryToAccelerationStructureKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, result);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkCopyMemoryToAccelerationStructureKHR", result); // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkCopyMemoryToAccelerationStructureKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkCopyMemoryToAccelerationStructureKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCopyMemoryToAccelerationStructureKHR", string_VkResult(result));
     }
 }
 
@@ -3213,7 +3547,8 @@ void BestPractices::PostCallRecordWriteAccelerationStructuresPropertiesKHR(
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures, queryType, dataSize, pData, stride, result);
     if (result < VK_SUCCESS) {
-        LogError("vkWriteAccelerationStructuresPropertiesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkWriteAccelerationStructuresPropertiesKHR", string_VkResult(result));
     }
 }
 
@@ -3229,11 +3564,13 @@ void BestPractices::PostCallRecordCreateRayTracingPipelinesKHR(
     void*                                       state_data) {
     ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines, result, state_data);
     if (result > VK_SUCCESS) {
-        LogSuccess("vkCreateRayTracingPipelinesKHR", result); // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR,VK_PIPELINE_COMPILE_REQUIRED_EXT
+        // VK_OPERATION_DEFERRED_KHR,VK_OPERATION_NOT_DEFERRED_KHR,VK_PIPELINE_COMPILE_REQUIRED_EXT
+        LogVerbose(instance, kVUID_BestPractices_Verbose_Success_Logging, "%s(): Returned %s.", "vkCreateRayTracingPipelinesKHR", string_VkResult(result));
         return;
     }
     if (result < VK_SUCCESS) {
-        LogError("vkCreateRayTracingPipelinesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY,VK_ERROR_INVALID_OPAQUE_CAPTURE_ADDRESS
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkCreateRayTracingPipelinesKHR", string_VkResult(result));
     }
 }
 
@@ -3247,7 +3584,8 @@ void BestPractices::PostCallRecordGetRayTracingCaptureReplayShaderGroupHandlesKH
     VkResult                                    result) {
     ValidationStateTracker::PostCallRecordGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData, result);
     if (result < VK_SUCCESS) {
-        LogError("vkGetRayTracingCaptureReplayShaderGroupHandlesKHR", result); // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        // VK_ERROR_OUT_OF_HOST_MEMORY,VK_ERROR_OUT_OF_DEVICE_MEMORY
+        LogWarning(instance, kVUID_BestPractices_Error_Result, "%s(): Returned error %s.", "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR", string_VkResult(result));
     }
 }
 


### PR DESCRIPTION
Remove helper functions BestPractices::LogSuccess and
BestPractices::LogError

Use regular LogVerbose, LogInfo, LogWarning directly instead.