### PR TITLE
android: Create android_hardware_buffer.h

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     ${VVL_SOURCE_DIR}/layers/generated/lvt_function_pointers.cpp
     ${VVL_SOURCE_DIR}/layers/generated/vk_format_utils.cpp
     ${VVL_SOURCE_DIR}/layers/generated/vk_safe_struct.cpp
+    framework/android_hardware_buffer.h
     framework/layer_validation_tests.h
     framework/layer_validation_tests.cpp
     framework/test_common.h

--- a/tests/framework/android_hardware_buffer.h
+++ b/tests/framework/android_hardware_buffer.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+#pragma once
+
+#include "utils/android_ndk_types.h"  // Defines AHB_VALIDATION_SUPPORT if supported
+
+#ifdef AHB_VALIDATION_SUPPORT
+
+// Helper to get the memory type index for AHB object that are being imported
+// returns false if can't set the values correctly
+inline bool SetAllocationInfoImportAHB(vk_testing::Device *device, VkAndroidHardwareBufferPropertiesANDROID ahb_props,
+                                       VkMemoryAllocateInfo &info) {
+    // Set index to match one of the bits in ahb_props that is also only Device Local
+    // Android implemenetations "should have" a DEVICE_LOCAL only index designed for AHB
+    VkMemoryPropertyFlagBits property = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    VkPhysicalDeviceMemoryProperties mem_props = device->phy().memory_properties();
+    // AHB object hold the real allocationSize needed
+    info.allocationSize = ahb_props.allocationSize;
+    info.memoryTypeIndex = mem_props.memoryTypeCount + 1;
+    for (uint32_t i = 0; i < mem_props.memoryTypeCount; i++) {
+        if ((ahb_props.memoryTypeBits & (1 << i)) && ((mem_props.memoryTypes[i].propertyFlags & property) == property)) {
+            info.memoryTypeIndex = i;
+            break;
+        }
+    }
+    return info.memoryTypeIndex < mem_props.memoryTypeCount;
+}
+
+#endif

--- a/tests/framework/test_framework_android.cpp
+++ b/tests/framework/test_framework_android.cpp
@@ -148,23 +148,3 @@ bool VkTestFramework::ASMtoSPV(const spv_target_env target_env, const uint32_t o
 
     return true;
 }
-
-// Helper to get the memory type index for AHB object that are being imported
-// returns false if can't set the values correctly
-bool VkTestFramework::SetAllocationInfoImportAHB(vk_testing::Device *device, VkAndroidHardwareBufferPropertiesANDROID ahb_props,
-                                                 VkMemoryAllocateInfo &info) {
-    // Set index to match one of the bits in ahb_props that is also only Device Local
-    // Android implemenetations "should have" a DEVICE_LOCAL only index designed for AHB
-    VkMemoryPropertyFlagBits property = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-    VkPhysicalDeviceMemoryProperties mem_props = device->phy().memory_properties();
-    // AHB object hold the real allocationSize needed
-    info.allocationSize = ahb_props.allocationSize;
-    info.memoryTypeIndex = mem_props.memoryTypeCount + 1;
-    for (uint32_t i = 0; i < mem_props.memoryTypeCount; i++) {
-        if ((ahb_props.memoryTypeBits & (1 << i)) && ((mem_props.memoryTypes[i].propertyFlags & property) == property)) {
-            info.memoryTypeIndex = i;
-            break;
-        }
-    }
-    return info.memoryTypeIndex < mem_props.memoryTypeCount;
-}

--- a/tests/framework/test_framework_android.h
+++ b/tests/framework/test_framework_android.h
@@ -34,8 +34,6 @@ class VkTestFramework : public ::testing::Test {
     bool GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type, const char *pshader,
                    std::vector<uint32_t> &spv, bool debug = false, const spv_target_env spv_ev = SPV_ENV_VULKAN_1_0);
     bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<uint32_t> &spv);
-    bool SetAllocationInfoImportAHB(vk_testing::Device *device, VkAndroidHardwareBufferPropertiesANDROID ahb_props,
-                                    VkMemoryAllocateInfo &info);
 
     static inline int m_phys_device_index = -1;
     static inline ANativeWindow *window = nullptr;

--- a/tests/negative/android_hardware_buffer.cpp
+++ b/tests/negative/android_hardware_buffer.cpp
@@ -14,7 +14,10 @@
 
 #include "../framework/layer_validation_tests.h"
 
-#include "utils/android_ndk_types.h"
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+#include "../framework/android_hardware_buffer.h"
+#endif
+
 #ifdef AHB_VALIDATION_SUPPORT
 
 TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {

--- a/tests/positive/android_hardware_buffer.cpp
+++ b/tests/positive/android_hardware_buffer.cpp
@@ -14,7 +14,10 @@
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_extension_helper.h"
 
-#include "utils/android_ndk_types.h"
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+#include "../framework/android_hardware_buffer.h"
+#endif
+
 #ifdef AHB_VALIDATION_SUPPORT
 TEST_F(VkPositiveLayerTest, AndroidHardwareBufferMemoryRequirements) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer doesn't conflict with memory requirements.");


### PR DESCRIPTION
Simplifies the Android build. This helper function has nothing to do with the test framework.

This makes it simpler to consolidate the 2 Android builds.