### PR TITLE
layers: Add XML workaround for param validation

### DIFF
--- a/layers/generated/parameter_validation.cpp
+++ b/layers/generated/parameter_validation.cpp
@@ -12228,7 +12228,8 @@ bool StatelessValidation::PreCallValidateGetMemoryFdKHR(
     const VkMemoryGetFdInfoKHR*                 pGetFdInfo,
     int*                                        pFd) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_external_memory_fd) && (IsExtEnabled(device_extensions.vk_khr_external_memory) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkGetMemoryFdKHR", "VK_KHR_external_memory_fd && (VK_KHR_external_memory || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_memory)) skip |= OutputExtensionError("vkGetMemoryFdKHR", "VK_KHR_external_memory");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_memory_fd)) skip |= OutputExtensionError("vkGetMemoryFdKHR", "VK_KHR_external_memory_fd");
     skip |= ValidateStructType("vkGetMemoryFdKHR", "pGetFdInfo", "VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR", pGetFdInfo, VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR, true, "VUID-vkGetMemoryFdKHR-pGetFdInfo-parameter", "VUID-VkMemoryGetFdInfoKHR-sType-sType");
     if (pGetFdInfo != nullptr)
     {
@@ -12249,7 +12250,8 @@ bool StatelessValidation::PreCallValidateGetMemoryFdPropertiesKHR(
     int                                         fd,
     VkMemoryFdPropertiesKHR*                    pMemoryFdProperties) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_external_memory_fd) && (IsExtEnabled(device_extensions.vk_khr_external_memory) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkGetMemoryFdPropertiesKHR", "VK_KHR_external_memory_fd && (VK_KHR_external_memory || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_memory)) skip |= OutputExtensionError("vkGetMemoryFdPropertiesKHR", "VK_KHR_external_memory");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_memory_fd)) skip |= OutputExtensionError("vkGetMemoryFdPropertiesKHR", "VK_KHR_external_memory_fd");
     skip |= ValidateFlags("vkGetMemoryFdPropertiesKHR", "handleType", "VkExternalMemoryHandleTypeFlagBits", AllVkExternalMemoryHandleTypeFlagBits, handleType, kRequiredSingleBit, "VUID-vkGetMemoryFdPropertiesKHR-handleType-parameter", "VUID-vkGetMemoryFdPropertiesKHR-handleType-parameter");
     skip |= ValidateStructType("vkGetMemoryFdPropertiesKHR", "pMemoryFdProperties", "VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR", pMemoryFdProperties, VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR, true, "VUID-vkGetMemoryFdPropertiesKHR-pMemoryFdProperties-parameter", "VUID-VkMemoryFdPropertiesKHR-sType-sType");
     if (pMemoryFdProperties != nullptr)
@@ -12341,7 +12343,8 @@ bool StatelessValidation::PreCallValidateImportSemaphoreFdKHR(
     VkDevice                                    device,
     const VkImportSemaphoreFdInfoKHR*           pImportSemaphoreFdInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_external_semaphore_fd) && (IsExtEnabled(device_extensions.vk_khr_external_semaphore) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkImportSemaphoreFdKHR", "VK_KHR_external_semaphore_fd && (VK_KHR_external_semaphore || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_semaphore)) skip |= OutputExtensionError("vkImportSemaphoreFdKHR", "VK_KHR_external_semaphore");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_semaphore_fd)) skip |= OutputExtensionError("vkImportSemaphoreFdKHR", "VK_KHR_external_semaphore_fd");
     skip |= ValidateStructType("vkImportSemaphoreFdKHR", "pImportSemaphoreFdInfo", "VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR", pImportSemaphoreFdInfo, VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR, true, "VUID-vkImportSemaphoreFdKHR-pImportSemaphoreFdInfo-parameter", "VUID-VkImportSemaphoreFdInfoKHR-sType-sType");
     if (pImportSemaphoreFdInfo != nullptr)
     {
@@ -12362,7 +12365,8 @@ bool StatelessValidation::PreCallValidateGetSemaphoreFdKHR(
     const VkSemaphoreGetFdInfoKHR*              pGetFdInfo,
     int*                                        pFd) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_external_semaphore_fd) && (IsExtEnabled(device_extensions.vk_khr_external_semaphore) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkGetSemaphoreFdKHR", "VK_KHR_external_semaphore_fd && (VK_KHR_external_semaphore || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_semaphore)) skip |= OutputExtensionError("vkGetSemaphoreFdKHR", "VK_KHR_external_semaphore");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_semaphore_fd)) skip |= OutputExtensionError("vkGetSemaphoreFdKHR", "VK_KHR_external_semaphore_fd");
     skip |= ValidateStructType("vkGetSemaphoreFdKHR", "pGetFdInfo", "VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR", pGetFdInfo, VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR, true, "VUID-vkGetSemaphoreFdKHR-pGetFdInfo-parameter", "VUID-VkSemaphoreGetFdInfoKHR-sType-sType");
     if (pGetFdInfo != nullptr)
     {
@@ -12789,7 +12793,6 @@ bool StatelessValidation::PreCallValidateGetSwapchainStatusKHR(
     VkDevice                                    device,
     VkSwapchainKHR                              swapchain) const {
     bool skip = false;
-    if (!instance_extensions.vk_feature_version_1_1) skip |= OutputExtensionError("vkGetSwapchainStatusKHR", "VK_VERSION_1_1");
     if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkGetSwapchainStatusKHR", "VK_KHR_get_physical_device_properties2");
     if (!IsExtEnabled(device_extensions.vk_khr_get_surface_capabilities2)) skip |= OutputExtensionError("vkGetSwapchainStatusKHR", "VK_KHR_get_surface_capabilities2");
     if (!IsExtEnabled(device_extensions.vk_khr_swapchain)) skip |= OutputExtensionError("vkGetSwapchainStatusKHR", "VK_KHR_swapchain");
@@ -12874,7 +12877,8 @@ bool StatelessValidation::PreCallValidateImportFenceFdKHR(
     VkDevice                                    device,
     const VkImportFenceFdInfoKHR*               pImportFenceFdInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_external_fence_fd) && (IsExtEnabled(device_extensions.vk_khr_external_fence) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkImportFenceFdKHR", "VK_KHR_external_fence_fd && (VK_KHR_external_fence || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_fence)) skip |= OutputExtensionError("vkImportFenceFdKHR", "VK_KHR_external_fence");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_fence_fd)) skip |= OutputExtensionError("vkImportFenceFdKHR", "VK_KHR_external_fence_fd");
     skip |= ValidateStructType("vkImportFenceFdKHR", "pImportFenceFdInfo", "VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR", pImportFenceFdInfo, VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR, true, "VUID-vkImportFenceFdKHR-pImportFenceFdInfo-parameter", "VUID-VkImportFenceFdInfoKHR-sType-sType");
     if (pImportFenceFdInfo != nullptr)
     {
@@ -12895,7 +12899,8 @@ bool StatelessValidation::PreCallValidateGetFenceFdKHR(
     const VkFenceGetFdInfoKHR*                  pGetFdInfo,
     int*                                        pFd) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_external_fence_fd) && (IsExtEnabled(device_extensions.vk_khr_external_fence) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkGetFenceFdKHR", "VK_KHR_external_fence_fd && (VK_KHR_external_fence || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_fence)) skip |= OutputExtensionError("vkGetFenceFdKHR", "VK_KHR_external_fence");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_fence_fd)) skip |= OutputExtensionError("vkGetFenceFdKHR", "VK_KHR_external_fence_fd");
     skip |= ValidateStructType("vkGetFenceFdKHR", "pGetFdInfo", "VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR", pGetFdInfo, VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR, true, "VUID-vkGetFenceFdKHR-pGetFdInfo-parameter", "VUID-VkFenceGetFdInfoKHR-sType-sType");
     if (pGetFdInfo != nullptr)
     {
@@ -12958,7 +12963,8 @@ bool StatelessValidation::PreCallValidateAcquireProfilingLockKHR(
     VkDevice                                    device,
     const VkAcquireProfilingLockInfoKHR*        pInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_performance_query) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkAcquireProfilingLockKHR", "VK_KHR_performance_query && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkAcquireProfilingLockKHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_performance_query)) skip |= OutputExtensionError("vkAcquireProfilingLockKHR", "VK_KHR_performance_query");
     skip |= ValidateStructType("vkAcquireProfilingLockKHR", "pInfo", "VK_STRUCTURE_TYPE_ACQUIRE_PROFILING_LOCK_INFO_KHR", pInfo, VK_STRUCTURE_TYPE_ACQUIRE_PROFILING_LOCK_INFO_KHR, true, "VUID-vkAcquireProfilingLockKHR-pInfo-parameter", "VUID-VkAcquireProfilingLockInfoKHR-sType-sType");
     if (pInfo != nullptr)
     {
@@ -12972,7 +12978,8 @@ bool StatelessValidation::PreCallValidateAcquireProfilingLockKHR(
 bool StatelessValidation::PreCallValidateReleaseProfilingLockKHR(
     VkDevice                                    device) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_performance_query) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkReleaseProfilingLockKHR", "VK_KHR_performance_query && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkReleaseProfilingLockKHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_performance_query)) skip |= OutputExtensionError("vkReleaseProfilingLockKHR", "VK_KHR_performance_query");
     // No xml-driven validation
     return skip;
 }
