### PR TITLE
Fix how Dynamic State is tracked

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -361,14 +361,15 @@ bool CoreChecks::ValidateDrawDynamicState(const LAST_BOUND_STATE &last_bound_sta
         const auto color_blend_state = cb_state.GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS)->ColorBlendState();
         if (color_blend_state) {
             uint32_t blend_attachment_count = color_blend_state->attachmentCount;
-            if (cb_state.dynamicColorWriteEnableAttachmentCount < blend_attachment_count) {
+            uint32_t dynamic_attachment_count = cb_state.dynamic_state_value.color_write_enable_attachment_count;
+            if (dynamic_attachment_count < blend_attachment_count) {
                 const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
                 skip |= LogError(
                     objlist, vuid.dynamic_color_write_enable_count_07750,
                     "%s(): Currently bound pipeline was created with VkPipelineColorBlendStateCreateInfo::attachmentCount %" PRIu32
                     " and VK_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT, but the number of attachments written by "
                     "vkCmdSetColorWriteEnableEXT() is %" PRIu32 ".",
-                    CommandTypeString(cmd_type), blend_attachment_count, cb_state.dynamicColorWriteEnableAttachmentCount);
+                    CommandTypeString(cmd_type), blend_attachment_count, dynamic_attachment_count);
             }
         }
     }

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -23,12 +23,11 @@
 #include "generated/chassis.h"
 #include "core_validation.h"
 
