### PR TITLE
DepthTestEnable overrides DepthWriteEnable

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -185,6 +185,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     CBDynamicFlags static_status;   // All state bits provided by current graphics pipeline
                                     // rather than dynamic state
     CBDynamicFlags dynamic_status;  // dynamic state set up in pipeline
+
+    // These are values that are being set with vkCmdSet* tied to a command buffer
     struct DynamicStateValue {
         // VK_DYNAMIC_STATE_STENCIL_WRITE_MASK
         uint32_t write_mask_front;

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -860,3 +860,17 @@ void LAST_BOUND_STATE::Reset() {
     push_descriptor_set.reset();
     per_set.clear();
 }
+
+bool LAST_BOUND_STATE::IsDepthTestEnable() const {
+    return pipeline_state->IsDynamic(VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE) ? cb_state.dynamic_state_value.depth_test_enable
+                                                                         : pipeline_state->DepthStencilState()->depthTestEnable;
+}
+
+bool LAST_BOUND_STATE::IsDepthWriteEnable() const {
+    // "Depth writes are always disabled when depthTestEnable is VK_FALSE"
+    if (!IsDepthTestEnable()) {
+        return false;
+    }
+    return pipeline_state->IsDynamic(VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE) ? cb_state.dynamic_state_value.depth_write_enable
+                                                                          : pipeline_state->DepthStencilState()->depthWriteEnable;
+}

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -477,12 +477,8 @@ class PIPELINE_STATE : public BASE_NODE {
     static StageStateVec GetStageStates(const ValidationStateTracker &state_data, const PIPELINE_STATE &pipe_state,
                                         CreateShaderModuleStates *csm_states);
 
-<<<<<<< HEAD
     // Return true if for a given PSO, the given state enum is dynamic, else return false
     bool IsDynamic(const VkDynamicState state) const { return dynamic_state.test(ConvertToCBDynamicState(state)); }
-=======
-    bool IsDynamic(const VkDynamicState state) const;
->>>>>>> 579d51609 (layers: DepthTestEnable overrides DepthWriteEnable)
 
     template <typename ValidationObject, typename CreateInfo>
     static bool EnablesRasterizationStates(const ValidationObject &vo, const CreateInfo &create_info) {

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -477,8 +477,12 @@ class PIPELINE_STATE : public BASE_NODE {
     static StageStateVec GetStageStates(const ValidationStateTracker &state_data, const PIPELINE_STATE &pipe_state,
                                         CreateShaderModuleStates *csm_states);
 
+<<<<<<< HEAD
     // Return true if for a given PSO, the given state enum is dynamic, else return false
     bool IsDynamic(const VkDynamicState state) const { return dynamic_state.test(ConvertToCBDynamicState(state)); }
+=======
+    bool IsDynamic(const VkDynamicState state) const;
+>>>>>>> 579d51609 (layers: DepthTestEnable overrides DepthWriteEnable)
 
     template <typename ValidationObject, typename CreateInfo>
     static bool EnablesRasterizationStates(const ValidationObject &vo, const CreateInfo &create_info) {
@@ -718,6 +722,10 @@ struct LAST_BOUND_STATE {
     void UnbindAndResetPushDescriptorSet(std::shared_ptr<cvdescriptorset::DescriptorSet> &&ds);
 
     inline bool IsUsing() const { return pipeline_state != nullptr; }
+
+    // Dynamic State helpers that require both the Pipeline and CommandBuffer state are here
+    bool IsDepthTestEnable() const;
+    bool IsDepthWriteEnable() const;
 };
 
 static inline bool IsBoundSetCompat(uint32_t set, const LAST_BOUND_STATE &last_bound,

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -51,6 +51,7 @@ VkRenderFramework::VkRenderFramework()
       m_height(256),  // default window height
       m_render_target_fmt(VK_FORMAT_R8G8B8A8_UNORM),
       m_depth_stencil_fmt(VK_FORMAT_UNDEFINED),
+      m_depth_stencil_layout(VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL),
       m_clear_via_load_op(true),
       m_depth_clear_color(1.0),
       m_stencil_clear_color(0),
@@ -926,8 +927,8 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
         att.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         att.stencilLoadOp = (m_clear_via_load_op) ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
         att.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
-        att.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-        att.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        att.initialLayout = m_depth_stencil_layout;
+        att.finalLayout = m_depth_stencil_layout;
         attachments.push_back(att);
 
         clear.depthStencil.depth = m_depth_clear_color;
@@ -937,7 +938,7 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, VkImageView *dsBindin
         bindings.push_back(*dsBinding);
 
         ds_reference.attachment = targets;
-        ds_reference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        ds_reference.layout = m_depth_stencil_layout;
         subpass.pDepthStencilAttachment = &ds_reference;
     } else {
         subpass.pDepthStencilAttachment = NULL;

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -273,6 +273,7 @@ class VkRenderFramework : public VkTestFramework {
     uint32_t m_width, m_height;
     VkFormat m_render_target_fmt;
     VkFormat m_depth_stencil_fmt;
+    VkImageLayout m_depth_stencil_layout;
     VkClearColorValue m_clear_color;
     bool m_clear_via_load_op;
     float m_depth_clear_color;

--- a/tests/negative/command.cpp
+++ b/tests/negative/command.cpp
@@ -6645,6 +6645,7 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
     render_pass.init(*m_device, rp_ci);
 
     auto depth_state_info = LvlInitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    depth_state_info.depthTestEnable = VK_TRUE;
     depth_state_info.depthWriteEnable = VK_TRUE;
 
     auto stencil_state_info = LvlInitStruct<VkPipelineDepthStencilStateCreateInfo>();


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5783

There is a lot more work to follow-up with the PR after, but for now, it adds a proper check to `LAST_BOUND_STATE` to check if `DepthWriteEnable` is really set or not