### PR TITLE
macOS portability fixes

### DIFF
--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -64,17 +64,29 @@ bool StatelessValidation::ValidateInstanceExtensions(const VkInstanceCreateInfo 
     InstanceExtensions local_instance_extensions;
     local_instance_extensions.InitFromInstanceCreateInfo(specified_version, pCreateInfo);
 
+    printf("Instance extension count = %d\n", pCreateInfo->enabledExtensionCount);
+    
+
     for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
         skip |= ValidateExtensionReqs(local_instance_extensions, "VUID-vkCreateInstance-ppEnabledExtensionNames-01388", "instance",
                                       pCreateInfo->ppEnabledExtensionNames[i]);
     }
+    printf("TESTING....\n\n");
+    if (pCreateInfo->flags & VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR)
+        printf("Flag is set\n");
+    
+    // This comes back 1, It should not be, no one is seeing it. I'm even hard coding enabledExtensionsCount == 0 and
+    // ppEnabledExtensionNames = nullptr;
+    printf("Enumeration flag: %d\n",local_instance_extensions.vk_khr_portability_enumeration);
+    
     if (pCreateInfo->flags & VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR &&
         !local_instance_extensions.vk_khr_portability_enumeration) {
+        printf("SHOULD HAVE TRIGGERED\n");
         skip |= LogError(instance, "VUID-VkInstanceCreateInfo-flags-06559",
                          "vkCreateInstance(): pCreateInfo->flags has VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR set, but "
                          "pCreateInfo->ppEnabledExtensionNames does not include VK_KHR_portability_enumeration");
     }
-
+    printf("Well, how did I get here? Skip = %d\n", skip);
     return skip;
 }
 

--- a/tests/negative/amd_best_practices.cpp
+++ b/tests/negative/amd_best_practices.cpp
@@ -641,6 +641,11 @@ TEST_F(VkAmdBestPracticesLayerTest, NumberOfSubmissions) {
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     InitSwapchain();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     VkImageCreateInfo img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                                  nullptr,

--- a/tests/negative/arm_best_practices.cpp
+++ b/tests/negative/arm_best_practices.cpp
@@ -901,8 +901,9 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
         GTEST_SKIP() << "Test temporarily disabled on S10 device";
     }
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     InitState();
 

--- a/tests/negative/arm_best_practices.cpp
+++ b/tests/negative/arm_best_practices.cpp
@@ -900,6 +900,9 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
     if (IsPlatform(kGalaxyS10)) {
         GTEST_SKIP() << "Test temporarily disabled on S10 device";
     }
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     InitState();
 

--- a/tests/negative/command.cpp
+++ b/tests/negative/command.cpp
@@ -310,6 +310,10 @@ TEST_F(NegativeCommand, PushConstants) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     VkPipelineLayout pipeline_layout;
     VkPushConstantRange pc_range = {};
