### PR TITLE
gpu: Lazily allocate gpu-side DescriptorSet data

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -164,6 +164,8 @@ core_validation_sources = [
   "layers/gpu_validation/gpu_validation.cpp",
   "layers/gpu_validation/gpu_validation.h",
   "layers/gpu_validation/gpu_vuids.h",
+  "layers/gpu_validation/gv_descriptor_sets.cpp",
+  "layers/gpu_validation/gv_descriptor_sets.h",
   "layers/containers/qfo_transfer.h",
   "layers/containers/range_vector.h",
   "layers/state_tracker/base_node.cpp",

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -84,6 +84,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/command_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/generated/dynamic_state_helper.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/gpu_validation/gpu_validation.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/gpu_validation/gpu_utils.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/gpu_validation/gv_descriptor_sets.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/gpu_validation/debug_printf.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/best_practices/best_practices_utils.cpp
 LOCAL_SRC_FILES += ${SRC_DIR}/layers/best_practices/bp_buffer.cpp

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -248,6 +248,8 @@ target_sources(VkLayer_khronos_validation PRIVATE
     gpu_validation/gpu_validation.cpp
     gpu_validation/gpu_validation.cpp
     gpu_validation/gpu_validation.h
+    gpu_validation/gv_descriptor_sets.cpp
+    gpu_validation/gv_descriptor_sets.h
     object_tracker/object_lifetime_validation.h
     object_tracker/object_tracker_utils.cpp
     state_tracker/base_node.cpp

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -4583,8 +4583,9 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSetKHR(VkCommandBuffer commandB
                 } else {
                     // Create an empty proxy in order to use the existing descriptor set update validation
                     // TODO move the validation (like this) that doesn't need descriptor set state to the DSL object so we
-                    // don't have to do this.
-                    cvdescriptorset::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, this);
+                    // don't have to do this. Note we need to const_cast<>(this) because GPU-AV needs a non-const version of
+                    // the state tracker. The proxy here could get away with const.
+                    cvdescriptorset::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<CoreChecks *>(this));
                     skip |= ValidatePushDescriptorsUpdate(&proxy_ds, descriptorWriteCount, pDescriptorWrites,
                                                           "vkCmdPushDescriptorSetKHR()");
                 }
@@ -4779,7 +4780,7 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSetWithTemplateKHR(VkCommandBuf
                              "VkDescriptorUpdateTemplateCreateInfo::descriptorSetLayout was accidentally destroy.");
         } else {
             // Create an empty proxy in order to use the existing descriptor set update validation
-            cvdescriptorset::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, this);
+            cvdescriptorset::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<CoreChecks *>(this));
             // Decode the template into a set of write updates
             cvdescriptorset::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state.get(), pData,
                                                                     dsl->GetDescriptorSetLayout());

