### PR TITLE
Refactoring and infrastructure for syncval aliasing support

### DIFF
--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -361,16 +361,6 @@ void IMAGE_STATE::SetSwapchain(std::shared_ptr<SWAPCHAIN_NODE> &swapchain, uint3
     bind_swapchain->AddParent(this);
 }
 
-VkDeviceSize IMAGE_STATE::GetFakeBaseAddress() const {
-    if (!IsSwapchainImage()) {
-        return BINDABLE::GetFakeBaseAddress();
-    }
-    if (!bind_swapchain) {
-        return 0;
-    }
-    return bind_swapchain->images[swapchain_image_index].fake_base_address;
-}
-
 static VkSamplerYcbcrConversion GetSamplerConversion(const VkImageViewCreateInfo *ci) {
     auto *conversion_info = LvlFindInChain<VkSamplerYcbcrConversionInfo>(ci->pNext);
     return conversion_info ? conversion_info->conversion : VK_NULL_HANDLE;

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -197,8 +197,6 @@ class IMAGE_STATE : public BINDABLE {
 
     void SetSwapchain(std::shared_ptr<SWAPCHAIN_NODE> &swapchain, uint32_t swapchain_index);
 
-    VkDeviceSize GetFakeBaseAddress() const override;
-
     void Destroy() override;
 
     // Returns the effective extent of the provided subresource, adjusted for mip level and array depth.
@@ -316,7 +314,6 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
 
 struct SWAPCHAIN_IMAGE {
     IMAGE_STATE *image_state = nullptr;
-    VkDeviceSize fake_base_address = 0;
     bool acquired = false;
 };
 

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -223,12 +223,15 @@ class IMAGE_STATE : public BINDABLE {
     void NotifyInvalidate(const BASE_NODE::NodeList &invalid_nodes, bool unlink) override;
 };
 
-using IMAGE_STATE_NO_BINDING = MEMORY_TRACKED_RESOURCE_STATE<IMAGE_STATE, BindableNoMemoryTracker>;
-using IMAGE_STATE_LINEAR = MEMORY_TRACKED_RESOURCE_STATE<IMAGE_STATE, BindableLinearMemoryTracker>;
-template <bool IS_RESIDENT>
-using IMAGE_STATE_SPARSE = MEMORY_TRACKED_RESOURCE_STATE<IMAGE_STATE, BindableSparseMemoryTracker<IS_RESIDENT>>;
-template <unsigned PLANE_COUNT>
-using IMAGE_STATE_MULTIPLANAR = MEMORY_TRACKED_RESOURCE_STATE<IMAGE_STATE, BindableMultiplanarMemoryTracker<PLANE_COUNT>>;
+template <typename ImageState>
+struct ImageStateBindingTraits {
+    using NoBinding = MEMORY_TRACKED_RESOURCE_STATE<ImageState, BindableNoMemoryTracker>;
+    using Linear = MEMORY_TRACKED_RESOURCE_STATE<ImageState, BindableLinearMemoryTracker>;
+    template <bool IS_RESIDENT>
+    using Sparse = MEMORY_TRACKED_RESOURCE_STATE<ImageState, BindableSparseMemoryTracker<IS_RESIDENT>>;
+    template <unsigned PLANE_COUNT>
+    using Multiplanar = MEMORY_TRACKED_RESOURCE_STATE<ImageState, BindableMultiplanarMemoryTracker<PLANE_COUNT>>;
+};
 
 // State for VkImageView objects.
 // Parent -> child relationships in the object usage tree:

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3808,14 +3808,19 @@ void ValidationStateTracker::UpdateBindImageMemoryState(const VkBindImageMemoryI
     }
 }
 
-void ValidationStateTracker::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem,
-                                                           VkDeviceSize memoryOffset, VkResult result) {
-    if (VK_SUCCESS != result) return;
+VkBindImageMemoryInfo ValidationStateTracker::ConvertImageMemoryInfo(VkDevice device, VkImage image, VkDeviceMemory mem,
+                                                                     VkDeviceSize memoryOffset) {
     auto bind_info = LvlInitStruct<VkBindImageMemoryInfo>();
     bind_info.image = image;
     bind_info.memory = mem;
     bind_info.memoryOffset = memoryOffset;
-    UpdateBindImageMemoryState(bind_info);
+    return bind_info;
+}
+
+void ValidationStateTracker::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem,
+                                                           VkDeviceSize memoryOffset, VkResult result) {
+    if (VK_SUCCESS != result) return;
+    UpdateBindImageMemoryState(ConvertImageMemoryInfo(device, image, mem, memoryOffset));
 }
 
 void ValidationStateTracker::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3782,12 +3782,6 @@ void ValidationStateTracker::UpdateBindImageMemoryState(const VkBindImageMemoryI
         if (swapchain_info) {
             auto swapchain = Get<SWAPCHAIN_NODE>(swapchain_info->swapchain);
             if (swapchain) {
-                SWAPCHAIN_IMAGE &swapchain_image = swapchain->images[swapchain_info->imageIndex];
-
-                if (!swapchain_image.fake_base_address) {
-                    auto size = image_state->fragment_encoder->TotalSize();
-                    swapchain_image.fake_base_address = fake_memory.Alloc(size);
-                }
                 // All images bound to this swapchain and index are aliases
                 image_state->SetSwapchain(swapchain, swapchain_info->imageIndex);
             }
@@ -5043,10 +5037,6 @@ void ValidationStateTracker::PostCallRecordGetSwapchainImagesKHR(VkDevice device
 
             auto image_state =
                 CreateImageState(pSwapchainImages[i], swapchain_state->image_create_info.ptr(), swapchain, i, format_features);
-            if (!swapchain_image.fake_base_address) {
-                auto size = image_state->fragment_encoder->TotalSize();
-                swapchain_image.fake_base_address = fake_memory.Alloc(size);
-            }
 
             image_state->SetSwapchain(swapchain_state, i);
             swapchain_image.image_state = image_state.get();

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -183,41 +183,13 @@ VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device
 
 std::shared_ptr<IMAGE_STATE> ValidationStateTracker::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
                                                                       VkFormatFeatureFlags2KHR features) {
-    std::shared_ptr<IMAGE_STATE> state;
-
-    if (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) {
-        if (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) {
-            state = std::make_shared<IMAGE_STATE_SPARSE<true>>(this, img, pCreateInfo, features);
-        } else {
-            state = std::make_shared<IMAGE_STATE_SPARSE<false>>(this, img, pCreateInfo, features);
-        }
-    } else if (pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT) {
-        uint32_t plane_count = FormatPlaneCount(pCreateInfo->format);
-        switch (plane_count) {
-            case 3:
-                state = std::make_shared<IMAGE_STATE_MULTIPLANAR<3>>(this, img, pCreateInfo, features);
-                break;
-            case 2:
-                state = std::make_shared<IMAGE_STATE_MULTIPLANAR<2>>(this, img, pCreateInfo, features);
-                break;
-            case 1:
-                state = std::make_shared<IMAGE_STATE_MULTIPLANAR<1>>(this, img, pCreateInfo, features);
-                break;
-            default:
-                // Not supported
-                assert(false);
-        }
-    } else {
-        state = std::make_shared<IMAGE_STATE_LINEAR>(this, img, pCreateInfo, features);
-    }
-
-    return state;
+    return CreateImageStateImpl<ImageStateBindingTraits<IMAGE_STATE>>(img, pCreateInfo, features);
 }
 
 std::shared_ptr<IMAGE_STATE> ValidationStateTracker::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
                                                                       VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                                       VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<IMAGE_STATE_NO_BINDING>(this, img, pCreateInfo, swapchain, swapchain_index, features);
+    return CreateImageStateImpl<ImageStateBindingTraits<IMAGE_STATE>>(img, pCreateInfo, swapchain, swapchain_index, features);
 }
 
 void ValidationStateTracker::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -315,6 +315,9 @@ class ValidationStateTracker : public ValidationObject {
     }
 
   public:
+    static VkBindImageMemoryInfo ConvertImageMemoryInfo(VkDevice device, VkImage image, VkDeviceMemory mem,
+                                                        VkDeviceSize memoryOffset);
+
     template <typename State, typename HandleType = typename state_object::Traits<State>::HandleType>
     void Add(std::shared_ptr<State>&& state_object) {
         auto& map = GetStateMap<State>();
@@ -483,6 +486,9 @@ class ValidationStateTracker : public ValidationObject {
             (*set_image_view_initial_layout_callback)(cb_state, iv_state, layout);
         }
     }
+
+    VkDeviceSize AllocFakeMemory(VkDeviceSize size) { return fake_memory.Alloc(size); }
+    void FreeFakeMemory(VkDeviceSize address) { fake_memory.Free(address); }
 
     // State update functions
     // Gets/Enumerations

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -333,8 +333,6 @@ struct SyncBarrier {
     }
 };
 
