### PR TITLE
layers: Improve GetEnvironment() for android

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -269,15 +269,6 @@ NDK r20 or greater required
   - SDK Tools > Android SDK Tools
   - SDK Tools > NDK
 
-#### Android Hardware Buffer support
-
-The Validation Layers by default build and release for Android 26 (Android Oreo). While Vulkan is supported in Android 24 and 25, there is no AHardwareBuffer support. To build a version of the Validation Layers for use with Android that will not require AHB support, simply addjust the `APP_PLATFORM` in [build-android/jni/Application.mk](build-android/jni/Application.mk)
-
-```patch
--APP_PLATFORM := android-26
-+APP_PLATFORM := android-24
-```
-
 #### Add Android specifics to environment
 
 For each of the below, you may need to specify a different build-tools

--- a/layers/android/CMakeLists.txt
+++ b/layers/android/CMakeLists.txt
@@ -19,15 +19,8 @@ if (ANDROID_USE_LEGACY_TOOLCHAIN_FILE)
     message(WARNING "Using legacy android toolchain!")
 endif()
 
-if (ANDROID_PLATFORM LESS "24")
-    message(FATAL_ERROR "Vulkan not supported on Android 23 and below!")
-endif()
-
 if (ANDROID_PLATFORM LESS "26")
-    message(WARNING "No Android HardwareBuffer support!\n"
-                    "While Vulkan is supported in Android 24 and 25, there is no AHardwareBuffer support.\n"
-                    "To build a version of the Validation Layers for use with Android that will not require AHB support,\n"
-                    "simply change `ANDROID_PLATFORM` parameter value in the CMake generate command to 24 or 25.")
+    message(FATAL_ERROR "Vulkan-ValidationLayers is not supported on Android 25 and below!")
 endif()
 
 # Required for __android_log_print. Marking as PUBLIC since the tests use __android_log_print as well.

--- a/layers/utils/android_ndk_types.h
+++ b/layers/utils/android_ndk_types.h
@@ -46,10 +46,8 @@
 //
 // NOTE: VK_USE_PLATFORM_ANDROID_KHR != Android Hardware Buffer
 //       AHB is all things not found in the Vulkan Spec
-#if __ANDROID_API__ < 24
-#error "Vulkan not supported on Android 23 and below"
-#elif __ANDROID_API__ < 26
-#warning "Building for Android without Android Hardware Buffer support"
+#if __ANDROID_API__ < 26
+#error "Vulkan-ValidationLayers is not supported on Android 25 and below"
 #else
 // This is used to allow building for Android without AHB support
 #define AHB_VALIDATION_SUPPORT

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -33,6 +33,10 @@
 #include <windows.h>
 #include <direct.h>
 #define GetCurrentDir _getcwd
+#elif defined(__ANDROID__)
+#include <sys/system_properties.h>
+#include <unistd.h>
+#define GetCurrentDir getcwd
 #else
 #include <unistd.h>
 #define GetCurrentDir getcwd
@@ -60,6 +64,13 @@ class ConfigFile {
 
 static ConfigFile layer_config;
 
+#if defined(__ANDROID__)
+static void PropCallback(void *cookie, [[maybe_unused]] const char *name, const char *value, [[maybe_unused]] uint32_t serial) {
+    std::string *property = static_cast<std::string *>(cookie);
+    *property = value;
+}
+#endif
+
 std::string GetEnvironment(const char *variable) {
 #if !defined(__ANDROID__) && !defined(_WIN32)
     const char *output = getenv(variable);
@@ -75,21 +86,12 @@ std::string GetEnvironment(const char *variable) {
     delete[] buffer;
     return output;
 #elif defined(__ANDROID__)
-    string command = "getprop " + string(variable);
-    FILE *pPipe = popen(command.c_str(), "r");
-    if (pPipe != nullptr) {
-        char value[256];
-        fgets(value, 256, pPipe);
-        pclose(pPipe);
+    const prop_info *prop_info = __system_property_find(variable);
 
-        // Make sure its not an empty line and does not end in a newline
-        const auto str_len = strcspn(value, "\r\n");
-        if (str_len == 0) {
-            return "";
-        } else {
-            value[str_len] = '\0';
-            return string(value);
-        }
+    if (prop_info) {
+        std::string property;
+        __system_property_read_callback(prop_info, PropCallback, &property);
+        return property;
     } else {
         return "";
     }


### PR DESCRIPTION
Use system_properties.h functions instead of spawning a process to run the getprop command.

NOTE: These functions are only supported in Android API version 26 or higher.

Fixes #4605 