### PR TITLE
layers: Add support VK_EXT_shader_tile_image 

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -484,12 +484,22 @@ class CoreChecks : public ValidationStateTracker {
                           uint32_t bufferBarrierCount, const VkBufferMemoryBarrier* pBufferMemBarriers,
                           uint32_t imageMemBarrierCount, const VkImageMemoryBarrier* pImageMemBarriers) const;
 
+    template <typename Barrier>
+    bool ValidateBarriersForShaderTileImage(const LogObjectList& objlist, const Location& outer_loc,
+                                            VkDependencyFlags dependencyFlags, uint32_t memBarrierCount,
+                                            const Barrier* pMemBarriers, uint32_t bufferBarrierCount, uint32_t imageMemBarrierCount,
+                                            VkPipelineStageFlags src_stage_mask = 0, VkPipelineStageFlags dst_stage_mask = 0) const;
+
     bool ValidatePipelineStageFeatureEnables(const LogObjectList& objlist, const Location& loc,
                                              VkPipelineStageFlags2KHR stage_mask) const;
     bool ValidatePipelineStage(const LogObjectList& objlist, const Location& loc, VkQueueFlags queue_flags,
                                VkPipelineStageFlags2KHR stage_mask) const;
+    bool ValidatePipelineStageForShaderTileImage(const LogObjectList& objlist, const Location& loc,
+                                                 VkPipelineStageFlags2KHR stage_mask, const std::string& vuid) const;
     bool ValidateAccessMask(const LogObjectList& objlist, const Location& loc, VkQueueFlags queue_flags,
                             VkAccessFlags2KHR access_mask, VkPipelineStageFlags2KHR stage_mask) const;
+    bool ValidateAccessMaskForShaderTileImage(const LogObjectList& objlist, const Location& loc, VkAccessFlags2KHR access_mask,
+                                              const std::string& vuid) const;
     template <typename Barrier>
     bool ValidateMemoryBarrier(const LogObjectList& objlist, const Location& loc, const CMD_BUFFER_STATE* cb_state,
                                const Barrier& barrier, VkPipelineStageFlags src_stage_mask,
@@ -502,8 +512,6 @@ class CoreChecks : public ValidationStateTracker {
 
     bool ValidateDependencyInfo(const LogObjectList& objlist, const Location& loc, const CMD_BUFFER_STATE* cb_state,
                                 const VkDependencyInfoKHR* dep_info) const;
-    bool ValidateDependencyInfoForShaderTileImage(const Location& loc, const CMD_BUFFER_STATE& cb_state,
-                                                  const VkDependencyInfoKHR& dep_info) const;
     template <typename ImgBarrier>
     bool ValidateBarrierQueueFamilies(const Location& loc, const CMD_BUFFER_STATE* cb_state, const ImgBarrier& barrier,
                                       const IMAGE_STATE* state_data) const;

--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -1168,4 +1168,27 @@ const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error) {
     return result;
 }
 
+const std::string &GetShaderTileImageVUID(const Location &loc, ShaderTileImageError error) {
+    static const std::map<ShaderTileImageError, std::vector<Entry>> kShaderTileImageErrors{
+        {ShaderTileImageError::kShaderTileImageFeatureError,
+         {
+             {Key(Func::vkCmdPipelineBarrier), "VUID-vkCmdPipelineBarrier-shaderTileImageColorReadAccess-08718"},
+             {Key(Func::vkCmdPipelineBarrier2), "VUID-vkCmdPipelineBarrier2-shaderTileImageColorReadAccess-08718"},
+         }},
+        {ShaderTileImageError::kShaderTileImageBarrierError,
+         {
+             {Key(Func::vkCmdPipelineBarrier), "VUID-vkCmdPipelineBarrier-None-08719"},
+             {Key(Func::vkCmdPipelineBarrier2), "VUID-vkCmdPipelineBarrier2-None-08719"},
+         }},
+    };
+
+    const auto &result = FindVUID(error, loc, kShaderTileImageErrors);
+    assert(!result.empty());
+    if (result.empty()) {
+        static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-barrier-error");
+        return unhandled;
+    }
+    return result;
+}
+
 };  // namespace sync_vuid_maps

--- a/layers/sync/sync_vuid_maps.h
+++ b/layers/sync/sync_vuid_maps.h
@@ -112,4 +112,8 @@ enum class SubmitError {
 
 const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error);
 
+enum class ShaderTileImageError { kShaderTileImageFeatureError, kShaderTileImageBarrierError };
+
+const std::string &GetShaderTileImageVUID(const Location &loc, ShaderTileImageError error);
+
 }  // namespace sync_vuid_maps

--- a/tests/positive/dynamic_rendering.cpp
+++ b/tests/positive/dynamic_rendering.cpp
@@ -938,7 +938,6 @@ TEST_F(PositiveDynamicRendering, SuspendSecondaryResumeInPrimary) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-
 TEST_F(PositiveDynamicRendering, WithShaderTileImageAndBarrier) {
     TEST_DESCRIPTION("Test setting memory barrier with shader tile image features are enabled.");
 
@@ -978,16 +977,16 @@ TEST_F(PositiveDynamicRendering, WithShaderTileImageAndBarrier) {
     begin_rendering_info.renderArea = clear_rect.rect;
     begin_rendering_info.layerCount = 1;
 
-    auto memory_barrier = LvlInitStruct<VkMemoryBarrier2KHR>();
-    memory_barrier.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    memory_barrier.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
-    memory_barrier.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    memory_barrier.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
+    auto memory_barrier_2 = LvlInitStruct<VkMemoryBarrier2KHR>();
+    memory_barrier_2.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    memory_barrier_2.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
+    memory_barrier_2.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    memory_barrier_2.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
 
     auto dependency_info = LvlInitStruct<VkDependencyInfoKHR>();
     dependency_info.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
     dependency_info.memoryBarrierCount = 1;
-    dependency_info.pMemoryBarriers = &memory_barrier;
+    dependency_info.pMemoryBarriers = &memory_barrier_2;
     dependency_info.bufferMemoryBarrierCount = 0;
     dependency_info.pBufferMemoryBarriers = VK_NULL_HANDLE;
     dependency_info.imageMemoryBarrierCount = 0;
@@ -995,6 +994,15 @@ TEST_F(PositiveDynamicRendering, WithShaderTileImageAndBarrier) {
 
     vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
     vk::CmdPipelineBarrier2(m_commandBuffer->handle(), &dependency_info);
+    vk::CmdEndRendering(m_commandBuffer->handle());
+
+    auto memory_barrier = LvlInitStruct<VkMemoryBarrier>();
+    memory_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    memory_barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+    vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
+    vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_DEPENDENCY_BY_REGION_BIT, 1, &memory_barrier, 0,
+                           nullptr, 0, nullptr);
     vk::CmdEndRendering(m_commandBuffer->handle());
     m_commandBuffer->end();
 }


### PR DESCRIPTION
This PR include the missing barrier support for vkCmdPipelineBarrier when extension enabled.