-enum class AccessAddressType : uint32_t { kLinear = 0, kIdealized = 1, kMaxType = 1, kTypeCount = kMaxType + 1 };
-
 struct SemaphoreScope : SyncExecScope {
     SemaphoreScope(QueueId qid, const SyncExecScope &exec_scope) : SyncExecScope(exec_scope), queue(qid) {}
     SemaphoreScope() = default;
@@ -342,8 +340,7 @@ struct SemaphoreScope : SyncExecScope {
 };
 
 struct AcquiredImage {
-    std::shared_ptr<const IMAGE_STATE> image;
-    AccessAddressType address_type;
+    std::shared_ptr<const syncval_state::ImageState> image;
     subresource_adapter::ImageRangeGenerator generator;
     ResourceUsageTag present_tag;
     ResourceUsageTag acquire_tag;
@@ -739,7 +736,6 @@ class AttachmentViewGen {
     AttachmentViewGen(const IMAGE_VIEW_STATE *view_, const VkOffset3D &offset, const VkExtent3D &extent);
     AttachmentViewGen(const AttachmentViewGen &other) = default;
     AttachmentViewGen(AttachmentViewGen &&other) = default;
-    AccessAddressType GetAddressType() const;
     const IMAGE_VIEW_STATE *GetViewState() const { return view_; }
     const std::optional<ImageRangeGen> &GetRangeGen(Gen type) const;
     bool IsValid() const { return gen_store_[Gen::kViewSubresource].has_value(); }
@@ -768,7 +764,8 @@ struct SyncBufferMemoryBarrier {
 };
 
 struct SyncImageMemoryBarrier {
-    using Image = std::shared_ptr<const IMAGE_STATE>;
+    using ImageState = syncval_state::ImageState;
+    using Image = std::shared_ptr<const ImageState>;
 
     Image image;
     uint32_t index;
@@ -779,7 +776,7 @@ struct SyncImageMemoryBarrier {
 
     bool IsLayoutTransition() const { return old_layout != new_layout; }
     const VkImageSubresourceRange &Range() const { return range; };
-    const IMAGE_STATE *GetState() const { return image.get(); }
+    const ImageState *GetState() const { return image.get(); }
     SyncImageMemoryBarrier(const Image &image_, uint32_t index_, const SyncBarrier &barrier_, VkImageLayout old_layout_,
                            VkImageLayout new_layout_, const VkImageSubresourceRange &subresource_range_)
         : image(image_),
@@ -853,6 +850,7 @@ class SyncOpBarriers : public SyncOpBase {
 
   protected:
     struct BarrierSet {
+        using ImageState = syncval_state::ImageState;
         VkDependencyFlags dependency_flags;
         SyncExecScope src_exec_scope;
         SyncExecScope dst_exec_scope;
@@ -1023,57 +1021,51 @@ class SyncOpEndRenderPass : public SyncOpBase {
 
 class AccessContext {
   public:
+    using ImageState = syncval_state::ImageState;
     enum DetectOptions : uint32_t {
         kDetectPrevious = 1U << 0,
         kDetectAsync = 1U << 1,
         kDetectAll = (kDetectPrevious | kDetectAsync)
     };
-    struct AddressRange {
-        AccessAddressType type;
-        ResourceAccessRange range;
-        AddressRange() = default;  // the explicit constructor below isn't needed in 20, but would delete the default.
-        AddressRange(AccessAddressType type_, ResourceAccessRange range_) : type(type_), range(range_) {}
-    };
-    using MapArray = std::array<ResourceAccessRangeMap, static_cast<size_t>(AccessAddressType::kTypeCount)>;
 
     using TrackBack = SubpassBarrierTrackback<AccessContext>;
 
     template <typename Detector, typename RangeGen>
-    HazardResult DetectHazard(AccessAddressType type, Detector &detector, RangeGen &range_gen, DetectOptions options) const;
+    HazardResult DetectHazard(Detector &detector, RangeGen &range_gen, DetectOptions options) const;
     template <typename Detector, typename RangeGen>
-    HazardResult DetectHazard(AccessAddressType type, Detector &detector, const RangeGen &range_gen, DetectOptions options) const {
+    HazardResult DetectHazard(Detector &detector, const RangeGen &range_gen, DetectOptions options) const {
         RangeGen mutable_gen(range_gen);
-        return DetectHazard<Detector, RangeGen>(type, detector, mutable_gen, options);
+        return DetectHazard<Detector, RangeGen>(detector, mutable_gen, options);
     }
 
     HazardResult DetectHazard(const BUFFER_STATE &buffer, SyncStageAccessIndex usage_index, const ResourceAccessRange &range) const;
-    HazardResult DetectHazard(const IMAGE_STATE &image, SyncStageAccessIndex current_usage,
+    HazardResult DetectHazard(const ImageState &image, SyncStageAccessIndex current_usage,
                               const VkImageSubresourceLayers &subresource, const VkOffset3D &offset, const VkExtent3D &extent,
                               bool is_depth_sliced) const;
     template <typename Detector>
     HazardResult DetectHazard(Detector &detector, const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type,
                               DetectOptions options) const;
     template <typename Detector>
-    HazardResult DetectHazard(Detector &detector, const IMAGE_STATE &image, const VkImageSubresourceRange &subresource_range,
+    HazardResult DetectHazard(Detector &detector, const ImageState &image, const VkImageSubresourceRange &subresource_range,
                               const VkOffset3D &offset, const VkExtent3D &extent, bool is_depth_sliced,
                               DetectOptions options) const;
     template <typename Detector>
-    HazardResult DetectHazard(Detector &detector, const IMAGE_STATE &image, const VkImageSubresourceRange &subresource_range,
+    HazardResult DetectHazard(Detector &detector, const ImageState &image, const VkImageSubresourceRange &subresource_range,
                               bool is_depth_sliced, DetectOptions options) const;
-    HazardResult DetectHazard(const IMAGE_STATE &image, SyncStageAccessIndex current_usage,
+    HazardResult DetectHazard(const ImageState &image, SyncStageAccessIndex current_usage,
                               const VkImageSubresourceRange &subresource_range, bool is_depth_sliced) const;
     HazardResult DetectHazard(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type,
                               SyncStageAccessIndex current_usage, SyncOrdering ordering_rule) const;
 
-    HazardResult DetectHazard(const IMAGE_STATE &image, SyncStageAccessIndex current_usage,
+    HazardResult DetectHazard(const ImageState &image, SyncStageAccessIndex current_usage,
                               const VkImageSubresourceRange &subresource_range, SyncOrdering ordering_rule,
                               const VkOffset3D &offset, const VkExtent3D &extent, bool is_depth_sliced) const;
-    HazardResult DetectImageBarrierHazard(const IMAGE_STATE &image, const VkImageSubresourceRange &subresource_range,
+    HazardResult DetectImageBarrierHazard(const ImageState &image, const VkImageSubresourceRange &subresource_range,
                                           VkPipelineStageFlags2KHR src_exec_scope, const SyncStageAccessFlags &src_access_scope,
                                           QueueId queue_id, const SyncEventState &sync_event, DetectOptions options) const;
     HazardResult DetectImageBarrierHazard(const AttachmentViewGen &attachment_view, const SyncBarrier &barrier,
                                           DetectOptions options) const;
-    HazardResult DetectImageBarrierHazard(const IMAGE_STATE &image, VkPipelineStageFlags2KHR src_exec_scope,
+    HazardResult DetectImageBarrierHazard(const ImageState &image, VkPipelineStageFlags2KHR src_exec_scope,
                                           const SyncStageAccessFlags &src_access_scope,
                                           const VkImageSubresourceRange &subresource_range, DetectOptions options) const;
     HazardResult DetectImageBarrierHazard(const SyncImageMemoryBarrier &image_barrier) const;
@@ -1093,9 +1085,7 @@ class AccessContext {
         src_external_ = nullptr;
         dst_external_ = TrackBack();
         start_tag_ = ResourceUsageTag();
-        for (auto &map : access_state_maps_) {
-            map.clear();
-        }
+        access_state_map_.clear();
     }
 
     // Follow the context previous to access the access state, supporting "lazy" import into the context. Not intended for
@@ -1103,9 +1093,9 @@ class AccessContext {
     // TODO: See if returning the lower_bound would be useful from a performance POV -- look at the lower_bound overhead
     // Would need to add a "hint" overload to parallel_iterator::invalidate_[AB] call, if so.
     template <typename BarrierAction>
-    void ResolvePreviousAccessStack(AccessAddressType type, const ResourceAccessRange &range, ResourceAccessRangeMap *descent_map,
+    void ResolvePreviousAccessStack(const ResourceAccessRange &range, ResourceAccessRangeMap *descent_map,
                                     const ResourceAccessState *infill_state, const BarrierAction &previous_barrie) const;
-    void ResolvePreviousAccess(AccessAddressType type, const ResourceAccessRange &range, ResourceAccessRangeMap *descent_map,
+    void ResolvePreviousAccess(const ResourceAccessRange &range, ResourceAccessRangeMap *descent_map,
                                const ResourceAccessState *infill_state,
                                const ResourceAccessStateFunction *previous_barrier = nullptr) const;
     void ResolvePreviousAccesses();
@@ -1113,27 +1103,25 @@ class AccessContext {
     void ResolveAccessRange(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type, BarrierAction &barrier_action,
                             ResourceAccessRangeMap *descent_map, const ResourceAccessState *infill_state) const;
     template <typename BarrierAction>
-    void ResolveAccessRange(AccessAddressType type, const ResourceAccessRange &range, BarrierAction &barrier_action,
-                            ResourceAccessRangeMap *resolve_map, const ResourceAccessState *infill_state,
-                            bool recur_to_infill = true) const;
+    void ResolveAccessRange(const ResourceAccessRange &range, BarrierAction &barrier_action, ResourceAccessRangeMap *resolve_map,
+                            const ResourceAccessState *infill_state, bool recur_to_infill = true) const;
     template <typename ResolveOp>
     void ResolveFromContext(ResolveOp &&resolve_op, const AccessContext &from_context,
                             const ResourceAccessState *infill_state = nullptr, bool recur_to_infill = false);
     template <typename ResolveOp, typename RangeGenerator>
-    void ResolveFromContext(ResolveOp &&resolve_op, const AccessContext &from_context, AccessAddressType address_type,
-                            RangeGenerator range_gen, const ResourceAccessState *infill_state = nullptr,
-                            bool recur_to_infill = false);
+    void ResolveFromContext(ResolveOp &&resolve_op, const AccessContext &from_context, RangeGenerator range_gen,
+                            const ResourceAccessState *infill_state = nullptr, bool recur_to_infill = false);
 
     void UpdateAccessState(const BUFFER_STATE &buffer, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                            const ResourceAccessRange &range, ResourceUsageTag tag);
-    void UpdateAccessState(const IMAGE_STATE &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
+    void UpdateAccessState(const ImageState &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                            const VkImageSubresourceRange &subresource_range, const ResourceUsageTag &tag);
-    void UpdateAccessState(const IMAGE_STATE &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
+    void UpdateAccessState(const ImageState &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                            const VkImageSubresourceRange &subresource_range, const VkOffset3D &offset, const VkExtent3D &extent,
                            ResourceUsageTag tag);
     void UpdateAccessState(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type, SyncStageAccessIndex current_usage,
                            SyncOrdering ordering_rule, ResourceUsageTag tag);
-    void UpdateAccessState(const IMAGE_STATE &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
+    void UpdateAccessState(const ImageState &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                            const VkImageSubresourceLayers &subresource, const VkOffset3D &offset, const VkExtent3D &extent,
                            ResourceUsageTag tag);
     void UpdateAttachmentResolveAccess(const RENDER_PASS_STATE &rp_state, const AttachmentViewGenVector &attachment_views,
@@ -1145,12 +1133,11 @@ class AccessContext {
 
     void ImportAsyncContexts(const AccessContext &from);
     template <typename Action, typename RangeGen>
-    void ApplyUpdateAction(AccessAddressType address_type, const Action &action, RangeGen *range_gen_arg);
+    void ApplyUpdateAction(const Action &action, RangeGen *range_gen_arg);
     template <typename Action>
     void ApplyUpdateAction(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type, const Action &action);
     template <typename Action>
     void ApplyToContext(const Action &barrier_action);
-    static AccessAddressType ImageAddressType(const IMAGE_STATE &image);
 
     AccessContext(uint32_t subpass, VkQueueFlags queue_flags, const std::vector<SubpassDependencyGraphNode> &dependencies,
                   const std::vector<AccessContext> &contexts, const AccessContext *external_context);
@@ -1160,10 +1147,8 @@ class AccessContext {
     void Trim();
     void AddReferencedTags(ResourceUsageTagSet &referenced) const;
 
-    ResourceAccessRangeMap &GetAccessStateMap(AccessAddressType type) { return access_state_maps_[static_cast<size_t>(type)]; }
-    const ResourceAccessRangeMap &GetAccessStateMap(AccessAddressType type) const {
-        return access_state_maps_[static_cast<size_t>(type)];
-    }
+    ResourceAccessRangeMap &GetAccessStateMap() { return access_state_map_; }
+    const ResourceAccessRangeMap &GetAccessStateMap() const { return access_state_map_; }
     const TrackBack *GetTrackBackFromSubpass(uint32_t subpass) const {
         if (subpass == VK_SUBPASS_EXTERNAL) {
             return src_external_;
@@ -1215,17 +1200,15 @@ class AccessContext {
 
   private:
     template <typename Detector>
-    HazardResult DetectHazard(AccessAddressType type, Detector &detector, const ResourceAccessRange &range,
-                              DetectOptions options) const;
+    HazardResult DetectHazard(Detector &detector, const ResourceAccessRange &range, DetectOptions options) const;
     template <typename Detector>
-    HazardResult DetectAsyncHazard(AccessAddressType type, const Detector &detector, const ResourceAccessRange &range,
-                                   ResourceUsageTag async_tag) const;
+    HazardResult DetectAsyncHazard(const Detector &detector, const ResourceAccessRange &range, ResourceUsageTag async_tag) const;
     template <typename Detector>
-    HazardResult DetectPreviousHazard(AccessAddressType type, Detector &detector, const ResourceAccessRange &range) const;
-    void UpdateAccessState(AccessAddressType type, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
-                           const ResourceAccessRange &range, ResourceUsageTag tag);
+    HazardResult DetectPreviousHazard(Detector &detector, const ResourceAccessRange &range) const;
+    void UpdateAccessState(SyncStageAccessIndex current_usage, SyncOrdering ordering_rule, const ResourceAccessRange &range,
+                           ResourceUsageTag tag);
 
-    MapArray access_state_maps_;
+    ResourceAccessRangeMap access_state_map_;
     std::vector<TrackBack> prev_;
     std::vector<TrackBack *> prev_by_subpass_;
     // These contexts *must* have the same lifespan as this context, or be cleared, before the referenced contexts can expire
@@ -1268,7 +1251,7 @@ struct SyncEventState {
     }
 
     void ResetFirstScope();
-    const ScopeMap &FirstScope(AccessAddressType address_type) const { return first_scope->GetAccessStateMap(address_type); }
+    const ScopeMap &FirstScope() const { return first_scope->GetAccessStateMap(); }
     IgnoreReason IsIgnoredByWait(CMD_TYPE cmd_type, VkPipelineStageFlags2KHR srcStageMask) const;
     bool HasBarrier(VkPipelineStageFlags2KHR stageMask, VkPipelineStageFlags2KHR exec_scope) const;
     void AddReferencedTags(ResourceUsageTagSet &referenced) const;
@@ -1692,13 +1675,12 @@ struct PresentedImageRecord {
     uint32_t image_index;
     uint32_t present_index;
     std::weak_ptr<const syncval_state::Swapchain> swapchain_state;
-    std::shared_ptr<const IMAGE_STATE> image;
+    std::shared_ptr<const syncval_state::ImageState> image;
 };
 
 struct PresentedImage : public PresentedImageRecord {
     std::shared_ptr<QueueBatchContext> batch;
     subresource_adapter::ImageRangeGenerator range_gen;
-    AccessAddressType address_type = AccessAddressType::kLinear;
 
     PresentedImage() = default;
     void UpdateMemoryAccess(SyncStageAccessIndex usage, ResourceUsageTag tag, AccessContext &access_context) const;

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -429,7 +429,7 @@ class VkImageObj : public vk_testing::Image {
 
     void Layout(VkImageLayout const layout) { m_descriptorImageInfo.imageLayout = layout; }
 
-    VkDeviceMemory memory() const { return Image::memory().handle(); }
+    VkDeviceMemory Memory() const { return Image::memory().handle(); }
 
     void *MapMemory() { return Image::memory().map(); }
 


### PR DESCRIPTION
1. DRY up the IMAGE_STATE subclass implementation.
2. Add sync val derived class for image
3. Add fake space allocation for opaque representations
4. Convert AccessContext to single flat range map for both linear bindings and opaque representations.