### PR TITLE
Fix imageOpaque sparse binding crash

### DIFF
--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -623,7 +623,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
         }
 
         if (bind_info.pImageOpaqueBinds) {
-            for (uint32_t image_opaque_idx = 0; image_opaque_idx < bind_info.bufferBindCount; ++image_opaque_idx) {
+            for (uint32_t image_opaque_idx = 0; image_opaque_idx < bind_info.imageOpaqueBindCount; ++image_opaque_idx) {
                 const VkSparseImageOpaqueMemoryBindInfo &image_opaque_bind = bind_info.pImageOpaqueBinds[image_opaque_idx];
                 if (image_opaque_bind.pBinds) {
                     auto image_state = Get<IMAGE_STATE>(image_opaque_bind.image);


### PR DESCRIPTION
The sparse-binding check has a copy-paste issue, it uses `bind_info.bufferBindCount` when iterating over the opaque image binds, causing it to possibly read-out-of-bounds or access garbage pointers. I had a crash in the validation layers during a submission of sparse-buffer-binds where `pImageOpaqueBinds` was set to garbage since `imageOpaqueBindCount` was 0 (in which case the pointer is ignored per spec).