### PR TITLE
Fixed rtti settings for chromium builds.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -445,6 +445,7 @@ foreach(layer_info, layers) {
     } else {
       configs -= [ "//build/config/compiler:chromium_code" ]
       configs += [ "//build/config/compiler:no_chromium_code" ]
+      configs -= [ "//build/config/compiler:no_rtti" ]
       configs += [ "//build/config/compiler:rtti" ]
     }
     configs -= vulkan_undefine_configs


### PR DESCRIPTION
I believe this is the proper thing to do in chromium builds.  In chromiums buildroot the default is `no_rtti`:https://chromium.googlesource.com/chromium/src/+/master/build/config/BUILDCONFIG.gn#347

I think this may only work for some people because it appears when having `rtti` and `no_rtti`; the ordering of the flags may result in `rtti`.

I'm not sure what the criteria are for changing this behavior now though.