### PR TITLE
layers: Remove false positive for Vertex Input Structs

### DIFF
--- a/layers/core_checks/cc_shader.cpp
+++ b/layers/core_checks/cc_shader.cpp
@@ -91,6 +91,11 @@ bool CoreChecks::ValidateViAgainstVsInputs(const PIPELINE_STATE &pipeline, const
             const uint32_t input_base_type_id = input->base_type.ResultId();
             const auto input_type = module_state.GetNumericType(input_base_type_id);
 
+            // TODO 5906 - This means there is a struct and we are not currently searching inside of it
+            if (input_type == NumericTypeUnknown) {
+                continue;
+            }
+
             // Type checking
             if (!(attrib_type & input_type)) {
                 skip |= LogError(module_state.vk_shader_module(), "VUID-VkGraphicsPipelineCreateInfo-Input-08733",

--- a/tests/negative/vertex_input.cpp
+++ b/tests/negative/vertex_input.cpp
@@ -787,6 +787,60 @@ TEST_F(NegativeVertexInput, AttributeTypeMismatch) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-Input-08733");
 }
 
+// Currently are not checking structs inside vertex input correctly
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5906
+TEST_F(NegativeVertexInput, DISABLED_AttributeStructType) {
+    TEST_DESCRIPTION("Input is OpTypeStruct but doesn't match");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    VkVertexInputBindingDescription input_binding = {0, 24, VK_VERTEX_INPUT_RATE_VERTEX};
+
+    VkVertexInputAttributeDescription input_attrib;
+    memset(&input_attrib, 0, sizeof(input_attrib));
+    input_attrib.format = VK_FORMAT_R32G32B32_SFLOAT;  // vec3
+    input_attrib.location = 4;
+
+    // This is not valid GLSL (but is valid SPIR-V) - would look like:
+    //     in VertexIn {
+    //         layout(location = 4) vec4 x;
+    //     } x_struct;
+    char const *vsSource = R"(
+               OpCapability Shader
+               OpMemoryModel Logical Simple
+               OpEntryPoint Vertex %1 "main" %2
+               OpMemberDecorate %_struct_3 0 Location 4
+               OpDecorate %_struct_3 Block
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+  %_struct_3 = OpTypeStruct %v4float
+%_ptr_Input__struct_3 = OpTypePointer Input %_struct_3
+          %2 = OpVariable %_ptr_Input__struct_3 Input
+          %1 = OpFunction %void None %5
+         %13 = OpLabel
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
+    VkShaderObj fs(this, bindStateFragShaderText, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitInfo();
+    pipe.vi_ci_.pVertexBindingDescriptions = &input_binding;
+    pipe.vi_ci_.vertexBindingDescriptionCount = 1;
+    pipe.vi_ci_.pVertexAttributeDescriptions = &input_attrib;
+    pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
+    pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    pipe.InitState();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-Input-08733");
+    pipe.CreateGraphicsPipeline();
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeVertexInput, AttributeBindingConflict) {
     TEST_DESCRIPTION(
         "Test that an error is produced for a vertex attribute setup where multiple bindings provide the same location");


### PR DESCRIPTION
tied to https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5906

We were giving false positives for Vertex Inputs if they were using a struct

This suppresses the false positive until the shader harness testing is setup and I can try fixing this