### PR TITLE
layers: Cleanup various CUBE_COMPATIBLE_BIT validation

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -106,14 +106,6 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         }
     }
 
-    if (pCreateInfo->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) {
-        if (VK_IMAGE_TYPE_2D != pCreateInfo->imageType) {
-            skip |= LogError(device, "VUID-VkImageCreateInfo-flags-00949",
-                             "vkCreateImage(): Image type must be VK_IMAGE_TYPE_2D when VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT "
-                             "flag bit is set");
-        }
-    }
-
     const VkPhysicalDeviceLimits *device_limits = &phys_dev_props.limits;
     const VkImageUsageFlags attach_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
                                            VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;


### PR DESCRIPTION
Touches up the following VUIDs:
- VUID-VkImageCreateInfo-flags-00949
- VUID-VkImageCreateInfo-imageType-00954

Move code to stateless validation.
Improve error messages.

Move code out of `NegativeImage.ImageMisc` which reveals issue
on known issue MacOS / Android where VUIDs are triggered.

Best solution is to just run on MockICD. Trying to fix the issue
complicates the tests and triggers other VUIDs for little gain.
There is also little gain to running this test on real hardware.

Minor cleanup:
- Create DefaultImageInfo helper funciton.
- Remove temp create infos