### PR TITLE
gpu: Split descriptor set status into separate buffers

### DIFF
--- a/build-android/known_good.json
+++ b/build-android/known_good.json
@@ -22,7 +22,7 @@
             "name": "SPIRV-Tools",
             "url": "https://github.com/KhronosGroup/SPIRV-Tools.git",
             "sub_dir": "shaderc/third_party/spirv-tools",
-            "commit": "d5f69dba559822c2c968a959238ab037b5556af6"
+            "commit": "d4c0abdcad60325a2ab3c00a81847e2dbdc927a2"
         },
         {
             "name": "SPIRV-Headers",

--- a/layers/generated/spirv_tools_commit_id.h
+++ b/layers/generated/spirv_tools_commit_id.h
@@ -22,4 +22,4 @@
  ****************************************************************************/
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "d5f69dba559822c2c968a959238ab037b5556af6"
+#define SPIRV_TOOLS_COMMIT_ID "d4c0abdcad60325a2ab3c00a81847e2dbdc927a2"

--- a/layers/gpu_validation/gpu_utils.h
+++ b/layers/gpu_validation/gpu_utils.h
@@ -78,7 +78,8 @@ class CommandBuffer : public CMD_BUFFER_STATE {
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkQueue, gpu_utils_state::Queue, QUEUE_STATE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, gpu_utils_state::CommandBuffer, CMD_BUFFER_STATE)
 
-VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, VmaAllocator *pAllocator);
+VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, bool use_buffer_device_address,
+                           VmaAllocator *pAllocator);
 
 void UtilGenerateStageMessage(const uint32_t *debug_record, std::string &msg);
 void UtilGenerateCommonMessage(const debug_report_data *report_data, const VkCommandBuffer commandBuffer,
@@ -214,6 +215,7 @@ class GpuAssistedBase : public ValidationStateTracker {
 
   public:
     bool aborted = false;
+    bool force_buffer_device_address;
     PFN_vkSetDeviceLoaderData vkSetDeviceLoaderData;
     const char *setup_vuid;
     VkPhysicalDeviceFeatures supported_features{};

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -28,6 +28,12 @@ struct GpuAssistedDeviceMemoryBlock {
     vvl::unordered_map<uint32_t, const cvdescriptorset::DescriptorBinding*> update_at_submit;
 };
 
+struct GpuAssistedInputBuffers {
+    VkBuffer address_buffer;
+    VmaAllocation address_buffer_allocation;
+    std::vector<GpuAssistedDeviceMemoryBlock> descriptor_set_buffers;
+};
+
 struct GpuAssistedPreDrawResources {
     VkDescriptorPool desc_pool = VK_NULL_HANDLE;
     VkDescriptorSet desc_set = VK_NULL_HANDLE;
@@ -149,7 +155,7 @@ namespace gpuav_state {
 class CommandBuffer : public gpu_utils_state::CommandBuffer {
   public:
     std::vector<GpuAssistedBufferInfo> per_draw_buffer_list;
-    std::vector<GpuAssistedDeviceMemoryBlock> di_input_buffer_list;
+    std::vector<GpuAssistedInputBuffers> di_input_buffer_list;
     std::vector<GpuAssistedAccelerationStructureBuildValidationBufferInfo> as_validation_buffers;
     VkBuffer current_input_buffer = VK_NULL_HANDLE;
 
@@ -179,6 +185,7 @@ class GpuAssisted : public GpuAssistedBase {
         desired_features.vertexPipelineStoresAndAtomics = true;
         desired_features.fragmentStoresAndAtomics = true;
         desired_features.shaderInt64 = true;
+        force_buffer_device_address = true;
     }
 
     bool CheckForDescriptorIndexing(DeviceFeatures enabled_features) const;

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -37,7 +37,7 @@
                 "-DSPIRV-Headers_SOURCE_DIR={repo_dir}/../SPIRV-Headers",
                 "-DSPIRV_WERROR=OFF"
             ],
-            "commit": "d5f69dba559822c2c968a959238ab037b5556af6"
+            "commit": "d4c0abdcad60325a2ab3c00a81847e2dbdc927a2"
         },
         {
             "name": "robin-hood-hashing",

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -2515,6 +2515,7 @@ std::pair<VkBufferObj &&, VkAccelerationStructureGeometryKHR> GetSimpleAABB(cons
 }
 
 void VkLayerTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);

--- a/tests/negative/gpu_av.cpp
+++ b/tests/negative/gpu_av.cpp
@@ -827,6 +827,9 @@ void VkGpuAssistedLayerTest::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDe
     if (IsPlatform(kGalaxyS10)) {
         GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
+    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on Shield TV";
+    }
 
     VkPhysicalDeviceFeatures features = {};  // Make sure robust buffer access is not enabled
     ASSERT_NO_FATAL_FAILURE(InitState(&features));
@@ -1744,6 +1747,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
+    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on Shield TV";
+    }
     auto indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
     auto inline_uniform_block_features = LvlInitStruct<VkPhysicalDeviceInlineUniformBlockFeaturesEXT>(&indexing_features);
     auto features2 = GetPhysicalDeviceFeatures2(inline_uniform_block_features);
@@ -2042,6 +2048,9 @@ TEST_F(VkGpuAssistedLayerTest, DrawingWithUnboundUnusedSet) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
+    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on Shield TV";
+    }
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     if (DeviceValidationVersion() != VK_API_VERSION_1_1) {
@@ -2107,10 +2116,14 @@ TEST_F(VkGpuAssistedLayerTest, DrawingWithUnboundUnusedSet) {
 
 TEST_F(VkGpuAssistedLayerTest, DispatchIndirectWorkgroupSize) {
     TEST_DESCRIPTION("GPU validation: Validate VkDispatchIndirectCommand");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     VkValidationFeaturesEXT validation_features = GetValidationFeatures();
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, &validation_features));
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "GPU-Assisted validation test requires a driver that can draw.";
+    }
+    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on Shield TV";
     }
 
     PFN_vkSetPhysicalDeviceLimitsEXT fpvkSetPhysicalDeviceLimitsEXT = nullptr;
@@ -2221,6 +2234,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPL) {
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on Shield TV";
     }
 
     auto robustness2_features = LvlInitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
@@ -2398,6 +2414,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPLIndependentSets) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(nullptr, &validation_features));
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
+    }
+    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on Shield TV";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";

--- a/tests/positive/gpu_av.cpp
+++ b/tests/positive/gpu_av.cpp
@@ -30,6 +30,9 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOBindDescriptor) {
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
+    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on Shield TV";
+    }
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -131,6 +134,9 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOPushDescriptor) {
     }
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
+    }
+    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+        GTEST_SKIP() << "This test should not run on Shield TV";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());


### PR DESCRIPTION
Split per-DescriptorSet state into separate memory blocks which are accessed via an array of buffer device addresses. This is being done to make it easier to update state for a single DescriptorSet without rebuilding the old giant flat buffer.

NOTE: This change requires SPIRV-Tools to be updated