### PR TITLE
layers: Only read relevant settings

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -308,6 +308,8 @@ target_sources(VkLayer_khronos_validation PRIVATE
     sync/sync_vuid_maps.cpp
     sync/sync_vuid_maps.h
     layer_options.cpp
+    layer_options.h
+    layer_settings_utils.h
     vk_layer_settings_ext.h
 )
 get_target_property(LAYER_SOURCES VkLayer_khronos_validation SOURCES)

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include "generated/chassis.h"
 
 extern std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info;

--- a/layers/layer_settings_utils.h
+++ b/layers/layer_settings_utils.h
@@ -1,0 +1,70 @@
+/**************************************************************************
+ *
+ * Copyright 2014-2023 Valve Software
+ * Copyright 2015-2022 Google Inc.
+ * Copyright 2019-2023 LunarG, Inc.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **************************************************************************/
+
+#pragma once
+
+#include "layer_options.h"
+#include <cstdlib>
+#include <cassert>
+
+static inline std::string GetNextToken(std::string *token_list, const std::string &delimiter, size_t *pos) {
+    assert(!delimiter.empty());
+
+    std::string token;
+    *pos = token_list->find(delimiter);
+    if (*pos != std::string::npos) {
+        token = token_list->substr(0, *pos);
+    } else {
+        *pos = token_list->length() - delimiter.length();
+        token = *token_list;
+    }
+    token_list->erase(0, *pos + delimiter.length());
+
+    // Remove quotes from quoted strings
+    if ((token.length() > 0) && (token[0] == '\"')) {
+        token.erase(token.begin());
+        if ((token.length() > 0) && (token[token.length() - 1] == '\"')) {
+            token.erase(--token.end());
+        }
+    }
+    return token;
+}
+
+static inline std::string FindDelimiter(const std::string &setting_values) {
+    if (setting_values.find(";")) {
+        return ";"; // Typically WIN32 env var
+    } else if (setting_values.find(":")) {
+        return ":"; // Typically UNIX env var
+    } else {
+        return ",";
+    }
+}
+
+static inline uint32_t TokenToUint(const std::string &token) {
+    assert(!token.empty());
+
+    uint32_t int_id = 0;
+    if ((token.find("0x") == 0) || token.find("0X") == 0) {  // Handle hex format
+        int_id = static_cast<uint32_t>(std::strtoul(token.c_str(), nullptr, 16));
+    } else {
+        int_id = static_cast<uint32_t>(std::strtoul(token.c_str(), nullptr, 10));  // Decimal format
+    }
+    return int_id;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     positive/image.cpp
     positive/instance.cpp
     positive/layer_utils.cpp
+    positive/layer_settings_utils.cpp
     positive/memory.cpp
     positive/mesh.cpp
     positive/other.cpp

--- a/tests/positive/layer_settings_utils.cpp
+++ b/tests/positive/layer_settings_utils.cpp
@@ -1,0 +1,49 @@
+
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+#include "layer_settings_utils.h"
+
+class PositiveLayerSettingUtils : public VkPositiveLayerTest {};
+
+// These test check utils in the layer without needing to create a full Vulkan instance
+
+TEST_F(PositiveLayerSettingUtils, GetNextToken_list) {
+	TEST_DESCRIPTION("Test GetNextToken");
+
+	std::string token_list = "token1,token2";
+	std::size_t pos = 0;
+
+	ASSERT_STREQ("token1", GetNextToken(&token_list, ",", &pos).c_str());
+	ASSERT_STREQ("token2", GetNextToken(&token_list, ",", &pos).c_str());
+	ASSERT_TRUE(token_list.empty());
+
+    ASSERT_STREQ("", GetNextToken(&token_list, ",", &pos).c_str()); // token_list is empty, return an empty value
+}
+
+TEST_F(PositiveLayerSettingUtils, FindDelimiter) {
+    TEST_DESCRIPTION("Test FindDelimiter");
+
+    ASSERT_STREQ(",", FindDelimiter("token1,token2").c_str());
+    ASSERT_STREQ(";", FindDelimiter("token1;token2").c_str());
+    ASSERT_STREQ(":", FindDelimiter("token1:token2").c_str());
+    ASSERT_STREQ(",", FindDelimiter("token1").c_str()); // If the token doesn't have a known seprator, we return "," by default
+    ASSERT_STREQ(",", FindDelimiter("").c_str());
+}
+
+TEST_F(PositiveLayerSettingUtils, TokenToUint) {
+    TEST_DESCRIPTION("Test TokenToUint");
+
+    ASSERT_EQ(255, TokenToUint("0xFF"));
+    ASSERT_EQ(255, TokenToUint("0XFF"));
+    ASSERT_EQ(255, TokenToUint("255"));
+}


### PR DESCRIPTION
Layers settings using environment variables on Android is slow. This is causing some C.I. performance issues.

To resolve this, we are now reading only settings which dependences are met.

Also, if legacy 'enables' and 'disables' settings are set, then we don't read the new settings.

WIP: Adding some unit tests on utility functions