### PR TITLE
bp: Remove best practice warnings generating false positives

### DIFF
--- a/layers/best_practices/best_practices_error_enums.h
+++ b/layers/best_practices/best_practices_error_enums.h
@@ -76,10 +76,6 @@
 [[maybe_unused]] static const char *kVUID_BestPractices_DisplayPlane_PropertiesNotCalled =
     "UNASSIGNED-BestPractices-vkGetDisplayPlaneSupportedDisplaysKHR-properties-not-retrieved";
 [[maybe_unused]] static const char *kVUID_BestPractices_MemTrack_InvalidState = "UNASSIGNED-BestPractices-MemTrack-InvalidState";
-[[maybe_unused]] static const char *kVUID_BestPractices_BufferMemReqNotCalled =
-    "UNASSIGNED-BestPractices-vkBindBufferMemory-requirements-not-retrieved";
-[[maybe_unused]] static const char *kVUID_BestPractices_ImageMemReqNotCalled =
-    "UNASSIGNED-BestPractices-vkBindImageMemory-requirements-not-retrieved";
 [[maybe_unused]] static const char *kVUID_BestPractices_BindAccelNV_NoMemReqQuery =
     "UNASSIGNED-BestPractices-BindAccelerationStructureMemoryNV-requirements-not-retrieved";
 [[maybe_unused]] static const char *kVUID_BestPractices_GetVideoSessionMemReqCountNotRetrieved =

--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -147,13 +147,6 @@ bool BestPractices::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory me
 bool BestPractices::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory, const char* api_name) const {
     bool skip = false;
     auto buffer_state = Get<BUFFER_STATE>(buffer);
-
-    if (!buffer_state->memory_requirements_checked && !buffer_state->external_memory_handle_types) {
-        skip |= LogWarning(device, kVUID_BestPractices_BufferMemReqNotCalled,
-                           "%s: Binding memory to %s but vkGetBufferMemoryRequirements() has not been called on that buffer.",
-                           api_name, report_data->FormatHandle(buffer).c_str());
-    }
-
     auto mem_state = Get<DEVICE_MEMORY_STATE>(memory);
 
     if (mem_state && mem_state->alloc_info.allocationSize == buffer_state->createInfo.size &&
@@ -211,18 +204,6 @@ bool BestPractices::PreCallValidateBindBufferMemory2KHR(VkDevice device, uint32_
 bool BestPractices::ValidateBindImageMemory(VkImage image, VkDeviceMemory memory, const char* api_name) const {
     bool skip = false;
     auto image_state = Get<IMAGE_STATE>(image);
-
-    if (image_state->disjoint == false) {
-        if (!image_state->memory_requirements_checked[0] && !image_state->external_memory_handle_types) {
-            skip |= LogWarning(device, kVUID_BestPractices_ImageMemReqNotCalled,
-                               "%s: Binding memory to %s but vkGetImageMemoryRequirements() has not been called on that image.",
-                               api_name, report_data->FormatHandle(image).c_str());
-        }
-    } else {
-        // TODO If binding disjoint image then this needs to check that VkImagePlaneMemoryRequirementsInfo was called for each
-        // plane.
-    }
-
     auto mem_state = Get<DEVICE_MEMORY_STATE>(memory);
 
     if (mem_state->alloc_info.allocationSize == image_state->requirements[0].size &&


### PR DESCRIPTION
closes #4730

Currently I'd just like to remove this false positive before our SDK release.

Here is my rational.

1.) It generates false positives. See issue for details.
2.) As discussed in the issue this way of checking for mem requirements is questionable. Just checking you called the function isn't very robust.
3.) It doesn't have any testing

My current plan of action is remove this invalid logging for the upcoming SDK release, then implement essentially the same thing except more robustly based on the advice here:

> Yeah it may end up being better to check the inputs for the memory binding function and emitting a warning based on that than to track which functions were called where + associated data. Looking for specific function calls probably really isn't that useful.

Thoughts?