@@ -532,6 +536,10 @@ TEST_F(NegativeCommand, SecondaryCommandBufferRerecordedNoReset) {
 TEST_F(NegativeCommand, CascadedInvalidation) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+    
     VkEventCreateInfo eci = LvlInitStruct<VkEventCreateInfo>();
     eci.flags = 0;
     VkEvent event;
@@ -4008,6 +4016,10 @@ TEST_F(NegativeCommand, ResolveInvalidSubresource) {
 TEST_F(NegativeCommand, ResolveImageImageType) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+    
     if (!ImageFormatAndFeaturesSupported(gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                          VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
@@ -5499,6 +5511,10 @@ TEST_F(NegativeCommand, DrawWithoutUpdatePushConstants) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     // push constant range: 0-99
     char const *const vsSource = R"glsl(
@@ -6606,6 +6622,10 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
     TEST_DESCRIPTION("invalid depth stencil state for subpass that uses read only image layout.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
 

--- a/tests/negative/descriptors.cpp
+++ b/tests/negative/descriptors.cpp
@@ -354,6 +354,10 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetIdentitySwizzle) {
     TEST_DESCRIPTION("Test descriptors that need to have identity swizzle set");
     ASSERT_NO_FATAL_FAILURE(Init());
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+    
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
                                            {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
@@ -2456,6 +2460,11 @@ TEST_F(NegativeDescriptors, Maint1BindingSliceOf3DImage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+
 
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
@@ -3349,6 +3358,10 @@ TEST_F(NegativeDescriptors, InlineUniformBlockEXT) {
     AddOptionalExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
     AddOptionalExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required.";

--- a/tests/negative/dynamic_rendering.cpp
+++ b/tests/negative/dynamic_rendering.cpp
@@ -5736,6 +5736,11 @@ TEST_F(NegativeDynamicRendering, InSecondaryCommandBuffers) {
     TEST_DESCRIPTION("Test drawing in secondary command buffers with dynamic rendering");
     InitBasicDynamicRendering();
     if (::testing::Test::IsSkipped()) return;
+    
+    // Fundamental incompatibility with Metal
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     VkFormat format = VK_FORMAT_R32G32B32A32_UINT;
 

--- a/tests/negative/geometry_tessellation.cpp
+++ b/tests/negative/geometry_tessellation.cpp
@@ -26,8 +26,9 @@ TEST_F(NegativeGeometryTessellation, StageMaskGsTsEnabled) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     std::vector<const char *> device_extension_names;
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
     
     auto features = m_device->phy().features();
     // Make sure gs & ts are disabled

--- a/tests/negative/geometry_tessellation.cpp
+++ b/tests/negative/geometry_tessellation.cpp
@@ -26,6 +26,9 @@ TEST_F(NegativeGeometryTessellation, StageMaskGsTsEnabled) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     std::vector<const char *> device_extension_names;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
     auto features = m_device->phy().features();
     // Make sure gs & ts are disabled
     features.geometryShader = false;

--- a/tests/negative/gpu_av.cpp
+++ b/tests/negative/gpu_av.cpp
@@ -1744,6 +1744,11 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+
     auto indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
     auto inline_uniform_block_features = LvlInitStruct<VkPhysicalDeviceInlineUniformBlockFeaturesEXT>(&indexing_features);
     auto features2 = GetPhysicalDeviceFeatures2(inline_uniform_block_features);

--- a/tests/negative/imageless_framebuffer.cpp
+++ b/tests/negative/imageless_framebuffer.cpp
@@ -1400,6 +1400,11 @@ TEST_F(NegativeImagelessFramebuffer, Image3D) {
         GTEST_SKIP() << "multiview feature not supported";
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+
 
     VkSubpassDescription subpass = {};
 

--- a/tests/negative/instanceless.cpp
+++ b/tests/negative/instanceless.cpp
@@ -218,10 +218,19 @@ void VKAPI_PTR DummyInfoFree(void*, size_t, VkInternalAllocationType, VkSystemAl
 TEST_F(NegativeInstanceless, DestroyInstanceAllocationCallbacksCompatibility) {
     TEST_DESCRIPTION("Test vkDestroyInstance with incompatible allocation callbacks.");
 
-    const auto ici = GetInstanceCreateInfo();
+    auto ici = GetInstanceCreateInfo();
     const VkAllocationCallbacks alloc_callbacks = {nullptr,    &DummyAlloc,     &DummyRealloc,
                                                    &DummyFree, &DummyInfoAlloc, &DummyInfoFree};
 
+    std::vector<const char *> extNames;
+    if (InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        extNames.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+        ici.enabledExtensionCount = (int)extNames.size();
+        ici.ppEnabledExtensionNames = extNames.data();
+        ici.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+        }
+
+    
     {
         VkInstance instance;
         ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &instance));

--- a/tests/negative/others.cpp
+++ b/tests/negative/others.cpp
@@ -2848,30 +2848,23 @@ TEST_F(VkLayerTest, InstanceCreateEnumeratePortability) {
     TEST_DESCRIPTION("Validate creating instances with VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR.");
 
     auto ici = GetInstanceCreateInfo();
-    ici.enabledExtensionCount = 0;      // Must whip out to get the error
-    ici.ppEnabledExtensionNames = nullptr;
     ici.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-    
+    ici.enabledExtensionCount = 0;
     VkInstance local_instance = VK_NULL_HANDLE;
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkInstanceCreateInfo-flags-06559");
-    vk::CreateInstance(&ici, nullptr, &local_instance);
-    m_errorMonitor->VerifyFound();
-
     if (InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
-//        std::vector<const char *> enabled_extensions;
-//        for (uint32_t i = 0; i < ici.enabledExtensionCount; ++i) {
-//            enabled_extensions.push_back(ici.ppEnabledExtensionNames[i]);
-//        }
-//        enabled_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-//
-//        ici.enabledExtensionCount++;
-        //ici.ppEnabledExtensionNames = enabled_extensions.data();
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkInstanceCreateInfo-flags-06559");
+        vk::CreateInstance(&ici, nullptr, &local_instance);
+        m_errorMonitor->VerifyFound();
+        printf("Local instance handle == %d\n", local_instance);
+    }
+    
+    if (InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
         std::vector<const char *> enabled_extensions = {VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME};
         ici.enabledExtensionCount = 1;
         ici.ppEnabledExtensionNames = enabled_extensions.data();
         
         ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &local_instance));
+        printf("Local instance handle (2nd time) == %d\n", local_instance);
         vk::DestroyInstance(local_instance, nullptr);
     }
 }

--- a/tests/negative/others.cpp
+++ b/tests/negative/others.cpp
@@ -1244,6 +1244,10 @@ TEST_F(VkLayerTest, UseObjectWithWrongDevice) {
     queue_info.queueFamilyIndex = 0;
     queue_info.queueCount = 1;
     queue_info.pQueuePriorities = &priorities[0];
+    
+    std::vector<const char *> device_extensions;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>();
     auto features = m_device->phy().features();
@@ -1252,6 +1256,9 @@ TEST_F(VkLayerTest, UseObjectWithWrongDevice) {
     device_create_info.enabledLayerCount = 0;
     device_create_info.ppEnabledLayerNames = NULL;
     device_create_info.pEnabledFeatures = &features;
+    
+    device_create_info.ppEnabledExtensionNames = device_extensions.data();
+    device_create_info.enabledExtensionCount = device_extensions.size();
 
     VkDevice second_device;
     ASSERT_VK_SUCCESS(vk::CreateDevice(gpu(), &device_create_info, NULL, &second_device));
@@ -1369,10 +1376,22 @@ TEST_F(VkLayerTest, DeviceFeature2AndVertexAttributeDivisorExtensionUnenabled) {
     VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>();
 
     ASSERT_NO_FATAL_FAILURE(Init());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    
     vk_testing::QueueCreateInfoArray queue_info(m_device->queue_props);
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>(&pd_features2);
+    
+    std::vector<const char *> device_extensions;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
     device_create_info.queueCreateInfoCount = queue_info.size();
     device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.ppEnabledExtensionNames = device_extensions.data();
+    device_create_info.enabledExtensionCount = device_extensions.size();
+    
     VkDevice testDevice;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-pNext-pNext");
     m_errorMonitor->SetUnexpectedError("Failed to create device chain");
@@ -1435,9 +1454,15 @@ TEST_F(VkLayerTest, Features12Features13AndpNext) {
         }
     }
 
+    std::vector<const char *> device_extensions;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>(&features12);
     device_create_info.queueCreateInfoCount = queue_info.size();
     device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.ppEnabledExtensionNames = device_extensions.data();
+    device_create_info.enabledExtensionCount = device_extensions.size();
     VkDevice testDevice;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-pNext-02829");
@@ -1522,6 +1547,9 @@ TEST_F(VkLayerTest, RequiredPromotedFeaturesExtensions) {
         m_errorMonitor->SetUnexpectedError("VUID-VkDeviceCreateInfo-pNext-pNext");
     }
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>(&features11);
     device_create_info.queueCreateInfoCount = queue_info.size();
     device_create_info.pQueueCreateInfos = queue_info.data();
@@ -1540,6 +1568,7 @@ TEST_F(VkLayerTest, FeaturesVariablePointer) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME);
+    
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -1549,6 +1578,10 @@ TEST_F(VkLayerTest, FeaturesVariablePointer) {
     device_extensions.push_back(VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME);
     device_extensions.push_back(VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME);
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
+    
     // Create a device that enables variablePointers but not variablePointersStorageBuffer
     auto variable_features = LvlInitStruct<VkPhysicalDeviceVariablePointersFeatures>();
     auto features2 = GetPhysicalDeviceFeatures2(variable_features);
@@ -1971,7 +2004,14 @@ TEST_F(VkLayerTest, Maintenance1AndNegativeViewport) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     vk_testing::QueueCreateInfoArray queue_info(m_device->queue_props);
-    const char *extension_names[2] = {"VK_KHR_maintenance1", "VK_AMD_negative_viewport_height"};
+    
+    std::vector<const char *> device_extensions;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
+    device_extensions.push_back("VK_KHR_maintenance1");
+    device_extensions.push_back("VK_AMD_negative_viewport_height");
+    
     VkDevice testDevice;
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>();
     auto features = m_device->phy().features();
@@ -1979,8 +2019,8 @@ TEST_F(VkLayerTest, Maintenance1AndNegativeViewport) {
     device_create_info.pQueueCreateInfos = queue_info.data();
     device_create_info.enabledLayerCount = 0;
     device_create_info.ppEnabledLayerNames = NULL;
-    device_create_info.enabledExtensionCount = 2;
-    device_create_info.ppEnabledExtensionNames = (const char *const *)extension_names;
+    device_create_info.enabledExtensionCount = device_extensions.size();
+    device_create_info.ppEnabledExtensionNames = device_extensions.data();
     device_create_info.pEnabledFeatures = &features;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-00374");
@@ -2008,15 +2048,21 @@ TEST_F(VkLayerTest, ApiVersion1_1AndNegativeViewport) {
     vk_testing::PhysicalDevice physical_device(gpu_);
     VkPhysicalDeviceFeatures features = physical_device.features();
     vk_testing::QueueCreateInfoArray queue_info(physical_device.queue_properties());
-    const char *extension_names[1] = {VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME};
+    
+    std::vector<const char *> device_extensions;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
+    device_extensions.push_back(VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME);
+    
     VkDevice testDevice;
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>();
     device_create_info.queueCreateInfoCount = queue_info.size();
     device_create_info.pQueueCreateInfos = queue_info.data();
     device_create_info.enabledLayerCount = 0;
     device_create_info.ppEnabledLayerNames = NULL;
-    device_create_info.enabledExtensionCount = 1;
-    device_create_info.ppEnabledExtensionNames = (const char *const *)extension_names;
+    device_create_info.enabledExtensionCount = device_extensions.size();
+    device_create_info.ppEnabledExtensionNames = device_extensions.data();
     device_create_info.pEnabledFeatures = &features;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-01840");
@@ -2031,6 +2077,10 @@ TEST_F(VkLayerTest, ResetEventThenSet) {
     TEST_DESCRIPTION("Reset an event then set it after the reset has been submitted.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    
     VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
     vk_testing::Event event(*m_device, event_create_info);
 
@@ -2291,6 +2341,9 @@ TEST_F(VkLayerTest, ValidateArrayLength) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     // Used to have a valid pointed to set object too
     VkCommandBuffer unused_command_buffer;
@@ -2537,11 +2590,18 @@ TEST_F(VkLayerTest, InvalidCombinationOfDeviceFeatures) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
+    
+    std::vector<const char *> device_extensions;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
     vk_testing::QueueCreateInfoArray queue_info(m_device->queue_props);
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>();
     device_create_info.pNext = &pd_features2;
     device_create_info.queueCreateInfoCount = queue_info.size();
     device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.ppEnabledExtensionNames = device_extensions.data();
+    device_create_info.enabledExtensionCount = device_extensions.size();
 
     {
         VkDevice testDevice;
@@ -2636,14 +2696,19 @@ TEST_F(VkLayerTest, Features12AndppEnabledExtensionNames) {
     queue_info.queueFamilyIndex = 0;
     queue_info.queueCount = 1;
     queue_info.pQueuePriorities = &priority;
+    
+    std::vector<const char *> device_extensions;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
+    device_extensions.push_back(VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
 
-    const char *enabled_ext = VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME;
 
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>(&features12);
     device_create_info.queueCreateInfoCount = 1;
     device_create_info.pQueueCreateInfos = &queue_info;
-    device_create_info.enabledExtensionCount = 1;
-    device_create_info.ppEnabledExtensionNames = &enabled_ext;
+    device_create_info.enabledExtensionCount = device_extensions.size();
+    device_create_info.ppEnabledExtensionNames = device_extensions.data();
 
     VkDevice testDevice;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-pNext-04748");

--- a/tests/negative/others.cpp
+++ b/tests/negative/others.cpp
@@ -1755,7 +1755,11 @@ TEST_F(VkLayerTest, StageMaskHost) {
     TEST_DESCRIPTION("Test invalid usage of VK_PIPELINE_STAGE_HOST_BIT.");
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+    
     VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
     vk_testing::Event event(*m_device, event_create_info);
     ASSERT_TRUE(event.initialized());
@@ -1812,6 +1816,10 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+    
     // Calls AllocateCommandBuffers
     VkCommandBufferObj commandBuffer(m_device, m_commandPool);
 

--- a/tests/negative/others.cpp
+++ b/tests/negative/others.cpp
@@ -1246,8 +1246,9 @@ TEST_F(VkLayerTest, UseObjectWithWrongDevice) {
     queue_info.pQueuePriorities = &priorities[0];
     
     std::vector<const char *> device_extensions;
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
 
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>();
     auto features = m_device->phy().features();
@@ -1377,8 +1378,9 @@ TEST_F(VkLayerTest, DeviceFeature2AndVertexAttributeDivisorExtensionUnenabled) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
     
     vk_testing::QueueCreateInfoArray queue_info(m_device->queue_props);
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>(&pd_features2);
@@ -1455,8 +1457,9 @@ TEST_F(VkLayerTest, Features12Features13AndpNext) {
     }
 
     std::vector<const char *> device_extensions;
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
     
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>(&features12);
     device_create_info.queueCreateInfoCount = queue_info.size();
@@ -1547,8 +1550,9 @@ TEST_F(VkLayerTest, RequiredPromotedFeaturesExtensions) {
         m_errorMonitor->SetUnexpectedError("VUID-VkDeviceCreateInfo-pNext-pNext");
     }
 
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
     
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>(&features11);
     device_create_info.queueCreateInfoCount = queue_info.size();
@@ -1578,9 +1582,9 @@ TEST_F(VkLayerTest, FeaturesVariablePointer) {
     device_extensions.push_back(VK_KHR_VARIABLE_POINTERS_EXTENSION_NAME);
     device_extensions.push_back(VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME);
 
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-    
+    }
     
     // Create a device that enables variablePointers but not variablePointersStorageBuffer
     auto variable_features = LvlInitStruct<VkPhysicalDeviceVariablePointersFeatures>();
@@ -2006,8 +2010,9 @@ TEST_F(VkLayerTest, Maintenance1AndNegativeViewport) {
     vk_testing::QueueCreateInfoArray queue_info(m_device->queue_props);
     
     std::vector<const char *> device_extensions;
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
     
     device_extensions.push_back("VK_KHR_maintenance1");
     device_extensions.push_back("VK_AMD_negative_viewport_height");
@@ -2050,8 +2055,9 @@ TEST_F(VkLayerTest, ApiVersion1_1AndNegativeViewport) {
     vk_testing::QueueCreateInfoArray queue_info(physical_device.queue_properties());
     
     std::vector<const char *> device_extensions;
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
     
     device_extensions.push_back(VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME);
     
@@ -2078,8 +2084,9 @@ TEST_F(VkLayerTest, ResetEventThenSet) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
     
     VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
     vk_testing::Event event(*m_device, event_create_info);
@@ -2592,8 +2599,9 @@ TEST_F(VkLayerTest, InvalidCombinationOfDeviceFeatures) {
     }
     
     std::vector<const char *> device_extensions;
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
     
     vk_testing::QueueCreateInfoArray queue_info(m_device->queue_props);
     VkDeviceCreateInfo device_create_info = LvlInitStruct<VkDeviceCreateInfo>();
@@ -2698,8 +2706,9 @@ TEST_F(VkLayerTest, Features12AndppEnabledExtensionNames) {
     queue_info.pQueuePriorities = &priority;
     
     std::vector<const char *> device_extensions;
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
     
     device_extensions.push_back(VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
 

--- a/tests/negative/others.cpp
+++ b/tests/negative/others.cpp
@@ -495,6 +495,15 @@ TEST_F(VkLayerTest, LayerInfoMessages) {
     TEST_DESCRIPTION("Ensure layer prints startup status messages.");
 
     auto ici = GetInstanceCreateInfo();
+    
+    std::vector<const char *> extNames;
+    if (InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        extNames.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+        ici.enabledExtensionCount = (int)extNames.size();
+        ici.ppEnabledExtensionNames = extNames.data();
+        ici.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+        }
+    
     LayerStatusCheckData callback_data;
     auto local_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, LayerStatusCheckData *data) {
         std::string message(pCallbackData->pMessage);
@@ -2839,24 +2848,29 @@ TEST_F(VkLayerTest, InstanceCreateEnumeratePortability) {
     TEST_DESCRIPTION("Validate creating instances with VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR.");
 
     auto ici = GetInstanceCreateInfo();
+    ici.enabledExtensionCount = 0;      // Must whip out to get the error
+    ici.ppEnabledExtensionNames = nullptr;
     ici.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-
-    VkInstance local_instance;
+    
+    VkInstance local_instance = VK_NULL_HANDLE;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkInstanceCreateInfo-flags-06559");
     vk::CreateInstance(&ici, nullptr, &local_instance);
     m_errorMonitor->VerifyFound();
 
     if (InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
-        std::vector<const char *> enabled_extensions;
-        for (uint32_t i = 0; i < ici.enabledExtensionCount; ++i) {
-            enabled_extensions.push_back(ici.ppEnabledExtensionNames[i]);
-        }
-        enabled_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-
-        ici.enabledExtensionCount++;
+//        std::vector<const char *> enabled_extensions;
+//        for (uint32_t i = 0; i < ici.enabledExtensionCount; ++i) {
+//            enabled_extensions.push_back(ici.ppEnabledExtensionNames[i]);
+//        }
+//        enabled_extensions.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+//
+//        ici.enabledExtensionCount++;
+        //ici.ppEnabledExtensionNames = enabled_extensions.data();
+        std::vector<const char *> enabled_extensions = {VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME};
+        ici.enabledExtensionCount = 1;
         ici.ppEnabledExtensionNames = enabled_extensions.data();
-
+        
         ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &local_instance));
         vk::DestroyInstance(local_instance, nullptr);
     }

--- a/tests/negative/portability_subset.cpp
+++ b/tests/negative/portability_subset.cpp
@@ -510,8 +510,9 @@ TEST_F(VkPortabilitySubsetTest, UpdateDescriptorSets) {
     sampler_info.compareEnable = VK_TRUE;  // Incompatible with portability setting
     vk_testing::Sampler sampler(*m_device, sampler_info);
 
+    constexpr VkFormat img_format = VK_FORMAT_R8G8B8A8_UNORM;
     VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_B4G4R4A4_UNORM_PACK16, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
+    image.Init(32, 32, 1, img_format, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     image.Layout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
@@ -519,7 +520,7 @@ TEST_F(VkPortabilitySubsetTest, UpdateDescriptorSets) {
                                        });
     const VkPipelineLayoutObj pipeline_layout(m_device, {&descriptor_set.layout_});
     vk_testing::ImageView view;
-    auto image_view_create_info = SafeSaneImageViewCreateInfo(image, VK_FORMAT_B4G4R4A4_UNORM_PACK16, VK_IMAGE_ASPECT_COLOR_BIT);
+    auto image_view_create_info = SafeSaneImageViewCreateInfo(image, img_format, VK_IMAGE_ASPECT_COLOR_BIT);
     view.init(*m_device, image_view_create_info);
 
     VkDescriptorImageInfo img_info = {};

--- a/tests/negative/protected_memory.cpp
+++ b/tests/negative/protected_memory.cpp
@@ -445,6 +445,14 @@ TEST_F(NegativeProtectedMemory, GetDeviceQueue) {
     device_create_info.pEnabledFeatures = nullptr;
     device_create_info.enabledLayerCount = 0;
     device_create_info.enabledExtensionCount = 0;
+    
+    std::vector<const char *> device_extensions;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+            
+    device_create_info.ppEnabledExtensionNames = device_extensions.data();
+    device_create_info.enabledExtensionCount = device_extensions.size();
+
 
     // Protect feature not set
     m_errorMonitor->SetUnexpectedError("VUID-VkDeviceQueueCreateInfo-flags-06449");

--- a/tests/negative/shader_spirv.cpp
+++ b/tests/negative/shader_spirv.cpp
@@ -1874,6 +1874,9 @@ TEST_F(VkLayerTest, CreatePipelineCheckFragmentShaderInterlockEnabled) {
     TEST_DESCRIPTION("Create a pipeline requiring the fragment shader interlock feature which has not enabled on the device.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     std::vector<const char *> device_extension_names;
     if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME)) {

--- a/tests/negative/shader_spirv.cpp
+++ b/tests/negative/shader_spirv.cpp
@@ -1875,8 +1875,9 @@ TEST_F(VkLayerTest, CreatePipelineCheckFragmentShaderInterlockEnabled) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     std::vector<const char *> device_extension_names;
     if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME)) {

--- a/tests/negative/sync_object.cpp
+++ b/tests/negative/sync_object.cpp
@@ -1406,8 +1406,9 @@ TEST_F(NegativeSyncObject, ImageBarrierWithBadRange) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     VkImageMemoryBarrier img_barrier_template = LvlInitStruct<VkImageMemoryBarrier>();
     img_barrier_template.srcAccessMask = 0;

--- a/tests/negative/sync_object.cpp
+++ b/tests/negative/sync_object.cpp
@@ -1405,6 +1405,9 @@ TEST_F(NegativeSyncObject, ImageBarrierWithBadRange) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     VkImageMemoryBarrier img_barrier_template = LvlInitStruct<VkImageMemoryBarrier>();
     img_barrier_template.srcAccessMask = 0;

--- a/tests/negative/sync_object.cpp
+++ b/tests/negative/sync_object.cpp
@@ -2252,6 +2252,10 @@ TEST_F(NegativeSyncObject, MixedTimelineAndBinarySemaphores) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     if (!timeline_semaphore_features.timelineSemaphore) {

--- a/tests/negative/sync_val.cpp
+++ b/tests/negative/sync_val.cpp
@@ -855,6 +855,11 @@ TEST_F(NegativeSyncVal, CopyOptimalMultiPlanarHazards) {
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     VkFormat format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;

--- a/tests/negative/ycbcr.cpp
+++ b/tests/negative/ycbcr.cpp
@@ -1335,6 +1335,9 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat) {
     if (IsDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY)) {
         GTEST_SKIP() << "This test should not be run on the NVIDIA proprietary driver.";
     }
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     auto features11 = LvlInitStruct<VkPhysicalDeviceVulkan11Features>();
     GetPhysicalDeviceFeatures2(features11);

--- a/tests/negative/ycbcr.cpp
+++ b/tests/negative/ycbcr.cpp
@@ -1336,8 +1336,9 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat) {
         GTEST_SKIP() << "This test should not be run on the NVIDIA proprietary driver.";
     }
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     auto features11 = LvlInitStruct<VkPhysicalDeviceVulkan11Features>();
     GetPhysicalDeviceFeatures2(features11);

--- a/tests/positive/atomics.cpp
+++ b/tests/positive/atomics.cpp
@@ -191,6 +191,10 @@ TEST_F(PositiveAtomic, Float) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required.";
     }
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+    
     // clang-format off
     std::string cs_32_base = R"glsl(
         #version 450

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -667,8 +667,9 @@ TEST_F(VkPositiveLayerTest, EventStageMaskSecondaryCommandBuffer) {
     TEST_DESCRIPTION("Check secondary command buffers transfer event data when executed by primary ones");
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
     
     VkCommandBufferObj commandBuffer(m_device, m_commandPool);
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -564,6 +564,14 @@ TEST_F(VkPositiveLayerTest, ClearRectWith2DArray) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
+    
+    if (InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        auto portability_features = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+        GetPhysicalDeviceFeatures2(portability_features);
+        
+        if(portability_features.imageView2DOn3DImage == VK_FALSE)
+            GTEST_SKIP() << "Required feature 'imageView2DOn3DImage' not supported by portability extension.";
+        }
 
     for (uint32_t i = 0; i < 2; ++i) {
         VkImageCreateInfo image_ci = LvlInitStruct<VkImageCreateInfo>();
@@ -659,6 +667,9 @@ TEST_F(VkPositiveLayerTest, EventStageMaskSecondaryCommandBuffer) {
     TEST_DESCRIPTION("Check secondary command buffers transfer event data when executed by primary ones");
     ASSERT_NO_FATAL_FAILURE(Init());
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    
     VkCommandBufferObj commandBuffer(m_device, m_commandPool);
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -639,6 +639,10 @@ TEST_F(PositiveDynamicRendering, SuspendPrimaryResumeInSecondary) {
     TEST_DESCRIPTION("Suspend in primary and resume in secondary");
     InitBasicDynamicRendering();
     if (::testing::Test::IsSkipped()) return;
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     VkShaderObj vs(this, bindStateVertShaderText, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, bindStateFragColorOutputText, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -714,6 +718,10 @@ TEST_F(PositiveDynamicRendering, SuspendSecondaryResumeInPrimary) {
     TEST_DESCRIPTION("Suspend in secondary and resume in primary");
     InitBasicDynamicRendering();
     if (::testing::Test::IsSkipped()) return;
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     char const* fsSource = R"glsl(
         #version 450

--- a/tests/positive/image.cpp
+++ b/tests/positive/image.cpp
@@ -373,9 +373,10 @@ TEST_F(VkPositiveLayerTest, TestCreatingFramebufferFrom3DImage) {
         auto portability_features = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
         GetPhysicalDeviceFeatures2(portability_features);
         
-        if(portability_features.imageView2DOn3DImage == VK_FALSE)
+        if(portability_features.imageView2DOn3DImage == VK_FALSE) {
             GTEST_SKIP() << "Required feature 'imageView2DOn3DImage' not supported by portability extension.";
         }
+    }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());

--- a/tests/positive/image.cpp
+++ b/tests/positive/image.cpp
@@ -368,6 +368,15 @@ TEST_F(VkPositiveLayerTest, TestCreatingFramebufferFrom3DImage) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
+    
+    if(InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        auto portability_features = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+        GetPhysicalDeviceFeatures2(portability_features);
+        
+        if(portability_features.imageView2DOn3DImage == VK_FALSE)
+            GTEST_SKIP() << "Required feature 'imageView2DOn3DImage' not supported by portability extension.";
+        }
+
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 

--- a/tests/positive/instance.cpp
+++ b/tests/positive/instance.cpp
@@ -24,7 +24,7 @@ TEST_F(VkPositiveLayerTest, TwoInstances) {
     TEST_DESCRIPTION("Create two instances before destroy");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
+    
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
@@ -34,9 +34,16 @@ TEST_F(VkPositiveLayerTest, TwoInstances) {
     VkInstanceCreateInfo ici = LvlInitStruct<VkInstanceCreateInfo>();
     ici.enabledLayerCount = instance_layers_.size();
     ici.ppEnabledLayerNames = instance_layers_.data();
+    std::vector<const char *> extNames;
+    
+    if (InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        extNames.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+        ici.enabledExtensionCount = (int)extNames.size();
+        ici.ppEnabledExtensionNames = extNames.data();
+        ici.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+    }
 
     ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &i1));
-
     ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &i2));
     ASSERT_NO_FATAL_FAILURE(vk::DestroyInstance(i2, nullptr));
 

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -36,8 +36,9 @@ TEST_F(VkPositiveLayerTest, StatelessValidationDisable) {
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, pool_flags, &features));
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     // Specify 0 for a reserved VkFlags parameter. Normally this is expected to trigger an stateless validation error, but this
     // validation was disabled via the features extension, so no errors should be forthcoming.
@@ -372,8 +373,9 @@ TEST_F(VkPositiveLayerTest, UseFirstQueueUnqueried) {
     queue_ci.pQueuePriorities = q_priority;
 
     std::vector<const char *> device_extensions;
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
     
     VkDeviceCreateInfo device_ci = LvlInitStruct<VkDeviceCreateInfo>();
     device_ci.queueCreateInfoCount = 1;
@@ -419,8 +421,9 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrExtensions) {
     if (nullptr != vkTrimCommandPoolKHR) m_errorMonitor->SetError("Didn't receive expected null pointer");
 
     std::vector<const char *> device_extensions;
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
 
     device_extensions.push_back(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -368,9 +368,15 @@ TEST_F(VkPositiveLayerTest, UseFirstQueueUnqueried) {
     queue_ci.queueCount = 1;
     queue_ci.pQueuePriorities = q_priority;
 
+    std::vector<const char *> device_extensions;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
     VkDeviceCreateInfo device_ci = LvlInitStruct<VkDeviceCreateInfo>();
     device_ci.queueCreateInfoCount = 1;
     device_ci.pQueueCreateInfos = &queue_ci;
+    device_ci.ppEnabledExtensionNames = device_extensions.data();
+    device_ci.enabledExtensionCount = device_extensions.size();
 
     VkDevice test_device;
     vk::CreateDevice(gpu(), &device_ci, nullptr, &test_device);
@@ -409,7 +415,12 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrExtensions) {
     if (nullptr == vkTrimCommandPool) m_errorMonitor->SetError("Unexpected null pointer");
     if (nullptr != vkTrimCommandPoolKHR) m_errorMonitor->SetError("Didn't receive expected null pointer");
 
-    const char *const extension = {VK_KHR_MAINTENANCE_1_EXTENSION_NAME};
+    std::vector<const char *> device_extensions;
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extensions.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+
+    device_extensions.push_back(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
+    
     const float q_priority[] = {1.0f};
     VkDeviceQueueCreateInfo queue_ci = LvlInitStruct<VkDeviceQueueCreateInfo>();
     queue_ci.queueFamilyIndex = 0;
@@ -417,8 +428,8 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrExtensions) {
     queue_ci.pQueuePriorities = q_priority;
 
     VkDeviceCreateInfo device_ci = LvlInitStruct<VkDeviceCreateInfo>();
-    device_ci.enabledExtensionCount = 1;
-    device_ci.ppEnabledExtensionNames = &extension;
+    device_ci.enabledExtensionCount = device_extensions.size();
+    device_ci.ppEnabledExtensionNames = device_extensions.data();
     device_ci.queueCreateInfoCount = 1;
     device_ci.pQueueCreateInfos = &queue_ci;
 

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -35,6 +35,9 @@ TEST_F(VkPositiveLayerTest, StatelessValidationDisable) {
     features.pDisabledValidationFeatures = disables;
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, pool_flags, &features));
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     // Specify 0 for a reserved VkFlags parameter. Normally this is expected to trigger an stateless validation error, but this
     // validation was disabled via the features extension, so no errors should be forthcoming.

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -697,6 +697,10 @@ TEST_F(VkPositiveLayerTest, PSOPolygonModeValid) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     std::vector<const char *> device_extension_names;
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    
     auto features = m_device->phy().features();
     // Artificially disable support for non-solid fill modes
     features.fillModeNonSolid = false;

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -1970,6 +1970,11 @@ TEST_F(VkPositiveLayerTest, PushConstantsCompatibilityGraphicsOnly) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+
 
     char const *const vsSource = R"glsl(
         #version 450
@@ -3885,6 +3890,14 @@ TEST_F(VkPositiveLayerTest, AllowedDuplicateStype) {
     ici.enabledLayerCount = instance_layers_.size();
     ici.ppEnabledLayerNames = instance_layers_.data();
 
+    std::vector<const char *> extNames;
+    if (InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        extNames.push_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+        ici.enabledExtensionCount = (int)extNames.size();
+        ici.ppEnabledExtensionNames = extNames.data();
+        ici.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+        }
+    
     auto dbgUtils0 = LvlInitStruct<VkDebugUtilsMessengerCreateInfoEXT>();
     auto dbgUtils1 = LvlInitStruct<VkDebugUtilsMessengerCreateInfoEXT>(&dbgUtils0);
     ici.pNext = &dbgUtils1;
@@ -4520,6 +4533,10 @@ TEST_F(VkPositiveLayerTest, TopologyAtRasterizer) {
     if (!m_device->phy().features().tessellationShader) {
         GTEST_SKIP() << "Device does not support tessellation shaders";
     }
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     char const *tcsSource = R"glsl(
         #version 450
@@ -4599,6 +4616,10 @@ TEST_F(VkPositiveLayerTest, TestPervertexNVShaderAttributes) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
+    
     VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV fragment_shader_barycentric_features =
         LvlInitStruct<VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV>();
     fragment_shader_barycentric_features.fragmentShaderBarycentric = VK_TRUE;
@@ -5012,6 +5033,10 @@ TEST_F(VkPositiveLayerTest, TestShaderInputOutputMatch) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     const char vsSource[] = R"glsl(#version 450
 

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -4155,6 +4155,9 @@ TEST_F(VkPositiveLayerTest, ImageDescriptor3D2DSubresourceLayout) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -698,8 +698,9 @@ TEST_F(VkPositiveLayerTest, PSOPolygonModeValid) {
 
     std::vector<const char *> device_extension_names;
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         device_extension_names.push_back(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
+    }
     
     auto features = m_device->phy().features();
     // Artificially disable support for non-solid fill modes
@@ -4156,8 +4157,9 @@ TEST_F(VkPositiveLayerTest, ImageDescriptor3D2DSubresourceLayout) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -1356,9 +1356,10 @@ TEST_F(VkPositiveLayerTest, FramebufferWithAttachmentsTo3DImageMultipleSubpasses
         auto portability_features = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
         GetPhysicalDeviceFeatures2(portability_features);
         
-        if(portability_features.imageView2DOn3DImage == VK_FALSE)
+        if(portability_features.imageView2DOn3DImage == VK_FALSE) {
             GTEST_SKIP() << "Required feature 'imageView2DOn3DImage' not supported by portability extension.";
         }
+    }
 
     constexpr unsigned depth_count = 2u;
 

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -1351,6 +1351,14 @@ TEST_F(VkPositiveLayerTest, FramebufferWithAttachmentsTo3DImageMultipleSubpasses
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " required extensions not supported.";
     }
+    
+    if(InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
+        auto portability_features = LvlInitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+        GetPhysicalDeviceFeatures2(portability_features);
+        
+        if(portability_features.imageView2DOn3DImage == VK_FALSE)
+            GTEST_SKIP() << "Required feature 'imageView2DOn3DImage' not supported by portability extension.";
+        }
 
     constexpr unsigned depth_count = 2u;
 

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -1077,6 +1077,9 @@ TEST_F(VkPositiveLayerTest, LoosePointSizeWrite) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     const char *LoosePointSizeWrite = R"(
                                        OpCapability Shader
@@ -1975,6 +1978,9 @@ TEST_F(VkPositiveLayerTest, OpTypeArraySpecConstant) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     std::stringstream spv_source;
     spv_source << R"(

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -1305,6 +1305,10 @@ TEST_F(VkPositiveLayerTest, TestShaderInputAndOutputComponents) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     char const *vsSource = R"glsl(
                 #version 450

--- a/tests/positive/shaderval.cpp
+++ b/tests/positive/shaderval.cpp
@@ -1078,8 +1078,9 @@ TEST_F(VkPositiveLayerTest, LoosePointSizeWrite) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     const char *LoosePointSizeWrite = R"(
                                        OpCapability Shader
@@ -1979,8 +1980,9 @@ TEST_F(VkPositiveLayerTest, OpTypeArraySpecConstant) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     std::stringstream spv_source;
     spv_source << R"(

--- a/tests/positive/sync_object.cpp
+++ b/tests/positive/sync_object.cpp
@@ -1724,6 +1724,9 @@ TEST_F(VkPositiveLayerTest, WaitEventThenSet) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    
     VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
     vk_testing::Event event(*m_device, event_create_info);
 

--- a/tests/positive/sync_object.cpp
+++ b/tests/positive/sync_object.cpp
@@ -1724,8 +1724,9 @@ TEST_F(VkPositiveLayerTest, WaitEventThenSet) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
     
     VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
     vk_testing::Event event(*m_device, event_create_info);

--- a/tests/positive/vertex_input.cpp
+++ b/tests/positive/vertex_input.cpp
@@ -109,6 +109,10 @@ TEST_F(VkPositiveLayerTest, CreatePipelineAttribComponents) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     VkVertexInputBindingDescription input_binding;
     memset(&input_binding, 0, sizeof(input_binding));

--- a/tests/positive/vertex_input.cpp
+++ b/tests/positive/vertex_input.cpp
@@ -19,6 +19,9 @@ TEST_F(VkPositiveLayerTest, CreatePipelineAttribMatrixType) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     VkVertexInputBindingDescription input_binding;
     memset(&input_binding, 0, sizeof(input_binding));
@@ -59,6 +62,9 @@ TEST_F(VkPositiveLayerTest, CreatePipelineAttribArrayType) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+        GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
 
     VkVertexInputBindingDescription input_binding;
     memset(&input_binding, 0, sizeof(input_binding));

--- a/tests/positive/vertex_input.cpp
+++ b/tests/positive/vertex_input.cpp
@@ -20,8 +20,9 @@ TEST_F(VkPositiveLayerTest, CreatePipelineAttribMatrixType) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     VkVertexInputBindingDescription input_binding;
     memset(&input_binding, 0, sizeof(input_binding));
@@ -63,8 +64,9 @@ TEST_F(VkPositiveLayerTest, CreatePipelineAttribArrayType) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
     
-    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME))
+    if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
+    }
 
     VkVertexInputBindingDescription input_binding;
     memset(&input_binding, 0, sizeof(input_binding));


### PR DESCRIPTION
A growing collection of VVL fixes for macOS CI tests. So far it is mostly adding support for the portability subset extension, or bailing if the test will never work on macOS.