--- a/layers/gpu_validation/gv_descriptor_sets.cpp
+++ b/layers/gpu_validation/gv_descriptor_sets.cpp
@@ -1,0 +1,225 @@
+/* Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gpu_validation/gv_descriptor_sets.h"
+#include "gpu_validation/gpu_validation.h"
+
+gpuav_state::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIPTOR_POOL_STATE *pool,
+                                          const std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> &layout,
+                                          uint32_t variable_count, ValidationStateTracker *state_data)
+    : cvdescriptorset::DescriptorSet(set, pool, layout, variable_count, state_data) {}
+
+std::shared_ptr<gpuav_state::DescriptorSet::State> gpuav_state::DescriptorSet::GetCurrentState() {
+    auto guard = Lock();
+    GpuAssisted *gv_dev = static_cast<GpuAssisted *>(state_data_);
+    uint32_t cur_version = current_version_.load();
+    if (last_used_state_ && last_used_state_->version == cur_version) {
+        return last_used_state_;
+    }
+    auto next_state = std::make_shared<State>();
+    next_state->version = cur_version;
+    next_state->allocator = gv_dev->vmaAllocator;
+
+    uint32_t descriptor_count = 0;  // Number of descriptors, including all array elements
+    uint32_t binding_count = 0;     // Number of bindings based on the max binding number used
+    if (GetBindingCount() > 0) {
+        binding_count += GetLayout()->GetMaxBinding() + 1;
+        for (const auto &binding : *this) {
+            // Shader instrumentation is tracking inline uniform blocks as scalers. Don't try to validate inline uniform
+            // blocks
+            if (binding->type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT) {
+                descriptor_count++;
+                // LogWarning(device, "UNASSIGNED-GPU-Assisted Validation Warning",
+                //            "VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT descriptors will not be validated by GPU assisted "
+                //            "validation");
+            } else {
+                descriptor_count += binding->count;
+            }
+        }
+    }
+
+    // For each set, allocate an input buffer that describes the descriptor set and its update status as follows
+    // Word 0 = the number of bindings in the descriptor set - note that the bindings can be sparse and this is the largest
+    // binding number + 1 which we'll refer to as N. Words 1 through Word N = the number of descriptors in each binding.
+    // Words N+1 through Word N+N = the index where the size and update status of each binding + index pair starts -
+    // unwritten is size 0 So for descriptor set:
+    //    Binding
+    //       0 Array[3]
+    //       1 Non Array
+    //       3 Array[2]
+    // offset 0 = number of bindings in the descriptor set = 4
+    // 1 = number of descriptors in binding 0  = 3
+    // 2 = number of descriptors in binding 1 = 1
+    // 3 = number of descriptors in binding 2 = 0 (ignored)
+    // 4 = number of descriptors in binding 3 = 2
+    // 5 = start of init data for binding 0 = 9
+    // 6 = start of init data for binding 1 = 12
+    // 7 = start of init data for binding 2 = 0 (ignored)
+    // 8 = start of init data for binding 3 =  13
+    // 9 =  Is set 0 binding 0 index 0 written
+    // 10 = Is set 0 binding 0 index 1 written
+    // 11 = Is set 0 binding 0 index 2 written
+    // 12 = is set 1 binding 1 index 0 written
+    // 13 = is set 3 binding 3 index 0 written
+    // 14 = is set 3 binding 3 index 1 written
+    //
+    // Once the buffer is complete, write its buffer device address into the address buffer
+    VkBufferCreateInfo buffer_info = LvlInitStruct<VkBufferCreateInfo>();
+    buffer_info.size = (1 + binding_count + binding_count + descriptor_count) * 4;
+    buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+
+    // The descriptor state buffer can be very large (4mb+ in some games). Allocating it as HOST_CACHED
+    // and manually flushing it at the end of the state updates is faster than using HOST_COHERENT.
+    VmaAllocationCreateInfo alloc_info{};
+    alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+    VkResult result =
+        vmaCreateBuffer(next_state->allocator, &buffer_info, &alloc_info, &next_state->buffer, &next_state->allocation, nullptr);
+    if (result != VK_SUCCESS) {
+        return nullptr;
+    }
+    uint32_t *descriptor_data_ptr;
+    result = vmaMapMemory(next_state->allocator, next_state->allocation, reinterpret_cast<void **>(&descriptor_data_ptr));
+    assert(result == VK_SUCCESS);
+    memset(descriptor_data_ptr, 0, static_cast<size_t>(buffer_info.size));
+    *descriptor_data_ptr = binding_count;
+    auto num_descriptors_ptr = descriptor_data_ptr + 1;
+    auto start_index_ptr = num_descriptors_ptr + binding_count;
+    auto written_index = 1 + binding_count + binding_count;
+    for (auto &binding : *this) {
+        // Note: the start index needs to start after element 0, which is a
+        // separate field in the SPIR-V structure.
+        *(start_index_ptr + binding->binding) = written_index - 1;
+        if (VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT == binding->type) {
+            *(num_descriptors_ptr + binding->binding) = 1;
+            descriptor_data_ptr[written_index++] = vvl::kU32Max;
+            continue;
+        }
+        *(num_descriptors_ptr + binding->binding) = binding->count;
+
+        SetBindingState(descriptor_data_ptr, written_index, binding.get());
+
+        written_index += binding->count;
+    }
+    auto buffer_device_address_info = LvlInitStruct<VkBufferDeviceAddressInfo>();
+    buffer_device_address_info.buffer = next_state->buffer;
+
+    // We cannot rely on device_extensions here, since we may be enabling BDA support even
+    // though the application has not requested it.
+    if (gv_dev->api_version >= VK_API_VERSION_1_2) {
+        next_state->device_addr = DispatchGetBufferDeviceAddress(gv_dev->device, &buffer_device_address_info);
+    } else {
+        next_state->device_addr = DispatchGetBufferDeviceAddressKHR(gv_dev->device, &buffer_device_address_info);
+    }
+    assert(next_state->device_addr != 0);
+
+    // Flush the descriptor state buffer before unmapping so that the new state is visible to the GPU
+    result = vmaFlushAllocation(next_state->allocator, next_state->allocation, 0, VK_WHOLE_SIZE);
+    // No good way to handle this error, we should still try to unmap.
+    assert(result == VK_SUCCESS);
+    vmaUnmapMemory(next_state->allocator, next_state->allocation);
+
+    last_used_state_ = next_state;
+    return next_state;
+}
+
+gpuav_state::DescriptorSet::State::~State() { vmaDestroyBuffer(allocator, buffer, allocation); }
+
+void gpuav_state::DescriptorSet::SetBindingState(uint32_t *data, uint32_t index,
+                                                 const cvdescriptorset::DescriptorBinding *binding) {
+    switch (binding->descriptor_class) {
+        case cvdescriptorset::DescriptorClass::GeneralBuffer: {
+            auto buffer_binding = static_cast<const cvdescriptorset::BufferBinding *>(binding);
+            for (uint32_t di = 0; di < buffer_binding->count; di++) {
+                const auto &desc = buffer_binding->descriptors[di];
+                if (!buffer_binding->updated[di]) {
+                    data[index++] = 0;
+                    continue;
+                }
+                auto buffer = desc.GetBuffer();
+                if (buffer == VK_NULL_HANDLE) {
+                    data[index++] = vvl::kU32Max;
+                } else {
+                    auto buffer_state = desc.GetBufferState();
+                    data[index++] = static_cast<uint32_t>(buffer_state->createInfo.size);
+                }
+            }
+            break;
+        }
+        case cvdescriptorset::DescriptorClass::TexelBuffer: {
+            auto texel_binding = static_cast<const cvdescriptorset::TexelBinding *>(binding);
+            for (uint32_t di = 0; di < texel_binding->count; di++) {
+                const auto &desc = texel_binding->descriptors[di];
+                if (!texel_binding->updated[di]) {
+                    data[index++] = 0;
+                    continue;
+                }
+                auto buffer_view = desc.GetBufferView();
+                if (buffer_view == VK_NULL_HANDLE) {
+                    data[index++] = vvl::kU32Max;
+                } else {
+                    auto buffer_view_state = desc.GetBufferViewState();
+                    data[index++] = static_cast<uint32_t>(buffer_view_state->buffer_state->createInfo.size);
+                }
+            }
+            break;
+        }
+        case cvdescriptorset::DescriptorClass::Mutable: {
+            auto mutable_binding = static_cast<const cvdescriptorset::MutableBinding *>(binding);
+            for (uint32_t di = 0; di < mutable_binding->count; di++) {
+                const auto &desc = mutable_binding->descriptors[di];
+                if (!mutable_binding->updated[di]) {
+                    data[index++] = 0;
+                    continue;
+                }
+                switch (desc.ActiveType()) {
+                    case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+                    case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+                    case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+                    case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                        data[index++] = static_cast<uint32_t>(desc.GetBufferSize());
+                        break;
+                    default:
+                        data[index++] = 1;
+                        break;
+                }
+            }
+            break;
+        }
+        default: {
+            for (uint32_t i = 0; i < binding->count; i++, index++) {
+                data[index] = static_cast<uint32_t>(binding->updated[i]);
+            }
+            break;
+        }
+    }
+}
+
+void gpuav_state::DescriptorSet::PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet *write_descs) {
+    cvdescriptorset::DescriptorSet::PerformPushDescriptorsUpdate(write_count, write_descs);
+    current_version_++;
+}
+
+void gpuav_state::DescriptorSet::PerformWriteUpdate(const VkWriteDescriptorSet &write_desc) {
+    cvdescriptorset::DescriptorSet::PerformWriteUpdate(write_desc);
+    current_version_++;
+}
+
+void gpuav_state::DescriptorSet::PerformCopyUpdate(const VkCopyDescriptorSet &copy_desc,
+                                                   const cvdescriptorset::DescriptorSet &src_set) {
+    cvdescriptorset::DescriptorSet::PerformCopyUpdate(copy_desc, src_set);
+    current_version_++;
+}

--- a/layers/gpu_validation/gv_descriptor_sets.h
+++ b/layers/gpu_validation/gv_descriptor_sets.h
@@ -1,0 +1,57 @@
+/* Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include "state_tracker/descriptor_sets.h"
+#include "vma/vma.h"
+
+namespace gpuav_state {
+
+class DescriptorSet : public cvdescriptorset::DescriptorSet {
+  public:
+    DescriptorSet(const VkDescriptorSet set, DESCRIPTOR_POOL_STATE *pool,
+                  const std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> &layout, uint32_t variable_count,
+                  ValidationStateTracker *state_data);
+    virtual ~DescriptorSet() { Destroy(); }
+    void Destroy() override { last_used_state_.reset(); };
+    struct State {
+        ~State();
+        uint32_t version;
+        VmaAllocator allocator{nullptr};
+        VmaAllocation allocation{nullptr};
+        VkBuffer buffer{VK_NULL_HANDLE};
+        VkDeviceAddress device_addr{0};
+    };
+    void PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet *write_descs) override;
+    void PerformWriteUpdate(const VkWriteDescriptorSet &) override;
+    void PerformCopyUpdate(const VkCopyDescriptorSet &, const cvdescriptorset::DescriptorSet &) override;
+
+    std::shared_ptr<State> GetCurrentState();
+
+  private:
+    void SetBindingState(uint32_t *data, uint32_t index, const cvdescriptorset::DescriptorBinding *binding);
+    std::lock_guard<std::mutex> Lock() const { return std::lock_guard<std::mutex>(state_lock_); }
+
+    std::atomic<uint32_t> current_version_{0};
+    std::shared_ptr<State> last_used_state_;
+    mutable std::mutex state_lock_;
+};
+
+}  // namespace gpuav_state

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1015,8 +1015,7 @@ void CMD_BUFFER_STATE::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPo
     auto &push_descriptor_set = last_bound.push_descriptor_set;
     // If we are disturbing the current push_desriptor_set clear it
     if (!push_descriptor_set || !IsBoundSetCompat(set, last_bound, pipeline_layout)) {
-        last_bound.UnbindAndResetPushDescriptorSet(
-            std::make_shared<cvdescriptorset::DescriptorSet>(VK_NULL_HANDLE, nullptr, dsl, 0, dev_data));
+        last_bound.UnbindAndResetPushDescriptorSet(dev_data->CreateDescriptorSet(VK_NULL_HANDLE, nullptr, dsl, 0));
     }
 
     UpdateLastBoundDescriptorSets(pipelineBindPoint, pipeline_layout, set, 1, nullptr, push_descriptor_set, 0, nullptr);

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -58,8 +58,8 @@ void DESCRIPTOR_POOL_STATE::Allocate(const VkDescriptorSetAllocateInfo *alloc_in
     for (uint32_t i = 0; i < alloc_info->descriptorSetCount; i++) {
         uint32_t variable_count = variable_count_valid ? variable_count_info->pDescriptorCounts[i] : 0;
 
-        auto new_ds = std::make_shared<cvdescriptorset::DescriptorSet>(descriptor_sets[i], this, ds_data->layout_nodes[i],
-                                                                       variable_count, dev_data_);
+        auto new_ds = dev_data_->CreateDescriptorSet(descriptor_sets[i], this, ds_data->layout_nodes[i], variable_count);
+
         sets_.emplace(descriptor_sets[i], new_ds.get());
         dev_data_->Add(std::move(new_ds));
     }
@@ -374,7 +374,7 @@ void cvdescriptorset::AllocateDescriptorSetsData::Init(uint32_t count) { layout_
 
 cvdescriptorset::DescriptorSet::DescriptorSet(const VkDescriptorSet set, DESCRIPTOR_POOL_STATE *pool_state,
                                               const std::shared_ptr<DescriptorSetLayout const> &layout, uint32_t variable_count,
-                                              const cvdescriptorset::DescriptorSet::StateTracker *state_data)
+                                              cvdescriptorset::DescriptorSet::StateTracker *state_data)
     : BASE_NODE(set, kVulkanObjectTypeDescriptorSet),
       some_update_(false),
       pool_state_(pool_state),

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -2606,6 +2606,12 @@ std::shared_ptr<DESCRIPTOR_POOL_STATE> ValidationStateTracker::CreateDescriptorP
     return std::make_shared<DESCRIPTOR_POOL_STATE>(this, pool, pCreateInfo);
 }
 
+std::shared_ptr<cvdescriptorset::DescriptorSet> ValidationStateTracker::CreateDescriptorSet(
+    VkDescriptorSet set, DESCRIPTOR_POOL_STATE *pool, const std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> &layout,
+    uint32_t variable_count) {
+    return std::make_shared<cvdescriptorset::DescriptorSet>(set, pool, layout, variable_count, this);
+}
+
 void ValidationStateTracker::PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,
                                                                 const VkAllocationCallbacks *pAllocator,
                                                                 VkDescriptorPool *pDescriptorPool, VkResult result) {

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -665,6 +665,10 @@ class ValidationStateTracker : public ValidationObject {
 
     virtual std::shared_ptr<DESCRIPTOR_POOL_STATE> CreateDescriptorPoolState(VkDescriptorPool pool,
                                                                              const VkDescriptorPoolCreateInfo* pCreateInfo);
+    virtual std::shared_ptr<cvdescriptorset::DescriptorSet> CreateDescriptorSet(
+        VkDescriptorSet, DESCRIPTOR_POOL_STATE*, const std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>& layout,
+        uint32_t variable_count);
+
     void PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo* pCreateInfo,
                                             const VkAllocationCallbacks* pAllocator, VkDescriptorPool* pDescriptorPool,
                                             VkResult result) override;


### PR DESCRIPTION
Rather than allocating memory for each descriptorset in every vkCmdBindDescriptorSets() call, track changes to the descriptors and only allocate new memory when there is a change.