@@ -13520,9 +13527,7 @@ bool StatelessValidation::PreCallValidateCmdSetFragmentShadingRateKHR(
     const VkExtent2D*                           pFragmentSize,
     const VkFragmentShadingRateCombinerOpKHR    combinerOps[2]) const {
     bool skip = false;
-    if (!instance_extensions.vk_feature_version_1_1) skip |= OutputExtensionError("vkCmdSetFragmentShadingRateKHR", "VK_VERSION_1_1");
     if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetFragmentShadingRateKHR", "VK_KHR_get_physical_device_properties2");
-    if (!instance_extensions.vk_feature_version_1_2) skip |= OutputExtensionError("vkCmdSetFragmentShadingRateKHR", "VK_VERSION_1_2");
     if (!IsExtEnabled(device_extensions.vk_khr_create_renderpass2)) skip |= OutputExtensionError("vkCmdSetFragmentShadingRateKHR", "VK_KHR_create_renderpass2");
     if (!IsExtEnabled(device_extensions.vk_khr_fragment_shading_rate)) skip |= OutputExtensionError("vkCmdSetFragmentShadingRateKHR", "VK_KHR_fragment_shading_rate");
     skip |= ValidateRequiredPointer("vkCmdSetFragmentShadingRateKHR", "pFragmentSize", pFragmentSize, "VUID-vkCmdSetFragmentShadingRateKHR-pFragmentSize-parameter");
@@ -13563,7 +13568,9 @@ bool StatelessValidation::PreCallValidateGetBufferDeviceAddressKHR(
     VkDevice                                    device,
     const VkBufferDeviceAddressInfo*            pInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_buffer_device_address) && ((IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) && IsExtEnabled(device_extensions.vk_khr_device_group)) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkGetBufferDeviceAddressKHR", "VK_KHR_buffer_device_address && ((VK_KHR_get_physical_device_properties2 && VK_KHR_device_group) || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_device_group)) skip |= OutputExtensionError("vkGetBufferDeviceAddressKHR", "VK_KHR_device_group");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkGetBufferDeviceAddressKHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_buffer_device_address)) skip |= OutputExtensionError("vkGetBufferDeviceAddressKHR", "VK_KHR_buffer_device_address");
     skip |= ValidateStructType("vkGetBufferDeviceAddressKHR", "pInfo", "VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO", pInfo, VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, true, "VUID-vkGetBufferDeviceAddress-pInfo-parameter", "VUID-VkBufferDeviceAddressInfo-sType-sType");
     if (pInfo != nullptr)
     {
@@ -13578,7 +13585,9 @@ bool StatelessValidation::PreCallValidateGetBufferOpaqueCaptureAddressKHR(
     VkDevice                                    device,
     const VkBufferDeviceAddressInfo*            pInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_buffer_device_address) && ((IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) && IsExtEnabled(device_extensions.vk_khr_device_group)) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkGetBufferOpaqueCaptureAddressKHR", "VK_KHR_buffer_device_address && ((VK_KHR_get_physical_device_properties2 && VK_KHR_device_group) || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_device_group)) skip |= OutputExtensionError("vkGetBufferOpaqueCaptureAddressKHR", "VK_KHR_device_group");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkGetBufferOpaqueCaptureAddressKHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_buffer_device_address)) skip |= OutputExtensionError("vkGetBufferOpaqueCaptureAddressKHR", "VK_KHR_buffer_device_address");
     skip |= ValidateStructType("vkGetBufferOpaqueCaptureAddressKHR", "pInfo", "VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO", pInfo, VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, true, "VUID-vkGetBufferOpaqueCaptureAddress-pInfo-parameter", "VUID-VkBufferDeviceAddressInfo-sType-sType");
     if (pInfo != nullptr)
     {
@@ -13593,7 +13602,9 @@ bool StatelessValidation::PreCallValidateGetDeviceMemoryOpaqueCaptureAddressKHR(
     VkDevice                                    device,
     const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_buffer_device_address) && ((IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) && IsExtEnabled(device_extensions.vk_khr_device_group)) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkGetDeviceMemoryOpaqueCaptureAddressKHR", "VK_KHR_buffer_device_address && ((VK_KHR_get_physical_device_properties2 && VK_KHR_device_group) || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_device_group)) skip |= OutputExtensionError("vkGetDeviceMemoryOpaqueCaptureAddressKHR", "VK_KHR_device_group");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkGetDeviceMemoryOpaqueCaptureAddressKHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_buffer_device_address)) skip |= OutputExtensionError("vkGetDeviceMemoryOpaqueCaptureAddressKHR", "VK_KHR_buffer_device_address");
     skip |= ValidateStructType("vkGetDeviceMemoryOpaqueCaptureAddressKHR", "pInfo", "VK_STRUCTURE_TYPE_DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO", pInfo, VK_STRUCTURE_TYPE_DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO, true, "VUID-vkGetDeviceMemoryOpaqueCaptureAddress-pInfo-parameter", "VUID-VkDeviceMemoryOpaqueCaptureAddressInfo-sType-sType");
     if (pInfo != nullptr)
     {
@@ -13906,7 +13917,8 @@ bool StatelessValidation::PreCallValidateCmdSetEvent2KHR(
     VkEvent                                     event,
     const VkDependencyInfo*                     pDependencyInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_synchronization2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetEvent2KHR", "VK_KHR_synchronization2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetEvent2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_synchronization2)) skip |= OutputExtensionError("vkCmdSetEvent2KHR", "VK_KHR_synchronization2");
     skip |= ValidateRequiredHandle("vkCmdSetEvent2KHR", "event", event);
     skip |= ValidateStructType("vkCmdSetEvent2KHR", "pDependencyInfo", "VK_STRUCTURE_TYPE_DEPENDENCY_INFO", pDependencyInfo, VK_STRUCTURE_TYPE_DEPENDENCY_INFO, true, "VUID-vkCmdSetEvent2-pDependencyInfo-parameter", "VUID-VkDependencyInfo-sType-sType");
     if (pDependencyInfo != nullptr)
