### PR TITLE
tests: Add missing vkCreateBuffer tests

### DIFF
--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -1082,7 +1082,7 @@
                     "maxMemoryAllocationSize": 4294967000
                 },
                 "VkPhysicalDeviceMaintenance4Properties": {
-                    "maxBufferSize": 4294967000
+                    "maxBufferSize": 1073741824
                 },
                 "VkPhysicalDeviceFloatControlsProperties": {
                     "shaderSignedZeroInfNanPreserveFloat16": true,
@@ -1485,7 +1485,7 @@
                     "storageTexelBufferOffsetAlignmentBytes": 16,
                     "uniformTexelBufferOffsetSingleTexelAlignment": true,
                     "uniformTexelBufferOffsetAlignmentBytes": 16,
-                    "maxBufferSize": 4294967000
+                    "maxBufferSize": 1073741824
                 },
                 "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
                     "maxCustomBorderColorSamplers": 4294967000


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5842

Adds missing tests for

- `VUID-VkBufferCreateInfo-flags-00915`   | sparse 
- `VUID-VkBufferCreateInfo-flags-00916`   | sparse 
- `VUID-VkBufferCreateInfo-flags-00917`   | sparse 
- `VUID-VkBufferCreateInfo-size-06409`    | (VK_VERSION_1_3,VK_KHR_maintenance4) 
- `VUID-VkBufferCreateInfo-usage-08103`   | (VK_EXT_descriptor_buffer) 