### PR TITLE
tests: Remove WORKAROUND for old devsim setup

### DIFF
--- a/layers/containers/subresource_adapter.cpp
+++ b/layers/containers/subresource_adapter.cpp
@@ -282,15 +282,6 @@ ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image, const AspectParam
     VkImageSubresourceLayers subres_layers = {limits_.aspectMask, 0, 0, limits_.arrayLayer};
     linear_image_ = false;
 
-    // WORKAROUND for profile and mock_icd not containing valid VkSubresourceLayout yet. Treat it as optimal image.
-    if (image.createInfo.tiling == VK_IMAGE_TILING_LINEAR) {
-        subres = {static_cast<VkImageAspectFlags>(AspectBit(0)), 0, 0};
-        DispatchGetImageSubresourceLayout(image.store_device_as_workaround, image.image(), &subres, &layout);
-        if (layout.size > 0) {
-            linear_image_ = true;
-        }
-    }
-
     is_compressed_ = FormatIsCompressed(image.createInfo.format);
     texel_extent_ = FormatTexelBlockExtent(image.createInfo.format);
 

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -379,14 +379,6 @@ VkFormat FindFormatLinearWithoutMips(VkPhysicalDevice gpu, VkImageCreateInfo ima
     for (VkFormat format = first_vk_format; format <= last_vk_format; format = static_cast<VkFormat>(format + 1)) {
         image_ci.format = format;
 
-        // WORKAROUND for profile and mock_icd not containing valid format limits yet
-        VkFormatProperties format_props;
-        vk::GetPhysicalDeviceFormatProperties(gpu, format, &format_props);
-        const VkFormatFeatureFlags core_filter = 0x1FFF;
-        const auto features = (image_ci.tiling == VK_IMAGE_TILING_LINEAR) ? format_props.linearTilingFeatures & core_filter
-                                                                          : format_props.optimalTilingFeatures & core_filter;
-        if (!(features & core_filter)) continue;
-
         VkImageFormatProperties img_limits;
         if (VK_SUCCESS == GPDIFPHelper(gpu, &image_ci, &img_limits) && img_limits.maxMipLevels == 1) return format;
     }

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -1426,17 +1426,6 @@ bool VkImageObj::IsCompatible(const VkImageUsageFlags usages, const VkFormatFeat
     if ((usages & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) && !(features & VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT))
         return false;
 
-    if (m_device->IsEnabledExtension(VK_KHR_MAINTENANCE_1_EXTENSION_NAME)) {
-        // WORKAROUND: for Profile not reporting extended enums, and possibly some drivers too
-        const auto all_nontransfer_feature_flags =
-            all_feature_flags ^ (VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR | VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR);
-        const bool transfer_probably_supported_anyway = (features & all_nontransfer_feature_flags) > 0;
-        if (!transfer_probably_supported_anyway) {
-            if ((usages & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) && !(features & VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT_KHR)) return false;
-            if ((usages & VK_IMAGE_USAGE_TRANSFER_DST_BIT) && !(features & VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT_KHR)) return false;
-        }
-    }
-
     return true;
 }
 VkImageCreateInfo VkImageObj::ImageCreateInfo2D(uint32_t const width, uint32_t const height, uint32_t const mipLevels,


### PR DESCRIPTION
I noticed these 3 `WORKAROUND` but didn't want to remove them when trying to originally setup the Profile/MockICD flow

I pinpointed the 3 commits that added these

https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/3f6978b4da36395461e2c93b1e3e64550205c4db
https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/b9659a01b805b9b61520c4d1cd95521c065bd617
https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/4ac77b358bfb8e7d29db34c4ab72508cd02433ff

Looking at it seems to not be needed anymore, also passed all the tests locally, so going to hope CI also is just happy with this