@@ -13989,7 +14001,8 @@ bool StatelessValidation::PreCallValidateCmdResetEvent2KHR(
     VkEvent                                     event,
     VkPipelineStageFlags2                       stageMask) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_synchronization2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdResetEvent2KHR", "VK_KHR_synchronization2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdResetEvent2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_synchronization2)) skip |= OutputExtensionError("vkCmdResetEvent2KHR", "VK_KHR_synchronization2");
     skip |= ValidateRequiredHandle("vkCmdResetEvent2KHR", "event", event);
     skip |= ValidateFlags("vkCmdResetEvent2KHR", "stageMask", "VkPipelineStageFlagBits2", AllVkPipelineStageFlagBits2, stageMask, kOptionalFlags, "VUID-vkCmdResetEvent2-stageMask-parameter");
     return skip;
@@ -14001,7 +14014,8 @@ bool StatelessValidation::PreCallValidateCmdWaitEvents2KHR(
     const VkEvent*                              pEvents,
     const VkDependencyInfo*                     pDependencyInfos) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_synchronization2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdWaitEvents2KHR", "VK_KHR_synchronization2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdWaitEvents2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_synchronization2)) skip |= OutputExtensionError("vkCmdWaitEvents2KHR", "VK_KHR_synchronization2");
     skip |= ValidateHandleArray("vkCmdWaitEvents2KHR", "eventCount", "pEvents", eventCount, pEvents, true, true, "VUID-vkCmdWaitEvents2-eventCount-arraylength");
     skip |= ValidateStructTypeArray("vkCmdWaitEvents2KHR", "eventCount", "pDependencyInfos", "VK_STRUCTURE_TYPE_DEPENDENCY_INFO", eventCount, pDependencyInfos, VK_STRUCTURE_TYPE_DEPENDENCY_INFO, true, true, "VUID-VkDependencyInfo-sType-sType", "VUID-vkCmdWaitEvents2-pDependencyInfos-parameter", "VUID-vkCmdWaitEvents2-eventCount-arraylength");
     if (pDependencyInfos != nullptr)
@@ -14086,7 +14100,8 @@ bool StatelessValidation::PreCallValidateCmdPipelineBarrier2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkDependencyInfo*                     pDependencyInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_synchronization2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdPipelineBarrier2KHR", "VK_KHR_synchronization2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdPipelineBarrier2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_synchronization2)) skip |= OutputExtensionError("vkCmdPipelineBarrier2KHR", "VK_KHR_synchronization2");
     skip |= ValidateStructType("vkCmdPipelineBarrier2KHR", "pDependencyInfo", "VK_STRUCTURE_TYPE_DEPENDENCY_INFO", pDependencyInfo, VK_STRUCTURE_TYPE_DEPENDENCY_INFO, true, "VUID-vkCmdPipelineBarrier2-pDependencyInfo-parameter", "VUID-VkDependencyInfo-sType-sType");
     if (pDependencyInfo != nullptr)
     {
@@ -14169,7 +14184,8 @@ bool StatelessValidation::PreCallValidateCmdWriteTimestamp2KHR(
     VkQueryPool                                 queryPool,
     uint32_t                                    query) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_synchronization2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdWriteTimestamp2KHR", "VK_KHR_synchronization2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdWriteTimestamp2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_synchronization2)) skip |= OutputExtensionError("vkCmdWriteTimestamp2KHR", "VK_KHR_synchronization2");
     skip |= ValidateFlags("vkCmdWriteTimestamp2KHR", "stage", "VkPipelineStageFlagBits2", AllVkPipelineStageFlagBits2, stage, kOptionalFlags, "VUID-vkCmdWriteTimestamp2-stage-parameter");
     skip |= ValidateRequiredHandle("vkCmdWriteTimestamp2KHR", "queryPool", queryPool);
     return skip;
