### PR TITLE
layers: Use FormatUtils for imageViewFormatReinterpretation

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -202,6 +202,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/framework/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/positive/image_buffer.cpp \
                    $(SRC_DIR)/tests/positive/instance.cpp \
                    $(SRC_DIR)/tests/positive/layer_utils.cpp \
+                   $(SRC_DIR)/tests/positive/format_utils.cpp \
                    $(SRC_DIR)/tests/positive/other.cpp \
                    $(SRC_DIR)/tests/positive/pipeline.cpp \
                    $(SRC_DIR)/tests/positive/render_pass.cpp \
@@ -287,6 +288,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/framework/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/positive/gpu_av.cpp \
                    $(SRC_DIR)/tests/positive/instance.cpp \
                    $(SRC_DIR)/tests/positive/layer_utils.cpp \
+                   $(SRC_DIR)/tests/positive/format_utils.cpp \
                    $(SRC_DIR)/tests/positive/other.cpp \
                    $(SRC_DIR)/tests/positive/pipeline.cpp \
                    $(SRC_DIR)/tests/positive/render_pass.cpp \

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -2065,13 +2065,8 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
 
         // Ensure ImageView's format has the same number of bits and components as Image's format if format reinterpretation is
         // disabled
-        // TODO (ncesario): This is not correct for some cases (e.g., VK_FORMAT_B10G11R11_UFLOAT_PACK32 and
-        // VK_FORMAT_E5B9G9R9_UFLOAT_PACK32), but requires additional information that should probably be generated from the
-        // spec. See Github issue #2361.
-        if ((VK_FALSE == enabled_features.portability_subset_features.imageViewFormatReinterpretation) &&
-            ((FormatElementSize(pCreateInfo->format, VK_IMAGE_ASPECT_COLOR_BIT) !=
-              FormatElementSize(image_state->createInfo.format, VK_IMAGE_ASPECT_COLOR_BIT)) ||
-             (FormatComponentCount(pCreateInfo->format) != FormatComponentCount(image_state->createInfo.format)))) {
+        if (!enabled_features.portability_subset_features.imageViewFormatReinterpretation &&
+            !FormatsSameComponentBits(pCreateInfo->format, image_state->createInfo.format)) {
             skip |= LogError(pCreateInfo->image, "VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466",
                              "vkCreateImageView (portability error): ImageView format must have"
                              " the same number of components and bits per component as the Image's format");

--- a/layers/generated/vk_format_utils.cpp
+++ b/layers/generated/vk_format_utils.cpp
@@ -1880,3 +1880,30 @@ bool FormatHasAlpha(VkFormat format) {
     return FormatHasComponentType(format, COMPONENT_TYPE::A);
 }
 
+bool FormatsSameComponentBits(VkFormat format_a, VkFormat format_b) {
+    const auto item_a = kVkFormatTable.find(format_a);
+    const auto item_b = kVkFormatTable.find(format_b);
+    if (item_a == kVkFormatTable.end() || item_b == kVkFormatTable.end()) {
+        return false;
+    } else if (item_a->second.component_count != item_b->second.component_count) {
+        return false;
+    }
+    // Need to loop match each component type is found in both formats
+    // formats are maxed at 4 components, so the double loop is not going to scale
+    for (uint32_t i = 0; i < item_a->second.component_count; i++) {
+        const auto& component_a = item_a->second.components[i];
+        bool component_match = false;
+        for (uint32_t j = 0; j < item_b->second.component_count; j++) {
+            const auto& component_b = item_b->second.components[j];
+            if ((component_a.type == component_b.type) && (component_a.size == component_b.size)) {
+                component_match = true;
+                break;
+            }
+        }
+        if (!component_match) {
+            return false;
+        }
+    }
+    return true;
+}
+

--- a/layers/generated/vk_format_utils.h
+++ b/layers/generated/vk_format_utils.h
@@ -254,6 +254,7 @@ bool FormatHasRed(VkFormat format);
 bool FormatHasGreen(VkFormat format);
 bool FormatHasBlue(VkFormat format);
 bool FormatHasAlpha(VkFormat format);
+bool FormatsSameComponentBits(VkFormat format_a, VkFormat format_b);
 
 
 // Utils/misc

--- a/scripts/format_utils_generator.py
+++ b/scripts/format_utils_generator.py
@@ -703,6 +703,7 @@ bool FormatHasRed(VkFormat format);
 bool FormatHasGreen(VkFormat format);
 bool FormatHasBlue(VkFormat format);
 bool FormatHasAlpha(VkFormat format);
+bool FormatsSameComponentBits(VkFormat format_a, VkFormat format_b);
 '''
         elif self.sourceFile:
             output += '''
@@ -806,6 +807,33 @@ bool FormatHasBlue(VkFormat format) {
 
 bool FormatHasAlpha(VkFormat format) {
     return FormatHasComponentType(format, COMPONENT_TYPE::A);
+}
+
+bool FormatsSameComponentBits(VkFormat format_a, VkFormat format_b) {
+    const auto item_a = kVkFormatTable.find(format_a);
+    const auto item_b = kVkFormatTable.find(format_b);
+    if (item_a == kVkFormatTable.end() || item_b == kVkFormatTable.end()) {
+        return false;
+    } else if (item_a->second.component_count != item_b->second.component_count) {
+        return false;
+    }
+    // Need to loop match each component type is found in both formats
+    // formats are maxed at 4 components, so the double loop is not going to scale
+    for (uint32_t i = 0; i < item_a->second.component_count; i++) {
+        const auto& component_a = item_a->second.components[i];
+        bool component_match = false;
+        for (uint32_t j = 0; j < item_b->second.component_count; j++) {
+            const auto& component_b = item_b->second.components[j];
+            if ((component_a.type == component_b.type) && (component_a.size == component_b.size)) {
+                component_match = true;
+                break;
+            }
+        }
+        if (!component_match) {
+            return false;
+        }
+    }
+    return true;
 }'''
         return output;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     positive/dynamic_state.cpp
     positive/external_memory_sync.cpp
     positive/fragment_shading_rate.cpp
+    positive/format_utils.cpp
     positive/gpu_av.cpp
     positive/graphics_library.cpp
     positive/image_buffer.cpp

--- a/tests/positive/format_utils.cpp
+++ b/tests/positive/format_utils.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+#include "generated/vk_format_utils.h"
+
+// These test check utils in the layer without needing to create a full Vulkan instance
+
+TEST_F(VkPositiveLayerTest, FormatsSameComponentBits) {
+    ASSERT_TRUE(FormatsSameComponentBits(VK_FORMAT_G8_B8R8_2PLANE_422_UNORM, VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM));
+    ASSERT_TRUE(FormatsSameComponentBits(VK_FORMAT_ASTC_10x10_UNORM_BLOCK, VK_FORMAT_ASTC_12x10_SRGB_BLOCK));
+    // Order doesn't matter
+    ASSERT_TRUE(FormatsSameComponentBits(VK_FORMAT_R8G8B8_UNORM, VK_FORMAT_B8G8R8_USCALED));
+    ASSERT_TRUE(FormatsSameComponentBits(VK_FORMAT_A4R4G4B4_UNORM_PACK16, VK_FORMAT_R4G4B4A4_UNORM_PACK16));
+    ASSERT_TRUE(FormatsSameComponentBits(VK_FORMAT_B5G5R5A1_UNORM_PACK16, VK_FORMAT_A1R5G5B5_UNORM_PACK16));
+    // Components mismatch
+    ASSERT_FALSE(FormatsSameComponentBits(VK_FORMAT_R8_UINT, VK_FORMAT_S8_UINT));
+    ASSERT_FALSE(FormatsSameComponentBits(VK_FORMAT_D16_UNORM, VK_FORMAT_X8_D24_UNORM_PACK32));
+    ASSERT_FALSE(FormatsSameComponentBits(VK_FORMAT_G8_B8R8_2PLANE_422_UNORM, VK_FORMAT_G8B8G8R8_422_UNORM));
+    ASSERT_FALSE(FormatsSameComponentBits(VK_FORMAT_R12X4_UNORM_PACK16, VK_FORMAT_R12X4G12X4_UNORM_2PACK16));
+    // Bits mismatch
+    ASSERT_FALSE(FormatsSameComponentBits(VK_FORMAT_R32_UINT, VK_FORMAT_R16_UINT));
+    ASSERT_FALSE(FormatsSameComponentBits(VK_FORMAT_B10G11R11_UFLOAT_PACK32, VK_FORMAT_B8G8R8_UINT));
+    ASSERT_FALSE(FormatsSameComponentBits(VK_FORMAT_D16_UNORM_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT));
+    ASSERT_FALSE(FormatsSameComponentBits(VK_FORMAT_G10X6_B10X6R10X6_2PLANE_444_UNORM_3PACK16, VK_FORMAT_G12X4_B12X4R12X4_2PLANE_444_UNORM_3PACK16));
+    // UNDEFINED is always bad
+    ASSERT_FALSE(FormatsSameComponentBits(VK_FORMAT_UNDEFINED, VK_FORMAT_B8G8R8_UINT));
+}
+


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2361

Before (when issue was opened 2+ years ago) we didn't have a generated Format Util that could check against each component bit size

Even if it is compressed formats, it will still match correctly