### PR TITLE
layers: Remove unnecessary stage_flags variable

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -248,11 +248,6 @@ void CMD_BUFFER_STATE::ResetPushConstantDataIfIncompatible(const PIPELINE_LAYOUT
     for (const auto &push_constant_range : *push_constant_data_ranges) {
         auto size = push_constant_range.offset + push_constant_range.size;
         size_needed = std::max(size_needed, size);
-
-        auto stage_flags = push_constant_range.stageFlags;
-        while (stage_flags) {
-            stage_flags = stage_flags >> 1;
-        }
     }
     push_constant_data.resize(size_needed, 0);
 }


### PR DESCRIPTION
Remove unnecessary stage_flags variable in
CMD_BUFFER_STATE::ResetPushConstantDataIfIncompatible.

From https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5829#discussion_r1200761011.