@@ -14181,7 +14197,8 @@ bool StatelessValidation::PreCallValidateQueueSubmit2KHR(
     const VkSubmitInfo2*                        pSubmits,
     VkFence                                     fence) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_synchronization2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkQueueSubmit2KHR", "VK_KHR_synchronization2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkQueueSubmit2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_synchronization2)) skip |= OutputExtensionError("vkQueueSubmit2KHR", "VK_KHR_synchronization2");
     skip |= ValidateStructTypeArray("vkQueueSubmit2KHR", "submitCount", "pSubmits", "VK_STRUCTURE_TYPE_SUBMIT_INFO_2", submitCount, pSubmits, VK_STRUCTURE_TYPE_SUBMIT_INFO_2, false, true, "VUID-VkSubmitInfo2-sType-sType", "VUID-vkQueueSubmit2-pSubmits-parameter", kVUIDUndefined);
     if (pSubmits != nullptr)
     {
@@ -14245,7 +14262,8 @@ bool StatelessValidation::PreCallValidateCmdWriteBufferMarker2AMD(
     uint32_t                                    marker) const {
     bool skip = false;
     if (!IsExtEnabled(device_extensions.vk_amd_buffer_marker)) skip |= OutputExtensionError("vkCmdWriteBufferMarker2AMD", "VK_AMD_buffer_marker");
-    if (!(IsExtEnabled(device_extensions.vk_khr_synchronization2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdWriteBufferMarker2AMD", "VK_KHR_synchronization2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdWriteBufferMarker2AMD", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_synchronization2)) skip |= OutputExtensionError("vkCmdWriteBufferMarker2AMD", "VK_KHR_synchronization2");
     skip |= ValidateFlags("vkCmdWriteBufferMarker2AMD", "stage", "VkPipelineStageFlagBits2", AllVkPipelineStageFlagBits2, stage, kOptionalFlags, "VUID-vkCmdWriteBufferMarker2AMD-stage-parameter");
     skip |= ValidateRequiredHandle("vkCmdWriteBufferMarker2AMD", "dstBuffer", dstBuffer);
     return skip;
@@ -14257,7 +14275,8 @@ bool StatelessValidation::PreCallValidateGetQueueCheckpointData2NV(
     VkCheckpointData2NV*                        pCheckpointData) const {
     bool skip = false;
     if (!IsExtEnabled(device_extensions.vk_nv_device_diagnostic_checkpoints)) skip |= OutputExtensionError("vkGetQueueCheckpointData2NV", "VK_NV_device_diagnostic_checkpoints");
-    if (!(IsExtEnabled(device_extensions.vk_khr_synchronization2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkGetQueueCheckpointData2NV", "VK_KHR_synchronization2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkGetQueueCheckpointData2NV", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_synchronization2)) skip |= OutputExtensionError("vkGetQueueCheckpointData2NV", "VK_KHR_synchronization2");
     skip |= ValidateStructTypeArray("vkGetQueueCheckpointData2NV", "pCheckpointDataCount", "pCheckpointData", "VK_STRUCTURE_TYPE_CHECKPOINT_DATA_2_NV", pCheckpointDataCount, pCheckpointData, VK_STRUCTURE_TYPE_CHECKPOINT_DATA_2_NV, true, false, false, "VUID-VkCheckpointData2NV-sType-sType", "VUID-vkGetQueueCheckpointData2NV-pCheckpointData-parameter", kVUIDUndefined);
     if (pCheckpointData != nullptr)
     {
@@ -14283,7 +14302,8 @@ bool StatelessValidation::PreCallValidateCmdCopyBuffer2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyBufferInfo2*                    pCopyBufferInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_copy_commands2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdCopyBuffer2KHR", "VK_KHR_copy_commands2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdCopyBuffer2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_copy_commands2)) skip |= OutputExtensionError("vkCmdCopyBuffer2KHR", "VK_KHR_copy_commands2");
     skip |= ValidateStructType("vkCmdCopyBuffer2KHR", "pCopyBufferInfo", "VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2", pCopyBufferInfo, VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2, true, "VUID-vkCmdCopyBuffer2-pCopyBufferInfo-parameter", "VUID-VkCopyBufferInfo2-sType-sType");
     if (pCopyBufferInfo != nullptr)
     {
@@ -14311,7 +14331,8 @@ bool StatelessValidation::PreCallValidateCmdCopyImage2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyImageInfo2*                     pCopyImageInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_copy_commands2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdCopyImage2KHR", "VK_KHR_copy_commands2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdCopyImage2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_copy_commands2)) skip |= OutputExtensionError("vkCmdCopyImage2KHR", "VK_KHR_copy_commands2");
     skip |= ValidateStructType("vkCmdCopyImage2KHR", "pCopyImageInfo", "VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2", pCopyImageInfo, VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2, true, "VUID-vkCmdCopyImage2-pCopyImageInfo-parameter", "VUID-VkCopyImageInfo2-sType-sType");
     if (pCopyImageInfo != nullptr)
     {
@@ -14352,7 +14373,8 @@ bool StatelessValidation::PreCallValidateCmdCopyBufferToImage2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyBufferToImageInfo2*             pCopyBufferToImageInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_copy_commands2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdCopyBufferToImage2KHR", "VK_KHR_copy_commands2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdCopyBufferToImage2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_copy_commands2)) skip |= OutputExtensionError("vkCmdCopyBufferToImage2KHR", "VK_KHR_copy_commands2");
     skip |= ValidateStructType("vkCmdCopyBufferToImage2KHR", "pCopyBufferToImageInfo", "VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2", pCopyBufferToImageInfo, VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2, true, "VUID-vkCmdCopyBufferToImage2-pCopyBufferToImageInfo-parameter", "VUID-VkCopyBufferToImageInfo2-sType-sType");
     if (pCopyBufferToImageInfo != nullptr)
     {
@@ -14389,7 +14411,8 @@ bool StatelessValidation::PreCallValidateCmdCopyImageToBuffer2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkCopyImageToBufferInfo2*             pCopyImageToBufferInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_copy_commands2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdCopyImageToBuffer2KHR", "VK_KHR_copy_commands2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdCopyImageToBuffer2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_copy_commands2)) skip |= OutputExtensionError("vkCmdCopyImageToBuffer2KHR", "VK_KHR_copy_commands2");
     skip |= ValidateStructType("vkCmdCopyImageToBuffer2KHR", "pCopyImageToBufferInfo", "VK_STRUCTURE_TYPE_COPY_IMAGE_TO_BUFFER_INFO_2", pCopyImageToBufferInfo, VK_STRUCTURE_TYPE_COPY_IMAGE_TO_BUFFER_INFO_2, true, "VUID-vkCmdCopyImageToBuffer2-pCopyImageToBufferInfo-parameter", "VUID-VkCopyImageToBufferInfo2-sType-sType");
     if (pCopyImageToBufferInfo != nullptr)
     {
@@ -14426,7 +14449,8 @@ bool StatelessValidation::PreCallValidateCmdBlitImage2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkBlitImageInfo2*                     pBlitImageInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_copy_commands2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdBlitImage2KHR", "VK_KHR_copy_commands2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdBlitImage2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_copy_commands2)) skip |= OutputExtensionError("vkCmdBlitImage2KHR", "VK_KHR_copy_commands2");
     skip |= ValidateStructType("vkCmdBlitImage2KHR", "pBlitImageInfo", "VK_STRUCTURE_TYPE_BLIT_IMAGE_INFO_2", pBlitImageInfo, VK_STRUCTURE_TYPE_BLIT_IMAGE_INFO_2, true, "VUID-vkCmdBlitImage2-pBlitImageInfo-parameter", "VUID-VkBlitImageInfo2-sType-sType");
     if (pBlitImageInfo != nullptr)
     {
@@ -14465,7 +14489,8 @@ bool StatelessValidation::PreCallValidateCmdResolveImage2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkResolveImageInfo2*                  pResolveImageInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_khr_copy_commands2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdResolveImage2KHR", "VK_KHR_copy_commands2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdResolveImage2KHR", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_khr_copy_commands2)) skip |= OutputExtensionError("vkCmdResolveImage2KHR", "VK_KHR_copy_commands2");
     skip |= ValidateStructType("vkCmdResolveImage2KHR", "pResolveImageInfo", "VK_STRUCTURE_TYPE_RESOLVE_IMAGE_INFO_2", pResolveImageInfo, VK_STRUCTURE_TYPE_RESOLVE_IMAGE_INFO_2, true, "VUID-vkCmdResolveImage2-pResolveImageInfo-parameter", "VUID-VkResolveImageInfo2-sType-sType");
     if (pResolveImageInfo != nullptr)
     {
@@ -15638,7 +15663,8 @@ bool StatelessValidation::PreCallValidateCmdSetDiscardRectangleEXT(
     uint32_t                                    discardRectangleCount,
     const VkRect2D*                             pDiscardRectangles) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_discard_rectangles) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetDiscardRectangleEXT", "VK_EXT_discard_rectangles && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetDiscardRectangleEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_discard_rectangles)) skip |= OutputExtensionError("vkCmdSetDiscardRectangleEXT", "VK_EXT_discard_rectangles");
     skip |= ValidateArray("vkCmdSetDiscardRectangleEXT", "discardRectangleCount", "pDiscardRectangles", discardRectangleCount, &pDiscardRectangles, true, true, "VUID-vkCmdSetDiscardRectangleEXT-discardRectangleCount-arraylength", "VUID-vkCmdSetDiscardRectangleEXT-pDiscardRectangles-parameter");
     if (pDiscardRectangles != nullptr)
     {
@@ -15657,7 +15683,8 @@ bool StatelessValidation::PreCallValidateCmdSetDiscardRectangleEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    discardRectangleEnable) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_discard_rectangles) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetDiscardRectangleEnableEXT", "VK_EXT_discard_rectangles && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetDiscardRectangleEnableEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_discard_rectangles)) skip |= OutputExtensionError("vkCmdSetDiscardRectangleEnableEXT", "VK_EXT_discard_rectangles");
     skip |= ValidateBool32("vkCmdSetDiscardRectangleEnableEXT", "discardRectangleEnable", discardRectangleEnable);
     if (!skip) skip |= manual_PreCallValidateCmdSetDiscardRectangleEnableEXT(commandBuffer, discardRectangleEnable);
     return skip;
