### PR TITLE
Remove OpImageSparseTexelsResident from ImageAccess

### DIFF
--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -541,7 +541,10 @@ ImageAccess::ImageAccess(const SHADER_MODULE_STATE& module_state, const Instruct
         case spv::OpImageQueryLevels:
         case spv::OpImageQuerySamples:
         case spv::OpImageQueryLod:
+            break;
+
         case spv::OpImageSparseTexelsResident:
+            assert(false);  // This is not a proper OpImage* instruction, has no OpImage operand
             break;
 
         default:
@@ -844,8 +847,7 @@ SHADER_MODULE_STATE::StaticData::StaticData(const SHADER_MODULE_STATE& module_st
             case spv::OpImageQueryLevels:
             case spv::OpImageQuerySamples:
             case spv::OpImageSparseFetch:
-            case spv::OpImageSparseGather:
-            case spv::OpImageSparseTexelsResident: {
+            case spv::OpImageSparseGather: {
                 image_instructions = true;
                 break;
             }


### PR DESCRIPTION
Closes #5870 and tests in `dEQP-VK.sparse_resources.shader_intrinsics.2d_sparse_fetch.*` for CTS

The issue is `OpImageSparseTexelsResident`, while being `OpImage*` actually has no `OpImage` operand, so there is no way to have a `ImageAccess` object around it

Test and special assert added in case this gets accidentally added in the future