### PR TITLE
tests: Add tests for Multi-Entrypoint

### DIFF
--- a/tests/positive/shader_storage_image.cpp
+++ b/tests/positive/shader_storage_image.cpp
@@ -300,3 +300,133 @@ TEST_F(PositiveShaderStorageImage, WriteSpecConstantMoreComponent) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 }
+
+TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
+    TEST_DESCRIPTION("Test writing to image unknown format with less components, but in unused Entrypoint.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    if (IsPlatform(kPixel3) || IsPlatform(kPixel3aXL)) {
+        GTEST_SKIP() << "Pixel 3 compilers can't compile this valid SPIR-V";
+    }
+
+    // The vertex and fragment shader are just a passthrough
+    // The compute shader has the invalid OpImageWrite
+    const char *source = R"(
+               OpCapability Shader
+               OpCapability StorageImageWriteWithoutFormat
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main_f "main" %4
+               OpEntryPoint Vertex %main_v "main" %2
+               OpEntryPoint GLCompute %main_c "main" %var_image
+               OpExecutionMode %main_f OriginUpperLeft
+               OpExecutionMode %main_c LocalSize 1 1 1
+               OpMemberDecorate %builtin_vert 0 BuiltIn Position
+               OpMemberDecorate %builtin_vert 1 BuiltIn PointSize
+               OpMemberDecorate %builtin_vert 2 BuiltIn ClipDistance
+               OpMemberDecorate %builtin_vert 3 BuiltIn CullDistance
+               OpDecorate %builtin_vert Block
+
+               OpDecorate %4 Location 0
+
+               OpDecorate %var_image DescriptorSet 0
+               OpDecorate %var_image Binding 0
+               OpDecorate %var_image NonReadable
+
+       %void = OpTypeVoid
+          %8 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+            ; Vertex types
+    %v4float = OpTypeVector %float 4
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+      %array = OpTypeArray %float %uint_1
+  %builtin_vert = OpTypeStruct %v4float %float %array %array
+%ptr_builtin_vert = OpTypePointer Output %builtin_vert
+          %2 = OpVariable %ptr_builtin_vert Output
+
+            ; Fragment types
+%ptr_output_frag = OpTypePointer Output %v4float
+          %4 = OpVariable %ptr_output_frag Output
+    %float_0 = OpConstant %float 0
+         %23 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+
+            ; Compute types
+        %int = OpTypeInt 32 1
+      %v2int = OpTypeVector %int 2
+      %int_1 = OpConstant %int 1
+      %coord = OpConstantComposite %v2int %int_1 %int_1
+     %v3uint = OpTypeVector %uint 3
+    %texelU3 = OpConstantComposite %v3uint %uint_1 %uint_1 %uint_1
+      %image = OpTypeImage %uint 2D 0 0 0 2 Unknown
+  %ptr_image = OpTypePointer UniformConstant %image
+  %var_image = OpVariable %ptr_image UniformConstant
+
+     %main_v = OpFunction %void None %8
+         %24 = OpLabel
+               OpReturn
+               OpFunctionEnd
+
+     %main_f = OpFunction %void None %8
+         %28 = OpLabel
+               OpStore %4 %23
+               OpReturn
+               OpFunctionEnd
+
+     %main_c = OpFunction %void None %8
+         %29 = OpLabel
+ %load_image = OpLoad %image %var_image
+               OpImageWrite %load_image %coord %texelU3 ZeroExtend
+               OpReturn
+               OpFunctionEnd
+    )";
+    OneOffDescriptorSet ds(m_device, {
+                                         {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+                                     });
+
+    const VkFormat format = VK_FORMAT_R8G8B8A8_UINT;
+    if (!ImageFormatAndFeaturesSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+        GTEST_SKIP() << "Format doesn't support storage image";
+    }
+
+    VkImageObj image(m_device);
+    image.Init(32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT, VK_IMAGE_TILING_OPTIMAL);
+
+    VkDescriptorImageInfo image_info = {};
+    image_info.imageView = image.targetView(format);
+    image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkWriteDescriptorSet descriptor_write = LvlInitStruct<VkWriteDescriptorSet>();
+    descriptor_write.dstSet = ds.set_;
+    descriptor_write.dstBinding = 0;
+    descriptor_write.descriptorCount = 1;
+    descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    descriptor_write.pImageInfo = &image_info;
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
+
+    VkShaderObj const vs(this, source, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    VkShaderObj const fs(this, source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitInfo();
+    pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    pipe.InitState();
+    pipe.pipeline_layout_ = VkPipelineLayoutObj(m_device, {&ds.layout_});
+    pipe.CreateGraphicsPipeline();
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
+                              &ds.set_, 0, nullptr);
+    // This does not invoke the Compute Entrypoint where the bad write would be
+    vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+}


### PR DESCRIPTION
After much refactoring of the Shader Validation over last year, these tests show that both https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4881 and https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2450 can be closed as we are now properly handling things per-Entrypoint!