### PR TITLE
layers: Remove stateless validation from config

### DIFF
--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -1515,8 +1515,7 @@ class VkVideoBestPracticesLayerTest : public VkVideoLayerTest {
 
   private:
     VkValidationFeatureEnableEXT enables_[1] = {VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT};
-    VkValidationFeatureDisableEXT disables_[4] = {
-        VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT, VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT,
-        VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT, VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
-    VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1, enables_, 4, disables_};
+    VkValidationFeatureDisableEXT disables_[2] = {VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT,
+                                                  VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
+    VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1, enables_, 2, disables_};
 };

--- a/tests/negative/arm_best_practices.cpp
+++ b/tests/negative/arm_best_practices.cpp
@@ -912,8 +912,10 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
     renderpasses.push_back(CreateRenderPass(FMT, VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE));
     framebuffers.push_back(CreateFramebuffer(WIDTH, HEIGHT, images[0]->targetView(FMT), renderpasses[0]));
 
-    images.push_back(
-        CreateImage(FMT, WIDTH, HEIGHT, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT));
+    auto img = std::unique_ptr<VkImageObj>(new VkImageObj(m_device));
+    img->Init(WIDTH, HEIGHT, 1, FMT, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+              VK_IMAGE_TILING_OPTIMAL);
+    images.push_back(std::move(img));
     renderpasses.push_back(CreateRenderPass(FMT, VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_DONT_CARE));
     framebuffers.push_back(CreateFramebuffer(WIDTH, HEIGHT, images[1]->targetView(FMT), renderpasses[1]));
 

--- a/tests/negative/best_practices.cpp
+++ b/tests/negative/best_practices.cpp
@@ -626,8 +626,8 @@ TEST_F(VkBestPracticesLayerTest, MSImageRequiresMemory) {
     attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
     attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     attachment.format = VK_FORMAT_B8G8R8A8_SRGB;
-    attachment.initialLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-    attachment.finalLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
     VkSubpassDescription sd{};
 
@@ -668,8 +668,8 @@ TEST_F(VkBestPracticesLayerTest, AttachmentShouldNotBeTransient) {
     attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
     attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
-    attachment.initialLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-    attachment.finalLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
     VkSubpassDescription sd{};
 
@@ -1663,12 +1663,12 @@ TEST_F(VkBestPracticesLayerTest, RenderPassClearWithoutLoadOpClear) {
     attachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;  // Specify that we do nothing with the contents of the attached image
     attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
     attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attachment.finalLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     attachment.format = image_info.format;
 
     VkAttachmentReference ar{};
     ar.attachment = 0;
-    ar.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+    ar.layout = VK_IMAGE_LAYOUT_GENERAL;
 
     VkSubpassDescription spd{};
     spd.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
@@ -2197,6 +2197,7 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
     TEST_DESCRIPTION("Transition image layout from undefined to read only");
 
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
 

--- a/tests/negative/gpu_av.cpp
+++ b/tests/negative/gpu_av.cpp
@@ -13,21 +13,20 @@
 
 #include "../framework/layer_validation_tests.h"
 
-static VkValidationFeatureEnableEXT gpu_av_enables[] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
-static VkValidationFeatureDisableEXT gpu_av_disables[] = {
-    VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT, VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT,
-    VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT, VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
+static std::array gpu_av_enables = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
+static std::array gpu_av_disables = {VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT,
+                                     VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
 
 // All VkGpuAssistedLayerTest should use this for setup as a single access point to more easily toggle which validation features are
 // enabled/disabled
 VkValidationFeaturesEXT VkGpuAssistedLayerTest::GetValidationFeatures() {
     VkValidationFeaturesEXT features = LvlInitStruct<VkValidationFeaturesEXT>();
-    features.enabledValidationFeatureCount = 1;
+    features.enabledValidationFeatureCount = size32(gpu_av_enables);
     // TODO - Add command line flag or env var or another system for setting this to 'zero' to allow for someone writting a new
     // GPU-AV test to easily check the test is valid
-    features.disabledValidationFeatureCount = 4;
-    features.pEnabledValidationFeatures = gpu_av_enables;
-    features.pDisabledValidationFeatures = gpu_av_disables;
+    features.disabledValidationFeatureCount = size32(gpu_av_disables);
+    features.pEnabledValidationFeatures = gpu_av_enables.data();
+    features.pDisabledValidationFeatures = gpu_av_disables.data();
     return features;
 }
 

--- a/tests/negative/nvidia_best_practices.cpp
+++ b/tests/negative/nvidia_best_practices.cpp
@@ -250,6 +250,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
 TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     InitBestPracticesFramework(kEnableNVIDIAValidation);
 
@@ -264,8 +265,9 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
     }
 
     auto as_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT>(&as_features);
-    auto features2 = GetPhysicalDeviceFeatures2(bda_features);
+    auto rt_pipeline_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&as_features);
+    GetPhysicalDeviceFeatures2(bda_features);
 
     if (as_features.accelerationStructure == VK_FALSE) {
         GTEST_SKIP() << "accelerationStructure feature is not supported";
@@ -275,7 +277,11 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
         GTEST_SKIP() << "bufferDeviceAddress feature is not supported";
     }
 
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    if (rt_pipeline_features.rayTracingPipeline == VK_FALSE) {
+        GTEST_SKIP() << "rayTracingPipeline feature is not supported";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &bda_features));
 
     VkQueueObj *graphics_queue = m_device->GetDefaultQueue();
 

--- a/tests/negative/sync_val.cpp
+++ b/tests/negative/sync_val.cpp
@@ -4991,7 +4991,11 @@ TEST_F(NegativeSyncVal, QSBufferEvents) {
 }
 
 TEST_F(NegativeSyncVal, QSOBarrierHazard) {
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     QSTestContext test(m_device);


### PR DESCRIPTION
Remove the stateless/parameter validation option from config settings
and leave it enabled by default.

Validation makes the assumption that stateless validation has run. In
addition, stateless validation is usually innocuous, having a negligible
affect on performance. For these reasons, it was determined that
stateless validation should always be enabled.