### PR TITLE
doc: Document 525.47.22 driver fix from Nvidia

### DIFF
--- a/tests/negative/wsi.cpp
+++ b/tests/negative/wsi.cpp
@@ -1872,6 +1872,7 @@ TEST_F(NegativeWsi, PresentIdWait) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &present_wait_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
+    // Fixed as of Nvidia Linux driver version 525.47.22.
     if (!InitSwapchain()) {
         GTEST_SKIP() << "Cannot create swapchain, skipping test";
     }
@@ -1968,6 +1969,8 @@ TEST_F(NegativeWsi, PresentIdWaitFeatures) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
+
+    // Fixed as of Nvidia Linux driver version 525.47.22.
     if (!InitSwapchain()) {
         GTEST_SKIP() << "Cannot create swapchain, skipping test";
     }


### PR DESCRIPTION
https://developer.nvidia.com/vulkan-driver

```
Fixes:
    Fixed a bug that caused Vulkan X11 swapchain creation to fail on GPUs without a display engine when the VK_KHR_present_id extension is used
    Improve vkCreateRayTracingPipelines performance with a warm pipeline cache
    Fix VK_ERROR_NATIVE_WINDOW_IN_USE_KHR reported when recreating a VkSwapchain on X11
    Fix rare device lost issue when copying to or from a 1D D24S8 image
    Fix issue that sometimes occurred when making sparse memory allocation changes on a transfer-only queue
    Fix issue with bound shader state persisting between command buffers
    Fix issue with out-of-date swapchain handling in vkWaitForPresentKHR
    Vulkan video: Correctly handle VkVideoDecodeUsageInfoKHR in the VkVideoProfileKHR pNext chain
    Vulkan video: Update VkVideoEncodeH265CapabilitiesEXT reported
```