### PR TITLE
Add Mesh/Task shader workgroup memory limits

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -171,6 +171,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/framework/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/negative/shader_interface.cpp \
                    $(SRC_DIR)/tests/negative/shader_limits.cpp \
                    $(SRC_DIR)/tests/negative/shader_push_constants.cpp \
+                   $(SRC_DIR)/tests/negative/shader_mesh.cpp \
                    $(SRC_DIR)/tests/negative/shader_spirv.cpp \
                    $(SRC_DIR)/tests/negative/shader_storage_image.cpp \
                    $(SRC_DIR)/tests/negative/shader_storage_texel.cpp \

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -877,7 +877,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderResolveQCOM(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                    const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderSubgroupSizeControl(const SHADER_MODULE_STATE& module_state, VkPipelineShaderStageCreateFlags flags) const;
-    bool ValidateComputeSharedMemory(const SHADER_MODULE_STATE& module_state, uint32_t total_shared_size) const;
+    bool ValidateWorkgroupSharedMemory(const SHADER_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
+                                       uint32_t total_workgroup_shared_memory) const;
     bool ValidateAtomicsTypes(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, const EntryPoint& entrypoint, VkShaderStageFlagBits stage,
                                 const PIPELINE_STATE& pipeline) const;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -924,8 +924,8 @@ bool SHADER_MODULE_STATE::FindLocalSize(const EntryPoint& entrypoint, uint32_t& 
     return false;  // not found
 }
 
-uint32_t SHADER_MODULE_STATE::CalculateComputeSharedMemory() const {
-    uint32_t total_shared_size = 0;
+uint32_t SHADER_MODULE_STATE::CalculateWorkgroupSharedMemory() const {
+    uint32_t total_size = 0;
     // when using WorkgroupMemoryExplicitLayoutKHR
     // either all or none the structs are decorated with Block,
     // if using block, all must decorated with Aliased.
@@ -945,13 +945,13 @@ uint32_t SHADER_MODULE_STATE::CalculateComputeSharedMemory() const {
             const uint32_t variable_shared_size = GetTypeBytesSize(type);
 
             if (find_max_block) {
-                total_shared_size = std::max(total_shared_size, variable_shared_size);
+                total_size = std::max(total_size, variable_shared_size);
             } else {
-                total_shared_size += variable_shared_size;
+                total_size += variable_shared_size;
             }
         }
     }
-    return total_shared_size;
+    return total_size;
 }
 
 // If the instruction at id is a constant or copy of a constant, returns a valid iterator pointing to that instruction.

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -571,7 +571,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
     std::shared_ptr<const EntryPoint> FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
     bool FindLocalSize(const EntryPoint &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y, uint32_t &local_size_z) const;
 
-    uint32_t CalculateComputeSharedMemory() const;
+    uint32_t CalculateWorkgroupSharedMemory() const;
 
     const Instruction *GetConstantDef(uint32_t id) const;
     uint32_t GetConstantValueById(uint32_t id) const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     negative/shader_interface.cpp
     negative/shader_limits.cpp
     negative/shader_push_constants.cpp
+    negative/shader_mesh.cpp
     negative/shader_spirv.cpp
     negative/shader_storage_image.cpp
     negative/shader_storage_texel.cpp

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -1179,65 +1179,65 @@
                     "shadingRateMaxCoarseSamples": 32
                 },
                 "VkPhysicalDeviceMeshShaderPropertiesNV": {
-                    "maxDrawMeshTasksCount": 4294967000,
-                    "maxTaskWorkGroupInvocations": 4294967000,
+                    "maxDrawMeshTasksCount": 65535,
+                    "maxTaskWorkGroupInvocations": 32,
                     "maxTaskWorkGroupSize": [
-                        4294967000,
-                        4294967000,
-                        4294967000
+                        32,
+                        1,
+                        1
                     ],
-                    "maxTaskTotalMemorySize": 4294967000,
-                    "maxTaskOutputCount": 4294967000,
-                    "maxMeshWorkGroupInvocations": 4294967000,
+                    "maxTaskTotalMemorySize": 16384,
+                    "maxTaskOutputCount": 65535,
+                    "maxMeshWorkGroupInvocations": 32,
                     "maxMeshWorkGroupSize": [
-                        4294967000,
-                        4294967000,
-                        4294967000
+                        128,
+                        128,
+                        128
                     ],
-                    "maxMeshTotalMemorySize": 4294967000,
-                    "maxMeshOutputVertices": 4294967000,
-                    "maxMeshOutputPrimitives": 4294967000,
-                    "maxMeshMultiviewViewCount": 4294967000
+                    "maxMeshTotalMemorySize": 16384,
+                    "maxMeshOutputVertices": 256,
+                    "maxMeshOutputPrimitives": 256,
+                    "maxMeshMultiviewViewCount": 4
                 },
                 "VkPhysicalDeviceMeshShaderPropertiesEXT": {
-                    "maxTaskWorkGroupTotalCount": 4294967000,
+                    "maxTaskWorkGroupTotalCount": 4194304,
                     "maxTaskWorkGroupCount": [
-                        4294967000,
-                        4294967000,
-                        4294967000
+                        65535,
+                        65535,
+                        65535
                     ],
-                    "maxTaskWorkGroupInvocations": 4294967000,
+                    "maxTaskWorkGroupInvocations": 32,
                     "maxTaskWorkGroupSize": [
-                        4294967000,
-                        4294967000,
-                        4294967000
+                        128,
+                        128,
+                        128
                     ],
-                    "maxTaskPayloadSize": 4294967000,
-                    "maxTaskSharedMemorySize": 4294967000,
-                    "maxTaskPayloadAndSharedMemorySize": 4294967000,
-                    "maxMeshWorkGroupTotalCount": 4294967000,
+                    "maxTaskPayloadSize": 16384,
+                    "maxTaskSharedMemorySize": 32768,
+                    "maxTaskPayloadAndSharedMemorySize": 32768,
+                    "maxMeshWorkGroupTotalCount": 4194304,
                     "maxMeshWorkGroupCount": [
-                        4294967000,
-                        4294967000,
-                        4294967000
+                        65535,
+                        65535,
+                        65535
                     ],
-                    "maxMeshWorkGroupInvocations": 4294967000,
+                    "maxMeshWorkGroupInvocations": 128,
                     "maxMeshWorkGroupSize": [
-                        4294967000,
-                        4294967000,
-                        4294967000
+                        128,
+                        128,
+                        128
                     ],
-                    "maxMeshSharedMemorySize": 4294967000,
-                    "maxMeshPayloadAndSharedMemorySize": 4294967000,
-                    "maxMeshOutputMemorySize": 4294967000,
-                    "maxMeshPayloadAndOutputMemorySize": 4294967000,
-                    "maxMeshOutputComponents": 4294967000,
-                    "maxMeshOutputVertices": 4294967000,
-                    "maxMeshOutputPrimitives": 4294967000,
-                    "maxMeshOutputLayers": 4294967000,
-                    "maxMeshMultiviewViewCount": 4294967000,
-                    "maxPreferredTaskWorkGroupInvocations": 4294967000,
-                    "maxPreferredMeshWorkGroupInvocations": 4294967000
+                    "maxMeshSharedMemorySize": 28672,
+                    "maxMeshPayloadAndSharedMemorySize": 28672,
+                    "maxMeshOutputMemorySize": 32768,
+                    "maxMeshPayloadAndOutputMemorySize": 48128,
+                    "maxMeshOutputComponents": 128,
+                    "maxMeshOutputVertices": 256,
+                    "maxMeshOutputPrimitives": 256,
+                    "maxMeshOutputLayers": 8,
+                    "maxMeshMultiviewViewCount": 8,
+                    "maxPreferredTaskWorkGroupInvocations": 4096,
+                    "maxPreferredMeshWorkGroupInvocations": 4096
                 },
                 "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
                     "maxGeometryCount": 16777215,

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -183,6 +183,14 @@ static char const bindStateFragColorOutputText[] = R"glsl(
     }
 )glsl";
 