@@ -15667,7 +15694,8 @@ bool StatelessValidation::PreCallValidateCmdSetDiscardRectangleModeEXT(
     VkCommandBuffer                             commandBuffer,
     VkDiscardRectangleModeEXT                   discardRectangleMode) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_discard_rectangles) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetDiscardRectangleModeEXT", "VK_EXT_discard_rectangles && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetDiscardRectangleModeEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_discard_rectangles)) skip |= OutputExtensionError("vkCmdSetDiscardRectangleModeEXT", "VK_EXT_discard_rectangles");
     skip |= ValidateRangedEnum("vkCmdSetDiscardRectangleModeEXT", "discardRectangleMode", "VkDiscardRectangleModeEXT", discardRectangleMode, "VUID-vkCmdSetDiscardRectangleModeEXT-discardRectangleMode-parameter");
     if (!skip) skip |= manual_PreCallValidateCmdSetDiscardRectangleModeEXT(commandBuffer, discardRectangleMode);
     return skip;
@@ -16099,7 +16127,8 @@ bool StatelessValidation::PreCallValidateCmdSetSampleLocationsEXT(
     VkCommandBuffer                             commandBuffer,
     const VkSampleLocationsInfoEXT*             pSampleLocationsInfo) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_sample_locations) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetSampleLocationsEXT", "VK_EXT_sample_locations && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetSampleLocationsEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_sample_locations)) skip |= OutputExtensionError("vkCmdSetSampleLocationsEXT", "VK_EXT_sample_locations");
     skip |= ValidateStructType("vkCmdSetSampleLocationsEXT", "pSampleLocationsInfo", "VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT", pSampleLocationsInfo, VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT, true, "VUID-vkCmdSetSampleLocationsEXT-pSampleLocationsInfo-parameter", "VUID-VkSampleLocationsInfoEXT-sType-sType");
     if (pSampleLocationsInfo != nullptr)
     {
@@ -16153,9 +16182,7 @@ bool StatelessValidation::PreCallValidateGetImageDrmFormatModifierPropertiesEXT(
     VkImage                                     image,
     VkImageDrmFormatModifierPropertiesEXT*      pProperties) const {
     bool skip = false;
-    if (!instance_extensions.vk_feature_version_1_2) skip |= OutputExtensionError("vkGetImageDrmFormatModifierPropertiesEXT", "VK_VERSION_1_2");
     if (!IsExtEnabled(device_extensions.vk_khr_image_format_list)) skip |= OutputExtensionError("vkGetImageDrmFormatModifierPropertiesEXT", "VK_KHR_image_format_list");
-    if (!instance_extensions.vk_feature_version_1_1) skip |= OutputExtensionError("vkGetImageDrmFormatModifierPropertiesEXT", "VK_VERSION_1_1");
     if (!IsExtEnabled(device_extensions.vk_khr_sampler_ycbcr_conversion)) skip |= OutputExtensionError("vkGetImageDrmFormatModifierPropertiesEXT", "VK_KHR_sampler_ycbcr_conversion");
     if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkGetImageDrmFormatModifierPropertiesEXT", "VK_KHR_get_physical_device_properties2");
     if (!IsExtEnabled(device_extensions.vk_khr_bind_memory2)) skip |= OutputExtensionError("vkGetImageDrmFormatModifierPropertiesEXT", "VK_KHR_bind_memory2");
@@ -16767,7 +16794,8 @@ bool StatelessValidation::PreCallValidateGetMemoryHostPointerPropertiesEXT(
     const void*                                 pHostPointer,
     VkMemoryHostPointerPropertiesEXT*           pMemoryHostPointerProperties) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_external_memory_host) && (IsExtEnabled(device_extensions.vk_khr_external_memory) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkGetMemoryHostPointerPropertiesEXT", "VK_EXT_external_memory_host && (VK_KHR_external_memory || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_external_memory)) skip |= OutputExtensionError("vkGetMemoryHostPointerPropertiesEXT", "VK_KHR_external_memory");
+    if (!IsExtEnabled(device_extensions.vk_ext_external_memory_host)) skip |= OutputExtensionError("vkGetMemoryHostPointerPropertiesEXT", "VK_EXT_external_memory_host");
     skip |= ValidateFlags("vkGetMemoryHostPointerPropertiesEXT", "handleType", "VkExternalMemoryHandleTypeFlagBits", AllVkExternalMemoryHandleTypeFlagBits, handleType, kRequiredSingleBit, "VUID-vkGetMemoryHostPointerPropertiesEXT-handleType-parameter", "VUID-vkGetMemoryHostPointerPropertiesEXT-handleType-parameter");
     skip |= ValidateRequiredPointer("vkGetMemoryHostPointerPropertiesEXT", "pHostPointer", pHostPointer, kVUIDUndefined);
     skip |= ValidateStructType("vkGetMemoryHostPointerPropertiesEXT", "pMemoryHostPointerProperties", "VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT", pMemoryHostPointerProperties, VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT, true, "VUID-vkGetMemoryHostPointerPropertiesEXT-pMemoryHostPointerProperties-parameter", "VUID-VkMemoryHostPointerPropertiesEXT-sType-sType");
@@ -16813,7 +16841,8 @@ bool StatelessValidation::PreCallValidateGetCalibratedTimestampsEXT(
     uint64_t*                                   pTimestamps,
     uint64_t*                                   pMaxDeviation) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_calibrated_timestamps) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkGetCalibratedTimestampsEXT", "VK_EXT_calibrated_timestamps && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkGetCalibratedTimestampsEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_calibrated_timestamps)) skip |= OutputExtensionError("vkGetCalibratedTimestampsEXT", "VK_EXT_calibrated_timestamps");
     skip |= ValidateStructTypeArray("vkGetCalibratedTimestampsEXT", "timestampCount", "pTimestampInfos", "VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT", timestampCount, pTimestampInfos, VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_EXT, true, true, "VUID-VkCalibratedTimestampInfoEXT-sType-sType", "VUID-vkGetCalibratedTimestampsEXT-pTimestampInfos-parameter", "VUID-vkGetCalibratedTimestampsEXT-timestampCount-arraylength");
     if (pTimestampInfos != nullptr)
     {
@@ -17372,7 +17401,8 @@ bool StatelessValidation::PreCallValidateCmdSetLineStippleEXT(
     uint32_t                                    lineStippleFactor,
     uint16_t                                    lineStipplePattern) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_line_rasterization) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetLineStippleEXT", "VK_EXT_line_rasterization && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetLineStippleEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_line_rasterization)) skip |= OutputExtensionError("vkCmdSetLineStippleEXT", "VK_EXT_line_rasterization");
     // No xml-driven validation
     if (!skip) skip |= manual_PreCallValidateCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern);
     return skip;
