### PR TITLE
Move rest of dynamic depth/stencil to lastBoundState

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -34,9 +34,10 @@ bool CoreChecks::ValidateCBDynamicStatus(const CMD_BUFFER_STATE &cb_state, CBDyn
 }
 
 // Makes sure the vkCmdSet* call was called correctly prior to a draw
-bool CoreChecks::ValidateDynamicStateSetStatus(const CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &pipeline,
-                                               CMD_TYPE cmd_type) const {
+bool CoreChecks::ValidateDynamicStateSetStatus(const LAST_BOUND_STATE &last_bound_state, CMD_TYPE cmd_type) const {
     bool skip = false;
+    const CMD_BUFFER_STATE &cb_state = last_bound_state.cb_state;
+    const PIPELINE_STATE &pipeline = *last_bound_state.pipeline_state;
     const DrawDispatchVuid &vuid = GetDrawDispatchVuid(cmd_type);
 
     // Check all state with no additional requirements
@@ -192,10 +193,11 @@ bool CoreChecks::ValidateDynamicStateSetStatus(const CMD_BUFFER_STATE &cb_state,
     return skip;
 }
 
-bool CoreChecks::ValidateDrawDynamicState(const CMD_BUFFER_STATE &cb_state, const PIPELINE_STATE &pipeline,
-                                          CMD_TYPE cmd_type) const {
+bool CoreChecks::ValidateDrawDynamicState(const LAST_BOUND_STATE &last_bound_state, CMD_TYPE cmd_type) const {
     bool skip = false;
-    skip = ValidateDynamicStateSetStatus(cb_state, pipeline, cmd_type);
+    const CMD_BUFFER_STATE &cb_state = last_bound_state.cb_state;
+    const PIPELINE_STATE &pipeline = *last_bound_state.pipeline_state;
+    skip = ValidateDynamicStateSetStatus(last_bound_state, cmd_type);
     // Dynamic state was not set, will produce garbage when trying to read to values
     if (skip) return skip;
 

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2941,23 +2941,8 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LAST_BOUND_STATE &last_bou
                                  caller, string_VkImageLayout(ds_attachment->layout));
             }
 
-            // Set with static values and update for anything dynamically set
-            VkStencilOpState front = ds_state->front;
-            VkStencilOpState back = ds_state->back;
-
-            const auto &dynamic_state_value = cb_state.dynamic_state_value;
-            if (pipeline.IsDynamic(VK_DYNAMIC_STATE_STENCIL_WRITE_MASK)) {
-                front.writeMask = dynamic_state_value.write_mask_front;
-                back.writeMask = dynamic_state_value.write_mask_back;
-            }
-            if (pipeline.IsDynamic(VK_DYNAMIC_STATE_STENCIL_OP)) {
-                front.failOp = dynamic_state_value.fail_op_front;
-                front.passOp = dynamic_state_value.pass_op_front;
-                front.depthFailOp = dynamic_state_value.depth_fail_op_front;
-                back.failOp = dynamic_state_value.fail_op_back;
-                back.passOp = dynamic_state_value.pass_op_back;
-                back.depthFailOp = dynamic_state_value.depth_fail_op_back;
-            }
+            VkStencilOpState front = last_bound_state.GetStencilOpStateFront();
+            VkStencilOpState back = last_bound_state.GetStencilOpStateBack();
 
             const bool all_keep_op = ((front.failOp == VK_STENCIL_OP_KEEP) && (front.passOp == VK_STENCIL_OP_KEEP) &&
                                       (front.depthFailOp == VK_STENCIL_OP_KEEP) && (back.failOp == VK_STENCIL_OP_KEEP) &&

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -403,8 +403,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkBindSparseInfo& submit, const Location& loc) const;
     bool ValidateCBDynamicStatus(const CMD_BUFFER_STATE& cb_state, CBDynamicState dynamic_state, CMD_TYPE cmd_type,
                                  const char* msg_code) const;
-    bool ValidateDynamicStateSetStatus(const CMD_BUFFER_STATE& cb_state, const PIPELINE_STATE& pipeline, CMD_TYPE cmd_type) const;
-    bool ValidateDrawDynamicState(const CMD_BUFFER_STATE& cb_state, const PIPELINE_STATE& pipeline, CMD_TYPE cmd_type) const;
+    bool ValidateDynamicStateSetStatus(const LAST_BOUND_STATE& last_bound_state, CMD_TYPE cmd_type) const;
+    bool ValidateDrawDynamicState(const LAST_BOUND_STATE& last_bound_state, CMD_TYPE cmd_type) const;
     bool LogInvalidAttachmentMessage(const char* type1_string, const RENDER_PASS_STATE& rp1_state, const char* type2_string,
                                      const RENDER_PASS_STATE& rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
                                      const char* msg, const char* caller, const char* error_code) const;
@@ -733,12 +733,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidatePrimaryCommandBufferState(const Location& loc, const CMD_BUFFER_STATE& cb_state, int current_submit_count,
                                            QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
                                            QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards) const;
-    bool ValidatePipelineRenderpassDraw(const LAST_BOUND_STATE& state, const CMD_BUFFER_STATE& cb_state, CMD_TYPE cmd_type,
-                                        const PIPELINE_STATE& pipeline) const;
-    bool ValidatePipelineDynamicRenderpassDraw(const LAST_BOUND_STATE& state, const CMD_BUFFER_STATE& cb_state, CMD_TYPE cmd_type,
-                                               const PIPELINE_STATE& pipeline) const;
-    bool ValidatePipelineDrawtimeState(const LAST_BOUND_STATE& state, const CMD_BUFFER_STATE& cb_state, CMD_TYPE cmd_type,
-                                       const PIPELINE_STATE& pipeline) const;
+    bool ValidatePipelineRenderpassDraw(const LAST_BOUND_STATE& last_bound_state, CMD_TYPE cmd_type) const;
+    bool ValidatePipelineDynamicRenderpassDraw(const LAST_BOUND_STATE& last_bound_state, CMD_TYPE cmd_type) const;
+    bool ValidatePipelineDrawtimeState(const LAST_BOUND_STATE& last_bound_state, CMD_TYPE cmd_type) const;
     bool ValidateCmdBufDrawState(const CMD_BUFFER_STATE& cb_state, CMD_TYPE cmd_type, const VkPipelineBindPoint bind_point) const;
     bool ValidateCmdRayQueryState(const CMD_BUFFER_STATE& cb_state, CMD_TYPE cmd_type, const VkPipelineBindPoint bind_point) const;
     static bool ValidateEventStageMask(const CMD_BUFFER_STATE& cb_state, size_t eventCount, size_t firstEventIndex,

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -882,3 +882,34 @@ bool LAST_BOUND_STATE::IsDepthWriteEnable() const {
     return pipeline_state->IsDynamic(VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE) ? cb_state.dynamic_state_value.depth_write_enable
                                                                           : pipeline_state->DepthStencilState()->depthWriteEnable;
 }
+
+bool LAST_BOUND_STATE::IsStencilTestEnable() const {
+    return pipeline_state->IsDynamic(VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE) ? cb_state.dynamic_state_value.stencil_test_enable
+                                                                           : pipeline_state->DepthStencilState()->stencilTestEnable;
+}
+
+VkStencilOpState LAST_BOUND_STATE::GetStencilOpStateFront() const {
+    VkStencilOpState front = pipeline_state->DepthStencilState()->front;
+    if (pipeline_state->IsDynamic(VK_DYNAMIC_STATE_STENCIL_WRITE_MASK)) {
+        front.writeMask = cb_state.dynamic_state_value.write_mask_front;
+    }
+    if (pipeline_state->IsDynamic(VK_DYNAMIC_STATE_STENCIL_OP)) {
+        front.failOp = cb_state.dynamic_state_value.fail_op_front;
+        front.passOp = cb_state.dynamic_state_value.pass_op_front;
+        front.depthFailOp = cb_state.dynamic_state_value.depth_fail_op_front;
+    }
+    return front;
+}
+
+VkStencilOpState LAST_BOUND_STATE::GetStencilOpStateBack() const {
+    VkStencilOpState back = pipeline_state->DepthStencilState()->back;
+    if (pipeline_state->IsDynamic(VK_DYNAMIC_STATE_STENCIL_WRITE_MASK)) {
+        back.writeMask = cb_state.dynamic_state_value.write_mask_back;
+    }
+    if (pipeline_state->IsDynamic(VK_DYNAMIC_STATE_STENCIL_OP)) {
+        back.failOp = cb_state.dynamic_state_value.fail_op_back;
+        back.passOp = cb_state.dynamic_state_value.pass_op_back;
+        back.depthFailOp = cb_state.dynamic_state_value.depth_fail_op_back;
+    }
+    return back;
+}

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -722,6 +722,9 @@ struct LAST_BOUND_STATE {
     // Dynamic State helpers that require both the Pipeline and CommandBuffer state are here
     bool IsDepthTestEnable() const;
     bool IsDepthWriteEnable() const;
+    bool IsStencilTestEnable() const;
+    VkStencilOpState GetStencilOpStateFront() const;
+    VkStencilOpState GetStencilOpStateBack() const;
 };
 
 static inline bool IsBoundSetCompat(uint32_t set, const LAST_BOUND_STATE &last_bound,


### PR DESCRIPTION
This does

- Use `LAST_BOUND_STATE` to pass around draw time validation that need both
- Move dynamic state checks for Depth/Stencil into `LAST_BOUND_STATE`