### PR TITLE
tests: Give better names for test groups

### DIFF
--- a/tests/negative/atomics.cpp
+++ b/tests/negative/atomics.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, VertexStoresAndAtomicsFeatureDisable) {
+class NegativeAtomic : public VkLayerTest {};
+
+TEST_F(NegativeAtomic, VertexStoresAndAtomicsFeatureDisable) {
     TEST_DESCRIPTION("Run shader with StoreOp or AtomicOp to verify if vertexPipelineStoresAndAtomics disable.");
 
     VkPhysicalDeviceFeatures features{};
@@ -68,7 +70,7 @@ TEST_F(VkLayerTest, VertexStoresAndAtomicsFeatureDisable) {
     }
 }
 
-TEST_F(VkLayerTest, FragmentStoresAndAtomicsFeatureDisable) {
+TEST_F(NegativeAtomic, FragmentStoresAndAtomicsFeatureDisable) {
     TEST_DESCRIPTION("Run shader with StoreOp or AtomicOp to verify if fragmentStoresAndAtomics disable.");
 
     VkPhysicalDeviceFeatures features{};
@@ -121,7 +123,7 @@ TEST_F(VkLayerTest, FragmentStoresAndAtomicsFeatureDisable) {
     }
 }
 
-TEST_F(VkLayerTest, ShaderAtomicInt64) {
+TEST_F(NegativeAtomic, Int64) {
     TEST_DESCRIPTION("Test VK_KHR_shader_atomic_int64.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -215,7 +217,7 @@ TEST_F(VkLayerTest, ShaderAtomicInt64) {
         std::vector<string>{"VUID-VkShaderModuleCreateInfo-pCode-08740", "VUID-RuntimeSpirv-None-06279"});
 }
 
-TEST_F(VkLayerTest, ShaderImageAtomicInt64) {
+TEST_F(NegativeAtomic, ImageInt64) {
     TEST_DESCRIPTION("Test VK_EXT_shader_image_atomic_int64.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -320,7 +322,7 @@ TEST_F(VkLayerTest, ShaderImageAtomicInt64) {
     }
 }
 
-TEST_F(VkLayerTest, ShaderImageAtomicInt64Drawtime64) {
+TEST_F(NegativeAtomic, ImageInt64Drawtime64) {
     TEST_DESCRIPTION("Test VK_EXT_shader_image_atomic_int64 draw time with 64 bit image view.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME);
@@ -380,7 +382,7 @@ TEST_F(VkLayerTest, ShaderImageAtomicInt64Drawtime64) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ShaderImageAtomicInt64Drawtime32) {
+TEST_F(NegativeAtomic, ImageInt64Drawtime32) {
     TEST_DESCRIPTION("Test VK_EXT_shader_image_atomic_int64 draw time with 32 bit image view.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME);
@@ -439,7 +441,7 @@ TEST_F(VkLayerTest, ShaderImageAtomicInt64Drawtime32) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ShaderImageAtomicInt64DrawtimeSparse) {
+TEST_F(NegativeAtomic, ImageInt64DrawtimeSparse) {
     TEST_DESCRIPTION("Test VK_EXT_shader_image_atomic_int64 at draw time with Sparse image.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -519,7 +521,7 @@ TEST_F(VkLayerTest, ShaderImageAtomicInt64DrawtimeSparse) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ShaderImageAtomicInt64Mesh32) {
+TEST_F(NegativeAtomic, ImageInt64Mesh32) {
     TEST_DESCRIPTION("Test VK_EXT_shader_image_atomic_int64 draw time with 32 bit image view in Mesh shaders.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME);
@@ -594,7 +596,7 @@ TEST_F(VkLayerTest, ShaderImageAtomicInt64Mesh32) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ShaderAtomicFloat) {
+TEST_F(NegativeAtomic, Float) {
     TEST_DESCRIPTION("Test VK_EXT_shader_atomic_float.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -857,7 +859,7 @@ TEST_F(VkLayerTest, ShaderAtomicFloat) {
                             "VUID-RuntimeSpirv-None-06282"});
 }
 
-TEST_F(VkLayerTest, ShaderAtomicFloat2) {
+TEST_F(NegativeAtomic, Float2) {
     TEST_DESCRIPTION("Test VK_EXT_shader_atomic_float2.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -1167,7 +1169,7 @@ TEST_F(VkLayerTest, ShaderAtomicFloat2) {
         std::vector<string>{"VUID-VkShaderModuleCreateInfo-pCode-08742", "VUID-RuntimeSpirv-None-06282"});
 }
 
-TEST_F(VkLayerTest, ShaderAtomicFloat2WidthMismatch) {
+TEST_F(NegativeAtomic, Float2WidthMismatch) {
     TEST_DESCRIPTION("VK_EXT_shader_atomic_float2 but enable wrong bitwidth.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME);
@@ -1235,7 +1237,7 @@ TEST_F(VkLayerTest, ShaderAtomicFloat2WidthMismatch) {
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, std::vector<string>{"VUID-RuntimeSpirv-None-06338"});
 }
 
-TEST_F(VkLayerTest, InvalidStorageAtomicOperation) {
+TEST_F(NegativeAtomic, InvalidStorageOperation) {
     TEST_DESCRIPTION(
         "If storage view use atomic operation, the view's format MUST support VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT or "
         "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT ");

--- a/tests/negative/mesh.cpp
+++ b/tests/negative/mesh.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, MeshShaderEXT) {
+class NegativeMesh : public VkLayerTest {};
+
+TEST_F(NegativeMesh, BasicUsage) {
     TEST_DESCRIPTION("Test VK_EXT_mesh_shader.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -237,7 +239,7 @@ TEST_F(VkLayerTest, MeshShaderEXT) {
     }
 }
 
-TEST_F(VkLayerTest, MeshShaderEXTDisabled) {
+TEST_F(NegativeMesh, ExtensionDisabled) {
     TEST_DESCRIPTION("Test VK_EXT_mesh_shader VUs with EXT_mesh_shader disabled.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -350,7 +352,7 @@ TEST_F(VkLayerTest, MeshShaderEXTDisabled) {
                                                            "VUID-VkPipelineShaderStageCreateInfo-stage-02092"}));
 }
 
-TEST_F(VkLayerTest, MeshShaderEXTRuntimeSpirv) {
+TEST_F(NegativeMesh, RuntimeSpirv) {
     TEST_DESCRIPTION("Test VK_EXT_mesh_shader spirv related VUIDs.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -530,7 +532,7 @@ TEST_F(VkLayerTest, MeshShaderEXTRuntimeSpirv) {
     CreatePipelineHelper::OneshotTest(*this, break_vp1, kErrorBit, error_vuids_1);
 }
 
-TEST_F(VkLayerTest, MeshShaderNVRuntimeSpirv) {
+TEST_F(NegativeMesh, RuntimeSpirvNV) {
     TEST_DESCRIPTION("Test VK_NV_mesh_shader spirv related VUIDs");
 
     AddRequiredExtensions(VK_NV_MESH_SHADER_EXTENSION_NAME);
@@ -591,7 +593,7 @@ TEST_F(VkLayerTest, MeshShaderNVRuntimeSpirv) {
                                       vector<std::string>({"VUID-RuntimeSpirv-MeshNV-07113", "VUID-RuntimeSpirv-MeshNV-07114"}));
 }
 
-TEST_F(VkLayerTest, MeshShaderNV) {
+TEST_F(NegativeMesh, BasicUsageNV) {
     TEST_DESCRIPTION("Test VK_NV_mesh_shader.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -692,7 +694,7 @@ TEST_F(VkLayerTest, MeshShaderNV) {
     vk::DestroyBuffer(m_device->device(), buffer, 0);
 }
 
-TEST_F(VkLayerTest, MeshShaderDisabledNV) {
+TEST_F(NegativeMesh, ExtensionDisabledNV) {
     TEST_DESCRIPTION("Test VK_NV_mesh_shader VUs with NV_mesh_shader disabled.");
 
     AddRequiredExtensions(VK_NV_MESH_SHADER_EXTENSION_NAME);
@@ -858,7 +860,7 @@ TEST_F(VkLayerTest, MeshShaderDisabledNV) {
                                                            "VUID-VkPipelineShaderStageCreateInfo-stage-02092"}));
 }
 
-TEST_F(VkLayerTest, MeshShaderEXTDrawCmds) {
+TEST_F(NegativeMesh, DrawCmds) {
     TEST_DESCRIPTION("Test VK_EXT_mesh_shader draw commands.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -1028,7 +1030,7 @@ TEST_F(VkLayerTest, MeshShaderEXTDrawCmds) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, MeshShaderEXTMultiDrawIndirect) {
+TEST_F(NegativeMesh, MultiDrawIndirect) {
     TEST_DESCRIPTION("Test VK_EXT_mesh_shader indirect draw command.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -1175,7 +1177,7 @@ TEST_F(VkLayerTest, MeshShaderEXTMultiDrawIndirect) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, MeshShaderNVDrawCmds) {
+TEST_F(NegativeMesh, DrawCmdsNV) {
     TEST_DESCRIPTION("Test VK_NV_mesh_shader draw commands.");
 
     AddRequiredExtensions(VK_NV_MESH_SHADER_EXTENSION_NAME);

--- a/tests/negative/query.cpp
+++ b/tests/negative/query.cpp
@@ -16,9 +16,9 @@
 #include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 
-class VkLayerQueryTest : public VkLayerTest {};
+class NegativeQuery : public VkLayerTest {};
 
-TEST_F(VkLayerQueryTest, QueryPerformanceCreation) {
+TEST_F(NegativeQuery, QueryPerformanceCreation) {
     TEST_DESCRIPTION("Create performance query without support");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
@@ -106,7 +106,7 @@ TEST_F(VkLayerQueryTest, QueryPerformanceCreation) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerQueryTest, QueryPerformanceCounterCommandbufferScope) {
+TEST_F(NegativeQuery, QueryPerformanceCounterCommandbufferScope) {
     TEST_DESCRIPTION("Insert a performance query begin/end with respect to the command buffer counter scope");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -286,7 +286,7 @@ TEST_F(VkLayerQueryTest, QueryPerformanceCounterCommandbufferScope) {
     vkReleaseProfilingLockKHR(device());
 }
 
-TEST_F(VkLayerQueryTest, QueryPerformanceCounterRenderPassScope) {
+TEST_F(NegativeQuery, QueryPerformanceCounterRenderPassScope) {
     TEST_DESCRIPTION("Insert a performance query begin/end with respect to the render pass counter scope");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -402,7 +402,7 @@ TEST_F(VkLayerQueryTest, QueryPerformanceCounterRenderPassScope) {
     vkReleaseProfilingLockKHR(device());
 }
 
-TEST_F(VkLayerQueryTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
+TEST_F(NegativeQuery, QueryPerformanceReleaseProfileLockBeforeSubmit) {
     TEST_DESCRIPTION("Verify that we get an error if we release the profiling lock during the recording of performance queries");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -568,7 +568,7 @@ TEST_F(VkLayerQueryTest, QueryPerformanceReleaseProfileLockBeforeSubmit) {
     vkReleaseProfilingLockKHR(device());
 }
 
-TEST_F(VkLayerQueryTest, QueryPerformanceIncompletePasses) {
+TEST_F(NegativeQuery, QueryPerformanceIncompletePasses) {
     TEST_DESCRIPTION("Verify that we get an error if we don't submit a command buffer for each passes before getting the results.");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
@@ -815,7 +815,7 @@ TEST_F(VkLayerQueryTest, QueryPerformanceIncompletePasses) {
     vkReleaseProfilingLockKHR(device());
 }
 
-TEST_F(VkLayerQueryTest, QueryPerformanceResetAndBegin) {
+TEST_F(NegativeQuery, QueryPerformanceResetAndBegin) {
     TEST_DESCRIPTION("Verify that we get an error if we reset & begin a performance query within the same primary command buffer.");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
@@ -964,7 +964,7 @@ TEST_F(VkLayerQueryTest, QueryPerformanceResetAndBegin) {
     vkReleaseProfilingLockKHR(device());
 }
 
-TEST_F(VkLayerQueryTest, HostQueryResetNotEnabled) {
+TEST_F(NegativeQuery, HostQueryResetNotEnabled) {
     TEST_DESCRIPTION("Use vkResetQueryPoolEXT without enabling the feature");
 
     AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
@@ -985,7 +985,7 @@ TEST_F(VkLayerQueryTest, HostQueryResetNotEnabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, HostQueryResetBadFirstQuery) {
+TEST_F(NegativeQuery, HostQueryResetBadFirstQuery) {
     TEST_DESCRIPTION("Bad firstQuery in vkResetQueryPoolEXT");
 
     AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
@@ -1014,7 +1014,7 @@ TEST_F(VkLayerQueryTest, HostQueryResetBadFirstQuery) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, HostQueryResetBadRange) {
+TEST_F(NegativeQuery, HostQueryResetBadRange) {
     TEST_DESCRIPTION("Bad range in vkResetQueryPoolEXT");
 
     AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
@@ -1042,7 +1042,7 @@ TEST_F(VkLayerQueryTest, HostQueryResetBadRange) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, HostQueryResetInvalidQueryPool) {
+TEST_F(NegativeQuery, HostQueryResetInvalidQueryPool) {
     TEST_DESCRIPTION("Invalid queryPool in vkResetQueryPoolEXT");
 
     AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
@@ -1075,7 +1075,7 @@ TEST_F(VkLayerQueryTest, HostQueryResetInvalidQueryPool) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, HostQueryResetWrongDevice) {
+TEST_F(NegativeQuery, HostQueryResetWrongDevice) {
     TEST_DESCRIPTION("Device not matching queryPool in vkResetQueryPoolEXT");
 
     AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
@@ -1121,7 +1121,7 @@ TEST_F(VkLayerQueryTest, HostQueryResetWrongDevice) {
     vk::DestroyDevice(second_device, nullptr);
 }
 
-TEST_F(VkLayerQueryTest, InvalidCmdBufferQueryPoolDestroyed) {
+TEST_F(NegativeQuery, InvalidCmdBufferQueryPoolDestroyed) {
     TEST_DESCRIPTION("Attempt to draw with a command buffer that is invalid due to a query pool dependency being destroyed.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -1148,7 +1148,7 @@ TEST_F(VkLayerQueryTest, InvalidCmdBufferQueryPoolDestroyed) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, BeginQueryOnTimestampPool) {
+TEST_F(NegativeQuery, BeginQueryOnTimestampPool) {
     TEST_DESCRIPTION("Call CmdBeginQuery on a TIMESTAMP query pool.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1168,7 +1168,7 @@ TEST_F(VkLayerQueryTest, BeginQueryOnTimestampPool) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, InvalidQueryPoolCreate) {
+TEST_F(NegativeQuery, InvalidQueryPoolCreate) {
     TEST_DESCRIPTION("Attempt to create a query pool for PIPELINE_STATISTICS without enabling pipeline stats for the device.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1208,7 +1208,7 @@ TEST_F(VkLayerQueryTest, InvalidQueryPoolCreate) {
     vk::DestroyDevice(local_device, nullptr);
 }
 
-TEST_F(VkLayerQueryTest, InvalidQuerySizes) {
+TEST_F(NegativeQuery, InvalidQuerySizes) {
     TEST_DESCRIPTION("Invalid size of using queries commands.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1310,7 +1310,7 @@ TEST_F(VkLayerQueryTest, InvalidQuerySizes) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, QueryPreciseBit) {
+TEST_F(NegativeQuery, QueryPreciseBit) {
     TEST_DESCRIPTION("Check for correct Query Precise Bit circumstances.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -1406,7 +1406,7 @@ TEST_F(VkLayerQueryTest, QueryPreciseBit) {
     vk::DestroyCommandPool(test_device.handle(), command_pool, nullptr);
 }
 
-TEST_F(VkLayerQueryTest, QueryPoolPartialTimestamp) {
+TEST_F(NegativeQuery, QueryPoolPartialTimestamp) {
     TEST_DESCRIPTION("Request partial result on timestamp query.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1459,7 +1459,7 @@ TEST_F(VkLayerQueryTest, QueryPoolPartialTimestamp) {
     vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
 }
 
-TEST_F(VkLayerQueryTest, PerformanceQueryIntel) {
+TEST_F(NegativeQuery, PerformanceQueryIntel) {
     TEST_DESCRIPTION("Call CmdCopyQueryPoolResults for an Intel performance query.");
 
     AddRequiredExtensions(VK_INTEL_PERFORMANCE_QUERY_EXTENSION_NAME);
@@ -1487,7 +1487,7 @@ TEST_F(VkLayerQueryTest, PerformanceQueryIntel) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, QueryPoolInUseDestroyedSignaled) {
+TEST_F(NegativeQuery, QueryPoolInUseDestroyedSignaled) {
     TEST_DESCRIPTION("Delete in-use query pool.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1530,7 +1530,7 @@ TEST_F(VkLayerQueryTest, QueryPoolInUseDestroyedSignaled) {
     vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
 }
 
-TEST_F(VkLayerQueryTest, WriteTimeStampInvalidQuery) {
+TEST_F(NegativeQuery, WriteTimeStampInvalidQuery) {
     TEST_DESCRIPTION("Test for invalid query slot in query pool.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1571,7 +1571,7 @@ TEST_F(VkLayerQueryTest, WriteTimeStampInvalidQuery) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerQueryTest, InvalidCmdEndQueryIndexedEXTIndex) {
+TEST_F(NegativeQuery, InvalidCmdEndQueryIndexedEXTIndex) {
     TEST_DESCRIPTION("Test InvalidCmdEndQueryIndexedEXT with invalid index");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -1616,7 +1616,7 @@ TEST_F(VkLayerQueryTest, InvalidCmdEndQueryIndexedEXTIndex) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, InvalidCmdEndQueryIndexedEXTPrimitiveGenerated) {
+TEST_F(NegativeQuery, InvalidCmdEndQueryIndexedEXTPrimitiveGenerated) {
     TEST_DESCRIPTION("Test InvalidCmdEndQueryIndexedEXT with invalid index");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1684,7 +1684,7 @@ TEST_F(VkLayerQueryTest, InvalidCmdEndQueryIndexedEXTPrimitiveGenerated) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, BeginQueryTypeTransformFeedbackStream) {
+TEST_F(NegativeQuery, BeginQueryTypeTransformFeedbackStream) {
     TEST_DESCRIPTION(
         "Call CmdBeginQuery with query type transform feedback stream when transformFeedbackQueries is not supported.");
 
@@ -1718,7 +1718,7 @@ TEST_F(VkLayerQueryTest, BeginQueryTypeTransformFeedbackStream) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerQueryTest, GetQueryPoolResultsFlags) {
+TEST_F(NegativeQuery, GetQueryPoolResultsFlags) {
     TEST_DESCRIPTION("Test GetQueryPoolResults with invalid pData and stride");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
@@ -1747,7 +1747,7 @@ TEST_F(VkLayerQueryTest, GetQueryPoolResultsFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, QueryPoolResultStatusOnly) {
+TEST_F(NegativeQuery, QueryPoolResultStatusOnly) {
     TEST_DESCRIPTION("Request result status only query result.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1776,7 +1776,7 @@ TEST_F(VkLayerQueryTest, QueryPoolResultStatusOnly) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, DestroyActiveQueryPool) {
+TEST_F(NegativeQuery, DestroyActiveQueryPool) {
     TEST_DESCRIPTION("Destroy query pool after GetQueryPoolResults() without VK_QUERY_RESULT_PARTIAL_BIT returns VK_SUCCESS");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1826,7 +1826,7 @@ TEST_F(VkLayerQueryTest, DestroyActiveQueryPool) {
     vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
 }
 
-TEST_F(VkLayerQueryTest, BeginQueryWithMultiview) {
+TEST_F(NegativeQuery, BeginQueryWithMultiview) {
     TEST_DESCRIPTION("Test CmdBeginQuery in subpass with multiview");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1938,7 +1938,7 @@ TEST_F(VkLayerQueryTest, BeginQueryWithMultiview) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerQueryTest, PipelineStatisticsQuery) {
+TEST_F(NegativeQuery, PipelineStatisticsQuery) {
     TEST_DESCRIPTION("Test unsupported pipeline statistics queries");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1994,7 +1994,7 @@ TEST_F(VkLayerQueryTest, PipelineStatisticsQuery) {
     }
 }
 
-TEST_F(VkLayerQueryTest, TestGetQueryPoolResultsDataAndStride) {
+TEST_F(NegativeQuery, TestGetQueryPoolResultsDataAndStride) {
     TEST_DESCRIPTION("Test pData and stride multiple in GetQueryPoolResults");
 
     AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
@@ -2017,7 +2017,7 @@ TEST_F(VkLayerQueryTest, TestGetQueryPoolResultsDataAndStride) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, PrimitivesGeneratedQuery) {
+TEST_F(NegativeQuery, PrimitivesGeneratedQuery) {
     TEST_DESCRIPTION("Test unsupported primitives generated queries");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2089,7 +2089,7 @@ TEST_F(VkLayerQueryTest, PrimitivesGeneratedQuery) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, PrimitivesGeneratedQueryFeature) {
+TEST_F(NegativeQuery, PrimitivesGeneratedQueryFeature) {
     TEST_DESCRIPTION("Test missing primitives generated query feature");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -2119,7 +2119,7 @@ TEST_F(VkLayerQueryTest, PrimitivesGeneratedQueryFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, PrimitivesGeneratedQueryAndDiscardEnabled) {
+TEST_F(NegativeQuery, PrimitivesGeneratedQueryAndDiscardEnabled) {
     TEST_DESCRIPTION("Test missing primitivesGeneratedQueryWithRasterizerDiscard feature.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2175,7 +2175,7 @@ TEST_F(VkLayerQueryTest, PrimitivesGeneratedQueryAndDiscardEnabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, PrimitivesGeneratedQueryStreams) {
+TEST_F(NegativeQuery, PrimitivesGeneratedQueryStreams) {
     TEST_DESCRIPTION("Test missing primitivesGeneratedQueryWithNonZeroStreams feature.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2243,7 +2243,7 @@ TEST_F(VkLayerQueryTest, PrimitivesGeneratedQueryStreams) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerQueryTest, CommandBufferMissingOcclusionQueryEnabled) {
+TEST_F(NegativeQuery, CommandBufferMissingOcclusionQueryEnabled) {
     TEST_DESCRIPTION(
         "Test executing secondary command buffer without VkCommandBufferInheritanceInfo::occlusionQueryEnable enabled while "
         "occlusion query is active.");

--- a/tests/negative/robustness.cpp
+++ b/tests/negative/robustness.cpp
@@ -13,7 +13,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, PipelineRobustnessDisabled) {
+class NegativeRobustness : public VkLayerTest {};
+
+TEST_F(NegativeRobustness, PipelineRobustnessDisabled) {
     TEST_DESCRIPTION("Create a pipeline using VK_EXT_pipeline_robustness but with pipelineRobustness == VK_FALSE");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -74,7 +76,7 @@ TEST_F(VkLayerTest, PipelineRobustnessDisabled) {
 
 // Need to fix check to check if feature is exposed
 // TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5657
-TEST_F(VkLayerTest, DISABLED_PipelineRobustnessRobustBufferAccess2Unsupported) {
+TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustBufferAccess2Unsupported) {
     TEST_DESCRIPTION("Create a pipeline using VK_EXT_pipeline_robustness with robustBufferAccess2 being unsupported");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -144,7 +146,7 @@ TEST_F(VkLayerTest, DISABLED_PipelineRobustnessRobustBufferAccess2Unsupported) {
 
 // Need to fix check to check if feature is exposed
 // TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5657
-TEST_F(VkLayerTest, DISABLED_PipelineRobustnessRobustImageAccess2Unsupported) {
+TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustImageAccess2Unsupported) {
     TEST_DESCRIPTION("Create a pipeline using VK_EXT_pipeline_robustness with robustImageAccess2 being unsupported");
 
     AddRequiredExtensions(VK_EXT_PIPELINE_ROBUSTNESS_EXTENSION_NAME);
@@ -192,7 +194,7 @@ TEST_F(VkLayerTest, DISABLED_PipelineRobustnessRobustImageAccess2Unsupported) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, PipelineRobustnessRobustImageAccessNotExposed) {
+TEST_F(NegativeRobustness, PipelineRobustnessRobustImageAccessNotExposed) {
     TEST_DESCRIPTION("Check if VK_EXT_image_robustness is not exposed");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/negative/subgroups.cpp
+++ b/tests/negative/subgroups.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, SubgroupSupportedProperties) {
+class NegativeSubgroup : public VkLayerTest {};
+
+TEST_F(NegativeSubgroup, Properties) {
     TEST_DESCRIPTION(
         "Test shader validation support for subgroup VkPhysicalDeviceSubgroupProperties such as supportedStages, and "
         "supportedOperations, quadOperationsInAllStages.");
@@ -268,7 +270,7 @@ TEST_F(VkLayerTest, SubgroupSupportedProperties) {
     }
 }
 
-TEST_F(VkLayerTest, SubgroupRequired) {
+TEST_F(NegativeSubgroup, Features) {
     TEST_DESCRIPTION("Test that the minimum required functionality for subgroups is present.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -309,7 +311,7 @@ TEST_F(VkLayerTest, SubgroupRequired) {
     ASSERT_TRUE(subgroup_prop.supportedOperations & VK_SUBGROUP_FEATURE_BASIC_BIT);
 }
 
-TEST_F(VkLayerTest, SubgroupExtendedTypesEnabled) {
+TEST_F(NegativeSubgroup, ExtendedTypesEnabled) {
     TEST_DESCRIPTION("Test VK_KHR_shader_subgroup_extended_types.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -358,7 +360,7 @@ TEST_F(VkLayerTest, SubgroupExtendedTypesEnabled) {
     pipe.CreateComputePipeline();
 }
 
-TEST_F(VkLayerTest, SubgroupExtendedTypesDisabled) {
+TEST_F(NegativeSubgroup, ExtendedTypesDisabled) {
     TEST_DESCRIPTION("Test VK_KHR_shader_subgroup_extended_types.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -411,7 +413,7 @@ TEST_F(VkLayerTest, SubgroupExtendedTypesDisabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, PipelineSubgroupSizeControl) {
+TEST_F(NegativeSubgroup, PipelineSubgroupSizeControl) {
     TEST_DESCRIPTION("Test Subgroub Size Control");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -544,7 +546,7 @@ TEST_F(VkLayerTest, PipelineSubgroupSizeControl) {
     }
 }
 
-TEST_F(VkLayerTest, SubgroupSizeControlFeaturesNotEnabled) {
+TEST_F(NegativeSubgroup, SubgroupSizeControlFeaturesNotEnabled) {
     TEST_DESCRIPTION("Use subgroup size control features when they are not enabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -599,7 +601,7 @@ TEST_F(VkLayerTest, SubgroupSizeControlFeaturesNotEnabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestSubgroupUniformControlFlow) {
+TEST_F(NegativeSubgroup, SubgroupUniformControlFlow) {
     TEST_DESCRIPTION("Test SubgroupUniformControlFlow spirv execution mode");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -656,7 +658,7 @@ TEST_F(VkLayerTest, TestSubgroupUniformControlFlow) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ComputeLocalWorkgroupSize) {
+TEST_F(NegativeSubgroup, ComputeLocalWorkgroupSize) {
     TEST_DESCRIPTION("Test size of local workgroud with requiredSubgroupSize.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -746,7 +748,7 @@ TEST_F(VkLayerTest, ComputeLocalWorkgroupSize) {
     }
 }
 
-TEST_F(VkLayerTest, MissingSubgroupSizeControlFeature) {
+TEST_F(NegativeSubgroup, SubgroupSizeControlFeature) {
     TEST_DESCRIPTION("Test using subgroupSizeControl feature when it's not enabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -774,7 +776,7 @@ TEST_F(VkLayerTest, MissingSubgroupSizeControlFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CooperativeMatrixNV) {
+TEST_F(NegativeSubgroup, CooperativeMatrixNV) {
     TEST_DESCRIPTION("Test VK_NV_cooperative_matrix.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);

--- a/tests/negative/viewport_inheritance.cpp
+++ b/tests/negative/viewport_inheritance.cpp
@@ -16,6 +16,8 @@
 
 #include "../framework/layer_validation_tests.h"
 
+class NegativeViewportInheritance : public VkLayerTest {};
+
 // Common data structures needed for tests.
 class ViewportInheritanceTestData {
     // Borrowed owner device.
@@ -400,7 +402,7 @@ class ViewportInheritanceTestData {
     }
 };
 
-TEST_F(VkLayerTest, ViewportInheritance) {
+TEST_F(NegativeViewportInheritance, BasicUsage) {
     TEST_DESCRIPTION("Simple correct and incorrect usage of VK_NV_inherited_viewport_scissor");
     m_instance_extension_names.push_back("VK_KHR_get_physical_device_properties2");
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -636,7 +638,7 @@ TEST_F(VkLayerTest, ViewportInheritance) {
     }
 }
 
-TEST_F(VkLayerTest, ViewportInheritanceMissingFeature) {
+TEST_F(NegativeViewportInheritance, MissingFeature) {
     TEST_DESCRIPTION("Error using VK_NV_inherited_viewport_scissor without enabling feature.");
     m_instance_extension_names.push_back("VK_KHR_get_physical_device_properties2");
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -663,7 +665,7 @@ TEST_F(VkLayerTest, ViewportInheritanceMissingFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ViewportInheritanceMultiViewport) {
+TEST_F(NegativeViewportInheritance, MultiViewport) {
     TEST_DESCRIPTION("VK_NV_inherited_viewport_scissor tests with multiple viewports/scissors");
     m_instance_extension_names.push_back("VK_KHR_get_physical_device_properties2");
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -893,7 +895,7 @@ TEST_F(VkLayerTest, ViewportInheritanceMultiViewport) {
     }
 }
 
-TEST_F(VkLayerTest, ViewportInheritanceScissorMissingFeature) {
+TEST_F(NegativeViewportInheritance, ScissorMissingFeature) {
     TEST_DESCRIPTION("Error using VK_NV_inherited_viewport_scissor without enabling multiViewport feature.");
     m_instance_extension_names.push_back("VK_KHR_get_physical_device_properties2");
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -918,7 +920,7 @@ TEST_F(VkLayerTest, ViewportInheritanceScissorMissingFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, PipelineMissingDynamicStateDiscardRectangle) {
+TEST_F(NegativeViewportInheritance, PipelineMissingDynamicStateDiscardRectangle) {
     TEST_DESCRIPTION("Bind pipeline with missing dynamic state discard rectangle.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -992,7 +994,6 @@ TEST_F(VkLayerTest, PipelineMissingDynamicStateDiscardRectangle) {
     vk::CmdBindPipeline(secondary.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     m_errorMonitor->VerifyFound();
 }
-
 
 // SPIR-V blobs for graphics pipeline.
 

--- a/tests/positive/atomics.cpp
+++ b/tests/positive/atomics.cpp
@@ -14,7 +14,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_extension_helper.h"
 
-TEST_F(VkPositiveLayerTest, ShaderImageAtomicInt64) {
+class PositiveAtomic : public VkPositiveLayerTest {};
+
+TEST_F(PositiveAtomic, ImageInt64) {
     TEST_DESCRIPTION("Test VK_EXT_shader_image_atomic_int64.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -91,7 +93,7 @@ TEST_F(VkPositiveLayerTest, ShaderImageAtomicInt64) {
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 }
 
-TEST_F(VkPositiveLayerTest, ShaderImageAtomicInt64DrawtimeSparse) {
+TEST_F(PositiveAtomic, ImageInt64DrawtimeSparse) {
     TEST_DESCRIPTION("Test VK_EXT_shader_image_atomic_int64 at draw time with Sparse image.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -170,7 +172,7 @@ TEST_F(VkPositiveLayerTest, ShaderImageAtomicInt64DrawtimeSparse) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkPositiveLayerTest, ShaderAtomicFloat) {
+TEST_F(PositiveAtomic, Float) {
     TEST_DESCRIPTION("Test VK_EXT_shader_atomic_float.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -425,7 +427,7 @@ TEST_F(VkPositiveLayerTest, ShaderAtomicFloat) {
     }
 }
 
-TEST_F(VkPositiveLayerTest, ShaderAtomicFloat2) {
+TEST_F(PositiveAtomic, Float2) {
     TEST_DESCRIPTION("Test VK_EXT_shader_atomic_float2.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -709,7 +711,7 @@ TEST_F(VkPositiveLayerTest, ShaderAtomicFloat2) {
     }
 }
 
-TEST_F(VkPositiveLayerTest, ShaderAtomicFromPhysicalPointer) {
+TEST_F(PositiveAtomic, PhysicalPointer) {
     TEST_DESCRIPTION("Make sure atomic validation handles if from a OpConvertUToPtr (physical pointer)");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -786,7 +788,7 @@ TEST_F(VkPositiveLayerTest, ShaderAtomicFromPhysicalPointer) {
     VkShaderObj cs(this, spv_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 }
 
-TEST_F(VkPositiveLayerTest, ShaderAtomicInt64) {
+TEST_F(PositiveAtomic, Int64) {
     TEST_DESCRIPTION("Test VK_KHR_shader_atomic_int64.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 

--- a/tests/positive/format_utils.cpp
+++ b/tests/positive/format_utils.cpp
@@ -12,9 +12,11 @@
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_format_utils.h"
 
+class PositiveFormatUtils : public VkPositiveLayerTest {};
+
 // These test check utils in the layer without needing to create a full Vulkan instance
 
-TEST_F(VkPositiveLayerTest, FormatsSameComponentBits) {
+TEST_F(PositiveFormatUtils, FormatsSameComponentBits) {
     ASSERT_TRUE(FormatsSameComponentBits(VK_FORMAT_G8_B8R8_2PLANE_422_UNORM, VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM));
     ASSERT_TRUE(FormatsSameComponentBits(VK_FORMAT_ASTC_10x10_UNORM_BLOCK, VK_FORMAT_ASTC_12x10_SRGB_BLOCK));
     // Order doesn't matter
@@ -34,4 +36,3 @@ TEST_F(VkPositiveLayerTest, FormatsSameComponentBits) {
     // UNDEFINED is always bad
     ASSERT_FALSE(FormatsSameComponentBits(VK_FORMAT_UNDEFINED, VK_FORMAT_B8G8R8_UINT));
 }
-

--- a/tests/positive/fragment_shading_rate.cpp
+++ b/tests/positive/fragment_shading_rate.cpp
@@ -11,7 +11,9 @@
 
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkPositiveLayerTest, FragmentShadingRateStageInVariousAPIs) {
+class PositiveFragmentShadingRate : public VkPositiveLayerTest {};
+
+TEST_F(PositiveFragmentShadingRate, StageInVariousAPIs) {
     TEST_DESCRIPTION("Specify shading rate pipeline stage with attachmentFragmentShadingRate feature enabled");
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -47,7 +49,7 @@ TEST_F(VkPositiveLayerTest, FragmentShadingRateStageInVariousAPIs) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkPositiveLayerTest, FragmentShadingRateStageWithPipelineBarrier) {
+TEST_F(PositiveFragmentShadingRate, StageWithPipelineBarrier) {
     TEST_DESCRIPTION("Test pipeline barrier with VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR stage");
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/positive/layer_utils.cpp
+++ b/tests/positive/layer_utils.cpp
@@ -14,9 +14,11 @@
 #include "generated/vk_extension_helper.h"
 #include "utils/vk_layer_utils.h"
 
+class PositiveLayerUtils : public VkPositiveLayerTest {};
+
 // These test check utils in the layer without needing to create a full Vulkan instance
 
-TEST_F(VkPositiveLayerTest, GetEffectiveExtent) {
+TEST_F(PositiveLayerUtils, GetEffectiveExtent) {
     TEST_DESCRIPTION("Test unlikely GetEffectiveExtent edge cases");
 
     auto ci = LvlInitStruct<VkImageCreateInfo>();
@@ -88,7 +90,7 @@ TEST_F(VkPositiveLayerTest, GetEffectiveExtent) {
     }
 }
 
-TEST_F(VkPositiveLayerTest, IsOnlyOneValidPlaneAspect) {
+TEST_F(PositiveLayerUtils, IsOnlyOneValidPlaneAspect) {
     const VkFormat two_plane_format = VK_FORMAT_G8_B8R8_2PLANE_422_UNORM;
     ASSERT_FALSE(IsOnlyOneValidPlaneAspect(two_plane_format, 0));
     ASSERT_FALSE(IsOnlyOneValidPlaneAspect(two_plane_format, VK_IMAGE_ASPECT_COLOR_BIT));
@@ -98,7 +100,7 @@ TEST_F(VkPositiveLayerTest, IsOnlyOneValidPlaneAspect) {
     ASSERT_FALSE(IsOnlyOneValidPlaneAspect(two_plane_format, VK_IMAGE_ASPECT_PLANE_2_BIT));
 }
 
-TEST_F(VkPositiveLayerTest, IsValidPlaneAspect) {
+TEST_F(PositiveLayerUtils, IsValidPlaneAspect) {
     const VkFormat two_plane_format = VK_FORMAT_G8_B8R8_2PLANE_422_UNORM;
     ASSERT_FALSE(IsValidPlaneAspect(two_plane_format, 0));
     ASSERT_FALSE(IsValidPlaneAspect(two_plane_format, VK_IMAGE_ASPECT_COLOR_BIT));
@@ -108,7 +110,7 @@ TEST_F(VkPositiveLayerTest, IsValidPlaneAspect) {
     ASSERT_FALSE(IsValidPlaneAspect(two_plane_format, VK_IMAGE_ASPECT_PLANE_2_BIT));
 }
 
-TEST_F(VkPositiveLayerTest, IsMultiplePlaneAspect) {
+TEST_F(PositiveLayerUtils, IsMultiplePlaneAspect) {
     ASSERT_FALSE(IsMultiplePlaneAspect(0));
     ASSERT_FALSE(IsMultiplePlaneAspect(VK_IMAGE_ASPECT_COLOR_BIT));
     ASSERT_FALSE(IsMultiplePlaneAspect(VK_IMAGE_ASPECT_PLANE_0_BIT));

--- a/tests/positive/mesh.cpp
+++ b/tests/positive/mesh.cpp
@@ -14,7 +14,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_extension_helper.h"
 
-TEST_F(VkPositiveLayerTest, MeshShaderEXT) {
+class PositiveMesh : public VkPositiveLayerTest {};
+
+TEST_F(PositiveMesh, BasicUsage) {
     TEST_DESCRIPTION("Test basic VK_EXT_mesh_shader.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
@@ -66,7 +68,7 @@ TEST_F(VkPositiveLayerTest, MeshShaderEXT) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkPositiveLayerTest, MeshShaderOnly) {
+TEST_F(PositiveMesh, MeshShaderOnly) {
     TEST_DESCRIPTION("Test using a mesh shader without a vertex shader.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -121,7 +123,7 @@ TEST_F(VkPositiveLayerTest, MeshShaderOnly) {
     helper.CreateGraphicsPipeline();
 }
 
-TEST_F(VkPositiveLayerTest, MeshShaderPointSize) {
+TEST_F(PositiveMesh, PointSize) {
     TEST_DESCRIPTION("Test writing point size in a mesh shader.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -173,7 +175,7 @@ TEST_F(VkPositiveLayerTest, MeshShaderPointSize) {
     helper.CreateGraphicsPipeline();
 }
 
-TEST_F(VkPositiveLayerTest, TaskAndMeshShader) {
+TEST_F(PositiveMesh, TaskAndMeshShader) {
     TEST_DESCRIPTION("Test task and mesh shader");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -267,7 +269,7 @@ TEST_F(VkPositiveLayerTest, TaskAndMeshShader) {
     CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit);
 }
 
-TEST_F(VkPositiveLayerTest, MeshPerTaskNV) {
+TEST_F(PositiveMesh, MeshPerTaskNV) {
     TEST_DESCRIPTION("Make sure PerTaskNV in handled");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_NV_MESH_SHADER_EXTENSION_NAME);

--- a/tests/positive/tooling.cpp
+++ b/tests/positive/tooling.cpp
@@ -17,12 +17,14 @@
 #include <algorithm>
 #include <chrono>
 
+class PositiveTooling : public VkPositiveLayerTest {};
+
 //
 // POSITIVE VALIDATION TESTS
 //
 // These tests do not expect to encounter ANY validation errors pass only if this is true
 
-TEST_F(VkPositiveLayerTest, ToolingExtension) {
+TEST_F(PositiveTooling, BasicUsage) {
     TEST_DESCRIPTION("Call Tooling Extension and verify layer results");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));


### PR DESCRIPTION
This is the first step to give better naming for tests, this is easy since it can just match the file name

These tests didn't have any exception with CI, so changing them should be no issue and a good "do we like this convention" test