@@ -17402,7 +17432,8 @@ bool StatelessValidation::PreCallValidateCmdSetCullModeEXT(
     VkCommandBuffer                             commandBuffer,
     VkCullModeFlags                             cullMode) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetCullModeEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetCullModeEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetCullModeEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateFlags("vkCmdSetCullModeEXT", "cullMode", "VkCullModeFlagBits", AllVkCullModeFlagBits, cullMode, kOptionalFlags, "VUID-vkCmdSetCullMode-cullMode-parameter");
     return skip;
 }
@@ -17411,7 +17442,8 @@ bool StatelessValidation::PreCallValidateCmdSetFrontFaceEXT(
     VkCommandBuffer                             commandBuffer,
     VkFrontFace                                 frontFace) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetFrontFaceEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetFrontFaceEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetFrontFaceEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateRangedEnum("vkCmdSetFrontFaceEXT", "frontFace", "VkFrontFace", frontFace, "VUID-vkCmdSetFrontFace-frontFace-parameter");
     return skip;
 }
@@ -17420,7 +17452,8 @@ bool StatelessValidation::PreCallValidateCmdSetPrimitiveTopologyEXT(
     VkCommandBuffer                             commandBuffer,
     VkPrimitiveTopology                         primitiveTopology) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetPrimitiveTopologyEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetPrimitiveTopologyEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetPrimitiveTopologyEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateRangedEnum("vkCmdSetPrimitiveTopologyEXT", "primitiveTopology", "VkPrimitiveTopology", primitiveTopology, "VUID-vkCmdSetPrimitiveTopology-primitiveTopology-parameter");
     return skip;
 }
@@ -17430,7 +17463,8 @@ bool StatelessValidation::PreCallValidateCmdSetViewportWithCountEXT(
     uint32_t                                    viewportCount,
     const VkViewport*                           pViewports) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetViewportWithCountEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetViewportWithCountEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetViewportWithCountEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateArray("vkCmdSetViewportWithCountEXT", "viewportCount", "pViewports", viewportCount, &pViewports, true, true, "VUID-vkCmdSetViewportWithCount-viewportCount-arraylength", "VUID-vkCmdSetViewportWithCount-pViewports-parameter");
     if (pViewports != nullptr)
     {
@@ -17448,7 +17482,8 @@ bool StatelessValidation::PreCallValidateCmdSetScissorWithCountEXT(
     uint32_t                                    scissorCount,
     const VkRect2D*                             pScissors) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetScissorWithCountEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetScissorWithCountEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetScissorWithCountEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateArray("vkCmdSetScissorWithCountEXT", "scissorCount", "pScissors", scissorCount, &pScissors, true, true, "VUID-vkCmdSetScissorWithCount-scissorCount-arraylength", "VUID-vkCmdSetScissorWithCount-pScissors-parameter");
     if (pScissors != nullptr)
     {
@@ -17472,7 +17507,8 @@ bool StatelessValidation::PreCallValidateCmdBindVertexBuffers2EXT(
     const VkDeviceSize*                         pSizes,
     const VkDeviceSize*                         pStrides) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdBindVertexBuffers2EXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdBindVertexBuffers2EXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdBindVertexBuffers2EXT", "VK_EXT_extended_dynamic_state");
     // No xml-driven validation
     if (!skip) skip |= manual_PreCallValidateCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes, pStrides);
     return skip;
@@ -17482,7 +17518,8 @@ bool StatelessValidation::PreCallValidateCmdSetDepthTestEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    depthTestEnable) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetDepthTestEnableEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetDepthTestEnableEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetDepthTestEnableEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateBool32("vkCmdSetDepthTestEnableEXT", "depthTestEnable", depthTestEnable);
     return skip;
 }
@@ -17491,7 +17528,8 @@ bool StatelessValidation::PreCallValidateCmdSetDepthWriteEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    depthWriteEnable) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetDepthWriteEnableEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetDepthWriteEnableEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetDepthWriteEnableEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateBool32("vkCmdSetDepthWriteEnableEXT", "depthWriteEnable", depthWriteEnable);
     return skip;
 }
