### PR TITLE
tests: Add tests if Sampler/SampledImage share same slot

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -223,6 +223,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/framework/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/positive/layer_utils.cpp \
                    $(SRC_DIR)/tests/positive/format_utils.cpp \
                    $(SRC_DIR)/tests/positive/other.cpp \
+                   $(SRC_DIR)/tests/positive/pipeline_layout.cpp \
                    $(SRC_DIR)/tests/positive/pipeline_topology.cpp \
                    $(SRC_DIR)/tests/positive/pipeline.cpp \
                    $(SRC_DIR)/tests/positive/protected_memory.cpp \

--- a/layers/core_checks/cc_shader.cpp
+++ b/layers/core_checks/cc_shader.cpp
@@ -459,7 +459,7 @@ static std::set<uint32_t> TypeToDescriptorTypeSet(const SHADER_MODULE_STATE &mod
 static std::string string_descriptorTypeSet(const std::set<uint32_t> &descriptor_type_set) {
     std::stringstream ss;
     for (auto it = descriptor_type_set.begin(); it != descriptor_type_set.end(); ++it) {
-        if (ss.tellp()) ss << ", ";
+        if (ss.tellp()) ss << " or ";
         ss << string_VkDescriptorType(VkDescriptorType(*it));
     }
     return ss.str();
@@ -2174,8 +2174,8 @@ bool CoreChecks::ValidateShaderDescriptorVariable(const SHADER_MODULE_STATE &mod
             const LogObjectList objlist(module_state.vk_shader_module(), pipeline.PipelineLayoutState()->layout());
             skip |=
                 LogError(objlist, vuid,
-                         "%s(): pCreateInfos[%" PRIu32 "] Set %" PRIu32 " Binding %" PRIu32
-                         " type mismatch on descriptor slot in shader (%s), uses type %s but expected %s",
+                         "%s(): pCreateInfos[%" PRIu32 "] has a type mismatch for descriptor slot [Set %" PRIu32 " Binding %" PRIu32
+                         "] for shader (%s), uses type %s but expected (%s).",
                          pipeline.GetCreateFunctionName(), pipeline.create_index, variable.decorations.set,
                          variable.decorations.binding, string_VkShaderStageFlagBits(variable.stage),
                          string_VkDescriptorType(binding->descriptorType), string_descriptorTypeSet(descriptor_type_set).c_str());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     positive/memory.cpp
     positive/mesh.cpp
     positive/other.cpp
+    positive/pipeline_layout.cpp
     positive/pipeline_topology.cpp
     positive/pipeline.cpp
     positive/protected_memory.cpp

--- a/tests/negative/pipeline_layout.cpp
+++ b/tests/negative/pipeline_layout.cpp
@@ -897,6 +897,64 @@ TEST_F(NegativePipelineLayout, DescriptorTypeMismatchCompute) {
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkComputePipelineCreateInfo-layout-07989");
 }
 
+TEST_F(NegativePipelineLayout, DescriptorTypeMismatchNonCombinedImageSampler) {
+    TEST_DESCRIPTION(
+        "HLSL will sometimes produce a SAMPLED_IMAGE / SAMPLER on the same slot that is same as COMBINED_IMAGE_SAMPLER");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget(0, nullptr));
+
+    char const *fsSource = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 610
+               OpDecorate %textureColor DescriptorSet 0
+               OpDecorate %textureColor Binding 1
+               OpDecorate %samplerColor DescriptorSet 0
+               OpDecorate %samplerColor Binding 1
+      %float = OpTypeFloat 32
+%type_2d_image = OpTypeImage %float 2D 2 0 0 1 Unknown
+%ptr_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+%type_sampler = OpTypeSampler
+%ptr_type_sampler = OpTypePointer UniformConstant %type_sampler
+    %v2float = OpTypeVector %float 2
+    %v4float = OpTypeVector %float 4
+    %float_0 = OpConstant %float 0
+         %uv = OpConstantComposite %v2float %float_0 %float_0
+       %void = OpTypeVoid
+         %16 = OpTypeFunction %void
+%type_sampled_image = OpTypeSampledImage %type_2d_image
+%textureColor = OpVariable %ptr_type_2d_image UniformConstant
+%samplerColor = OpVariable %ptr_type_sampler UniformConstant
+       %main = OpFunction %void None %16
+         %17 = OpLabel
+         %35 = OpLoad %type_2d_image %textureColor
+         %36 = OpLoad %type_sampler %samplerColor
+         %38 = OpSampledImage %type_sampled_image %35 %36
+         %39 = OpImageSampleImplicitLod %v4float %38 %uv None
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
+
+    // Should be VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
+
+    const auto set_sampled_image = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+        helper.dsl_bindings_ = {{1, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_sampled_image, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07989");
+
+    const auto set_sampler = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+        helper.dsl_bindings_ = {{1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_sampler, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07989");
+}
+
 TEST_F(NegativePipelineLayout, DescriptorNotAccessible) {
     TEST_DESCRIPTION(
         "Create a pipeline in which a descriptor used by a shader stage does not include that stage in its stageFlags.");

--- a/tests/positive/pipeline_layout.cpp
+++ b/tests/positive/pipeline_layout.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+
+class PositivePipelineLayout : public VkLayerTest {};
+
+TEST_F(PositivePipelineLayout, DescriptorTypeMismatchNonCombinedImageSampler) {
+    TEST_DESCRIPTION("HLSL will sometimes produce a SAMPLED_IMAGE / SAMPLER on the same slot that is same as COMBINED_IMAGE_SAMPLER");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget(0, nullptr));
+
+    OneOffDescriptorSet descriptor_set(m_device, {
+                                                     {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                 });
+
+    char const *fsSource = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint Fragment %main "main"
+               OpExecutionMode %main OriginUpperLeft
+               OpSource HLSL 610
+               OpDecorate %textureColor DescriptorSet 0
+               OpDecorate %textureColor Binding 1
+               OpDecorate %samplerColor DescriptorSet 0
+               OpDecorate %samplerColor Binding 1
+      %float = OpTypeFloat 32
+%type_2d_image = OpTypeImage %float 2D 2 0 0 1 Unknown
+%ptr_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+%type_sampler = OpTypeSampler
+%ptr_type_sampler = OpTypePointer UniformConstant %type_sampler
+    %v2float = OpTypeVector %float 2
+%ptr_v2float = OpTypePointer Input %v2float
+       %void = OpTypeVoid
+         %16 = OpTypeFunction %void
+%type_sampled_image = OpTypeSampledImage %type_2d_image
+%textureColor = OpVariable %ptr_type_2d_image UniformConstant
+%samplerColor = OpVariable %ptr_type_sampler UniformConstant
+       %main = OpFunction %void None %16
+         %17 = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitInfo();
+    pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    pipe.InitState();
+    pipe.pipeline_layout_ = VkPipelineLayoutObj(m_device, {&descriptor_set.layout_});
+
+    pipe.CreateGraphicsPipeline();
+}


### PR DESCRIPTION
Make sure we are testing correctly that if both a `SAMPLER` and `SAMPLED_IMAGE` are sharing the same descriptor slot, it really is a `COMBINED_IMAGE_SAMPLER`

Also improved the VU wording to be more clear what is going on