### PR TITLE
layers: Prevent crash on Core_DrawState_NoActiveRenderpass

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2873,7 +2873,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &last_boun
                 }
             }
         } else {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline(), cb_state.activeRenderPass->renderPass());
+            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
             skip |=
                 LogError(objlist, kVUID_Core_DrawState_NoActiveRenderpass, "%s: No active render pass found at draw-time.", caller);
         }


### PR DESCRIPTION
cb_state.activeRenderPass will always be null when logging kVUID_Core_DrawState_NoActiveRenderpass.  Layers would always crash due to dereferencing cb_state.activeRenderPass for inclusion in the LogObjectList.