### PR TITLE
layers: Remove global stage ordering functions

### DIFF
--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -2209,8 +2209,6 @@ bool CoreChecks::ValidateRenderPassDAG(RenderPassCreateVersion rp_version, const
 
     for (uint32_t i = 0; i < pCreateInfo->dependencyCount; ++i) {
         const VkSubpassDependency2 &dependency = pCreateInfo->pDependencies[i];
-        auto latest_src_stage = sync_utils::GetLogicallyLatestGraphicsPipelineStage(dependency.srcStageMask);
-        auto earliest_dst_stage = sync_utils::GetLogicallyEarliestGraphicsPipelineStage(dependency.dstStageMask);
 
         // The first subpass here serves as a good proxy for "is multiview enabled" - since all view masks need to be non-zero if
         // any are, which enables multiview.
@@ -2267,11 +2265,9 @@ bool CoreChecks::ValidateRenderPassDAG(RenderPassCreateVersion rp_version, const
                 vuid = use_rp2 ? "VUID-VkSubpassDependency2-srcSubpass-06810" : "VUID-VkSubpassDependency-srcSubpass-06809";
                 skip |= LogError(device, vuid,
                                  "Dependency %" PRIu32
-                                 " specifies a self-dependency from a stage (%s) that accesses framebuffer space (%s) to a stage "
-                                 "(%s) that accesses non-framebuffer space (%s).",
-                                 i, sync_utils::StringPipelineStageFlags(latest_src_stage).c_str(),
-                                 string_VkPipelineStageFlags(dependency.srcStageMask).c_str(),
-                                 sync_utils::StringPipelineStageFlags(earliest_dst_stage).c_str(),
+                                 " specifies a self-dependency from stage(s) that access framebuffer space %s to stage(s) that "
+                                 "access non-framebuffer space %s.",
+                                 i, string_VkPipelineStageFlags(dependency.srcStageMask).c_str(),
                                  string_VkPipelineStageFlags(dependency.dstStageMask).c_str());
             } else if ((HasNonFramebufferStagePipelineStageFlags(dependency.srcStageMask) == false) &&
                        (HasNonFramebufferStagePipelineStageFlags(dependency.dstStageMask) == false) &&

--- a/layers/sync/sync_utils.h
+++ b/layers/sync/sync_utils.h
@@ -40,12 +40,6 @@ VkPipelineStageFlags2KHR WithEarlierPipelineStages(VkPipelineStageFlags2KHR stag
 
 VkPipelineStageFlags2KHR WithLaterPipelineStages(VkPipelineStageFlags2KHR stage_mask);
 
-int GetGraphicsPipelineStageLogicalOrdinal(VkPipelineStageFlags2KHR flag);
-
-VkPipelineStageFlags2KHR GetLogicallyEarliestGraphicsPipelineStage(VkPipelineStageFlags2KHR inflags);
-
-VkPipelineStageFlags2KHR GetLogicallyLatestGraphicsPipelineStage(VkPipelineStageFlags2KHR inflags);
-
 std::string StringPipelineStageFlags(VkPipelineStageFlags2KHR mask);
 
 std::string StringAccessFlags(VkAccessFlags2KHR mask);


### PR DESCRIPTION
These functions can produce unexpected result. The problem is that `GetLogicallyEarLiest(Latest)GraphicsPipelineStage` tries to create global ordering of __all__ pipeline stages (not only graphics as the name suggests). So, if the mask specifies `fragment+raytracing` stages then the earliest stage will always be evaluated to a `fragment` stage (because it has lower index), independenty if the application logic is concerned with the fragment or with the raytracing stage.

Also added a comment here:
https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4246#discussion_r1190329610

This PR is a side effect from a parallel work to update current syncval codegen to use xml input instead of `validusage.json` and adhoc text snippets.
