### PR TITLE
Various GHA improvements

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -21,6 +21,9 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+
 jobs:
   code-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -24,8 +24,6 @@ on:
 jobs:
   code-format:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -98,8 +98,6 @@ jobs:
 
   gn:
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -181,7 +179,6 @@ jobs:
   android_cmake:
       runs-on: ubuntu-22.04
       strategy:
-        fail-fast: false
         matrix:
           abi: [ arm64-v8a ]
           build_tests: [ "ON" ]
@@ -217,8 +214,6 @@ jobs:
 
   android_mk:
       runs-on: ubuntu-22.04
-      strategy:
-        fail-fast: false
       steps:
         - uses: actions/checkout@v3
         - uses: actions/setup-python@v4
@@ -230,7 +225,6 @@ jobs:
   macos:
     runs-on: macos-latest
     strategy:
-      fail-fast: false
       matrix:
         macos_version: ["min","latest"]
     steps:
@@ -255,8 +249,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -293,8 +285,6 @@ jobs:
   # If we do intentionally want to break them, we just need to update the integration test code to account for that.
   integration_test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -132,13 +132,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ x64, Win32 ]
+        arch: [ amd64, amd64_x86 ] # 64 bit compiler, 64 bit compiler targeting 32 bit
         config: [ debug, release ]
         os: [ windows-latest ]
         exclude:
-          - arch: Win32
+          - arch: amd64_x86
             config: release
-          - arch: x64
+          - arch: amd64
             config: debug
 
     steps:

--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -38,21 +38,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        cc: [gcc]
-        cxx: [g++]
+        compiler: [{cc: gcc, cxx: g++}]
         config: [debug, release]
         cpp_std: [17]
         include:
           # Test C++ 20 support
           - os: ubuntu-22.04
-            cc: gcc
-            cxx: g++
+            compiler: {cc: gcc, cxx: g++}
             config: release
             cpp_std: 20
           # Test clang support
           - os: ubuntu-22.04
-            cc: clang
-            cxx: clang++
+            compiler: {cc: clang, cxx: clang++}
             config: release
             cpp_std: 17
 
@@ -67,7 +64,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ runner.os }}-${{ matrix.config }}-${{ matrix.cc }}-${{ matrix.cpp_std }}
+          key: ${{ runner.os }}-${{ matrix.config }}-${{ matrix.compiler.cc }}-${{ matrix.compiler.cxx }}-${{ matrix.cpp_std }}
       - name: Install build dependencies
         run: |
           python3 -m pip install jsonschema pyparsing
@@ -80,8 +77,8 @@ jobs:
       - name: Build Vulkan-ValidationLayers
         run: python3 scripts/github_ci_win_linux.py --build --config ${{ matrix.config }} --cmake='-DVVL_CPP_STANDARD=${{ matrix.cpp_std }} -DVVL_ENABLE_ASAN=ON'
         env:
-          CC: ${{ matrix.cc }}
-          CXX: ${{ matrix.cxx }}
+          CC: ${{ matrix.compiler.cc }}
+          CXX: ${{ matrix.compiler.cxx }}
       - name: Test Vulkan-ValidationLayers - Pixel 6 Adreno profile
         run: python3 scripts/github_ci_win_linux.py --test
         env:

--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -28,6 +28,9 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- ci: Use fail-fast judiciously
- ci: Fix permissions
- ci: Cleanup compiler usage for linux testing
- ci: Use 64 bit compiler when targeting x86
