### PR TITLE
tests: Use new Negative test name

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -384,7 +384,7 @@ class VkGpuAssistedLayerTest : public VkLayerTest {
     bool CanEnableGpuAV();
 };
 
-class VkDebugPrintfTest : public VkLayerTest {
+class NegativeDebugPrintf : public VkLayerTest {
   public:
     void InitDebugPrintfFramework();
 

--- a/tests/negative/android_hardware_buffer.cpp
+++ b/tests/negative/android_hardware_buffer.cpp
@@ -20,7 +20,9 @@
 
 #ifdef AHB_VALIDATION_SUPPORT
 
-TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
+class NegativeAndroidHardwareBuffer : public VkLayerTest {};
+
+TEST_F(NegativeAndroidHardwareBuffer, ImageCreate) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer image create info.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -134,7 +136,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageCreate) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferFetchUnboundImageInfo) {
+TEST_F(NegativeAndroidHardwareBuffer, FetchUnboundImageInfo) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer retreive image properties while memory unbound.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -181,7 +183,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferFetchUnboundImageInfo) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferGpuDataBuffer) {
+TEST_F(NegativeAndroidHardwareBuffer, GpuDataBuffer) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer missing USAGE_GPU_DATA_BUFFER.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -228,7 +230,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferGpuDataBuffer) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferAllocationSize) {
+TEST_F(NegativeAndroidHardwareBuffer, AllocationSize) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer correct allocationSize is used.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -287,7 +289,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferAllocationSize) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferDedicatedUsageColor) {
+TEST_F(NegativeAndroidHardwareBuffer, DedicatedUsageColor) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer correct usage for dedicated allocated color image.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -355,7 +357,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferDedicatedUsageColor) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferDedicatedUsageDS) {
+TEST_F(NegativeAndroidHardwareBuffer, DedicatedUsageDS) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer correct usage for dedicated allocated depth/stencil image.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -433,7 +435,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferDedicatedUsageDS) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferMipmapChain) {
+TEST_F(NegativeAndroidHardwareBuffer, MipmapChain) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer correct mipmap chain.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -503,7 +505,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferMipmapChain) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferImageDimensions) {
+TEST_F(NegativeAndroidHardwareBuffer, ImageDimensions) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer dimension and VkImage match.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -571,7 +573,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImageDimensions) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferUnknownFormat) {
+TEST_F(NegativeAndroidHardwareBuffer, UnknownFormat) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer uses VK_FORMAT_UNDEFINED for external.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -636,7 +638,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferUnknownFormat) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferGpuUsage) {
+TEST_F(NegativeAndroidHardwareBuffer, GpuUsage) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer has a GPU usage flag.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -723,7 +725,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferGpuUsage) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferExportMemoryAllocate) {
+TEST_F(NegativeAndroidHardwareBuffer, ExportMemoryAllocate) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer VkExportMemoryAllocateInfo instead of import.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -791,7 +793,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExportMemoryAllocate) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
+TEST_F(NegativeAndroidHardwareBuffer, CreateYCbCrSampler) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer YCbCr sampler creation.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -836,7 +838,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateYCbCrSampler) {
     vk_testing::SamplerYcbcrConversion conversion(*m_device, sycci);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferPhysDevImageFormatProp2) {
+TEST_F(NegativeAndroidHardwareBuffer, PhysDevImageFormatProp2) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer GetPhysicalDeviceImageFormatProperties.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -877,7 +879,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferPhysDevImageFormatProp2) {
 }
 
 #if DISABLEUNTILAHBWORKS
-TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
+TEST_F(NegativeAndroidHardwareBuffer, CreateImageView) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer image view creation.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1042,7 +1044,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferCreateImageView) {
 }
 #endif  // DISABLEUNTILAHBWORKS
 
-TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
+TEST_F(NegativeAndroidHardwareBuffer, ImportBuffer) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer import as buffer.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1096,7 +1098,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBuffer) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferExportBufferHandleType) {
+TEST_F(NegativeAndroidHardwareBuffer, ExportBufferHandleType) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer export memory as AHB has a valid handleType.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1127,7 +1129,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExportBufferHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferExportImageNonBound) {
+TEST_F(NegativeAndroidHardwareBuffer, ExportImageNonBound) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer export memory as AHB has image bound already.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1192,7 +1194,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferExportImageNonBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
+TEST_F(NegativeAndroidHardwareBuffer, InvalidBindBufferMemory) {
     TEST_DESCRIPTION("Validate binding AndroidHardwareBuffer VkBuffer act same as non-AHB buffers.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1269,7 +1271,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferInvalidBindBufferMemory) {
     AHardwareBuffer_release(ahb);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferImportBufferHandleType) {
+TEST_F(NegativeAndroidHardwareBuffer, ImportBufferHandleType) {
     TEST_DESCRIPTION("Don't use proper resource handleType for import buffer");
 
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
@@ -1337,7 +1339,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportBufferHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
+TEST_F(NegativeAndroidHardwareBuffer, ImportImageHandleType) {
     TEST_DESCRIPTION("Don't use proper resource handleType for import image");
 
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
@@ -1421,7 +1423,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferImportImageHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferDeviceImageMemoryReq) {
+TEST_F(NegativeAndroidHardwareBuffer, DeviceImageMemoryReq) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer image create info.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1458,7 +1460,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferDeviceImageMemoryReq) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferNullAHBProperties) {
+TEST_F(NegativeAndroidHardwareBuffer, NullAHBProperties) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer calls must have non-null AHB objects passed in.");
 
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
@@ -1491,7 +1493,7 @@ TEST_F(VkLayerTest, AndroidHardwareBufferNullAHBProperties) {
     vk::GetAndroidHardwareBufferPropertiesANDROID(m_device->device(), ahb, &ahb_props);
 }
 
-TEST_F(VkLayerTest, AndroidHardwareBufferNullAHBImport) {
+TEST_F(NegativeAndroidHardwareBuffer, NullAHBImport) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer calls must have non-null AHB objects passed in.");
 
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);

--- a/tests/negative/buffer.cpp
+++ b/tests/negative/buffer.cpp
@@ -17,7 +17,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "utils/vk_layer_utils.h"
 
-TEST_F(VkLayerTest, BufferExtents) {
+class NegativeBuffer : public VkLayerTest {};
+
+TEST_F(NegativeBuffer, Extents) {
     TEST_DESCRIPTION("Perform copies across a buffer, provoking out-of-range errors.");
 
     AddOptionalExtensions(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
@@ -112,7 +114,7 @@ TEST_F(VkLayerTest, BufferExtents) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, UpdateBufferAlignment) {
+TEST_F(NegativeBuffer, UpdateBufferAlignment) {
     TEST_DESCRIPTION("Check alignment parameters for vkCmdUpdateBuffer");
     uint32_t updateData[] = {1, 2, 3, 4, 5, 6, 7, 8};
 
@@ -146,7 +148,7 @@ TEST_F(VkLayerTest, UpdateBufferAlignment) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, FillBufferAlignmentAndSize) {
+TEST_F(NegativeBuffer, FillBufferAlignmentAndSize) {
     TEST_DESCRIPTION("Check alignment and size parameters for vkCmdFillBuffer");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -185,7 +187,7 @@ TEST_F(VkLayerTest, FillBufferAlignmentAndSize) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidBufferViewObject) {
+TEST_F(NegativeBuffer, BufferViewObject) {
     // Create a single TEXEL_BUFFER descriptor and send it an invalid bufferView
     // First, cause the bufferView to be invalid due to underlying buffer being destroyed
     // Then destroy view itself and verify that same error is hit
@@ -236,7 +238,7 @@ TEST_F(VkLayerTest, InvalidBufferViewObject) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CreateBufferViewNoMemoryBoundToBuffer) {
+TEST_F(NegativeBuffer, CreateBufferViewNoMemoryBoundToBuffer) {
     TEST_DESCRIPTION("Attempt to create a buffer view with a buffer that has no memory bound to it.");
 
     VkResult err;
@@ -264,7 +266,7 @@ TEST_F(VkLayerTest, CreateBufferViewNoMemoryBoundToBuffer) {
     vk::DestroyBuffer(m_device->device(), buffer, NULL);
 }
 
-TEST_F(VkLayerTest, InvalidBufferViewCreateInfoEntries) {
+TEST_F(NegativeBuffer, BufferViewCreateInfoEntries) {
     TEST_DESCRIPTION("Attempt to create a buffer view with invalid create info.");
 
     // Attempt to enable texel buffer alignmnet extension
@@ -379,7 +381,7 @@ TEST_F(VkLayerTest, InvalidBufferViewCreateInfoEntries) {
     CreateBufferViewTest(*this, &buff_view_ci, {"VUID-VkBufferViewCreateInfo-buffer-00934"});
 }
 
-TEST_F(VkLayerTest, TexelBufferAlignmentIn12) {
+TEST_F(NegativeBuffer, TexelBufferAlignmentIn12) {
     TEST_DESCRIPTION("texelBufferAlignment is not enabled by default in 1.2.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -410,7 +412,7 @@ TEST_F(VkLayerTest, TexelBufferAlignmentIn12) {
     CreateBufferViewTest(*this, &buff_view_ci, {"VUID-VkBufferViewCreateInfo-offset-00926"});
 }
 
-TEST_F(VkLayerTest, InvalidTexelBufferAlignment) {
+TEST_F(NegativeBuffer, TexelBufferAlignment) {
     TEST_DESCRIPTION("Test VK_EXT_texel_buffer_alignment.");
     AddRequiredExtensions(VK_EXT_TEXEL_BUFFER_ALIGNMENT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -496,7 +498,7 @@ TEST_F(VkLayerTest, InvalidTexelBufferAlignment) {
     }
 }
 
-TEST_F(VkLayerTest, FillBufferWithinRenderPass) {
+TEST_F(NegativeBuffer, FillBufferWithinRenderPass) {
     // Call CmdFillBuffer within an active renderpass
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdFillBuffer-renderpass");
 
@@ -518,7 +520,7 @@ TEST_F(VkLayerTest, FillBufferWithinRenderPass) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, UpdateBufferWithinRenderPass) {
+TEST_F(NegativeBuffer, UpdateBufferWithinRenderPass) {
     // Call CmdUpdateBuffer within an active renderpass
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdUpdateBuffer-renderpass");
 
@@ -543,7 +545,7 @@ TEST_F(VkLayerTest, UpdateBufferWithinRenderPass) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, IdxBufferAlignmentError) {
+TEST_F(NegativeBuffer, IdxBufferAlignmentError) {
     // Bind a BeginRenderPass within an active RenderPass
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -568,7 +570,7 @@ TEST_F(VkLayerTest, IdxBufferAlignmentError) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, VertexBufferInvalid) {
+TEST_F(NegativeBuffer, VertexBuffer) {
     TEST_DESCRIPTION(
         "Submit a command buffer using deleted vertex buffer, delete a buffer twice, use an invalid offset for each buffer type, "
         "and attempt to bind a null buffer");
@@ -649,7 +651,7 @@ TEST_F(VkLayerTest, VertexBufferInvalid) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, BadVertexBufferOffset) {
+TEST_F(NegativeBuffer, VertexBufferOffset) {
     TEST_DESCRIPTION("Submit an offset past the end of a vertex buffer");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -678,7 +680,7 @@ TEST_F(VkLayerTest, BadVertexBufferOffset) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, BadIndexBufferOffset) {
+TEST_F(NegativeBuffer, IndexBufferOffset) {
     TEST_DESCRIPTION("Submit bad offsets binding the index buffer");
 
     AddRequiredExtensions(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME);
@@ -714,7 +716,7 @@ TEST_F(VkLayerTest, BadIndexBufferOffset) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidCreateBufferSize) {
+TEST_F(NegativeBuffer, CreateBufferSize) {
     TEST_DESCRIPTION("Attempt to create VkBuffer with size of zero");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -725,7 +727,7 @@ TEST_F(VkLayerTest, InvalidCreateBufferSize) {
     CreateBufferTest(*this, &info, "VUID-VkBufferCreateInfo-size-00912");
 }
 
-TEST_F(VkLayerTest, DedicatedAllocationBufferWithInvalidFlags) {
+TEST_F(NegativeBuffer, DedicatedAllocationBufferFlags) {
     TEST_DESCRIPTION("Verify that flags are valid with VkDedicatedAllocationBufferCreateInfoNV");
 
     // Positive test to check parameter_validation and unique_objects support for NV_dedicated_allocation
@@ -754,7 +756,7 @@ TEST_F(VkLayerTest, DedicatedAllocationBufferWithInvalidFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, FillBufferCmdPoolUnsupported) {
+TEST_F(NegativeBuffer, FillBufferCmdPoolUnsupported) {
     TEST_DESCRIPTION(
         "Use a command buffer with vkCmdFillBuffer that was allocated from a command pool that does not support graphics or "
         "compute opeartions");
@@ -781,7 +783,7 @@ TEST_F(VkLayerTest, FillBufferCmdPoolUnsupported) {
     cb.end();
 }
 
-TEST_F(VkLayerTest, InvalidConditionalRenderingBufferUsage) {
+TEST_F(NegativeBuffer, ConditionalRenderingBufferUsage) {
     TEST_DESCRIPTION("Use a buffer without conditional rendering usage when needed.");
 
     AddRequiredExtensions(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
@@ -808,7 +810,7 @@ TEST_F(VkLayerTest, InvalidConditionalRenderingBufferUsage) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidConditionalRenderingOffset) {
+TEST_F(NegativeBuffer, ConditionalRenderingOffset) {
     TEST_DESCRIPTION("Begin conditional rendering with invalid offset.");
 
     AddRequiredExtensions(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
@@ -843,7 +845,7 @@ TEST_F(VkLayerTest, InvalidConditionalRenderingOffset) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidBeginConditionalRendering) {
+TEST_F(NegativeBuffer, BeginConditionalRendering) {
     TEST_DESCRIPTION("Begin conditional rendering when it is already active.");
 
     AddRequiredExtensions(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
@@ -871,7 +873,7 @@ TEST_F(VkLayerTest, InvalidBeginConditionalRendering) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, TestCompletelyOverlappingBufferCopy) {
+TEST_F(NegativeBuffer, CompletelyOverlappingBufferCopy) {
     TEST_DESCRIPTION("Test copying between buffers with completely overlapping source and destination regions.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -901,7 +903,7 @@ TEST_F(VkLayerTest, TestCompletelyOverlappingBufferCopy) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestCopyingInterleavedRegions) {
+TEST_F(NegativeBuffer, CopyingInterleavedRegions) {
     TEST_DESCRIPTION("Test copying between interleaved source and destination regions.");
     ASSERT_NO_FATAL_FAILURE(Init());
 

--- a/tests/negative/command.cpp
+++ b/tests/negative/command.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, InvalidCommandPoolConsistency) {
+class NegativeCommand : public VkLayerTest {};
+
+TEST_F(NegativeCommand, CommandPoolConsistency) {
     TEST_DESCRIPTION("Allocate command buffers from one command pool and attempt to delete them from another.");
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkFreeCommandBuffers-pCommandBuffers-parent");
@@ -40,7 +42,7 @@ TEST_F(VkLayerTest, InvalidCommandPoolConsistency) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidSecondaryCommandBufferBarrier) {
+TEST_F(NegativeCommand, SecondaryCommandBufferBarrier) {
     TEST_DESCRIPTION("Add an invalid image barrier in a secondary command buffer");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -117,7 +119,7 @@ TEST_F(VkLayerTest, InvalidSecondaryCommandBufferBarrier) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, IndexBufferNotBound) {
+TEST_F(NegativeCommand, IndexBufferNotBound) {
     TEST_DESCRIPTION("Run an indexed draw call without an index buffer bound.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -126,7 +128,7 @@ TEST_F(VkLayerTest, IndexBufferNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, IndexBufferBadSize) {
+TEST_F(NegativeCommand, IndexBufferSize) {
     TEST_DESCRIPTION("Run indexed draw call with bad index buffer size.");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -135,7 +137,7 @@ TEST_F(VkLayerTest, IndexBufferBadSize) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, IndexBufferBadOffset) {
+TEST_F(NegativeCommand, IndexBufferOffset) {
     TEST_DESCRIPTION("Run indexed draw call with bad index buffer offset.");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -144,7 +146,7 @@ TEST_F(VkLayerTest, IndexBufferBadOffset) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, IndexBufferBadBindSize) {
+TEST_F(NegativeCommand, IndexBufferBindSize) {
     TEST_DESCRIPTION("Run bind index buffer with a size greater than the index buffer.");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -153,7 +155,7 @@ TEST_F(VkLayerTest, IndexBufferBadBindSize) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, IndexBufferBadBindOffset) {
+TEST_F(NegativeCommand, IndexBufferBindOffset) {
     TEST_DESCRIPTION("Run bind index buffer with an offset greater than the size of the index buffer.");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -162,7 +164,7 @@ TEST_F(VkLayerTest, IndexBufferBadBindOffset) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MissingClearAttachment) {
+TEST_F(NegativeCommand, MissingClearAttachment) {
     TEST_DESCRIPTION("Points to a wrong colorAttachment index in a VkClearAttachment structure passed to vkCmdClearAttachments");
     ASSERT_NO_FATAL_FAILURE(Init());
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-aspectMask-07271");
@@ -171,7 +173,7 @@ TEST_F(VkLayerTest, MissingClearAttachment) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SecondaryCommandbufferAsPrimary) {
+TEST_F(NegativeCommand, SecondaryCommandbufferAsPrimary) {
     TEST_DESCRIPTION("Create a secondary command buffer and pass it to QueueSubmit.");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSubmitInfo-pCommandBuffers-00075");
 
@@ -195,7 +197,7 @@ TEST_F(VkLayerTest, SecondaryCommandbufferAsPrimary) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, Sync2SecondaryCommandbufferAsPrimary) {
+TEST_F(NegativeCommand, Sync2SecondaryCommandbufferAsPrimary) {
     TEST_DESCRIPTION("Create a secondary command buffer and pass it to QueueSubmit2KHR.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -224,7 +226,7 @@ TEST_F(VkLayerTest, Sync2SecondaryCommandbufferAsPrimary) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CommandBufferTwoSubmits) {
+TEST_F(NegativeCommand, CommandBufferTwoSubmits) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "was begun w/ VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT set, but has been submitted");
 
@@ -261,7 +263,7 @@ TEST_F(VkLayerTest, CommandBufferTwoSubmits) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, Sync2CommandBufferTwoSubmits) {
+TEST_F(NegativeCommand, Sync2CommandBufferTwoSubmits) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -304,7 +306,7 @@ TEST_F(VkLayerTest, Sync2CommandBufferTwoSubmits) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidPushConstants) {
+TEST_F(NegativeCommand, PushConstants) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -469,7 +471,7 @@ TEST_F(VkLayerTest, InvalidPushConstants) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, NoBeginCommandBuffer) {
+TEST_F(NegativeCommand, NoBeginCommandBuffer) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkEndCommandBuffer-commandBuffer-00059");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -480,7 +482,7 @@ TEST_F(VkLayerTest, NoBeginCommandBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SecondaryCommandBufferRerecordedExplicitReset) {
+TEST_F(NegativeCommand, SecondaryCommandBufferRerecordedExplicitReset) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "was destroyed or rerecorded");
@@ -504,7 +506,7 @@ TEST_F(VkLayerTest, SecondaryCommandBufferRerecordedExplicitReset) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SecondaryCommandBufferRerecordedNoReset) {
+TEST_F(NegativeCommand, SecondaryCommandBufferRerecordedNoReset) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "was destroyed or rerecorded");
@@ -527,7 +529,7 @@ TEST_F(VkLayerTest, SecondaryCommandBufferRerecordedNoReset) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CascadedInvalidation) {
+TEST_F(NegativeCommand, CascadedInvalidation) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     VkEventCreateInfo eci = LvlInitStruct<VkEventCreateInfo>();
@@ -552,7 +554,7 @@ TEST_F(VkLayerTest, CascadedInvalidation) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CommandBufferResetErrors) {
+TEST_F(NegativeCommand, CommandBufferReset) {
     // Cause error due to Begin while recording CB
     // Then cause 2 errors for attempting to reset CB w/o having
     // VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT set for the pool from
@@ -590,7 +592,7 @@ TEST_F(VkLayerTest, CommandBufferResetErrors) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CommandBufferPrimaryFlags) {
+TEST_F(NegativeCommand, CommandBufferPrimaryFlags) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     // Calls AllocateCommandBuffers
@@ -604,7 +606,7 @@ TEST_F(VkLayerTest, CommandBufferPrimaryFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ClearColorAttachmentsOutsideRenderPass) {
+TEST_F(NegativeCommand, ClearColorAttachmentsOutsideRenderPass) {
     // Call CmdClearAttachmentss outside of an active RenderPass
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkCmdClearAttachments: This call must be issued inside an active render pass");
@@ -628,7 +630,7 @@ TEST_F(VkLayerTest, ClearColorAttachmentsOutsideRenderPass) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ClearColorAttachmentsZeroLayercount) {
+TEST_F(NegativeCommand, ClearColorAttachmentsZeroLayercount) {
     TEST_DESCRIPTION("Call CmdClearAttachments with a pRect having a layerCount of zero.");
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-layerCount-01934");
@@ -652,7 +654,7 @@ TEST_F(VkLayerTest, ClearColorAttachmentsZeroLayercount) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ClearColorAttachmentsZeroExtent) {
+TEST_F(NegativeCommand, ClearColorAttachmentsZeroExtent) {
     TEST_DESCRIPTION("Call CmdClearAttachments with a pRect having a rect2D extent of zero.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -684,7 +686,7 @@ TEST_F(VkLayerTest, ClearColorAttachmentsZeroExtent) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ClearAttachmentsInvalidAspectMasks) {
+TEST_F(NegativeCommand, ClearAttachmentsAspectMasks) {
     TEST_DESCRIPTION("Check VkClearAttachment invalid aspect masks.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -726,7 +728,7 @@ TEST_F(VkLayerTest, ClearAttachmentsInvalidAspectMasks) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ClearAttachmentsImplicitCheck) {
+TEST_F(NegativeCommand, ClearAttachmentsImplicitCheck) {
     TEST_DESCRIPTION("Check VkClearAttachment implicit VUs.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -758,7 +760,7 @@ TEST_F(VkLayerTest, ClearAttachmentsImplicitCheck) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ClearAttachmentsDepth) {
+TEST_F(NegativeCommand, ClearAttachmentsDepth) {
     TEST_DESCRIPTION("Call CmdClearAttachments with invalid depth aspect masks.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -791,7 +793,7 @@ TEST_F(VkLayerTest, ClearAttachmentsDepth) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ClearAttachmentsStencil) {
+TEST_F(NegativeCommand, ClearAttachmentsStencil) {
     TEST_DESCRIPTION("Call CmdClearAttachments with invalid stencil aspect masks.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -820,7 +822,7 @@ TEST_F(VkLayerTest, ClearAttachmentsStencil) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ExecuteCommandsPrimaryCB) {
+TEST_F(NegativeCommand, ExecuteCommandsPrimaryCB) {
     TEST_DESCRIPTION("Attempt vkCmdExecuteCommands with a primary command buffer (should only be secondary)");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -845,7 +847,7 @@ TEST_F(VkLayerTest, ExecuteCommandsPrimaryCB) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ExecuteCommandsToSecondaryCB) {
+TEST_F(NegativeCommand, ExecuteCommandsToSecondaryCB) {
     TEST_DESCRIPTION("Attempt vkCmdExecuteCommands to a Secondary command buffer");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -861,7 +863,7 @@ TEST_F(VkLayerTest, ExecuteCommandsToSecondaryCB) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, NonSimultaneousSecondaryMarksPrimary) {
+TEST_F(NegativeCommand, NonSimultaneousSecondaryMarksPrimary) {
     ASSERT_NO_FATAL_FAILURE(Init());
     const char *simultaneous_use_message = "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBufferSimultaneousUse";
 
@@ -884,7 +886,7 @@ TEST_F(VkLayerTest, NonSimultaneousSecondaryMarksPrimary) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, SimultaneousUseSecondaryTwoExecutes) {
+TEST_F(NegativeCommand, SimultaneousUseSecondaryTwoExecutes) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     const char *simultaneous_use_message = "VUID-vkCmdExecuteCommands-pCommandBuffers-00092";
@@ -905,7 +907,7 @@ TEST_F(VkLayerTest, SimultaneousUseSecondaryTwoExecutes) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, SimultaneousUseSecondarySingleExecute) {
+TEST_F(NegativeCommand, SimultaneousUseSecondarySingleExecute) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     // variation on previous test executing the same CB twice in the same
@@ -929,7 +931,7 @@ TEST_F(VkLayerTest, SimultaneousUseSecondarySingleExecute) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, SimultaneousUseOneShot) {
+TEST_F(NegativeCommand, SimultaneousUseOneShot) {
     TEST_DESCRIPTION("Submit the same command buffer twice in one submit looking for simultaneous use and one time submit errors");
     const char *simultaneous_use_message = "is already in use and is not marked for simultaneous use";
     const char *one_shot_message = "VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT set, but has been submitted";
@@ -972,7 +974,7 @@ TEST_F(VkLayerTest, SimultaneousUseOneShot) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, DrawTimeImageViewTypeMismatchWithPipeline) {
+TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipeline) {
     TEST_DESCRIPTION(
         "Test that an error is produced when an image view type does not match the dimensionality declared in the shader");
 
@@ -1024,7 +1026,7 @@ TEST_F(VkLayerTest, DrawTimeImageViewTypeMismatchWithPipeline) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DrawTimeImageMultisampleMismatchWithPipeline) {
+TEST_F(NegativeCommand, DrawTimeImageMultisampleMismatchWithPipeline) {
     TEST_DESCRIPTION(
         "Test that an error is produced when a multisampled images are consumed via singlesample images types in the shader, or "
         "vice versa.");
@@ -1077,7 +1079,7 @@ TEST_F(VkLayerTest, DrawTimeImageMultisampleMismatchWithPipeline) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DrawTimeImageComponentTypeMismatchWithPipeline) {
+TEST_F(NegativeCommand, DrawTimeImageComponentTypeMismatchWithPipeline) {
     TEST_DESCRIPTION(
         "Test that an error is produced when the component type of an imageview disagrees with the type in the shader.");
 
@@ -1129,7 +1131,7 @@ TEST_F(VkLayerTest, DrawTimeImageComponentTypeMismatchWithPipeline) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageLayerCountMismatch) {
+TEST_F(NegativeCommand, CopyImageLayerCountMismatch) {
     TEST_DESCRIPTION(
         "Try to copy between images with the source subresource having a different layerCount than the destination subresource");
     AddOptionalExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -1196,7 +1198,7 @@ TEST_F(VkLayerTest, CopyImageLayerCountMismatch) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CompressedImageMipCopyTests) {
+TEST_F(NegativeCommand, CompressedImageMipCopy) {
     TEST_DESCRIPTION("Image/Buffer copies for higher mip levels");
 
     AddOptionalExtensions(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
@@ -1441,7 +1443,7 @@ TEST_F(VkLayerTest, CompressedImageMipCopyTests) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImageBufferCopyTests) {
+TEST_F(NegativeCommand, ImageBufferCopy) {
     TEST_DESCRIPTION("Image to buffer and buffer to image tests");
 
     // Enable KHR multiplane req'd extensions for multi-planar copy tests
@@ -2069,7 +2071,7 @@ TEST_F(VkLayerTest, ImageBufferCopyTests) {
     }
 }
 
-TEST_F(VkLayerTest, MiscImageLayerTests) {
+TEST_F(NegativeCommand, MiscImageLayer) {
     TEST_DESCRIPTION("Image-related tests that don't belong elsewhere");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -2158,7 +2160,7 @@ TEST_F(VkLayerTest, MiscImageLayerTests) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CopyImageTypeExtentMismatch) {
+TEST_F(NegativeCommand, CopyImageTypeExtentMismatch) {
     TEST_DESCRIPTION("Image copy tests where format type and extents don't match");
     AddOptionalExtensions(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -2440,7 +2442,7 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatch) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageTypeExtentMismatchMaintenance1) {
+TEST_F(NegativeCommand, CopyImageTypeExtentMismatchMaintenance1) {
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
@@ -2573,7 +2575,7 @@ TEST_F(VkLayerTest, CopyImageTypeExtentMismatchMaintenance1) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageCompressedBlockAlignment) {
+TEST_F(NegativeCommand, CopyImageCompressedBlockAlignment) {
     // Image copy tests on compressed images with block alignment errors
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -2711,7 +2713,7 @@ TEST_F(VkLayerTest, CopyImageCompressedBlockAlignment) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageSrcSizeExceeded) {
+TEST_F(NegativeCommand, CopyImageSrcSizeExceeded) {
     // Image copy with source region specified greater than src image size
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -2796,7 +2798,7 @@ TEST_F(VkLayerTest, CopyImageSrcSizeExceeded) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageDstSizeExceeded) {
+TEST_F(NegativeCommand, CopyImageDstSizeExceeded) {
     // Image copy with dest region specified greater than dest image size
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -2880,7 +2882,7 @@ TEST_F(VkLayerTest, CopyImageDstSizeExceeded) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageZeroSize) {
+TEST_F(NegativeCommand, CopyImageZeroSize) {
     TEST_DESCRIPTION("Image Copy with empty regions");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -2974,7 +2976,7 @@ TEST_F(VkLayerTest, CopyImageZeroSize) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageMultiPlaneSizeExceeded) {
+TEST_F(NegativeCommand, CopyImageMultiPlaneSizeExceeded) {
     TEST_DESCRIPTION("Image Copy for multi-planar format that exceed size of plane for both src and dst");
 
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
@@ -3097,7 +3099,7 @@ TEST_F(VkLayerTest, CopyImageMultiPlaneSizeExceeded) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageFormatSizeMismatch) {
+TEST_F(NegativeCommand, CopyImageFormatSizeMismatch) {
     // Enable KHR multiplane req'd extensions
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -3262,7 +3264,7 @@ TEST_F(VkLayerTest, CopyImageFormatSizeMismatch) {
     }
 }
 
-TEST_F(VkLayerTest, CopyImageDepthStencilFormatMismatch) {
+TEST_F(NegativeCommand, CopyImageDepthStencilFormatMismatch) {
     ASSERT_NO_FATAL_FAILURE(Init());
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
 
@@ -3309,7 +3311,7 @@ TEST_F(VkLayerTest, CopyImageDepthStencilFormatMismatch) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CopyImageSampleCountMismatch) {
+TEST_F(NegativeCommand, CopyImageSampleCountMismatch) {
     TEST_DESCRIPTION("Image copies with sample count mis-matches");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3393,7 +3395,7 @@ TEST_F(VkLayerTest, CopyImageSampleCountMismatch) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageAspectMismatch) {
+TEST_F(NegativeCommand, CopyImageAspectMismatch) {
     TEST_DESCRIPTION("Image copies with aspect mask errors");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -3541,7 +3543,7 @@ TEST_F(VkLayerTest, CopyImageAspectMismatch) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ResolveImageLowSampleCount) {
+TEST_F(NegativeCommand, ResolveImageLowSampleCount) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdResolveImage-srcImage-00257");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3600,7 +3602,7 @@ TEST_F(VkLayerTest, ResolveImageLowSampleCount) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ResolveImageHighSampleCount) {
+TEST_F(NegativeCommand, ResolveImageHighSampleCount) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdResolveImage-dstImage-00259");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3665,7 +3667,7 @@ TEST_F(VkLayerTest, ResolveImageHighSampleCount) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ResolveImageFormatMismatch) {
+TEST_F(NegativeCommand, ResolveImageFormatMismatch) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdResolveImage-srcImage-01386");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3732,7 +3734,7 @@ TEST_F(VkLayerTest, ResolveImageFormatMismatch) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ResolveImageLayoutMismatch) {
+TEST_F(NegativeCommand, ResolveImageLayoutMismatch) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     if (!ImageFormatAndFeaturesSupported(gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
@@ -3811,7 +3813,7 @@ TEST_F(VkLayerTest, ResolveImageLayoutMismatch) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ResolveInvalidSubresource) {
+TEST_F(NegativeCommand, ResolveInvalidSubresource) {
     AddOptionalExtensions(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(Init());
     const bool copy_commands2 = IsExtensionsEnabled(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
@@ -4003,7 +4005,7 @@ TEST_F(VkLayerTest, ResolveInvalidSubresource) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ResolveImageImageType) {
+TEST_F(NegativeCommand, ResolveImageImageType) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     if (!ImageFormatAndFeaturesSupported(gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
@@ -4100,7 +4102,7 @@ TEST_F(VkLayerTest, ResolveImageImageType) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ResolveImageSizeExceeded) {
+TEST_F(NegativeCommand, ResolveImageSizeExceeded) {
     TEST_DESCRIPTION("Resolve Image with subresource region greater than size of src/dst image");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -4211,7 +4213,7 @@ TEST_F(VkLayerTest, ResolveImageSizeExceeded) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ClearImageErrors) {
+TEST_F(NegativeCommand, ClearImage) {
     TEST_DESCRIPTION("Call ClearColorImage w/ a depth|stencil image and ClearDepthStencilImage with a color image.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -4284,7 +4286,7 @@ TEST_F(VkLayerTest, ClearImageErrors) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CommandQueueFlags) {
+TEST_F(NegativeCommand, CommandQueueFlags) {
     TEST_DESCRIPTION(
         "Allocate a command buffer on a queue that does not support graphics and try to issue a graphics-only command");
 
@@ -4309,7 +4311,7 @@ TEST_F(VkLayerTest, CommandQueueFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DepthStencilImageCopyNoGraphicsQueueFlags) {
+TEST_F(NegativeCommand, DepthStencilImageCopyNoGraphicsQueueFlags) {
     TEST_DESCRIPTION(
         "Allocate a command buffer on a queue that does not support graphics and try to issue a depth/stencil image copy to "
         "buffer");
@@ -4356,7 +4358,7 @@ TEST_F(VkLayerTest, DepthStencilImageCopyNoGraphicsQueueFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImageCopyTransferQueueFlags) {
+TEST_F(NegativeCommand, ImageCopyTransferQueueFlags) {
     TEST_DESCRIPTION(
         "Allocate a command buffer on a queue that does not support graphics/compute and try to issue an invalid image copy to "
         "buffer");
@@ -4403,7 +4405,7 @@ TEST_F(VkLayerTest, ImageCopyTransferQueueFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ExecuteDiffertQueueFlagsSecondaryCB) {
+TEST_F(NegativeCommand, ExecuteDiffertQueueFlagsSecondaryCB) {
     TEST_DESCRIPTION("Allocate a command buffer from two different queues and try to use a secondary command buffer");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -4458,7 +4460,7 @@ TEST_F(VkLayerTest, ExecuteDiffertQueueFlagsSecondaryCB) {
     command_buffer_primary.end();
 }
 
-TEST_F(VkLayerTest, ExecuteUnrecordedSecondaryCB) {
+TEST_F(NegativeCommand, ExecuteUnrecordedSecondaryCB) {
     TEST_DESCRIPTION("Attempt vkCmdExecuteCommands with a CB in the initial state");
     ASSERT_NO_FATAL_FAILURE(Init());
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
@@ -4471,7 +4473,7 @@ TEST_F(VkLayerTest, ExecuteUnrecordedSecondaryCB) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ExecuteSecondaryCBWithLayoutMismatch) {
+TEST_F(NegativeCommand, ExecuteSecondaryCBWithLayoutMismatch) {
     TEST_DESCRIPTION("Attempt vkCmdExecuteCommands with a CB with incorrect initial layout.");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -4531,7 +4533,7 @@ TEST_F(VkLayerTest, ExecuteSecondaryCBWithLayoutMismatch) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, BadRenderPassScopeSecondaryCmdBuffer) {
+TEST_F(NegativeCommand, RenderPassScopeSecondaryCmdBuffer) {
     TEST_DESCRIPTION(
         "Test secondary buffers executed in wrong render pass scope wrt VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT");
 
@@ -4578,7 +4580,7 @@ TEST_F(VkLayerTest, BadRenderPassScopeSecondaryCmdBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SecondaryCommandBufferClearColorAttachmentsRenderArea) {
+TEST_F(NegativeCommand, SecondaryCommandBufferClearColorAttachmentsRenderArea) {
     TEST_DESCRIPTION(
         "Create a secondary command buffer with CmdClearAttachments call that has a rect outside of renderPass renderArea");
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -4623,7 +4625,7 @@ TEST_F(VkLayerTest, SecondaryCommandBufferClearColorAttachmentsRenderArea) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, PushDescriptorSetCmdPushBadArgs) {
+TEST_F(NegativeCommand, PushDescriptorSetCmdPush) {
     TEST_DESCRIPTION("Attempt to push a push descriptor set with incorrect arguments.");
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
 
@@ -4725,7 +4727,7 @@ TEST_F(VkLayerTest, PushDescriptorSetCmdPushBadArgs) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, PushDescriptorSetCmdBufferOffsetUnaligned) {
+TEST_F(NegativeCommand, PushDescriptorSetCmdBufferOffsetUnaligned) {
     TEST_DESCRIPTION("Attempt to push a push descriptor set buffer with unaligned offset.");
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
 
@@ -4765,7 +4767,7 @@ TEST_F(VkLayerTest, PushDescriptorSetCmdBufferOffsetUnaligned) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, MultiDrawTests) {
+TEST_F(NegativeCommand, MultiDraw) {
     TEST_DESCRIPTION("Test validation of multi_draw extension");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
@@ -4865,7 +4867,7 @@ TEST_F(VkLayerTest, MultiDrawTests) {
     }
 }
 
-TEST_F(VkLayerTest, MultiDrawFeatures) {
+TEST_F(NegativeCommand, MultiDrawFeatures) {
     TEST_DESCRIPTION("Test validation of multi draw feature enabled");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
@@ -4904,7 +4906,7 @@ TEST_F(VkLayerTest, MultiDrawFeatures) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, IndirectDrawTests) {
+TEST_F(NegativeCommand, IndirectDraw) {
     TEST_DESCRIPTION("Test covered valid usage for vkCmdDrawIndirect and vkCmdDrawIndexedIndirect");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -4978,7 +4980,7 @@ TEST_F(VkLayerTest, IndirectDrawTests) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DrawIndirectCountKHR) {
+TEST_F(NegativeCommand, DrawIndirectCountKHR) {
     TEST_DESCRIPTION("Test covered valid usage for vkCmdDrawIndirectCountKHR");
 
     AddRequiredExtensions(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
@@ -5073,7 +5075,7 @@ TEST_F(VkLayerTest, DrawIndirectCountKHR) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DrawIndexedIndirectCountKHR) {
+TEST_F(NegativeCommand, DrawIndexedIndirectCountKHR) {
     TEST_DESCRIPTION("Test covered valid usage for vkCmdDrawIndexedIndirectCountKHR");
 
     AddRequiredExtensions(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
@@ -5182,7 +5184,7 @@ TEST_F(VkLayerTest, DrawIndexedIndirectCountKHR) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DrawIndirectCountFeature) {
+TEST_F(NegativeCommand, DrawIndirectCountFeature) {
     TEST_DESCRIPTION("Test covered valid usage for the 1.2 drawIndirectCount feature");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -5233,7 +5235,7 @@ TEST_F(VkLayerTest, DrawIndirectCountFeature) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ExclusiveScissorNV) {
+TEST_F(NegativeCommand, ExclusiveScissorNV) {
     TEST_DESCRIPTION("Test VK_NV_scissor_exclusive with multiViewport disabled.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -5372,7 +5374,7 @@ TEST_F(VkLayerTest, ExclusiveScissorNV) {
     }
 }
 
-TEST_F(VkLayerTest, ViewportWScalingNV) {
+TEST_F(NegativeCommand, ViewportWScalingNV) {
     TEST_DESCRIPTION("Verify VK_NV_clip_space_w_scaling");
 
     AddRequiredExtensions(VK_NV_CLIP_SPACE_W_SCALING_EXTENSION_NAME);
@@ -5492,7 +5494,7 @@ TEST_F(VkLayerTest, ViewportWScalingNV) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DrawWithoutUpdatePushConstants) {
+TEST_F(NegativeCommand, DrawWithoutUpdatePushConstants) {
     TEST_DESCRIPTION("Not every bytes in used push constant ranges has been set before Draw ");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -5610,7 +5612,7 @@ TEST_F(VkLayerTest, DrawWithoutUpdatePushConstants) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, VerifyFilterCubicSamplerInCmdDraw) {
+TEST_F(NegativeCommand, FilterCubicSamplerInCmdDraw) {
     TEST_DESCRIPTION("Verify if sampler is filter cubic, image view needs to support it.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_FILTER_CUBIC_EXTENSION_NAME);
@@ -5714,7 +5716,7 @@ TEST_F(VkLayerTest, VerifyFilterCubicSamplerInCmdDraw) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, VerifyImgFilterCubicSamplerInCmdDraw) {
+TEST_F(NegativeCommand, ImageFilterCubicSamplerInCmdDraw) {
     TEST_DESCRIPTION("Verify if sampler is filter cubic with the VK_IMG_filter cubic extension that it's a valid ImageViewType.");
 
     AddRequiredExtensions(VK_IMG_FILTER_CUBIC_EXTENSION_NAME);
@@ -5790,7 +5792,7 @@ TEST_F(VkLayerTest, VerifyImgFilterCubicSamplerInCmdDraw) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidCmdUpdateBufferSize) {
+TEST_F(NegativeCommand, CmdUpdateBufferSize) {
     TEST_DESCRIPTION("Update buffer with invalid dataSize");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -5808,7 +5810,7 @@ TEST_F(VkLayerTest, InvalidCmdUpdateBufferSize) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidCmdUpdateBufferDstOffset) {
+TEST_F(NegativeCommand, CmdUpdateBufferDstOffset) {
     TEST_DESCRIPTION("Update buffer with invalid dst offset");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -5826,7 +5828,7 @@ TEST_F(VkLayerTest, InvalidCmdUpdateBufferDstOffset) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidDescriptorSetPipelineBindPoint) {
+TEST_F(NegativeCommand, DescriptorSetPipelineBindPoint) {
     TEST_DESCRIPTION(
         "Attempt to bind descriptor set to a bind point not supported by command pool the command buffer was allocated from");
 
@@ -5882,7 +5884,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSetPipelineBindPoint) {
     command_buffer.end();
 }
 
-TEST_F(VkLayerTest, CmdClearColorImageNullColor) {
+TEST_F(NegativeCommand, CmdClearColorImageNullColor) {
     TEST_DESCRIPTION("Test invalid null entries for clear color");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -5905,7 +5907,7 @@ TEST_F(VkLayerTest, CmdClearColorImageNullColor) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, TestEndCommandBufferWithConditionalRendering) {
+TEST_F(NegativeCommand, EndCommandBufferWithConditionalRendering) {
     TEST_DESCRIPTION("Call EndCommandBuffer when conditional rendering is active");
 
     AddRequiredExtensions(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
@@ -5934,7 +5936,7 @@ TEST_F(VkLayerTest, TestEndCommandBufferWithConditionalRendering) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DrawBlendEnabledFormatFeatures) {
+TEST_F(NegativeCommand, DrawBlendEnabledFormatFeatures) {
     TEST_DESCRIPTION("Test pipeline blend enabled with missing image views format features");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -5980,7 +5982,7 @@ TEST_F(VkLayerTest, DrawBlendEnabledFormatFeatures) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidEndConditionalRendering) {
+TEST_F(NegativeCommand, EndConditionalRendering) {
     TEST_DESCRIPTION("Invalid calls to vkCmdEndConditionalRenderingEXT.");
 
     AddRequiredExtensions(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME);
@@ -6078,7 +6080,7 @@ TEST_F(VkLayerTest, InvalidEndConditionalRendering) {
     vk::CmdEndRenderPass(m_commandBuffer->handle());
 }
 
-TEST_F(VkLayerTest, BadRenderPassContentsWhenCallingCmdExecuteCommandsWithBeginRenderPass) {
+TEST_F(NegativeCommand, RenderPassContentsWhenCallingCmdExecuteCommandsWithBeginRenderPass) {
     TEST_DESCRIPTION(
         "Test CmdExecuteCommands inside a render pass begun with CmdBeginRenderPass that hasn't set "
         "VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS");
@@ -6118,7 +6120,7 @@ TEST_F(VkLayerTest, BadRenderPassContentsWhenCallingCmdExecuteCommandsWithBeginR
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, BadExecuteCommandsSubpassIndices) {
+TEST_F(NegativeCommand, ExecuteCommandsSubpassIndices) {
     TEST_DESCRIPTION("Test invalid subpass when calling CmdExecuteCommands");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -6192,7 +6194,7 @@ TEST_F(VkLayerTest, BadExecuteCommandsSubpassIndices) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, IncompatibleRenderPassesInExecuteCommands) {
+TEST_F(NegativeCommand, IncompatibleRenderPassesInExecuteCommands) {
     TEST_DESCRIPTION("Test invalid subpass when calling CmdExecuteCommands");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -6253,7 +6255,7 @@ TEST_F(VkLayerTest, IncompatibleRenderPassesInExecuteCommands) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyCommands2V13) {
+TEST_F(NegativeCommand, CopyCommands2V13) {
     TEST_DESCRIPTION("Ensure copy_commands2 promotions are validated");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -6383,7 +6385,7 @@ TEST_F(VkLayerTest, CopyCommands2V13) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ResolveInvalidUsage) {
+TEST_F(NegativeCommand, ResolveUsage) {
     TEST_DESCRIPTION("Resolve image with missing usage flags.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -6519,7 +6521,7 @@ TEST_F(VkLayerTest, ResolveInvalidUsage) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageRemainingLayers) {
+TEST_F(NegativeCommand, CopyImageRemainingLayers) {
     TEST_DESCRIPTION("Test copying an image with VkImageSubresourceLayers.layerCount = VK_REMAINING_ARRAY_LAYERS");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -6600,7 +6602,7 @@ TEST_F(VkLayerTest, CopyImageRemainingLayers) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidDepthStencilStateForReadOnlyLayout) {
+TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
     TEST_DESCRIPTION("invalid depth stencil state for subpass that uses read only image layout.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -6740,7 +6742,7 @@ TEST_F(VkLayerTest, InvalidDepthStencilStateForReadOnlyLayout) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ClearColorImageWithBadRange) {
+TEST_F(NegativeCommand, ClearColorImageWithRange) {
     TEST_DESCRIPTION("Record clear color with an invalid VkImageSubresourceRange");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -6824,7 +6826,7 @@ TEST_F(VkLayerTest, ClearColorImageWithBadRange) {
     }
 }
 
-TEST_F(VkLayerTest, ClearDepthStencilWithBadAspect) {
+TEST_F(NegativeCommand, ClearDepthStencilWithAspect) {
     TEST_DESCRIPTION("Verify ClearDepth with an invalid VkImageAspectFlags.");
 
     AddOptionalExtensions(VK_EXT_SEPARATE_STENCIL_USAGE_EXTENSION_NAME);
@@ -6914,7 +6916,7 @@ TEST_F(VkLayerTest, ClearDepthStencilWithBadAspect) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ClearDepthStencilWithBadRange) {
+TEST_F(NegativeCommand, ClearDepthStencilWithRange) {
     TEST_DESCRIPTION("Record clear depth with an invalid VkImageSubresourceRange");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -7000,7 +7002,7 @@ TEST_F(VkLayerTest, ClearDepthStencilWithBadRange) {
     }
 }
 
-TEST_F(VkLayerTest, ClearColorImageWithinRenderPass) {
+TEST_F(NegativeCommand, ClearColorImageWithinRenderPass) {
     // Call CmdClearColorImage within an active RenderPass
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearColorImage-renderpass");
 
@@ -7040,7 +7042,7 @@ TEST_F(VkLayerTest, ClearColorImageWithinRenderPass) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ClearDepthStencilImageErrors) {
+TEST_F(NegativeCommand, ClearDepthStencilImage) {
     // Hit errors related to vk::CmdClearDepthStencilImage()
     // 1. Use an image that doesn't have VK_IMAGE_USAGE_TRANSFER_DST_BIT set
     // 2. Call CmdClearDepthStencilImage within an active RenderPass
@@ -7088,7 +7090,7 @@ TEST_F(VkLayerTest, ClearDepthStencilImageErrors) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ClearDepthRangeUnrestricted) {
+TEST_F(NegativeCommand, ClearDepthRangeUnrestricted) {
     TEST_DESCRIPTION("Test clearing without VK_EXT_depth_range_unrestricted");
 
     // Extension doesn't have feature bit, so not enabling extension invokes restrictions
@@ -7133,7 +7135,7 @@ TEST_F(VkLayerTest, ClearDepthRangeUnrestricted) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ClearColorImageInvalidImageLayout) {
+TEST_F(NegativeCommand, ClearColorImageImageLayout) {
     TEST_DESCRIPTION("Check ClearImage layouts with SHARED_PRESENTABLE_IMAGE extension active.");
 
     AddRequiredExtensions(VK_KHR_SHARED_PRESENTABLE_IMAGE_EXTENSION_NAME);

--- a/tests/negative/debug_printf.cpp
+++ b/tests/negative/debug_printf.cpp
@@ -13,7 +13,7 @@
 
 #include "../framework/layer_validation_tests.h"
 
-void VkDebugPrintfTest::InitDebugPrintfFramework() {
+void NegativeDebugPrintf::InitDebugPrintfFramework() {
     VkValidationFeatureEnableEXT enables[] = {VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT};
     VkValidationFeatureDisableEXT disables[] = {
         VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT, VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT,
@@ -27,7 +27,7 @@ void VkDebugPrintfTest::InitDebugPrintfFramework() {
     InitFramework(m_errorMonitor, &features);
 }
 
-TEST_F(VkDebugPrintfTest, GpuDebugPrintf) {
+TEST_F(NegativeDebugPrintf, BasicUsage) {
     TEST_DESCRIPTION("Verify that calls to debugPrintfEXT are received in debug stream");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
@@ -331,7 +331,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintf) {
         m_errorMonitor->VerifyFound();
     }
 }
-TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
+TEST_F(NegativeDebugPrintf, MeshTaskShaders) {
     TEST_DESCRIPTION("Test debug printf in mesh and task shaders.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -421,7 +421,7 @@ TEST_F(VkDebugPrintfTest, MeshTaskShadersPrintf) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPL) {
+TEST_F(NegativeDebugPrintf, GPL) {
     TEST_DESCRIPTION("Verify that calls to debugPrintfEXT are received in debug stream");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
@@ -755,7 +755,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPL) {
     }
 }
 
-TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragment) {
+TEST_F(NegativeDebugPrintf, GPLFragment) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -909,7 +909,7 @@ TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragment) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkDebugPrintfTest, GpuDebugPrintfGPLFragmentIndependentSets) {
+TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);

--- a/tests/negative/descriptor_buffer.cpp
+++ b/tests/negative/descriptor_buffer.cpp
@@ -17,7 +17,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/ray_tracing_objects.h"
 
-TEST_F(VkLayerTest, DescriptorBufferSetLayout) {
+class NegativeDescriptorBuffer : public VkLayerTest {};
+
+TEST_F(NegativeDescriptorBuffer, SetLayout) {
     TEST_DESCRIPTION("Descriptor buffer set layout tests.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -181,7 +183,7 @@ TEST_F(VkLayerTest, DescriptorBufferSetLayout) {
     }
 }
 
-TEST_F(VkLayerTest, DescriptorBufferNotEnabled) {
+TEST_F(NegativeDescriptorBuffer, NotEnabled) {
     TEST_DESCRIPTION("Tests for when descriptor buffer is not enabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -540,7 +542,7 @@ TEST_F(VkLayerTest, DescriptorBufferNotEnabled) {
     }
 }
 
-TEST_F(VkLayerTest, DescriptorBufferBindingAndOffsets) {
+TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
     TEST_DESCRIPTION("Descriptor buffer binding and offsets.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -836,7 +838,7 @@ TEST_F(VkLayerTest, DescriptorBufferBindingAndOffsets) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DescriptorBufferInconsistentBuffer) {
+TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
     TEST_DESCRIPTION("Dispatch pipeline with descriptor set bound while descriptor buffer expected");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -909,7 +911,7 @@ TEST_F(VkLayerTest, DescriptorBufferInconsistentBuffer) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DescriptorBufferInconsistentSet) {
+TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
     TEST_DESCRIPTION("Dispatch pipeline with descriptor buffer bound while of descriptor set expected");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -980,7 +982,7 @@ TEST_F(VkLayerTest, DescriptorBufferInconsistentSet) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DescriptorBufferInvalidBindPoint) {
+TEST_F(NegativeDescriptorBuffer, BindPoint) {
     TEST_DESCRIPTION("Descriptor buffer invalid bind point.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1054,7 +1056,7 @@ TEST_F(VkLayerTest, DescriptorBufferInvalidBindPoint) {
     }
 }
 
-TEST_F(VkLayerTest, DescriptorBufferDescriptorGetInfo) {
+TEST_F(NegativeDescriptorBuffer, DescriptorGetInfo) {
     TEST_DESCRIPTION("Descriptor buffer vkDescriptorGetInfo().");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -1275,7 +1277,7 @@ TEST_F(VkLayerTest, DescriptorBufferDescriptorGetInfo) {
     }
 }
 
-TEST_F(VkLayerTest, DescriptorBufferVarious) {
+TEST_F(NegativeDescriptorBuffer, Various) {
     TEST_DESCRIPTION("Descriptor buffer various tests.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -1454,7 +1456,7 @@ TEST_F(VkLayerTest, DescriptorBufferVarious) {
     }
 }
 
-TEST_F(VkLayerTest, DescriptorBufferInvalidExtensionCombination) {
+TEST_F(NegativeDescriptorBuffer, ExtensionCombination) {
     TEST_DESCRIPTION("Descriptor invalid extension combination.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -1500,7 +1502,7 @@ TEST_F(VkLayerTest, DescriptorBufferInvalidExtensionCombination) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DescriptorBufferSetBufferAddressSpaceLimits) {
+TEST_F(NegativeDescriptorBuffer, SetBufferAddressSpaceLimits) {
     TEST_DESCRIPTION("Create VkBuffer with extension.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);

--- a/tests/negative/descriptors.cpp
+++ b/tests/negative/descriptors.cpp
@@ -17,7 +17,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/ray_tracing_objects.h"
 
-TEST_F(VkLayerTest, InvalidDescriptorPoolConsistency) {
+class NegativeDescriptors : public VkLayerTest {};
+
+TEST_F(NegativeDescriptors, DescriptorPoolConsistency) {
     TEST_DESCRIPTION("Allocate descriptor sets from one DS pool and attempt to delete them from another.");
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkFreeDescriptorSets-pDescriptorSets-parent");
@@ -46,7 +48,7 @@ TEST_F(VkLayerTest, InvalidDescriptorPoolConsistency) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AllocDescriptorFromEmptyPool) {
+TEST_F(NegativeDescriptors, AllocDescriptorFromEmptyPool) {
     TEST_DESCRIPTION("Attempt to allocate more sets and descriptors than descriptor pool has available.");
     SetTargetApiVersion(VK_API_VERSION_1_0);
 
@@ -111,7 +113,7 @@ TEST_F(VkLayerTest, AllocDescriptorFromEmptyPool) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, FreeDescriptorFromOneShotPool) {
+TEST_F(NegativeDescriptors, FreeDescriptorFromOneShotPool) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -151,7 +153,7 @@ TEST_F(VkLayerTest, FreeDescriptorFromOneShotPool) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidDescriptorPool) {
+TEST_F(NegativeDescriptors, DescriptorPool) {
     // Attempt to clear Descriptor Pool with bad object.
     // ObjectTracker should catch this.
 
@@ -163,7 +165,7 @@ TEST_F(VkLayerTest, InvalidDescriptorPool) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidDescriptorSet) {
+TEST_F(NegativeDescriptors, DescriptorSet) {
     // Attempt to bind an invalid Descriptor Set to a valid Command Buffer
     // ObjectTracker should catch this.
     // Create a valid cmd buffer
@@ -205,7 +207,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSet) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidDescriptorSetLayout) {
+TEST_F(NegativeDescriptors, DescriptorSetLayout) {
     // Attempt to create a Pipeline Layout with an invalid Descriptor Set Layout.
     // ObjectTracker should catch this.
     constexpr uint64_t fake_layout_handle = 0xbaad6001;
@@ -221,7 +223,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSetLayout) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, WriteDescriptorSetIntegrityCheck) {
+TEST_F(NegativeDescriptors, WriteDescriptorSetIntegrity) {
     TEST_DESCRIPTION(
         "This test verifies some requirements of chapter 13.2.3 of the Vulkan Spec "
         "1) A uniform buffer update must have a valid buffer index. "
@@ -348,7 +350,7 @@ TEST_F(VkLayerTest, WriteDescriptorSetIntegrityCheck) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, WriteDescriptorSetIdentitySwizzle) {
+TEST_F(NegativeDescriptors, WriteDescriptorSetIdentitySwizzle) {
     TEST_DESCRIPTION("Test descriptors that need to have identity swizzle set");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -385,7 +387,7 @@ TEST_F(VkLayerTest, WriteDescriptorSetIdentitySwizzle) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, WriteDescriptorSetConsecutiveUpdates) {
+TEST_F(NegativeDescriptors, WriteDescriptorSetConsecutiveUpdates) {
     TEST_DESCRIPTION(
         "Verifies that updates rolling over to next descriptor work correctly by destroying buffer from consecutive update known "
         "to be used in descriptor set and verifying that error is flagged.");
@@ -482,7 +484,7 @@ TEST_F(VkLayerTest, WriteDescriptorSetConsecutiveUpdates) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetBufferDestroyed) {
+TEST_F(NegativeDescriptors, CmdBufferDescriptorSetBufferDestroyed) {
     TEST_DESCRIPTION(
         "Attempt to draw with a command buffer that is invalid due to a bound descriptor set with a buffer dependency being "
         "destroyed.");
@@ -552,9 +554,9 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetBufferDestroyed) {
     m_errorMonitor->VerifyFound();
 }
 
-// This is similar to the InvalidCmdBufferDescriptorSetBufferDestroyed test above except that the buffer
+// This is similar to the CmdBufferDescriptorSetBufferDestroyed test above except that the buffer
 // is destroyed before recording the Draw cmd.
-TEST_F(VkLayerTest, InvalidDrawDescriptorSetBufferDestroyed) {
+TEST_F(NegativeDescriptors, DrawDescriptorSetBufferDestroyed) {
     TEST_DESCRIPTION("Attempt to bind a descriptor set that is invalid at Draw time due to its buffer dependency being destroyed.");
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
@@ -614,7 +616,7 @@ TEST_F(VkLayerTest, InvalidDrawDescriptorSetBufferDestroyed) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
+TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     TEST_DESCRIPTION(
         "Attempt to draw with a command buffer that is invalid due to a bound descriptor sets with a combined image sampler having "
         "their image, sampler, and descriptor set each respectively destroyed and then attempting to submit associated cmd "
@@ -899,7 +901,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferDescriptorSetImageSamplerDestroyed) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidDescriptorSetSamplerDestroyed) {
+TEST_F(NegativeDescriptors, DescriptorSetSamplerDestroyed) {
     TEST_DESCRIPTION("Attempt to draw with a bound descriptor sets with a combined image sampler where sampler has been deleted.");
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitViewport());
@@ -996,7 +998,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSetSamplerDestroyed) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ImageDescriptorLayoutMismatch) {
+TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
     TEST_DESCRIPTION("Create an image sampler layout->image layout mismatch within/without a command buffer");
 
     AddOptionalExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
@@ -1162,7 +1164,7 @@ TEST_F(VkLayerTest, ImageDescriptorLayoutMismatch) {
     }
 }
 
-TEST_F(VkLayerTest, DescriptorPoolInUseResetSignaled) {
+TEST_F(NegativeDescriptors, DescriptorPoolInUseResetSignaled) {
     TEST_DESCRIPTION("Reset a DescriptorPool with a DescriptorSet that is in use.");
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
@@ -1223,7 +1225,7 @@ TEST_F(VkLayerTest, DescriptorPoolInUseResetSignaled) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, DescriptorImageUpdateNoMemoryBound) {
+TEST_F(NegativeDescriptors, DescriptorImageUpdateNoMemoryBound) {
     TEST_DESCRIPTION("Attempt an image descriptor set update where image's bound memory has been freed.");
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
@@ -1277,7 +1279,7 @@ TEST_F(VkLayerTest, DescriptorImageUpdateNoMemoryBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidDynamicOffsetCases) {
+TEST_F(NegativeDescriptors, DynamicOffsetCases) {
     // Create a descriptorSet w/ dynamic descriptor and then hit 3 offset error
     // cases:
     // 1. No dynamicOffset supplied
@@ -1351,7 +1353,7 @@ TEST_F(VkLayerTest, InvalidDynamicOffsetCases) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DescriptorBufferUpdateNoMemoryBound) {
+TEST_F(NegativeDescriptors, DescriptorBufferUpdateNoMemoryBound) {
     TEST_DESCRIPTION("Attempt to update a descriptor with a non-sparse buffer that doesn't have memory bound");
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-00329");
@@ -1383,7 +1385,7 @@ TEST_F(VkLayerTest, DescriptorBufferUpdateNoMemoryBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidDynamicDescriptorSet) {
+TEST_F(NegativeDescriptors, DynamicDescriptorSet) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     const VkDeviceSize partial_size = m_device->props.limits.minUniformBufferOffsetAlignment;
@@ -1514,7 +1516,7 @@ TEST_F(VkLayerTest, InvalidDynamicDescriptorSet) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicOffsetWithNullBuffer) {
+TEST_F(NegativeDescriptors, DynamicOffsetWithNullBuffer) {
     TEST_DESCRIPTION("Create a descriptorSet w/ dynamic descriptors where 1 binding is inactive, but all have null buffers");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1593,7 +1595,7 @@ TEST_F(VkLayerTest, DynamicOffsetWithNullBuffer) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, UpdateDescriptorSetMismatchType) {
+TEST_F(NegativeDescriptors, UpdateDescriptorSetMismatchType) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     uint32_t qfi = 0;
@@ -1617,7 +1619,7 @@ TEST_F(VkLayerTest, UpdateDescriptorSetMismatchType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DescriptorSetCompatibility) {
+TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
     // Test various desriptorSet errors with bad binding combinations
     using std::vector;
     VkResult err;
@@ -1826,7 +1828,7 @@ TEST_F(VkLayerTest, DescriptorSetCompatibility) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DSUsageBitsErrors) {
+TEST_F(NegativeDescriptors, DSUsageBits) {
     TEST_DESCRIPTION("Attempt to update descriptor sets for images and buffers that do not have correct usage bits sets.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1937,7 +1939,7 @@ TEST_F(VkLayerTest, DSUsageBitsErrors) {
     }
 }
 
-TEST_F(VkLayerTest, DSBufferInfoErrors) {
+TEST_F(NegativeDescriptors, DSBufferInfo) {
     TEST_DESCRIPTION(
         "Attempt to update buffer descriptor set that has incorrect parameters in VkDescriptorBufferInfo struct. This includes:\n"
         "1. offset value greater than or equal to buffer size\n"
@@ -2064,7 +2066,7 @@ TEST_F(VkLayerTest, DSBufferInfoErrors) {
     vk::DestroyDescriptorUpdateTemplateKHR(m_device->device(), push_template, nullptr);
 }
 
-TEST_F(VkLayerTest, DSBufferLimitErrors) {
+TEST_F(NegativeDescriptors, DSBufferLimit) {
     TEST_DESCRIPTION(
         "Attempt to update buffer descriptor set that has VkDescriptorBufferInfo values that violate device limits.\n"
         "Test cases include:\n"
@@ -2170,7 +2172,7 @@ TEST_F(VkLayerTest, DSBufferLimitErrors) {
     }
 }
 
-TEST_F(VkLayerTest, DSTypeMismatch) {
+TEST_F(NegativeDescriptors, DSTypeMismatch) {
     // Create DS w/ layout of one type and attempt Update w/ mis-matched type
     m_errorMonitor->SetDesiredFailureMsg(
         kErrorBit, " binding #0 with type VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER but update type is VK_DESCRIPTOR_TYPE_SAMPLER");
@@ -2189,7 +2191,7 @@ TEST_F(VkLayerTest, DSTypeMismatch) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DSUpdateOutOfBounds) {
+TEST_F(NegativeDescriptors, DSUpdateOutOfBounds) {
     // For overlapping Update, have arrayIndex exceed that of layout
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-dstArrayElement-00321");
 
@@ -2223,7 +2225,7 @@ TEST_F(VkLayerTest, DSUpdateOutOfBounds) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidDSUpdateIndex) {
+TEST_F(NegativeDescriptors, DSUpdateIndex) {
     // Create layout w/ count of 1 and attempt update to that layout w/ binding index 2
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-dstBinding-00315");
@@ -2241,7 +2243,7 @@ TEST_F(VkLayerTest, InvalidDSUpdateIndex) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DSUpdateEmptyBinding) {
+TEST_F(NegativeDescriptors, DSUpdateEmptyBinding) {
     // Create layout w/ empty binding and attempt to update it
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -2261,7 +2263,7 @@ TEST_F(VkLayerTest, DSUpdateEmptyBinding) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidDSUpdateStruct) {
+TEST_F(NegativeDescriptors, DSUpdateStruct) {
     // Call UpdateDS w/ struct type other than valid VK_STRUCTUR_TYPE_UPDATE_*
     // types
 
@@ -2292,7 +2294,7 @@ TEST_F(VkLayerTest, InvalidDSUpdateStruct) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SampleDescriptorUpdateError) {
+TEST_F(NegativeDescriptors, SampleDescriptorUpdate) {
     // Create a single Sampler descriptor and send it an invalid Sampler
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkWriteDescriptorSet-descriptorType-00325");
 
@@ -2308,7 +2310,7 @@ TEST_F(VkLayerTest, SampleDescriptorUpdateError) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImageViewDescriptorUpdateError) {
+TEST_F(NegativeDescriptors, ImageViewDescriptorUpdate) {
     // Create a single combined Image/Sampler descriptor and send it an invalid
     // imageView
 
@@ -2329,7 +2331,7 @@ TEST_F(VkLayerTest, ImageViewDescriptorUpdateError) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InputAttachmentDescriptorUpdateError) {
+TEST_F(NegativeDescriptors, InputAttachmentDescriptorUpdate) {
     ASSERT_NO_FATAL_FAILURE(Init());
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
@@ -2344,7 +2346,7 @@ TEST_F(VkLayerTest, InputAttachmentDescriptorUpdateError) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InputAttachmentDepthStencilAspect) {
+TEST_F(NegativeDescriptors, InputAttachmentDepthStencilAspect) {
     TEST_DESCRIPTION("Checks for InputAttachment image view with more than one aspect.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -2373,7 +2375,7 @@ TEST_F(VkLayerTest, InputAttachmentDepthStencilAspect) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CopyDescriptorUpdateErrors) {
+TEST_F(NegativeDescriptors, CopyDescriptorUpdate) {
     // Create DS w/ layout of 2 types, write update 1 and attempt to copy-update
     // into the other
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, " binding #1 with type VK_DESCRIPTOR_TYPE_SAMPLER. Types do not match.");
@@ -2444,7 +2446,7 @@ TEST_F(VkLayerTest, CopyDescriptorUpdateErrors) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, Maint1BindingSliceOf3DImage) {
+TEST_F(NegativeDescriptors, Maint1BindingSliceOf3DImage) {
     TEST_DESCRIPTION(
         "Attempt to bind a slice of a 3D texture in a descriptor set. This is explicitly disallowed by KHR_maintenance1 to keep "
         "things simple for drivers.");
@@ -2486,7 +2488,7 @@ TEST_F(VkLayerTest, Maint1BindingSliceOf3DImage) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UpdateDestroyDescriptorSetLayout) {
+TEST_F(NegativeDescriptors, UpdateDestroyDescriptorSetLayout) {
     TEST_DESCRIPTION("Attempt updates to descriptor sets with destroyed descriptor set layouts");
     // TODO: Update to match the descriptor set layout specific VUIDs/VALIDATION_ERROR_* when present
     const auto kWriteDestroyedLayout = "VUID-VkWriteDescriptorSet-dstSet-00320";
@@ -2564,7 +2566,7 @@ TEST_F(VkLayerTest, UpdateDestroyDescriptorSetLayout) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidCreateDescriptorPool) {
+TEST_F(NegativeDescriptors, CreateDescriptorPool) {
     TEST_DESCRIPTION("Attempt to create descriptor pool with invalid parameters");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -2603,7 +2605,7 @@ TEST_F(VkLayerTest, InvalidCreateDescriptorPool) {
     }
 }
 
-TEST_F(VkLayerTest, DuplicateDescriptorBinding) {
+TEST_F(NegativeDescriptors, DuplicateDescriptorBinding) {
     TEST_DESCRIPTION("Create a descriptor set layout with a duplicate binding number.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -2636,7 +2638,7 @@ TEST_F(VkLayerTest, DuplicateDescriptorBinding) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidPushDescriptorSetLayout) {
+TEST_F(NegativeDescriptors, IPushDescriptorSetLayout) {
     TEST_DESCRIPTION("Create a push descriptor set layout with invalid bindings.");
 
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
@@ -2682,7 +2684,7 @@ TEST_F(VkLayerTest, InvalidPushDescriptorSetLayout) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidPushDescriptorImageLayout) {
+TEST_F(NegativeDescriptors, PushDescriptorImageLayout) {
     TEST_DESCRIPTION("Use a push descriptor with a mismatched image layout.");
 
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
@@ -2777,7 +2779,7 @@ TEST_F(VkLayerTest, InvalidPushDescriptorImageLayout) {
     }
 }
 
-TEST_F(VkLayerTest, PushDescriptorSetLayoutWithoutExtension) {
+TEST_F(NegativeDescriptors, PushDescriptorSetLayoutWithoutExtension) {
     TEST_DESCRIPTION("Create a push descriptor set layout without loading the needed extension.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -2795,7 +2797,7 @@ TEST_F(VkLayerTest, PushDescriptorSetLayoutWithoutExtension) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DescriptorIndexingSetLayoutWithoutExtension) {
+TEST_F(NegativeDescriptors, DescriptorIndexingSetLayoutWithoutExtension) {
     TEST_DESCRIPTION("Create an update_after_bind set layout without loading the needed extension.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -2809,7 +2811,7 @@ TEST_F(VkLayerTest, DescriptorIndexingSetLayoutWithoutExtension) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DescriptorIndexingSetLayout) {
+TEST_F(NegativeDescriptors, DescriptorIndexingSetLayout) {
     TEST_DESCRIPTION("Exercise various create/allocate-time errors related to VK_EXT_descriptor_indexing.");
 
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
@@ -2963,7 +2965,7 @@ TEST_F(VkLayerTest, DescriptorIndexingSetLayout) {
     }
 }
 
-TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
+TEST_F(NegativeDescriptors, DescriptorIndexingUpdateAfterBind) {
     TEST_DESCRIPTION("Exercise errors for updating a descriptor set after it is bound.");
 
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
@@ -3126,7 +3128,7 @@ TEST_F(VkLayerTest, DescriptorIndexingUpdateAfterBind) {
     }
 }
 
-TEST_F(VkLayerTest, DescriptorIndexingSetNonIdenticalWrite) {
+TEST_F(NegativeDescriptors, DescriptorIndexingSetNonIdenticalWrite) {
     TEST_DESCRIPTION("VkWriteDescriptorSet must have identical VkDescriptorBindingFlagBits");
 
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
@@ -3204,7 +3206,7 @@ TEST_F(VkLayerTest, DescriptorIndexingSetNonIdenticalWrite) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AllocatePushDescriptorSet) {
+TEST_F(NegativeDescriptors, AllocatePushDescriptorSet) {
     TEST_DESCRIPTION("Attempt to allocate a push descriptor set.");
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
 
@@ -3239,7 +3241,7 @@ TEST_F(VkLayerTest, AllocatePushDescriptorSet) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CreateDescriptorUpdateTemplate) {
+TEST_F(NegativeDescriptors, CreateDescriptorUpdateTemplate) {
     TEST_DESCRIPTION("Verify error messages for invalid vkCreateDescriptorUpdateTemplate calls.");
 
 #ifdef __ANDROID__
@@ -3339,7 +3341,7 @@ TEST_F(VkLayerTest, CreateDescriptorUpdateTemplate) {
     do_test("VUID-VkDescriptorUpdateTemplateCreateInfo-templateType-00350");
 }
 
-TEST_F(VkLayerTest, InlineUniformBlockEXT) {
+TEST_F(NegativeDescriptors, InlineUniformBlockEXT) {
     TEST_DESCRIPTION("Test VK_EXT_inline_uniform_block.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3549,7 +3551,7 @@ TEST_F(VkLayerTest, InlineUniformBlockEXT) {
     vk::UpdateDescriptorSets(m_device->device(), 0, NULL, 1, &copy_ds_update);
 }
 
-TEST_F(VkLayerTest, InlineUniformBlockEXTFeature) {
+TEST_F(NegativeDescriptors, InlineUniformBlockEXTFeature) {
     TEST_DESCRIPTION("Test VK_EXT_inline_uniform_block features.");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -3578,7 +3580,7 @@ TEST_F(VkLayerTest, InlineUniformBlockEXTFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, WrongdstArrayElement) {
+TEST_F(NegativeDescriptors, DstArrayElement) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     OneOffDescriptorSet descriptor_set(m_device,
@@ -3634,7 +3636,7 @@ TEST_F(VkLayerTest, WrongdstArrayElement) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DescriptorSetLayoutMisc) {
+TEST_F(NegativeDescriptors, DescriptorSetLayoutMisc) {
     TEST_DESCRIPTION("Various invalid ways to create a VkDescriptorSetLayout.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3665,7 +3667,7 @@ TEST_F(VkLayerTest, DescriptorSetLayoutMisc) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, NullDescriptorsDisabled) {
+TEST_F(NegativeDescriptors, NullDescriptorsDisabled) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr));
 
@@ -3702,7 +3704,7 @@ TEST_F(VkLayerTest, NullDescriptorsDisabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, NullDescriptorsEnabled) {
+TEST_F(NegativeDescriptors, NullDescriptorsEnabled) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -3787,7 +3789,7 @@ TEST_F(VkLayerTest, NullDescriptorsEnabled) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ImageSubresourceOverlapBetweenAttachmentsAndDescriptorSets) {
+TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenAttachmentsAndDescriptorSets) {
     TEST_DESCRIPTION("Validate if attachments and descriptor set use the same image subresources");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3958,7 +3960,7 @@ TEST_F(VkLayerTest, ImageSubresourceOverlapBetweenAttachmentsAndDescriptorSets) 
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidCreateDescriptorPoolFlags) {
+TEST_F(NegativeDescriptors, CreateDescriptorPoolFlags) {
     TEST_DESCRIPTION("Create descriptor pool with invalid flags.");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
@@ -3990,7 +3992,7 @@ TEST_F(VkLayerTest, InvalidCreateDescriptorPoolFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MissingMutableDescriptorTypeFeature) {
+TEST_F(NegativeDescriptors, MissingMutableDescriptorTypeFeature) {
     TEST_DESCRIPTION("Create mutable descriptor pool with feature not enabled.");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
@@ -4022,7 +4024,7 @@ TEST_F(VkLayerTest, MissingMutableDescriptorTypeFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MutableDescriptorPoolsWithPartialOverlap) {
+TEST_F(NegativeDescriptors, MutableDescriptorPoolsWithPartialOverlap) {
     TEST_DESCRIPTION("Create mutable descriptor pools with partial overlap.");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
@@ -4092,7 +4094,7 @@ TEST_F(VkLayerTest, MutableDescriptorPoolsWithPartialOverlap) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidCreateDescriptorPoolAllocateFlags) {
+TEST_F(NegativeDescriptors, CreateDescriptorPoolAllocateFlags) {
     TEST_DESCRIPTION("Create descriptor pool with invalid flags.");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
@@ -4143,7 +4145,7 @@ TEST_F(VkLayerTest, InvalidCreateDescriptorPoolAllocateFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) {
+TEST_F(NegativeDescriptors, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) {
     TEST_DESCRIPTION("Update a descriptor set containing multiple bindings with only one update");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -4245,7 +4247,7 @@ TEST_F(VkLayerTest, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) {
     vk::UpdateDescriptorSets(m_device->device(), 1, &writeDesc, 0, nullptr);
 }
 
-TEST_F(VkLayerTest, InvalidWriteMutableDescriptorSet) {
+TEST_F(NegativeDescriptors, WriteMutableDescriptorSet) {
     TEST_DESCRIPTION("Write mutable descriptor set with invalid type.");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
@@ -4337,7 +4339,7 @@ TEST_F(VkLayerTest, InvalidWriteMutableDescriptorSet) {
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
 }
 
-TEST_F(VkLayerTest, MutableDescriptors) {
+TEST_F(NegativeDescriptors, MutableDescriptors) {
     TEST_DESCRIPTION("Test mutable descriptors");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
@@ -4415,7 +4417,7 @@ TEST_F(VkLayerTest, MutableDescriptors) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DescriptorUpdateTemplate) {
+TEST_F(NegativeDescriptors, DescriptorUpdateTemplate) {
     TEST_DESCRIPTION("Use more bindings with a descriptorType of VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV than allowed");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4494,7 +4496,7 @@ TEST_F(VkLayerTest, DescriptorUpdateTemplate) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MutableDescriptorSetLayout) {
+TEST_F(NegativeDescriptors, MutableDescriptorSetLayout) {
     TEST_DESCRIPTION("Create mutable descriptor set layout.");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
@@ -4574,7 +4576,7 @@ TEST_F(VkLayerTest, MutableDescriptorSetLayout) {
     }
 }
 
-TEST_F(VkLayerTest, MutableDescriptorSetLayoutMissingFeature) {
+TEST_F(NegativeDescriptors, MutableDescriptorSetLayoutMissingFeature) {
     TEST_DESCRIPTION("Create mutable descriptor set layout without mutableDescriptorType feature enabled.");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
@@ -4623,7 +4625,7 @@ TEST_F(VkLayerTest, MutableDescriptorSetLayoutMissingFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImageSubresourceOverlapBetweenRenderPassAndDescriptorSets) {
+TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescriptorSets) {
     TEST_DESCRIPTION("Validate if attachments in render pass and descriptor set use the same image subresources");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -4780,7 +4782,7 @@ TEST_F(VkLayerTest, ImageSubresourceOverlapBetweenRenderPassAndDescriptorSets) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestDescriptorReadFromWriteAttachment) {
+TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
     TEST_DESCRIPTION("Validate reading from a descriptor that uses same image view as framebuffer write attachment");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -4930,7 +4932,7 @@ TEST_F(VkLayerTest, TestDescriptorReadFromWriteAttachment) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestDescriptorWriteFromReadAttachment) {
+TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     TEST_DESCRIPTION("Validate writting to a descriptor that uses same image view as framebuffer read attachment");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -5101,7 +5103,7 @@ TEST_F(VkLayerTest, TestDescriptorWriteFromReadAttachment) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, TestAllocatingVariableDescriptorSets) {
+TEST_F(NegativeDescriptors, AllocatingVariableDescriptorSets) {
     TEST_DESCRIPTION("Test allocating large variable descriptor sets");
 
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
@@ -5156,7 +5158,7 @@ TEST_F(VkLayerTest, TestAllocatingVariableDescriptorSets) {
     ASSERT_VK_SUCCESS(err);
 }
 
-TEST_F(VkLayerTest, InvalidDescriptorSetLayoutBindings) {
+TEST_F(NegativeDescriptors, DescriptorSetLayoutBindings) {
     TEST_DESCRIPTION("Create descriptor set layout with incompatible bindings.");
 
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
@@ -5206,7 +5208,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSetLayoutBindings) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidDescriptorSetLayoutBinding) {
+TEST_F(NegativeDescriptors, DescriptorSetLayoutBinding) {
     TEST_DESCRIPTION("Create invalid descriptor set layout.");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
@@ -5251,7 +5253,7 @@ TEST_F(VkLayerTest, InvalidDescriptorSetLayoutBinding) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestBindingDescriptorSetFromHostOnlyPool) {
+TEST_F(NegativeDescriptors, BindingDescriptorSetFromHostOnlyPool) {
     TEST_DESCRIPTION(
         "Try to bind a descriptor set that was allocated from a pool with VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT.");
 
@@ -5309,7 +5311,7 @@ TEST_F(VkLayerTest, TestBindingDescriptorSetFromHostOnlyPool) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyMutableDescriptors) {
+TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
     TEST_DESCRIPTION("Copy mutable descriptors.");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
@@ -5616,7 +5618,7 @@ TEST_F(VkLayerTest, CopyMutableDescriptors) {
     }
 }
 
-TEST_F(VkLayerTest, ValidateUpdatingMutableDescriptors) {
+TEST_F(NegativeDescriptors, UpdatingMutableDescriptors) {
     TEST_DESCRIPTION("Validate updating mutable descriptors.");
 
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);

--- a/tests/negative/dynamic_rendering.cpp
+++ b/tests/negative/dynamic_rendering.cpp
@@ -123,7 +123,9 @@ TEST_F(DynamicRenderingCommandBufferInheritanceRenderingInfoTest, LinearColorAtt
     Test(true);
 }
 
-TEST_F(VkLayerTest, DynamicRenderingCommandDraw) {
+class NegativeDynamicRendering : public VkLayerTest {};
+
+TEST_F(NegativeDynamicRendering, CommandDraw) {
     TEST_DESCRIPTION("vkCmdDraw* Dynamic Rendering Tests.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -221,7 +223,7 @@ TEST_F(VkLayerTest, DynamicRenderingCommandDraw) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingCmdClearAttachmentTests) {
+TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
     TEST_DESCRIPTION("Various tests for validating usage of vkCmdClearAttachments with Dynamic Rendering");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -371,7 +373,7 @@ TEST_F(VkLayerTest, DynamicRenderingCmdClearAttachmentTests) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingClearAttachments) {
+TEST_F(NegativeDynamicRendering, ClearAttachments) {
     TEST_DESCRIPTION("Call CmdClearAttachments with invalid aspect masks.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -776,7 +778,7 @@ TEST_F(VkLayerTest, DynamicRenderingClearAttachments) {
     clear_cmd_test(false);
 }
 
-TEST_F(VkLayerTest, DynamicRenderingGraphicsPipelineCreateInfo) {
+TEST_F(NegativeDynamicRendering, GraphicsPipelineCreateInfo) {
     TEST_DESCRIPTION("Test graphics pipeline creation with dynamic rendering.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -887,7 +889,7 @@ TEST_F(VkLayerTest, DynamicRenderingGraphicsPipelineCreateInfo) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingWithMismatchingViewMask) {
+TEST_F(NegativeDynamicRendering, MismatchingViewMask) {
     TEST_DESCRIPTION("Draw with Dynamic Rendering and a mismatching viewMask");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -974,7 +976,7 @@ TEST_F(VkLayerTest, DynamicRenderingWithMismatchingViewMask) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingWithMistmatchingAttachments) {
+TEST_F(NegativeDynamicRendering, MistmatchingAttachments) {
     TEST_DESCRIPTION("Draw with Dynamic Rendering with mismatching color attachment counts and depth/stencil formats");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1166,7 +1168,7 @@ TEST_F(VkLayerTest, DynamicRenderingWithMistmatchingAttachments) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingWithMistmatchingAttachmentSamples) {
+TEST_F(NegativeDynamicRendering, MistmatchingAttachmentSamples) {
     TEST_DESCRIPTION("Draw with Dynamic Rendering with mismatching color/depth/stencil sample counts");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1334,7 +1336,7 @@ TEST_F(VkLayerTest, DynamicRenderingWithMistmatchingAttachmentSamples) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingWithMismatchingMixedAttachmentSamples) {
+TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamples) {
     TEST_DESCRIPTION("Draw with Dynamic Rendering with mismatching mixed color/depth/stencil sample counts");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1517,7 +1519,7 @@ TEST_F(VkLayerTest, DynamicRenderingWithMismatchingMixedAttachmentSamples) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAttachmentInfo) {
+TEST_F(NegativeDynamicRendering, AttachmentInfo) {
     TEST_DESCRIPTION("AttachmentInfo Dynamic Rendering Tests.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1638,7 +1640,7 @@ TEST_F(VkLayerTest, DynamicRenderingAttachmentInfo) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBufferBeginInfoLegacy) {
+TEST_F(NegativeDynamicRendering, BufferBeginInfoLegacy) {
     TEST_DESCRIPTION("VkCommandBufferBeginInfo Dynamic Rendering Tests.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1700,7 +1702,7 @@ TEST_F(VkLayerTest, DynamicRenderingBufferBeginInfoLegacy) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingSecondaryCommandBuffer) {
+TEST_F(NegativeDynamicRendering, SecondaryCommandBuffer) {
     TEST_DESCRIPTION("VkCommandBufferBeginInfo Dynamic Rendering Tests.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -1750,7 +1752,7 @@ TEST_F(VkLayerTest, DynamicRenderingSecondaryCommandBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingPipelineMissingFlags) {
+TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
     TEST_DESCRIPTION("Test dynamic rendering with pipeline missing flags.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1916,7 +1918,7 @@ TEST_F(VkLayerTest, DynamicRenderingPipelineMissingFlags) {
     }
 }
 
-TEST_F(VkLayerTest, DynamicRenderingLayerCount) {
+TEST_F(NegativeDynamicRendering, LayerCount) {
     TEST_DESCRIPTION("Test dynamic rendering with viewMask 0 and invalid layer count.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1949,7 +1951,7 @@ TEST_F(VkLayerTest, DynamicRenderingLayerCount) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInfoMismatchedSamples) {
+TEST_F(NegativeDynamicRendering, InfoMismatchedSamples) {
     TEST_DESCRIPTION("Test beginning rendering with mismatched sample counts.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2040,7 +2042,7 @@ TEST_F(VkLayerTest, DynamicRenderingInfoMismatchedSamples) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBeginRenderingFragmentShadingRate) {
+TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRate) {
     TEST_DESCRIPTION("Test BeginRenderingInfo with FragmentShadingRateAttachment.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -2138,7 +2140,7 @@ TEST_F(VkLayerTest, DynamicRenderingBeginRenderingFragmentShadingRate) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingDeviceGroupRenderPassBeginInfo) {
+TEST_F(NegativeDynamicRendering, DeviceGroupRenderPassBeginInfo) {
     TEST_DESCRIPTION("Test render area of DeviceGroupRenderPassBeginInfo.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2203,7 +2205,7 @@ TEST_F(VkLayerTest, DynamicRenderingDeviceGroupRenderPassBeginInfo) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBeginRenderingInvalidFragmentShadingRateImage) {
+TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImage) {
     TEST_DESCRIPTION("Test BeginRendering with FragmentShadingRateAttachmentInfo with missing image usage bit.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2314,7 +2316,7 @@ TEST_F(VkLayerTest, DynamicRenderingBeginRenderingInvalidFragmentShadingRateImag
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBeginRenderingInvalidDepthAttachmentFormat) {
+TEST_F(NegativeDynamicRendering, BeginRenderingDepthAttachmentFormat) {
     TEST_DESCRIPTION("Test begin rendering with a depth attachment that has an invalid format");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -2362,7 +2364,7 @@ TEST_F(VkLayerTest, DynamicRenderingBeginRenderingInvalidDepthAttachmentFormat) 
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingTestFragmentDensityMapRenderArea) {
+TEST_F(NegativeDynamicRendering, TestFragmentDensityMapRenderArea) {
     TEST_DESCRIPTION("Validate VkRenderingFragmentDensityMapAttachmentInfo attachment image view extent.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2471,7 +2473,7 @@ TEST_F(VkLayerTest, DynamicRenderingTestFragmentDensityMapRenderArea) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingFragmentDensityMapRenderAreaWithoutDeviceGroupExt) {
+TEST_F(NegativeDynamicRendering, FragmentDensityMapRenderAreaWithoutDeviceGroupExt) {
     TEST_DESCRIPTION("Validate VkRenderingFragmentDensityMapAttachmentInfo attachment image view extent.");
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
@@ -2530,7 +2532,7 @@ TEST_F(VkLayerTest, DynamicRenderingFragmentDensityMapRenderAreaWithoutDeviceGro
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingWithBarrier) {
+TEST_F(NegativeDynamicRendering, WithBarrier) {
     TEST_DESCRIPTION("Test setting buffer memory barrier when dynamic rendering is active.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -2589,7 +2591,7 @@ TEST_F(VkLayerTest, DynamicRenderingWithBarrier) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBeginRenderingInvalidStencilAttachmentFormat) {
+TEST_F(NegativeDynamicRendering, BeginRenderingStencilAttachmentFormat) {
     TEST_DESCRIPTION("Test begin rendering with a stencil attachment that has an invalid format");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -2634,7 +2636,7 @@ TEST_F(VkLayerTest, DynamicRenderingBeginRenderingInvalidStencilAttachmentFormat
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInheritanceRenderingInfoStencilAttachmentFormat) {
+TEST_F(NegativeDynamicRendering, InheritanceRenderingInfoStencilAttachmentFormat) {
     TEST_DESCRIPTION("Test begin rendering with a stencil attachment that has an invalid format");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -2690,7 +2692,7 @@ TEST_F(VkLayerTest, DynamicRenderingInheritanceRenderingInfoStencilAttachmentFor
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingCreateGraphicsPipelineWithInvalidAttachmentSampleCount) {
+TEST_F(NegativeDynamicRendering, CreateGraphicsPipelineWithAttachmentSampleCount) {
     TEST_DESCRIPTION("Create pipeline with fragment shader that uses samples, but multisample state not begin set");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2735,7 +2737,7 @@ TEST_F(VkLayerTest, DynamicRenderingCreateGraphicsPipelineWithInvalidAttachmentS
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingCreatePipelineWithoutFeature) {
+TEST_F(NegativeDynamicRendering, CreatePipelineWithoutFeature) {
     TEST_DESCRIPTION("Create graphcis pipeline that uses dynamic rendering, but feature is not enabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -2764,7 +2766,7 @@ TEST_F(VkLayerTest, DynamicRenderingCreatePipelineWithoutFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAreaGreaterThanAttachmentExtent) {
+TEST_F(NegativeDynamicRendering, AreaGreaterThanAttachmentExtent) {
     TEST_DESCRIPTION("Begin dynamic rendering with render area greater than extent of attachments");
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
@@ -2868,7 +2870,7 @@ TEST_F(VkLayerTest, DynamicRenderingAreaGreaterThanAttachmentExtent) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingDeviceGroupAreaGreaterThanAttachmentExtent) {
+TEST_F(NegativeDynamicRendering, DeviceGroupAreaGreaterThanAttachmentExtent) {
     TEST_DESCRIPTION("Begin dynamic rendering with device group with render area greater than extent of attachments");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2971,7 +2973,7 @@ TEST_F(VkLayerTest, DynamicRenderingDeviceGroupAreaGreaterThanAttachmentExtent) 
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingSecondaryCommandBufferIncompatibleRenderPass) {
+TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleRenderPass) {
     TEST_DESCRIPTION("Execute secondary command buffers within render pass instance with incompatible render pass");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3015,7 +3017,7 @@ TEST_F(VkLayerTest, DynamicRenderingSecondaryCommandBufferIncompatibleRenderPass
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingSecondaryCommandBufferIncompatibleSubpass) {
+TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
     TEST_DESCRIPTION("Execute secondary command buffers with different subpass");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3074,7 +3076,7 @@ TEST_F(VkLayerTest, DynamicRenderingSecondaryCommandBufferIncompatibleSubpass) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingSecondaryCommandBufferInvalidContents) {
+TEST_F(NegativeDynamicRendering, SecondaryCommandBufferContents) {
     TEST_DESCRIPTION("Execute secondary command buffers within active render pass that was not begun with VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3110,7 +3112,7 @@ TEST_F(VkLayerTest, DynamicRenderingSecondaryCommandBufferInvalidContents) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingWithInvalidShaderLayerBuiltIn) {
+TEST_F(NegativeDynamicRendering, ShaderLayerBuiltIn) {
     TEST_DESCRIPTION("Create invalid pipeline that writes to Layer built-in");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3173,7 +3175,7 @@ TEST_F(VkLayerTest, DynamicRenderingWithInvalidShaderLayerBuiltIn) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingWithInputAttachmentCapability) {
+TEST_F(NegativeDynamicRendering, InputAttachmentCapability) {
     TEST_DESCRIPTION("Create invalid pipeline that uses InputAttachment capability");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3238,7 +3240,7 @@ TEST_F(VkLayerTest, DynamicRenderingWithInputAttachmentCapability) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInvalidRenderingInfoColorAttachmentFormat) {
+TEST_F(NegativeDynamicRendering, RenderingInfoColorAttachmentFormat) {
     TEST_DESCRIPTION("Create pipeline with invalid color attachment format");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3278,7 +3280,7 @@ TEST_F(VkLayerTest, DynamicRenderingInvalidRenderingInfoColorAttachmentFormat) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInvalidLibraryViewMask) {
+TEST_F(NegativeDynamicRendering, LibraryViewMask) {
     TEST_DESCRIPTION("Create pipeline with invalid view mask");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3350,7 +3352,7 @@ TEST_F(VkLayerTest, DynamicRenderingInvalidLibraryViewMask) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInvalidAttachmentSampleCount) {
+TEST_F(NegativeDynamicRendering, AttachmentSampleCount) {
     TEST_DESCRIPTION("Create pipeline with invalid color attachment samples");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3390,7 +3392,7 @@ TEST_F(VkLayerTest, DynamicRenderingInvalidAttachmentSampleCount) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInvalidLibrariesViewMask) {
+TEST_F(NegativeDynamicRendering, LibrariesViewMask) {
     TEST_DESCRIPTION("Create pipeline with libaries that have incompatible view mask");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3474,7 +3476,7 @@ TEST_F(VkLayerTest, DynamicRenderingInvalidLibrariesViewMask) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInvalidLibraryRenderPass) {
+TEST_F(NegativeDynamicRendering, LibraryRenderPass) {
     TEST_DESCRIPTION("Create pipeline with invalid library render pass");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3544,7 +3546,7 @@ TEST_F(VkLayerTest, DynamicRenderingInvalidLibraryRenderPass) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingPipelineMissingMultisampleState) {
+TEST_F(NegativeDynamicRendering, PipelineMissingMultisampleState) {
     TEST_DESCRIPTION("Create pipeline with missing multisample state");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3597,7 +3599,7 @@ TEST_F(VkLayerTest, DynamicRenderingPipelineMissingMultisampleState) {
     }
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInvalidRenderingFragmentDensityMapAttachment) {
+TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachment) {
     TEST_DESCRIPTION("Use invalid VkRenderingFragmentDensityMapAttachmentInfoEXT");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3666,7 +3668,7 @@ TEST_F(VkLayerTest, DynamicRenderingInvalidRenderingFragmentDensityMapAttachment
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInvalidRenderingFragmentDensityMapAttachmentUsage) {
+TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachmentUsage) {
     TEST_DESCRIPTION("Use VkRenderingFragmentDensityMapAttachmentInfoEXT with invalid imageLayout");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3707,7 +3709,7 @@ TEST_F(VkLayerTest, DynamicRenderingInvalidRenderingFragmentDensityMapAttachment
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingFragmentDensityMapAttachmentCreateFlags) {
+TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentCreateFlags) {
     TEST_DESCRIPTION("Use VkRenderingFragmentDensityMapAttachmentInfoEXT with invalid image create flags");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3759,7 +3761,7 @@ TEST_F(VkLayerTest, DynamicRenderingFragmentDensityMapAttachmentCreateFlags) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingFragmentDensityMapAttachmentLayerCount) {
+TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentLayerCount) {
     TEST_DESCRIPTION("Use VkRenderingFragmentDensityMapAttachmentInfoEXT with invalid layer count");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3816,7 +3818,7 @@ TEST_F(VkLayerTest, DynamicRenderingFragmentDensityMapAttachmentLayerCount) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingPNextImageView) {
+TEST_F(NegativeDynamicRendering, PNextImageView) {
     TEST_DESCRIPTION(
         "Use different image views in VkRenderingFragmentShadingRateAttachmentInfoKHR and "
         "VkRenderingFragmentDensityMapAttachmentInfoEXT");
@@ -3876,7 +3878,7 @@ TEST_F(VkLayerTest, DynamicRenderingPNextImageView) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingRenderArea) {
+TEST_F(NegativeDynamicRendering, RenderArea) {
     TEST_DESCRIPTION("Use negative offset in RenderingInfo render area");
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
@@ -3959,7 +3961,7 @@ TEST_F(VkLayerTest, DynamicRenderingRenderArea) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInfoViewMask) {
+TEST_F(NegativeDynamicRendering, InfoViewMask) {
     TEST_DESCRIPTION("Use negative offset in RenderingInfo render area");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4009,7 +4011,7 @@ TEST_F(VkLayerTest, DynamicRenderingInfoViewMask) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingColorAttachmentFormat) {
+TEST_F(NegativeDynamicRendering, ColorAttachmentFormat) {
     TEST_DESCRIPTION("Use format with missing potential format features in rendering color attachment");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4049,7 +4051,7 @@ TEST_F(VkLayerTest, DynamicRenderingColorAttachmentFormat) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingResolveModeWithNonIntegerColorFormat) {
+TEST_F(NegativeDynamicRendering, ResolveModeWithNonIntegerColorFormat) {
     TEST_DESCRIPTION("Use invalid resolve mode with non integer color format");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4111,7 +4113,7 @@ TEST_F(VkLayerTest, DynamicRenderingResolveModeWithNonIntegerColorFormat) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingResolveModeWithIntegerColorFormat) {
+TEST_F(NegativeDynamicRendering, ResolveModeWithIntegerColorFormat) {
     TEST_DESCRIPTION("Use invalid resolve mode with integer color format");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4174,7 +4176,7 @@ TEST_F(VkLayerTest, DynamicRenderingResolveModeWithIntegerColorFormat) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingResolveModeSamples) {
+TEST_F(NegativeDynamicRendering, ResolveModeSamples) {
     TEST_DESCRIPTION("Use invalid sample count with resolve mode that is not none");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4222,7 +4224,7 @@ TEST_F(VkLayerTest, DynamicRenderingResolveModeSamples) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingResolveImageViewSamples) {
+TEST_F(NegativeDynamicRendering, ResolveImageViewSamples) {
     TEST_DESCRIPTION("Use resolve image view with invalid sample count");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4289,7 +4291,7 @@ TEST_F(VkLayerTest, DynamicRenderingResolveImageViewSamples) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingResolveImageViewFormatMatch) {
+TEST_F(NegativeDynamicRendering, ResolveImageViewFormatMatch) {
     TEST_DESCRIPTION("Use resolve image view with different format from image view");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4351,7 +4353,7 @@ TEST_F(VkLayerTest, DynamicRenderingResolveImageViewFormatMatch) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAttachmentImageViewLayout) {
+TEST_F(NegativeDynamicRendering, AttachmentImageViewLayout) {
     TEST_DESCRIPTION("Use rendering attachment image view with invalid layout");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4396,7 +4398,7 @@ TEST_F(VkLayerTest, DynamicRenderingAttachmentImageViewLayout) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingResolveImageViewLayout) {
+TEST_F(NegativeDynamicRendering, ResolveImageViewLayout) {
     TEST_DESCRIPTION("Use resolve image view with invalid layout");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4458,7 +4460,7 @@ TEST_F(VkLayerTest, DynamicRenderingResolveImageViewLayout) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingResolveImageViewLayoutSeparateDepthStencil) {
+TEST_F(NegativeDynamicRendering, ResolveImageViewLayoutSeparateDepthStencil) {
     TEST_DESCRIPTION("Use resolve image view with invalid layout");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4521,7 +4523,7 @@ TEST_F(VkLayerTest, DynamicRenderingResolveImageViewLayoutSeparateDepthStencil) 
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAttachmentImageViewShadingRateLayout) {
+TEST_F(NegativeDynamicRendering, AttachmentImageViewShadingRateLayout) {
     TEST_DESCRIPTION("Use image view with invalid layout");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4577,7 +4579,7 @@ TEST_F(VkLayerTest, DynamicRenderingAttachmentImageViewShadingRateLayout) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingResolveImageViewShadingRateLayout) {
+TEST_F(NegativeDynamicRendering, ResolveImageViewShadingRateLayout) {
     TEST_DESCRIPTION("Use resolve image view with invalid shading ratelayout");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4650,7 +4652,7 @@ TEST_F(VkLayerTest, DynamicRenderingResolveImageViewShadingRateLayout) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAttachmentImageViewFragmentDensityLayout) {
+TEST_F(NegativeDynamicRendering, AttachmentImageViewFragmentDensityLayout) {
     TEST_DESCRIPTION("Use image view with invalid layout");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4696,7 +4698,7 @@ TEST_F(VkLayerTest, DynamicRenderingAttachmentImageViewFragmentDensityLayout) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingResolveImageViewFragmentDensityLayout) {
+TEST_F(NegativeDynamicRendering, ResolveImageViewFragmentDensityLayout) {
     TEST_DESCRIPTION("Use resolve image view with invalid fragment density layout");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4759,7 +4761,7 @@ TEST_F(VkLayerTest, DynamicRenderingResolveImageViewFragmentDensityLayout) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingResolveImageViewReadOnlyOptimalLayout) {
+TEST_F(NegativeDynamicRendering, ResolveImageViewReadOnlyOptimalLayout) {
     TEST_DESCRIPTION("Use resolve image view with invalid read only optimal layout");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4822,7 +4824,7 @@ TEST_F(VkLayerTest, DynamicRenderingResolveImageViewReadOnlyOptimalLayout) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBeginRenderingFragmentShadingRateImageView) {
+TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImageView) {
     TEST_DESCRIPTION("Test BeginRenderingInfo image view with FragmentShadingRateAttachment.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4885,7 +4887,7 @@ TEST_F(VkLayerTest, DynamicRenderingBeginRenderingFragmentShadingRateImageView) 
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingRenderingInfoColorAttachment) {
+TEST_F(NegativeDynamicRendering, RenderingInfoColorAttachment) {
     TEST_DESCRIPTION("Test RenderingInfo color attachment.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -5005,7 +5007,7 @@ TEST_F(VkLayerTest, DynamicRenderingRenderingInfoColorAttachment) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingRenderingInfoDepthAttachment) {
+TEST_F(NegativeDynamicRendering, RenderingInfoDepthAttachment) {
     TEST_DESCRIPTION("Test RenderingInfo depth attachment.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -5231,7 +5233,7 @@ TEST_F(VkLayerTest, DynamicRenderingRenderingInfoDepthAttachment) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingRenderAreaWithDeviceGroupExt) {
+TEST_F(NegativeDynamicRendering, RenderAreaWithDeviceGroupExt) {
     TEST_DESCRIPTION("Use negative offset in RenderingInfo render area");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -5276,7 +5278,7 @@ TEST_F(VkLayerTest, DynamicRenderingRenderAreaWithDeviceGroupExt) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingPipeline) {
+TEST_F(NegativeDynamicRendering, Pipeline) {
     TEST_DESCRIPTION("Use pipeline created with render pass in dynamic render pass.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -5322,7 +5324,7 @@ TEST_F(VkLayerTest, DynamicRenderingPipeline) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBeginRenderingFragmentShadingRateAttachmentSize) {
+TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateAttachmentSize) {
     TEST_DESCRIPTION("Test FragmentShadingRateAttachment size.");
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
@@ -5394,7 +5396,7 @@ TEST_F(VkLayerTest, DynamicRenderingBeginRenderingFragmentShadingRateAttachmentS
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingFragmentShadingRateAttachmentSizeWithDeviceGroupExt) {
+TEST_F(NegativeDynamicRendering, FragmentShadingRateAttachmentSizeWithDeviceGroupExt) {
     TEST_DESCRIPTION("Test FragmentShadingRateAttachment size with device group extension.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -5513,7 +5515,7 @@ TEST_F(VkLayerTest, DynamicRenderingFragmentShadingRateAttachmentSizeWithDeviceG
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingSuspendingRenderPassInstance) {
+TEST_F(NegativeDynamicRendering, SuspendingRenderPassInstance) {
     TEST_DESCRIPTION("Test suspending render pass instance.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -5607,7 +5609,7 @@ TEST_F(VkLayerTest, DynamicRenderingSuspendingRenderPassInstance) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingSuspendingRenderPassInstanceQueueSubmit2) {
+TEST_F(NegativeDynamicRendering, SuspendingRenderPassInstanceQueueSubmit2) {
     TEST_DESCRIPTION("Test suspending render pass instance with QueueSubmit2.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -5712,7 +5714,7 @@ TEST_F(VkLayerTest, DynamicRenderingSuspendingRenderPassInstanceQueueSubmit2) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingNullDepthStencilExecuteCommands) {
+TEST_F(NegativeDynamicRendering, NullDepthStencilExecuteCommands) {
     TEST_DESCRIPTION(
         "Test for NULL depth stencil attachments in dynamic rendering with secondary command buffer with depth stencil format "
         "inheritance info");
@@ -5813,7 +5815,7 @@ TEST_F(VkLayerTest, DynamicRenderingNullDepthStencilExecuteCommands) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBeginRenderingWithSecondaryContents) {
+TEST_F(NegativeDynamicRendering, BeginRenderingWithSecondaryContents) {
     TEST_DESCRIPTION("Test that an error is produced when a secondary command buffer calls BeginRendering with secondary contents");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -5858,7 +5860,7 @@ TEST_F(VkLayerTest, DynamicRenderingBeginRenderingWithSecondaryContents) {
     secondary.end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBadRenderPassContentsWhenCallingCmdExecuteCommands) {
+TEST_F(NegativeDynamicRendering, BadRenderPassContentsWhenCallingCmdExecuteCommands) {
     TEST_DESCRIPTION(
         "Test CmdExecuteCommands inside a render pass begun with CmdBeginRendering that hasn't set "
         "VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR");
@@ -5930,7 +5932,7 @@ TEST_F(VkLayerTest, DynamicRenderingBadRenderPassContentsWhenCallingCmdExecuteCo
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithNonNullRenderPass) {
+TEST_F(NegativeDynamicRendering, ExecuteCommandsWithNonNullRenderPass) {
     TEST_DESCRIPTION(
         "Test CmdExecuteCommands inside a render pass begun with CmdBeginRendering that hasn't set "
         "renderPass to VK_NULL_HANDLE in pInheritanceInfo");
@@ -6017,7 +6019,7 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithNonNullRenderPass) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingFlags) {
+TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingFlags) {
     TEST_DESCRIPTION("Test CmdExecuteCommands inside a render pass begun with CmdBeginRendering that has mismatching flags");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -6089,7 +6091,7 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingFlags) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingColorAttachmentCount) {
+TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingColorAttachmentCount) {
     TEST_DESCRIPTION(
         "Test CmdExecuteCommands inside a render pass begun with CmdBeginRendering that has mismatching colorAttachmentCount");
 
@@ -6161,7 +6163,7 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingColorAttach
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingColorImageViewFormat) {
+TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingColorImageViewFormat) {
     TEST_DESCRIPTION(
         "Test CmdExecuteCommands inside a render pass begun with CmdBeginRendering that has mismatching color image view format");
 
@@ -6238,7 +6240,7 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingColorImageV
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingDepthStencilImageViewFormat) {
+TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingDepthStencilImageViewFormat) {
     TEST_DESCRIPTION(
         "Test CmdExecuteCommands inside a render pass begun with CmdBeginRendering that has mismatching depth/stencil image view "
         "format");
@@ -6318,7 +6320,7 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingDepthStenci
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingViewMask) {
+TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingViewMask) {
     TEST_DESCRIPTION(
         "Test CmdExecuteCommands inside a render pass begun with CmdBeginRendering that has mismatching viewMask format");
 
@@ -6392,7 +6394,7 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingViewMask) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingImageViewRasterizationSamples) {
+TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewRasterizationSamples) {
     TEST_DESCRIPTION(
         "Test CmdExecuteCommands inside a render pass begun with CmdBeginRendering that has mismatching rasterization samples");
 
@@ -6512,7 +6514,7 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingImageViewRa
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingImageViewAttachmentSamples) {
+TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewAttachmentSamples) {
     TEST_DESCRIPTION(
         "Test CmdExecuteCommands inside a render pass begun with CmdBeginRendering that has mismatching that has mismatching "
         "attachment samples");
@@ -6648,7 +6650,7 @@ TEST_F(VkLayerTest, DynamicRenderingAndExecuteCommandsWithMismatchingImageViewAt
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInSecondaryCommandBuffers) {
+TEST_F(NegativeDynamicRendering, InSecondaryCommandBuffers) {
     TEST_DESCRIPTION("Test drawing in secondary command buffers with dynamic rendering");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -6706,7 +6708,7 @@ TEST_F(VkLayerTest, DynamicRenderingInSecondaryCommandBuffers) {
     secondary.end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingCommandBufferInheritanceWithInvalidDepthFormat) {
+TEST_F(NegativeDynamicRendering, CommandBufferInheritanceDepthFormat) {
     TEST_DESCRIPTION(
         "Test VkCommandBufferInheritanceRenderingInfoKHR with depthAttachmentFormat that does not include depth aspect");
 
@@ -6755,7 +6757,7 @@ TEST_F(VkLayerTest, DynamicRenderingCommandBufferInheritanceWithInvalidDepthForm
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingInvalidDeviceGroupRenderArea) {
+TEST_F(NegativeDynamicRendering, DeviceGroupRenderArea) {
     TEST_DESCRIPTION("Begin rendering with invaid device group render area.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -6819,7 +6821,7 @@ TEST_F(VkLayerTest, DynamicRenderingInvalidDeviceGroupRenderArea) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingMaxFramebufferLayers) {
+TEST_F(NegativeDynamicRendering, MaxFramebufferLayers) {
     TEST_DESCRIPTION("Go over maxFramebufferLayers");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
@@ -6856,7 +6858,7 @@ TEST_F(VkLayerTest, DynamicRenderingMaxFramebufferLayers) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingEndRenderingWithIncorrectlyStartedRenderpassInstance) {
+TEST_F(NegativeDynamicRendering, EndRenderingWithIncorrectlyStartedRenderpassInstance) {
     TEST_DESCRIPTION(
         "Test EndRendering without starting the instance with BeginRendering, in the same command buffer or in a different once");
 
@@ -6940,7 +6942,7 @@ TEST_F(VkLayerTest, DynamicRenderingEndRenderingWithIncorrectlyStartedRenderpass
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingEndRenderpassWithBeginRenderingRenderpassInstance) {
+TEST_F(NegativeDynamicRendering, EndRenderpassWithBeginRenderingRenderpassInstance) {
     TEST_DESCRIPTION("Test EndRenderpass(2) starting the renderpass instance with BeginRendering");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -6997,7 +6999,7 @@ TEST_F(VkLayerTest, DynamicRenderingEndRenderpassWithBeginRenderingRenderpassIns
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBeginRenderingDisabled) {
+TEST_F(NegativeDynamicRendering, BeginRenderingDisabled) {
     TEST_DESCRIPTION("Validate VK_KHR_dynamic_rendering VUs when disabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -7040,7 +7042,7 @@ TEST_F(VkLayerTest, DynamicRenderingBeginRenderingDisabled) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingPipelineRenderingParameters) {
+TEST_F(NegativeDynamicRendering, PipelineRenderingParameters) {
     TEST_DESCRIPTION("Test pipeline rendering formats and viewmask");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -7162,7 +7164,7 @@ TEST_F(VkLayerTest, DynamicRenderingPipelineRenderingParameters) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingPipelineRenderingViewMaskParameter) {
+TEST_F(NegativeDynamicRendering, PipelineRenderingViewMaskParameter) {
     TEST_DESCRIPTION("Test pipeline rendering viewmask maximum index");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -7236,7 +7238,7 @@ TEST_F(VkLayerTest, DynamicRenderingPipelineRenderingViewMaskParameter) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingCreateGraphicsPipeline) {
+TEST_F(NegativeDynamicRendering, CreateGraphicsPipeline) {
     TEST_DESCRIPTION("Test for a creating a pipeline with VK_KHR_dynamic_rendering enabled");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -7291,7 +7293,7 @@ TEST_F(VkLayerTest, DynamicRenderingCreateGraphicsPipeline) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingCreateGraphicsPipelineNoInfo) {
+TEST_F(NegativeDynamicRendering, CreateGraphicsPipelineNoInfo) {
     TEST_DESCRIPTION("Test for a creating a pipeline with VK_KHR_dynamic_rendering enabled but no rendering info struct.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -7341,7 +7343,7 @@ TEST_F(VkLayerTest, DynamicRenderingCreateGraphicsPipelineNoInfo) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingDynamicColorBlendAttchment) {
+TEST_F(NegativeDynamicRendering, DynamicColorBlendAttchment) {
     TEST_DESCRIPTION("Test all color blend attachments are dynamically set at draw time with Dynamic Rendering.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -7411,7 +7413,7 @@ TEST_F(VkLayerTest, DynamicRenderingDynamicColorBlendAttchment) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingBeginTwice) {
+TEST_F(NegativeDynamicRendering, BeginTwice) {
     TEST_DESCRIPTION("Call vkCmdBeginRendering twice in a row");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
@@ -7450,7 +7452,7 @@ TEST_F(VkLayerTest, DynamicRenderingBeginTwice) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRenderingEndTwice) {
+TEST_F(NegativeDynamicRendering, EndTwice) {
     TEST_DESCRIPTION("Call vkCmdEndRendering twice in a row");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);

--- a/tests/negative/dynamic_state.cpp
+++ b/tests/negative/dynamic_state.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, DynamicDepthBiasNotBound) {
+class NegativeDynamicState : public VkLayerTest {};
+
+TEST_F(NegativeDynamicState, DepthBiasNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Depth Bias dynamic state is required but not correctly bound.");
 
@@ -26,7 +28,7 @@ TEST_F(VkLayerTest, DynamicDepthBiasNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicLineWidthNotBound) {
+TEST_F(NegativeDynamicState, LineWidthNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Line Width dynamic state is required but not correctly bound.");
 
@@ -37,7 +39,7 @@ TEST_F(VkLayerTest, DynamicLineWidthNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicLineStippleNotBound) {
+TEST_F(NegativeDynamicState, LineStippleNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Line Stipple dynamic state is required but not correctly bound.");
 
@@ -60,7 +62,7 @@ TEST_F(VkLayerTest, DynamicLineStippleNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicViewportNotBound) {
+TEST_F(NegativeDynamicState, ViewportNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Viewport dynamic state is required but not correctly bound.");
 
@@ -71,7 +73,7 @@ TEST_F(VkLayerTest, DynamicViewportNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicScissorNotBound) {
+TEST_F(NegativeDynamicState, ScissorNotBound) {
     TEST_DESCRIPTION("Run a simple draw calls to validate failure when Scissor dynamic state is required but not correctly bound.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -81,7 +83,7 @@ TEST_F(VkLayerTest, DynamicScissorNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicBlendConstantsNotBound) {
+TEST_F(NegativeDynamicState, BlendConstantsNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Blend Constants dynamic state is required but not correctly bound.");
 
@@ -92,7 +94,7 @@ TEST_F(VkLayerTest, DynamicBlendConstantsNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicDepthBoundsNotBound) {
+TEST_F(NegativeDynamicState, DepthBoundsNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Depth Bounds dynamic state is required but not correctly bound.");
 
@@ -106,7 +108,7 @@ TEST_F(VkLayerTest, DynamicDepthBoundsNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicStencilReadNotBound) {
+TEST_F(NegativeDynamicState, StencilReadNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Stencil Read dynamic state is required but not correctly bound.");
 
@@ -117,7 +119,7 @@ TEST_F(VkLayerTest, DynamicStencilReadNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicStencilWriteNotBound) {
+TEST_F(NegativeDynamicState, StencilWriteNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Stencil Write dynamic state is required but not correctly bound.");
 
@@ -128,7 +130,7 @@ TEST_F(VkLayerTest, DynamicStencilWriteNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DynamicStencilRefNotBound) {
+TEST_F(NegativeDynamicState, StencilRefNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Stencil Ref dynamic state is required but not correctly bound.");
 
@@ -139,7 +141,7 @@ TEST_F(VkLayerTest, DynamicStencilRefNotBound) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SetDynScissorParamTests) {
+TEST_F(NegativeDynamicState, SetScissorParam) {
     TEST_DESCRIPTION("Test parameters of vkCmdSetScissor without multiViewport feature");
 
     VkPhysicalDeviceFeatures features{};
@@ -195,7 +197,7 @@ TEST_F(VkLayerTest, SetDynScissorParamTests) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, SetDynScissorParamMultiviewportTests) {
+TEST_F(NegativeDynamicState, SetScissorParamMultiviewport) {
     TEST_DESCRIPTION("Test parameters of vkCmdSetScissor with multiViewport feature enabled");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -248,7 +250,7 @@ void ExtendedDynStateCalls(ErrorMonitor *error_monitor, VkCommandBuffer cmd_buf,
     error_monitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicStateDisabled) {
+TEST_F(NegativeDynamicState, ExtendedDynamicStateDisabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -338,7 +340,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateDisabled) {
     commandBuffer.end();
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
+TEST_F(NegativeDynamicState, ExtendedDynamicStateEnabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -678,7 +680,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabled) {
     commandBuffer.end();
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabledNoMultiview) {
+TEST_F(NegativeDynamicState, ExtendedDynamicStateEnabledNoMultiview) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -720,7 +722,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicStateEnabledNoMultiview) {
     commandBuffer.end();
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicState2Disabled) {
+TEST_F(NegativeDynamicState, ExtendedDynamicState2Disabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state2 VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -780,7 +782,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2Disabled) {
     m_commandBuffer.end();
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicState2PatchControlPointsDisabled) {
+TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsDisabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state2 PatchControlPoints VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -826,7 +828,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2PatchControlPointsDisabled) {
     m_commandBuffer.end();
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicState2LogicOpDisabled) {
+TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpDisabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state2LogicOp VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -872,7 +874,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2LogicOpDisabled) {
     m_commandBuffer.end();
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicState2Enabled) {
+TEST_F(NegativeDynamicState, ExtendedDynamicState2Enabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state2 LogicOp VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -943,7 +945,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2Enabled) {
     }
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicState2PatchControlPointsEnabled) {
+TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsEnabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state2 PatchControlPoints VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1012,7 +1014,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2PatchControlPointsEnabled) {
     }
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicState2LogicOpEnabled) {
+TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpEnabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state2 LogicOp VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1077,7 +1079,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState2LogicOpEnabled) {
     }
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicState3Disabled) {
+TEST_F(NegativeDynamicState, ExtendedDynamicState3Disabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state3 VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -1483,7 +1485,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState3Disabled) {
     m_commandBuffer.end();
 }
 
-TEST_F(VkLayerTest, ValidateExtendedDynamicState3Enabled) {
+TEST_F(NegativeDynamicState, ExtendedDynamicState3Enabled) {
     TEST_DESCRIPTION("Validate VK_EXT_extended_dynamic_state3 VUs");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -1925,7 +1927,7 @@ TEST_F(VkLayerTest, ValidateExtendedDynamicState3Enabled) {
     }
 }
 
-TEST_F(VkLayerTest, ValidateVertexInputDynamicStateDisabled) {
+TEST_F(NegativeDynamicState, VertexInputDynamicStateDisabled) {
     TEST_DESCRIPTION("Validate VK_EXT_vertex_input_dynamic_state VUs when disabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1964,7 +1966,7 @@ TEST_F(VkLayerTest, ValidateVertexInputDynamicStateDisabled) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ValidateVertexInputDynamicStateEnabled) {
+TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
     TEST_DESCRIPTION("Validate VK_EXT_vertex_input_dynamic_state VUs when enabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2168,7 +2170,7 @@ TEST_F(VkLayerTest, ValidateVertexInputDynamicStateEnabled) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ValidateVertexInputDynamicStateDivisor) {
+TEST_F(NegativeDynamicState, VertexInputDynamicStateDivisor) {
     TEST_DESCRIPTION("Validate VK_EXT_vertex_input_dynamic_state VUs when VK_EXT_vertex_attribute_divisor is enabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2225,7 +2227,7 @@ TEST_F(VkLayerTest, ValidateVertexInputDynamicStateDivisor) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRasterizationSamples) {
+TEST_F(NegativeDynamicState, RasterizationSamples) {
     TEST_DESCRIPTION("Make sure VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT is updating rasterizationSamples");
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     AddOptionalExtensions(VK_EXT_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_EXTENSION_NAME);
@@ -2277,7 +2279,7 @@ TEST_F(VkLayerTest, DynamicRasterizationSamples) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicColorBlendAttchment) {
+TEST_F(NegativeDynamicState, ColorBlendAttchment) {
     TEST_DESCRIPTION("Test all color blend attachments are dynamically set at draw time.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
@@ -2346,7 +2348,7 @@ TEST_F(VkLayerTest, DynamicColorBlendAttchment) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicRasterizationLine) {
+TEST_F(NegativeDynamicState, RasterizationLine) {
     TEST_DESCRIPTION("tests VK_EXT_line_rasterization dynamic state");
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -2493,7 +2495,7 @@ TEST_F(VkLayerTest, DynamicRasterizationLine) {
     }
 }
 
-TEST_F(VkLayerTest, PipelineColorWriteCreateInfoEXTDynaimcState3) {
+TEST_F(NegativeDynamicState, PipelineColorWriteCreateInfoEXTDynaimcState3) {
     TEST_DESCRIPTION("Test VkPipelineColorWriteCreateInfoEXT in color blend state pNext with VK_EXT_extended_dynamic_state3");
 
     AddRequiredExtensions(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
@@ -2517,7 +2519,7 @@ TEST_F(VkLayerTest, PipelineColorWriteCreateInfoEXTDynaimcState3) {
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5208
-TEST_F(VkLayerTest, DISABLED_MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
+TEST_F(NegativeDynamicState, DISABLED_MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     TEST_DESCRIPTION(
         "Test drawing with dual source blending with too many fragment output attachments, but using dynamic blending.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2610,7 +2612,7 @@ TEST_F(VkLayerTest, DISABLED_MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ValidateColorWriteDynamicStateDisabled) {
+TEST_F(NegativeDynamicState, ColorWriteDisabled) {
     TEST_DESCRIPTION("Validate VK_EXT_color_write_enable VUs when disabled");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -2637,7 +2639,7 @@ TEST_F(VkLayerTest, ValidateColorWriteDynamicStateDisabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ValidateColorWriteDynamicStateNotSet) {
+TEST_F(NegativeDynamicState, ColorWriteNotSet) {
     TEST_DESCRIPTION("Validate dynamic state color write enable was set before draw command");
 
     AddRequiredExtensions(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
@@ -2705,7 +2707,7 @@ TEST_F(VkLayerTest, ValidateColorWriteDynamicStateNotSet) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidColorWriteEnableAttachmentCount) {
+TEST_F(NegativeDynamicState, ColorWriteEnableAttachmentCount) {
     TEST_DESCRIPTION("Invalid usage of attachmentCount for vkCmdSetColorWriteEnableEXT");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -2755,7 +2757,7 @@ TEST_F(VkLayerTest, InvalidColorWriteEnableAttachmentCount) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidColorWriteEnableFeature) {
+TEST_F(NegativeDynamicState, ColorWriteEnableFeature) {
     TEST_DESCRIPTION("Invalid usage of vkCmdSetColorWriteEnableEXT with feature not enabled");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -2783,7 +2785,7 @@ TEST_F(VkLayerTest, InvalidColorWriteEnableFeature) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ValidateDiscardRectanglesDynamicStateNotSet) {
+TEST_F(NegativeDynamicState, DiscardRectanglesNotSet) {
     TEST_DESCRIPTION("Validate dynamic state for VK_EXT_discard_rectangles");
 
     AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
@@ -2830,7 +2832,7 @@ TEST_F(VkLayerTest, ValidateDiscardRectanglesDynamicStateNotSet) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicStateNotSetWithCommandBufferResetBitmask) {
+TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferResetBitmask) {
     TEST_DESCRIPTION("Make sure state tracker of dynamic state accounts for resetting command buffers");
 
     AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
@@ -2892,7 +2894,7 @@ TEST_F(VkLayerTest, DynamicStateNotSetWithCommandBufferResetBitmask) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DynamicStateNotSetWithCommandBufferReset) {
+TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferReset) {
     TEST_DESCRIPTION("Make sure state tracker of dynamic state accounts for resetting command buffers");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2968,7 +2970,7 @@ TEST_F(VkLayerTest, DynamicStateNotSetWithCommandBufferReset) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidSampleLocations) {
+TEST_F(NegativeDynamicState, SampleLocations) {
     TEST_DESCRIPTION("Test invalid cases of VK_EXT_sample_location");
 
     AddRequiredExtensions(VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME);
@@ -3204,7 +3206,7 @@ TEST_F(VkLayerTest, InvalidSampleLocations) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, SetDynViewportParamTests) {
+TEST_F(NegativeDynamicState, SetViewportParam) {
     TEST_DESCRIPTION("Test parameters of vkCmdSetViewport without multiViewport feature");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3291,7 +3293,7 @@ TEST_F(VkLayerTest, SetDynViewportParamTests) {
     }
 }
 
-TEST_F(VkLayerTest, SetDynViewportParamMaintenance1Tests) {
+TEST_F(NegativeDynamicState, SetViewportParamMaintenance1) {
     TEST_DESCRIPTION("Verify errors are detected on misuse of SetViewport with a negative viewport extension enabled.");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -3304,7 +3306,7 @@ TEST_F(VkLayerTest, SetDynViewportParamMaintenance1Tests) {
     NegHeightViewportTests(m_device, m_commandBuffer, m_errorMonitor);
 }
 
-TEST_F(VkLayerTest, SetDynViewportParamMultiviewportTests) {
+TEST_F(NegativeDynamicState, SetViewportParamMultiviewport) {
     TEST_DESCRIPTION("Test parameters of vkCmdSetViewport with multiViewport feature enabled");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3350,7 +3352,7 @@ TEST_F(VkLayerTest, SetDynViewportParamMultiviewportTests) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidCmdSetDiscardRectangleEXTOffsets) {
+TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTOffsets) {
     TEST_DESCRIPTION("Test CmdSetDiscardRectangleEXT with invalid offsets in pDiscardRectangles");
 
     AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
@@ -3391,7 +3393,7 @@ TEST_F(VkLayerTest, InvalidCmdSetDiscardRectangleEXTOffsets) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CmdSetDiscardRectangleEXTRectangleCountOverflow) {
+TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTRectangleCountOverflow) {
     TEST_DESCRIPTION("Test CmdSetDiscardRectangleEXT with invalid offsets in pDiscardRectangles");
 
     AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
@@ -3421,7 +3423,7 @@ TEST_F(VkLayerTest, CmdSetDiscardRectangleEXTRectangleCountOverflow) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidCmdSetDiscardRectangleEXTRectangleCount) {
+TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTRectangleCount) {
     TEST_DESCRIPTION("Test CmdSetDiscardRectangleEXT with invalid offsets in pDiscardRectangles");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -3453,7 +3455,7 @@ TEST_F(VkLayerTest, InvalidCmdSetDiscardRectangleEXTRectangleCount) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DiscardRectanglesVersion) {
+TEST_F(NegativeDynamicState, DiscardRectanglesVersion) {
     TEST_DESCRIPTION("check version of VK_EXT_discard_rectangles");
 
     AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
@@ -3495,7 +3497,7 @@ TEST_F(VkLayerTest, DiscardRectanglesVersion) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ExtensionDynamicStatesSetWOExtensionEnabled) {
+TEST_F(NegativeDynamicState, ExtensionDynamicStatesSetWOExtensionEnabled) {
     TEST_DESCRIPTION("Create a graphics pipeline with Extension dynamic states without enabling the required Extensions.");
 
     GTEST_SKIP() << "Not possible to hit the desired failure messages given invalid enums.";
@@ -3532,7 +3534,7 @@ TEST_F(VkLayerTest, ExtensionDynamicStatesSetWOExtensionEnabled) {
     }
 }
 
-TEST_F(VkLayerTest, DynamicViewportAndScissorUndefinedDrawState) {
+TEST_F(NegativeDynamicState, ViewportAndScissorUndefinedDrawState) {
     TEST_DESCRIPTION("Test viewport and scissor dynamic state that is not set before draw");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3587,7 +3589,7 @@ TEST_F(VkLayerTest, DynamicViewportAndScissorUndefinedDrawState) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DuplicateDynamicStates) {
+TEST_F(NegativeDynamicState, Duplicate) {
     TEST_DESCRIPTION("Create a pipeline with duplicate dynamic states set.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3616,7 +3618,7 @@ TEST_F(VkLayerTest, DuplicateDynamicStates) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, NonGraphicsDynamicStates) {
+TEST_F(NegativeDynamicState, NonGraphics) {
     TEST_DESCRIPTION("Create a pipeline with non graphics dynamic states set.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3647,7 +3649,7 @@ TEST_F(VkLayerTest, NonGraphicsDynamicStates) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidViewportCountWithExtendedDynamicState) {
+TEST_F(NegativeDynamicState, ViewportCountWithExtendedDynamicState) {
     TEST_DESCRIPTION("Create a pipeline with invalid viewport count with extended dynamic state.");
 
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
@@ -3681,7 +3683,7 @@ TEST_F(VkLayerTest, InvalidViewportCountWithExtendedDynamicState) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, PipelineColorBlendStateCreateInfoValidArrayNonDynamic) {
+TEST_F(NegativeDynamicState, PipelineColorBlendStateCreateInfoArrayNonDynamic) {
     TEST_DESCRIPTION("Validate VkPipelineColorBlendStateCreateInfo array with no extensions");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3691,7 +3693,7 @@ TEST_F(VkLayerTest, PipelineColorBlendStateCreateInfoValidArrayNonDynamic) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-07354");
 }
 
-TEST_F(VkLayerTest, PipelineColorBlendStateCreateInfoValidArrayDynamic) {
+TEST_F(NegativeDynamicState, PipelineColorBlendStateCreateInfoArrayDynamic) {
     TEST_DESCRIPTION("Validate VkPipelineColorBlendStateCreateInfo array with VK_EXT_extended_dynamic_state3");
 
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
@@ -3731,7 +3733,7 @@ TEST_F(VkLayerTest, PipelineColorBlendStateCreateInfoValidArrayDynamic) {
     }
 }
 
-TEST_F(VkLayerTest, VerifyDynamicStateSettingCommands) {
+TEST_F(NegativeDynamicState, SettingCommands) {
     TEST_DESCRIPTION("Verify if pipeline doesn't setup dynamic state, but set dynamic commands");
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());

--- a/tests/negative/external_memory_sync.cpp
+++ b/tests/negative/external_memory_sync.cpp
@@ -17,7 +17,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "utils/vk_layer_utils.h"
 
-TEST_F(VkLayerTest, CreateBufferIncompatibleExternalHandleTypes) {
+class NegativeExternalMemorySync : public VkLayerTest {};
+
+TEST_F(NegativeExternalMemorySync, CreateBufferIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Creating buffer with incompatible external memory handle types");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -59,7 +61,7 @@ TEST_F(VkLayerTest, CreateBufferIncompatibleExternalHandleTypes) {
     }
 }
 
-TEST_F(VkLayerTest, CreateImageIncompatibleExternalHandleTypes) {
+TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Creating image with incompatible external memory handle types");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -118,7 +120,7 @@ TEST_F(VkLayerTest, CreateImageIncompatibleExternalHandleTypes) {
     }
 }
 
-TEST_F(VkLayerTest, CreateImageIncompatibleExternalHandleTypesNV) {
+TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypesNV) {
     TEST_DESCRIPTION("Creating image with incompatible external memory handle types from NVIDIA extension");
 
     AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
@@ -170,7 +172,7 @@ TEST_F(VkLayerTest, CreateImageIncompatibleExternalHandleTypesNV) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidExportExternalImageHandleType) {
+TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
     TEST_DESCRIPTION("Test exporting memory with mismatching handleTypes.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -227,7 +229,7 @@ TEST_F(VkLayerTest, InvalidExportExternalImageHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, BufferMemoryWithUnsupportedExternalHandleType) {
+TEST_F(NegativeExternalMemorySync, BufferMemoryWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Bind buffer memory with unsupported external memory handle type.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -270,7 +272,7 @@ TEST_F(VkLayerTest, BufferMemoryWithUnsupportedExternalHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, BufferMemoryWithIncompatibleExternalHandleTypes) {
+TEST_F(NegativeExternalMemorySync, BufferMemoryWithIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Bind buffer memory with incompatible external memory handle types.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -303,7 +305,7 @@ TEST_F(VkLayerTest, BufferMemoryWithIncompatibleExternalHandleTypes) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImageMemoryWithUnsupportedExternalHandleType) {
+TEST_F(NegativeExternalMemorySync, ImageMemoryWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Bind image memory with unsupported external memory handle type.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -357,7 +359,7 @@ TEST_F(VkLayerTest, ImageMemoryWithUnsupportedExternalHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImageMemoryWithIncompatibleExternalHandleTypes) {
+TEST_F(NegativeExternalMemorySync, ImageMemoryWithIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Bind image memory with incompatible external memory handle types.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -402,7 +404,7 @@ TEST_F(VkLayerTest, ImageMemoryWithIncompatibleExternalHandleTypes) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidExportExternalBufferHandleType) {
+TEST_F(NegativeExternalMemorySync, ExportBufferHandleType) {
     TEST_DESCRIPTION("Test exporting memory with mismatching handleTypes.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -452,7 +454,7 @@ TEST_F(VkLayerTest, InvalidExportExternalBufferHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ExternalTimelineSemaphore) {
+TEST_F(NegativeExternalMemorySync, TimelineSemaphore) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     const auto extension_name = VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR;
@@ -528,7 +530,7 @@ TEST_F(VkLayerTest, ExternalTimelineSemaphore) {
     ASSERT_VK_SUCCESS(err);
 }
 
-TEST_F(VkLayerTest, ExternalSyncFdSemaphore) {
+TEST_F(NegativeExternalMemorySync, SyncFdSemaphore) {
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
 
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
@@ -625,7 +627,7 @@ TEST_F(VkLayerTest, ExternalSyncFdSemaphore) {
     ASSERT_VK_SUCCESS(err);
 }
 
-TEST_F(VkLayerTest, TemporaryExternalFence) {
+TEST_F(NegativeExternalMemorySync, TemporaryFence) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     const auto extension_name = VK_KHR_EXTERNAL_FENCE_WIN32_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT_KHR;
@@ -695,7 +697,7 @@ TEST_F(VkLayerTest, TemporaryExternalFence) {
     ASSERT_VK_SUCCESS(err);
 }
 
-TEST_F(VkLayerTest, InvalidExternalFence) {
+TEST_F(NegativeExternalMemorySync, Fence) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     const auto extension_name = VK_KHR_EXTERNAL_FENCE_WIN32_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
@@ -789,7 +791,7 @@ TEST_F(VkLayerTest, InvalidExternalFence) {
     ASSERT_VK_SUCCESS(err);
 }
 
-TEST_F(VkLayerTest, ExternalSyncFdFence) {
+TEST_F(NegativeExternalMemorySync, SyncFdFence) {
     const auto handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT_KHR;
 
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME);
@@ -846,7 +848,7 @@ TEST_F(VkLayerTest, ExternalSyncFdFence) {
     import_fence.wait(1000000000);
 }
 
-TEST_F(VkLayerTest, TemporaryExternalSemaphore) {
+TEST_F(NegativeExternalMemorySync, TemporarySemaphore) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     const auto extension_name = VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT_KHR;
@@ -940,7 +942,7 @@ TEST_F(VkLayerTest, TemporaryExternalSemaphore) {
     ASSERT_VK_SUCCESS(err);
 }
 
-TEST_F(VkLayerTest, InvalidExternalSemaphore) {
+TEST_F(NegativeExternalMemorySync, Semaphore) {
     TEST_DESCRIPTION("Import and export invalid external semaphores, no queue sumbits involved.");
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     const auto extension_name = VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME;
@@ -1018,7 +1020,7 @@ TEST_F(VkLayerTest, InvalidExternalSemaphore) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
+TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     TEST_DESCRIPTION("Validate import memory handleType for buffers and images");
 
 #ifdef _WIN32
@@ -1261,7 +1263,7 @@ TEST_F(VkLayerTest, ValidateImportMemoryHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, FenceExportWithUnsupportedHandleType) {
+TEST_F(NegativeExternalMemorySync, FenceExportWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Create fence with unsupported external handle type in VkExportFenceCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -1289,7 +1291,7 @@ TEST_F(VkLayerTest, FenceExportWithUnsupportedHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, FenceExportWithIncompatibleHandleType) {
+TEST_F(NegativeExternalMemorySync, FenceExportWithIncompatibleHandleType) {
     TEST_DESCRIPTION("Create fence with incompatible external handle types in VkExportFenceCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -1319,7 +1321,7 @@ TEST_F(VkLayerTest, FenceExportWithIncompatibleHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SemaphoreExportWithUnsupportedHandleType) {
+TEST_F(NegativeExternalMemorySync, SemaphoreExportWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Create semaphore with unsupported external handle type in VkExportSemaphoreCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -1347,7 +1349,7 @@ TEST_F(VkLayerTest, SemaphoreExportWithUnsupportedHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SemaphoreExportWithIncompatibleHandleType) {
+TEST_F(NegativeExternalMemorySync, SemaphoreExportWithIncompatibleHandleType) {
     TEST_DESCRIPTION("Create semaphore with incompatible external handle types in VkExportSemaphoreCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -1377,7 +1379,7 @@ TEST_F(VkLayerTest, SemaphoreExportWithIncompatibleHandleType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ExternalMemoryAndExternalMemoryNV) {
+TEST_F(NegativeExternalMemorySync, MemoryAndMemoryNV) {
     TEST_DESCRIPTION("Test for both external memory and external memory NV in image create pNext chain.");
 
     AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME);
@@ -1417,7 +1419,7 @@ TEST_F(VkLayerTest, ExternalMemoryAndExternalMemoryNV) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ValidateExternalMemoryImageLayout) {
+TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
     TEST_DESCRIPTION("Validate layout of image with external memory");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1463,7 +1465,7 @@ TEST_F(VkLayerTest, ValidateExternalMemoryImageLayout) {
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-TEST_F(VkLayerTest, InvalidD3D12FenceSubmitInfo) {
+TEST_F(NegativeExternalMemorySync, D3D12FenceSubmitInfo) {
     TEST_DESCRIPTION("Test invalid D3D12FenceSubmitInfo");
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -1499,7 +1501,7 @@ TEST_F(VkLayerTest, InvalidD3D12FenceSubmitInfo) {
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
-TEST_F(VkLayerTest, GetMemoryFdHandle) {
+TEST_F(NegativeExternalMemorySync, GetMemoryFdHandle) {
     TEST_DESCRIPTION("Validate VkMemoryGetFdInfoKHR passed to vkGetMemoryFdKHR");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
@@ -1570,7 +1572,7 @@ TEST_F(VkLayerTest, GetMemoryFdHandle) {
     }
 }
 
-TEST_F(VkLayerTest, ImportMemoryFromFdHandle) {
+TEST_F(NegativeExternalMemorySync, ImportMemoryFromFdHandle) {
     TEST_DESCRIPTION("POSIX fd handle memory import. Import parameters do not match payload's parameters");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
@@ -1665,7 +1667,7 @@ TEST_F(VkLayerTest, ImportMemoryFromFdHandle) {
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-TEST_F(VkLayerTest, ImportMemoryFromWin32Handle) {
+TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
     TEST_DESCRIPTION("Win32 handle memory import. Import parameters do not match payload's parameters");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);

--- a/tests/negative/fragment_shading_rate.cpp
+++ b/tests/negative/fragment_shading_rate.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, InvalidSetFragmentShadingRateValues) {
+class NegativeFragmentShadingRate : public VkLayerTest {};
+
+TEST_F(NegativeFragmentShadingRate, Values) {
     TEST_DESCRIPTION("Specify invalid fragment shading rate values");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -78,7 +80,7 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateValues) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidSetFragmentShadingRateValuesNoFeatures) {
+TEST_F(NegativeFragmentShadingRate, ValuesNoFeatures) {
     TEST_DESCRIPTION("Specify invalid fsr pipeline settings for the enabled features");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -107,7 +109,7 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateValuesNoFeatures) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsNoFeatures) {
+TEST_F(NegativeFragmentShadingRate, CombinerOpsNoFeatures) {
     TEST_DESCRIPTION("Specify combiner operations when only pipeline rate is supported");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -154,7 +156,7 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsNoFeatures) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsNoPipelineRate) {
+TEST_F(NegativeFragmentShadingRate, CombinerOpsNoPipelineRate) {
     TEST_DESCRIPTION("Specify pipeline rate when only attachment or primitive rate are supported");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -200,7 +202,7 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsNoPipelineRate) {
     fragmentSize.height = 1;
 }
 
-TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsLimit) {
+TEST_F(NegativeFragmentShadingRate, CombinerOpsLimit) {
     TEST_DESCRIPTION("Specify invalid fsr pipeline settings for the enabled features");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -261,7 +263,7 @@ TEST_F(VkLayerTest, InvalidSetFragmentShadingRateCombinerOpsLimit) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidPrimitiveFragmentShadingRateWriteMultiViewportLimitDynamic) {
+TEST_F(NegativeFragmentShadingRate, PrimitiveFragmentShadingRateWriteMultiViewportLimitDynamic) {
     TEST_DESCRIPTION("Test dynamic validation of the primitiveFragmentShadingRateWithMultipleViewports limit");
 
     // Enable KHR_fragment_shading_rate and all of its required extensions
@@ -331,7 +333,7 @@ TEST_F(VkLayerTest, InvalidPrimitiveFragmentShadingRateWriteMultiViewportLimitDy
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RenderPassCreateInvalidFragmentDensityMapReferences) {
+TEST_F(NegativeFragmentShadingRate, FragmentDensityMapReferences) {
     TEST_DESCRIPTION("Create a subpass with the wrong attachment information for a fragment density map ");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -416,7 +418,7 @@ TEST_F(VkLayerTest, RenderPassCreateInvalidFragmentDensityMapReferences) {
                          "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02551", nullptr);
 }
 
-TEST_F(VkLayerTest, InvalidFragmentDensityMapLayerCount) {
+TEST_F(NegativeFragmentShadingRate, FragmentDensityMapLayerCount) {
     TEST_DESCRIPTION("Specify a fragment density map attachment with incorrect layerCount");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -499,7 +501,7 @@ TEST_F(VkLayerTest, InvalidFragmentDensityMapLayerCount) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, FragmentDensityMapEnabled) {
+TEST_F(NegativeFragmentShadingRate, FragmentDensityMapEnabled) {
     TEST_DESCRIPTION("Validation must check several conditions that apply only when Fragment Density Maps are used.");
 
     // VK_EXT_fragment_density_map2 requires VK_EXT_fragment_density_map
@@ -693,7 +695,7 @@ TEST_F(VkLayerTest, FragmentDensityMapEnabled) {
     }
 }
 
-TEST_F(VkLayerTest, FragmentDensityMapDisabled) {
+TEST_F(NegativeFragmentShadingRate, FragmentDensityMapDisabled) {
     TEST_DESCRIPTION("Checks for when the fragment density map features are not enabled.");
 
     // VK_EXT_fragment_density_map2 requires VK_EXT_fragment_density_map
@@ -738,7 +740,7 @@ TEST_F(VkLayerTest, FragmentDensityMapDisabled) {
     CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-flags-02572");
 }
 
-TEST_F(VkLayerTest, RenderPassCreateFragmentDensityMapReferenceToInvalidAttachment) {
+TEST_F(NegativeFragmentShadingRate, FragmentDensityMapReferenceAttachment) {
     TEST_DESCRIPTION(
         "Test creating a framebuffer with fragment density map reference to an attachment with layer count different from 1");
 
@@ -823,7 +825,7 @@ TEST_F(VkLayerTest, RenderPassCreateFragmentDensityMapReferenceToInvalidAttachme
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRateDeviceFeatureCombinations) {
+TEST_F(NegativeFragmentShadingRate, DeviceFeatureCombinations) {
     TEST_DESCRIPTION(
         "Specify invalid combinations of fragment shading rate, shading rate image, and fragment density map features");
 
@@ -939,7 +941,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateDeviceFeatureCombinations) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferUsage) {
+TEST_F(NegativeFragmentShadingRate, FramebufferUsage) {
     TEST_DESCRIPTION("Specify a fragment shading rate attachment without the correct usage");
 
     // Enable KHR_fragment_shading_rate and all of its required extensions
@@ -1005,7 +1007,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferUsage) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
+TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
     TEST_DESCRIPTION("Specify a fragment shading rate attachment with too small dimensions");
 
     // Enable KHR_fragment_shading_rate and all of its required extensions
@@ -1122,7 +1124,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateFramebufferDimensions) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
+TEST_F(NegativeFragmentShadingRate, Attachments) {
     TEST_DESCRIPTION("Specify a fragment shading rate attachment with too small dimensions");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -1257,7 +1259,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateAttachments) {
     }
 }
 
-TEST_F(VkLayerTest, IncompatibleFragmentRateShadingAttachmentInExecuteCommands) {
+TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInExecuteCommands) {
     TEST_DESCRIPTION(
         "Test incompatible fragment shading rate attachments "
         "calling CmdExecuteCommands");
@@ -1470,7 +1472,7 @@ TEST_F(VkLayerTest, IncompatibleFragmentRateShadingAttachmentInExecuteCommands) 
     secondary.reset();
 }
 
-TEST_F(VkLayerTest, InvalidShadingRateUsage) {
+TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
     TEST_DESCRIPTION("Specify invalid usage of the fragment shading rate image view usage.");
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
@@ -1559,7 +1561,7 @@ TEST_F(VkLayerTest, InvalidShadingRateUsage) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRatePipeline) {
+TEST_F(NegativeFragmentShadingRate, Pipeline) {
     TEST_DESCRIPTION("Specify invalid fragment shading rate values");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -1607,7 +1609,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRatePipeline) {
     fsr_ci.fragmentSize.height = 1;
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRatePipelineFeatureUsage) {
+TEST_F(NegativeFragmentShadingRate, PipelineFeatureUsage) {
     TEST_DESCRIPTION("Specify invalid fsr pipeline settings for the enabled features");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -1643,7 +1645,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRatePipelineFeatureUsage) {
     fsr_ci.combinerOps[1] = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR;
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRatePipelineCombinerOpsLimit) {
+TEST_F(NegativeFragmentShadingRate, PipelineCombinerOpsLimit) {
     TEST_DESCRIPTION("Specify invalid use of combiner ops when non trivial ops aren't supported");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -1699,7 +1701,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRatePipelineCombinerOpsLimit) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidPrimitiveFragmentShadingRateWriteMultiViewportLimit) {
+TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
     TEST_DESCRIPTION("Test static validation of the primitiveFragmentShadingRateWithMultipleViewports limit");
 
     // Enable KHR_fragment_shading_rate and all of its required extensions
@@ -1882,7 +1884,7 @@ TEST_F(VkLayerTest, InvalidPrimitiveFragmentShadingRateWriteMultiViewportLimit) 
     }
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRateOps) {
+TEST_F(NegativeFragmentShadingRate, Ops) {
     TEST_DESCRIPTION("Specify invalid fsr pipeline settings for the enabled features");
 
     // Enable KHR_fragment_shading_rate and all of its required extensions
@@ -1923,7 +1925,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateOps) {
     CreatePipelineHelper::OneshotTest(*this, set_fsr_ci, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-06568");
 }
 
-TEST_F(VkLayerTest, FragmentDensityMappAttachmentCount) {
+TEST_F(NegativeFragmentShadingRate, FragmentDensityMapAttachmentCount) {
     TEST_DESCRIPTION("Test attachmentCount of VkRenderPassFragmentDensityMapCreateInfoEXT.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1976,7 +1978,7 @@ TEST_F(VkLayerTest, FragmentDensityMappAttachmentCount) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidRenderPassEndFragmentDensityMapOffsetQCOM) {
+TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
     TEST_DESCRIPTION("Ensure RenderPass end meets the requirements for VK_QCOM_fragment_density_map_offset");
 
     AddRequiredExtensions(VK_QCOM_FRAGMENT_DENSITY_MAP_OFFSET_EXTENSION_NAME);
@@ -2313,7 +2315,7 @@ TEST_F(VkLayerTest, InvalidRenderPassEndFragmentDensityMapOffsetQCOM) {
     }
 }
 
-TEST_F(VkLayerTest, ShadingRateImageNV) {
+TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
     TEST_DESCRIPTION("Test VK_NV_shading_rate_image.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -2607,7 +2609,7 @@ TEST_F(VkLayerTest, ShadingRateImageNV) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRateStageUsage) {
+TEST_F(NegativeFragmentShadingRate, StageUsage) {
     TEST_DESCRIPTION("Specify shading rate pipeline stage with attachmentFragmentShadingRate feature disabled");
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -2640,7 +2642,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateStageUsage) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRateStageUsageNV) {
+TEST_F(NegativeFragmentShadingRate, StageUsageNV) {
     TEST_DESCRIPTION(
         "Specify shading rate pipeline stage with shading rate features disabled and NV shading rate extension enabled");
     AddRequiredExtensions(VK_NV_SHADING_RATE_IMAGE_EXTENSION_NAME);

--- a/tests/negative/geometry_tessellation.cpp
+++ b/tests/negative/geometry_tessellation.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, StageMaskGsTsEnabled) {
+class NegativeGeometryTessellation : public VkLayerTest {};
+
+TEST_F(NegativeGeometryTessellation, StageMaskGsTsEnabled) {
     TEST_DESCRIPTION(
         "Attempt to use a stageMask w/ geometry shader and tesselation shader bits enabled when those features are disabled on the "
         "device.");
@@ -65,7 +67,7 @@ TEST_F(VkLayerTest, StageMaskGsTsEnabled) {
     vk::DestroyCommandPool(test_device.handle(), command_pool, NULL);
 }
 
-TEST_F(VkLayerTest, ValidateGeometryShaderEnabled) {
+TEST_F(NegativeGeometryTessellation, GeometryShaderEnabled) {
     TEST_DESCRIPTION("Validate geometry shader feature is enabled if geometry shader stage is used");
 
     VkPhysicalDeviceFeatures deviceFeatures = {};
@@ -90,7 +92,7 @@ TEST_F(VkLayerTest, ValidateGeometryShaderEnabled) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
 }
 
-TEST_F(VkLayerTest, ValidateTessellationShaderEnabled) {
+TEST_F(NegativeGeometryTessellation, TessellationShaderEnabled) {
     TEST_DESCRIPTION(
         "Validate tessellation shader feature is enabled if tessellation control or tessellation evaluation shader stage is used");
 
@@ -145,7 +147,7 @@ TEST_F(VkLayerTest, ValidateTessellationShaderEnabled) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
 }
 
-TEST_F(VkLayerTest, PointSizeGeomShaderDontWrite) {
+TEST_F(NegativeGeometryTessellation, PointSizeGeomShaderDontWrite) {
     TEST_DESCRIPTION(
         "Create a pipeline using TOPOLOGY_POINT_LIST, set PointSize vertex shader, but not in the final geometry stage.");
 
@@ -180,7 +182,7 @@ TEST_F(VkLayerTest, PointSizeGeomShaderDontWrite) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-Geometry-07725");
 }
 
-TEST_F(VkLayerTest, PointSizeGeomShaderWrite) {
+TEST_F(NegativeGeometryTessellation, PointSizeGeomShaderWrite) {
     TEST_DESCRIPTION(
         "Create a pipeline using TOPOLOGY_POINT_LIST, set PointSize vertex shader, but not in the final geometry stage.");
 
@@ -259,7 +261,7 @@ TEST_F(VkLayerTest, PointSizeGeomShaderWrite) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-Geometry-07726");
 }
 
-TEST_F(VkLayerTest, BuiltinBlockOrderMismatchVsGs) {
+TEST_F(NegativeGeometryTessellation, BuiltinBlockOrderMismatchVsGs) {
     TEST_DESCRIPTION("Use different order of gl_Position and gl_PointSize in builtin block interface between VS and GS.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -350,7 +352,7 @@ TEST_F(VkLayerTest, BuiltinBlockOrderMismatchVsGs) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpVariable-08746");
 }
 
-TEST_F(VkLayerTest, BuiltinBlockSizeMismatchVsGs) {
+TEST_F(NegativeGeometryTessellation, BuiltinBlockSizeMismatchVsGs) {
     TEST_DESCRIPTION("Use different number of elements in builtin block interface between VS and GS.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -391,7 +393,7 @@ TEST_F(VkLayerTest, BuiltinBlockSizeMismatchVsGs) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpVariable-08746");
 }
 
-TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationControlInputOutputComponents) {
+TEST_F(NegativeGeometryTessellation, MaxTessellationControlInputOutputComponents) {
     TEST_DESCRIPTION(
         "Test that errors are produced when the number of per-vertex input and/or output components to the tessellation control "
         "stage exceeds the device limit");
@@ -508,7 +510,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationControlInputOutputCompone
     }
 }
 
-TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationEvaluationInputOutputComponents) {
+TEST_F(NegativeGeometryTessellation, MaxTessellationEvaluationInputOutputComponents) {
     TEST_DESCRIPTION(
         "Test that errors are produced when the number of input and/or output components to the tessellation evaluation stage "
         "exceeds the device limit");
@@ -627,7 +629,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxTessellationEvaluationInputOutputComp
     }
 }
 
-TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
+TEST_F(NegativeGeometryTessellation, MaxGeometryInputOutputComponents) {
     TEST_DESCRIPTION(
         "Test that errors are produced when the number of input and/or output components to the geometry stage exceeds the device "
         "limit");
@@ -736,7 +738,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInputOutputComponents) {
     }
 }
 
-TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInstanceVertexCount) {
+TEST_F(NegativeGeometryTessellation, MaxGeometryInstanceVertexCount) {
     TEST_DESCRIPTION(
         "Test that errors are produced when the number of output vertices/instances in the geometry stage exceeds the device "
         "limit");
@@ -795,7 +797,7 @@ TEST_F(VkLayerTest, CreatePipelineExceedMaxGeometryInstanceVertexCount) {
     }
 }
 
-TEST_F(VkLayerTest, CreatePipelineTessPatchDecorationMismatch) {
+TEST_F(NegativeGeometryTessellation, TessellationPatchDecorationMismatch) {
     TEST_DESCRIPTION(
         "Test that an error is produced for a variable output from the TCS without the patch decoration, but consumed in the TES "
         "with the decoration.");
@@ -843,7 +845,7 @@ TEST_F(VkLayerTest, CreatePipelineTessPatchDecorationMismatch) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-OpVariable-08746");
 }
 
-TEST_F(VkLayerTest, CreatePipelineTessErrors) {
+TEST_F(NegativeGeometryTessellation, Tessellation) {
     TEST_DESCRIPTION("Test various errors when creating a graphics pipeline with tessellation stages active.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -935,7 +937,7 @@ TEST_F(VkLayerTest, CreatePipelineTessErrors) {
 }
 
 /*// TODO : This test should be good, but needs Tess support in compiler to run
-TEST_F(VkLayerTest, InvalidPatchControlPoints)
+TEST_F(NegativeGeometryTessellation, PatchControlPoints)
 {
     // Attempt to Create Gfx Pipeline w/o a VS
     VkResult err;

--- a/tests/negative/graphics_library.cpp
+++ b/tests/negative/graphics_library.cpp
@@ -18,9 +18,9 @@
 #include <array>
 #include <chrono>
 
-class VkGraphicsLibraryLayerTest : public VkLayerTest {};
+class NegativeGraphicsLibrary : public VkLayerTest {};
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidDSLs) {
+TEST_F(NegativeGraphicsLibrary, DSLs) {
     TEST_DESCRIPTION("Create a pipeline layout with invalid descriptor set layouts");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -49,7 +49,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidDSLs) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, GPLInvalidDSLs) {
+TEST_F(NegativeGraphicsLibrary, GPLDSLs) {
     TEST_DESCRIPTION("Create a pipeline layout with invalid descriptor set layouts with VK_EXT_grahpics_pipeline_library enabled");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -85,7 +85,7 @@ TEST_F(VkGraphicsLibraryLayerTest, GPLInvalidDSLs) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidIndependentSetsLinkOnly) {
+TEST_F(NegativeGraphicsLibrary, IndependentSetsLinkOnly) {
     TEST_DESCRIPTION("Link pre-raster and FS subsets with invalid VkPipelineLayout create flags");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -164,7 +164,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidIndependentSetsLinkOnly) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidIndependentSetsLinkCreate) {
+TEST_F(NegativeGraphicsLibrary, IndependentSetsLinkCreate) {
     TEST_DESCRIPTION("Create pre-raster subset while linking FS subset with invalid VkPipelineLayout create flags");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -237,7 +237,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidIndependentSetsLinkCreate) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidDescriptorSets) {
+TEST_F(NegativeGraphicsLibrary, DescriptorSets) {
     TEST_DESCRIPTION(
         "Attempt to bind invalid descriptor sets with and without VK_EXT_graphics_pipeline_library and independent sets");
 
@@ -264,7 +264,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidDescriptorSets) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidDescriptorSetsGPL) {
+TEST_F(NegativeGraphicsLibrary, DescriptorSetsGPL) {
     TEST_DESCRIPTION("Attempt to bind invalid descriptor sets with and with VK_EXT_graphics_pipeline_library");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -299,7 +299,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidDescriptorSetsGPL) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, MissingDSState) {
+TEST_F(NegativeGraphicsLibrary, MissingDSState) {
     TEST_DESCRIPTION("Create a library with fragment shader state, but no fragment output state, and invalid DS state");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -349,7 +349,7 @@ TEST_F(VkGraphicsLibraryLayerTest, MissingDSState) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, MissingDSStateWithFragOutputState) {
+TEST_F(NegativeGraphicsLibrary, MissingDSStateWithFragOutputState) {
     TEST_DESCRIPTION("Create a library with both fragment shader state and fragment output state, and invalid DS state");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -456,7 +456,7 @@ TEST_F(VkGraphicsLibraryLayerTest, MissingDSStateWithFragOutputState) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, MissingColorBlendState) {
+TEST_F(NegativeGraphicsLibrary, MissingColorBlendState) {
     TEST_DESCRIPTION("Create a library with fragment output state and invalid ColorBlendState state");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -530,7 +530,7 @@ TEST_F(VkGraphicsLibraryLayerTest, MissingColorBlendState) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, ImplicitVUIDs) {
+TEST_F(NegativeGraphicsLibrary, ImplicitVUIDs) {
     TEST_DESCRIPTION("Test various VUIDs that were previously implicit, but now explicit due to VK_EXT_graphics_pipeline_library");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -562,7 +562,7 @@ TEST_F(VkGraphicsLibraryLayerTest, ImplicitVUIDs) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidCreateStateGPL) {
+TEST_F(NegativeGraphicsLibrary, CreateStateGPL) {
     TEST_DESCRIPTION("Create invalid graphics pipeline state with VK_EXT_graphics_pipeline_library enabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -630,7 +630,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidCreateStateGPL) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidLinkOptimization) {
+TEST_F(NegativeGraphicsLibrary, LinkOptimization) {
     TEST_DESCRIPTION("Create graphics pipeline libraries with mismatching link-time optimization flags");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -706,7 +706,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidLinkOptimization) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidDSLShaderBindingsNullInCreate) {
+TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsNullInCreate) {
     TEST_DESCRIPTION("Link pre-raster state while creating FS state with invalid null DSL + shader stage bindings");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -792,7 +792,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidDSLShaderBindingsNullInCreate) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidDSLShaderBindingsNullInLink) {
+TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsNullInLink) {
     TEST_DESCRIPTION("Link pre-raster state with invalid null DSL + shader stage bindings while creating FS state");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -878,7 +878,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidDSLShaderBindingsNullInLink) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidDSLShaderBindingsLinkOnly) {
+TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsLinkOnly) {
     TEST_DESCRIPTION("Link pre-raster and FS subsets with invalid null DSL + shader stage bindings");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -970,7 +970,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidDSLShaderBindingsLinkOnly) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, CreateGraphicsPipelineWithMissingMultisampleState) {
+TEST_F(NegativeGraphicsLibrary, MissingMultisampleState) {
     TEST_DESCRIPTION("Create pipeline with fragment shader that uses samples, but multisample state not begin set");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1004,7 +1004,7 @@ TEST_F(VkGraphicsLibraryLayerTest, CreateGraphicsPipelineWithMissingMultisampleS
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, PreRasterStateNoLayout) {
+TEST_F(NegativeGraphicsLibrary, PreRasterStateNoLayout) {
     TEST_DESCRIPTION("Create a pre-raster graphics library");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1048,7 +1048,7 @@ TEST_F(VkGraphicsLibraryLayerTest, PreRasterStateNoLayout) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, ImmutableSamplersIncompatibleDSL) {
+TEST_F(NegativeGraphicsLibrary, ImmutableSamplersIncompatibleDSL) {
     TEST_DESCRIPTION("Link pipelines with DSLs that only differ by immutable samplers");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -1193,7 +1193,7 @@ TEST_F(VkGraphicsLibraryLayerTest, ImmutableSamplersIncompatibleDSL) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, PreRasterWithFS) {
+TEST_F(NegativeGraphicsLibrary, PreRasterWithFS) {
     TEST_DESCRIPTION("Create a library with no FS state, but an FS");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -1248,7 +1248,7 @@ TEST_F(VkGraphicsLibraryLayerTest, PreRasterWithFS) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, FragmentStateWithPreRaster) {
+TEST_F(NegativeGraphicsLibrary, FragmentStateWithPreRaster) {
     TEST_DESCRIPTION("Create a library with no pre-raster state, but that contains a pre-raster shader.");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -1302,7 +1302,7 @@ TEST_F(VkGraphicsLibraryLayerTest, FragmentStateWithPreRaster) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, MissingShaderStages) {
+TEST_F(NegativeGraphicsLibrary, MissingShaderStages) {
     TEST_DESCRIPTION("Create a library with pre-raster state, but no pre-raster shader");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -1335,7 +1335,7 @@ TEST_F(VkGraphicsLibraryLayerTest, MissingShaderStages) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, DescriptorBufferLibrary) {
+TEST_F(NegativeGraphicsLibrary, DescriptorBufferLibrary) {
     TEST_DESCRIPTION("Descriptor buffer and graphics library");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1442,7 +1442,7 @@ TEST_F(VkGraphicsLibraryLayerTest, DescriptorBufferLibrary) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, BadDSLShaderStageMask) {
+TEST_F(NegativeGraphicsLibrary, DSLShaderStageMask) {
     TEST_DESCRIPTION(
         "Attempt to bind invalid descriptor sets with and without VK_EXT_graphics_pipeline_library and independent sets");
 
@@ -1542,7 +1542,7 @@ TEST_F(VkGraphicsLibraryLayerTest, BadDSLShaderStageMask) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, CreatePipelineTessErrors) {
+TEST_F(NegativeGraphicsLibrary, Tessellation) {
     TEST_DESCRIPTION("Test various errors when creating a graphics pipeline with tessellation stages active.");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -1756,7 +1756,7 @@ TEST_F(VkGraphicsLibraryLayerTest, CreatePipelineTessErrors) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, PipelineExecutableProperties) {
+TEST_F(NegativeGraphicsLibrary, PipelineExecutableProperties) {
     TEST_DESCRIPTION("VK_KHR_pipeline_executable_properties with GPL");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -1848,7 +1848,7 @@ TEST_F(VkGraphicsLibraryLayerTest, PipelineExecutableProperties) {
     }
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, BindEmptyDS) {
+TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
     TEST_DESCRIPTION("Bind an empty descriptor set");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -1996,7 +1996,7 @@ TEST_F(VkGraphicsLibraryLayerTest, BindEmptyDS) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, BindLibraryPipeline) {
+TEST_F(NegativeGraphicsLibrary, BindLibraryPipeline) {
     TEST_DESCRIPTION("Test binding a pipeline that was created with library flag");
 
     AddRequiredExtensions(VK_KHR_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -2027,7 +2027,7 @@ TEST_F(VkGraphicsLibraryLayerTest, BindLibraryPipeline) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, ShaderModuleIdentifier) {
+TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
     TEST_DESCRIPTION("Test for VK_EXT_shader_module_identifier extension.");
     TEST_DESCRIPTION("Create a pipeline using a shader module identifier");
     SetTargetApiVersion(VK_API_VERSION_1_3);  // Pipeline cache control needed
@@ -2141,7 +2141,7 @@ TEST_F(VkGraphicsLibraryLayerTest, ShaderModuleIdentifier) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, ShaderModuleIdentifierFeatures) {
+TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifierFeatures) {
     TEST_DESCRIPTION("Test for VK_EXT_shader_module_identifier extension with missing features.");
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_SHADER_MODULE_IDENTIFIER_EXTENSION_NAME);
@@ -2197,7 +2197,7 @@ TEST_F(VkGraphicsLibraryLayerTest, ShaderModuleIdentifierFeatures) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, InvalidLayouts) {
+TEST_F(NegativeGraphicsLibrary, Layouts) {
     TEST_DESCRIPTION("Various invalid layouts");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -2268,7 +2268,7 @@ TEST_F(VkGraphicsLibraryLayerTest, InvalidLayouts) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkGraphicsLibraryLayerTest, IncompatibleLayouts) {
+TEST_F(NegativeGraphicsLibrary, IncompatibleLayouts) {
     TEST_DESCRIPTION("Link pre-raster state while creating FS state with invalid null DSL + shader stage bindings");
 
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);

--- a/tests/negative/image.cpp
+++ b/tests/negative/image.cpp
@@ -17,7 +17,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "utils/vk_layer_utils.h"
 
-TEST_F(VkLayerTest, InvalidUsageBits) {
+class NegativeImage : public VkLayerTest {};
+
+TEST_F(NegativeImage, UsageBits) {
     TEST_DESCRIPTION(
         "Specify wrong usage for image then create conflicting view of image Initialize buffer with wrong usage then perform copy "
         "expecting errors from both the image and the buffer (2 calls)");
@@ -96,7 +98,7 @@ TEST_F(VkLayerTest, InvalidUsageBits) {
     }
 }
 
-TEST_F(VkLayerTest, CopyBufferToCompressedImage) {
+TEST_F(NegativeImage, CopyBufferToCompressedImage) {
     TEST_DESCRIPTION("Copy buffer to compressed image when buffer is larger than image.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -178,7 +180,7 @@ TEST_F(VkLayerTest, CopyBufferToCompressedImage) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CreateUnknownObject) {
+TEST_F(NegativeImage, UnknownObject) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageMemoryRequirements-image-parameter");
 
     TEST_DESCRIPTION("Pass an invalid image object handle into a Vulkan API call.");
@@ -195,7 +197,7 @@ TEST_F(VkLayerTest, CreateUnknownObject) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImageSampleCounts) {
+TEST_F(NegativeImage, SampleCounts) {
     TEST_DESCRIPTION("Use bad sample counts in image transfer calls to trigger validation errors.");
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -314,7 +316,7 @@ TEST_F(VkLayerTest, ImageSampleCounts) {
     }
 }
 
-TEST_F(VkLayerTest, BlitImageFormatTypes) {
+TEST_F(NegativeImage, BlitFormatTypes) {
     AddOptionalExtensions(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -544,7 +546,7 @@ TEST_F(VkLayerTest, BlitImageFormatTypes) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, BlitImageFilters) {
+TEST_F(NegativeImage, BlitFilters) {
     AddOptionalExtensions(VK_IMG_FILTER_CUBIC_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(Init());
     const bool cubic_support = IsExtensionsEnabled(VK_IMG_FILTER_CUBIC_EXTENSION_NAME);
@@ -623,7 +625,7 @@ TEST_F(VkLayerTest, BlitImageFilters) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, BlitImageLayout) {
+TEST_F(NegativeImage, BlitLayout) {
     TEST_DESCRIPTION("Incorrect vkCmdBlitImage layouts");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -779,7 +781,7 @@ TEST_F(VkLayerTest, BlitImageLayout) {
     ASSERT_VK_SUCCESS(err);
 }
 
-TEST_F(VkLayerTest, BlitImageOffsets) {
+TEST_F(NegativeImage, BlitOffsets) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     VkFormat fmt = VK_FORMAT_R8G8B8A8_UNORM;
@@ -920,7 +922,7 @@ TEST_F(VkLayerTest, BlitImageOffsets) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, BlitImageOverlap) {
+TEST_F(NegativeImage, BlitOverlap) {
     TEST_DESCRIPTION("Try to blit an image on same region.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -974,7 +976,7 @@ TEST_F(VkLayerTest, BlitImageOverlap) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, MiscBlitImageTests) {
+TEST_F(NegativeImage, MiscBlitTests) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     VkFormat f_color = VK_FORMAT_R32_SFLOAT;  // Need features ..BLIT_SRC_BIT & ..BLIT_DST_BIT
@@ -1132,7 +1134,7 @@ TEST_F(VkLayerTest, MiscBlitImageTests) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, BlitToDepthImageTests) {
+TEST_F(NegativeImage, BlitToDepth) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     const VkFormat f_depth = VK_FORMAT_D32_SFLOAT;
@@ -1189,7 +1191,7 @@ TEST_F(VkLayerTest, BlitToDepthImageTests) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, MinImageTransferGranularity) {
+TEST_F(NegativeImage, MinImageTransferGranularity) {
     TEST_DESCRIPTION("Tests for validation of Queue Family property minImageTransferGranularity.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -1316,7 +1318,7 @@ TEST_F(VkLayerTest, MinImageTransferGranularity) {
     command_buffer.end();
 }
 
-TEST_F(VkLayerTest, Bad2DArrayImageType) {
+TEST_F(NegativeImage, Array2DImageType) {
     TEST_DESCRIPTION("Create an image with a flag specifying 2D_ARRAY_COMPATIBLE but not of imageType 3D.");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -1345,7 +1347,7 @@ TEST_F(VkLayerTest, Bad2DArrayImageType) {
     CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-flags-00950");
 }
 
-TEST_F(VkLayerTest, Bad2DViewImageType) {
+TEST_F(NegativeImage, View2DImageType) {
     TEST_DESCRIPTION("Create an image with a flag specifying 2D_VIEW_COMPATIBLE but not of imageType 3D.");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -1376,7 +1378,7 @@ TEST_F(VkLayerTest, Bad2DViewImageType) {
 }
 
 // INVALID_IMAGE_LAYOUT tests (one other case is hit by MapMemWithoutHostVisibleBit and not here)
-TEST_F(VkLayerTest, InvalidImageLayout) {
+TEST_F(NegativeImage, ImageLayout) {
     TEST_DESCRIPTION(
         "Hit all possible validation checks associated with the UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout error. "
         "Generally these involve having images in the wrong layout when they're copied or transitioned.");
@@ -1670,7 +1672,7 @@ TEST_F(VkLayerTest, InvalidImageLayout) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidStorageImageLayout) {
+TEST_F(NegativeImage, StorageImageLayout) {
     TEST_DESCRIPTION("Attempt to update a STORAGE_IMAGE descriptor w/o GENERAL layout.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1704,7 +1706,7 @@ TEST_F(VkLayerTest, InvalidStorageImageLayout) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CopyInvalidImageMemory) {
+TEST_F(NegativeImage, CopyImageMemory) {
     TEST_DESCRIPTION("Validate 4 invalid image memory VUIDs ");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddOptionalExtensions(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
@@ -1797,7 +1799,7 @@ TEST_F(VkLayerTest, CopyInvalidImageMemory) {
     }
 }
 
-TEST_F(VkLayerTest, CreateImageViewBreaksParameterCompatibilityRequirements) {
+TEST_F(NegativeImage, ImageViewBreaksParameterCompatibilityRequirements) {
     TEST_DESCRIPTION(
         "Attempts to create an Image View with a view type that does not match the image type it is being created from.");
 
@@ -1987,7 +1989,7 @@ TEST_F(VkLayerTest, CreateImageViewBreaksParameterCompatibilityRequirements) {
     vk::DestroyImage(m_device->device(), imageSparse, nullptr);
 }
 
-TEST_F(VkLayerTest, CreateImageViewFormatFeatureMismatch) {
+TEST_F(NegativeImage, ImageViewFormatFeatureMismatch) {
     TEST_DESCRIPTION("Create view with a format that does not have the same features as the image format.");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -2136,7 +2138,7 @@ TEST_F(VkLayerTest, CreateImageViewFormatFeatureMismatch) {
     CreateImageViewTest(*this, &ivci, optimal_error_codes[i]);
 }
 
-TEST_F(VkLayerTest, InvalidImageViewUsageCreateInfo) {
+TEST_F(NegativeImage, ImageViewUsageCreateInfo) {
     TEST_DESCRIPTION("Usage modification via a chained VkImageViewUsageCreateInfo struct");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
@@ -2219,7 +2221,7 @@ TEST_F(VkLayerTest, InvalidImageViewUsageCreateInfo) {
     CreateImageViewTest(*this, &ivci, "VUID-VkImageViewUsageCreateInfo-usage-parameter");
 }
 
-TEST_F(VkLayerTest, CreateImageViewNoSeparateStencilUsage) {
+TEST_F(NegativeImage, ImageViewNoSeparateStencilUsage) {
     TEST_DESCRIPTION("Verify CreateImageView create info for the case VK_EXT_separate_stencil_usage is not supported.");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
@@ -2275,7 +2277,7 @@ TEST_F(VkLayerTest, CreateImageViewNoSeparateStencilUsage) {
     CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageViewCreateInfo-pNext-02661");
 }
 
-TEST_F(VkLayerTest, CreateImageViewStencilUsageCreateInfo) {
+TEST_F(NegativeImage, ImageViewStencilUsageCreateInfo) {
     TEST_DESCRIPTION("Verify CreateImageView with stencil usage.");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
@@ -2355,7 +2357,7 @@ TEST_F(VkLayerTest, CreateImageViewStencilUsageCreateInfo) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CreateImageViewNoMemoryBoundToImage) {
+TEST_F(NegativeImage, ImageViewNoMemoryBoundToImage) {
     VkResult err;
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -2397,7 +2399,7 @@ TEST_F(VkLayerTest, CreateImageViewNoMemoryBoundToImage) {
     vk::DestroyImage(m_device->device(), image, NULL);
 }
 
-TEST_F(VkLayerTest, InvalidImageViewAspect) {
+TEST_F(NegativeImage, ImageViewAspect) {
     TEST_DESCRIPTION("Create an image and try to create a view with an invalid aspectMask");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -2420,7 +2422,7 @@ TEST_F(VkLayerTest, InvalidImageViewAspect) {
     CreateImageViewTest(*this, &image_view_create_info, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
 }
 
-TEST_F(VkLayerTest, ExerciseGetImageSubresourceLayout) {
+TEST_F(NegativeImage, GetImageSubresourceLayout) {
     TEST_DESCRIPTION("Test vkGetImageSubresourceLayout() valid usages");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -2568,7 +2570,7 @@ TEST_F(VkLayerTest, ExerciseGetImageSubresourceLayout) {
     }
 }
 
-TEST_F(VkLayerTest, ImageWithUndefinedFormat) {
+TEST_F(NegativeImage, UndefinedFormat) {
     TEST_DESCRIPTION("Create image with undefined format");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -2588,7 +2590,7 @@ TEST_F(VkLayerTest, ImageWithUndefinedFormat) {
     CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-00943");
 }
 
-TEST_F(VkLayerTest, CreateImageViewFormatMismatchUnrelated) {
+TEST_F(NegativeImage, ImageViewFormatMismatchUnrelated) {
     TEST_DESCRIPTION("Create an image with a color format, then try to create a depth view of it");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -2626,7 +2628,7 @@ TEST_F(VkLayerTest, CreateImageViewFormatMismatchUnrelated) {
                         "Formats MUST be IDENTICAL unless VK_IMAGE_CREATE_MUTABLE_FORMAT BIT was set on image creation.");
 }
 
-TEST_F(VkLayerTest, CreateImageViewNoMutableFormatBit) {
+TEST_F(NegativeImage, ImageViewNoMutableFormatBit) {
     TEST_DESCRIPTION("Create an image view with a different format, when the image does not have MUTABLE_FORMAT bit");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -2662,7 +2664,7 @@ TEST_F(VkLayerTest, CreateImageViewNoMutableFormatBit) {
     CreateImageViewTest(*this, &imgViewInfo, "VUID-VkImageViewCreateInfo-image-01019");
 }
 
-TEST_F(VkLayerTest, CreateImageViewDifferentClass) {
+TEST_F(NegativeImage, ImageViewDifferentClass) {
     TEST_DESCRIPTION("Passing bad parameters to CreateImageView");
 
     VkPhysicalDeviceFeatures device_features = {};
@@ -2738,7 +2740,7 @@ TEST_F(VkLayerTest, CreateImageViewDifferentClass) {
     }
 }
 
-TEST_F(VkLayerTest, CreateImageViewInvalidSubresourceRange) {
+TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
     TEST_DESCRIPTION("Passing bad image subrange to CreateImageView");
     ASSERT_NO_FATAL_FAILURE(Init());
     const bool maintenance1 = IsExtensionsEnabled(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -3131,7 +3133,7 @@ TEST_F(VkLayerTest, CreateImageViewInvalidSubresourceRange) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidImageViewLayerCount) {
+TEST_F(NegativeImage, ImageViewLayerCount) {
     TEST_DESCRIPTION("Image and ImageView arrayLayers/layerCount parameters not being compatibile");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3277,7 +3279,7 @@ TEST_F(VkLayerTest, InvalidImageViewLayerCount) {
     }
 }
 
-TEST_F(VkLayerTest, CreateImageMiscErrors) {
+TEST_F(NegativeImage, ImageMisc) {
     TEST_DESCRIPTION("Misc leftover valid usage errors in VkImageCreateInfo struct");
 
     VkPhysicalDeviceFeatures features{};
@@ -3403,7 +3405,7 @@ TEST_F(VkLayerTest, CreateImageMiscErrors) {
     }
 }
 
-TEST_F(VkLayerTest, CreateImageMinLimitsViolation) {
+TEST_F(NegativeImage, ImageMinLimits) {
     TEST_DESCRIPTION("Create invalid image with invalid parameters violation minimum limit, such as being zero.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3505,7 +3507,7 @@ TEST_F(VkLayerTest, CreateImageMinLimitsViolation) {
     }
 }
 
-TEST_F(VkLayerTest, CreateImageMaxLimitsViolation) {
+TEST_F(NegativeImage, ImageMaxLimits) {
     TEST_DESCRIPTION("Create invalid image with invalid parameters exceeding physical device limits.");
 
     // Check for VK_KHR_get_physical_device_properties2
@@ -3661,7 +3663,7 @@ TEST_F(VkLayerTest, CreateImageMaxLimitsViolation) {
     }
 }
 
-TEST_F(VkLayerTest, DepthStencilImageViewWithColorAspectBitError) {
+TEST_F(NegativeImage, DepthStencilImageViewWithColorAspectBit) {
     // Create a single Image descriptor and cause it to first hit an error due
     //  to using a DS format, then cause it to hit error due to COLOR_BIT not
     //  set in aspect
@@ -3715,7 +3717,7 @@ TEST_F(VkLayerTest, DepthStencilImageViewWithColorAspectBitError) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CornerSampledImageNV) {
+TEST_F(NegativeImage, CornerSampledImageNV) {
     TEST_DESCRIPTION("Test VK_NV_corner_sampled_image.");
     AddRequiredExtensions(VK_NV_CORNER_SAMPLED_IMAGE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -3790,7 +3792,7 @@ TEST_F(VkLayerTest, CornerSampledImageNV) {
     CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-mipLevels-00958");
 }
 
-TEST_F(VkLayerTest, ImageStencilCreate) {
+TEST_F(NegativeImage, Stencil) {
     TEST_DESCRIPTION("Verify ImageStencil create info.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -3915,7 +3917,7 @@ TEST_F(VkLayerTest, ImageStencilCreate) {
     CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-02798");
 }
 
-TEST_F(VkLayerTest, AstcDecodeMode) {
+TEST_F(NegativeImage, AstcDecodeMode) {
     TEST_DESCRIPTION("Tests for VUs for VK_EXT_astc_decode_mode");
     AddRequiredExtensions(VK_EXT_ASTC_DECODE_MODE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -3976,7 +3978,7 @@ TEST_F(VkLayerTest, AstcDecodeMode) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CreateImageViewIncompatibleFormat) {
+TEST_F(NegativeImage, ImageViewIncompatibleFormat) {
     TEST_DESCRIPTION("Tests for VUID-VkImageViewCreateInfo-image-01761");
     // original issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2203
 
@@ -4055,7 +4057,7 @@ TEST_F(VkLayerTest, CreateImageViewIncompatibleFormat) {
     CreateImageViewTest(*this, &imgViewInfo, {});
 }
 
-TEST_F(VkLayerTest, CreateImageViewIncompatibleDepthFormat) {
+TEST_F(NegativeImage, ImageViewIncompatibleDepthFormat) {
     TEST_DESCRIPTION("Tests for VUID-VkImageViewCreateInfo-image-01761 with depth format");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -4121,7 +4123,7 @@ TEST_F(VkLayerTest, CreateImageViewIncompatibleDepthFormat) {
     CreateImageViewTest(*this, &imgViewInfo, error_vuid);
 }
 
-TEST_F(VkLayerTest, CreateImageViewMissingYcbcrConversion) {
+TEST_F(NegativeImage, ImageViewMissingYcbcrConversion) {
     TEST_DESCRIPTION("Do not use VkSamplerYcbcrConversionInfo when required for an image view.");
 
     // Use 1.1 to get VK_KHR_sampler_ycbcr_conversion easier
@@ -4156,7 +4158,7 @@ TEST_F(VkLayerTest, CreateImageViewMissingYcbcrConversion) {
     CreateImageViewTest(*this, &view_info, "VUID-VkImageViewCreateInfo-format-06415");
 }
 
-TEST_F(VkLayerTest, InvalidImageFormatList) {
+TEST_F(NegativeImage, ImageFormatList) {
     TEST_DESCRIPTION("Tests for VK_KHR_image_format_list");
 
     AddRequiredExtensions(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
@@ -4248,7 +4250,7 @@ TEST_F(VkLayerTest, InvalidImageFormatList) {
     CreateImageViewTest(*this, &imageViewInfo, {});
 }
 
-TEST_F(VkLayerTest, InvalidImageFormatListSizeCompatible) {
+TEST_F(NegativeImage, ImageFormatListSizeCompatible) {
     TEST_DESCRIPTION("Tests for VK_KHR_image_format_list with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT");
 
     AddRequiredExtensions(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
@@ -4300,7 +4302,7 @@ TEST_F(VkLayerTest, InvalidImageFormatListSizeCompatible) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCount) {
+TEST_F(NegativeImage, ImageSplitInstanceBindRegionCount) {
     TEST_DESCRIPTION("Bind image memory with VkBindImageMemoryDeviceGroupInfo but invalid flags");
 
     AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
@@ -4370,7 +4372,7 @@ TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCount) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCountWithDeviceGroup) {
+TEST_F(NegativeImage, ImageSplitInstanceBindRegionCountWithDeviceGroup) {
     TEST_DESCRIPTION("Bind image memory with VkBindImageMemoryDeviceGroupInfo but invalid splitInstanceBindRegionCount");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4462,7 +4464,7 @@ TEST_F(VkLayerTest, InvalidImageSplitInstanceBindRegionCountWithDeviceGroup) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, BlockTexelViewInvalidLevelOrLayerCount) {
+TEST_F(NegativeImage, BlockTexelViewLevelOrLayerCount) {
     TEST_DESCRIPTION(
         "Attempts to create an Image View with an image using VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT, but levelCount and "
         "layerCount are not 1.");
@@ -4518,7 +4520,7 @@ TEST_F(VkLayerTest, BlockTexelViewInvalidLevelOrLayerCount) {
     CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-07072");
 }
 
-TEST_F(VkLayerTest, InvalidBindIMageMemoryDeviceGroupInfo) {
+TEST_F(NegativeImage, BindIMageMemoryDeviceGroupInfo) {
     TEST_DESCRIPTION("Checks for invalid BindIMageMemoryDeviceGroupInfo.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -4614,7 +4616,7 @@ TEST_F(VkLayerTest, InvalidBindIMageMemoryDeviceGroupInfo) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, BlockTexelViewInvalidType) {
+TEST_F(NegativeImage, BlockTexelViewType) {
     TEST_DESCRIPTION(
         "Create Image with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT and non-compressed format and ImageView with view type "
         "VK_IMAGE_VIEW_TYPE_3D.");
@@ -4665,7 +4667,7 @@ TEST_F(VkLayerTest, BlockTexelViewInvalidType) {
     CreateImageViewTest(*this, &ivci);
 }
 
-TEST_F(VkLayerTest, BlockTexelViewInvalidFormat) {
+TEST_F(NegativeImage, BlockTexelViewFormat) {
     TEST_DESCRIPTION("Create Image with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT with non compatible formats.");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
@@ -4719,7 +4721,7 @@ TEST_F(VkLayerTest, BlockTexelViewInvalidFormat) {
     CreateImageViewTest(*this, &ivci);
 }
 
-TEST_F(VkLayerTest, InvalidImageSubresourceRangeAspectMask) {
+TEST_F(NegativeImage, ImageSubresourceRangeAspectMask) {
     TEST_DESCRIPTION("Test creating Image with invalid VkImageSubresourceRange aspectMask.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -4791,7 +4793,7 @@ TEST_F(VkLayerTest, InvalidImageSubresourceRangeAspectMask) {
     CreateImageViewTest(*this, &ivci, "VUID-VkImageSubresourceRange-aspectMask-01670");
 }
 
-TEST_F(VkLayerTest, CreateImageSharingModeConcurrentInvalidQueueFamilies) {
+TEST_F(NegativeImage, CreateImageSharingModeConcurrentQueueFamilies) {
     TEST_DESCRIPTION("Checks for invalid queue families in ImageCreateInfo when sharingMode is VK_SHARING_MODE_CONCURRENT");
 
     AddOptionalExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -4854,7 +4856,7 @@ TEST_F(VkLayerTest, CreateImageSharingModeConcurrentInvalidQueueFamilies) {
     }
 }
 
-TEST_F(VkLayerTest, ImageFormatInfoDrmFormatModifier) {
+TEST_F(NegativeImage, ImageFormatInfoDrmFormatModifier) {
     TEST_DESCRIPTION("Validate VkPhysicalDeviceImageFormatInfo2.");
 
     AddRequiredExtensions(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
@@ -4908,7 +4910,7 @@ TEST_F(VkLayerTest, ImageFormatInfoDrmFormatModifier) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidMultiSampleImageView) {
+TEST_F(NegativeImage, MultiSampleImageView) {
     TEST_DESCRIPTION("Begin conditional rendering when it is already active.");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
@@ -4963,7 +4965,7 @@ TEST_F(VkLayerTest, InvalidMultiSampleImageView) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, Image2DViewOf3D) {
+TEST_F(NegativeImage, Image2DViewOf3D) {
     TEST_DESCRIPTION("Checks for invalid use of 2D views of 3D images");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_IMAGE_2D_VIEW_OF_3D_EXTENSION_NAME);
@@ -5046,7 +5048,7 @@ TEST_F(VkLayerTest, Image2DViewOf3D) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, Image2DViewOf3DFeature) {
+TEST_F(NegativeImage, Image2DViewOf3DFeature) {
     TEST_DESCRIPTION("Checks for image image_2d_view_of_3d features");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_IMAGE_2D_VIEW_OF_3D_EXTENSION_NAME);
@@ -5107,7 +5109,7 @@ TEST_F(VkLayerTest, Image2DViewOf3DFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImageViewMinLod) {
+TEST_F(NegativeImage, ImageViewMinLod) {
     TEST_DESCRIPTION("Checks for image view minimum level of detail.");
 
     AddRequiredExtensions(VK_EXT_IMAGE_VIEW_MIN_LOD_EXTENSION_NAME);
@@ -5167,7 +5169,7 @@ TEST_F(VkLayerTest, ImageViewMinLod) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImageViewMinLodFeature) {
+TEST_F(NegativeImage, ImageViewMinLodFeature) {
     TEST_DESCRIPTION("Checks for image view minimum level of detail feature enabled.");
     ASSERT_NO_FATAL_FAILURE(Init());
     VkImageObj image(m_device);
@@ -5190,7 +5192,7 @@ TEST_F(VkLayerTest, ImageViewMinLodFeature) {
     CreateImageViewTest(*this, &ivci, "VUID-VkImageViewMinLodCreateInfoEXT-minLod-06455");
 }
 
-TEST_F(VkLayerTest, CreateColorImageWithDepthAspect) {
+TEST_F(NegativeImage, ColorWthDepthAspect) {
     TEST_DESCRIPTION("Test creating an image with color format but depth aspect.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -5215,7 +5217,7 @@ TEST_F(VkLayerTest, CreateColorImageWithDepthAspect) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestImageCopyMissingUsage) {
+TEST_F(NegativeImage, ImageCopyMissingUsage) {
     TEST_DESCRIPTION("Test copying from src image without VK_IMAGE_USAGE_TRANSFER_SRC_BIT.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -5305,7 +5307,7 @@ TEST_F(VkLayerTest, TestImageCopyMissingUsage) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, GetImageSubresourceLayoutInvalidDrmPlane) {
+TEST_F(NegativeImage, GetImageSubresourceLayoutDrmPlane) {
     TEST_DESCRIPTION("Try to get image subresource layout for drm image plane 3 when it only has 2");
 
     // Try to enable 1.2 since all required extensions were promoted
@@ -5376,7 +5378,7 @@ TEST_F(VkLayerTest, GetImageSubresourceLayoutInvalidDrmPlane) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImageDrmFormatModifer) {
+TEST_F(NegativeImage, DrmFormatModifer) {
     TEST_DESCRIPTION("General testing of VK_EXT_image_drm_format_modifier");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
@@ -5499,7 +5501,7 @@ TEST_F(VkLayerTest, ImageDrmFormatModifer) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidImageCompressionControl) {
+TEST_F(NegativeImage, ImageCompressionControl) {
     TEST_DESCRIPTION("Checks image compression controls with invalid parameters.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -5722,7 +5724,7 @@ TEST_F(VkLayerTest, InvalidImageCompressionControl) {
     }
 }
 
-TEST_F(VkLayerTest, TransitionNonSparseImageLayoutWithoutBoundMemory) {
+TEST_F(NegativeImage, TransitionNonSparseImageLayoutWithoutBoundMemory) {
     TEST_DESCRIPTION("Try to change layout of non sparse image with no memory bound.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -5738,7 +5740,7 @@ TEST_F(VkLayerTest, TransitionNonSparseImageLayoutWithoutBoundMemory) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AttachmentFeedbackLoopLayoutFeature) {
+TEST_F(NegativeImage, AttachmentFeedbackLoopLayoutFeature) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_EXTENSION_NAME);
@@ -5842,7 +5844,7 @@ TEST_F(VkLayerTest, AttachmentFeedbackLoopLayoutFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SlicedCreateInfoDeviceFeature) {
+TEST_F(NegativeImage, SlicedDeviceFeature) {
     TEST_DESCRIPTION("Test SlicedCreateInfo feature support validation");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -5893,7 +5895,7 @@ TEST_F(VkLayerTest, SlicedCreateInfoDeviceFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SlicedCreateInfoInvalidImageType) {
+TEST_F(NegativeImage, SlicedImageType) {
     TEST_DESCRIPTION("Test SlicedCreateInfo ImageType validation");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -5951,7 +5953,7 @@ TEST_F(VkLayerTest, SlicedCreateInfoInvalidImageType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SlicedCreateInfoInvalidMipLevel) {
+TEST_F(NegativeImage, SlicedMipLevel) {
     TEST_DESCRIPTION("When using VkImageViewSlicedCreateInfoEXT the image view must reference exactly 1 mip level");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -6044,7 +6046,7 @@ TEST_F(VkLayerTest, SlicedCreateInfoInvalidMipLevel) {
     }
 }
 
-TEST_F(VkLayerTest, SlicedCreateInfoInvalidUsage) {
+TEST_F(NegativeImage, SlicedUsage) {
     TEST_DESCRIPTION("Test invalid sliceCount/sliceOffset of VkImageViewSlicedCreateInfoEXT");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -6151,7 +6153,7 @@ TEST_F(VkLayerTest, SlicedCreateInfoInvalidUsage) {
     }
 }
 
-TEST_F(VkLayerTest, ImageViewTextureSampleWeighted) {
+TEST_F(NegativeImage, ImageViewTextureSampleWeighted) {
     TEST_DESCRIPTION("Checks for image view texture sample weighted.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_QCOM_IMAGE_PROCESSING_EXTENSION_NAME);

--- a/tests/negative/imageless_framebuffer.cpp
+++ b/tests/negative/imageless_framebuffer.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, ImagelessFramebufferRenderPassBeginImageViewMismatchTests) {
+class NegativeImagelessFramebuffer : public VkLayerTest {};
+
+TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     TEST_DESCRIPTION(
         "Begin a renderPass where the image views specified do not match the parameters used to create the framebuffer and render "
         "pass.");
@@ -355,7 +357,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferRenderPassBeginImageViewMismatchTests) {
     }
 }
 
-TEST_F(VkLayerTest, ImagelessFramebufferFeatureEnableTest) {
+TEST_F(NegativeImagelessFramebuffer, FeatureEnable) {
     TEST_DESCRIPTION("Use imageless framebuffer functionality without enabling the feature");
 
     AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
@@ -414,7 +416,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferFeatureEnableTest) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImagelessFramebufferCreationTests) {
+TEST_F(NegativeImagelessFramebuffer, BasicUsage) {
     TEST_DESCRIPTION("Create an imageless framebuffer in various invalid ways");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -538,7 +540,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferCreationTests) {
     framebufferCreateInfo.height -= 1;
 }
 
-TEST_F(VkLayerTest, ImagelessFramebufferAttachmentImageUsageMismatchTests) {
+TEST_F(NegativeImagelessFramebuffer, AttachmentImageUsageMismatch) {
     TEST_DESCRIPTION("Create an imageless framebuffer with mismatched attachment image usage");
 
     AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
@@ -686,7 +688,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferAttachmentImageUsageMismatchTests) {
     framebufferAttachmentImageInfos[3].usage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
 }
 
-TEST_F(VkLayerTest, ImagelessFramebufferAttachmentMultiviewImageLayerCountMismatchTests) {
+TEST_F(NegativeImagelessFramebuffer, AttachmentMultiviewImageLayerCountMismatch) {
     TEST_DESCRIPTION("Create an imageless framebuffer against a multiview-enabled render pass with mismatched layer counts");
 
     AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
@@ -841,7 +843,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferAttachmentMultiviewImageLayerCountMismat
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImagelessFramebufferDepthStencilResolveAttachmentTests) {
+TEST_F(NegativeImagelessFramebuffer, DepthStencilResolveAttachment) {
     TEST_DESCRIPTION(
         "Create an imageless framebuffer against a render pass using depth stencil resolve, with mismatched information");
 
@@ -960,7 +962,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferDepthStencilResolveAttachmentTests) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferUsage) {
+TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateUsage) {
     TEST_DESCRIPTION("Specify a fragment shading rate attachment without the correct usage");
 
     // Enable KHR_fragment_shading_rate and all of its required extensions
@@ -1037,7 +1039,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferUsage) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferDimensions) {
+TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensions) {
     TEST_DESCRIPTION("Specify a fragment shading rate attachment without the correct usage");
 
     // Enable KHR_fragment_shading_rate and all of its required extensions
@@ -1153,7 +1155,7 @@ TEST_F(VkLayerTest, InvalidFragmentShadingRateImagelessFramebufferDimensions) {
     }
 }
 
-TEST_F(VkLayerTest, ImagelessFramebufferRenderPassBeginImageView3D) {
+TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     TEST_DESCRIPTION("Misuse of VK_IMAGE_VIEW_TYPE_3D.");
 
     AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
@@ -1271,7 +1273,7 @@ TEST_F(VkLayerTest, ImagelessFramebufferRenderPassBeginImageView3D) {
                         "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-04114");
 }
 
-TEST_F(VkLayerTest, FramebufferAttachmentImageInfoPNext) {
+TEST_F(NegativeImagelessFramebuffer, AttachmentImagePNext) {
     TEST_DESCRIPTION("Begin render pass with missing framebuffer attachment");
     AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
 
@@ -1334,7 +1336,7 @@ TEST_F(VkLayerTest, FramebufferAttachmentImageInfoPNext) {
     }
 }
 
-TEST_F(VkLayerTest, DescriptorUpdateTemplateEntryWithInlineUniformBlock) {
+TEST_F(NegativeImagelessFramebuffer, DescriptorUpdateTemplateEntryWithInlineUniformBlock) {
     TEST_DESCRIPTION("Test VkDescriptorUpdateTemplateEntry with descriptor type VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT");
 
     AddRequiredExtensions(VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME);
@@ -1384,7 +1386,7 @@ TEST_F(VkLayerTest, DescriptorUpdateTemplateEntryWithInlineUniformBlock) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ImagelessFramebufferWith3DImage) {
+TEST_F(NegativeImagelessFramebuffer, Image3D) {
     TEST_DESCRIPTION("Create imageless framebuffer with image view from 3D image.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/negative/instanceless.cpp
+++ b/tests/negative/instanceless.cpp
@@ -35,7 +35,9 @@
 
 static VkInstance dummy_instance;
 
-TEST_F(VkLayerTest, InstanceExtensionDependencies) {
+class NegativeInstanceless : public VkLayerTest {};
+
+TEST_F(NegativeInstanceless, InstanceExtensionDependencies) {
     TEST_DESCRIPTION("Test enabling instance extension without dependencies met.");
 
     if (!InstanceExtensionSupported(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME)) {
@@ -50,7 +52,7 @@ TEST_F(VkLayerTest, InstanceExtensionDependencies) {
     Monitor().VerifyFound();
 }
 
-TEST_F(VkLayerTest, InstanceBadStype) {
+TEST_F(NegativeInstanceless, InstanceBadStype) {
     TEST_DESCRIPTION("Test creating instance with bad sType.");
 
     auto ici = GetInstanceCreateInfo();
@@ -61,7 +63,7 @@ TEST_F(VkLayerTest, InstanceBadStype) {
     Monitor().VerifyFound();
 }
 
-TEST_F(VkLayerTest, InstanceDuplicatePnextStype) {
+TEST_F(NegativeInstanceless, InstanceDuplicatePnextStype) {
     TEST_DESCRIPTION("Test creating instance with duplicate sType in the pNext chain.");
 
     if (!InstanceExtensionSupported(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME)) {
@@ -79,7 +81,7 @@ TEST_F(VkLayerTest, InstanceDuplicatePnextStype) {
     Monitor().VerifyFound();
 }
 
-TEST_F(VkLayerTest, InstanceAppInfoBadStype) {
+TEST_F(NegativeInstanceless, InstanceAppInfoBadStype) {
     TEST_DESCRIPTION("Test creating instance with invalid sType in VkApplicationInfo.");
 
     auto ici = GetInstanceCreateInfo();
@@ -94,7 +96,7 @@ TEST_F(VkLayerTest, InstanceAppInfoBadStype) {
     Monitor().VerifyFound();
 }
 
-TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
+TEST_F(NegativeInstanceless, InstanceValidationFeaturesBadFlags) {
     TEST_DESCRIPTION("Test creating instance with invalid flags in VkValidationFeaturesEXT.");
 
     if (!InstanceExtensionSupported(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME)) {
@@ -141,7 +143,7 @@ TEST_F(VkLayerTest, InstanceValidationFeaturesBadFlags) {
     }
 }
 
-TEST_F(VkLayerTest, InstanceBadValidationFlags) {
+TEST_F(NegativeInstanceless, InstanceValidationFlags) {
     TEST_DESCRIPTION("Test creating instance with invalid VkValidationFlagsEXT.");
 
     if (!InstanceExtensionSupported(VK_EXT_VALIDATION_FLAGS_EXTENSION_NAME)) {
@@ -213,7 +215,7 @@ void* VKAPI_PTR DummyRealloc(void* pUserData, void* pOriginal, size_t size, size
 void VKAPI_PTR DummyInfoAlloc(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {}
 void VKAPI_PTR DummyInfoFree(void*, size_t, VkInternalAllocationType, VkSystemAllocationScope) {}
 
-TEST_F(VkLayerTest, DestroyInstanceAllocationCallbacksCompatibility) {
+TEST_F(NegativeInstanceless, DestroyInstanceAllocationCallbacksCompatibility) {
     TEST_DESCRIPTION("Test vkDestroyInstance with incompatible allocation callbacks.");
 
     const auto ici = GetInstanceCreateInfo();
@@ -231,7 +233,7 @@ TEST_F(VkLayerTest, DestroyInstanceAllocationCallbacksCompatibility) {
 }
 
 // TODO - Currently can not be ran with Profile layer
-TEST_F(VkLayerTest, DISABLED_DestroyInstanceHandleLeak) {
+TEST_F(NegativeInstanceless, DISABLED_DestroyInstanceHandleLeak) {
     TEST_DESCRIPTION("Test vkDestroyInstance while leaking a VkDevice object.");
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!IsPlatform(kMockICD)) {

--- a/tests/negative/memory.cpp
+++ b/tests/negative/memory.cpp
@@ -17,7 +17,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "utils/vk_layer_utils.h"
 
-TEST_F(VkLayerTest, InvalidMemoryMapping) {
+class NegativeMemory : public VkLayerTest {};
+
+TEST_F(NegativeMemory, MapMemory) {
     TEST_DESCRIPTION("Attempt to map memory in a number of incorrect ways");
     bool pass;
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -188,7 +190,7 @@ TEST_F(VkLayerTest, InvalidMemoryMapping) {
     vk::FreeMemory(m_device->device(), mem, NULL);
 }
 
-TEST_F(VkLayerTest, MapMemory2) {
+TEST_F(NegativeMemory, MapMemory2) {
     TEST_DESCRIPTION("Attempt to map memory in a number of incorrect ways");
 
     AddRequiredExtensions(VK_KHR_MAP_MEMORY_2_EXTENSION_NAME);
@@ -258,7 +260,7 @@ TEST_F(VkLayerTest, MapMemory2) {
     vk::FreeMemory(m_device->device(), memory, NULL);
 }
 
-TEST_F(VkLayerTest, MapMemWithoutHostVisibleBit) {
+TEST_F(NegativeMemory, MapMemWithoutHostVisibleBit) {
     TEST_DESCRIPTION("Allocate memory that is not mappable and then attempt to map it.");
     VkResult err;
     bool pass;
@@ -300,7 +302,7 @@ TEST_F(VkLayerTest, MapMemWithoutHostVisibleBit) {
     vk::FreeMemory(m_device->device(), mem, NULL);
 }
 
-TEST_F(VkLayerTest, RebindMemoryMultiObjectDebugUtils) {
+TEST_F(NegativeMemory, RebindMemoryMultiObjectDebugUtils) {
     VkResult err;
     bool pass;
 
@@ -372,7 +374,7 @@ TEST_F(VkLayerTest, RebindMemoryMultiObjectDebugUtils) {
     vk::FreeMemory(m_device->device(), mem2, NULL);
 }
 
-TEST_F(VkLayerTest, QueryMemoryCommitmentWithoutLazyProperty) {
+TEST_F(NegativeMemory, QueryMemoryCommitmentWithoutLazyProperty) {
     TEST_DESCRIPTION("Attempt to query memory commitment on memory without lazy allocation");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -404,7 +406,7 @@ TEST_F(VkLayerTest, QueryMemoryCommitmentWithoutLazyProperty) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, BindImageInvalidMemoryType) {
+TEST_F(NegativeMemory, BindImageMemoryType) {
     VkResult err;
 
     TEST_DESCRIPTION("Test validation check for an invalid memory type index during bind[Buffer|Image]Memory time");
@@ -477,7 +479,7 @@ TEST_F(VkLayerTest, BindImageInvalidMemoryType) {
     vk::FreeMemory(m_device->device(), mem, nullptr);
 }
 
-TEST_F(VkLayerTest, BindInvalidMemory) {
+TEST_F(NegativeMemory, BindMemory) {
     VkResult err;
     bool pass;
 
@@ -821,7 +823,7 @@ TEST_F(VkLayerTest, BindInvalidMemory) {
     }
 }
 
-TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
+TEST_F(NegativeMemory, BindMemoryNoCheck) {
     TEST_DESCRIPTION("Tests case were no call to memory requirements was made prior to binding");
 
     // Enable KHR YCbCr req'd extensions for Disjoint Bit
@@ -1039,7 +1041,7 @@ TEST_F(VkLayerTest, BindInvalidMemoryNoCheck) {
     }
 }
 
-TEST_F(VkLayerTest, BindInvalidMemory2BindInfos) {
+TEST_F(NegativeMemory, BindMemory2BindInfos) {
     TEST_DESCRIPTION("These tests deal with VK_KHR_bind_memory_2 and invalid VkBindImageMemoryInfo* pBindInfos");
 
     // Enable KHR YCbCr req'd extensions for Disjoint Bit
@@ -1227,7 +1229,7 @@ TEST_F(VkLayerTest, BindInvalidMemory2BindInfos) {
     }
 }
 
-TEST_F(VkLayerTest, BindMemoryToDestroyedObject) {
+TEST_F(NegativeMemory, BindMemoryToDestroyedObject) {
     VkResult err;
     bool pass;
 
@@ -1289,7 +1291,7 @@ TEST_F(VkLayerTest, BindMemoryToDestroyedObject) {
     vk::FreeMemory(m_device->device(), mem, NULL);
 }
 
-TEST_F(VkLayerTest, ExceedMemoryAllocationCount) {
+TEST_F(NegativeMemory, AllocationCount) {
     VkResult err = VK_SUCCESS;
     const int max_mems = 32;
     VkDeviceMemory mems[max_mems + 1];
@@ -1329,7 +1331,7 @@ TEST_F(VkLayerTest, ExceedMemoryAllocationCount) {
     }
 }
 
-TEST_F(VkLayerTest, ImageMemoryNotBound) {
+TEST_F(NegativeMemory, ImageMemoryNotBound) {
     TEST_DESCRIPTION("Attempt to draw with an image which has not had memory bound to it.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -1386,7 +1388,7 @@ TEST_F(VkLayerTest, ImageMemoryNotBound) {
     vk::FreeMemory(m_device->device(), image_mem, nullptr);
 }
 
-TEST_F(VkLayerTest, BufferMemoryNotBound) {
+TEST_F(NegativeMemory, BufferMemoryNotBound) {
     TEST_DESCRIPTION("Attempt to copy from a buffer which has not had memory bound to it.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -1441,7 +1443,7 @@ TEST_F(VkLayerTest, BufferMemoryNotBound) {
     vk::FreeMemory(m_device->handle(), mem, NULL);
 }
 
-TEST_F(VkLayerTest, DedicatedAllocationBinding) {
+TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     AddRequiredExtensions(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!AreRequiredExtensionsEnabled()) {
@@ -1516,7 +1518,7 @@ TEST_F(VkLayerTest, DedicatedAllocationBinding) {
     vk::BindImageMemory(m_device->handle(), image.handle(), dedicated_image_memory.handle(), 0);
 }
 
-TEST_F(VkLayerTest, DedicatedAllocationImageAliasing) {
+TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
     AddRequiredExtensions(VK_NV_DEDICATED_ALLOCATION_IMAGE_ALIASING_EXTENSION_NAME);
@@ -1599,7 +1601,7 @@ TEST_F(VkLayerTest, DedicatedAllocationImageAliasing) {
     vk::BindImageMemory(m_device->handle(), post_delete_image.handle(), dedicated_image_memory.handle(), 0);
 }
 
-TEST_F(VkLayerTest, BufferDeviceAddressEXT) {
+TEST_F(NegativeMemory, BufferDeviceAddressEXT) {
     TEST_DESCRIPTION("Test VK_EXT_buffer_device_address.");
     AddRequiredExtensions(VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -1657,7 +1659,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXT) {
     vk::DestroyBuffer(m_device->device(), buffer, NULL);
 }
 
-TEST_F(VkLayerTest, BufferDeviceAddressEXTDisabled) {
+TEST_F(NegativeMemory, BufferDeviceAddressEXTDisabled) {
     TEST_DESCRIPTION("Test VK_EXT_buffer_device_address.");
     AddRequiredExtensions(VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -1691,7 +1693,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressEXTDisabled) {
     vk::DestroyBuffer(m_device->device(), buffer, NULL);
 }
 
-TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
+TEST_F(NegativeMemory, BufferDeviceAddressKHR) {
     TEST_DESCRIPTION("Test VK_KHR_buffer_device_address.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
@@ -1776,7 +1778,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHR) {
     vk::DestroyBuffer(m_device->device(), buffer, NULL);
 }
 
-TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
+TEST_F(NegativeMemory, BufferDeviceAddressKHRDisabled) {
     TEST_DESCRIPTION("Test VK_KHR_buffer_device_address.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
@@ -1842,7 +1844,7 @@ TEST_F(VkLayerTest, BufferDeviceAddressKHRDisabled) {
     vk::DestroyBuffer(m_device->device(), buffer, NULL);
 }
 
-TEST_F(VkLayerTest, InvalidMemoryType) {
+TEST_F(NegativeMemory, MemoryType) {
     // Attempts to allocate from a memory type that doesn't exist
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -1863,7 +1865,7 @@ TEST_F(VkLayerTest, InvalidMemoryType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AllocationBeyondHeapSize) {
+TEST_F(NegativeMemory, AllocationBeyondHeapSize) {
     // Attempts to allocate a single piece of memory that's larger than the heap size
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -1884,7 +1886,7 @@ TEST_F(VkLayerTest, AllocationBeyondHeapSize) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DeviceCoherentMemoryDisabledAMD) {
+TEST_F(NegativeMemory, DeviceCoherentMemoryDisabledAMD) {
     // Attempts to allocate device coherent memory without enabling the extension/feature
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_AMD_DEVICE_COHERENT_MEMORY_EXTENSION_NAME);
@@ -1931,7 +1933,7 @@ TEST_F(VkLayerTest, DeviceCoherentMemoryDisabledAMD) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DedicatedAllocation) {
+TEST_F(NegativeMemory, DedicatedAllocation) {
     TEST_DESCRIPTION("Create invalid requests to dedicated allocation of memory");
 
     // Both VK_KHR_dedicated_allocation and VK_KHR_sampler_ycbcr_conversion supported in 1.1
@@ -2088,7 +2090,7 @@ TEST_F(VkLayerTest, DedicatedAllocation) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidMemoryRequirements) {
+TEST_F(NegativeMemory, MemoryRequirements) {
     TEST_DESCRIPTION("Create invalid requests to image and buffer memory requirments.");
 
     // Enable KHR YCbCr req'd extensions for Disjoint Bit
@@ -2202,7 +2204,7 @@ TEST_F(VkLayerTest, InvalidMemoryRequirements) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidMemoryAllocatepNextChain) {
+TEST_F(NegativeMemory, MemoryAllocatepNextChain) {
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
@@ -2259,7 +2261,7 @@ TEST_F(VkLayerTest, InvalidMemoryAllocatepNextChain) {
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 }
 
-TEST_F(VkLayerTest, DeviceImageMemoryRequirementsSwapchain) {
+TEST_F(NegativeMemory, DeviceImageMemoryRequirementsSwapchain) {
     TEST_DESCRIPTION("Validate usage of VkDeviceImageMemoryRequirementsKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2301,7 +2303,7 @@ TEST_F(VkLayerTest, DeviceImageMemoryRequirementsSwapchain) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DeviceImageMemoryRequirementsDrmFormatModifier) {
+TEST_F(NegativeMemory, DeviceImageMemoryRequirementsDrmFormatModifier) {
     TEST_DESCRIPTION("Validate usage of VkDeviceImageMemoryRequirementsKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2346,7 +2348,7 @@ TEST_F(VkLayerTest, DeviceImageMemoryRequirementsDrmFormatModifier) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DeviceImageMemoryRequirementsDisjoint) {
+TEST_F(NegativeMemory, DeviceImageMemoryRequirementsDisjoint) {
     TEST_DESCRIPTION("Validate usage of VkDeviceImageMemoryRequirementsKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2397,7 +2399,7 @@ TEST_F(VkLayerTest, DeviceImageMemoryRequirementsDisjoint) {
     vk::GetDeviceImageMemoryRequirementsKHR(device(), &device_image_memory_requirements, &memory_requirements);
 }
 
-TEST_F(VkLayerTest, TestBindBufferMemoryDeviceGroup) {
+TEST_F(NegativeMemory, BindBufferMemoryDeviceGroup) {
     TEST_DESCRIPTION("Test VkBindBufferMemoryDeviceGroupInfo.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/negative/multiview.cpp
+++ b/tests/negative/multiview.cpp
@@ -16,7 +16,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, VerifyMaxMultiviewInstanceIndex) {
+class NegativeMultiview : public VkLayerTest {};
+
+TEST_F(NegativeMultiview, MaxInstanceIndex) {
     TEST_DESCRIPTION("Verify if instance index in CmdDraw is greater than maxMultiviewInstanceIndex.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
@@ -62,7 +64,7 @@ TEST_F(VkLayerTest, VerifyMaxMultiviewInstanceIndex) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidClearColorAttachmentsWithMultiview) {
+TEST_F(NegativeMultiview, ClearColorAttachments) {
     TEST_DESCRIPTION("Test cmdClearAttachments with active render pass that uses multiview");
 
     AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
@@ -172,7 +174,7 @@ TEST_F(VkLayerTest, InvalidClearColorAttachmentsWithMultiview) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ValidateMultiviewUnboundResourcesAfterBeginRenderPassAndNextSubpass) {
+TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
     TEST_DESCRIPTION(
         "Validate all required resources are bound if multiview is enabled after vkCmdBeginRenderPass and vkCmdNextSubpass");
 
@@ -674,7 +676,7 @@ TEST_F(VkLayerTest, ValidateMultiviewUnboundResourcesAfterBeginRenderPassAndNext
     }
 }
 
-TEST_F(VkLayerTest, InvalidBeginTransformFeedbackInMultiviewRenderPass) {
+TEST_F(NegativeMultiview, BeginTransformFeedback) {
     TEST_DESCRIPTION("Test beginning transform feedback in a render pass with multiview enabled");
 
     AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
@@ -779,7 +781,7 @@ TEST_F(VkLayerTest, InvalidBeginTransformFeedbackInMultiviewRenderPass) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, FeaturesMultiview) {
+TEST_F(NegativeMultiview, Features) {
     TEST_DESCRIPTION("Checks VK_KHR_multiview features.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -828,7 +830,7 @@ TEST_F(VkLayerTest, FeaturesMultiview) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RenderPassCreateOverlappingCorrelationMasks) {
+TEST_F(NegativeMultiview, RenderPassCreateOverlappingCorrelationMasks) {
     TEST_DESCRIPTION("Create a subpass with overlapping correlation masks");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -873,7 +875,7 @@ TEST_F(VkLayerTest, RenderPassCreateOverlappingCorrelationMasks) {
     }
 }
 
-TEST_F(VkLayerTest, RenderPassCreateInvalidViewMasks) {
+TEST_F(NegativeMultiview, RenderPassViewMasksNotEnough) {
     TEST_DESCRIPTION("Create a subpass with the wrong number of view masks, or inconsistent setting of view masks");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -901,7 +903,7 @@ TEST_F(VkLayerTest, RenderPassCreateInvalidViewMasks) {
                          "VUID-VkRenderPassCreateInfo2-viewMask-03058");
 }
 
-TEST_F(VkLayerTest, RenderPassCreateSubpassMissingAttributesBitMultiviewNVX) {
+TEST_F(NegativeMultiview, RenderPassCreateSubpassMissingAttributesBitNVX) {
     TEST_DESCRIPTION("Create a subpass with the VK_SUBPASS_DESCRIPTION_PER_VIEW_ATTRIBUTES_BIT_NVX flag missing");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -926,7 +928,7 @@ TEST_F(VkLayerTest, RenderPassCreateSubpassMissingAttributesBitMultiviewNVX) {
                          "VUID-VkSubpassDescription2-flags-03076");
 }
 
-TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPassMultiview) {
+TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
     TEST_DESCRIPTION(
         "Hit RenderPass incompatible cases: drawing with an active renderpass that's not compatible with the bound pipeline state "
         "object's creation renderpass since only the former uses Multiview.");
@@ -1178,7 +1180,7 @@ TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPassMultiview) {
     }
 }
 
-TEST_F(VkLayerTest, RenderPassMultiViewCreateInvalidViewMasks) {
+TEST_F(NegativeMultiview, RenderPassViewMasksZero) {
     TEST_DESCRIPTION("Create a render pass with some view masks 0 and some not 0");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1209,7 +1211,7 @@ TEST_F(VkLayerTest, RenderPassMultiViewCreateInvalidViewMasks) {
     TestRenderPassCreate(m_errorMonitor, m_device->device(), &rpci, false, "VUID-VkRenderPassCreateInfo-pNext-02513", nullptr);
 }
 
-TEST_F(VkLayerTest, RenderPassMultiViewCreateInvalidViewOffsets) {
+TEST_F(NegativeMultiview, RenderPassViewOffsets) {
     TEST_DESCRIPTION("Create a render pass with invalid multiview pViewOffsets");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1242,7 +1244,7 @@ TEST_F(VkLayerTest, RenderPassMultiViewCreateInvalidViewOffsets) {
     TestRenderPassCreate(m_errorMonitor, m_device->device(), &rpci, false, "VUID-VkRenderPassCreateInfo-pNext-02512", nullptr);
 }
 
-TEST_F(VkLayerTest, RenderPassMultiViewCreateInvalidViewMask) {
+TEST_F(NegativeMultiview, RenderPassViewMasksLimit) {
     TEST_DESCRIPTION("Create a render pass with invalid view mask");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1277,7 +1279,7 @@ TEST_F(VkLayerTest, RenderPassMultiViewCreateInvalidViewMask) {
                          nullptr);
 }
 
-TEST_F(VkLayerTest, TestUsingDisabledMultiviewFeatures) {
+TEST_F(NegativeMultiview, FeaturesDisabled) {
     TEST_DESCRIPTION("Create graphics pipeline using multiview features which are not enabled.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/negative/object_lifetime.cpp
+++ b/tests/negative/object_lifetime.cpp
@@ -16,7 +16,9 @@
 #include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, InvalidCmdBufferBufferDestroyed) {
+class NegativeObjectLifetime : public VkLayerTest {};
+
+TEST_F(NegativeObjectLifetime, CmdBufferBufferDestroyed) {
     TEST_DESCRIPTION("Attempt to draw with a command buffer that is invalid due to a buffer dependency being destroyed.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -65,7 +67,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferDestroyed) {
     vk::FreeMemory(m_device->handle(), mem, NULL);
 }
 
-TEST_F(VkLayerTest, InvalidCmdBarrierBufferDestroyed) {
+TEST_F(NegativeObjectLifetime, CmdBarrierBufferDestroyed) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     auto buf_info = LvlInitStruct<VkBufferCreateInfo>();
@@ -112,7 +114,7 @@ TEST_F(VkLayerTest, InvalidCmdBarrierBufferDestroyed) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, InvalidCmdBarrierImageDestroyed) {
+TEST_F(NegativeObjectLifetime, CmdBarrierImageDestroyed) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     vk_testing::Image image;
@@ -160,7 +162,7 @@ TEST_F(VkLayerTest, InvalidCmdBarrierImageDestroyed) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, Sync2InvalidCmdBarrierBufferDestroyed) {
+TEST_F(NegativeObjectLifetime, Sync2CmdBarrierBufferDestroyed) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -230,7 +232,7 @@ TEST_F(VkLayerTest, Sync2InvalidCmdBarrierBufferDestroyed) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, Sync2InvalidCmdBarrierImageDestroyed) {
+TEST_F(NegativeObjectLifetime, Sync2CmdBarrierImageDestroyed) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -296,7 +298,7 @@ TEST_F(VkLayerTest, Sync2InvalidCmdBarrierImageDestroyed) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidCmdBufferBufferViewDestroyed) {
+TEST_F(NegativeObjectLifetime, CmdBufferBufferViewDestroyed) {
     TEST_DESCRIPTION("Delete bufferView bound to cmd buffer, then attempt to submit cmd buffer.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -399,7 +401,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferBufferViewDestroyed) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidCmdBufferImageDestroyed) {
+TEST_F(NegativeObjectLifetime, CmdBufferImageDestroyed) {
     TEST_DESCRIPTION("Attempt to draw with a command buffer that is invalid due to an image dependency being destroyed.");
     ASSERT_NO_FATAL_FAILURE(Init());
     {
@@ -445,7 +447,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferImageDestroyed) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidCmdBufferFramebufferImageDestroyed) {
+TEST_F(NegativeObjectLifetime, CmdBufferFramebufferImageDestroyed) {
     TEST_DESCRIPTION(
         "Attempt to draw with a command buffer that is invalid due to a framebuffer image dependency being destroyed.");
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -513,7 +515,7 @@ TEST_F(VkLayerTest, InvalidCmdBufferFramebufferImageDestroyed) {
     vk::DestroyImageView(m_device->device(), view, nullptr);
 }
 
-TEST_F(VkLayerTest, FramebufferAttachmentMemoryFreed) {
+TEST_F(NegativeObjectLifetime, FramebufferAttachmentMemoryFreed) {
     TEST_DESCRIPTION("Attempt to create framebuffer with attachment which memory was freed.");
     ASSERT_NO_FATAL_FAILURE(Init());
     VkFormatProperties format_properties;
@@ -568,7 +570,7 @@ TEST_F(VkLayerTest, FramebufferAttachmentMemoryFreed) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DescriptorPoolInUseDestroyedSignaled) {
+TEST_F(NegativeObjectLifetime, DescriptorPoolInUseDestroyedSignaled) {
     TEST_DESCRIPTION("Delete a DescriptorPool with a DescriptorSet that is in use.");
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
@@ -633,7 +635,7 @@ TEST_F(VkLayerTest, DescriptorPoolInUseDestroyedSignaled) {
     // TODO : It seems Validation layers think ds_pool was already destroyed, even though it wasn't?
 }
 
-TEST_F(VkLayerTest, FramebufferInUseDestroyedSignaled) {
+TEST_F(NegativeObjectLifetime, FramebufferInUseDestroyedSignaled) {
     TEST_DESCRIPTION("Delete in-use framebuffer.");
     ASSERT_NO_FATAL_FAILURE(Init());
     VkFormatProperties format_properties;
@@ -675,7 +677,7 @@ TEST_F(VkLayerTest, FramebufferInUseDestroyedSignaled) {
     vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
 }
 
-TEST_F(VkLayerTest, PushDescriptorUniformDestroySignaled) {
+TEST_F(NegativeObjectLifetime, PushDescriptorUniformDestroySignaled) {
     TEST_DESCRIPTION("Destroy a uniform buffer in use by a push descriptor set");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -743,7 +745,7 @@ TEST_F(VkLayerTest, PushDescriptorUniformDestroySignaled) {
     vbo.reset();
 }
 
-TEST_F(VkLayerTest, FramebufferImageInUseDestroyedSignaled) {
+TEST_F(NegativeObjectLifetime, FramebufferImageInUseDestroyedSignaled) {
     TEST_DESCRIPTION("Delete in-use image that's child of framebuffer.");
     ASSERT_NO_FATAL_FAILURE(Init());
     VkFormatProperties format_properties;
@@ -799,7 +801,7 @@ TEST_F(VkLayerTest, FramebufferImageInUseDestroyedSignaled) {
     vk::DestroyFramebuffer(m_device->device(), fb, nullptr);
 }
 
-TEST_F(VkLayerTest, EventInUseDestroyedSignaled) {
+TEST_F(NegativeObjectLifetime, EventInUseDestroyedSignaled) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -821,7 +823,7 @@ TEST_F(VkLayerTest, EventInUseDestroyedSignaled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InUseDestroyedSignaled) {
+TEST_F(NegativeObjectLifetime, InUseDestroyedSignaled) {
     TEST_DESCRIPTION(
         "Use vkCmdExecuteCommands with invalid state in primary and secondary command buffers. Delete objects that are in use. "
         "Call VkQueueSubmit with an event that has been deleted.");
@@ -892,7 +894,7 @@ TEST_F(VkLayerTest, InUseDestroyedSignaled) {
     vk::DestroyEvent(m_device->device(), event, nullptr);
 }
 
-TEST_F(VkLayerTest, PipelineInUseDestroyedSignaled) {
+TEST_F(NegativeObjectLifetime, PipelineInUseDestroyedSignaled) {
     TEST_DESCRIPTION("Delete in-use pipeline.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -933,7 +935,7 @@ TEST_F(VkLayerTest, PipelineInUseDestroyedSignaled) {
     vk::DestroyPipeline(m_device->handle(), delete_this_pipeline, nullptr);
 }
 
-TEST_F(VkLayerTest, ImageViewInUseDestroyedSignaled) {
+TEST_F(NegativeObjectLifetime, ImageViewInUseDestroyedSignaled) {
     TEST_DESCRIPTION("Delete in-use imageView.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1005,7 +1007,7 @@ TEST_F(VkLayerTest, ImageViewInUseDestroyedSignaled) {
     vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
-TEST_F(VkLayerTest, BufferViewInUseDestroyedSignaled) {
+TEST_F(NegativeObjectLifetime, BufferViewInUseDestroyedSignaled) {
     TEST_DESCRIPTION("Delete in-use bufferView.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1090,7 +1092,7 @@ TEST_F(VkLayerTest, BufferViewInUseDestroyedSignaled) {
     vk::DestroyBufferView(m_device->device(), view, NULL);
 }
 
-TEST_F(VkLayerTest, SamplerInUseDestroyedSignaled) {
+TEST_F(NegativeObjectLifetime, SamplerInUseDestroyedSignaled) {
     TEST_DESCRIPTION("Delete in-use sampler.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1163,7 +1165,7 @@ TEST_F(VkLayerTest, SamplerInUseDestroyedSignaled) {
     vk::DestroySampler(m_device->device(), sampler, NULL);  // Destroyed for real
 }
 
-TEST_F(VkLayerTest, InvalidCmdBufferEventDestroyed) {
+TEST_F(NegativeObjectLifetime, CmdBufferEventDestroyed) {
     TEST_DESCRIPTION("Attempt to draw with a command buffer that is invalid due to an event dependency being destroyed.");
     ASSERT_NO_FATAL_FAILURE(Init());
 

--- a/tests/negative/portability_subset.cpp
+++ b/tests/negative/portability_subset.cpp
@@ -13,9 +13,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-class VkPortabilitySubsetTest : public VkLayerTest {};
+class NegativePortabilitySubset : public VkLayerTest {};
 
-TEST_F(VkPortabilitySubsetTest, ValidatePortabilityCreateDevice) {
+TEST_F(NegativePortabilitySubset, Device) {
     TEST_DESCRIPTION("Portability: CreateDevice called and VK_KHR_portability_subset not enabled");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -53,7 +53,7 @@ TEST_F(VkPortabilitySubsetTest, ValidatePortabilityCreateDevice) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkPortabilitySubsetTest, PortabilityCreateEvent) {
+TEST_F(NegativePortabilitySubset, Event) {
     TEST_DESCRIPTION("Portability: CreateEvent when not supported");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -74,7 +74,7 @@ TEST_F(VkPortabilitySubsetTest, PortabilityCreateEvent) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkPortabilitySubsetTest, CreateImage) {
+TEST_F(NegativePortabilitySubset, Image) {
     TEST_DESCRIPTION("Portability: CreateImage - VUIDs 04459, 04460");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -115,7 +115,7 @@ TEST_F(VkPortabilitySubsetTest, CreateImage) {
     CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-multisampleArrayImage-04460");
 }
 
-TEST_F(VkPortabilitySubsetTest, ImageViewFormatSwizzle) {
+TEST_F(NegativePortabilitySubset, ImageViewFormatSwizzle) {
     TEST_DESCRIPTION("Portability: If imageViewFormatSwizzle is not enabled");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -169,7 +169,7 @@ TEST_F(VkPortabilitySubsetTest, ImageViewFormatSwizzle) {
     CreateImageViewTest(*this, &ci);
 }
 
-TEST_F(VkPortabilitySubsetTest, ImageViewFormatReinterpretationComponentCount) {
+TEST_F(NegativePortabilitySubset, ImageViewFormatReinterpretationComponentCount) {
     TEST_DESCRIPTION("Portability: If ImageViewFormatReinterpretation is not enabled");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -216,7 +216,7 @@ TEST_F(VkPortabilitySubsetTest, ImageViewFormatReinterpretationComponentCount) {
     CreateImageViewTest(*this, &ci, "VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466");
 }
 
-TEST_F(VkPortabilitySubsetTest, CreateSampler) {
+TEST_F(NegativePortabilitySubset, Sampler) {
     TEST_DESCRIPTION("Portability: CreateSampler - VUID 04467");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -236,7 +236,7 @@ TEST_F(VkPortabilitySubsetTest, CreateSampler) {
     CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-samplerMipLodBias-04467");
 }
 
-TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesTriangleFans) {
+TEST_F(NegativePortabilitySubset, TriangleFans) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUID 04452");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -267,7 +267,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesTriangleFans) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexInputStride) {
+TEST_F(NegativePortabilitySubset, VertexInputStride) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUID 04456");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -314,7 +314,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexInputStride) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexAttributes) {
+TEST_F(NegativePortabilitySubset, VertexAttributes) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUID 04457");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -356,7 +356,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesVertexAttributes) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesRasterizationState) {
+TEST_F(NegativePortabilitySubset, RasterizationState) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUID 04458");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -405,7 +405,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesRasterizationState) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesDepthStencilState) {
+TEST_F(NegativePortabilitySubset, DepthStencilState) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUID 04453");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -447,7 +447,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesDepthStencilState) {
     pipe.CreateGraphicsPipeline();
 }
 
-TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesColorBlendAttachmentState) {
+TEST_F(NegativePortabilitySubset, ColorBlendAttachmentState) {
     TEST_DESCRIPTION("Portability: CreateGraphicsPipelines - VUIDs 04454, 04455");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -491,6 +491,7 @@ TEST_F(VkPortabilitySubsetTest, CreateGraphicsPipelinesColorBlendAttachmentState
     m_errorMonitor->VerifyFound();
 }
 
+class VkPortabilitySubsetTest : public VkLayerTest {};
 TEST_F(VkPortabilitySubsetTest, UpdateDescriptorSets) {
     TEST_DESCRIPTION("Portability: UpdateDescriptorSets - VUID 04450");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);

--- a/tests/negative/protected_memory.cpp
+++ b/tests/negative/protected_memory.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, InvalidProtectedQueue) {
+class NegativeProtectedMemory : public VkLayerTest {};
+
+TEST_F(NegativeProtectedMemory, Queue) {
     TEST_DESCRIPTION("Try creating queue without VK_QUEUE_PROTECTED_BIT capability");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -78,7 +80,7 @@ TEST_F(VkLayerTest, InvalidProtectedQueue) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidProtectedSubmit) {
+TEST_F(NegativeProtectedMemory, Submit) {
     TEST_DESCRIPTION("Setting protectedSubmit with a queue not created with VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -165,7 +167,7 @@ TEST_F(VkLayerTest, InvalidProtectedSubmit) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidProtectedMemory) {
+TEST_F(NegativeProtectedMemory, Memory) {
     TEST_DESCRIPTION("Validate cases where protectedMemory feature is enabled and usages are invalid");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -317,7 +319,7 @@ TEST_F(VkLayerTest, InvalidProtectedMemory) {
     vk::FreeMemory(device(), memory_unprotected, nullptr);
 }
 
-TEST_F(VkLayerTest, UniqueQueueDeviceCreationBothProtected) {
+TEST_F(NegativeProtectedMemory, UniqueQueueDeviceCreationBothProtected) {
     TEST_DESCRIPTION("Vulkan 1.1 unique queue detection where both are protected and same queue family");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -394,7 +396,7 @@ TEST_F(VkLayerTest, UniqueQueueDeviceCreationBothProtected) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidGetDeviceQueue) {
+TEST_F(NegativeProtectedMemory, GetDeviceQueue) {
     TEST_DESCRIPTION("General testing of vkGetDeviceQueue and general Device creation cases");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -528,7 +530,7 @@ TEST_F(VkLayerTest, InvalidGetDeviceQueue) {
     vk::DestroyDevice(test_device, nullptr);
 }
 
-TEST_F(VkLayerTest, PipelineProtectedAccess) {
+TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
     TEST_DESCRIPTION("Test VUIDs from VK_EXT_pipeline_protected_access");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -662,7 +664,7 @@ TEST_F(VkLayerTest, PipelineProtectedAccess) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidUnprotectedCommands) {
+TEST_F(NegativeProtectedMemory, UnprotectedCommands) {
     TEST_DESCRIPTION("Test making commands in unprotected command buffers that can't be used");
 
     // protect memory added in VK 1.1
@@ -745,7 +747,7 @@ TEST_F(VkLayerTest, InvalidUnprotectedCommands) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidMixingProtectedResources) {
+TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     TEST_DESCRIPTION("Test where there is mixing of protectedMemory backed resource in command buffers");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/negative/query.cpp
+++ b/tests/negative/query.cpp
@@ -18,7 +18,7 @@
 
 class NegativeQuery : public VkLayerTest {};
 
-TEST_F(NegativeQuery, QueryPerformanceCreation) {
+TEST_F(NegativeQuery, PerformanceCreation) {
     TEST_DESCRIPTION("Create performance query without support");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
@@ -106,7 +106,7 @@ TEST_F(NegativeQuery, QueryPerformanceCreation) {
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeQuery, QueryPerformanceCounterCommandbufferScope) {
+TEST_F(NegativeQuery, PerformanceCounterCommandbufferScope) {
     TEST_DESCRIPTION("Insert a performance query begin/end with respect to the command buffer counter scope");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -286,7 +286,7 @@ TEST_F(NegativeQuery, QueryPerformanceCounterCommandbufferScope) {
     vkReleaseProfilingLockKHR(device());
 }
 
-TEST_F(NegativeQuery, QueryPerformanceCounterRenderPassScope) {
+TEST_F(NegativeQuery, PerformanceCounterRenderPassScope) {
     TEST_DESCRIPTION("Insert a performance query begin/end with respect to the render pass counter scope");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -402,7 +402,7 @@ TEST_F(NegativeQuery, QueryPerformanceCounterRenderPassScope) {
     vkReleaseProfilingLockKHR(device());
 }
 
-TEST_F(NegativeQuery, QueryPerformanceReleaseProfileLockBeforeSubmit) {
+TEST_F(NegativeQuery, PerformanceReleaseProfileLockBeforeSubmit) {
     TEST_DESCRIPTION("Verify that we get an error if we release the profiling lock during the recording of performance queries");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -568,7 +568,7 @@ TEST_F(NegativeQuery, QueryPerformanceReleaseProfileLockBeforeSubmit) {
     vkReleaseProfilingLockKHR(device());
 }
 
-TEST_F(NegativeQuery, QueryPerformanceIncompletePasses) {
+TEST_F(NegativeQuery, PerformanceIncompletePasses) {
     TEST_DESCRIPTION("Verify that we get an error if we don't submit a command buffer for each passes before getting the results.");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
@@ -815,7 +815,7 @@ TEST_F(NegativeQuery, QueryPerformanceIncompletePasses) {
     vkReleaseProfilingLockKHR(device());
 }
 
-TEST_F(NegativeQuery, QueryPerformanceResetAndBegin) {
+TEST_F(NegativeQuery, PerformanceResetAndBegin) {
     TEST_DESCRIPTION("Verify that we get an error if we reset & begin a performance query within the same primary command buffer.");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
@@ -964,7 +964,7 @@ TEST_F(NegativeQuery, QueryPerformanceResetAndBegin) {
     vkReleaseProfilingLockKHR(device());
 }
 
-TEST_F(NegativeQuery, HostQueryResetNotEnabled) {
+TEST_F(NegativeQuery, HostResetNotEnabled) {
     TEST_DESCRIPTION("Use vkResetQueryPoolEXT without enabling the feature");
 
     AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
@@ -985,7 +985,7 @@ TEST_F(NegativeQuery, HostQueryResetNotEnabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, HostQueryResetBadFirstQuery) {
+TEST_F(NegativeQuery, HostResetFirstQuery) {
     TEST_DESCRIPTION("Bad firstQuery in vkResetQueryPoolEXT");
 
     AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
@@ -1014,7 +1014,7 @@ TEST_F(NegativeQuery, HostQueryResetBadFirstQuery) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, HostQueryResetBadRange) {
+TEST_F(NegativeQuery, HostyResetBadRange) {
     TEST_DESCRIPTION("Bad range in vkResetQueryPoolEXT");
 
     AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
@@ -1042,7 +1042,7 @@ TEST_F(NegativeQuery, HostQueryResetBadRange) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, HostQueryResetInvalidQueryPool) {
+TEST_F(NegativeQuery, HostyResetQueryPool) {
     TEST_DESCRIPTION("Invalid queryPool in vkResetQueryPoolEXT");
 
     AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
@@ -1075,7 +1075,7 @@ TEST_F(NegativeQuery, HostQueryResetInvalidQueryPool) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, HostQueryResetWrongDevice) {
+TEST_F(NegativeQuery, HostyResetDevice) {
     TEST_DESCRIPTION("Device not matching queryPool in vkResetQueryPoolEXT");
 
     AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
@@ -1121,7 +1121,7 @@ TEST_F(NegativeQuery, HostQueryResetWrongDevice) {
     vk::DestroyDevice(second_device, nullptr);
 }
 
-TEST_F(NegativeQuery, InvalidCmdBufferQueryPoolDestroyed) {
+TEST_F(NegativeQuery, CmdBufferQueryPoolDestroyed) {
     TEST_DESCRIPTION("Attempt to draw with a command buffer that is invalid due to a query pool dependency being destroyed.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -1168,7 +1168,7 @@ TEST_F(NegativeQuery, BeginQueryOnTimestampPool) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, InvalidQueryPoolCreate) {
+TEST_F(NegativeQuery, PoolCreate) {
     TEST_DESCRIPTION("Attempt to create a query pool for PIPELINE_STATISTICS without enabling pipeline stats for the device.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1208,7 +1208,7 @@ TEST_F(NegativeQuery, InvalidQueryPoolCreate) {
     vk::DestroyDevice(local_device, nullptr);
 }
 
-TEST_F(NegativeQuery, InvalidQuerySizes) {
+TEST_F(NegativeQuery, Sizes) {
     TEST_DESCRIPTION("Invalid size of using queries commands.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1310,7 +1310,7 @@ TEST_F(NegativeQuery, InvalidQuerySizes) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, QueryPreciseBit) {
+TEST_F(NegativeQuery, PreciseBit) {
     TEST_DESCRIPTION("Check for correct Query Precise Bit circumstances.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -1406,7 +1406,7 @@ TEST_F(NegativeQuery, QueryPreciseBit) {
     vk::DestroyCommandPool(test_device.handle(), command_pool, nullptr);
 }
 
-TEST_F(NegativeQuery, QueryPoolPartialTimestamp) {
+TEST_F(NegativeQuery, PoolPartialTimestamp) {
     TEST_DESCRIPTION("Request partial result on timestamp query.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1487,7 +1487,7 @@ TEST_F(NegativeQuery, PerformanceQueryIntel) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, QueryPoolInUseDestroyedSignaled) {
+TEST_F(NegativeQuery, PoolInUseDestroyedSignaled) {
     TEST_DESCRIPTION("Delete in-use query pool.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1530,7 +1530,7 @@ TEST_F(NegativeQuery, QueryPoolInUseDestroyedSignaled) {
     vk::DestroyQueryPool(m_device->handle(), query_pool, NULL);
 }
 
-TEST_F(NegativeQuery, WriteTimeStampInvalidQuery) {
+TEST_F(NegativeQuery, WriteTimeStamp) {
     TEST_DESCRIPTION("Test for invalid query slot in query pool.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1571,7 +1571,7 @@ TEST_F(NegativeQuery, WriteTimeStampInvalidQuery) {
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeQuery, InvalidCmdEndQueryIndexedEXTIndex) {
+TEST_F(NegativeQuery, CmdEndQueryIndexedEXTIndex) {
     TEST_DESCRIPTION("Test InvalidCmdEndQueryIndexedEXT with invalid index");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -1616,7 +1616,7 @@ TEST_F(NegativeQuery, InvalidCmdEndQueryIndexedEXTIndex) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, InvalidCmdEndQueryIndexedEXTPrimitiveGenerated) {
+TEST_F(NegativeQuery, CmdEndQueryIndexedEXTPrimitiveGenerated) {
     TEST_DESCRIPTION("Test InvalidCmdEndQueryIndexedEXT with invalid index");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1684,7 +1684,7 @@ TEST_F(NegativeQuery, InvalidCmdEndQueryIndexedEXTPrimitiveGenerated) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, BeginQueryTypeTransformFeedbackStream) {
+TEST_F(NegativeQuery, TransformFeedbackStream) {
     TEST_DESCRIPTION(
         "Call CmdBeginQuery with query type transform feedback stream when transformFeedbackQueries is not supported.");
 
@@ -1718,7 +1718,7 @@ TEST_F(NegativeQuery, BeginQueryTypeTransformFeedbackStream) {
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeQuery, GetQueryPoolResultsFlags) {
+TEST_F(NegativeQuery, GetResultsFlags) {
     TEST_DESCRIPTION("Test GetQueryPoolResults with invalid pData and stride");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_VIDEO_QUEUE_EXTENSION_NAME);
@@ -1747,7 +1747,7 @@ TEST_F(NegativeQuery, GetQueryPoolResultsFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, QueryPoolResultStatusOnly) {
+TEST_F(NegativeQuery, ResultStatusOnly) {
     TEST_DESCRIPTION("Request result status only query result.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1826,7 +1826,7 @@ TEST_F(NegativeQuery, DestroyActiveQueryPool) {
     vk::DestroyQueryPool(m_device->handle(), query_pool, nullptr);
 }
 
-TEST_F(NegativeQuery, BeginQueryWithMultiview) {
+TEST_F(NegativeQuery, MultiviewBeginQuery) {
     TEST_DESCRIPTION("Test CmdBeginQuery in subpass with multiview");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -2017,7 +2017,7 @@ TEST_F(NegativeQuery, TestGetQueryPoolResultsDataAndStride) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, PrimitivesGeneratedQuery) {
+TEST_F(NegativeQuery, PrimitivesGenerated) {
     TEST_DESCRIPTION("Test unsupported primitives generated queries");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2089,7 +2089,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedQuery) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, PrimitivesGeneratedQueryFeature) {
+TEST_F(NegativeQuery, PrimitivesGeneratedFeature) {
     TEST_DESCRIPTION("Test missing primitives generated query feature");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -2119,7 +2119,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedQueryFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, PrimitivesGeneratedQueryAndDiscardEnabled) {
+TEST_F(NegativeQuery, PrimitivesGeneratedDiscardEnabled) {
     TEST_DESCRIPTION("Test missing primitivesGeneratedQueryWithRasterizerDiscard feature.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2175,7 +2175,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedQueryAndDiscardEnabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, PrimitivesGeneratedQueryStreams) {
+TEST_F(NegativeQuery, PrimitivesGeneratedStreams) {
     TEST_DESCRIPTION("Test missing primitivesGeneratedQueryWithNonZeroStreams feature.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2243,7 +2243,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedQueryStreams) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeQuery, CommandBufferMissingOcclusionQueryEnabled) {
+TEST_F(NegativeQuery, CommandBufferMissingOcclusion) {
     TEST_DESCRIPTION(
         "Test executing secondary command buffer without VkCommandBufferInheritanceInfo::occlusionQueryEnable enabled while "
         "occlusion query is active.");
@@ -2289,7 +2289,7 @@ TEST_F(NegativeQuery, CommandBufferMissingOcclusionQueryEnabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, EndQueryWithMultiview) {
+TEST_F(NegativeQuery, MultiviewEndQuery) {
     TEST_DESCRIPTION("Test CmdEndQuery in subpass with multiview");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/negative/ray_tracing.cpp
+++ b/tests/negative/ray_tracing.cpp
@@ -15,7 +15,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/ray_tracing_objects.h"
 
-TEST_F(VkLayerTest, RayTracingTestBarrierAccessAccelerationStructure) {
+class NegativeRayTracing : public VkLayerTest {};
+
+TEST_F(NegativeRayTracing, BarrierAccessAccelerationStructure) {
     TEST_DESCRIPTION("Test barrier with access ACCELERATION_STRUCTURE bit.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -67,7 +69,7 @@ TEST_F(VkLayerTest, RayTracingTestBarrierAccessAccelerationStructure) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingValidateDescriptorBindingUpdateAfterBindWithAccelerationStructure) {
+TEST_F(NegativeRayTracing, DescriptorBindingUpdateAfterBindWithAccelerationStructure) {
     TEST_DESCRIPTION("Validate acceleration structure descriptor writing.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -107,7 +109,7 @@ TEST_F(VkLayerTest, RayTracingValidateDescriptorBindingUpdateAfterBindWithAccele
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingAccelerationStructureBindings) {
+TEST_F(NegativeRayTracing, AccelerationStructureBindings) {
     TEST_DESCRIPTION("Use more bindings with a descriptorType of VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR than allowed");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -317,7 +319,7 @@ TEST_F(VkLayerTest, RayTracingAccelerationStructureBindings) {
     }
 }
 
-TEST_F(VkLayerTest, RayTracingValidateBeginQueryQueryPoolType) {
+TEST_F(NegativeRayTracing, BeginQueryQueryPoolType) {
     TEST_DESCRIPTION("Test CmdBeginQuery with invalid queryPool queryType");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -397,7 +399,7 @@ TEST_F(VkLayerTest, RayTracingValidateBeginQueryQueryPoolType) {
     }
 }
 
-TEST_F(VkLayerTest, RayTracingCopyUnboundAccelerationStructure) {
+TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure) {
     TEST_DESCRIPTION("Test CmdCopyQueryPoolResults with unsupported query type");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -446,7 +448,7 @@ TEST_F(VkLayerTest, RayTracingCopyUnboundAccelerationStructure) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, RayTracingCmdCopyUnboundAccelerationStructure) {
+TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
     TEST_DESCRIPTION("Test CmdCopyAccelerationStructureKHR with buffers not bound to memory");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -532,7 +534,7 @@ TEST_F(VkLayerTest, RayTracingCmdCopyUnboundAccelerationStructure) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingTestCmdCopyMemoryToAccelerationStructureKHR) {
+TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate CmdCopyMemoryToAccelerationStructureKHR with dst buffer not bound to memory");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -584,7 +586,7 @@ TEST_F(VkLayerTest, RayTracingTestCmdCopyMemoryToAccelerationStructureKHR) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingBuildAccelerationStructureKHR) {
+TEST_F(NegativeRayTracing, BuildAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate buffers used in vkBuildAccelerationStructureKHR");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -648,7 +650,7 @@ TEST_F(VkLayerTest, RayTracingBuildAccelerationStructureKHR) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingTestWriteAccelerationStructureMemory) {
+TEST_F(NegativeRayTracing, WriteAccelerationStructureMemory) {
     TEST_DESCRIPTION("Test memory in vkWriteAccelerationStructuresPropertiesKHR is host visible");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -711,7 +713,7 @@ TEST_F(VkLayerTest, RayTracingTestWriteAccelerationStructureMemory) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingTestCopyMemoryToAsBuffer) {
+TEST_F(NegativeRayTracing, CopyMemoryToAsBuffer) {
     TEST_DESCRIPTION("Test invalid buffer used in vkCopyMemoryToAccelerationStructureKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -765,7 +767,7 @@ TEST_F(VkLayerTest, RayTracingTestCopyMemoryToAsBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingValidationArrayOOBRayTracingShaders) {
+TEST_F(NegativeRayTracing, ArrayOOBRayTracingShaders) {
     TEST_DESCRIPTION(
         "Core validation: Verify detection of out-of-bounds descriptor array indexing and use of uninitialized descriptors for "
         "ray tracing shaders.");
@@ -773,7 +775,7 @@ TEST_F(VkLayerTest, RayTracingValidationArrayOOBRayTracingShaders) {
     OOBRayTracingShadersTestBody(false);
 }
 
-TEST_F(VkLayerTest, RayTracingValidateCreateAccelerationStructureKHR) {
+TEST_F(NegativeRayTracing, CreateAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate acceleration structure creation.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -867,7 +869,7 @@ TEST_F(VkLayerTest, RayTracingValidateCreateAccelerationStructureKHR) {
     }
 }
 
-TEST_F(VkLayerTest, RayTracingValidateCreateAccelerationStructureKHRReplayFeature) {
+TEST_F(NegativeRayTracing, CreateAccelerationStructureKHRReplayFeature) {
     TEST_DESCRIPTION("Validate acceleration structure creation replay feature.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -906,7 +908,7 @@ TEST_F(VkLayerTest, RayTracingValidateCreateAccelerationStructureKHRReplayFeatur
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingValidateCmdTraceRaysKHR) {
+TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
     TEST_DESCRIPTION("Validate vkCmdTraceRaysKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1104,7 +1106,7 @@ TEST_F(VkLayerTest, RayTracingValidateCmdTraceRaysKHR) {
     vk::DestroyPipeline(device(), raytracing_pipeline, nullptr);
 }
 
-TEST_F(VkLayerTest, RayTracingValidateCmdTraceRaysIndirectKHR) {
+TEST_F(NegativeRayTracing, CmdTraceRaysIndirectKHR) {
     TEST_DESCRIPTION("Validate vkCmdTraceRaysIndirectKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1193,7 +1195,7 @@ TEST_F(VkLayerTest, RayTracingValidateCmdTraceRaysIndirectKHR) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ValidateCmdTraceRaysIndirect2KHRFeatureDisabled) {
+TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRFeatureDisabled) {
     TEST_DESCRIPTION("Validate vkCmdTraceRaysIndirect2KHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1237,7 +1239,7 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysIndirect2KHRFeatureDisabled) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ValidateCmdTraceRaysIndirect2KHRInvalidAddress) {
+TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRAddress) {
     TEST_DESCRIPTION("Validate vkCmdTraceRaysIndirect2KHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1283,7 +1285,7 @@ TEST_F(VkLayerTest, ValidateCmdTraceRaysIndirect2KHRInvalidAddress) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, RayTracingValidateVkAccelerationStructureVersionInfoKHR) {
+TEST_F(NegativeRayTracing, AccelerationStructureVersionInfoKHR) {
     TEST_DESCRIPTION("Validate VkAccelerationStructureVersionInfoKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1323,7 +1325,7 @@ TEST_F(VkLayerTest, RayTracingValidateVkAccelerationStructureVersionInfoKHR) {
     }
 }
 
-TEST_F(VkLayerTest, RayTracingValidateCmdBuildAccelerationStructuresKHR) {
+TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     TEST_DESCRIPTION("Validate acceleration structure building.");
 
     AddOptionalExtensions(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME);
@@ -1637,7 +1639,7 @@ TEST_F(VkLayerTest, RayTracingValidateCmdBuildAccelerationStructuresKHR) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, RayTracingObjInUseCmdBuildAccelerationStructureKHR) {
+TEST_F(NegativeRayTracing, ObjInUseCmdBuildAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate acceleration structure building tracks the objects used.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1681,7 +1683,7 @@ TEST_F(VkLayerTest, RayTracingObjInUseCmdBuildAccelerationStructureKHR) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, RayTracingCmdCopyAccelerationStructureToMemoryKHR) {
+TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
     TEST_DESCRIPTION("Validate CmdCopyAccelerationStructureToMemoryKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1738,7 +1740,7 @@ TEST_F(VkLayerTest, RayTracingCmdCopyAccelerationStructureToMemoryKHR) {
     vk::DestroyAccelerationStructureKHR(device(), as, nullptr);
 }
 
-TEST_F(VkLayerTest, RayTracingUpdateAccelerationStructureKHR) {
+TEST_F(NegativeRayTracing, UpdateAccelerationStructureKHR) {
     TEST_DESCRIPTION("Test for updating an acceleration structure without a srcAccelerationStructure");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1774,7 +1776,7 @@ TEST_F(VkLayerTest, RayTracingUpdateAccelerationStructureKHR) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, RayTracingBuffersAndBufferDeviceAddressesMapping) {
+TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
     TEST_DESCRIPTION(
         "Test that buffers and buffer device addresses mapping is correctly handled."
         "Bound multiple buffers to the same memory so that they have the same buffer device address."
@@ -1875,7 +1877,7 @@ TEST_F(VkLayerTest, RayTracingBuffersAndBufferDeviceAddressesMapping) {
     }
 }
 
-TEST_F(VkLayerTest, WriteAccelerationStructuresProperties) {
+TEST_F(NegativeRayTracing, WriteAccelerationStructuresProperties) {
     TEST_DESCRIPTION("Test queryType validation in vkCmdWriteAccelerationStructuresPropertiesKHR");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1981,7 +1983,7 @@ TEST_F(VkLayerTest, WriteAccelerationStructuresProperties) {
     }
 }
 
-TEST_F(VkLayerTest, WriteAccelerationStructuresPropertiesMaintenance1) {
+TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1) {
     TEST_DESCRIPTION("Test queryType validation in vkCmdWriteAccelerationStructuresPropertiesKHR");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2139,7 +2141,7 @@ TEST_F(VkLayerTest, WriteAccelerationStructuresPropertiesMaintenance1) {
     }
 }
 
-TEST_F(VkLayerTest, NVRayTracingAccelerationStructureBindings) {
+TEST_F(NegativeRayTracing, AccelerationStructureBindingsNV) {
     TEST_DESCRIPTION("Use more bindings with a descriptorType of VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV than allowed");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {
@@ -2190,7 +2192,7 @@ TEST_F(VkLayerTest, NVRayTracingAccelerationStructureBindings) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, NVRayTracingValidateGeometry) {
+TEST_F(NegativeRayTracing, ValidateGeometryNV) {
     TEST_DESCRIPTION("Validate acceleration structure geometries.");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {
@@ -2444,7 +2446,7 @@ TEST_F(VkLayerTest, NVRayTracingValidateGeometry) {
     }
 }
 
-TEST_F(VkLayerTest, NVRayTracingValidateCreateAccelerationStructure) {
+TEST_F(NegativeRayTracing, ValidateCreateAccelerationStructureNV) {
     TEST_DESCRIPTION("Validate acceleration structure creation.");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {
@@ -2553,7 +2555,7 @@ TEST_F(VkLayerTest, NVRayTracingValidateCreateAccelerationStructure) {
     }
 }
 
-TEST_F(VkLayerTest, NVRayTracingValidateBindAccelerationStructure) {
+TEST_F(NegativeRayTracing, ValidateBindAccelerationStructureNV) {
     TEST_DESCRIPTION("Validate acceleration structure binding.");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {
@@ -2703,7 +2705,7 @@ TEST_F(VkLayerTest, NVRayTracingValidateBindAccelerationStructure) {
     }
 }
 
-TEST_F(VkLayerTest, NVRayTracingValidateWriteDescriptorSetAccelerationStructure) {
+TEST_F(NegativeRayTracing, ValidateWriteDescriptorSetAccelerationStructureNV) {
     TEST_DESCRIPTION("Validate acceleration structure descriptor writing.");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {
@@ -2737,7 +2739,7 @@ TEST_F(VkLayerTest, NVRayTracingValidateWriteDescriptorSetAccelerationStructure)
     vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
 }
 
-TEST_F(VkLayerTest, NVRayTracingValidateCmdBuildAccelerationStructure) {
+TEST_F(NegativeRayTracing, ValidateCmdBuildAccelerationStructureNV) {
     TEST_DESCRIPTION("Validate acceleration structure building.");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {
@@ -2861,7 +2863,7 @@ TEST_F(VkLayerTest, NVRayTracingValidateCmdBuildAccelerationStructure) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, NVRayTracingObjInUseCmdBuildAccelerationStructure) {
+TEST_F(NegativeRayTracing, ObjInUseCmdBuildAccelerationStructureNV) {
     TEST_DESCRIPTION("Validate acceleration structure building tracks the objects used.");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {
@@ -2914,7 +2916,7 @@ TEST_F(VkLayerTest, NVRayTracingObjInUseCmdBuildAccelerationStructure) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, NVRayTracingValidateGetAccelerationStructureHandle) {
+TEST_F(NegativeRayTracing, ValidateGetAccelerationStructureHandleNV) {
     TEST_DESCRIPTION("Validate acceleration structure handle querying.");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {
@@ -2955,7 +2957,7 @@ TEST_F(VkLayerTest, NVRayTracingValidateGetAccelerationStructureHandle) {
     }
 }
 
-TEST_F(VkLayerTest, NVRayTracingValidateCmdCopyAccelerationStructure) {
+TEST_F(NegativeRayTracing, ValidateCmdCopyAccelerationStructureNV) {
     TEST_DESCRIPTION("Validate acceleration structure copying.");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {

--- a/tests/negative/ray_tracing_pipeline.cpp
+++ b/tests/negative/ray_tracing_pipeline.cpp
@@ -14,7 +14,9 @@
 
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, RayTracingPipelineCreateInfoKHR) {
+class NegativeRayTracing : public VkLayerTest {};
+
+TEST_F(NegativeRayTracing, BasicUsage) {
     TEST_DESCRIPTION("Validate CreateInfo parameters during ray-tracing pipeline creation");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -179,7 +181,7 @@ TEST_F(VkLayerTest, RayTracingPipelineCreateInfoKHR) {
     }
 }
 
-TEST_F(VkLayerTest, RayTracingPipelineShaderGroupsKHR) {
+TEST_F(NegativeRayTracing, ShaderGroupsKHR) {
     TEST_DESCRIPTION("Validate shader groups during ray-tracing pipeline creation");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -681,7 +683,7 @@ TEST_F(VkLayerTest, RayTracingPipelineShaderGroupsKHR) {
     }
 }
 
-TEST_F(VkLayerTest, RayTracingLibraryFlags) {
+TEST_F(NegativeRayTracing, LibraryFlags) {
     TEST_DESCRIPTION("Validate ray tracing pipeline flags match library flags.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -822,7 +824,7 @@ TEST_F(VkLayerTest, RayTracingLibraryFlags) {
     vk::DestroyPipeline(m_device->handle(), invalid_library, nullptr);
 }
 
-TEST_F(VkLayerTest, RayTracingValidateGetCaptureReplayShaderGroupHandlesKHR) {
+TEST_F(NegativeRayTracing, GetCaptureReplayShaderGroupHandlesKHR) {
     TEST_DESCRIPTION("Validate vkGetRayTracingCaptureReplayShaderGroupHandlesKHR.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -899,7 +901,7 @@ TEST_F(VkLayerTest, RayTracingValidateGetCaptureReplayShaderGroupHandlesKHR) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingPipelineDeferredOp) {
+TEST_F(NegativeRayTracing, DeferredOp) {
     TEST_DESCRIPTION(
         "Test that objects created with deferred operations are recorded once the operation has successfully completed.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1018,7 +1020,7 @@ TEST_F(VkLayerTest, RayTracingPipelineDeferredOp) {
     vk::DestroyPipeline(m_device->handle(), library, nullptr);
 }
 
-TEST_F(VkLayerTest, RayTracingPipelineWrongBindPoint) {
+TEST_F(NegativeRayTracing, BindPoint) {
     TEST_DESCRIPTION("Bind a graphics pipeline in the ray-tracing bind point");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1045,7 +1047,7 @@ TEST_F(VkLayerTest, RayTracingPipelineWrongBindPoint) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingPipelineMaxResources) {
+TEST_F(NegativeRayTracing, MaxResources) {
     TEST_DESCRIPTION("Create ray tracing pipeline with too many resources.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1118,7 +1120,7 @@ TEST_F(VkLayerTest, RayTracingPipelineMaxResources) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingInvalidPipelineFlags) {
+TEST_F(NegativeRayTracing, PipelineFlags) {
     TEST_DESCRIPTION("Validate ray tracing pipeline flags.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1172,7 +1174,7 @@ TEST_F(VkLayerTest, RayTracingInvalidPipelineFlags) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingTestWrongPipelineType) {
+TEST_F(NegativeRayTracing, PipelineType) {
     TEST_DESCRIPTION("Use a compute pipeline in GetRayTracingShaderGroupStackSizeKHR");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1200,7 +1202,7 @@ TEST_F(VkLayerTest, RayTracingTestWrongPipelineType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RayTracingPipelineLibraryGroupHandlesEXT) {
+TEST_F(NegativeRayTracing, LibraryGroupHandlesEXT) {
     TEST_DESCRIPTION("Validate VK_EXT_pipeline_library_group_handles");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_PIPELINE_LIBRARY_GROUP_HANDLES_EXTENSION_NAME);
@@ -1281,7 +1283,7 @@ TEST_F(VkLayerTest, RayTracingPipelineLibraryGroupHandlesEXT) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, NVRayTracingValidatePipeline) {
+TEST_F(NegativeRayTracing, BasicUsageNV) {
     TEST_DESCRIPTION("Validate vkCreateRayTracingPipelinesNV and CreateInfo parameters during ray-tracing pipeline creation");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {
@@ -1417,7 +1419,7 @@ TEST_F(VkLayerTest, NVRayTracingValidatePipeline) {
     }
 }
 
-TEST_F(VkLayerTest, NVRayTracingPipelineShaderGroups) {
+TEST_F(NegativeRayTracing, ShaderGroupsNV) {
     TEST_DESCRIPTION("Validate shader groups during ray-tracing pipeline creation");
 
     if (!InitFrameworkForRayTracingTest(this, false)) {
@@ -1892,7 +1894,7 @@ TEST_F(VkLayerTest, NVRayTracingPipelineShaderGroups) {
     }
 }
 
-TEST_F(VkLayerTest, NVRayTracingPipelineStageCreationFeedbackCount) {
+TEST_F(NegativeRayTracing, StageCreationFeedbackCountNV) {
     TEST_DESCRIPTION("Test NV ray tracing pipeline feedback stage count check.");
 
     AddRequiredExtensions(VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
@@ -1926,7 +1928,7 @@ TEST_F(VkLayerTest, NVRayTracingPipelineStageCreationFeedbackCount) {
                                                   "VUID-VkRayTracingPipelineCreateInfoNV-pipelineStageCreationFeedbackCount-06651");
 }
 
-TEST_F(VkLayerTest, NVRayTracingMissingEntrypoint) {
+TEST_F(NegativeRayTracing, MissingEntrypointNV) {
     TEST_DESCRIPTION("Test NV ray tracing pipeline with missing entrypoint.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     if (!InitFrameworkForRayTracingTest(this, false)) {

--- a/tests/negative/renderpass.cpp
+++ b/tests/negative/renderpass.cpp
@@ -16,7 +16,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, RenderPassCreateAttachmentIndexOutOfRange) {
+class NegativeRenderPass : public VkLayerTest {};
+
+TEST_F(NegativeRenderPass, AttachmentIndexOutOfRange) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -37,7 +39,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentIndexOutOfRange) {
                          "VUID-VkRenderPassCreateInfo2-attachment-03051");
 }
 
-TEST_F(VkLayerTest, RenderPassCreateAttachmentReadOnlyButCleared) {
+TEST_F(NegativeRenderPass, AttachmentReadOnlyButCleared) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
@@ -101,7 +103,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReadOnlyButCleared) {
     description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;  // reset
 }
 
-TEST_F(VkLayerTest, RenderPassCreateAttachmentMismatchingLayoutsColor) {
+TEST_F(NegativeRenderPass, AttachmentMismatchingLayoutsColor) {
     TEST_DESCRIPTION("Attachment is used simultaneously as two color attachments with different layouts.");
 
     AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
@@ -129,7 +131,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentMismatchingLayoutsColor) {
                          "subpass 0 already uses attachment 0 with a different image layout");
 }
 
-TEST_F(VkLayerTest, RenderPassCreateAttachmentDescriptionInvalidFinalLayout) {
+TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayout) {
     TEST_DESCRIPTION("VkAttachmentDescription's finalLayout must not be UNDEFINED or PREINITIALIZED");
 
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -408,7 +410,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentDescriptionInvalidFinalLayout) {
     }
 }
 
-TEST_F(VkLayerTest, RenderPassCreateAttachmentsMisc) {
+TEST_F(NegativeRenderPass, AttachmentsMisc) {
     TEST_DESCRIPTION(
         "Ensure that CreateRenderPass produces the expected validation errors when a subpass's attachments violate the valid usage "
         "conditions.");
@@ -635,7 +637,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentsMisc) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidRenderPassCreateRenderPassShaderResolveQCOM) {
+TEST_F(NegativeRenderPass, ShaderResolveQCOM) {
     TEST_DESCRIPTION("Ensure RenderPass create meets the requirements for QCOM_render_pass_shader_resolve");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -723,7 +725,7 @@ TEST_F(VkLayerTest, InvalidRenderPassCreateRenderPassShaderResolveQCOM) {
     }
 }
 
-TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidLayout) {
+TEST_F(NegativeRenderPass, AttachmentReferenceLayout) {
     TEST_DESCRIPTION("Attachment reference uses PREINITIALIZED or UNDEFINED layouts");
 
     AddRequiredExtensions(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
@@ -799,7 +801,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidLayout) {
     }
 }
 
-TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidLayoutSeparateDepthStencilLayoutsFeature) {
+TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsFeature) {
     TEST_DESCRIPTION("Attachment reference uses PREINITIALIZED or UNDEFINED layouts");
 
     AddRequiredExtensions(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
@@ -953,7 +955,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidLayoutSeparateDept
     }
 }
 
-TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidSync2Layout) {
+TEST_F(NegativeRenderPass, AttachmentReferenceSync2Layout) {
     TEST_DESCRIPTION("Attachment reference uses sync2 and ATTACHMENT_OPTIMAL_KHR or READ_ONLY_OPTIMAL_KHR layouts");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
@@ -996,7 +998,7 @@ TEST_F(VkLayerTest, RenderPassCreateAttachmentReferenceInvalidSync2Layout) {
                          "VUID-VkAttachmentReference2-synchronization2-06910");
 }
 
-TEST_F(VkLayerTest, RenderPassCreateInvalidMixedAttachmentSamplesAMD) {
+TEST_F(NegativeRenderPass, MixedAttachmentSamplesAMD) {
     TEST_DESCRIPTION("Verify error messages for supported and unsupported sample counts in render pass attachments.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1069,7 +1071,7 @@ TEST_F(VkLayerTest, RenderPassCreateInvalidMixedAttachmentSamplesAMD) {
                          "VUID-VkSubpassDescription-pColorAttachments-01506", "VUID-VkSubpassDescription2-pColorAttachments-03070");
 }
 
-TEST_F(VkLayerTest, RenderPassBeginInvalidRenderArea) {
+TEST_F(NegativeRenderPass, BeginRenderArea) {
     TEST_DESCRIPTION("Generate INVALID_RENDER_AREA error by beginning renderpass with extent outside of framebuffer");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1117,7 +1119,7 @@ TEST_F(VkLayerTest, RenderPassBeginInvalidRenderArea) {
                         vuid);
 }
 
-TEST_F(VkLayerTest, RenderPassBeginWithinRenderPass) {
+TEST_F(NegativeRenderPass, BeginWithinRenderPass) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -1147,7 +1149,7 @@ TEST_F(VkLayerTest, RenderPassBeginWithinRenderPass) {
     }
 }
 
-TEST_F(VkLayerTest, RenderPassBeginIncompatibleFramebufferRenderPass) {
+TEST_F(NegativeRenderPass, BeginIncompatibleFramebuffer) {
     TEST_DESCRIPTION("Test that renderpass begin is compatible with the framebuffer renderpass ");
 
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -1202,7 +1204,7 @@ TEST_F(VkLayerTest, RenderPassBeginIncompatibleFramebufferRenderPass) {
                         "VUID-VkRenderPassBeginInfo-renderPass-00904", nullptr);
 }
 
-TEST_F(VkLayerTest, RenderPassBeginLayoutsFramebufferImageUsageMismatches) {
+TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
     TEST_DESCRIPTION(
         "Test that renderpass initial/final layouts match up with the usage bits set for each attachment of the framebuffer");
 
@@ -1386,7 +1388,7 @@ TEST_F(VkLayerTest, RenderPassBeginLayoutsFramebufferImageUsageMismatches) {
     }
 }
 
-TEST_F(VkLayerTest, RenderPassBeginLayoutsStencilBufferImageUsageMismatches) {
+TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
     TEST_DESCRIPTION("Test that separate stencil initial/final layouts match up with the usage bits in framebuffer attachment");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1480,7 +1482,7 @@ TEST_F(VkLayerTest, RenderPassBeginLayoutsStencilBufferImageUsageMismatches) {
          "VUID-vkCmdBeginRenderPass2-stencilInitialLayout-02845");
 }
 
-TEST_F(VkLayerTest, RenderPassBeginInvalidStencilFormat) {
+TEST_F(NegativeRenderPass, BeginStencilFormat) {
     TEST_DESCRIPTION("Test that separate stencil initial/final layouts match up with the usage bits in framebuffer attachment");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1541,7 +1543,7 @@ TEST_F(VkLayerTest, RenderPassBeginInvalidStencilFormat) {
     test(VK_FORMAT_S8_UINT, VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, "VUID-VkRenderPassCreateInfo2-attachment-06246");
 }
 
-TEST_F(VkLayerTest, RenderPassBeginClearOpMismatch) {
+TEST_F(NegativeRenderPass, BeginClearOpMismatch) {
     TEST_DESCRIPTION(
         "Begin a renderPass where clearValueCount is less than the number of renderPass attachments that use "
         "loadOp VK_ATTACHMENT_LOAD_OP_CLEAR.");
@@ -1585,7 +1587,7 @@ TEST_F(VkLayerTest, RenderPassBeginClearOpMismatch) {
                         "VUID-VkRenderPassBeginInfo-clearValueCount-00902", "VUID-VkRenderPassBeginInfo-clearValueCount-00902");
 }
 
-TEST_F(VkLayerTest, RenderPassBeginSampleLocationsInvalidIndicesEXT) {
+TEST_F(NegativeRenderPass, BeginSampleLocationsIndicesEXT) {
     TEST_DESCRIPTION("Test that attachment indices and subpass indices specifed by sample locations structures are valid");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1673,7 +1675,7 @@ TEST_F(VkLayerTest, RenderPassBeginSampleLocationsInvalidIndicesEXT) {
                         "VUID-VkSubpassSampleLocationsEXT-subpassIndex-01532", nullptr);
 }
 
-TEST_F(VkLayerTest, RenderPassDestroyWhileInUse) {
+TEST_F(NegativeRenderPass, DestroyWhileInUse) {
     TEST_DESCRIPTION("Delete in-use renderPass.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1723,7 +1725,7 @@ TEST_F(VkLayerTest, RenderPassDestroyWhileInUse) {
     m_errorMonitor->SetUnexpectedError("Was it created? Has it already been destroyed?");
 }
 
-TEST_F(VkLayerTest, FramebufferDepthStencilResolveAttachmentTests) {
+TEST_F(NegativeRenderPass, FramebufferDepthStencilResolveAttachment) {
     TEST_DESCRIPTION("Create a framebuffer against a render pass using depth stencil resolve, with mismatched information");
 
     AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
@@ -1822,7 +1824,7 @@ TEST_F(VkLayerTest, FramebufferDepthStencilResolveAttachmentTests) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, FramebufferIncompatible) {
+TEST_F(NegativeRenderPass, FramebufferIncompatible) {
     TEST_DESCRIPTION(
         "Bind a secondary command buffer with a framebuffer that does not match the framebuffer for the active renderpass.");
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1892,7 +1894,7 @@ TEST_F(VkLayerTest, FramebufferIncompatible) {
     vk::EndCommandBuffer(m_commandBuffer->handle());
 }
 
-TEST_F(VkLayerTest, NullRenderPass) {
+TEST_F(NegativeRenderPass, NullRenderPass) {
     // Bind a NULL RenderPass
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkCmdBeginRenderPass: required parameter pRenderPassBegin specified as NULL");
 
@@ -1909,7 +1911,7 @@ TEST_F(VkLayerTest, NullRenderPass) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, FramebufferCreateErrors) {
+TEST_F(NegativeRenderPass, Framebuffer) {
     TEST_DESCRIPTION("VUIDs related to framebuffer creation");
 
     AddOptionalExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
@@ -2340,7 +2342,7 @@ TEST_F(VkLayerTest, FramebufferCreateErrors) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, EndCommandBufferWithinRenderPass) {
+TEST_F(NegativeRenderPass, EndCommandBufferWithinRenderPass) {
     TEST_DESCRIPTION("End a command buffer with an active render pass");
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkEndCommandBuffer-commandBuffer-00060");
@@ -2363,7 +2365,7 @@ TEST_F(VkLayerTest, EndCommandBufferWithinRenderPass) {
     // TODO: Add test for VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT
 }
 
-TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPass) {
+TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPass) {
     TEST_DESCRIPTION(
         "Hit RenderPass incompatible cases. Initial case is drawing with an active renderpass that's not compatible with the bound "
         "pipeline state object's creation renderpass");
@@ -2430,7 +2432,7 @@ TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPass) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPassFragmentDensityMap) {
+TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPassFragmentDensityMap) {
     TEST_DESCRIPTION(
         "Hit RenderPass incompatible case: drawing with an active renderpass that's not compatible with the bound pipeline state "
         "object's creation renderpass since only the former uses a Fragment Density Map.");
@@ -2544,7 +2546,7 @@ TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithRenderPassFragmentDensityMap
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, RenderPassMissingAttachment) {
+TEST_F(NegativeRenderPass, MissingAttachment) {
     TEST_DESCRIPTION("Begin render pass with missing framebuffer attachment");
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -2607,7 +2609,7 @@ TEST_F(VkLayerTest, RenderPassMissingAttachment) {
     m_commandBuffer->end();
 }
 
-class RenderPassCreatePotentialFormatFeaturesTest : public VkLayerTest {
+class RenderPassCreatePotentialFormatFeaturesTest : public NegativeRenderPass {
   public:
     void Test(bool const useLinearColorAttachment);
 };
@@ -2760,7 +2762,7 @@ TEST_F(RenderPassCreatePotentialFormatFeaturesTest, LinearColorAttachment) {
     Test(true);
 }
 
-TEST_F(VkLayerTest, DepthStencilResolveMode) {
+TEST_F(NegativeRenderPass, DepthStencilResolveMode) {
     TEST_DESCRIPTION("Test valid usage of the VkResolveModeFlagBits");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -2934,7 +2936,7 @@ TEST_F(VkLayerTest, DepthStencilResolveMode) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidRenderArea) {
+TEST_F(NegativeRenderPass, RenderArea) {
     TEST_DESCRIPTION("Begin render pass with render area that is not within the framebuffer.");
 
     AddOptionalExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
@@ -2998,7 +3000,7 @@ TEST_F(VkLayerTest, InvalidRenderArea) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidDeviceGroupRenderArea) {
+TEST_F(NegativeRenderPass, DeviceGroupRenderArea) {
     TEST_DESCRIPTION("Begin render pass with device group render area that is not within the framebuffer.");
 
     AddRequiredExtensions(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME);
@@ -3052,7 +3054,7 @@ TEST_F(VkLayerTest, InvalidDeviceGroupRenderArea) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, RenderPassBeginNullValues) {
+TEST_F(NegativeRenderPass, RenderPassBeginNullValues) {
     TEST_DESCRIPTION("Test invalid null entries for clear color");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -3066,7 +3068,7 @@ TEST_F(VkLayerTest, RenderPassBeginNullValues) {
                         "VUID-VkRenderPassBeginInfo-clearValueCount-04962", nullptr);
 }
 
-TEST_F(VkLayerTest, DepthStencilResolveAttachmentInvalidFormat) {
+TEST_F(NegativeRenderPass, DepthStencilResolveAttachmentFormat) {
     TEST_DESCRIPTION("Create subpass with VkSubpassDescriptionDepthStencilResolve that has an ");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -3125,7 +3127,7 @@ TEST_F(VkLayerTest, DepthStencilResolveAttachmentInvalidFormat) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidRenderPassAttachmentFormat) {
+TEST_F(NegativeRenderPass, RenderPassAttachmentFormat) {
     TEST_DESCRIPTION("Test creating render pass with attachment format VK_FORMAT_UNDEFINED");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -3180,7 +3182,7 @@ TEST_F(VkLayerTest, InvalidRenderPassAttachmentFormat) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SamplingFromReadOnlyDepthStencilAttachment) {
+TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     TEST_DESCRIPTION("Use same image as depth stencil attachment in read only layer and as sampler");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -3328,7 +3330,7 @@ TEST_F(VkLayerTest, SamplingFromReadOnlyDepthStencilAttachment) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, TestColorAttachmentImageViewUsage) {
+TEST_F(NegativeRenderPass, ColorAttachmentImageViewUsage) {
     TEST_DESCRIPTION("Create image view with missing usage bits.");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
@@ -3381,7 +3383,7 @@ TEST_F(VkLayerTest, TestColorAttachmentImageViewUsage) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CreateRenderPassWithInvalidStencilLoadOp) {
+TEST_F(NegativeRenderPass, StencilLoadOp) {
     TEST_DESCRIPTION("Create render pass with invalid stencil load op.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3434,7 +3436,7 @@ TEST_F(VkLayerTest, CreateRenderPassWithInvalidStencilLoadOp) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CreateRenderPassWithViewMask) {
+TEST_F(NegativeRenderPass, ViewMask) {
     TEST_DESCRIPTION("Create render pass with view mask, but multiview feature disabled.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3470,7 +3472,7 @@ TEST_F(VkLayerTest, CreateRenderPassWithViewMask) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestAllViewMasksZero) {
+TEST_F(NegativeRenderPass, AllViewMasksZero) {
     TEST_DESCRIPTION("Test VkRenderPassMultiviewCreateInfo with all view mask elements being 0.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -3509,7 +3511,7 @@ TEST_F(VkLayerTest, TestAllViewMasksZero) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidRenderPassAttachmentUndefinedLayout) {
+TEST_F(NegativeRenderPass, AttachmentUndefinedLayout) {
     TEST_DESCRIPTION("Create render pass with invalid attachment undefined layout.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -3554,7 +3556,7 @@ TEST_F(VkLayerTest, InvalidRenderPassAttachmentUndefinedLayout) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MultisampledRenderToSingleSampled) {
+TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     TEST_DESCRIPTION("Test VK_EXT_multisampled_render_to_single_sampled");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -4033,7 +4035,7 @@ TEST_F(VkLayerTest, MultisampledRenderToSingleSampled) {
     vk::DestroyDevice(second_device, nullptr);
 }
 
-TEST_F(VkLayerTest, AttachmentDescriptionUndefinedFormat) {
+TEST_F(NegativeRenderPass, AttachmentDescriptionUndefinedFormat) {
     TEST_DESCRIPTION("Create a render pass with an attachment description format set to VK_FORMAT_UNDEFINED");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -4062,7 +4064,7 @@ TEST_F(VkLayerTest, AttachmentDescriptionUndefinedFormat) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, IncompatibleRenderPass) {
+TEST_F(NegativeRenderPass, IncompatibleRenderPass) {
     TEST_DESCRIPTION("Validate if attachments in render pass and descriptor set use the same image subresources");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -4154,7 +4156,7 @@ TEST_F(VkLayerTest, IncompatibleRenderPass) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, IncompatibleRenderPass2) {
+TEST_F(NegativeRenderPass, IncompatibleRenderPass2) {
     TEST_DESCRIPTION("Validate if attachments in render pass and descriptor set use the same image subresources");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/negative/sampler.cpp
+++ b/tests/negative/sampler.cpp
@@ -17,7 +17,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "utils/vk_layer_utils.h"
 
-TEST_F(VkLayerTest, MirrorClampToEdgeNotEnabled) {
+class NegativeSampler : public VkLayerTest {};
+
+TEST_F(NegativeSampler, MirrorClampToEdgeNotEnabled) {
     TEST_DESCRIPTION("Validation should catch using CLAMP_TO_EDGE addressing mode if the extension is not enabled.");
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
@@ -35,7 +37,7 @@ TEST_F(VkLayerTest, MirrorClampToEdgeNotEnabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MirrorClampToEdgeNotEnabled12) {
+TEST_F(NegativeSampler, MirrorClampToEdgeNotEnabled12) {
     TEST_DESCRIPTION("Validation using CLAMP_TO_EDGE for Vulkan 1.2 without the samplerMirrorClampToEdge feature enabled.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -53,7 +55,7 @@ TEST_F(VkLayerTest, MirrorClampToEdgeNotEnabled12) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AnisotropyFeatureDisabled) {
+TEST_F(NegativeSampler, AnisotropyFeatureDisabled) {
     TEST_DESCRIPTION("Validation should check anisotropy parameters are correct with samplerAnisotropy disabled.");
 
     // Determine if required device features are available
@@ -71,7 +73,7 @@ TEST_F(VkLayerTest, AnisotropyFeatureDisabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, AnisotropyFeatureEnabled) {
+TEST_F(NegativeSampler, AnisotropyFeatureEnabled) {
     TEST_DESCRIPTION("Validation must check several conditions that apply only when Anisotropy is enabled.");
 
     AddOptionalExtensions(VK_IMG_FILTER_CUBIC_EXTENSION_NAME);
@@ -122,7 +124,7 @@ TEST_F(VkLayerTest, AnisotropyFeatureEnabled) {
     }
 }
 
-TEST_F(VkLayerTest, UnnormalizedCoordinatesEnabled) {
+TEST_F(NegativeSampler, UnnormalizedCoordinatesEnabled) {
     TEST_DESCRIPTION("Validate restrictions on sampler parameters when unnormalizedCoordinates is true.");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -183,7 +185,7 @@ TEST_F(VkLayerTest, UnnormalizedCoordinatesEnabled) {
     sampler_info = sampler_info_ref;
 }
 
-TEST_F(VkLayerTest, InvalidSamplerCreateInfo) {
+TEST_F(NegativeSampler, BasicUsage) {
     TEST_DESCRIPTION("Checks various cases where VkSamplerCreateInfo is invalid");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -204,7 +206,7 @@ TEST_F(VkLayerTest, InvalidSamplerCreateInfo) {
     sampler_info.mipLodBias = sampler_info_ref.mipLodBias;
 }
 
-TEST_F(VkLayerTest, ExceedSamplerAllocationCount) {
+TEST_F(NegativeSampler, AllocationCount) {
     VkResult err = VK_SUCCESS;
     const int max_samplers = 32;
     VkSampler samplers[max_samplers + 1];
@@ -241,7 +243,7 @@ TEST_F(VkLayerTest, ExceedSamplerAllocationCount) {
     }
 }
 
-TEST_F(VkLayerTest, SamplerImageViewFormatUnsupportedFilter) {
+TEST_F(NegativeSampler, ImageViewFormatUnsupportedFilter) {
     TEST_DESCRIPTION(
         "Create sampler with a filter and use with image view using a format that does not support the sampler filter.");
 
@@ -461,7 +463,7 @@ TEST_F(VkLayerTest, SamplerImageViewFormatUnsupportedFilter) {
     }
 }
 
-TEST_F(VkLayerTest, IllegalAddressModeWithCornerSampledNV) {
+TEST_F(NegativeSampler, AddressModeWithCornerSampledNV) {
     TEST_DESCRIPTION(
         "Create image with VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV flag and sample it with something other than "
         "VK_SAMPLER_ADDRESS_MODE_CLAMP_EDGE.");
@@ -534,7 +536,7 @@ TEST_F(VkLayerTest, IllegalAddressModeWithCornerSampledNV) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
+TEST_F(NegativeSampler, MultiplaneImageSamplerConversionMismatch) {
     TEST_DESCRIPTION(
         "Create sampler with ycbcr conversion and use with an image created without ycrcb conversion or immutable sampler");
 
@@ -692,7 +694,7 @@ TEST_F(VkLayerTest, MultiplaneImageSamplerConversionMismatch) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidSamplerFilterMinmax) {
+TEST_F(NegativeSampler, FilterMinmax) {
     TEST_DESCRIPTION("Invalid uses of VK_EXT_sampler_filter_minmax.");
 
     // Enable KHR multiplane req'd extensions
@@ -755,7 +757,7 @@ TEST_F(VkLayerTest, InvalidSamplerFilterMinmax) {
     vk::DestroySamplerYcbcrConversionKHR(m_device->handle(), conversion, nullptr);
 }
 
-TEST_F(VkLayerTest, CustomBorderColor) {
+TEST_F(NegativeSampler, CustomBorderColor) {
     TEST_DESCRIPTION("Tests for VUs for VK_EXT_custom_border_color");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
@@ -833,7 +835,7 @@ TEST_F(VkLayerTest, CustomBorderColor) {
     vk::DestroySampler(m_device->device(), sampler, nullptr);
 }
 
-TEST_F(VkLayerTest, CustomBorderColorFormatUndefined) {
+TEST_F(NegativeSampler, CustomBorderColorFormatUndefined) {
     TEST_DESCRIPTION("Tests for VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04015");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
@@ -916,7 +918,7 @@ TEST_F(VkLayerTest, CustomBorderColorFormatUndefined) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, UnnormalizedCoordinatesCombinedSampler) {
+TEST_F(NegativeSampler, UnnormalizedCoordinatesCombinedSampler) {
     TEST_DESCRIPTION(
         "If a samper is unnormalizedCoordinates, the imageview has to be some specific types. Uses COMBINED_IMAGE_SAMPLER");
 
@@ -1017,7 +1019,7 @@ TEST_F(VkLayerTest, UnnormalizedCoordinatesCombinedSampler) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, UnnormalizedCoordinatesSeparateSampler) {
+TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSampler) {
     TEST_DESCRIPTION(
         "If a samper is unnormalizedCoordinates, the imageview has to be some specific types. Doesn't use COMBINED_IMAGE_SAMPLER");
 
@@ -1132,7 +1134,7 @@ TEST_F(VkLayerTest, UnnormalizedCoordinatesSeparateSampler) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, UnnormalizedCoordinatesSeparateSamplerSharedImage) {
+TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSamplerSharedImage) {
     TEST_DESCRIPTION("Doesn't use COMBINED_IMAGE_SAMPLER, but multiple OpLoad share Image OpVariable");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1202,7 +1204,7 @@ TEST_F(VkLayerTest, UnnormalizedCoordinatesSeparateSamplerSharedImage) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, UnnormalizedCoordinatesSeparateSamplerSharedSampler) {
+TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSamplerSharedSampler) {
     TEST_DESCRIPTION("Doesn't use COMBINED_IMAGE_SAMPLER, but multiple OpLoad share Sampler OpVariable");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1278,7 +1280,7 @@ TEST_F(VkLayerTest, UnnormalizedCoordinatesSeparateSamplerSharedSampler) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, UnnormalizedCoordinatesInBoundsAccess) {
+TEST_F(NegativeSampler, UnnormalizedCoordinatesInBoundsAccess) {
     TEST_DESCRIPTION("If a samper is unnormalizedCoordinates, but using OpInBoundsAccessChain");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1376,7 +1378,7 @@ TEST_F(VkLayerTest, UnnormalizedCoordinatesInBoundsAccess) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, TestSamplerReductionMode) {
+TEST_F(NegativeSampler, ReductionModeFeature) {
     TEST_DESCRIPTION("Test using VkSamplerReductionModeCreateInfo without required feature.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1396,7 +1398,7 @@ TEST_F(VkLayerTest, TestSamplerReductionMode) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestInvalidSamplerReductionMode) {
+TEST_F(NegativeSampler, ReductionMode) {
     TEST_DESCRIPTION("Create sampler with invalid combination of filter and reduction mode.");
 
     GTEST_SKIP() << "Not possible to hit 01422 without first hitting an early return in parameter validation.";
@@ -1419,7 +1421,7 @@ TEST_F(VkLayerTest, TestInvalidSamplerReductionMode) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, NonSeamlessCubeMapNotEnabled) {
+TEST_F(NegativeSampler, NonSeamlessCubeMapNotEnabled) {
     TEST_DESCRIPTION("Validation should catch using NON_SEAMLESS_CUBE_MAP if the feature is not enabled.");
 
     AddRequiredExtensions(VK_EXT_NON_SEAMLESS_CUBE_MAP_EXTENSION_NAME);
@@ -1445,7 +1447,7 @@ TEST_F(VkLayerTest, NonSeamlessCubeMapNotEnabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ValidateCreateSamplerWithBorderColorSwizzle) {
+TEST_F(NegativeSampler, BorderColorSwizzle) {
     TEST_DESCRIPTION("Validate vkCreateSampler with VkSamplerBorderColorComponentMappingCreateInfoEXT");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());

--- a/tests/negative/sparse.cpp
+++ b/tests/negative/sparse.cpp
@@ -16,7 +16,9 @@
 #include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, SparseBindingImageBufferCreate) {
+class NegativeSparse : public VkLayerTest {};
+
+TEST_F(NegativeSparse, BindingImageBufferCreate) {
     TEST_DESCRIPTION("Create buffer/image with sparse attributes but without the sparse_binding bit set");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -73,7 +75,7 @@ TEST_F(VkLayerTest, SparseBindingImageBufferCreate) {
     }
 }
 
-TEST_F(VkLayerTest, SparseResidencyImageCreateUnsupportedTypes) {
+TEST_F(NegativeSparse, ResidencyImageCreateUnsupportedTypes) {
     TEST_DESCRIPTION("Create images with sparse residency with unsupported types");
 
     // Determine which device feature are available
@@ -121,7 +123,7 @@ TEST_F(VkLayerTest, SparseResidencyImageCreateUnsupportedTypes) {
     CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageType-00972");
 }
 
-TEST_F(VkLayerTest, SparseResidencyImageCreateUnsupportedSamples) {
+TEST_F(NegativeSparse, ResidencyImageCreateUnsupportedSamples) {
     TEST_DESCRIPTION("Create images with sparse residency with unsupported tiling or sample counts");
 
     // Determine which device feature are available
@@ -177,7 +179,7 @@ TEST_F(VkLayerTest, SparseResidencyImageCreateUnsupportedSamples) {
     CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageType-00976");
 }
 
-TEST_F(VkLayerTest, SparseResidencyFlagMissing) {
+TEST_F(NegativeSparse, ResidencyFlag) {
     TEST_DESCRIPTION("Try to use VkSparseImageMemoryBindInfo without sparse residency flag");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -223,7 +225,7 @@ TEST_F(VkLayerTest, SparseResidencyFlagMissing) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidSparseImageUsageBits) {
+TEST_F(NegativeSparse, ImageUsageBits) {
     TEST_DESCRIPTION("Try to use VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT with sparse image");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -260,7 +262,7 @@ TEST_F(VkLayerTest, InvalidSparseImageUsageBits) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SparseMemoryBindOffset) {
+TEST_F(NegativeSparse, MemoryBindOffset) {
     TEST_DESCRIPTION("Try to use VkSparseImageMemoryBind with offset not less than memory size");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -353,7 +355,7 @@ TEST_F(VkLayerTest, SparseMemoryBindOffset) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidQueueBindSparseMemoryType) {
+TEST_F(NegativeSparse, QueueBindSparseMemoryType) {
     TEST_DESCRIPTION("Test QueueBindSparse with lazily allocated memory");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -450,7 +452,7 @@ TEST_F(VkLayerTest, InvalidQueueBindSparseMemoryType) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, QueueBindSparseInvalidSparseMemoryBindSize) {
+TEST_F(NegativeSparse, QueueBindSparseMemoryBindSize) {
     TEST_DESCRIPTION("Test QueueBindSparse with invalid sparse memory bind size");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -497,7 +499,7 @@ TEST_F(VkLayerTest, QueueBindSparseInvalidSparseMemoryBindSize) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, QueueBindSparseInvalidSparseMemoryBindResourceOffset) {
+TEST_F(NegativeSparse, QueueBindSparseMemoryBindResourceOffset) {
     TEST_DESCRIPTION("Test QueueBindSparse with invalid sparse memory bind resource offset");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -546,7 +548,7 @@ TEST_F(VkLayerTest, QueueBindSparseInvalidSparseMemoryBindResourceOffset) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, QueueBindSparseInvalidSparseMemoryBindSizeResourceOffset) {
+TEST_F(NegativeSparse, QueueBindSparseMemoryBindSizeResourceOffset) {
     TEST_DESCRIPTION("Test QueueBindSparse with invalid sparse memory bind size due to resource offset");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -595,7 +597,7 @@ TEST_F(VkLayerTest, QueueBindSparseInvalidSparseMemoryBindSizeResourceOffset) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, QueueBindSparseInvalidSparseMemoryBindSizeMemoryOffset) {
+TEST_F(NegativeSparse, QueueBindSparseMemoryBindSizeMemoryOffset) {
     TEST_DESCRIPTION("Test QueueBindSparse with invalid sparse memory bind size due to memory offset");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -644,7 +646,7 @@ TEST_F(VkLayerTest, QueueBindSparseInvalidSparseMemoryBindSizeMemoryOffset) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidVkSparseImageMemoryBind) {
+TEST_F(NegativeSparse, ImageMemoryBind) {
     TEST_DESCRIPTION("Try to bind sparse resident image with invalid VkSparseImageMemoryBind");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -768,7 +770,7 @@ TEST_F(VkLayerTest, InvalidVkSparseImageMemoryBind) {
     image_bind.subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 }
 
-TEST_F(VkLayerTest, OverlappingSparseBufferCopy) {
+TEST_F(NegativeSparse, OverlappingBufferCopy) {
     TEST_DESCRIPTION("Test overlapping sparse buffers' copy with overlapping device memory");
 
     ASSERT_NO_FATAL_FAILURE(Init());

--- a/tests/negative/subpass.cpp
+++ b/tests/negative/subpass.cpp
@@ -16,7 +16,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, RenderPassCreateSubpassNonGraphicsPipeline) {
+class NegativeSubpass : public VkLayerTest {};
+
+TEST_F(NegativeSubpass, NonGraphicsPipeline) {
     TEST_DESCRIPTION("Create a subpass with the compute pipeline bind point");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
@@ -37,7 +39,7 @@ TEST_F(VkLayerTest, RenderPassCreateSubpassNonGraphicsPipeline) {
                          "VUID-VkSubpassDescription-pipelineBindPoint-00844", "VUID-VkSubpassDescription2-pipelineBindPoint-03062");
 }
 
-TEST_F(VkLayerTest, RenderPassCreate2SubpassInvalidInputAttachmentParameters) {
+TEST_F(NegativeSubpass, InputAttachmentParameters) {
     TEST_DESCRIPTION("Create a subpass with parameters in the input attachment ref which are invalid");
 
     // Check for VK_KHR_get_physical_device_properties2
@@ -91,7 +93,7 @@ TEST_F(VkLayerTest, RenderPassCreate2SubpassInvalidInputAttachmentParameters) {
     TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, rpci2, {"VUID-VkSubpassDescription2-attachment-02801"});
 }
 
-TEST_F(VkLayerTest, RenderPassCreateInvalidSubpassDependencies) {
+TEST_F(NegativeSubpass, SubpassDependencies) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
@@ -311,7 +313,7 @@ TEST_F(VkLayerTest, RenderPassCreateInvalidSubpassDependencies) {
     }
 }
 
-TEST_F(VkLayerTest, RenderPassNextSubpassExcessive) {
+TEST_F(NegativeSubpass, NextSubpassExcessive) {
     TEST_DESCRIPTION("Test that an error is produced when CmdNextSubpass is called too many times in a renderpass instance");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -345,7 +347,7 @@ TEST_F(VkLayerTest, RenderPassNextSubpassExcessive) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, RenderPassEndBeforeFinalSubpass) {
+TEST_F(NegativeSubpass, RenderPassEndBeforeFinalSubpass) {
     TEST_DESCRIPTION("Test that an error is produced when CmdEndRenderPass is called before the final subpass has been reached");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -391,7 +393,7 @@ TEST_F(VkLayerTest, RenderPassEndBeforeFinalSubpass) {
     }
 }
 
-TEST_F(VkLayerTest, BadSubpassIndices) {
+TEST_F(NegativeSubpass, SubpassIndices) {
     TEST_DESCRIPTION("Create render pass with valid stages");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -443,7 +445,7 @@ TEST_F(VkLayerTest, BadSubpassIndices) {
     }
 }
 
-TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithSubpass) {
+TEST_F(NegativeSubpass, DrawWithPipelineIncompatibleWithSubpass) {
     TEST_DESCRIPTION("Use a pipeline for the wrong subpass in a render pass instance");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -519,7 +521,7 @@ TEST_F(VkLayerTest, DrawWithPipelineIncompatibleWithSubpass) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, ImageBarrierSubpassConflict) {
+TEST_F(NegativeSubpass, ImageBarrierSubpassConflict) {
     TEST_DESCRIPTION("Check case where subpass index references different image from image barrier");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -584,7 +586,7 @@ TEST_F(VkLayerTest, ImageBarrierSubpassConflict) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SubpassInputNotBoundDescriptorSet) {
+TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
     TEST_DESCRIPTION("Validate subpass input isn't bound to fragment shader or descriptor set");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -716,7 +718,7 @@ TEST_F(VkLayerTest, SubpassInputNotBoundDescriptorSet) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidSubpassDescriptionViewMask) {
+TEST_F(NegativeSubpass, SubpassDescriptionViewMask) {
     TEST_DESCRIPTION("Test creating render with invalid view mask bit");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -771,7 +773,7 @@ TEST_F(VkLayerTest, InvalidSubpassDescriptionViewMask) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestPipelineSubpassIndex) {
+TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     TEST_DESCRIPTION("Test using pipeline with incompatible subpass index for current renderpass subpass");
 
     AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
@@ -879,7 +881,7 @@ TEST_F(VkLayerTest, TestPipelineSubpassIndex) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, IgnoreSubpassDependencyMasksSync2) {
+TEST_F(NegativeSubpass, SubpassDependencyMasksSync2) {
     // Testing from the spec:
     // If a VkMemoryBarrier2 is included in the pNext chain,
     // srcStageMask, dstStageMask, srcAccessMask, and dstAccessMask parameters are ignored.
@@ -959,7 +961,7 @@ TEST_F(VkLayerTest, IgnoreSubpassDependencyMasksSync2) {
     }
 }
 
-TEST_F(VkLayerTest, RenderPassCreateInvalidInputAttachmentReferences) {
+TEST_F(NegativeSubpass, InputAttachmentReferences) {
     TEST_DESCRIPTION("Create a subpass with the meta data aspect mask set for an input attachment");
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
@@ -1017,7 +1019,7 @@ TEST_F(VkLayerTest, RenderPassCreateInvalidInputAttachmentReferences) {
     TestRenderPassCreate(m_errorMonitor, m_device->device(), &rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01927", nullptr);
 }
 
-TEST_F(VkLayerTest, RenderPassCreateInvalidInputAttachmentLayout) {
+TEST_F(NegativeSubpass, InputAttachmentLayout) {
     TEST_DESCRIPTION("Create renderpass where an input attachment is also uses as another type");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1098,7 +1100,7 @@ TEST_F(VkLayerTest, RenderPassCreateInvalidInputAttachmentLayout) {
     vk_testing::RenderPass render_pass(*m_device, rpci);
 }
 
-TEST_F(VkLayerTest, CreatePipelineInputAttachmentMissing) {
+TEST_F(NegativeSubpass, InputAttachmentMissing) {
     TEST_DESCRIPTION(
         "Test that an error is produced for a shader consuming an input attachment which is not included in the subpass "
         "description");
@@ -1124,7 +1126,7 @@ TEST_F(VkLayerTest, CreatePipelineInputAttachmentMissing) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06038");
 }
 
-TEST_F(VkLayerTest, CreatePipelineInputAttachmentMissingArray) {
+TEST_F(NegativeSubpass, InputAttachmentMissingArray) {
     TEST_DESCRIPTION(
         "Test that an error is produced for a shader consuming an input attachment which is not included in the subpass "
         "description -- array case");
@@ -1150,7 +1152,7 @@ TEST_F(VkLayerTest, CreatePipelineInputAttachmentMissingArray) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06038");
 }
 
-TEST_F(VkLayerTest, CreatePipelineInputAttachmentSharingVariable) {
+TEST_F(NegativeSubpass, InputAttachmentSharingVariable) {
     TEST_DESCRIPTION("Make sure if 2 loads use same variable, both are tracked");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1210,7 +1212,7 @@ TEST_F(VkLayerTest, CreatePipelineInputAttachmentSharingVariable) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06038");
 }
 
-TEST_F(VkLayerTest, SubpassInputWithoutFormat) {
+TEST_F(NegativeSubpass, SubpassInputWithoutFormat) {
     TEST_DESCRIPTION("Non-InputAttachment shader input with unknown image format");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/negative/sync_object.cpp
+++ b/tests/negative/sync_object.cpp
@@ -17,7 +17,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "utils/vk_layer_utils.h"
 
-TEST_F(VkLayerTest, ImageBarrierSubpassConflicts) {
+class NegativeSyncObject : public VkLayerTest {};
+
+TEST_F(NegativeSyncObject, ImageBarrierSubpassConflicts) {
     TEST_DESCRIPTION("Add a pipeline barrier within a subpass that has conflicting state");
     ASSERT_NO_FATAL_FAILURE(Init());
 
@@ -209,7 +211,7 @@ TEST_F(VkLayerTest, ImageBarrierSubpassConflicts) {
     vk::CmdEndRenderPass(m_commandBuffer->handle());
 }
 
-TEST_F(VkLayerTest, BufferMemoryBarrierNoBuffer) {
+TEST_F(NegativeSyncObject, BufferMemoryBarrierNoBuffer) {
     // Try to add a buffer memory barrier with no buffer.
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "required parameter pBufferMemoryBarriers[0].buffer specified as VK_NULL_HANDLE");
@@ -231,7 +233,7 @@ TEST_F(VkLayerTest, BufferMemoryBarrierNoBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidBarriers) {
+TEST_F(NegativeSyncObject, Barriers) {
     TEST_DESCRIPTION("A variety of ways to get VK_INVALID_BARRIER ");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -785,7 +787,7 @@ TEST_F(VkLayerTest, InvalidBarriers) {
     bad_command_buffer.end();
 }
 
-TEST_F(VkLayerTest, Sync2InvalidBarriers) {
+TEST_F(NegativeSyncObject, Sync2Barriers) {
     TEST_DESCRIPTION("Synchronization2 test for invalid Memory Barriers");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -1237,7 +1239,7 @@ TEST_F(VkLayerTest, Sync2InvalidBarriers) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidBarrierQueueFamily) {
+TEST_F(NegativeSyncObject, BarrierQueueFamily) {
     TEST_DESCRIPTION("Create and submit barriers with invalid queue families");
     SetTargetApiVersion(VK_API_VERSION_1_0);
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -1339,7 +1341,7 @@ TEST_F(VkLayerTest, InvalidBarrierQueueFamily) {
     }
 }
 
-TEST_F(VkLayerTest, InvalidBarrierQueueFamilyWithMemExt) {
+TEST_F(NegativeSyncObject, BarrierQueueFamilyWithMemExt) {
     TEST_DESCRIPTION("Create and submit barriers with invalid queue families when memory extension is enabled ");
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -1398,7 +1400,7 @@ TEST_F(VkLayerTest, InvalidBarrierQueueFamilyWithMemExt) {
     excl_test(VK_QUEUE_FAMILY_EXTERNAL_KHR, submit_family);
 }
 
-TEST_F(VkLayerTest, ImageBarrierWithBadRange) {
+TEST_F(NegativeSyncObject, ImageBarrierWithBadRange) {
     TEST_DESCRIPTION("VkImageMemoryBarrier with an invalid subresourceRange");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1589,7 +1591,7 @@ TEST_F(VkLayerTest, ImageBarrierWithBadRange) {
     // clang-format on
 }
 
-TEST_F(VkLayerTest, Sync2InvalidBarrierQueueFamily) {
+TEST_F(NegativeSyncObject, Sync2BarrierQueueFamily) {
     TEST_DESCRIPTION("Create and submit barriers with invalid queue families with synchronization2");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -1657,7 +1659,7 @@ TEST_F(VkLayerTest, Sync2InvalidBarrierQueueFamily) {
     excl_test(VK_QUEUE_FAMILY_EXTERNAL_KHR, submit_family);
 }
 
-TEST_F(VkLayerTest, TestInvalidBarrierQueues) {
+TEST_F(NegativeSyncObject, BarrierQueues) {
     TEST_DESCRIPTION("Test buffer memory with both src and dst queue VK_QUEUE_FAMILY_EXTERNAL.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -1683,7 +1685,7 @@ TEST_F(VkLayerTest, TestInvalidBarrierQueues) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, TestBarrierAccessSync2) {
+TEST_F(NegativeSyncObject, BarrierAccessSync2) {
     TEST_DESCRIPTION("Test barrier VkAccessFlagBits2.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1880,7 +1882,7 @@ TEST_F(VkLayerTest, TestBarrierAccessSync2) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestBarrierAccessVideoDecode) {
+TEST_F(NegativeSyncObject, BarrierAccessVideoDecode) {
     TEST_DESCRIPTION("Test barrier with access decode read bit.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1929,7 +1931,7 @@ TEST_F(VkLayerTest, TestBarrierAccessVideoDecode) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, Sync2LayoutFeature) {
+TEST_F(NegativeSyncObject, Sync2LayoutFeature) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
@@ -1967,7 +1969,7 @@ TEST_F(VkLayerTest, Sync2LayoutFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SubmitSignaledFence) {
+TEST_F(NegativeSyncObject, SubmitSignaledFence) {
     vk_testing::Fence testFence;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "submitted in SIGNALED state.  Fences must be reset before being submitted");
@@ -2000,7 +2002,7 @@ TEST_F(VkLayerTest, SubmitSignaledFence) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, QueueSubmitWaitingSameSemaphore) {
+TEST_F(NegativeSyncObject, QueueSubmitWaitingSameSemaphore) {
     TEST_DESCRIPTION("Submit to queue with waitSemaphore that another queue is already waiting on.");
 
     AddOptionalExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -2088,7 +2090,7 @@ TEST_F(VkLayerTest, QueueSubmitWaitingSameSemaphore) {
     }
 }
 
-TEST_F(VkLayerTest, QueueSubmit2KHRUsedButSynchronizaion2Disabled) {
+TEST_F(NegativeSyncObject, QueueSubmit2KHRUsedButSynchronizaion2Disabled) {
     TEST_DESCRIPTION("Using QueueSubmit2KHR when synchronization2 is not enabled");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -2111,7 +2113,7 @@ TEST_F(VkLayerTest, QueueSubmit2KHRUsedButSynchronizaion2Disabled) {
     }
 }
 
-TEST_F(VkLayerTest, WaitEventsDifferentQueues) {
+TEST_F(NegativeSyncObject, WaitEventsDifferentQueues) {
     TEST_DESCRIPTION("Using CmdWaitEvents with invalid barrier queues");
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -2167,7 +2169,7 @@ TEST_F(VkLayerTest, WaitEventsDifferentQueues) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidVkSemaphoreTypeCreateInfoCore) {
+TEST_F(NegativeSyncObject, SemaphoreTypeCreateInfoCore) {
     TEST_DESCRIPTION("Invalid usage of VkSemaphoreTypeCreateInfo with a 1.2 core version");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -2200,7 +2202,7 @@ TEST_F(VkLayerTest, InvalidVkSemaphoreTypeCreateInfoCore) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidVkSemaphoreTypeCreateInfoExtension) {
+TEST_F(NegativeSyncObject, SemaphoreTypeCreateInfoExtension) {
     TEST_DESCRIPTION("Invalid usage of VkSemaphoreTypeCreateInfo with extension");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);  // before timelineSemaphore was added to core
@@ -2235,7 +2237,7 @@ TEST_F(VkLayerTest, InvalidVkSemaphoreTypeCreateInfoExtension) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MixedTimelineAndBinarySemaphores) {
+TEST_F(NegativeSyncObject, MixedTimelineAndBinarySemaphores) {
     TEST_DESCRIPTION("Submit mixtures of timeline and binary semaphores");
 
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
@@ -2336,7 +2338,7 @@ TEST_F(VkLayerTest, MixedTimelineAndBinarySemaphores) {
     vk::DestroySemaphore(m_device->device(), extra_binary, nullptr);
 }
 
-TEST_F(VkLayerTest, QueueSubmitNoTimelineSemaphoreInfo) {
+TEST_F(NegativeSyncObject, QueueSubmitNoTimelineSemaphoreInfo) {
     TEST_DESCRIPTION("Submit a queue with a timeline semaphore but not a VkTimelineSemaphoreSubmitInfoKHR.");
 
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
@@ -2393,7 +2395,7 @@ TEST_F(VkLayerTest, QueueSubmitNoTimelineSemaphoreInfo) {
     vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
 }
 
-TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreBadValue) {
+TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreValue) {
     TEST_DESCRIPTION("Submit a queue with a timeline semaphore using a wrong payload value.");
 
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
@@ -2522,7 +2524,7 @@ TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreBadValue) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, QueueBindSparseTimelineSemaphoreBadValue) {
+TEST_F(NegativeSyncObject, QueueBindSparseTimelineSemaphoreValue) {
     TEST_DESCRIPTION("Submit a queue with a timeline semaphore using a wrong payload value.");
 
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
@@ -2664,7 +2666,7 @@ TEST_F(VkLayerTest, QueueBindSparseTimelineSemaphoreBadValue) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, Sync2QueueSubmitTimelineSemaphoreBadValue) {
+TEST_F(NegativeSyncObject, Sync2QueueSubmitTimelineSemaphoreValue) {
     TEST_DESCRIPTION("Submit a queue with a timeline semaphore using a wrong payload value.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -2770,7 +2772,7 @@ TEST_F(VkLayerTest, Sync2QueueSubmitTimelineSemaphoreBadValue) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, QueueSubmitBinarySemaphoreNotSignaled) {
+TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
     TEST_DESCRIPTION("Submit a queue with a waiting binary semaphore not previously signaled.");
 
     AddOptionalExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
@@ -2915,7 +2917,7 @@ TEST_F(VkLayerTest, QueueSubmitBinarySemaphoreNotSignaled) {
     }
 }
 
-TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreOutOfOrder) {
+TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreOutOfOrder) {
     TEST_DESCRIPTION("Submit out-of-order timeline semaphores.");
 
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
@@ -3019,7 +3021,7 @@ TEST_F(VkLayerTest, QueueSubmitTimelineSemaphoreOutOfOrder) {
     vk::DestroyDevice(dev, nullptr);
 }
 
-TEST_F(VkLayerTest, InvalidWaitSemaphoresType) {
+TEST_F(NegativeSyncObject, WaitSemaphoresType) {
     TEST_DESCRIPTION("Wait for a non Timeline Semaphore");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -3061,7 +3063,7 @@ TEST_F(VkLayerTest, InvalidWaitSemaphoresType) {
     vk::DestroySemaphore(m_device->device(), semaphore[1], nullptr);
 }
 
-TEST_F(VkLayerTest, InvalidSignalSemaphoreType) {
+TEST_F(NegativeSyncObject, SignalSemaphoreType) {
     TEST_DESCRIPTION("Signal a non Timeline Semaphore");
 
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
@@ -3094,7 +3096,7 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreType) {
     vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
 }
 
-TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
+TEST_F(NegativeSyncObject, SignalSemaphoreValue) {
     TEST_DESCRIPTION("Signal a Timeline Semaphore with invalid values");
 
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
@@ -3232,7 +3234,7 @@ TEST_F(VkLayerTest, InvalidSignalSemaphoreValue) {
     vk::DestroySemaphore(m_device->device(), semaphore[1], nullptr);
 }
 
-TEST_F(VkLayerTest, Sync2InvalidSignalSemaphoreValue) {
+TEST_F(NegativeSyncObject, Sync2SignalSemaphoreValue) {
     TEST_DESCRIPTION("Signal a Timeline Semaphore with invalid values");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
@@ -3343,7 +3345,7 @@ TEST_F(VkLayerTest, Sync2InvalidSignalSemaphoreValue) {
     ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_device->m_queue));
 }
 
-TEST_F(VkLayerTest, InvalidSemaphoreCounterType) {
+TEST_F(NegativeSyncObject, SemaphoreCounterType) {
     TEST_DESCRIPTION("Get payload from a non Timeline Semaphore");
 
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
@@ -3375,7 +3377,7 @@ TEST_F(VkLayerTest, InvalidSemaphoreCounterType) {
     vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
 }
 
-TEST_F(VkLayerTest, EventStageMaskOneCommandBufferPass) {
+TEST_F(NegativeSyncObject, EventStageMaskOneCommandBufferPass) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -3398,7 +3400,7 @@ TEST_F(VkLayerTest, EventStageMaskOneCommandBufferPass) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, EventStageMaskOneCommandBufferFail) {
+TEST_F(NegativeSyncObject, EventStageMaskOneCommandBufferFail) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -3424,7 +3426,7 @@ TEST_F(VkLayerTest, EventStageMaskOneCommandBufferFail) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, EventStageMaskTwoCommandBufferPass) {
+TEST_F(NegativeSyncObject, EventStageMaskTwoCommandBufferPass) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -3453,7 +3455,7 @@ TEST_F(VkLayerTest, EventStageMaskTwoCommandBufferPass) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, EventStageMaskTwoCommandBufferFail) {
+TEST_F(NegativeSyncObject, EventStageMaskTwoCommandBufferFail) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -3485,7 +3487,7 @@ TEST_F(VkLayerTest, EventStageMaskTwoCommandBufferFail) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, QueueForwardProgressFenceWait) {
+TEST_F(NegativeSyncObject, QueueForwardProgressFenceWait) {
     TEST_DESCRIPTION("Call VkQueueSubmit with a semaphore that is already signaled but not waited on by the queue.");
 
     ASSERT_NO_FATAL_FAILURE(Init());

--- a/tests/negative/sync_val.cpp
+++ b/tests/negative/sync_val.cpp
@@ -16,7 +16,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_enum_string_helper.h"
 
-TEST_F(VkSyncValTest, SyncBufferCopyHazards) {
+class NegativeSyncVal : public VkSyncValTest {};
+
+TEST_F(NegativeSyncVal, BufferCopyHazards) {
     AddOptionalExtensions(VK_AMD_BUFFER_MARKER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -209,7 +211,7 @@ TEST_F(VkSyncValTest, SyncBufferCopyHazards) {
     }
 }
 
-TEST_F(VkSyncValTest, Sync2BufferCopyHazards) {
+TEST_F(NegativeSyncVal, BufferCopyHazardsSync2) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
@@ -297,7 +299,7 @@ TEST_F(VkSyncValTest, Sync2BufferCopyHazards) {
     }
 }
 
-TEST_F(VkSyncValTest, SyncCmdClearAttachmentsHazards) {
+TEST_F(NegativeSyncVal, CmdClearAttachmentsHazards) {
     TEST_DESCRIPTION("Test for hazards when attachment is cleared inside render pass.");
 
     // VK_EXT_load_store_op_none is needed to disable render pass load/store accesses, so clearing
@@ -533,7 +535,7 @@ TEST_F(VkSyncValTest, SyncCmdClearAttachmentsHazards) {
     }
 }
 
-TEST_F(VkSyncValTest, SyncCopyOptimalImageHazards) {
+TEST_F(NegativeSyncVal, CopyOptimalImageHazards) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -726,7 +728,7 @@ TEST_F(VkSyncValTest, SyncCopyOptimalImageHazards) {
     }
 }
 
-TEST_F(VkSyncValTest, Sync2CopyOptimalImageHazards) {
+TEST_F(NegativeSyncVal, CopyOptimalImageHazardsSync2) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
@@ -845,7 +847,7 @@ TEST_F(VkSyncValTest, Sync2CopyOptimalImageHazards) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkSyncValTest, SyncCopyOptimalMultiPlanarHazards) {
+TEST_F(NegativeSyncVal, CopyOptimalMultiPlanarHazards) {
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     if (!AreRequiredExtensionsEnabled()) {
@@ -969,7 +971,7 @@ TEST_F(VkSyncValTest, SyncCopyOptimalMultiPlanarHazards) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkSyncValTest, SyncCopyLinearImageHazards) {
+TEST_F(NegativeSyncVal, CopyLinearImageHazards) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
 
@@ -1038,7 +1040,7 @@ TEST_F(VkSyncValTest, SyncCopyLinearImageHazards) {
     vk::CmdCopyImage(cb, image_c.handle(), VK_IMAGE_LAYOUT_GENERAL, image_a.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &region_back);
 }
 
-TEST_F(VkSyncValTest, SyncCopyLinearMultiPlanarHazards) {
+TEST_F(NegativeSyncVal, CopyLinearMultiPlanarHazards) {
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     if (!AreRequiredExtensionsEnabled()) {
@@ -1158,7 +1160,7 @@ TEST_F(VkSyncValTest, SyncCopyLinearMultiPlanarHazards) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkSyncValTest, SyncCopyBufferImageHazards) {
+TEST_F(NegativeSyncVal, CopyBufferImageHazards) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
 
@@ -1291,7 +1293,7 @@ TEST_F(VkSyncValTest, SyncCopyBufferImageHazards) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkSyncValTest, SyncBlitImageHazards) {
+TEST_F(NegativeSyncVal, BlitImageHazards) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
 
@@ -1338,7 +1340,7 @@ TEST_F(VkSyncValTest, SyncBlitImageHazards) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkSyncValTest, SyncRenderPassBeginTransitionHazard) {
+TEST_F(NegativeSyncVal, RenderPassBeginTransitionHazard) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
     const VkSubpassDependency external_subpass_dependency = {VK_SUBPASS_EXTERNAL,
@@ -1410,7 +1412,7 @@ TEST_F(VkSyncValTest, SyncRenderPassBeginTransitionHazard) {
     m_commandBuffer->EndRenderPass();
 }
 
-TEST_F(VkSyncValTest, SyncCmdDispatchDrawHazards) {
+TEST_F(NegativeSyncVal, CmdDispatchDrawHazards) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
     // Enable VK_KHR_draw_indirect_count for KHR variants
@@ -1918,7 +1920,7 @@ TEST_F(VkSyncValTest, SyncCmdDispatchDrawHazards) {
     }
 }
 
-TEST_F(VkSyncValTest, SyncCmdClear) {
+TEST_F(NegativeSyncVal, CmdClear) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     // CmdClearColorImage
@@ -1995,7 +1997,7 @@ TEST_F(VkSyncValTest, SyncCmdClear) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkSyncValTest, SyncCmdQuery) {
+TEST_F(NegativeSyncVal, CmdQuery) {
     // CmdCopyQueryPoolResults
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -2049,7 +2051,7 @@ TEST_F(VkSyncValTest, SyncCmdQuery) {
     // TODO:CmdWriteTimestamp
 }
 
-TEST_F(VkSyncValTest, SyncCmdDrawDepthStencil) {
+TEST_F(NegativeSyncVal, CmdDrawDepthStencil) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -2183,8 +2185,7 @@ TEST_F(VkSyncValTest, SyncCmdDrawDepthStencil) {
     m_errorMonitor->VerifyFound();
 }
 
-
-TEST_F(VkSyncValTest, RenderPassLoadHazardVsInitialLayout) {
+TEST_F(NegativeSyncVal, RenderPassLoadHazardVsInitialLayout) {
     AddOptionalExtensions(VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -2280,7 +2281,7 @@ TEST_F(VkSyncValTest, RenderPassLoadHazardVsInitialLayout) {
     }
 }
 
-TEST_F(VkSyncValTest, SyncRenderPassWithWrongDepthStencilInitialLayout) {
+TEST_F(NegativeSyncVal, RenderPassWithWrongDepthStencilInitialLayout) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
     if (IsPlatform(kNexusPlayer)) {
@@ -2698,7 +2699,7 @@ struct SyncTestPipeline {
     }
 };
 
-TEST_F(VkSyncValTest, SyncLayoutTransition) {
+TEST_F(NegativeSyncVal, LayoutTransition) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
     if (IsPlatform(kNexusPlayer)) {
@@ -2787,7 +2788,7 @@ TEST_F(VkSyncValTest, SyncLayoutTransition) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkSyncValTest, SyncSubpassMultiDep) {
+TEST_F(NegativeSyncVal, SubpassMultiDep) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
     if (IsPlatform(kNexusPlayer)) {
@@ -2931,7 +2932,7 @@ TEST_F(VkSyncValTest, SyncSubpassMultiDep) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
+TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
 
@@ -3321,7 +3322,7 @@ TEST_F(VkSyncValTest, RenderPassAsyncHazard) {
     }
 }
 
-TEST_F(VkSyncValTest, SyncEventsBufferCopy) {
+TEST_F(NegativeSyncVal, EventsBufferCopy) {
     TEST_DESCRIPTION("Check Set/Wait protection for a variety of use cases using buffer copies");
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -3412,7 +3413,7 @@ TEST_F(VkSyncValTest, SyncEventsBufferCopy) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkSyncValTest, SyncEventsCopyImageHazards) {
+TEST_F(NegativeSyncVal, EventsCopyImageHazards) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -3536,7 +3537,7 @@ TEST_F(VkSyncValTest, SyncEventsCopyImageHazards) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkSyncValTest, SyncEventsCommandHazards) {
+TEST_F(NegativeSyncVal, EventsCommandHazards) {
     TEST_DESCRIPTION("Check Set/Reset/Wait command hazard checking");
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -3752,7 +3753,7 @@ TEST_F(VkLayerTest, Sync2FeatureDisabled) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkSyncValTest, DestroyedUnusedDescriptors) {
+TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     TEST_DESCRIPTION("Verify unused descriptors are ignored and don't crash syncval if they've been destroyed.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
@@ -3975,7 +3976,7 @@ TEST_F(VkSyncValTest, DestroyedUnusedDescriptors) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkSyncValTest, TestInvalidExternalSubpassDependency) {
+TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {
     TEST_DESCRIPTION("Test write after write hazard with invalid external subpass dependency");
 
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
@@ -4099,7 +4100,7 @@ TEST_F(VkSyncValTest, TestInvalidExternalSubpassDependency) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkSyncValTest, TestCopyingToCompressedImage) {
+TEST_F(NegativeSyncVal, TestCopyingToCompressedImage) {
     TEST_DESCRIPTION("Copy from uncompressed to compressed image with and without overlap.");
 
     AddOptionalExtensions(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
@@ -4213,7 +4214,7 @@ TEST_F(VkSyncValTest, TestCopyingToCompressedImage) {
     }
 }
 
-TEST_F(VkSyncValTest, StageAccessExpansion) {
+TEST_F(NegativeSyncVal, StageAccessExpansion) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
@@ -4652,7 +4653,7 @@ void QSTestContext::RecordCopy(VkCommandBufferObj& cb, VkBufferObj& from, VkBuff
     End();
 }
 
-TEST_F(VkSyncValTest, SyncQSBufferCopyHazards) {
+TEST_F(NegativeSyncVal, QSBufferCopyHazards) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -4708,7 +4709,7 @@ TEST_F(VkSyncValTest, SyncQSBufferCopyHazards) {
     test.DeviceWait();
 }
 
-TEST_F(VkSyncValTest, SyncQSSubmit2) {
+TEST_F(NegativeSyncVal, QSSubmit2) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
@@ -4746,7 +4747,7 @@ TEST_F(VkSyncValTest, SyncQSSubmit2) {
     test.DeviceWait();
 }
 
-TEST_F(VkSyncValTest, SyncQSBufferCopyVsIdle) {
+TEST_F(NegativeSyncVal, QSBufferCopyVsIdle) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -4786,7 +4787,7 @@ TEST_F(VkSyncValTest, SyncQSBufferCopyVsIdle) {
     m_device->wait();
 }
 
-TEST_F(VkSyncValTest, SyncQSBufferCopyVsFence) {
+TEST_F(NegativeSyncVal, QSBufferCopyVsFence) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -4836,7 +4837,7 @@ TEST_F(VkSyncValTest, SyncQSBufferCopyVsFence) {
     test.DeviceWait();
 }
 
-TEST_F(VkSyncValTest, SyncQSBufferCopyQSORules) {
+TEST_F(NegativeSyncVal, QSBufferCopyQSORules) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -4920,7 +4921,7 @@ TEST_F(VkSyncValTest, SyncQSBufferCopyQSORules) {
     m_device->wait();
 }
 
-TEST_F(VkSyncValTest, SyncQSBufferEvents) {
+TEST_F(NegativeSyncVal, QSBufferEvents) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -4996,7 +4997,7 @@ TEST_F(VkSyncValTest, SyncQSBufferEvents) {
     m_device->wait();
 }
 
-TEST_F(VkSyncValTest, SyncQSOBarrierHazard) {
+TEST_F(NegativeSyncVal, QSOBarrierHazard) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -5053,7 +5054,7 @@ TEST_F(VkSyncValTest, SyncQSOBarrierHazard) {
     m_device->wait();
 }
 
-TEST_F(VkSyncValTest, SyncQSRenderPass) {
+TEST_F(NegativeSyncVal, QSRenderPass) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     if (IsPlatform(kNexusPlayer)) {
@@ -5119,7 +5120,7 @@ TEST_F(VkSyncValTest, SyncQSRenderPass) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkSyncValTest, SyncQSPresentAcquire) {
+TEST_F(NegativeSyncVal, QSPresentAcquire) {
     TEST_DESCRIPTION("Try destroying a swapchain presentable image with vkDestroyImage");
 
     AddSurfaceExtension();

--- a/tests/negative/transform_feedback.cpp
+++ b/tests/negative/transform_feedback.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, TransformFeedbackFeatureEnabled) {
+class NegativeTransformFeedback : public VkLayerTest {};
+
+TEST_F(NegativeTransformFeedback, FeatureEnabled) {
     TEST_DESCRIPTION("VkPhysicalDeviceTransformFeedbackFeaturesEXT::transformFeedback must be enabled");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -66,7 +68,7 @@ TEST_F(VkLayerTest, TransformFeedbackFeatureEnabled) {
     }
 }
 
-TEST_F(VkLayerTest, TransformFeedbackNoBoundPipeline) {
+TEST_F(NegativeTransformFeedback, NoBoundPipeline) {
     TEST_DESCRIPTION("Call vkCmdBeginTransformFeedbackEXT without a bound pipeline");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -98,7 +100,7 @@ TEST_F(VkLayerTest, TransformFeedbackNoBoundPipeline) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
+TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
     TEST_DESCRIPTION("Submit invalid arguments to vkCmdBindTransformFeedbackBuffersEXT");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -265,7 +267,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBindTransformFeedbackBuffersEXT) {
     }
 }
 
-TEST_F(VkLayerTest, TransformFeedbackCmdBeginTransformFeedbackEXT) {
+TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackEXT) {
     TEST_DESCRIPTION("Submit invalid arguments to vkCmdBeginTransformFeedbackEXT");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -368,7 +370,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdBeginTransformFeedbackEXT) {
     }
 }
 
-TEST_F(VkLayerTest, TransformFeedbackCmdEndTransformFeedbackEXT) {
+TEST_F(NegativeTransformFeedback, CmdEndTransformFeedbackEXT) {
     TEST_DESCRIPTION("Submit invalid arguments to vkCmdEndTransformFeedbackEXT");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -476,7 +478,7 @@ TEST_F(VkLayerTest, TransformFeedbackCmdEndTransformFeedbackEXT) {
     }
 }
 
-TEST_F(VkLayerTest, ExecuteSecondaryCommandBuffersDuringTransformFeedback) {
+TEST_F(NegativeTransformFeedback, ExecuteSecondaryCommandBuffers) {
     TEST_DESCRIPTION("Call CmdExecuteCommandBuffers when transform feedback is active");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -532,7 +534,7 @@ TEST_F(VkLayerTest, ExecuteSecondaryCommandBuffersDuringTransformFeedback) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, BindPipelineDuringTransformFeedback) {
+TEST_F(NegativeTransformFeedback, BindPipeline) {
     TEST_DESCRIPTION("Call CmdBindPipeline when transform feedback is active");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -569,7 +571,7 @@ TEST_F(VkLayerTest, BindPipelineDuringTransformFeedback) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, EndRenderPassWithActiveTransformFeedback) {
+TEST_F(NegativeTransformFeedback, EndRenderPass) {
     TEST_DESCRIPTION("Call CmdEndRenderPass when transform feedback is active");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -610,7 +612,7 @@ TEST_F(VkLayerTest, EndRenderPassWithActiveTransformFeedback) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, DrawIndirectByteCountEXT) {
+TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
     TEST_DESCRIPTION("Test covered valid usage for vkCmdDrawIndirectByteCountEXT");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -712,7 +714,7 @@ TEST_F(VkLayerTest, DrawIndirectByteCountEXT) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, UsingRasterizationStateStreamExtWithoutEnabled) {
+TEST_F(NegativeTransformFeedback, UsingRasterizationStateStreamExtDisabled) {
     TEST_DESCRIPTION("Test using TestRasterizationStateStreamCreateInfoEXT but it doesn't enable geometryStreams.");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
@@ -743,7 +745,7 @@ TEST_F(VkLayerTest, UsingRasterizationStateStreamExtWithoutEnabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestRuntimeSpirvTransformFeedback) {
+TEST_F(NegativeTransformFeedback, RuntimeSpirv) {
     TEST_DESCRIPTION("Test runtime spirv transform feedback.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1136,7 +1138,7 @@ TEST_F(VkLayerTest, TestRuntimeSpirvTransformFeedback) {
     }
 }
 
-TEST_F(VkLayerTest, TestPipelineRasterizationStateStreamCreateInfoEXT) {
+TEST_F(NegativeTransformFeedback, PipelineRasterizationStateStreamCreateInfoEXT) {
     TEST_DESCRIPTION("Test using TestRasterizationStateStreamCreateInfoEXT with invalid rasterizationStream.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1185,7 +1187,7 @@ TEST_F(VkLayerTest, TestPipelineRasterizationStateStreamCreateInfoEXT) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidCmdNextSubpassDuringTransformFeedback) {
+TEST_F(NegativeTransformFeedback, CmdNextSubpass) {
     TEST_DESCRIPTION("Call CmdNextSubpass while transform feeback is active");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 

--- a/tests/negative/vertex_input.cpp
+++ b/tests/negative/vertex_input.cpp
@@ -15,7 +15,9 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
-TEST_F(VkLayerTest, CreatePipelineBadVertexAttributeFormat) {
+class NegativeVertexInput : public VkLayerTest {};
+
+TEST_F(NegativeVertexInput, AttributeFormat) {
     TEST_DESCRIPTION("Test that pipeline validation catches invalid vertex attribute formats");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -45,7 +47,7 @@ TEST_F(VkLayerTest, CreatePipelineBadVertexAttributeFormat) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkVertexInputAttributeDescription-format-00623");
 }
 
-TEST_F(VkLayerTest, VertexAttributeDivisorExtension) {
+TEST_F(NegativeVertexInput, DivisorExtension) {
     TEST_DESCRIPTION("Test VUIDs added with VK_EXT_vertex_attribute_divisor extension.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -132,7 +134,7 @@ TEST_F(VkLayerTest, VertexAttributeDivisorExtension) {
     }
 }
 
-TEST_F(VkLayerTest, VertexAttributeDivisorDisabled) {
+TEST_F(NegativeVertexInput, DivisorDisabled) {
     TEST_DESCRIPTION("Test instance divisor feature disabled for VK_EXT_vertex_attribute_divisor extension.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -178,7 +180,7 @@ TEST_F(VkLayerTest, VertexAttributeDivisorDisabled) {
                                       "VUID-VkVertexInputBindingDivisorDescriptionEXT-vertexAttributeInstanceRateDivisor-02229");
 }
 
-TEST_F(VkLayerTest, VertexAttributeDivisorInstanceRateZero) {
+TEST_F(NegativeVertexInput, DivisorInstanceRateZero) {
     TEST_DESCRIPTION("Test instanceRateZero feature of VK_EXT_vertex_attribute_divisor extension.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -216,7 +218,7 @@ TEST_F(VkLayerTest, VertexAttributeDivisorInstanceRateZero) {
         "VUID-VkVertexInputBindingDivisorDescriptionEXT-vertexAttributeInstanceRateZeroDivisor-02228");
 }
 
-TEST_F(VkLayerTest, VUID_VkVertexInputBindingDescription_binding_00618) {
+TEST_F(NegativeVertexInput, InputBindingMaxVertexInputBindings) {
     TEST_DESCRIPTION(
         "Test VUID-VkVertexInputBindingDescription-binding-00618: binding must be less than "
         "VkPhysicalDeviceLimits::maxVertexInputBindings");
@@ -235,7 +237,7 @@ TEST_F(VkLayerTest, VUID_VkVertexInputBindingDescription_binding_00618) {
     CreatePipelineHelper::OneshotTest(*this, set_binding, kErrorBit, "VUID-VkVertexInputBindingDescription-binding-00618");
 }
 
-TEST_F(VkLayerTest, VUID_VkVertexInputBindingDescription_stride_00619) {
+TEST_F(NegativeVertexInput, InputBindingMaxVertexInputBindingStride) {
     TEST_DESCRIPTION(
         "Test VUID-VkVertexInputBindingDescription-stride-00619: stride must be less than or equal to "
         "VkPhysicalDeviceLimits::maxVertexInputBindingStride");
@@ -254,7 +256,7 @@ TEST_F(VkLayerTest, VUID_VkVertexInputBindingDescription_stride_00619) {
     CreatePipelineHelper::OneshotTest(*this, set_binding, kErrorBit, "VUID-VkVertexInputBindingDescription-stride-00619");
 }
 
-TEST_F(VkLayerTest, VUID_VkVertexInputAttributeDescription_location_00620) {
+TEST_F(NegativeVertexInput, InputAttributeMaxVertexInputAttributes) {
     TEST_DESCRIPTION(
         "Test VUID-VkVertexInputAttributeDescription-location-00620: location must be less than "
         "VkPhysicalDeviceLimits::maxVertexInputAttributes");
@@ -276,7 +278,7 @@ TEST_F(VkLayerTest, VUID_VkVertexInputAttributeDescription_location_00620) {
                                                      "VUID-VkVertexInputAttributeDescription-format-00623"});
 }
 
-TEST_F(VkLayerTest, VUID_VkVertexInputAttributeDescription_binding_00621) {
+TEST_F(NegativeVertexInput, InputAttributeMaxVertexInputBindings) {
     TEST_DESCRIPTION(
         "Test VUID-VkVertexInputAttributeDescription-binding-00621: binding must be less than "
         "VkPhysicalDeviceLimits::maxVertexInputBindings");
@@ -298,7 +300,7 @@ TEST_F(VkLayerTest, VUID_VkVertexInputAttributeDescription_binding_00621) {
                                                      "VUID-VkVertexInputAttributeDescription-format-00623"});
 }
 
-TEST_F(VkLayerTest, VertexInputAttributeDescriptionOffset) {
+TEST_F(NegativeVertexInput, AttributeDescriptionOffset) {
     TEST_DESCRIPTION(
         "Test VUID-VkVertexInputAttributeDescription-offset-00622: offset must be less than or equal to "
         "VkPhysicalDeviceLimits::maxVertexInputAttributeOffset");
@@ -331,7 +333,7 @@ TEST_F(VkLayerTest, VertexInputAttributeDescriptionOffset) {
     CreatePipelineHelper::OneshotTest(*this, set_attribute, kErrorBit, "VUID-VkVertexInputAttributeDescription-offset-00622");
 }
 
-TEST_F(VkLayerTest, InvalidVertexBindingDescriptions) {
+TEST_F(NegativeVertexInput, BindingDescriptions) {
     TEST_DESCRIPTION(
         "Attempt to create a graphics pipeline where:"
         "1) count of vertex bindings exceeds device's maxVertexInputBindings limit"
@@ -368,7 +370,7 @@ TEST_F(VkLayerTest, InvalidVertexBindingDescriptions) {
     CreatePipelineHelper::OneshotTest(*this, set_Info, kErrorBit, vuids);
 }
 
-TEST_F(VkLayerTest, InvalidVertexAttributeDescriptions) {
+TEST_F(NegativeVertexInput, AttributeDescriptions) {
     TEST_DESCRIPTION(
         "Attempt to create a graphics pipeline where:"
         "1) count of vertex attributes exceeds device's maxVertexInputAttributes limit"
@@ -408,7 +410,7 @@ TEST_F(VkLayerTest, InvalidVertexAttributeDescriptions) {
     CreatePipelineHelper::OneshotTest(*this, set_Info, kErrorBit, vuids);
 }
 
-TEST_F(VkLayerTest, UsingProvokingVertexModeLastVertexExtWithoutEnabled) {
+TEST_F(NegativeVertexInput, UsingProvokingVertexModeLastVertexExtDisabled) {
     TEST_DESCRIPTION("Test using VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT but it doesn't enable provokingVertexLast.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -427,7 +429,7 @@ TEST_F(VkLayerTest, UsingProvokingVertexModeLastVertexExtWithoutEnabled) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, NotSupportProvokingVertexModePerPipeline) {
+TEST_F(NegativeVertexInput, ProvokingVertexModePerPipeline) {
     TEST_DESCRIPTION(
         "Test using different VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT but it doesn't support provokingVertexModePerPipeline.");
 
@@ -496,7 +498,7 @@ TEST_F(VkLayerTest, NotSupportProvokingVertexModePerPipeline) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, VerifyVertextBinding) {
+TEST_F(NegativeVertexInput, VertextBinding) {
     TEST_DESCRIPTION("Verify if VkPipelineVertexInputStateCreateInfo matches vkCmdBindVertexBuffers");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -542,7 +544,7 @@ TEST_F(VkLayerTest, VerifyVertextBinding) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, InvalidVertexAttributeAlignment) {
+TEST_F(NegativeVertexInput, AttributeAlignment) {
     TEST_DESCRIPTION("Check for proper aligment of attribAddress which depends on a bound pipeline and on a bound vertex buffer");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -649,7 +651,7 @@ TEST_F(VkLayerTest, InvalidVertexAttributeAlignment) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CreatePipelineAttribNotConsumed) {
+TEST_F(NegativeVertexInput, AttributeNotConsumed) {
     TEST_DESCRIPTION("Test that a warning is produced for a vertex attribute which is not consumed by the vertex shader");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -671,7 +673,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribNotConsumed) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit, "location 0 not consumed by vertex shader");
 }
 
-TEST_F(VkLayerTest, CreatePipelineAttribLocationMismatch) {
+TEST_F(NegativeVertexInput, AttributeLocationMismatch) {
     TEST_DESCRIPTION(
         "Test that a warning is produced for a location mismatch on vertex attributes. This flushes out bad behavior in the "
         "interface walker");
@@ -697,7 +699,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribLocationMismatch) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kPerformanceWarningBit, "location 0 not consumed by vertex shader");
 }
 
-TEST_F(VkLayerTest, CreatePipelineAttribNotProvided) {
+TEST_F(NegativeVertexInput, AttributeNotProvided) {
     TEST_DESCRIPTION("Test that an error is produced for a vertex shader input which is not provided by a vertex attribute");
 
     ASSERT_NO_FATAL_FAILURE(Init());
@@ -718,7 +720,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribNotProvided) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "Vertex shader consumes input at location 0 but not provided");
 }
 
-TEST_F(VkLayerTest, CreatePipelineAttribTypeMismatch) {
+TEST_F(NegativeVertexInput, AttributeTypeMismatch) {
     TEST_DESCRIPTION(
         "Test that an error is produced for a mismatch between the fundamental type (float/int/uint) of an attribute and the "
         "vertex shader input that consumes it");
@@ -752,7 +754,7 @@ TEST_F(VkLayerTest, CreatePipelineAttribTypeMismatch) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "location 0 does not match vertex shader input type");
 }
 
-TEST_F(VkLayerTest, CreatePipelineAttribBindingConflict) {
+TEST_F(NegativeVertexInput, AttributeBindingConflict) {
     TEST_DESCRIPTION(
         "Test that an error is produced for a vertex attribute setup where multiple bindings provide the same location");
 

--- a/tests/negative/wsi.cpp
+++ b/tests/negative/wsi.cpp
@@ -19,7 +19,9 @@
 #include "wayland-client.h"
 #endif
 
-TEST_F(VkLayerTest, InitSwapchainPotentiallyIncompatibleFlag) {
+class NegativeWsi : public VkLayerTest {};
+
+TEST_F(NegativeWsi, InitSwapchainPotentiallyIncompatibleFlag) {
     TEST_DESCRIPTION("Initialize swapchain with potentially incompatible flags");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -102,7 +104,7 @@ TEST_F(VkLayerTest, InitSwapchainPotentiallyIncompatibleFlag) {
     }
 }
 
-TEST_F(VkLayerTest, BindImageMemorySwapchain) {
+TEST_F(NegativeWsi, BindImageMemorySwapchain) {
     TEST_DESCRIPTION("Invalid bind image with a swapchain");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -204,7 +206,7 @@ TEST_F(VkLayerTest, BindImageMemorySwapchain) {
     vk::BindImageMemory2(m_device->device(), 1, &bind_info);
 }
 
-TEST_F(VkLayerTest, ValidSwapchainImage) {
+TEST_F(NegativeWsi, SwapchainImage) {
     TEST_DESCRIPTION("Swapchain images with invalid parameters");
     const char *vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
 
@@ -291,7 +293,7 @@ TEST_F(VkLayerTest, ValidSwapchainImage) {
     }
 }
 
-TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
+TEST_F(NegativeWsi, TransferImageToSwapchainLayoutDeviceGroup) {
     TEST_DESCRIPTION("Transfer an image to a swapchain's image with a invalid layout between device group");
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
@@ -421,7 +423,7 @@ TEST_F(VkLayerTest, TransferImageToSwapchainWithInvalidLayoutDeviceGroup) {
     // peer_image is a presentable image and controlled by the implementation
 }
 
-TEST_F(VkLayerTest, ValidSwapchainImageParams) {
+TEST_F(NegativeWsi, SwapchainImageParams) {
     TEST_DESCRIPTION("Swapchain with invalid implied image creation parameters");
     const char *vuid = "VUID-VkSwapchainCreateInfoKHR-imageFormat-01778";
 
@@ -522,7 +524,7 @@ TEST_F(VkLayerTest, ValidSwapchainImageParams) {
     m_swapchain = VK_NULL_HANDLE;
 }
 
-TEST_F(VkLayerTest, SwapchainAcquireImageNoSync) {
+TEST_F(NegativeWsi, SwapchainAcquireImageNoSync) {
     TEST_DESCRIPTION("Test vkAcquireNextImageKHR with VK_NULL_HANDLE semaphore and fence");
 
     AddSurfaceExtension();
@@ -544,7 +546,7 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoSync) {
     }
 }
 
-TEST_F(VkLayerTest, SwapchainAcquireImageNoSync2KHR) {
+TEST_F(NegativeWsi, SwapchainAcquireImageNoSync2KHR) {
     TEST_DESCRIPTION("Test vkAcquireNextImage2KHR with VK_NULL_HANDLE semaphore and fence");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -578,7 +580,7 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoSync2KHR) {
     }
 }
 
-TEST_F(VkLayerTest, SwapchainAcquireImageNoBinarySemaphore) {
+TEST_F(NegativeWsi, SwapchainAcquireImageNoBinarySemaphore) {
     TEST_DESCRIPTION("Test vkAcquireNextImageKHR with non-binary semaphore");
 
     AddSurfaceExtension();
@@ -617,7 +619,7 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoBinarySemaphore) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SwapchainAcquireImageNoBinarySemaphore2KHR) {
+TEST_F(NegativeWsi, SwapchainAcquireImageNoBinarySemaphore2KHR) {
     TEST_DESCRIPTION("Test vkAcquireNextImage2KHR with non-binary semaphore");
 
     TEST_DESCRIPTION("Test vkAcquireNextImage2KHR with VK_NULL_HANDLE semaphore and fence");
@@ -672,7 +674,7 @@ TEST_F(VkLayerTest, SwapchainAcquireImageNoBinarySemaphore2KHR) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
+TEST_F(NegativeWsi, SwapchainAcquireTooManyImages) {
     TEST_DESCRIPTION("Acquiring invalid amount of images from the swapchain.");
 
     AddSurfaceExtension();
@@ -708,7 +710,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages) {
     vk::WaitForFences(device(), fences.size(), MakeVkHandles<VkFence>(fences).data(), VK_TRUE, kWaitTimeout);
 }
 
-TEST_F(VkLayerTest, GetSwapchainImageAndTryDestroy) {
+TEST_F(NegativeWsi, GetSwapchainImageAndTryDestroy) {
     TEST_DESCRIPTION("Try destroying a swapchain presentable image with vkDestroyImage");
 
     AddSurfaceExtension();
@@ -729,7 +731,7 @@ TEST_F(VkLayerTest, GetSwapchainImageAndTryDestroy) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SwapchainNotSupported) {
+TEST_F(NegativeWsi, SwapchainNotSupported) {
     TEST_DESCRIPTION("Test creating a swapchain when GetPhysicalDeviceSurfaceSupportKHR returns VK_FALSE");
 
     AddSurfaceExtension();
@@ -817,7 +819,7 @@ TEST_F(VkLayerTest, SwapchainNotSupported) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
+TEST_F(NegativeWsi, SwapchainAcquireTooManyImages2KHR) {
     TEST_DESCRIPTION("Acquiring invalid amount of images from the swapchain via vkAcquireNextImage2KHR.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -866,7 +868,7 @@ TEST_F(VkLayerTest, SwapchainAcquireTooManyImages2KHR) {
     vk::WaitForFences(device(), fences.size(), MakeVkHandles<VkFence>(fences).data(), VK_TRUE, kWaitTimeout);
 }
 
-TEST_F(VkLayerTest, InvalidSwapchainImageFormatList) {
+TEST_F(NegativeWsi, SwapchainImageFormatList) {
     TEST_DESCRIPTION("Test VK_KHR_image_format_list and VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR with swapchains");
 
     AddSurfaceExtension();
@@ -971,7 +973,7 @@ TEST_F(VkLayerTest, InvalidSwapchainImageFormatList) {
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
 }
 
-TEST_F(VkLayerTest, SwapchainMinImageCountNonShared) {
+TEST_F(NegativeWsi, SwapchainMinImageCountNonShared) {
     TEST_DESCRIPTION("Use invalid minImageCount for non shared swapchain creation");
     AddSurfaceExtension();
 
@@ -1020,7 +1022,7 @@ TEST_F(VkLayerTest, SwapchainMinImageCountNonShared) {
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
 }
 
-TEST_F(VkLayerTest, SwapchainMinImageCountShared) {
+TEST_F(NegativeWsi, SwapchainMinImageCountShared) {
     TEST_DESCRIPTION("Use invalid minImageCount for shared swapchain creation");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1097,7 +1099,7 @@ TEST_F(VkLayerTest, SwapchainMinImageCountShared) {
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
 }
 
-TEST_F(VkLayerTest, SwapchainInvalidUsageNonShared) {
+TEST_F(NegativeWsi, SwapchainUsageNonShared) {
     TEST_DESCRIPTION("Use invalid imageUsage for non-shared swapchain creation");
     AddSurfaceExtension();
 
@@ -1144,7 +1146,7 @@ TEST_F(VkLayerTest, SwapchainInvalidUsageNonShared) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, SwapchainInvalidUsageShared) {
+TEST_F(NegativeWsi, SwapchainUsageShared) {
     TEST_DESCRIPTION("Use invalid imageUsage for shared swapchain creation");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -1218,7 +1220,7 @@ TEST_F(VkLayerTest, SwapchainInvalidUsageShared) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidDeviceMask) {
+TEST_F(NegativeWsi, DeviceMask) {
     TEST_DESCRIPTION("Invalid deviceMask.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -1403,7 +1405,7 @@ TEST_F(VkLayerTest, InvalidDeviceMask) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, DisplayPlaneSurface) {
+TEST_F(NegativeWsi, DisplayPlaneSurface) {
     TEST_DESCRIPTION("Create and use VkDisplayKHR objects to test VkDisplaySurfaceCreateInfoKHR.");
 
     AddSurfaceExtension();
@@ -1542,7 +1544,7 @@ TEST_F(VkLayerTest, DisplayPlaneSurface) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, WarningSwapchainCreateInfoPreTransform) {
+TEST_F(NegativeWsi, WarningSwapchainCreateInfoPreTransform) {
     TEST_DESCRIPTION("Print warning when preTransform doesn't match curretTransform");
 
     AddSurfaceExtension();
@@ -1562,7 +1564,7 @@ TEST_F(VkLayerTest, WarningSwapchainCreateInfoPreTransform) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DeviceGroupSubmitInfoSemaphoreCount) {
+TEST_F(NegativeWsi, DeviceGroupSubmitInfoSemaphoreCount) {
     TEST_DESCRIPTION("Test semaphoreCounts in DeviceGroupSubmitInfo");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1642,7 +1644,7 @@ TEST_F(VkLayerTest, DeviceGroupSubmitInfoSemaphoreCount) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-TEST_F(VkLayerTest, SwapchainAcquireImageWithSignaledSemaphore) {
+TEST_F(NegativeWsi, SwapchainAcquireImageWithSignaledSemaphore) {
     TEST_DESCRIPTION("Test vkAcquireNextImageKHR with signaled semaphore");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
@@ -1685,7 +1687,7 @@ TEST_F(VkLayerTest, SwapchainAcquireImageWithSignaledSemaphore) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, DisplayPresentInfoSrcRect) {
+TEST_F(NegativeWsi, DisplayPresentInfoSrcRect) {
     TEST_DESCRIPTION("Test layout tracking on imageless framebuffers");
     AddSurfaceExtension();
     AddRequiredExtensions(VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME);
@@ -1731,7 +1733,7 @@ TEST_F(VkLayerTest, DisplayPresentInfoSrcRect) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, LeakASwapchain) {
+TEST_F(NegativeWsi, LeakASwapchain) {
     TEST_DESCRIPTION("Leak a VkSwapchainKHR.");
     // Because this test intentionally leaks swapchains & surfaces, we need to disable leak checking because drivers may leak memory
     // that cannot be cleaned up from this test.
@@ -1764,7 +1766,7 @@ TEST_F(VkLayerTest, LeakASwapchain) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, PresentIdWait) {
+TEST_F(NegativeWsi, PresentIdWait) {
     TEST_DESCRIPTION("Test present wait extension");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_PRESENT_WAIT_EXTENSION_NAME);
@@ -1867,7 +1869,7 @@ TEST_F(VkLayerTest, PresentIdWait) {
     DestroySurfaceContext(surface_context);
 }
 
-TEST_F(VkLayerTest, PresentIdWaitFeatures) {
+TEST_F(NegativeWsi, PresentIdWaitFeatures) {
     TEST_DESCRIPTION("Test present wait extension");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddSurfaceExtension();
@@ -1918,7 +1920,7 @@ TEST_F(VkLayerTest, PresentIdWaitFeatures) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, GetSwapchainImagesCountButNotImages) {
+TEST_F(NegativeWsi, GetSwapchainImagesCountButNotImages) {
     TEST_DESCRIPTION("Test for getting swapchain images count and presenting before getting swapchain images.");
     AddSurfaceExtension();
     ASSERT_NO_FATAL_FAILURE(InitFramework());
@@ -1972,7 +1974,7 @@ TEST_F(VkLayerTest, GetSwapchainImagesCountButNotImages) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestSurfaceSupportByPhysicalDevice) {
+TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
     TEST_DESCRIPTION("Test if physical device supports surface.");
     AddOptionalExtensions(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
@@ -2109,7 +2111,7 @@ TEST_F(VkLayerTest, TestSurfaceSupportByPhysicalDevice) {
     }
 }
 
-TEST_F(VkLayerTest, SwapchainMaintenance1ExtensionTestsAcquire) {
+TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
     TEST_DESCRIPTION("Test swapchain Maintenance1 extensions.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -2435,7 +2437,7 @@ TEST_F(VkLayerTest, SwapchainMaintenance1ExtensionTestsAcquire) {
     }
 }
 
-TEST_F(VkLayerTest, SwapchainMaintenance1ExtensionTestsCaps) {
+TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionCaps) {
     TEST_DESCRIPTION("Test swapchain and surface Maintenance1 extensions.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
@@ -2588,7 +2590,7 @@ TEST_F(VkLayerTest, SwapchainMaintenance1ExtensionTestsCaps) {
     }
 }
 
-TEST_F(VkLayerTest, SwapchainMaintenance1ExtensionTestsRelease) {
+TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionRelease) {
     TEST_DESCRIPTION("Test acquiring swapchain images with Maint1 features.");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
@@ -2757,7 +2759,7 @@ TEST_F(VkLayerTest, SwapchainMaintenance1ExtensionTestsRelease) {
 }
 
 #if defined(VVL_TESTS_ENABLE_EXCLUSIVE_FULLSCREEN) && defined(VK_USE_PLATFORM_WIN32_KHR)
-TEST_F(VkLayerTest, AcquireFullScreenExclusiveModeEXT) {
+TEST_F(NegativeWsi, AcquireFullScreenExclusiveModeEXT) {
     TEST_DESCRIPTION("Test vkAcquireFullScreenExclusiveModeEXT.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -2841,7 +2843,7 @@ TEST_F(VkLayerTest, AcquireFullScreenExclusiveModeEXT) {
 #endif
 
 #if defined(VVL_TESTS_ENABLE_EXCLUSIVE_FULLSCREEN) && defined(VK_USE_PLATFORM_WIN32_KHR)
-TEST_F(VkLayerTest, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullscreenEXT) {
+TEST_F(NegativeWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullscreenEXT) {
     TEST_DESCRIPTION("Test vkAcquireFullScreenExclusiveModeEXT.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -2874,7 +2876,7 @@ TEST_F(VkLayerTest, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullscreenEXT) {
 }
 #endif
 
-TEST_F(VkLayerTest, TestCreatingWin32Surface) {
+TEST_F(NegativeWsi, CreatingWin32Surface) {
     TEST_DESCRIPTION("Test creating win32 surface with invalid hwnd");
 
 #ifndef VK_USE_PLATFORM_WIN32_KHR
@@ -2894,7 +2896,7 @@ TEST_F(VkLayerTest, TestCreatingWin32Surface) {
 #endif
 }
 
-TEST_F(VkLayerTest, CreatingWaylandSurface) {
+TEST_F(NegativeWsi, CreatingWaylandSurface) {
     TEST_DESCRIPTION("Test creating wayland surface with invalid display/surface");
 
 #ifndef VK_USE_PLATFORM_WAYLAND_KHR
@@ -2986,7 +2988,7 @@ TEST_F(VkLayerTest, CreatingWaylandSurface) {
 #endif
 }
 
-TEST_F(VkLayerTest, CreatingXcbSurface) {
+TEST_F(NegativeWsi, CreatingXcbSurface) {
     TEST_DESCRIPTION("Test creating xcb surface with invalid connection/window");
 
 #ifndef VK_USE_PLATFORM_XCB_KHR
@@ -3042,7 +3044,7 @@ TEST_F(VkLayerTest, CreatingXcbSurface) {
 #endif
 }
 
-TEST_F(VkLayerTest, CreatingX11Surface) {
+TEST_F(NegativeWsi, CreatingX11Surface) {
     TEST_DESCRIPTION("Test creating invalid x11 surface");
 
 #ifndef VK_USE_PLATFORM_XLIB_KHR
@@ -3098,7 +3100,7 @@ TEST_F(VkLayerTest, CreatingX11Surface) {
 #endif
 }
 
-TEST_F(VkLayerTest, UseSwapchainImageBeforeWait) {
+TEST_F(NegativeWsi, UseSwapchainImageBeforeWait) {
     TEST_DESCRIPTION("Test using a swapchain image that was acquired but not waited on.");
 
     AddSurfaceExtension();
@@ -3138,7 +3140,7 @@ TEST_F(VkLayerTest, UseSwapchainImageBeforeWait) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestCreatingSwapchainWithInvalidExtent) {
+TEST_F(NegativeWsi, CreatingSwapchainWithExtent) {
     TEST_DESCRIPTION("Create swapchain with extent greater than maxImageExtent of SurfaceCapabilities");
 
     AddSurfaceExtension();
@@ -3182,7 +3184,7 @@ TEST_F(VkLayerTest, TestCreatingSwapchainWithInvalidExtent) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, TestSurfaceQueryImageCompressionControlWithoutExtension) {
+TEST_F(NegativeWsi, SurfaceQueryImageCompressionControlWithoutExtension) {
     TEST_DESCRIPTION("Test querying surface image compression control without extension.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddSurfaceExtension();
@@ -3225,7 +3227,7 @@ TEST_F(VkLayerTest, TestSurfaceQueryImageCompressionControlWithoutExtension) {
 }
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-TEST_F(VkLayerTest, PhysicalDeviceSurfaceCapabilities) {
+TEST_F(NegativeWsi, PhysicalDeviceSurfaceCapabilities) {
     TEST_DESCRIPTION("Test pNext in GetPhysicalDeviceSurfaceCapabilities2KHR");
 
     AddSurfaceExtension();
@@ -3259,7 +3261,7 @@ TEST_F(VkLayerTest, PhysicalDeviceSurfaceCapabilities) {
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         //
-TEST_F(VkLayerTest, QueuePresentWaitingSameSemaphore) {
+TEST_F(NegativeWsi, QueuePresentWaitingSameSemaphore) {
     TEST_DESCRIPTION("Submit to queue with waitSemaphore that another queue is already waiting on.");
     AddSurfaceExtension();
     AddRequiredExtensions(VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME);
@@ -3314,7 +3316,7 @@ TEST_F(VkLayerTest, QueuePresentWaitingSameSemaphore) {
     vk::QueueWaitIdle(other);
 }
 
-TEST_F(VkLayerTest, QueuePresentBinarySemaphoreNotSignaled) {
+TEST_F(NegativeWsi, QueuePresentBinarySemaphoreNotSignaled) {
     TEST_DESCRIPTION("Submit a present operation with a waiting binary semaphore not previously signaled.");
     AddSurfaceExtension();
     AddRequiredExtensions(VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME);
@@ -3374,7 +3376,7 @@ TEST_F(VkLayerTest, QueuePresentBinarySemaphoreNotSignaled) {
     ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_device->m_queue));
 }
 
-TEST_F(VkLayerTest, SwapchainAcquireImageRetired) {
+TEST_F(NegativeWsi, SwapchainAcquireImageRetired) {
     TEST_DESCRIPTION("Test vkAcquireNextImageKHR with retired swapchain");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 

--- a/tests/negative/ycbcr.cpp
+++ b/tests/negative/ycbcr.cpp
@@ -17,7 +17,9 @@
 #include "../framework/layer_validation_tests.h"
 #include "utils/vk_layer_utils.h"
 
-TEST_F(VkLayerTest, CreateYCbCrSampler) {
+class NegativeYcbcr : public VkLayerTest {};
+
+TEST_F(NegativeYcbcr, Sampler) {
     TEST_DESCRIPTION("Verify YCbCr sampler creation.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -146,7 +148,7 @@ TEST_F(VkLayerTest, CreateYCbCrSampler) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
+TEST_F(NegativeYcbcr, Swizzle) {
     TEST_DESCRIPTION("Verify Invalid use of siwizzle components when dealing with YCbCr.");
 
     // Use 1.1 to get VK_KHR_sampler_ycbcr_conversion easier
@@ -310,7 +312,7 @@ TEST_F(VkLayerTest, InvalidSwizzleYCbCr) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, CreateImageYcbcrFormats) {
+TEST_F(NegativeYcbcr, Formats) {
     TEST_DESCRIPTION("Creating images with Ycbcr Formats.");
 
     // Enable KHR multiplane req'd extensions
@@ -412,7 +414,7 @@ TEST_F(VkLayerTest, CreateImageYcbcrFormats) {
     image_create_info = reset_create_info;
 }
 
-TEST_F(VkLayerTest, CopyImageSinglePlane422Alignment) {
+TEST_F(NegativeYcbcr, CopyImageSinglePlane422Alignment) {
     // Image copy tests on single-plane _422 formats with block alignment errors
 
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
@@ -507,7 +509,7 @@ TEST_F(VkLayerTest, CopyImageSinglePlane422Alignment) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CopyImageMultiplaneAspectBits) {
+TEST_F(NegativeYcbcr, CopyImageMultiplaneAspectBits) {
     // Image copy tests on multiplane images with aspect errors
 
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
@@ -621,7 +623,7 @@ TEST_F(VkLayerTest, CopyImageMultiplaneAspectBits) {
     m_commandBuffer->end();
 }
 
-TEST_F(VkLayerTest, CreateSamplerYcbcrConversionEnable) {
+TEST_F(NegativeYcbcr, SamplerYcbcrConversionEnable) {
     TEST_DESCRIPTION("Checks samplerYcbcrConversion is enabled before calling vkCreateSamplerYcbcrConversion");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -654,7 +656,7 @@ TEST_F(VkLayerTest, CreateSamplerYcbcrConversionEnable) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, ClearColorImageWithInvalidFormat) {
+TEST_F(NegativeYcbcr, ClearColorImageFormat) {
     TEST_DESCRIPTION("Record clear color with an invalid image formats");
 
     // Enable KHR multiplane req'd extensions
@@ -703,7 +705,7 @@ TEST_F(VkLayerTest, ClearColorImageWithInvalidFormat) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, WriteDescriptorSetYcbcr) {
+TEST_F(NegativeYcbcr, WriteDescriptorSet) {
     TEST_DESCRIPTION("Attempt to use VkSamplerYcbcrConversion ImageView to update descriptors that are not allowed.");
 
     // Enable KHR multiplane req'd extensions
@@ -768,7 +770,7 @@ TEST_F(VkLayerTest, WriteDescriptorSetYcbcr) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, MultiplaneImageLayoutBadAspectFlags) {
+TEST_F(NegativeYcbcr, MultiplaneImageLayoutAspectFlags) {
     TEST_DESCRIPTION("Query layout of a multiplane image using illegal aspect flag masks");
 
     // Enable KHR multiplane req'd extensions
@@ -832,7 +834,7 @@ TEST_F(VkLayerTest, MultiplaneImageLayoutBadAspectFlags) {
     vk::DestroyImage(device(), image_3plane, NULL);
 }
 
-TEST_F(VkLayerTest, BindInvalidMemoryYcbcr) {
+TEST_F(NegativeYcbcr, BindMemory) {
     // Enable KHR YCbCr req'd extensions for Disjoint Bit
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
@@ -964,7 +966,7 @@ TEST_F(VkLayerTest, BindInvalidMemoryYcbcr) {
     }
 }
 
-TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
+TEST_F(NegativeYcbcr, BindMemory2Disjoint) {
     TEST_DESCRIPTION("These tests deal with VK_KHR_bind_memory_2 and disjoint memory being bound");
 
     // Enable KHR YCbCr req'd extensions for Disjoint Bit
@@ -1268,7 +1270,7 @@ TEST_F(VkLayerTest, BindInvalidMemory2Disjoint) {
     }
 }
 
-TEST_F(VkLayerTest, MismatchedImageViewAndSamplerYcbcrFormat) {
+TEST_F(NegativeYcbcr, MismatchedImageViewAndSamplerFormat) {
     TEST_DESCRIPTION("Create image view with a different format that SamplerYcbcr was created with.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1320,7 +1322,7 @@ TEST_F(VkLayerTest, MismatchedImageViewAndSamplerYcbcrFormat) {
     CreateImageViewTest(*this, &view_info, "VUID-VkImageViewCreateInfo-pNext-06658");
 }
 
-TEST_F(VkLayerTest, MultiplaneIncompatibleViewFormat) {
+TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat) {
     TEST_DESCRIPTION("Postive/negative tests of multiplane imageview format compatibility");
 
     // Use 1.1 to get VK_KHR_sampler_ycbcr_conversion easier
@@ -1455,7 +1457,7 @@ TEST_F(VkLayerTest, MultiplaneIncompatibleViewFormat) {
     }
 }
 
-TEST_F(VkLayerTest, MultiplaneImageViewAspectMasks) {
+TEST_F(NegativeYcbcr, MultiplaneImageViewAspectMasks) {
     TEST_DESCRIPTION("Create a VkImageView with multiple planar aspect masks");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1537,7 +1539,7 @@ TEST_F(VkLayerTest, MultiplaneImageViewAspectMasks) {
     }
 }
 
-TEST_F(VkLayerTest, MultiplaneAspectBits) {
+TEST_F(NegativeYcbcr, MultiplaneAspectBits) {
     TEST_DESCRIPTION("Attempt to update descriptor sets for images that do not have correct aspect bits sets.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);


### PR DESCRIPTION
This adds more tests with the `Negative*` schema

I didn't touch the GPU-AV or Best Practices here

While doing this, I remove some redundant keywords such as

- `Tests`
- `Invalid`
- `Validate`
- `Validation`
- `Violation`
- `Bad`
- `Verify`
- `Error`
- `Illegal`