### PR TITLE
build: Update SPIRV-Headers and -Tools

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -22,7 +22,7 @@
             "name": "SPIRV-Tools",
             "url": "https://github.com/KhronosGroup/SPIRV-Tools.git",
             "sub_dir": "shaderc/third_party/spirv-tools",
-            "commit": "d5f69dba559822c2c968a959238ab037b5556af6"
+            "commit": "9e627132a8f17dedab6580f666cebc141396a344"
         },
         {
             "name": "SPIRV-Headers",

--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -22,4 +22,4 @@
  ****************************************************************************/
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "d5f69dba559822c2c968a959238ab037b5556af6"
+#define SPIRV_TOOLS_COMMIT_ID "9e627132a8f17dedab6580f666cebc141396a344"

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -37,7 +37,7 @@
                 "-DSPIRV-Headers_SOURCE_DIR={repo_dir}/../SPIRV-Headers",
                 "-DSPIRV_WERROR=OFF"
             ],
-            "commit": "d5f69dba559822c2c968a959238ab037b5556af6"
+            "commit": "9e627132a8f17dedab6580f666cebc141396a344"
         },
         {
             "name": "robin-hood-hashing",


### PR DESCRIPTION
This is a test change, updating these dependencies to the last commit before a GPU-AV ABI change.