+[[maybe_unused]] static const char *bindStateMeshShaderText = R"glsl(
+    #version 460
+    #extension GL_EXT_mesh_shader : require // Requires SPIR-V 1.5 (Vulkan 1.2)
+    layout(max_vertices = 3, max_primitives=1) out;
+    layout(triangles) out;
+    void main() {}
+)glsl";
+
 [[maybe_unused]] static const char *bindStateRTShaderText = R"glsl(
     #version 460
     #extension GL_EXT_ray_tracing : require // Requires SPIR-V 1.5 (Vulkan 1.2)

--- a/tests/negative/shader_mesh.cpp
+++ b/tests/negative/shader_mesh.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+
+class NegativeShaderMesh : public VkLayerTest {};
+
+TEST_F(NegativeShaderMesh, SharedMemoryOverLimit) {
+    TEST_DESCRIPTION("Validate mesh shader shared memory does not exceed maxMeshSharedMemorySize");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    auto mesh_shader_features = LvlInitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    GetPhysicalDeviceFeatures2(mesh_shader_features);
+    if (!mesh_shader_features.meshShader) {
+        GTEST_SKIP() << "Mesh shader not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mesh_shader_features));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
+    }
+
+    auto mesh_shader_properties = LvlInitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    GetPhysicalDeviceProperties2(mesh_shader_properties);
+
+    const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
+    const uint32_t max_shared_ints = max_shared_memory_size / 4;
+
+    std::stringstream mesh_source;
+    mesh_source << R"glsl(
+        #version 460
+        #extension GL_EXT_mesh_shader : require
+        layout(max_vertices = 3, max_primitives=1) out;
+        layout(triangles) out;
+        shared int a[)glsl";
+    mesh_source << (max_shared_ints + 16);
+    mesh_source << R"glsl(];
+        void main(){}
+    )glsl";
+
+    VkShaderObj mesh(this, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.fs_->GetStageCreateInfo(), mesh.GetStageCreateInfo()};
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshSharedMemorySize-08754");
+}
+
+TEST_F(NegativeShaderMesh, SharedMemoryOverLimitWorkgroupMemoryExplicitLayout) {
+    TEST_DESCRIPTION(
+        "Validate mesh shader shared memory does not exceed maxMeshSharedMemorySize when using "
+        "VK_KHR_workgroup_memory_explicit_layout");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    auto explicit_layout_features = LvlInitStruct<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>();
+    auto mesh_shader_features = LvlInitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>(&explicit_layout_features);
+    GetPhysicalDeviceFeatures2(mesh_shader_features);
+    if (!mesh_shader_features.meshShader) {
+        GTEST_SKIP() << "Mesh shader not supported";
+    } else if (!explicit_layout_features.workgroupMemoryExplicitLayout) {
+        GTEST_SKIP() << "workgroupMemoryExplicitLayout feature not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mesh_shader_features));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
+    }
+
+    auto mesh_shader_properties = LvlInitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    GetPhysicalDeviceProperties2(mesh_shader_properties);
+
+    const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
+    const uint32_t max_shared_ints = max_shared_memory_size / 4;
+
+    std::stringstream mesh_source;
+    mesh_source << R"glsl(
+        #version 460
+        #extension GL_EXT_mesh_shader : require
+        #extension GL_EXT_shared_memory_block : enable
+        layout(max_vertices = 3, max_primitives=1) out;
+        layout(triangles) out;
+
+        shared X {
+            int x;
+        };
+
+        shared Y {
+            int y1[)glsl";
+    mesh_source << (max_shared_ints + 16);
+    mesh_source << R"glsl(];
+            int y2;
+        };
+
+        void main() {
+            x = 0; // prevent dead-code elimination
+            y2 = 0;
+        }
+    )glsl";
+
+    VkShaderObj mesh(this, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.fs_->GetStageCreateInfo(), mesh.GetStageCreateInfo()};
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshSharedMemorySize-08754");
+}
+
+TEST_F(NegativeShaderMesh, SharedMemorySpecConstantDefault) {
+    TEST_DESCRIPTION("Validate shared memory exceed maxMeshSharedMemorySize limit with spec constants default");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    auto mesh_shader_features = LvlInitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    GetPhysicalDeviceFeatures2(mesh_shader_features);
+    if (!mesh_shader_features.meshShader) {
+        GTEST_SKIP() << "Mesh shader not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mesh_shader_features));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
+    }
+
+    auto mesh_shader_properties = LvlInitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    GetPhysicalDeviceProperties2(mesh_shader_properties);
+
+    const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
+    const uint32_t max_shared_ints = max_shared_memory_size / 4;
+
+    std::stringstream mesh_source;
+    mesh_source << R"glsl(
+        #version 460
+        #extension GL_EXT_mesh_shader : require
+        layout(max_vertices = 3, max_primitives=1) out;
+        layout(triangles) out;
+        layout(constant_id = 0) const uint Condition = 1;
+        layout(constant_id = 1) const uint SharedSize = )glsl";
+    mesh_source << (max_shared_ints + 16);
+    mesh_source << R"glsl(;
+
+        #define enableSharedMemoryOpt (Condition == 1)
+        shared uint arr[enableSharedMemoryOpt ? SharedSize : 1];
+        void main(){}
+    )glsl";
+
+    VkShaderObj mesh(this, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.fs_->GetStageCreateInfo(), mesh.GetStageCreateInfo()};
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshSharedMemorySize-08754");
+}
+
+TEST_F(NegativeShaderMesh, SharedMemorySpecConstantSet) {
+    TEST_DESCRIPTION("Validate shared memory exceed maxMeshSharedMemorySize limit with spec constants set");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    auto mesh_shader_features = LvlInitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    GetPhysicalDeviceFeatures2(mesh_shader_features);
+    if (!mesh_shader_features.meshShader) {
+        GTEST_SKIP() << "Mesh shader not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mesh_shader_features));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
+    }
+
+    auto mesh_shader_properties = LvlInitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    GetPhysicalDeviceProperties2(mesh_shader_properties);
+
+    const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
+    const uint32_t max_shared_ints = max_shared_memory_size / 4;
+
+    std::stringstream mesh_source;
+    mesh_source << R"glsl(
+        #version 460
+        #extension GL_EXT_mesh_shader : require
+        layout(max_vertices = 3, max_primitives=1) out;
+        layout(triangles) out;
+        layout(constant_id = 0) const uint Condition = 1;
+        layout(constant_id = 1) const uint SharedSize = )glsl";
+    mesh_source << (max_shared_ints + 16);
+    mesh_source << R"glsl(;
+
+        #define enableSharedMemoryOpt (Condition == 1)
+        shared uint arr[enableSharedMemoryOpt ? SharedSize : 1];
+        void main(){}
+    )glsl";
+
+    uint32_t data = 1;  // set Condition
+
+    VkSpecializationMapEntry entry;
+    entry.constantID = 0;
+    entry.offset = 0;
+    entry.size = sizeof(uint32_t);
+
+    VkSpecializationInfo specialization_info = {};
+    specialization_info.mapEntryCount = 1;
+    specialization_info.pMapEntries = &entry;
+    specialization_info.dataSize = sizeof(uint32_t);
+    specialization_info.pData = &data;
+
+    VkShaderObj mesh(this, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_GLSL,
+                     &specialization_info);
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.fs_->GetStageCreateInfo(), mesh.GetStageCreateInfo()};
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshSharedMemorySize-08754");
+}
+
+TEST_F(NegativeShaderMesh, TaskSharedMemoryOverLimit) {
+    TEST_DESCRIPTION("Validate Task shader shared memory does not exceed maxTaskSharedMemorySize");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    auto mesh_shader_features = LvlInitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    GetPhysicalDeviceFeatures2(mesh_shader_features);
+    if (!mesh_shader_features.meshShader || !mesh_shader_features.taskShader) {
+        GTEST_SKIP() << "Mesh and Task shader not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mesh_shader_features));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
+    }
+
+    auto mesh_shader_properties = LvlInitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    GetPhysicalDeviceProperties2(mesh_shader_properties);
+
+    const uint32_t max_shared_memory_size = mesh_shader_properties.maxTaskSharedMemorySize;
+    const uint32_t max_shared_ints = max_shared_memory_size / 4;
+
+    std::stringstream task_source;
+    task_source << R"glsl(
+        #version 460
+        #extension GL_EXT_mesh_shader : require
+        shared int a[)glsl";
+    task_source << (max_shared_ints + 16);
+    task_source << R"glsl(];
+        void main(){}
+    )glsl";
+
+    VkShaderObj task(this, task_source.str().c_str(), VK_SHADER_STAGE_TASK_BIT_EXT, SPV_ENV_VULKAN_1_2);
+    VkShaderObj mesh(this, bindStateMeshShaderText, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {task.GetStageCreateInfo(), mesh.GetStageCreateInfo()};
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxTaskSharedMemorySize-08759");
+}


### PR DESCRIPTION
Adds `VUID-RuntimeSpirv-maxMeshSharedMemorySize-08754` and `VUID-RuntimeSpirv-maxTaskSharedMemorySize-08759` which check the Workgroup Shader memory size against Mesh and Task shaders