### PR TITLE
android: Remove usage of AHB_VALIDATION_SUPPORT

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -252,15 +252,8 @@ export PKG_CONFIG_LIBDIR=/usr/lib/i386-linux-gnu
 
 ### Android Build Requirements
 
-Note that the minimum supported Android SDK API Level is 26, revision
-level 3.
-
-NDK r20 or greater required
-
-- Install [Android Studio 2.3](https://developer.android.com/studio/index.html)
-  or later.
-- From the "Welcome to Android Studio" splash screen, add the following
-  components using Configure > SDK Manager:
+- Install [Android Studio 2.3](https://developer.android.com/studio/index.html) or later.
+- From the `Welcome to Android Studio` splash screen, add the following components using Configure > SDK Manager:
   - SDK Platforms > Android 8.0.0 and newer
   - SDK Tools > Android SDK Build-Tools
   - SDK Tools > Android SDK Platform-Tools
@@ -269,8 +262,7 @@ NDK r20 or greater required
 
 #### Add Android specifics to environment
 
-For each of the below, you may need to specify a different build-tools
-version, as Android Studio will roll it forward fairly regularly.
+For each of the below, you may need to specify a different build-tools version, as Android Studio will roll it forward fairly regularly.
 
 On Linux:
 
@@ -285,9 +277,11 @@ export PATH=$ANDROID_SDK_HOME/build-tools/X.Y.Z:$PATH
 
 On Windows:
 
-    set ANDROID_SDK_HOME=%LOCALAPPDATA%\Android\sdk
-    set ANDROID_NDK_HOME=%LOCALAPPDATA%\Android\sdk\ndk-bundle
-    set PATH=%LOCALAPPDATA%\Android\sdk\ndk-bundle;%PATH%
+```
+set ANDROID_SDK_HOME=%LOCALAPPDATA%\Android\sdk
+set ANDROID_NDK_HOME=%LOCALAPPDATA%\Android\sdk\ndk-bundle
+set PATH=%LOCALAPPDATA%\Android\sdk\ndk-bundle;%PATH%
+```
 
 On OSX:
 
@@ -300,10 +294,11 @@ export PATH=$ANDROID_SDK_HOME/build-tools/X.Y.Z:$PATH
 ```
 
 Note: If `apksigner` gives a `java: not found` error you do not have Java in your path.
+
 A common way to install on the system:
 
 ```bash
-  sudo apt install default-jre
+sudo apt install default-jre
 ```
 
 #### Additional OSX System Requirements
@@ -331,8 +326,10 @@ everything in the repository for Android, including validation layers, tests,
 demos, and APK packaging: This script does retrieve and use the upstream SPRIV
 tools.
 
-    cd build-android
-    ./build_all.sh
+```bash
+cd build-android
+./build_all.sh
+```
 
 > **NOTE:** To allow manual installation of Android layer libraries on development devices, `build_all.sh` will use the static version of the c++ library (libc++_static.so). For testing purposes and general usage including installation via APK the c++ shared library should be used (libc++_shared.so). See comments in [build_all.sh](build-android/build_all.sh) for details.
 

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -21,7 +21,7 @@
 #include "generated/vk_enum_string_helper.h"
 #include "core_validation.h"
 
-#ifdef AHB_VALIDATION_SUPPORT
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
 // Android-specific validation that uses types defined only on Android and only for NDK versions
 // that support the VK_ANDROID_external_memory_android_hardware_buffer extension.
 // This chunk could move into a seperate core_validation_android.cpp file... ?
@@ -471,7 +471,6 @@ bool CoreChecks::ValidateImageImportedHandleANDROID(const char *func_name, VkExt
 }
 
 // Validate creating an image with an external format
-// This could be wrapped with VK_USE_PLATFORM_ANDROID_KHR instead of AHB_VALIDATION_SUPPORT, but this check is only for AHB
 bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo *create_info) const {
     bool skip = false;
 
@@ -548,7 +547,6 @@ bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo *create_info
 }
 
 // Validate creating an image view with an AHB format
-// This could be wrapped with VK_USE_PLATFORM_ANDROID_KHR instead of AHB_VALIDATION_SUPPORT, but this check is only for AHB
 bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *create_info) const {
     bool skip = false;
     auto image_state = Get<IMAGE_STATE>(create_info->image);
@@ -596,20 +594,7 @@ bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *cre
     return skip;
 }
 
-#else  // !AHB_VALIDATION_SUPPORT
-
-// Case building for Android without AHB Validation
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
-bool CoreChecks::PreCallValidateGetAndroidHardwareBufferPropertiesANDROID(
-    VkDevice device, const struct AHardwareBuffer *buffer, VkAndroidHardwareBufferPropertiesANDROID *pProperties) const {
-    return false;
-}
-bool CoreChecks::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(VkDevice device,
-                                                                      const VkMemoryGetAndroidHardwareBufferInfoANDROID *pInfo,
-                                                                      struct AHardwareBuffer **pBuffer) const {
-    return false;
-}
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
+#else  // !defined(VK_USE_PLATFORM_ANDROID_KHR)
 
 bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc_info) const { return false; }
 
@@ -634,4 +619,4 @@ bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo *create_info
 
 bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *create_info) const { return false; }
 
-#endif  // AHB_VALIDATION_SUPPORT
+#endif

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -290,14 +290,14 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
     }
 
     bool imported_ahb = false;
-#ifdef AHB_VALIDATION_SUPPORT
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
     //  "memory is not an imported Android Hardware Buffer" refers to VkImportAndroidHardwareBufferInfoANDROID with a non-NULL
     //  buffer value. Memory imported has another VUID to check size and allocationSize match up
-    auto imported_ahb_info = LvlFindInChain<VkImportAndroidHardwareBufferInfoANDROID>(pAllocateInfo->pNext);
-    if (imported_ahb_info != nullptr) {
+    if (auto imported_ahb_info = LvlFindInChain<VkImportAndroidHardwareBufferInfoANDROID>(pAllocateInfo->pNext);
+        imported_ahb_info != nullptr) {
         imported_ahb = imported_ahb_info->buffer != nullptr;
     }
-#endif  // AHB_VALIDATION_SUPPORT
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
     auto dedicated_allocate_info = LvlFindInChain<VkMemoryDedicatedAllocateInfo>(pAllocateInfo->pNext);
     if (dedicated_allocate_info) {
         if ((dedicated_allocate_info->buffer != VK_NULL_HANDLE) && (dedicated_allocate_info->image != VK_NULL_HANDLE)) {

--- a/layers/utils/android_ndk_types.h
+++ b/layers/utils/android_ndk_types.h
@@ -22,51 +22,24 @@
 //    - All enums referenced by VK_ANDROID_external_memory_android_hardware_buffer
 // <android/api-level.h>
 //     - __ANDROID_API_
-//     - The version of android compiling **for**
-//     - Currently there is no need for the VVL to build for anything greater than android-26
+//     - The version of android we are compiling for
 // <android/ndk-version.h>
 //     - __NDK_MAJOR__
-//     - Is the version of NDK compiling **with**
-//     - r16 has a subset of needed hardware_buffer.h enums value
-//     - r18 proper ANDROID_API checking added
-//     - r20 YCbCr was added
-//     - r23 (current) no differences from r20 being used
+//     - The NDK version we are compiling with
 
 #pragma once
 
+#if defined(__ANDROID__) && !defined(VK_USE_PLATFORM_ANDROID_KHR)
+#error "VK_USE_PLATFORM_ANDROID_KHR not defined for Android build!"
+#endif
+
 // Everyone should be able to include this file and ignore it if not building for Android
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
 
-#ifdef __ANDROID__  // Compiling for Android
+#include <android/api-level.h>
+
+#include <android/ndk-version.h>
+
 #include <android/hardware_buffer.h>
-
-// Building Vulkan validation with NDK header files prior to platform-26 is supported, but will remove
-// all validation checks for Android Hardware Buffers.
-// This is due to AHB not being introduced until Android 26 (Android Oreo)
-//
-// NOTE: VK_USE_PLATFORM_ANDROID_KHR != Android Hardware Buffer
-//       AHB is all things not found in the Vulkan Spec
-#if __ANDROID_API__ < 26
-#error "Vulkan-ValidationLayers is not supported on Android 25 and below"
-#else
-// This is used to allow building for Android without AHB support
-#define AHB_VALIDATION_SUPPORT
-#endif  // __ANDROID_API__
-
-// Require at least NDK 20 to build Validation Layers. Makes everything simpler to just have people building the layers to use a
-// recent (over 2 years old) version of the NDK.
-#if __NDK_MAJOR__ < 20
-#error "Validation Layers require at least NDK r20 or greater to build"
-#endif  // __NDK_MAJOR__
-
-// Not in public NDK headers, only AOSP headers, but NDK will allow it for usage of camera apps and we use for AHB tests
-constexpr uint32_t AHARDWAREBUFFER_FORMAT_IMPLEMENTATION_DEFINED = 0x22;
-constexpr uint64_t AHARDWAREBUFFER_USAGE_CAMERA_WRITE = 0x20000;
-constexpr uint64_t AHARDWAREBUFFER_USAGE_CAMERA_READ = 0x40000;
-
-#else  // Not __ANDROID__, but VK_USE_PLATFORM_ANDROID_KHR
-// This combination should not be seen in the wild
-// There use to be a mock set of enums and functions to use, but it was not maintained and seems no one was in need of it anyways
-#endif  // __ANDROID__
 
 #endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,8 +151,6 @@ target_compile_definitions(vk_layer_validation_tests PRIVATE VVL_TESTS_USE_CMAKE
 
 add_dependencies(vk_layer_validation_tests vvl)
 
-target_include_directories(vk_layer_validation_tests PRIVATE .)
-
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
     target_compile_options(vk_layer_validation_tests PRIVATE
         -Wno-sign-compare

--- a/tests/framework/android_hardware_buffer.h
+++ b/tests/framework/android_hardware_buffer.h
@@ -10,9 +10,15 @@
  */
 #pragma once
 
-#include "utils/android_ndk_types.h"  // Defines AHB_VALIDATION_SUPPORT if supported
+#include "utils/android_ndk_types.h"
+#include "../framework/layer_validation_tests.h"
 
-#ifdef AHB_VALIDATION_SUPPORT
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+
+// Not in public NDK headers, only AOSP headers, but NDK will allow it for usage of camera apps and we use for AHB tests
+constexpr uint32_t AHARDWAREBUFFER_FORMAT_IMPLEMENTATION_DEFINED = 0x22;
+constexpr uint64_t AHARDWAREBUFFER_USAGE_CAMERA_WRITE = 0x20000;
+constexpr uint64_t AHARDWAREBUFFER_USAGE_CAMERA_READ = 0x40000;
 
 // Helper to get the memory type index for AHB object that are being imported
 // returns false if can't set the values correctly
@@ -34,4 +40,4 @@ inline bool SetAllocationInfoImportAHB(vk_testing::Device *device, VkAndroidHard
     return info.memoryTypeIndex < mem_props.memoryTypeCount;
 }
 
-#endif
+#endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/tests/negative/android_hardware_buffer.cpp
+++ b/tests/negative/android_hardware_buffer.cpp
@@ -13,12 +13,9 @@
  */
 
 #include "../framework/layer_validation_tests.h"
+#include "../framework/android_hardware_buffer.h"
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#include "../framework/android_hardware_buffer.h"
-#endif
-
-#ifdef AHB_VALIDATION_SUPPORT
 
 class NegativeAndroidHardwareBuffer : public VkLayerTest {};
 
@@ -1560,4 +1557,4 @@ TEST_F(NegativeAndroidHardwareBuffer, NullAHBImport) {
     AHardwareBuffer_release(ahb);
 }
 
-#endif  // AHB_VALIDATION_SUPPORT
+#endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/tests/positive/android_hardware_buffer.cpp
+++ b/tests/positive/android_hardware_buffer.cpp
@@ -12,15 +12,13 @@
  */
 
 #include "../framework/layer_validation_tests.h"
+#include "../framework/android_hardware_buffer.h"
 #include "generated/vk_extension_helper.h"
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-#include "../framework/android_hardware_buffer.h"
-#endif
 
 class PositiveAndroidHardwareBuffer : public VkPositiveLayerTest {};
 
-#ifdef AHB_VALIDATION_SUPPORT
 TEST_F(PositiveAndroidHardwareBuffer, MemoryRequirements) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer doesn't conflict with memory requirements.");
 
@@ -553,4 +551,4 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalCameraFormat) {
     AHardwareBuffer_release(ahb);
 }
 
-#endif  // AHB_VALIDATION_SUPPORT
+#endif  // VK_USE_PLATFORM_ANDROID_KHR


### PR DESCRIPTION
Removes usage of AHB_VALIDATION_SUPPORT and cleans up surrounding Android code.

Use C++17 std::from_chars to convert string to integer. It's also much safer to use considering it's non-allocating and non-throwing.