### PR TITLE
Check correct feature for 04097 VUID

### DIFF
--- a/layers/sync/sync_utils.cpp
+++ b/layers/sync/sync_utils.cpp
@@ -45,7 +45,7 @@ VkPipelineStageFlags2KHR DisabledPipelineStages(const DeviceFeatures &features) 
     if (!features.mesh_shader_features.taskShader) {
         result |= VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV;
     }
-    if (!features.fragment_shading_rate_features.pipelineFragmentShadingRate &&
+    if (!features.fragment_shading_rate_features.attachmentFragmentShadingRate &&
         !features.shading_rate_image_features.shadingRateImage) {
         result |= VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR;
     }


### PR DESCRIPTION
A while ago the spec was clarified that pipeline stage `VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR` requires the feature `attachmentFragmentShadingRate`

Validation here is not completely correct yet, because VUIDs 07318 still need to be implemented. 