### PR TITLE
scripts: Use glob to get files for vk_validaiton_stats.py

### DIFF
--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -725,60 +725,23 @@ def main(argv):
     import common_codegen
 
     layer_source_files = [common_codegen.repo_relative(path) for path in [
-        'layers/core_checks/cc_android.cpp',
-        'layers/core_checks/cc_buffer.cpp',
         'layers/state_tracker/cmd_buffer_state.cpp', # some Video VUIDs are in here
-        'layers/core_checks/cc_cmd_buffer_dynamic.cpp',
-        'layers/core_checks/cc_cmd_buffer.cpp',
-        'layers/core_checks/cc_copy_blit_resolve.cpp',
         'layers/state_tracker/descriptor_sets.cpp',
-        'layers/core_checks/cc_descriptor.cpp',
-        'layers/core_checks/cc_device.cpp',
-        'layers/core_checks/cc_device_memory.cpp',
-        'layers/core_checks/cc_drawdispatch.cpp',
-        'layers/core_checks/cc_external_object.cpp',
-        'layers/gpu_validation/gpu_vuids.h',
-        'layers/stateless/sl_buffer.cpp',
-        'layers/stateless/sl_cmd_buffer_dynamic.cpp',
-        'layers/stateless/sl_cmd_buffer.cpp',
-        'layers/stateless/sl_descriptor.cpp',
-        'layers/stateless/sl_device_memory.cpp',
-        'layers/stateless/sl_external_object.cpp',
-        'layers/stateless/sl_framebuffer.cpp',
-        'layers/stateless/sl_image.cpp',
-        'layers/stateless/sl_instance_device.cpp',
-        'layers/stateless/sl_pipeline.cpp',
-        'layers/stateless/sl_ray_tracing.cpp',
-        'layers/stateless/sl_render_pass.cpp',
-        'layers/stateless/sl_synchronization.cpp',
-        'layers/stateless/sl_wsi.cpp',
-        'layers/core_checks/cc_image.cpp',
-        'layers/core_checks/cc_image_layout.cpp',
-        'layers/core_checks/cc_pipeline_compute.cpp',
-        'layers/core_checks/cc_pipeline_graphics.cpp',
-        'layers/core_checks/cc_pipeline_ray_tracing.cpp',
-        'layers/core_checks/cc_pipeline.cpp',
-        'layers/object_tracker/object_tracker_utils.cpp',
-        'layers/core_checks/cc_query.cpp',
-        'layers/core_checks/cc_queue.cpp',
-        'layers/core_checks/cc_ray_tracing.cpp',
-        'layers/core_checks/cc_render_pass.cpp',
         'layers/state_tracker/shader_module.cpp',
-        'layers/core_checks/cc_shader.cpp',
-        'layers/core_checks/cc_synchronization.cpp',
+        'layers/gpu_validation/gpu_vuids.h',
         'layers/stateless/stateless_validation.h',
-        'layers/sync/sync_validation.cpp',
-        'layers/sync/sync_vuid_maps.cpp',
-        'layers/core_checks/cc_video.cpp',
-        'layers/core_checks/cc_wsi.cpp',
-        'layers/core_checks/cc_ycbcr.cpp',
         'layers/generated/parameter_validation.cpp',
         'layers/generated/object_tracker.cpp',
         'layers/generated/spirv_validation_helper.cpp',
         'layers/generated/command_validation.cpp',
     ]]
+    # Be careful not to add vk_validation_error_messages.h or it will show 100% test coverage
+    layer_source_files.extend(glob.glob(os.path.join(common_codegen.repo_relative('layers/core_checks/'), '*.cpp')))
+    layer_source_files.extend(glob.glob(os.path.join(common_codegen.repo_relative('layers/stateless/'), '*.cpp')))
+    layer_source_files.extend(glob.glob(os.path.join(common_codegen.repo_relative('layers/sync/'), '*.cpp')))
+    layer_source_files.extend(glob.glob(os.path.join(common_codegen.repo_relative('layers/object_tracker/'), '*.cpp')))
 
-    test_source_files = glob.glob(os.path.join(common_codegen.repo_relative('tests'), '*.cpp'))
+    test_source_files = glob.glob(os.path.join(common_codegen.repo_relative('tests/negative'), '*.cpp'))
 
     unassigned_vuid_files = [common_codegen.repo_relative(path) for path in [
         'layers/best_practices/best_practices_error_enums.h',


### PR DESCRIPTION
1. We were not tracking the tests anymore since making the new `negative` folder
2. It is annoying listing all the "main" layer files, so just use `glob`