@@ -17500,7 +17538,8 @@ bool StatelessValidation::PreCallValidateCmdSetDepthCompareOpEXT(
     VkCommandBuffer                             commandBuffer,
     VkCompareOp                                 depthCompareOp) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetDepthCompareOpEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetDepthCompareOpEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetDepthCompareOpEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateRangedEnum("vkCmdSetDepthCompareOpEXT", "depthCompareOp", "VkCompareOp", depthCompareOp, "VUID-vkCmdSetDepthCompareOp-depthCompareOp-parameter");
     return skip;
 }
@@ -17509,7 +17548,8 @@ bool StatelessValidation::PreCallValidateCmdSetDepthBoundsTestEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    depthBoundsTestEnable) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetDepthBoundsTestEnableEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetDepthBoundsTestEnableEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetDepthBoundsTestEnableEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateBool32("vkCmdSetDepthBoundsTestEnableEXT", "depthBoundsTestEnable", depthBoundsTestEnable);
     return skip;
 }
@@ -17518,7 +17558,8 @@ bool StatelessValidation::PreCallValidateCmdSetStencilTestEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    stencilTestEnable) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetStencilTestEnableEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetStencilTestEnableEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetStencilTestEnableEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateBool32("vkCmdSetStencilTestEnableEXT", "stencilTestEnable", stencilTestEnable);
     return skip;
 }
@@ -17531,7 +17572,8 @@ bool StatelessValidation::PreCallValidateCmdSetStencilOpEXT(
     VkStencilOp                                 depthFailOp,
     VkCompareOp                                 compareOp) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetStencilOpEXT", "VK_EXT_extended_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetStencilOpEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state)) skip |= OutputExtensionError("vkCmdSetStencilOpEXT", "VK_EXT_extended_dynamic_state");
     skip |= ValidateFlags("vkCmdSetStencilOpEXT", "faceMask", "VkStencilFaceFlagBits", AllVkStencilFaceFlagBits, faceMask, kRequiredFlags, "VUID-vkCmdSetStencilOp-faceMask-parameter", "VUID-vkCmdSetStencilOp-faceMask-requiredbitmask");
     skip |= ValidateRangedEnum("vkCmdSetStencilOpEXT", "failOp", "VkStencilOp", failOp, "VUID-vkCmdSetStencilOp-failOp-parameter");
     skip |= ValidateRangedEnum("vkCmdSetStencilOpEXT", "passOp", "VkStencilOp", passOp, "VUID-vkCmdSetStencilOp-passOp-parameter");
@@ -18326,7 +18368,8 @@ bool StatelessValidation::PreCallValidateCmdSetVertexInputEXT(
     uint32_t                                    vertexAttributeDescriptionCount,
     const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_vertex_input_dynamic_state) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetVertexInputEXT", "VK_EXT_vertex_input_dynamic_state && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetVertexInputEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_vertex_input_dynamic_state)) skip |= OutputExtensionError("vkCmdSetVertexInputEXT", "VK_EXT_vertex_input_dynamic_state");
     skip |= ValidateStructTypeArray("vkCmdSetVertexInputEXT", "vertexBindingDescriptionCount", "pVertexBindingDescriptions", "VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT", vertexBindingDescriptionCount, pVertexBindingDescriptions, VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT, false, true, "VUID-VkVertexInputBindingDescription2EXT-sType-sType", "VUID-vkCmdSetVertexInputEXT-pVertexBindingDescriptions-parameter", kVUIDUndefined);
     if (pVertexBindingDescriptions != nullptr)
     {
@@ -18723,7 +18766,8 @@ bool StatelessValidation::PreCallValidateCmdSetPatchControlPointsEXT(
     VkCommandBuffer                             commandBuffer,
     uint32_t                                    patchControlPoints) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetPatchControlPointsEXT", "VK_EXT_extended_dynamic_state2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetPatchControlPointsEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state2)) skip |= OutputExtensionError("vkCmdSetPatchControlPointsEXT", "VK_EXT_extended_dynamic_state2");
     // No xml-driven validation
     return skip;
 }
@@ -18732,7 +18776,8 @@ bool StatelessValidation::PreCallValidateCmdSetRasterizerDiscardEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    rasterizerDiscardEnable) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetRasterizerDiscardEnableEXT", "VK_EXT_extended_dynamic_state2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetRasterizerDiscardEnableEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state2)) skip |= OutputExtensionError("vkCmdSetRasterizerDiscardEnableEXT", "VK_EXT_extended_dynamic_state2");
     skip |= ValidateBool32("vkCmdSetRasterizerDiscardEnableEXT", "rasterizerDiscardEnable", rasterizerDiscardEnable);
     return skip;
 }
@@ -18741,7 +18786,8 @@ bool StatelessValidation::PreCallValidateCmdSetDepthBiasEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    depthBiasEnable) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetDepthBiasEnableEXT", "VK_EXT_extended_dynamic_state2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetDepthBiasEnableEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state2)) skip |= OutputExtensionError("vkCmdSetDepthBiasEnableEXT", "VK_EXT_extended_dynamic_state2");
     skip |= ValidateBool32("vkCmdSetDepthBiasEnableEXT", "depthBiasEnable", depthBiasEnable);
     return skip;
 }
@@ -18750,7 +18796,8 @@ bool StatelessValidation::PreCallValidateCmdSetLogicOpEXT(
     VkCommandBuffer                             commandBuffer,
     VkLogicOp                                   logicOp) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetLogicOpEXT", "VK_EXT_extended_dynamic_state2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetLogicOpEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state2)) skip |= OutputExtensionError("vkCmdSetLogicOpEXT", "VK_EXT_extended_dynamic_state2");
     skip |= ValidateRangedEnum("vkCmdSetLogicOpEXT", "logicOp", "VkLogicOp", logicOp, "VUID-vkCmdSetLogicOpEXT-logicOp-parameter");
     return skip;
 }
@@ -18759,7 +18806,8 @@ bool StatelessValidation::PreCallValidateCmdSetPrimitiveRestartEnableEXT(
     VkCommandBuffer                             commandBuffer,
     VkBool32                                    primitiveRestartEnable) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state2) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetPrimitiveRestartEnableEXT", "VK_EXT_extended_dynamic_state2 && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetPrimitiveRestartEnableEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_extended_dynamic_state2)) skip |= OutputExtensionError("vkCmdSetPrimitiveRestartEnableEXT", "VK_EXT_extended_dynamic_state2");
     skip |= ValidateBool32("vkCmdSetPrimitiveRestartEnableEXT", "primitiveRestartEnable", primitiveRestartEnable);
     return skip;
 }