-// Check object status for selected flag state
-bool CoreChecks::ValidateCBDynamicStatus(const CMD_BUFFER_STATE &cb_state, CBDynamicState dynamic_state, CMD_TYPE cmd_type,
-                                         const char *msg_code) const {
-    if (!(cb_state.status[dynamic_state])) {
-        return LogError(cb_state.commandBuffer(), msg_code, "%s: %s state not set for this command buffer.",
-                        CommandTypeString(cmd_type), DynamicStateToString(dynamic_state));
+bool CoreChecks::ValidateDynamicStateIsSet(CBDynamicFlags state_status_cb, CBDynamicState dynamic_state,
+                                           const LogObjectList &objlist, CMD_TYPE cmd_type, const char *msg_code) const {
+    if (!state_status_cb[dynamic_state]) {
+        return LogError(objlist, msg_code, "%s: %s state not set for this command buffer.", CommandTypeString(cmd_type),
+                        DynamicStateToString(dynamic_state));
     }
     return false;
 }
@@ -39,123 +38,146 @@ bool CoreChecks::ValidateDynamicStateSetStatus(const LAST_BOUND_STATE &last_boun
     const CMD_BUFFER_STATE &cb_state = last_bound_state.cb_state;
     const PIPELINE_STATE &pipeline = *last_bound_state.pipeline_state;
     const DrawDispatchVuid &vuid = GetDrawDispatchVuid(cmd_type);
+    const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
 
-    // Check all state with no additional requirements
+    // Verify vkCmdSet* calls since last bound pipeline
+    const CBDynamicFlags unset_status_pipeline =
+        (cb_state.dynamic_state_status.pipeline ^ pipeline.dynamic_state) & cb_state.dynamic_state_status.pipeline;
+    if (unset_status_pipeline.any()) {
+        skip |= LogError(objlist, vuid.dynamic_state_setting_commands_02859,
+                         "%s: %s doesn't set up %s, but it calls the related dynamic state setting commands.",
+                         CommandTypeString(cmd_type), report_data->FormatHandle(pipeline.pipeline()).c_str(),
+                         DynamicStatesToString(unset_status_pipeline).c_str());
+    }
+
+    // build the mask of what has been set in the Pipeline, but yet to be set in the Command Buffer
+    const CBDynamicFlags state_status_cb = ~((cb_state.dynamic_state_status.cb ^ pipeline.dynamic_state) & pipeline.dynamic_state);
 
     // VK_EXT_extended_dynamic_state
     {
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_CULL_MODE, cmd_type, vuid.dynamic_cull_mode_07840);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_FRONT_FACE, cmd_type, vuid.dynamic_front_face_07841);
         skip |=
-            ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY, cmd_type, vuid.dynamic_primitive_topology_07842);
-        skip |=
-            ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE, cmd_type, vuid.dynamic_depth_test_enable_07843);
-        skip |=
-            ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE, cmd_type, vuid.dynamic_depth_write_enable_07844);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DEPTH_COMPARE_OP, cmd_type, vuid.dynamic_depth_compare_op_07845);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE, cmd_type,
-                                        vuid.dynamic_depth_bound_test_enable_07846);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE, cmd_type,
-                                        vuid.dynamic_stencil_test_enable_07847);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_STENCIL_OP, cmd_type, vuid.dynamic_stencil_op_07848);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE, cmd_type,
-                                        vuid.vertex_input_binding_stride_04884);
+            ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_CULL_MODE, objlist, cmd_type, vuid.dynamic_cull_mode_07840);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_FRONT_FACE, objlist, cmd_type,
+                                          vuid.dynamic_front_face_07841);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY, objlist, cmd_type,
+                                          vuid.dynamic_primitive_topology_07842);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE, objlist, cmd_type,
+                                          vuid.dynamic_depth_test_enable_07843);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE, objlist, cmd_type,
+                                          vuid.dynamic_depth_write_enable_07844);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_COMPARE_OP, objlist, cmd_type,
+                                          vuid.dynamic_depth_compare_op_07845);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE, objlist, cmd_type,
+                                          vuid.dynamic_depth_bound_test_enable_07846);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE, objlist, cmd_type,
+                                          vuid.dynamic_stencil_test_enable_07847);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_STENCIL_OP, objlist, cmd_type,
+                                          vuid.dynamic_stencil_op_07848);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE, objlist, cmd_type,
+                                          vuid.vertex_input_binding_stride_04884);
     }
 
     // VK_EXT_extended_dynamic_state2
     {
-        skip |=
-            ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT, cmd_type, vuid.patch_control_points_04875);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE, cmd_type,
-                                        vuid.rasterizer_discard_enable_04876);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DEPTH_BIAS_ENABLE, cmd_type, vuid.depth_bias_enable_04877);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_LOGIC_OP_EXT, cmd_type, vuid.logic_op_04878);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE, cmd_type,
-                                        vuid.primitive_restart_enable_04879);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT, objlist, cmd_type,
+                                          vuid.patch_control_points_04875);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE, objlist, cmd_type,
+                                          vuid.rasterizer_discard_enable_04876);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_BIAS_ENABLE, objlist, cmd_type,
+                                          vuid.depth_bias_enable_04877);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_LOGIC_OP_EXT, objlist, cmd_type, vuid.logic_op_04878);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE, objlist, cmd_type,
+                                          vuid.primitive_restart_enable_04879);
     }
 
     // VK_EXT_extended_dynamic_state3
     {
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT, cmd_type,
-                                        vuid.dynamic_depth_clamp_enable_07620);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_POLYGON_MODE_EXT, cmd_type, vuid.dynamic_polygon_mode_07621);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT, cmd_type,
-                                        vuid.dynamic_rasterization_samples_07622);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_SAMPLE_MASK_EXT, cmd_type, vuid.dynamic_sample_mask_07623);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_TESSELLATION_DOMAIN_ORIGIN_EXT, cmd_type,
-                                        vuid.dynamic_tessellation_domain_origin_07619);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT, cmd_type,
-                                        vuid.dynamic_alpha_to_coverage_enable_07624);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT, cmd_type,
-                                        vuid.dynamic_alpha_to_one_enable_07625);
-        skip |=
-            ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT, cmd_type, vuid.dynamic_logic_op_enable_07626);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_RASTERIZATION_STREAM_EXT, cmd_type,
-                                        vuid.dynamic_rasterization_stream_07630);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_CONSERVATIVE_RASTERIZATION_MODE_EXT, cmd_type,
-                                        vuid.dynamic_conservative_rasterization_mode_07631);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_EXTRA_PRIMITIVE_OVERESTIMATION_SIZE_EXT, cmd_type,
-                                        vuid.dynamic_extra_primitive_overestimation_size_07632);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DEPTH_CLIP_ENABLE_EXT, cmd_type,
-                                        vuid.dynamic_depth_clip_enable_07633);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT, cmd_type,
-                                        vuid.dynamic_sample_locations_enable_07634);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_PROVOKING_VERTEX_MODE_EXT, cmd_type,
-                                        vuid.dynamic_provoking_vertex_mode_07636);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT, cmd_type,
-                                        vuid.dynamic_line_rasterization_mode_07637);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT, cmd_type,
-                                        vuid.dynamic_line_stipple_enable_07638);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DEPTH_CLIP_NEGATIVE_ONE_TO_ONE_EXT, cmd_type,
-                                        vuid.dynamic_depth_clip_negative_one_to_one_07639);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_VIEWPORT_W_SCALING_ENABLE_NV, cmd_type,
-                                        vuid.dynamic_viewport_w_scaling_enable_07640);
-        skip |=
-            ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_VIEWPORT_SWIZZLE_NV, cmd_type, vuid.dynamic_viewport_swizzle_07641);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_COVERAGE_TO_COLOR_ENABLE_NV, cmd_type,
-                                        vuid.dynamic_coverage_to_color_enable_07642);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_COVERAGE_TO_COLOR_LOCATION_NV, cmd_type,
-                                        vuid.dynamic_coverage_to_color_location_07643);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_COVERAGE_MODULATION_MODE_NV, cmd_type,
-                                        vuid.dynamic_coverage_modulation_mode_07644);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_COVERAGE_MODULATION_TABLE_ENABLE_NV, cmd_type,
-                                        vuid.dynamic_coverage_modulation_table_enable_07645);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_COVERAGE_MODULATION_TABLE_NV, cmd_type,
-                                        vuid.dynamic_coverage_modulation_table_07646);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_SHADING_RATE_IMAGE_ENABLE_NV, cmd_type,
-                                        vuid.dynamic_shading_rate_image_enable_07649);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_REPRESENTATIVE_FRAGMENT_TEST_ENABLE_NV, cmd_type,
-                                        vuid.dynamic_representative_fragment_test_enable_07648);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_COVERAGE_REDUCTION_MODE_NV, cmd_type,
-                                        vuid.dynamic_coverage_reduction_mode_07647);
-        skip |=
-            ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT, cmd_type, vuid.dynamic_sample_locations_06666);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV, cmd_type,
-                                        vuid.dynamic_exclusive_scissor_07878);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_ENABLE_NV, cmd_type,
-                                        vuid.dynamic_exclusive_scissor_enable_07879);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_depth_clamp_enable_07620);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_POLYGON_MODE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_polygon_mode_07621);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT, objlist, cmd_type,
+                                          vuid.dynamic_rasterization_samples_07622);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_SAMPLE_MASK_EXT, objlist, cmd_type,
+                                          vuid.dynamic_sample_mask_07623);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_TESSELLATION_DOMAIN_ORIGIN_EXT, objlist, cmd_type,
+                                          vuid.dynamic_tessellation_domain_origin_07619);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_alpha_to_coverage_enable_07624);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_alpha_to_one_enable_07625);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_logic_op_enable_07626);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_RASTERIZATION_STREAM_EXT, objlist, cmd_type,
+                                          vuid.dynamic_rasterization_stream_07630);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_CONSERVATIVE_RASTERIZATION_MODE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_conservative_rasterization_mode_07631);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_EXTRA_PRIMITIVE_OVERESTIMATION_SIZE_EXT, objlist,
+                                          cmd_type, vuid.dynamic_extra_primitive_overestimation_size_07632);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_CLIP_ENABLE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_depth_clip_enable_07633);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_sample_locations_enable_07634);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_PROVOKING_VERTEX_MODE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_provoking_vertex_mode_07636);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_line_rasterization_mode_07637);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_line_stipple_enable_07638);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_CLIP_NEGATIVE_ONE_TO_ONE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_depth_clip_negative_one_to_one_07639);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_VIEWPORT_W_SCALING_ENABLE_NV, objlist, cmd_type,
+                                          vuid.dynamic_viewport_w_scaling_enable_07640);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_VIEWPORT_SWIZZLE_NV, objlist, cmd_type,
+                                          vuid.dynamic_viewport_swizzle_07641);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_COVERAGE_TO_COLOR_ENABLE_NV, objlist, cmd_type,
+                                          vuid.dynamic_coverage_to_color_enable_07642);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_COVERAGE_TO_COLOR_LOCATION_NV, objlist, cmd_type,
+                                          vuid.dynamic_coverage_to_color_location_07643);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_COVERAGE_MODULATION_MODE_NV, objlist, cmd_type,
+                                          vuid.dynamic_coverage_modulation_mode_07644);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_COVERAGE_MODULATION_TABLE_ENABLE_NV, objlist, cmd_type,
+                                          vuid.dynamic_coverage_modulation_table_enable_07645);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_COVERAGE_MODULATION_TABLE_NV, objlist, cmd_type,
+                                          vuid.dynamic_coverage_modulation_table_07646);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_SHADING_RATE_IMAGE_ENABLE_NV, objlist, cmd_type,
+                                          vuid.dynamic_shading_rate_image_enable_07649);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_REPRESENTATIVE_FRAGMENT_TEST_ENABLE_NV, objlist,
+                                          cmd_type, vuid.dynamic_representative_fragment_test_enable_07648);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_COVERAGE_REDUCTION_MODE_NV, objlist, cmd_type,
+                                          vuid.dynamic_coverage_reduction_mode_07647);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT, objlist, cmd_type,
+                                          vuid.dynamic_sample_locations_06666);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV, objlist, cmd_type,
+                                          vuid.dynamic_exclusive_scissor_07878);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_ENABLE_NV, objlist, cmd_type,
+                                          vuid.dynamic_exclusive_scissor_enable_07879);
     }
 
     // VK_EXT_discard_rectangles
     {
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT, cmd_type,
-                                        vuid.dynamic_discard_rectangle_enable_07880);
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DISCARD_RECTANGLE_MODE_EXT, cmd_type,
-                                        vuid.dynamic_discard_rectangle_mode_07881);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_discard_rectangle_enable_07880);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DISCARD_RECTANGLE_MODE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_discard_rectangle_mode_07881);
     }
 
     // VK_EXT_vertex_input_dynamic_state
