### PR TITLE
layers: Use new helpers for Spec Constant

### DIFF
--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -569,8 +569,9 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
     const StructInfo *FindEntrypointPushConstant(char const *name, VkShaderStageFlagBits stageBits) const;
     std::shared_ptr<const EntryPoint> FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
-    [[nodiscard]] bool FindLocalSize(const EntryPoint &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y,
-                                     uint32_t &local_size_z) const;
+    bool FindLocalSize(const EntryPoint &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y, uint32_t &local_size_z) const;
+
+    uint32_t CalculateComputeSharedMemory() const;
 
     const Instruction *GetConstantDef(uint32_t id) const;
     uint32_t GetConstantValueById(uint32_t id) const;


### PR DESCRIPTION
When I added this logic for Spec Constant we didn't have the `StaticData` or `EntryPoint` helpers

Currently we are doing the logic twice, so this eliminates the copy-and-pasted logic