@@ -18825,7 +18873,8 @@ bool StatelessValidation::PreCallValidateCmdSetColorWriteEnableEXT(
     uint32_t                                    attachmentCount,
     const VkBool32*                             pColorWriteEnables) const {
     bool skip = false;
-    if (!(IsExtEnabled(device_extensions.vk_ext_color_write_enable) && (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2) || instance_extensions.vk_feature_version_1_1))) skip |= OutputExtensionError("vkCmdSetColorWriteEnableEXT", "VK_EXT_color_write_enable && (VK_KHR_get_physical_device_properties2 || VK_VERSION_1_1)");
+    if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdSetColorWriteEnableEXT", "VK_KHR_get_physical_device_properties2");
+    if (!IsExtEnabled(device_extensions.vk_ext_color_write_enable)) skip |= OutputExtensionError("vkCmdSetColorWriteEnableEXT", "VK_EXT_color_write_enable");
     skip |= ValidateBool32Array("vkCmdSetColorWriteEnableEXT", "attachmentCount", "pColorWriteEnables", attachmentCount, pColorWriteEnables, true, true);
     return skip;
 }
@@ -20007,9 +20056,7 @@ bool StatelessValidation::PreCallValidateCreateShadersEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkShaderEXT*                                pShaders) const {
     bool skip = false;
-    if (!instance_extensions.vk_feature_version_1_3) skip |= OutputExtensionError("vkCreateShadersEXT", "VK_VERSION_1_3");
     if (!IsExtEnabled(device_extensions.vk_khr_dynamic_rendering)) skip |= OutputExtensionError("vkCreateShadersEXT", "VK_KHR_dynamic_rendering");
-    if (!instance_extensions.vk_feature_version_1_1) skip |= OutputExtensionError("vkCreateShadersEXT", "VK_VERSION_1_1");
     if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCreateShadersEXT", "VK_KHR_get_physical_device_properties2");
     if (!IsExtEnabled(device_extensions.vk_ext_shader_object)) skip |= OutputExtensionError("vkCreateShadersEXT", "VK_EXT_shader_object");
     skip |= ValidateStructTypeArray("vkCreateShadersEXT", "createInfoCount", "pCreateInfos", "VK_STRUCTURE_TYPE_SHADER_CREATE_INFO_EXT", createInfoCount, pCreateInfos, VK_STRUCTURE_TYPE_SHADER_CREATE_INFO_EXT, true, true, "VUID-VkShaderCreateInfoEXT-sType-sType", "VUID-vkCreateShadersEXT-pCreateInfos-parameter", "VUID-vkCreateShadersEXT-createInfoCount-arraylength");
@@ -20084,9 +20131,7 @@ bool StatelessValidation::PreCallValidateDestroyShaderEXT(
     VkShaderEXT                                 shader,
     const VkAllocationCallbacks*                pAllocator) const {
     bool skip = false;
-    if (!instance_extensions.vk_feature_version_1_3) skip |= OutputExtensionError("vkDestroyShaderEXT", "VK_VERSION_1_3");
     if (!IsExtEnabled(device_extensions.vk_khr_dynamic_rendering)) skip |= OutputExtensionError("vkDestroyShaderEXT", "VK_KHR_dynamic_rendering");
-    if (!instance_extensions.vk_feature_version_1_1) skip |= OutputExtensionError("vkDestroyShaderEXT", "VK_VERSION_1_1");
     if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkDestroyShaderEXT", "VK_KHR_get_physical_device_properties2");
     if (!IsExtEnabled(device_extensions.vk_ext_shader_object)) skip |= OutputExtensionError("vkDestroyShaderEXT", "VK_EXT_shader_object");
     skip |= ValidateRequiredHandle("vkDestroyShaderEXT", "shader", shader);
@@ -20119,9 +20164,7 @@ bool StatelessValidation::PreCallValidateGetShaderBinaryDataEXT(
     size_t*                                     pDataSize,
     void*                                       pData) const {
     bool skip = false;
-    if (!instance_extensions.vk_feature_version_1_3) skip |= OutputExtensionError("vkGetShaderBinaryDataEXT", "VK_VERSION_1_3");
     if (!IsExtEnabled(device_extensions.vk_khr_dynamic_rendering)) skip |= OutputExtensionError("vkGetShaderBinaryDataEXT", "VK_KHR_dynamic_rendering");
-    if (!instance_extensions.vk_feature_version_1_1) skip |= OutputExtensionError("vkGetShaderBinaryDataEXT", "VK_VERSION_1_1");
     if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkGetShaderBinaryDataEXT", "VK_KHR_get_physical_device_properties2");
     if (!IsExtEnabled(device_extensions.vk_ext_shader_object)) skip |= OutputExtensionError("vkGetShaderBinaryDataEXT", "VK_EXT_shader_object");
     skip |= ValidateRequiredHandle("vkGetShaderBinaryDataEXT", "shader", shader);
@@ -20135,9 +20178,7 @@ bool StatelessValidation::PreCallValidateCmdBindShadersEXT(
     const VkShaderStageFlagBits*                pStages,
     const VkShaderEXT*                          pShaders) const {
     bool skip = false;
-    if (!instance_extensions.vk_feature_version_1_3) skip |= OutputExtensionError("vkCmdBindShadersEXT", "VK_VERSION_1_3");
     if (!IsExtEnabled(device_extensions.vk_khr_dynamic_rendering)) skip |= OutputExtensionError("vkCmdBindShadersEXT", "VK_KHR_dynamic_rendering");
-    if (!instance_extensions.vk_feature_version_1_1) skip |= OutputExtensionError("vkCmdBindShadersEXT", "VK_VERSION_1_1");
     if (!IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) skip |= OutputExtensionError("vkCmdBindShadersEXT", "VK_KHR_get_physical_device_properties2");
     if (!IsExtEnabled(device_extensions.vk_ext_shader_object)) skip |= OutputExtensionError("vkCmdBindShadersEXT", "VK_EXT_shader_object");
     skip |= ValidateArray("vkCmdBindShadersEXT", "stageCount", "pStages", stageCount, &pStages, true, true, "VUID-vkCmdBindShadersEXT-stageCount-arraylength", "VUID-vkCmdBindShadersEXT-pStages-parameter");

--- a/scripts/parameter_validation_generator.py
+++ b/scripts/parameter_validation_generator.py
@@ -728,7 +728,9 @@ class ParameterValidationOutputGenerator(OutputGenerator):
         if requires is not None:
             base_req_exts.append(f'({requires})')
         if len(base_req_exts) > 0:
-            base_required_extension_expressions.append(parseExpr('+'.join(base_req_exts)))
+            # This is a work around for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5372
+            expr_str = re.sub(r',VK_VERSION_1_\d+', '', '+'.join(base_req_exts))
+            base_required_extension_expressions.append(parseExpr(expr_str))
         # Build dictionary of extension dependencies for each item in this extension
         self.required_extension_expressions = dict()
         for require_element in interface.findall('require'):


### PR DESCRIPTION
Parameter validation was missing the workaround required for recent
upstream vulkan XML changes.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5733.