-    { skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_VERTEX_INPUT_EXT, cmd_type, vuid.vertex_input_04914); }
+    {
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_VERTEX_INPUT_EXT, objlist, cmd_type,
+                                          vuid.vertex_input_04914);
+    }
 
     // VK_EXT_color_write_enable
     {
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT, cmd_type,
-                                        vuid.dynamic_color_write_enable_07749);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT, objlist, cmd_type,
+                                          vuid.dynamic_color_write_enable_07749);
     }
 
     if (const auto *rp_state = pipeline.RasterizationState(); rp_state) {
         if (rp_state->depthBiasEnable == VK_TRUE) {
-            skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DEPTH_BIAS, cmd_type, vuid.dynamic_depth_bias_07834);
+            skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_BIAS, objlist, cmd_type,
+                                              vuid.dynamic_depth_bias_07834);
         }
 
         // Any line topology
@@ -163,30 +185,33 @@ bool CoreChecks::ValidateDynamicStateSetStatus(const LAST_BOUND_STATE &last_boun
             pipeline.topology_at_rasterizer == VK_PRIMITIVE_TOPOLOGY_LINE_STRIP ||
             pipeline.topology_at_rasterizer == VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY ||
             pipeline.topology_at_rasterizer == VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY) {
-            skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_LINE_WIDTH, cmd_type, vuid.dynamic_line_width_07833);
+            skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_LINE_WIDTH, objlist, cmd_type,
+                                              vuid.dynamic_line_width_07833);
             const auto *line_state = LvlFindInChain<VkPipelineRasterizationLineStateCreateInfoEXT>(rp_state);
             if (line_state && line_state->stippledLineEnable) {
-                skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_LINE_STIPPLE_EXT, cmd_type,
-                                                vuid.dynamic_line_stipple_ext_07849);
+                skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_LINE_STIPPLE_EXT, objlist, cmd_type,
+                                                  vuid.dynamic_line_stipple_ext_07849);
             }
         }
     }
 
     if (pipeline.BlendConstantsEnabled()) {
-        skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_BLEND_CONSTANTS, cmd_type, vuid.dynamic_blend_constants_07835);
+        skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_BLEND_CONSTANTS, objlist, cmd_type,
+                                          vuid.dynamic_blend_constants_07835);
     }
 
     if (const auto *ds_state = pipeline.DepthStencilState(); ds_state) {
         if (ds_state->depthBoundsTestEnable == VK_TRUE) {
-            skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_DEPTH_BOUNDS, cmd_type, vuid.dynamic_depth_bounds_07836);
+            skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_BOUNDS, objlist, cmd_type,
+                                              vuid.dynamic_depth_bounds_07836);
         }
         if (ds_state->stencilTestEnable == VK_TRUE) {
-            skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_STENCIL_COMPARE_MASK, cmd_type,
-                                            vuid.dynamic_stencil_compare_mask_07837);
-            skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_STENCIL_WRITE_MASK, cmd_type,
-                                            vuid.dynamic_stencil_write_mask_07838);
-            skip |= ValidateCBDynamicStatus(cb_state, CB_DYNAMIC_STATE_STENCIL_REFERENCE, cmd_type,
-                                            vuid.dynamic_stencil_reference_07839);
+            skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_STENCIL_COMPARE_MASK, objlist, cmd_type,
+                                              vuid.dynamic_stencil_compare_mask_07837);
+            skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_STENCIL_WRITE_MASK, objlist, cmd_type,
+                                              vuid.dynamic_stencil_write_mask_07838);
+            skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_STENCIL_REFERENCE, objlist, cmd_type,
+                                              vuid.dynamic_stencil_reference_07839);
         }
     }
 
