### PR TITLE
Cleanup some RT tests variable names

### DIFF
--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -1,9 +1,6 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
- * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -333,7 +330,7 @@ BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetScratchBuffer(vk_testing::Buffer 
 }
 
 BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetBottomLevelAS(std::shared_ptr<BuildGeometryInfoKHR> bottom_level_as) {
-    bottom_level_as_ = std::move(bottom_level_as);
+    blas_ = std::move(bottom_level_as);
     return *this;
 }
 
@@ -355,8 +352,8 @@ BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetNullBuildRangeInfos(bool use_null
 
 void BuildGeometryInfoKHR::BuildCmdBuffer(VkInstance instance, const vk_testing::Device &device, VkCommandBuffer cmd_buffer,
                                           bool use_ppGeometries /*= true*/) {
-    if (bottom_level_as_) {
-        bottom_level_as_->BuildCmdBuffer(instance, device, cmd_buffer, use_ppGeometries);
+    if (blas_) {
+        blas_->BuildCmdBuffer(instance, device, cmd_buffer, use_ppGeometries);
     }
     BuildCommon(instance, device, true);
     VkCmdBuildAccelerationStructuresKHR(device, cmd_buffer, true);
@@ -364,16 +361,16 @@ void BuildGeometryInfoKHR::BuildCmdBuffer(VkInstance instance, const vk_testing:
 
 void BuildGeometryInfoKHR::BuildCmdBufferIndirect(VkInstance instance, const vk_testing::Device &device,
                                                   VkCommandBuffer cmd_buffer) {
-    if (bottom_level_as_) {
-        bottom_level_as_->BuildCmdBufferIndirect(instance, device, cmd_buffer);
+    if (blas_) {
+        blas_->BuildCmdBufferIndirect(instance, device, cmd_buffer);
     }
     BuildCommon(instance, device, true);
     VkCmdBuildAccelerationStructuresIndirectKHR(device, cmd_buffer);
 }
 
 void BuildGeometryInfoKHR::BuildHost(VkInstance instance, const vk_testing::Device &device) {
-    if (bottom_level_as_) {
-        bottom_level_as_->BuildHost(instance, device);
+    if (blas_) {
+        blas_->BuildHost(instance, device);
     }
     BuildCommon(instance, device, false);
     VkBuildAccelerationStructuresKHR(instance, device);

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -1,9 +1,6 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
- * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,7 +176,7 @@ class BuildGeometryInfoKHR {
     auto& GetGeometries() { return geometries_; }
     auto& GetSrcAS() { return src_as_; }
     auto& GetDstAS() { return dst_as_; }
-    auto& GetBottomLevelAS() { return bottom_level_as_; }
+    auto& GetBottomLevelAS() { return blas_; }
     const auto& GetScratchBuffer() const { return device_scratch_; }
     VkAccelerationStructureBuildSizesInfoKHR GetSizeInfo(VkDevice device, bool use_ppGeometries = true);
 
@@ -195,7 +192,7 @@ class BuildGeometryInfoKHR {
     std::shared_ptr<AccelerationStructureKHR> src_as_, dst_as_;
     vk_testing::Buffer device_scratch_;
     std::unique_ptr<uint8_t[]> host_scratch_;
-    std::shared_ptr<BuildGeometryInfoKHR> bottom_level_as_;
+    std::shared_ptr<BuildGeometryInfoKHR> blas_;
 };
 
 // Helper functions providing simple, valid objects.

--- a/tests/negative/descriptor_buffer.cpp
+++ b/tests/negative/descriptor_buffer.cpp
@@ -499,13 +499,13 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
     }
 
     if (IsExtensionsEnabled(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME)) {
-        auto as = rt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(DeviceValidationVersion(), 4096);
-        as->Build(*m_device);
+        auto blas = rt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(DeviceValidationVersion(), 4096);
+        blas->Build(*m_device);
 
         uint8_t data[256];
 
         auto ascddi = LvlInitStruct<VkAccelerationStructureCaptureDescriptorDataInfoEXT>();
-        ascddi.accelerationStructure = as->handle();
+        ascddi.accelerationStructure = blas->handle();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT-None-08088");
         m_errorMonitor->SetDesiredFailureMsg(


### PR DESCRIPTION
Try to consistently use `blas` (bottom level acceleration structure) and `tlas` (top level acceleration structure) for acceleration structure variable names. This naming convention can probably be considered as the standard found in the literature.