### PR TITLE
layers: Add condition to validate clear attachments

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -953,7 +953,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
 
                     color_attachment_count = subpass_desc->colorAttachmentCount;
 
-                    if (subpass_desc->pDepthStencilAttachment &&
+                    if (framebuffer && subpass_desc->pDepthStencilAttachment &&
                         (subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED)) {
                         depth_view_state =
                             cb_state.GetActiveAttachmentImageViewState(subpass_desc->pDepthStencilAttachment->attachment);


### PR DESCRIPTION
Issue with `VkCmdClearAttachments` was spotted after changing VL version to 1.3.243 and higher.
This is very similar to issue #657.

While using `VkCmdClearAttachments` in secondary command buffer with null in framebuffer pointer at inheritance structure I see that application is crashing in `CoreChecks::PreCallValidateCmdClearAttachments`. VL are trying to operate on image view's that comes from framebuffer pointer which is NULL.

I propose to add additional conditions to if statement for covering that case (skip checking framebuffer related objects when framebuffer pointer is NULL).