@@ -252,19 +277,6 @@ bool CoreChecks::ValidateDrawDynamicState(const LAST_BOUND_STATE &last_bound_sta
                              " for this command buffer.",
                              CommandTypeString(cmd_type), color_index);
         }
-    }
-
-    // Verify if using dynamic state setting commands that it doesn't set up in pipeline
-    CBDynamicFlags invalid_status(~CBDynamicFlags(0));
-    invalid_status &= ~cb_state.dynamic_status;
-    invalid_status &= ~cb_state.static_status;
-
-    if (invalid_status.any()) {
-        const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
-        skip |= LogError(objlist, vuid.dynamic_state_setting_commands_02859,
-                         "%s: %s doesn't set up %s, but it calls the related dynamic state setting commands",
-                         CommandTypeString(cmd_type), report_data->FormatHandle(pipeline.pipeline()).c_str(),
-                         DynamicStatesToString(invalid_status).c_str());
     }
 
     // If Viewport or scissors are dynamic, verify that dynamic count matches PSO count.
@@ -357,7 +369,8 @@ bool CoreChecks::ValidateDrawDynamicState(const LAST_BOUND_STATE &last_bound_sta
         }
     }
 
-    if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT) && cb_state.status[CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT]) {
+    if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT) &&
+        cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT]) {
         const auto color_blend_state = cb_state.GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS)->ColorBlendState();
         if (color_blend_state) {
             uint32_t blend_attachment_count = color_blend_state->attachmentCount;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -401,8 +401,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkSubmitInfo& submit, const Location& loc) const;
     bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkSubmitInfo2KHR& submit, const Location& loc) const;
     bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkBindSparseInfo& submit, const Location& loc) const;
