### PR TITLE
scripts: Clean fetched dependencies on new configuration

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -82,12 +82,16 @@ if (UPDATE_DEPS)
     set(UPDATE_DEPS_HASH "0" CACHE STRING "Default value until we run update_deps.py")
     mark_as_advanced(UPDATE_DEPS_HASH)
 
+    if ("${UPDATE_DEPS_HASH}" STREQUAL "0")
+        list(APPEND update_dep_command "--clean-build")
+        list(APPEND update_dep_command "--clean-install")
+    endif()
+
     if ("${md5_hash}" STREQUAL $CACHE{UPDATE_DEPS_HASH})
         message(DEBUG "update_deps.py: no work to do.")
     else()
         execute_process(
             COMMAND ${Python3_EXECUTABLE} ${update_dep_command}
-            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             RESULT_VARIABLE _update_deps_result
         )
         if (NOT (${_update_deps_result} EQUAL 0))

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -32,11 +32,6 @@ this home repository depend on.  It also checks out each dependent
 repository at a "known-good" commit in order to provide stability in
 the dependent repositories.
 
-Python Compatibility
---------------------
-
-This program can be used with Python 2.7 and Python 3.
-
 Known-Good JSON Database
 ------------------------
 
@@ -238,8 +233,6 @@ option can be a relative or absolute path.
 
 """
 
-from __future__ import print_function
-
 import argparse
 import json
 import os.path
@@ -269,7 +262,7 @@ DEVNULL = open(os.devnull, 'wb')
 def on_rm_error( func, path, exc_info):
     """Error handler for recursively removing a directory. The
     shutil.rmtree function can fail on Windows due to read-only files.
-    This handler will change the permissions for tha file and continue.
+    This handler will change the permissions for the file and continue.
     """
     os.chmod( path, stat.S_IWRITE )
     os.unlink( path )
@@ -431,9 +424,11 @@ class GoodRepo(object):
     def CMakeConfig(self, repos):
         """Build CMake command for the configuration phase and execute it"""
         if self._args.do_clean_build:
-            shutil.rmtree(self.build_dir)
+            if os.path.isdir(self.build_dir):
+                shutil.rmtree(self.build_dir, onerror=on_rm_error)
         if self._args.do_clean_install:
-            shutil.rmtree(self.install_dir)
+            if os.path.isdir(self.install_dir):
+                shutil.rmtree(self.install_dir, onerror=on_rm_error)
 
         # Create and change to build directory
         make_or_exist_dirs(self.build_dir)


### PR DESCRIPTION
Makes switching architectures easier since CMake will delete old build artifacts.