-    bool ValidateCBDynamicStatus(const CMD_BUFFER_STATE& cb_state, CBDynamicState dynamic_state, CMD_TYPE cmd_type,
-                                 const char* msg_code) const;
+    bool ValidateDynamicStateIsSet(CBDynamicFlags not_set_status, CBDynamicState dynamic_state, const LogObjectList& objlist,
+                                   CMD_TYPE cmd_type, const char* msg_code) const;
     bool ValidateDynamicStateSetStatus(const LAST_BOUND_STATE& last_bound_state, CMD_TYPE cmd_type) const;
     bool ValidateDrawDynamicState(const LAST_BOUND_STATE& last_bound_state, CMD_TYPE cmd_type) const;
     bool LogInvalidAttachmentMessage(const char* type1_string, const RENDER_PASS_STATE& rp1_state, const char* type2_string,

--- a/layers/generated/dynamic_state_helper.cpp
+++ b/layers/generated/dynamic_state_helper.cpp
@@ -342,15 +342,3 @@ std::string DynamicStatesToString(CBDynamicFlags const &dynamic_states) {
     return ret;
 }
 
-CBDynamicFlags MakeStaticStateMask(VkPipelineDynamicStateCreateInfo const *info) {
-    // initially assume everything is static state
-    CBDynamicFlags flags(~CBDynamicFlags(0));
-
-    if (info) {
-        for (uint32_t i = 0; i < info->dynamicStateCount; i++) {
-            flags.reset(ConvertToCBDynamicState(info->pDynamicStates[i]));
-        }
-    }
-    return flags;
-}
-

--- a/layers/generated/dynamic_state_helper.h
+++ b/layers/generated/dynamic_state_helper.h
@@ -104,6 +104,4 @@ using CBDynamicFlags = std::bitset<CB_DYNAMIC_STATE_STATUS_NUM>;
 CBDynamicState ConvertToCBDynamicState(VkDynamicState dynamic_state);
 const char* DynamicStateToString(CBDynamicState dynamic_state);
 std::string DynamicStatesToString(CBDynamicFlags const &dynamic_states);
-struct VkPipelineDynamicStateCreateInfo;
-CBDynamicFlags MakeStaticStateMask(VkPipelineDynamicStateCreateInfo const *info);
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -153,7 +153,6 @@ void CMD_BUFFER_STATE::ResetCBState() {
     trashedScissorCount = false;
     usedDynamicViewportCount = false;
     usedDynamicScissorCount = false;
-    dynamicColorWriteEnableAttachmentCount = 0;
 
     activeRenderPassBeginInfo = safe_VkRenderPassBeginInfo();
     activeRenderPass = nullptr;
@@ -1382,11 +1381,6 @@ void CMD_BUFFER_STATE::RecordStateCmd(CMD_TYPE cmd_type, CBDynamicFlags const &s
     RecordCmd(cmd_type);
     status |= state_bits;
     static_status &= ~state_bits;
-}
-
-void CMD_BUFFER_STATE::RecordColorWriteEnableStateCmd(CMD_TYPE cmd_type, CBDynamicState state, uint32_t attachment_count) {
-    RecordStateCmd(cmd_type, state);
-    dynamicColorWriteEnableAttachmentCount = std::max(dynamicColorWriteEnableAttachmentCount, attachment_count);
 }
 
 void CMD_BUFFER_STATE::RecordTransferCmd(CMD_TYPE cmd_type, std::shared_ptr<BINDABLE> &&buf1, std::shared_ptr<BINDABLE> &&buf2) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -216,6 +216,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
         // VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT
         bool stippled_line_enable;
 
+        uint32_t color_write_enable_attachment_count;
+
         // maxColorAttachments is at max 8 on all known implementations currently
         std::bitset<32> color_blend_enable_attachments;    // VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT
         std::bitset<32> color_blend_equation_attachments;  // VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT
@@ -376,7 +378,6 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     bool conditional_rendering_active{false};
     bool conditional_rendering_inside_render_pass{false};
     uint32_t conditional_rendering_subpass{0};
-    uint32_t dynamicColorWriteEnableAttachmentCount{0};
     std::vector<VkDescriptorBufferBindingInfoEXT> descriptor_buffer_binding_info;
 
     mutable std::shared_mutex lock;
@@ -503,7 +504,6 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     virtual void RecordCmd(CMD_TYPE cmd_type);
     void RecordStateCmd(CMD_TYPE cmd_type, CBDynamicState dynamic_state);
     void RecordStateCmd(CMD_TYPE cmd_type, CBDynamicFlags const &state_bits);
-    void RecordColorWriteEnableStateCmd(CMD_TYPE cmd_type, CBDynamicState dynamic_state, uint32_t attachment_count);
     void RecordTransferCmd(CMD_TYPE cmd_type, std::shared_ptr<BINDABLE> &&buf1, std::shared_ptr<BINDABLE> &&buf2 = nullptr);
     void RecordSetEvent(CMD_TYPE cmd_type, VkEvent event, VkPipelineStageFlags2KHR stageMask);
     void RecordResetEvent(CMD_TYPE cmd_type, VkEvent event, VkPipelineStageFlags2KHR stageMask);

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -180,11 +180,11 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     typedef uint64_t ImageLayoutUpdateCount;
     ImageLayoutUpdateCount image_layout_change_count;  // The sequence number for changes to image layout (for cached validation)
 
-    // Dynamic State
-    CBDynamicFlags status;          // Track status of various bindings on cmd buffer
-    CBDynamicFlags static_status;   // All state bits provided by current graphics pipeline
-                                    // rather than dynamic state
-    CBDynamicFlags dynamic_status;  // dynamic state set up in pipeline
+    // Track status of all vkCmdSet* calls, if 1, means it was set
+    struct DynamicStateStatus {
+        CBDynamicFlags cb;        // for lifetime of CommandBuffer
+        CBDynamicFlags pipeline;  // for lifetime since last bound pipeline
+    } dynamic_state_status;
 
     // These are values that are being set with vkCmdSet* tied to a command buffer
     struct DynamicStateValue {
@@ -225,7 +225,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
         std::bitset<32> color_blend_advanced_attachments;  // VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT
 
         // When the Command Buffer resets, the value most things in this struct don't matter because if they are read without
-        // setting the state, it will fail in ValidateCBDynamicStatus() for us. Some values (ex. the bitset) are tracking in
+        // setting the state, it will fail in ValidateDynamicStateIsSet() for us. Some values (ex. the bitset) are tracking in
         // replacement for static_status/dynamic_status so this needs to reset along with those
         void reset() {
             discard_rectangles.reset();

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5441,16 +5441,8 @@ void ValidationStateTracker::PostCallRecordCmdSetVertexInputEXT(
 
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
     const auto pipeline_state = cb_state->lastBound[lv_bind_point].pipeline_state;
-    if (pipeline_state) {
-        const auto *dynamic_state = pipeline_state->DynamicState();
-        if (dynamic_state) {
-            for (uint32_t i = 0; i < dynamic_state->dynamicStateCount; ++i) {
-                if (dynamic_state->pDynamicStates[i] == VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT) {
-                    status_flags.set(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
-                    break;
-                }
-            }
-        }
+    if (pipeline_state && pipeline_state->IsDynamic(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT)) {
+        status_flags.set(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
     }
     cb_state->RecordStateCmd(CMD_SETVERTEXINPUTEXT, status_flags);
 }
@@ -5458,7 +5450,8 @@ void ValidationStateTracker::PostCallRecordCmdSetVertexInputEXT(
 void ValidationStateTracker::PostCallRecordCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                                      const VkBool32 *pColorWriteEnables) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
-    cb_state->RecordColorWriteEnableStateCmd(CMD_SETCOLORWRITEENABLEEXT, CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT, attachmentCount);
+    cb_state->RecordStateCmd(CMD_SETCOLORWRITEENABLEEXT, CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT);
+    cb_state->dynamic_state_value.color_write_enable_attachment_count = attachmentCount;
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR

--- a/scripts/dynamic_state_generator.py
+++ b/scripts/dynamic_state_generator.py
@@ -164,8 +164,6 @@ using CBDynamicFlags = std::bitset<CB_DYNAMIC_STATE_STATUS_NUM>;
 CBDynamicState ConvertToCBDynamicState(VkDynamicState dynamic_state);
 const char* DynamicStateToString(CBDynamicState dynamic_state);
 std::string DynamicStatesToString(CBDynamicFlags const &dynamic_states);
-struct VkPipelineDynamicStateCreateInfo;
-CBDynamicFlags MakeStaticStateMask(VkPipelineDynamicStateCreateInfo const *info);
 '''
         return output
 
@@ -214,18 +212,6 @@ std::string DynamicStatesToString(CBDynamicFlags const &dynamic_states) {
     }
     if (ret.empty()) ret.append(string_VkDynamicState(ConvertToDynamicState(CB_DYNAMIC_STATE_STATUS_NUM)));
     return ret;
-}
-
-CBDynamicFlags MakeStaticStateMask(VkPipelineDynamicStateCreateInfo const *info) {
-    // initially assume everything is static state
-    CBDynamicFlags flags(~CBDynamicFlags(0));
-
-    if (info) {
-        for (uint32_t i = 0; i < info->dynamicStateCount; i++) {
-            flags.reset(ConvertToCBDynamicState(info->pDynamicStates[i]));
-        }
-    }
-    return flags;
 }
 '''
         return output


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5551 (maybe even https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5677)

Refactor how we track dynamic state, the previous `status` had bugs, the way  around it was simply to us the same `CBDynamicFlags` in both the Command Buffer and Pipeline. Before, we were trying to track Pipeline state in `CMB_BUFFER_STATE`