### PR TITLE
tests: Add SPIRV-Hopper

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -66,7 +66,10 @@ target_sources(VkLayer_utils PRIVATE
 # https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4640
 target_compile_definitions(VkLayer_utils PUBLIC XXH_NO_LONG_LONG)
 
-target_link_libraries(VkLayer_utils PUBLIC Vulkan::Headers)
+target_link_libraries(VkLayer_utils PUBLIC
+    Vulkan::Headers
+    ${CMAKE_DL_LIBS}
+)
 target_include_directories(VkLayer_utils SYSTEM PRIVATE external)
 target_include_directories(VkLayer_utils PUBLIC . ${API_TYPE})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -194,7 +194,6 @@ target_link_libraries(vk_layer_validation_tests PRIVATE
     VVL-SPIRV-LIBS
     GTest::gtest
     GTest::gtest_main
-    ${CMAKE_DL_LIBS}
     $<TARGET_NAME_IF_EXISTS:PkgConfig::XCB>
     $<TARGET_NAME_IF_EXISTS:PkgConfig::X11>
     $<TARGET_NAME_IF_EXISTS:PkgConfig::WAYlAND_CLIENT>
@@ -211,3 +210,4 @@ include(GoogleTest)
 gtest_discover_tests(vk_layer_validation_tests DISCOVERY_TIMEOUT 100)
 
 add_subdirectory(layers)
+add_subdirectory(spirv_hopper)

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,12 +13,13 @@ Make sure `-DBUILD_TESTS` was passed into the CMake command when generating the 
 
 The tests are grouped into different categories. Some of the main test categories are:
 
-- `VkLayerTest` - General tests that expect the Validation Layers to trigger an error
-    - Also known as "negative tests"
-- `VkPositiveLayerTest` - Tests that make sure Validation isn't accidentally triggering an error
-- `VkBestPracticesLayerTest` - Tests the [best practice layer](../docs/best_practices.md)
-- `VkGpuAssistedLayerTest` - Test [GPU-Assisted Validation](../docs/gpu_validation.md)
-- `VkPortabilitySubsetTest` - Test [VK_KHR_portability_subset validation](../docs/portability_validation.md)
+- Negative testing
+    - General tests that expect the Validation Layers to trigger an error
+- Positive testing
+    - Make sure Validation isn't accidentally triggering an error
+    - Commonly created to prevent bug regressions
+- SPIR-V testing with [SPIRV-Hopper](./spirv_hopper/)
+    - Seperate tool for testing shader runtime validation
 
 ## Implicit Layers note
 

--- a/tests/device_profiles/spirv_hopper_profile.json
+++ b/tests/device_profiles/spirv_hopper_profile.json
@@ -1,0 +1,793 @@
+{
+    "$schema": "https://schema.khronos.org/vulkan/profiles-0.8.0-latest.json#",
+    "profiles": {
+        "SPIRV_HOPPER_PROFILE": {
+            "version": 1,
+            "api-version": "1.3.250",
+            "label": "SPIRV-Hopper Profile",
+            "description": "Profile that supports as much for SPIR-V shaders",
+            "contributors": {},
+            "history": [
+                {
+                    "revision": 1,
+                    "date": "2023-05-31",
+                    "author": "SPIRV-Hopper",
+                    "comment": "handed-groomed from what is only needed for SPIRV-Hopper"
+                }
+            ],
+            "capabilities": [
+                "device"
+            ]
+        }
+    },
+    "capabilities": {
+        "device": {
+            "features": {
+                "VkPhysicalDeviceFeatures": {
+                    "robustBufferAccess": true,
+                    "geometryShader": true,
+                    "tessellationShader": true,
+                    "sampleRateShading": true,
+                    "alphaToOne": true,
+                    "multiViewport": true,
+                    "vertexPipelineStoresAndAtomics": true,
+                    "fragmentStoresAndAtomics": true,
+                    "shaderTessellationAndGeometryPointSize": true,
+                    "shaderImageGatherExtended": true,
+                    "shaderStorageImageExtendedFormats": true,
+                    "shaderStorageImageMultisample": true,
+                    "shaderStorageImageReadWithoutFormat": true,
+                    "shaderStorageImageWriteWithoutFormat": true,
+                    "shaderUniformBufferArrayDynamicIndexing": true,
+                    "shaderSampledImageArrayDynamicIndexing": true,
+                    "shaderStorageBufferArrayDynamicIndexing": true,
+                    "shaderStorageImageArrayDynamicIndexing": true,
+                    "shaderClipDistance": true,
+                    "shaderCullDistance": true,
+                    "shaderFloat64": true,
+                    "shaderInt64": true,
+                    "shaderInt16": true,
+                    "shaderResourceResidency": true,
+                    "shaderResourceMinLod": true,
+                    "sparseBinding": true,
+                    "sparseResidencyBuffer": true,
+                    "sparseResidencyImage2D": true,
+                    "sparseResidencyImage3D": true,
+                    "sparseResidency2Samples": true,
+                    "sparseResidency4Samples": true,
+                    "sparseResidency8Samples": true,
+                    "sparseResidency16Samples": true,
+                    "sparseResidencyAliased": true,
+                    "variableMultisampleRate": true
+                },
+                "VkPhysicalDeviceVariablePointersFeatures": {
+                    "variablePointersStorageBuffer": true,
+                    "variablePointers": true
+                },
+                "VkPhysicalDeviceMultiviewFeatures": {
+                    "multiview": true,
+                    "multiviewGeometryShader": true,
+                    "multiviewTessellationShader": true
+                },
+                "VkPhysicalDevice16BitStorageFeatures": {
+                    "storageBuffer16BitAccess": true,
+                    "uniformAndStorageBuffer16BitAccess": true,
+                    "storagePushConstant16": true,
+                    "storageInputOutput16": true
+                },
+                "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures": {
+                    "shaderSubgroupExtendedTypes": true
+                },
+                "VkPhysicalDeviceSubgroupSizeControlFeatures": {
+                    "subgroupSizeControl": true,
+                    "computeFullSubgroups": true
+                },
+                "VkPhysicalDeviceMaintenance4Features": {
+                    "maintenance4": true
+                },
+                "VkPhysicalDeviceShaderDrawParametersFeatures": {
+                    "shaderDrawParameters": true
+                },
+                "VkPhysicalDeviceShaderFloat16Int8Features": {
+                    "shaderFloat16": true,
+                    "shaderInt8": true
+                },
+                "VkPhysicalDeviceDescriptorIndexingFeatures": {
+                    "shaderInputAttachmentArrayDynamicIndexing": true,
+                    "shaderUniformTexelBufferArrayDynamicIndexing": true,
+                    "shaderStorageTexelBufferArrayDynamicIndexing": true,
+                    "shaderUniformBufferArrayNonUniformIndexing": true,
+                    "shaderSampledImageArrayNonUniformIndexing": true,
+                    "shaderStorageBufferArrayNonUniformIndexing": true,
+                    "shaderStorageImageArrayNonUniformIndexing": true,
+                    "shaderInputAttachmentArrayNonUniformIndexing": true,
+                    "shaderUniformTexelBufferArrayNonUniformIndexing": true,
+                    "shaderStorageTexelBufferArrayNonUniformIndexing": true,
+                    "descriptorBindingUniformBufferUpdateAfterBind": true,
+                    "descriptorBindingSampledImageUpdateAfterBind": true,
+                    "descriptorBindingStorageImageUpdateAfterBind": true,
+                    "descriptorBindingStorageBufferUpdateAfterBind": true,
+                    "descriptorBindingUniformTexelBufferUpdateAfterBind": true,
+                    "descriptorBindingStorageTexelBufferUpdateAfterBind": true,
+                    "descriptorBindingUpdateUnusedWhilePending": true,
+                    "descriptorBindingPartiallyBound": true,
+                    "descriptorBindingVariableDescriptorCount": true,
+                    "runtimeDescriptorArray": true
+                },
+                "VkPhysicalDevice8BitStorageFeatures": {
+                    "storageBuffer8BitAccess": true,
+                    "uniformAndStorageBuffer8BitAccess": true,
+                    "storagePushConstant8": true
+                },
+                "VkPhysicalDeviceVulkanMemoryModelFeatures": {
+                    "vulkanMemoryModel": true,
+                    "vulkanMemoryModelDeviceScope": true,
+                    "vulkanMemoryModelAvailabilityVisibilityChains": true
+                },
+                "VkPhysicalDeviceShaderAtomicInt64Features": {
+                    "shaderBufferInt64Atomics": true,
+                    "shaderSharedInt64Atomics": true
+                },
+                "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT": {
+                    "shaderBufferFloat32Atomics": true,
+                    "shaderBufferFloat32AtomicAdd": true,
+                    "shaderBufferFloat64Atomics": true,
+                    "shaderBufferFloat64AtomicAdd": true,
+                    "shaderSharedFloat32Atomics": true,
+                    "shaderSharedFloat32AtomicAdd": true,
+                    "shaderSharedFloat64Atomics": true,
+                    "shaderSharedFloat64AtomicAdd": true,
+                    "shaderImageFloat32Atomics": true,
+                    "shaderImageFloat32AtomicAdd": true,
+                    "sparseImageFloat32Atomics": true,
+                    "sparseImageFloat32AtomicAdd": true
+                },
+                "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT": {
+                    "shaderBufferFloat16Atomics": true,
+                    "shaderBufferFloat16AtomicAdd": true,
+                    "shaderBufferFloat16AtomicMinMax": true,
+                    "shaderBufferFloat32AtomicMinMax": true,
+                    "shaderBufferFloat64AtomicMinMax": true,
+                    "shaderSharedFloat16Atomics": true,
+                    "shaderSharedFloat16AtomicAdd": true,
+                    "shaderSharedFloat16AtomicMinMax": true,
+                    "shaderSharedFloat32AtomicMinMax": true,
+                    "shaderSharedFloat64AtomicMinMax": true,
+                    "shaderImageFloat32AtomicMinMax": true,
+                    "sparseImageFloat32AtomicMinMax": true
+                },
+                "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
+                    "transformFeedback": true,
+                    "geometryStreams": true
+                },
+                "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV": {
+                    "computeDerivativeGroupQuads": true,
+                    "computeDerivativeGroupLinear": true
+                },
+                "VkPhysicalDeviceShaderImageFootprintFeaturesNV": {
+                    "imageFootprint": true
+                },
+                "VkPhysicalDeviceShadingRateImageFeaturesNV": {
+                    "shadingRateImage": true,
+                    "shadingRateCoarseSampleOrder": true
+                },
+                "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI": {
+                    "invocationMask": true
+                },
+                "VkPhysicalDeviceMeshShaderFeaturesNV": {
+                    "taskShader": true,
+                    "meshShader": true
+                },
+                "VkPhysicalDeviceMeshShaderFeaturesEXT": {
+                    "taskShader": true,
+                    "meshShader": true,
+                    "multiviewMeshShader": true,
+                    "primitiveFragmentShadingRateMeshShader": true,
+                    "meshShaderQueries": true
+                },
+                "VkPhysicalDeviceRayTracingPipelineFeaturesKHR": {
+                    "rayTracingPipeline": true,
+                    "rayTracingPipelineShaderGroupHandleCaptureReplay": true,
+                    "rayTracingPipelineShaderGroupHandleCaptureReplayMixed": true,
+                    "rayTracingPipelineTraceRaysIndirect": true,
+                    "rayTraversalPrimitiveCulling": true
+                },
+                "VkPhysicalDeviceRayQueryFeaturesKHR": {
+                    "rayQuery": true
+                },
+                "VkPhysicalDeviceFragmentDensityMapFeaturesEXT": {
+                    "fragmentDensityMap": true,
+                    "fragmentDensityMapDynamic": true,
+                    "fragmentDensityMapNonSubsampledImages": true
+                },
+                "VkPhysicalDeviceScalarBlockLayoutFeatures": {
+                    "scalarBlockLayout": true
+                },
+                "VkPhysicalDeviceUniformBufferStandardLayoutFeatures": {
+                    "uniformBufferStandardLayout": true
+                },
+                "VkPhysicalDeviceBufferDeviceAddressFeatures": {
+                    "bufferDeviceAddress": true,
+                    "bufferDeviceAddressCaptureReplay": true,
+                    "bufferDeviceAddressMultiDevice": true
+                },
+                "VkPhysicalDeviceCooperativeMatrixFeaturesNV": {
+                    "cooperativeMatrix": true,
+                    "cooperativeMatrixRobustBufferAccess": true
+                },
+                "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL": {
+                    "shaderIntegerFunctions2": true
+                },
+                "VkPhysicalDeviceShaderClockFeaturesKHR": {
+                    "shaderSubgroupClock": true,
+                    "shaderDeviceClock": true
+                },
+                "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV": {
+                    "shaderSMBuiltins": true
+                },
+                "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT": {
+                    "fragmentShaderSampleInterlock": true,
+                    "fragmentShaderPixelInterlock": true,
+                    "fragmentShaderShadingRateInterlock": true
+                },
+                "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures": {
+                    "shaderDemoteToHelperInvocation": true
+                },
+                "VkPhysicalDeviceVulkan11Features": {
+                    "storageBuffer16BitAccess": true,
+                    "uniformAndStorageBuffer16BitAccess": true,
+                    "storagePushConstant16": true,
+                    "storageInputOutput16": true,
+                    "multiview": true,
+                    "multiviewGeometryShader": true,
+                    "multiviewTessellationShader": true,
+                    "variablePointersStorageBuffer": true,
+                    "variablePointers": true,
+                    "shaderDrawParameters": true
+                },
+                "VkPhysicalDeviceVulkan12Features": {
+                    "samplerMirrorClampToEdge": true,
+                    "drawIndirectCount": true,
+                    "storageBuffer8BitAccess": true,
+                    "uniformAndStorageBuffer8BitAccess": true,
+                    "storagePushConstant8": true,
+                    "shaderBufferInt64Atomics": true,
+                    "shaderSharedInt64Atomics": true,
+                    "shaderFloat16": true,
+                    "shaderInt8": true,
+                    "descriptorIndexing": true,
+                    "shaderInputAttachmentArrayDynamicIndexing": true,
+                    "shaderUniformTexelBufferArrayDynamicIndexing": true,
+                    "shaderStorageTexelBufferArrayDynamicIndexing": true,
+                    "shaderUniformBufferArrayNonUniformIndexing": true,
+                    "shaderSampledImageArrayNonUniformIndexing": true,
+                    "shaderStorageBufferArrayNonUniformIndexing": true,
+                    "shaderStorageImageArrayNonUniformIndexing": true,
+                    "shaderInputAttachmentArrayNonUniformIndexing": true,
+                    "shaderUniformTexelBufferArrayNonUniformIndexing": true,
+                    "shaderStorageTexelBufferArrayNonUniformIndexing": true,
+                    "descriptorBindingUniformBufferUpdateAfterBind": true,
+                    "descriptorBindingSampledImageUpdateAfterBind": true,
+                    "descriptorBindingStorageImageUpdateAfterBind": true,
+                    "descriptorBindingStorageBufferUpdateAfterBind": true,
+                    "descriptorBindingUniformTexelBufferUpdateAfterBind": true,
+                    "descriptorBindingStorageTexelBufferUpdateAfterBind": true,
+                    "descriptorBindingUpdateUnusedWhilePending": true,
+                    "descriptorBindingPartiallyBound": true,
+                    "descriptorBindingVariableDescriptorCount": true,
+                    "runtimeDescriptorArray": true,
+                    "samplerFilterMinmax": true,
+                    "scalarBlockLayout": true,
+                    "uniformBufferStandardLayout": true,
+                    "shaderSubgroupExtendedTypes": true,
+                    "bufferDeviceAddress": true,
+                    "bufferDeviceAddressCaptureReplay": true,
+                    "bufferDeviceAddressMultiDevice": true,
+                    "vulkanMemoryModel": true,
+                    "vulkanMemoryModelDeviceScope": true,
+                    "vulkanMemoryModelAvailabilityVisibilityChains": true,
+                    "shaderOutputViewportIndex": true,
+                    "shaderOutputLayer": true,
+                    "subgroupBroadcastDynamicId": true
+                },
+                "VkPhysicalDeviceVulkan13Features": {
+                    "pipelineCreationCacheControl": true,
+                    "shaderDemoteToHelperInvocation": true,
+                    "shaderTerminateInvocation": true,
+                    "subgroupSizeControl": true,
+                    "computeFullSubgroups": true,
+                    "shaderZeroInitializeWorkgroupMemory": true,
+                    "shaderIntegerDotProduct": true,
+                    "maintenance4": true
+                },
+                "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures": {
+                    "shaderZeroInitializeWorkgroupMemory": true
+                },
+                "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR": {
+                    "shaderSubgroupUniformControlFlow": true
+                },
+                "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR": {
+                    "workgroupMemoryExplicitLayout": true,
+                    "workgroupMemoryExplicitLayoutScalarBlockLayout": true,
+                    "workgroupMemoryExplicitLayout8BitAccess": true,
+                    "workgroupMemoryExplicitLayout16BitAccess": true
+                },
+                "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT": {
+                    "shaderImageInt64Atomics": true,
+                    "sparseImageInt64Atomics": true
+                },
+                "VkPhysicalDeviceFragmentShadingRateFeaturesKHR": {
+                    "pipelineFragmentShadingRate": true,
+                    "primitiveFragmentShadingRate": true,
+                    "attachmentFragmentShadingRate": true
+                },
+                "VkPhysicalDeviceShaderTerminateInvocationFeatures": {
+                    "shaderTerminateInvocation": true
+                },
+                "VkPhysicalDeviceShaderIntegerDotProductFeatures": {
+                    "shaderIntegerDotProduct": true
+                },
+                "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR": {
+                    "fragmentShaderBarycentric": true
+                },
+                "VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM": {
+                    "shaderCoreBuiltins": true
+                },
+                "VkPhysicalDeviceShaderTileImageFeaturesEXT": {
+                    "shaderTileImageColorReadAccess": true,
+                    "shaderTileImageDepthReadAccess": true,
+                    "shaderTileImageStencilReadAccess": true
+                }
+            },
+            "properties": {
+                "VkPhysicalDeviceProperties": {
+                    "vendorID": 1,
+                    "apiVersion": 4206842,
+                    "sparseProperties": {
+                        "residencyAlignedMipSize": true,
+                        "residencyNonResidentStrict": true,
+                        "residencyStandard2DBlockShape": true,
+                        "residencyStandard2DMultisampleBlockShape": true,
+                        "residencyStandard3DBlockShape": true
+                    },
+                    "limits": {
+                        "bufferImageGranularity": 1024,
+                        "maxClipDistances": 4294967000,
+                        "maxColorAttachments": 4294967000,
+                        "maxCombinedClipAndCullDistances": 4294967000,
+                        "maxComputeSharedMemorySize": 4294967000,
+                        "maxComputeWorkGroupInvocations": 4294967000,
+                        "maxCullDistances": 4294967000,
+                        "maxDescriptorSetInputAttachments": 1048576,
+                        "maxDescriptorSetSampledImages": 1048576,
+                        "maxDescriptorSetSamplers": 1048576,
+                        "maxDescriptorSetStorageBuffers": 1048576,
+                        "maxDescriptorSetStorageBuffersDynamic": 16,
+                        "maxDescriptorSetStorageImages": 1048576,
+                        "maxDescriptorSetUniformBuffers": 1048576,
+                        "maxDescriptorSetUniformBuffersDynamic": 15,
+                        "maxDrawIndexedIndexValue": 4294967000,
+                        "maxDrawIndirectCount": 4294967000,
+                        "maxFragmentCombinedOutputResources": 4294967000,
+                        "maxFragmentDualSrcAttachments": 4294967000,
+                        "maxFragmentInputComponents": 4294967000,
+                        "maxFragmentOutputAttachments": 4294967000,
+                        "maxFramebufferHeight": 32768,
+                        "maxFramebufferLayers": 2048,
+                        "maxFramebufferWidth": 32768,
+                        "maxGeometryInputComponents": 4294967000,
+                        "maxGeometryOutputComponents": 4294967000,
+                        "maxGeometryOutputVertices": 4294967000,
+                        "maxGeometryShaderInvocations": 4294967000,
+                        "maxGeometryTotalOutputComponents": 4294967000,
+                        "maxImageArrayLayers": 2048,
+                        "maxImageDimension1D": 32768,
+                        "maxImageDimension2D": 32768,
+                        "maxImageDimension3D": 16384,
+                        "maxImageDimensionCube": 32768,
+                        "maxInterpolationOffset": 0.4375,
+                        "maxMemoryAllocationCount": 4096,
+                        "maxPerStageDescriptorInputAttachments": 4294967000,
+                        "maxPerStageDescriptorSampledImages": 4294967000,
+                        "maxPerStageDescriptorSamplers": 4294967000,
+                        "maxPerStageDescriptorStorageBuffers": 4294967000,
+                        "maxPerStageDescriptorStorageImages": 4294967000,
+                        "maxPerStageDescriptorUniformBuffers": 4294967000,
+                        "maxPerStageResources": 4294967000,
+                        "maxPushConstantsSize": 4294967000,
+                        "maxSampleMaskWords": 1,
+                        "maxSamplerAllocationCount": 4000,
+                        "maxSamplerAnisotropy": 16,
+                        "maxSamplerLodBias": 15,
+                        "maxStorageBufferRange": 4294967000,
+                        "maxTessellationControlPerPatchOutputComponents": 4294967000,
+                        "maxTessellationControlPerVertexInputComponents": 4294967000,
+                        "maxTessellationControlPerVertexOutputComponents": 4294967000,
+                        "maxTessellationControlTotalOutputComponents": 4294967000,
+                        "maxTessellationEvaluationInputComponents": 4294967000,
+                        "maxTessellationEvaluationOutputComponents": 4294967000,
+                        "maxTessellationGenerationLevel": 4294967000,
+                        "maxTessellationPatchSize": 4294967000,
+                        "maxTexelBufferElements": 134217728,
+                        "maxTexelGatherOffset": 31,
+                        "maxTexelOffset": 7,
+                        "maxUniformBufferRange": 65536,
+                        "maxVertexInputAttributeOffset": 4294967000,
+                        "maxVertexInputAttributes": 4294967000,
+                        "maxVertexInputBindingStride": 4294967000,
+                        "maxVertexInputBindings": 4294967000,
+                        "maxVertexOutputComponents": 4294967000,
+                        "maxViewports": 16,
+                        "minStorageBufferOffsetAlignment": 16,
+                        "minTexelBufferOffsetAlignment": 16,
+                        "minTexelGatherOffset": -32,
+                        "minTexelOffset": -8,
+                        "minUniformBufferOffsetAlignment": 64,
+                        "nonCoherentAtomSize": 64,
+                        "optimalBufferCopyOffsetAlignment": 1,
+                        "optimalBufferCopyRowPitchAlignment": 1,
+                        "pointSizeGranularity": 0.0625,
+                        "sparseAddressSpaceSize": 1099510000000,
+                        "standardSampleLocations": true,
+                        "storageImageSampleCounts": [],
+                        "maxComputeWorkGroupCount": [
+                            4294967000,
+                            4294967000,
+                            4294967000
+                        ],
+                        "maxComputeWorkGroupSize": [
+                            4294967000,
+                            4294967000,
+                            4294967000
+                        ],
+                        "maxViewportDimensions": [
+                            32768,
+                            32768
+                        ],
+                        "pointSizeRange": [
+                            1,
+                            2048
+                        ],
+                        "viewportBoundsRange": [
+                            -65536,
+                            65536
+                        ],
+                        "lineWidthRange": [
+                            1,
+                            64
+                        ]
+                    }
+                },
+                "VkPhysicalDeviceVulkan11Properties": {
+                    "subgroupSize": 32,
+                    "subgroupSupportedStages": [
+                        "VK_SHADER_STAGE_VERTEX_BIT",
+                        "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                        "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                        "VK_SHADER_STAGE_GEOMETRY_BIT",
+                        "VK_SHADER_STAGE_FRAGMENT_BIT",
+                        "VK_SHADER_STAGE_COMPUTE_BIT",
+                        "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                        "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                        "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                        "VK_SHADER_STAGE_MISS_BIT_KHR",
+                        "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                        "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                        "VK_SHADER_STAGE_TASK_BIT_EXT",
+                        "VK_SHADER_STAGE_MESH_BIT_EXT",
+                        "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI"
+                    ],
+                    "subgroupSupportedOperations": [
+                        "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                        "VK_SUBGROUP_FEATURE_VOTE_BIT",
+                        "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                        "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                        "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                        "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                        "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                        "VK_SUBGROUP_FEATURE_QUAD_BIT",
+                        "VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV"
+                    ]
+                },
+                "VkPhysicalDeviceVulkan12Properties": {
+                    "shaderSignedZeroInfNanPreserveFloat16": true,
+                    "shaderSignedZeroInfNanPreserveFloat32": true,
+                    "shaderSignedZeroInfNanPreserveFloat64": true,
+                    "shaderDenormPreserveFloat16": true,
+                    "shaderDenormPreserveFloat32": true,
+                    "shaderDenormPreserveFloat64": true,
+                    "shaderDenormFlushToZeroFloat16": true,
+                    "shaderDenormFlushToZeroFloat32": true,
+                    "shaderDenormFlushToZeroFloat64": true,
+                    "shaderRoundingModeRTEFloat16": true,
+                    "shaderRoundingModeRTEFloat32": true,
+                    "shaderRoundingModeRTEFloat64": true,
+                    "shaderRoundingModeRTZFloat16": true,
+                    "shaderRoundingModeRTZFloat32": true,
+                    "shaderRoundingModeRTZFloat64": true,
+                    "shaderUniformBufferArrayNonUniformIndexingNative": true,
+                    "shaderSampledImageArrayNonUniformIndexingNative": true,
+                    "shaderStorageBufferArrayNonUniformIndexingNative": true,
+                    "shaderStorageImageArrayNonUniformIndexingNative": true,
+                    "shaderInputAttachmentArrayNonUniformIndexingNative": true,
+                    "maxPerStageDescriptorUpdateAfterBindSamplers": 4294967000,
+                    "maxPerStageDescriptorUpdateAfterBindUniformBuffers": 4294967000,
+                    "maxPerStageDescriptorUpdateAfterBindStorageBuffers": 4294967000,
+                    "maxPerStageDescriptorUpdateAfterBindSampledImages": 4294967000,
+                    "maxPerStageDescriptorUpdateAfterBindStorageImages": 4294967000,
+                    "maxPerStageDescriptorUpdateAfterBindInputAttachments": 4294967000,
+                    "maxPerStageUpdateAfterBindResources": 4294967000,
+                    "maxDescriptorSetUpdateAfterBindSamplers": 4294967000,
+                    "maxDescriptorSetUpdateAfterBindUniformBuffers": 4294967000,
+                    "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic": 4294967000,
+                    "maxDescriptorSetUpdateAfterBindStorageBuffers": 4294967000,
+                    "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic": 4294967000,
+                    "maxDescriptorSetUpdateAfterBindSampledImages": 4294967000,
+                    "maxDescriptorSetUpdateAfterBindStorageImages": 4294967000,
+                    "maxDescriptorSetUpdateAfterBindInputAttachments": 4294967000
+                },
+                "VkPhysicalDeviceVulkan13Properties": {
+                    "minSubgroupSize": 1,
+                    "maxSubgroupSize": 4294967000,
+                    "maxComputeWorkgroupSubgroups": 4294967000,
+                    "requiredSubgroupSizeStages": [
+                        "VK_SHADER_STAGE_VERTEX_BIT",
+                        "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                        "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                        "VK_SHADER_STAGE_GEOMETRY_BIT",
+                        "VK_SHADER_STAGE_FRAGMENT_BIT",
+                        "VK_SHADER_STAGE_COMPUTE_BIT",
+                        "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                        "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                        "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                        "VK_SHADER_STAGE_MISS_BIT_KHR",
+                        "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                        "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                        "VK_SHADER_STAGE_TASK_BIT_EXT",
+                        "VK_SHADER_STAGE_MESH_BIT_EXT",
+                        "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI"
+                    ],
+                    "maxPerStageDescriptorInlineUniformBlocks": 4294967000,
+                    "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks": 4294967000,
+                    "maxDescriptorSetInlineUniformBlocks": 4294967000,
+                    "maxDescriptorSetUpdateAfterBindInlineUniformBlocks": 4294967000,
+                    "maxInlineUniformTotalSize": 4294967000
+                },
+                "VkPhysicalDeviceAccelerationStructurePropertiesKHR": {
+                    "maxGeometryCount": 4294967000,
+                    "maxInstanceCount": 16777215,
+                    "maxPrimitiveCount": 4294967000,
+                    "maxPerStageDescriptorAccelerationStructures": 4294967000,
+                    "maxPerStageDescriptorUpdateAfterBindAccelerationStructures": 4294967000,
+                    "maxDescriptorSetAccelerationStructures": 4294967000,
+                    "maxDescriptorSetUpdateAfterBindAccelerationStructures": 4294967000,
+                    "minAccelerationStructureScratchOffsetAlignment": 1
+                },
+                "VkPhysicalDeviceTransformFeedbackPropertiesEXT": {
+                    "maxTransformFeedbackStreams": 4294967000,
+                    "maxTransformFeedbackBuffers": 4294967000,
+                    "maxTransformFeedbackBufferSize": 4294967000,
+                    "maxTransformFeedbackStreamDataSize": 4294967000,
+                    "maxTransformFeedbackBufferDataSize": 4294967000,
+                    "maxTransformFeedbackBufferDataStride": 4294967000,
+                    "transformFeedbackQueries": true,
+                    "transformFeedbackStreamsLinesTriangles": true,
+                    "transformFeedbackRasterizationStreamSelect": true,
+                    "transformFeedbackDraw": true
+                },
+                "VkPhysicalDeviceMeshShaderPropertiesNV": {
+                    "maxDrawMeshTasksCount": 4294967000,
+                    "maxTaskWorkGroupInvocations": 4294967000,
+                    "maxTaskWorkGroupSize": [
+                        4294967000,
+                        4294967000,
+                        4294967000
+                    ],
+                    "maxTaskTotalMemorySize": 4294967000,
+                    "maxTaskOutputCount": 4294967000,
+                    "maxMeshWorkGroupInvocations": 4294967000,
+                    "maxMeshWorkGroupSize": [
+                        4294967000,
+                        4294967000,
+                        4294967000
+                    ],
+                    "maxMeshTotalMemorySize": 4294967000,
+                    "maxMeshOutputVertices": 4294967000,
+                    "maxMeshOutputPrimitives": 4294967000,
+                    "maxMeshMultiviewViewCount": 4294967000
+                },
+                "VkPhysicalDeviceMeshShaderPropertiesEXT": {
+                    "maxTaskWorkGroupTotalCount": 4294967000,
+                    "maxTaskWorkGroupCount": [
+                        4294967000,
+                        4294967000,
+                        4294967000
+                    ],
+                    "maxTaskWorkGroupInvocations": 4294967000,
+                    "maxTaskWorkGroupSize": [
+                        4294967000,
+                        4294967000,
+                        4294967000
+                    ],
+                    "maxTaskPayloadSize": 4294967000,
+                    "maxTaskSharedMemorySize": 4294967000,
+                    "maxTaskPayloadAndSharedMemorySize": 4294967000,
+                    "maxMeshWorkGroupTotalCount": 4294967000,
+                    "maxMeshWorkGroupCount": [
+                        4294967000,
+                        4294967000,
+                        4294967000
+                    ],
+                    "maxMeshWorkGroupInvocations": 4294967000,
+                    "maxMeshWorkGroupSize": [
+                        4294967000,
+                        4294967000,
+                        4294967000
+                    ],
+                    "maxMeshSharedMemorySize": 4294967000,
+                    "maxMeshPayloadAndSharedMemorySize": 4294967000,
+                    "maxMeshOutputMemorySize": 4294967000,
+                    "maxMeshPayloadAndOutputMemorySize": 4294967000,
+                    "maxMeshOutputComponents": 4294967000,
+                    "maxMeshOutputVertices": 4294967000,
+                    "maxMeshOutputPrimitives": 4294967000,
+                    "maxMeshOutputLayers": 4294967000,
+                    "maxMeshMultiviewViewCount": 4294967000,
+                    "maxPreferredTaskWorkGroupInvocations": 4294967000,
+                    "maxPreferredMeshWorkGroupInvocations": 4294967000
+                },
+                "VkPhysicalDeviceCooperativeMatrixPropertiesNV": {
+                    "cooperativeMatrixSupportedStages": [
+                        "VK_SHADER_STAGE_VERTEX_BIT",
+                        "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                        "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                        "VK_SHADER_STAGE_GEOMETRY_BIT",
+                        "VK_SHADER_STAGE_FRAGMENT_BIT",
+                        "VK_SHADER_STAGE_COMPUTE_BIT",
+                        "VK_SHADER_STAGE_RAYGEN_BIT_KHR",
+                        "VK_SHADER_STAGE_ANY_HIT_BIT_KHR",
+                        "VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR",
+                        "VK_SHADER_STAGE_MISS_BIT_KHR",
+                        "VK_SHADER_STAGE_INTERSECTION_BIT_KHR",
+                        "VK_SHADER_STAGE_CALLABLE_BIT_KHR",
+                        "VK_SHADER_STAGE_TASK_BIT_EXT",
+                        "VK_SHADER_STAGE_MESH_BIT_EXT",
+                        "VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI"
+                    ]
+                }
+            },
+            "extensions": {
+                "VK_AMD_gcn_shader": 1,
+                "VK_AMD_gpu_shader_half_float": 1,
+                "VK_AMD_gpu_shader_int16": 1,
+                "VK_AMD_pipeline_compiler_control": 1,
+                "VK_AMD_shader_ballot": 1,
+                "VK_AMD_shader_core_properties": 1,
+                "VK_AMD_shader_core_properties2": 1,
+                "VK_AMD_shader_early_and_late_fragment_tests": 1,
+                "VK_AMD_shader_explicit_vertex_parameter": 1,
+                "VK_AMD_shader_fragment_mask": 1,
+                "VK_AMD_shader_image_load_store_lod": 1,
+                "VK_AMD_shader_info": 1,
+                "VK_AMD_shader_trinary_minmax": 1,
+                "VK_AMD_texture_gather_bias_lod": 1,
+                "VK_ARM_shader_core_builtins": 1,
+                "VK_EXT_buffer_device_address": 1,
+                "VK_EXT_conditional_rendering": 1,
+                "VK_EXT_conservative_rasterization": 1,
+                "VK_EXT_descriptor_indexing": 1,
+                "VK_EXT_fragment_density_map": 1,
+                "VK_EXT_fragment_density_map2": 1,
+                "VK_EXT_fragment_shader_interlock": 1,
+                "VK_EXT_mesh_shader": 1,
+                "VK_EXT_opacity_micromap": 1,
+                "VK_EXT_post_depth_coverage": 1,
+                "VK_EXT_sample_locations": 1,
+                "VK_EXT_sampler_filter_minmax": 1,
+                "VK_EXT_scalar_block_layout": 1,
+                "VK_EXT_shader_atomic_float": 1,
+                "VK_EXT_shader_atomic_float2": 1,
+                "VK_EXT_shader_demote_to_helper_invocation": 1,
+                "VK_EXT_shader_image_atomic_int64": 1,
+                "VK_EXT_shader_module_identifier": 1,
+                "VK_EXT_shader_stencil_export": 1,
+                "VK_EXT_shader_subgroup_ballot": 1,
+                "VK_EXT_shader_subgroup_vote": 1,
+                "VK_EXT_shader_viewport_index_layer": 1,
+                "VK_EXT_subgroup_size_control": 1,
+                "VK_EXT_tooling_info": 1,
+                "VK_EXT_transform_feedback": 1,
+                "VK_EXT_validation_cache": 1,
+                "VK_EXT_validation_features": 1,
+                "VK_EXT_validation_flags": 1,
+                "VK_GOOGLE_decorate_string": 1,
+                "VK_GOOGLE_hlsl_functionality1": 1,
+                "VK_GOOGLE_user_type": 1,
+                "VK_HUAWEI_invocation_mask": 1,
+                "VK_HUAWEI_subpass_shading": 1,
+                "VK_INTEL_performance_query": 1,
+                "VK_INTEL_shader_integer_functions2": 1,
+                "VK_KHR_16bit_storage": 1,
+                "VK_KHR_8bit_storage": 1,
+                "VK_KHR_acceleration_structure": 1,
+                "VK_KHR_deferred_host_operations": 1,
+                "VK_KHR_bind_memory2": 1,
+                "VK_KHR_buffer_device_address": 1,
+                "VK_KHR_driver_properties": 1,
+                "VK_KHR_dynamic_rendering": 1,
+                "VK_KHR_format_feature_flags2": 1,
+                "VK_KHR_fragment_shader_barycentric": 1,
+                "VK_KHR_fragment_shading_rate": 1,
+                "VK_KHR_get_display_properties2": 1,
+                "VK_KHR_get_memory_requirements2": 1,
+                "VK_KHR_get_physical_device_properties2": 1,
+                "VK_KHR_get_surface_capabilities2": 1,
+                "VK_KHR_maintenance1": 1,
+                "VK_KHR_maintenance2": 1,
+                "VK_KHR_maintenance3": 1,
+                "VK_KHR_maintenance4": 1,
+                "VK_KHR_multiview": 1,
+                "VK_KHR_ray_query": 1,
+                "VK_KHR_ray_tracing_maintenance1": 1,
+                "VK_KHR_ray_tracing_pipeline": 1,
+                "VK_KHR_shader_atomic_int64": 1,
+                "VK_KHR_shader_clock": 1,
+                "VK_KHR_shader_draw_parameters": 1,
+                "VK_KHR_shader_float16_int8": 1,
+                "VK_KHR_shader_float_controls": 1,
+                "VK_KHR_shader_integer_dot_product": 1,
+                "VK_KHR_shader_non_semantic_info": 1,
+                "VK_KHR_shader_subgroup_extended_types": 1,
+                "VK_KHR_shader_subgroup_uniform_control_flow": 1,
+                "VK_KHR_shader_terminate_invocation": 1,
+                "VK_KHR_spirv_1_4": 1,
+                "VK_KHR_storage_buffer_storage_class": 1,
+                "VK_KHR_synchronization2": 1,
+                "VK_KHR_uniform_buffer_standard_layout": 1,
+                "VK_KHR_variable_pointers": 1,
+                "VK_KHR_vulkan_memory_model": 1,
+                "VK_KHR_workgroup_memory_explicit_layout": 1,
+                "VK_KHR_zero_initialize_workgroup_memory": 1,
+                "VK_NVX_multiview_per_view_attributes": 1,
+                "VK_NV_compute_shader_derivatives": 1,
+                "VK_NV_cooperative_matrix": 1,
+                "VK_NV_fragment_coverage_to_color": 1,
+                "VK_NV_fragment_shader_barycentric": 1,
+                "VK_NV_fragment_shading_rate_enums": 1,
+                "VK_NV_geometry_shader_passthrough": 1,
+                "VK_NV_glsl_shader": 1,
+                "VK_NV_linear_color_attachment": 1,
+                "VK_NV_mesh_shader": 1,
+                "VK_NV_ray_tracing": 1,
+                "VK_NV_ray_tracing_invocation_reorder": 1,
+                "VK_NV_ray_tracing_motion_blur": 1,
+                "VK_NV_sample_mask_override_coverage": 1,
+                "VK_NV_shader_image_footprint": 1,
+                "VK_NV_shader_sm_builtins": 1,
+                "VK_NV_shader_subgroup_partitioned": 1,
+                "VK_NV_shading_rate_image": 1,
+                "VK_NV_viewport_array2": 1,
+                "VK_QCOM_image_processing": 1,
+                "VK_EXT_shader_tile_image": 1
+            },
+            "formats": {},
+            "queueFamiliesProperties": [
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_GRAPHICS_BIT",
+                            "VK_QUEUE_COMPUTE_BIT"
+                        ],
+                        "queueCount": 16,
+                        "timestampValidBits": 16,
+                        "minImageTransferGranularity": {
+                            "width": 1,
+                            "height": 1,
+                            "depth": 1
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/tests/spirv_hopper/CMakeLists.txt
+++ b/tests/spirv_hopper/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ~~~
+# Copyright (c) 2023 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+add_subdirectory(external)
+add_executable(spirv-hopper)
+
+target_sources(spirv-hopper PRIVATE
+    main.cpp
+    spirv_hopper.h
+    spirv_hopper.cpp
+    pass_through_shaders.cpp
+    vulkan_object.h
+    vulkan_object.cpp
+)
+
+target_link_libraries(spirv-hopper PRIVATE
+    Vulkan::Headers
+    glslang::SPIRV
+    VkLayer_utils
+    spirv-reflect
+)

--- a/tests/spirv_hopper/README.md
+++ b/tests/spirv_hopper/README.md
@@ -1,0 +1,58 @@
+# SPIRV-Hopper
+
+The goal of `SPIRV-Hopper` is to feed SPIR-V binaries into the Validation Layers
+
+## How To Run
+
+```bash
+./spirv-hopper file.spv
+
+# or
+
+./spirv-hopper folder/with/files/
+```
+
+## How it works
+
+- Takes a SPIR-V file(s)
+- Uses [SPIRV-Reflect](https://github.com/KhronosGroup/SPIRV-Reflect) to get the basic interface information
+- Creates everything needed to make a valid `VkPipeline`
+    - `VkPipelineLayout`
+    - Descriptor Sets
+    - Passthrough shaders
+- `vkCreate*Pipelines()`
+
+## Goals
+
+This tool is designed to be simple, its main job is to help catch issues in Shader Validation by allowing us to run against MANY shaders quickly. Paired with a database of SPIR-V binaries from various SPIR-V generated tools (not just `glslang`), we can catch bugs/crashes at a per-commit testing level
+
+Being able to execute the shaders is outside the scope of `SPIRV-Hopper`
+
+## What about {Insert Testing Framework}
+
+The idea behind `SPIRV-Hopper` is not to have to worry about creating a "testing file". This tool only wants to worry about the SPIR-V binary.
+
+This is also faster because we can create a single `VkInstance`/`VkDevice` to run all the SPIR-V through
+
+## Current limitations
+
+### Only handles single Entry Point
+
+For getting things up and running, only single Entry Points are tested.
+
+A future goal is to take each entry point and run each as there own "sub-run"
+
+### Single threaded
+
+Currently `SPIRV-Hopper` is single-threaded. It would be nice to look into making it run multi-threaded.
+
+### Need MockICD and Profiles
+
+This is only designed to run with the [MockICD and Profiles layers](https://github.com/KhronosGroup/Vulkan-ValidationLayers/tree/main/tests#running-tests-on-mockicd-and-profiles-layer) (using [special profile designed for SPIRV-Hopper](../device_profiles/spirv_hopper_profile.json)).
+
+The reasons to not use the [max_profile.json](../device_profiles/max_profile.json) instead are
+
+- Some limits we want to be max `UINT32_T` for SPIRV-Hopper that we don't for normal testing
+    - Because the tests need to be `limit + 1`
+- Some features in `max_profile.json` are set to `false` so they can be tested
+- This is smaller, more portable profile if there is a desire to decouple`SPIRV-Hopper` for VVL

--- a/tests/spirv_hopper/external/CMakeLists.txt
+++ b/tests/spirv_hopper/external/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ~~~
+# Copyright (c) 2023 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+add_library(spirv-reflect STATIC)
+
+target_sources(spirv-reflect PRIVATE
+    spirv_reflect.h
+    spirv_reflect.cpp
+)
+
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    target_compile_options(spirv-reflect PUBLIC
+        -Wno-sign-conversion
+    )
+endif()
+
+target_compile_definitions(spirv-reflect PUBLIC SPIRV_REFLECT_USE_SYSTEM_SPIRV_H)
+
+target_link_libraries(spirv-reflect PUBLIC
+    VVL-SPIRV-LIBS
+)

--- a/tests/spirv_hopper/external/README.md
+++ b/tests/spirv_hopper/external/README.md
@@ -1,0 +1,17 @@
+# SPIRV-Reflect
+
+These files are taken from https://github.com/KhronosGroup/SPIRV-Reflect
+
+The reasons to check these in instead of adding to `known_good.json` are
+
+- This repo is not updated often
+- These files are designed for people to include in their build
+- Ideally there will not need to be fixes once `SPIRV-Hopper` is working
+    - We only use it so we don't have to re-write the same SPIR-V parsing logic
+
+## Current state
+
+The files were taken from `1fd43331f0bd77cc0f421745781f79a14d8f2bb1` commit with the following 3 PR cherry picked on top
+- https://github.com/KhronosGroup/SPIRV-Reflect/pull/181
+- https://github.com/KhronosGroup/SPIRV-Reflect/pull/182
+- https://github.com/KhronosGroup/SPIRV-Reflect/pull/183

--- a/tests/spirv_hopper/external/spirv_reflect.cpp
+++ b/tests/spirv_hopper/external/spirv_reflect.cpp
@@ -1,0 +1,4662 @@
+/*
+ Copyright 2017-2022 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+#include "spirv_reflect.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+#if defined(WIN32)
+#define _CRTDBG_MAP_ALLOC
+#include <stdlib.h>
+#include <crtdbg.h>
+#else
+#include <stdlib.h>
+#endif
+
+#if defined(__clang__)
+#define FALLTHROUGH __attribute__((fallthrough))
+#else
+#define FALLTHROUGH
+#endif
+
+#if defined(SPIRV_REFLECT_ENABLE_ASSERTS)
+#define SPV_REFLECT_ASSERT(COND) assert(COND);
+#else
+#define SPV_REFLECT_ASSERT(COND)
+#endif
+
+// Temporary enums until these make it into SPIR-V/Vulkan
+// clang-format off
+enum {
+  SpvReflectOpDecorateId                      = 332,
+  SpvReflectOpDecorateStringGOOGLE            = 5632,
+  SpvReflectOpMemberDecorateStringGOOGLE      = 5633,
+  SpvReflectDecorationHlslCounterBufferGOOGLE = 5634,
+  SpvReflectDecorationHlslSemanticGOOGLE      = 5635
+};
+// clang-format on
+
+// clang-format off
+enum {
+  SPIRV_STARTING_WORD_INDEX       = 5,
+  SPIRV_WORD_SIZE                 = sizeof(uint32_t),
+  SPIRV_BYTE_WIDTH                = 8,
+  SPIRV_MINIMUM_FILE_SIZE         = SPIRV_STARTING_WORD_INDEX * SPIRV_WORD_SIZE,
+  SPIRV_DATA_ALIGNMENT            = 4 * SPIRV_WORD_SIZE, // 16
+  SPIRV_ACCESS_CHAIN_INDEX_OFFSET = 4,
+};
+// clang-format on
+
+// clang-format off
+enum {
+  INVALID_VALUE  = 0xFFFFFFFF,
+};
+// clang-format on
+
+// clang-format off
+enum {
+  MAX_NODE_NAME_LENGTH      = 1024,
+};
+// clang-format on
+
+// clang-format off
+enum {
+  IMAGE_SAMPLED = 1,
+  IMAGE_STORAGE = 2
+};
+// clang-format on
+
+// clang-format off
+typedef struct SpvReflectPrvArrayTraits {
+  uint32_t                        element_type_id;
+  uint32_t                        length_id;
+} SpvReflectPrvArrayTraits;
+// clang-format on
+
+// clang-format off
+typedef struct SpvReflectPrvImageTraits {
+  uint32_t                        sampled_type_id;
+  SpvDim                          dim;
+  uint32_t                        depth;
+  uint32_t                        arrayed;
+  uint32_t                        ms;
+  uint32_t                        sampled;
+  SpvImageFormat                  image_format;
+} SpvReflectPrvImageTraits;
+// clang-format on
+
+// clang-format off
+typedef struct SpvReflectPrvNumberDecoration {
+  uint32_t                        word_offset;
+  uint32_t                        value;
+} SpvReflectPrvNumberDecoration;
+// clang-format on
+
+// clang-format off
+typedef struct SpvReflectPrvStringDecoration {
+  uint32_t                        word_offset;
+  const char*                     value;
+} SpvReflectPrvStringDecoration;
+// clang-format on
+
+// clang-format off
+typedef struct SpvReflectPrvDecorations {
+  bool                            is_relaxed_precision;
+  bool                            is_block;
+  bool                            is_buffer_block;
+  bool                            is_row_major;
+  bool                            is_column_major;
+  bool                            is_built_in;
+  bool                            is_noperspective;
+  bool                            is_flat;
+  bool                            is_non_writable;
+  bool                            is_non_readable;
+  SpvReflectPrvNumberDecoration   set;
+  SpvReflectPrvNumberDecoration   binding;
+  SpvReflectPrvNumberDecoration   input_attachment_index;
+  SpvReflectPrvNumberDecoration   location;
+  SpvReflectPrvNumberDecoration   component;
+  SpvReflectPrvNumberDecoration   offset;
+  SpvReflectPrvNumberDecoration   uav_counter_buffer;
+  SpvReflectPrvStringDecoration   semantic;
+  uint32_t                        array_stride;
+  uint32_t                        matrix_stride;
+  SpvBuiltIn                      built_in;
+} SpvReflectPrvDecorations;
+// clang-format on
+
+// clang-format off
+typedef struct SpvReflectPrvNode {
+  uint32_t                        result_id;
+  SpvOp                           op;
+  uint32_t                        result_type_id;
+  uint32_t                        type_id;
+  SpvCapability                   capability;
+  SpvStorageClass                 storage_class;
+  uint32_t                        word_offset;
+  uint32_t                        word_count;
+  bool                            is_type;
+
+  SpvReflectPrvArrayTraits        array_traits;
+  SpvReflectPrvImageTraits        image_traits;
+  uint32_t                        image_type_id;
+
+  const char*                     name;
+  SpvReflectPrvDecorations        decorations;
+  uint32_t                        member_count;
+  const char**                    member_names;
+  SpvReflectPrvDecorations*       member_decorations;
+} SpvReflectPrvNode;
+// clang-format on
+
+// clang-format off
+typedef struct SpvReflectPrvString {
+  uint32_t                        result_id;
+  const char*                     string;
+} SpvReflectPrvString;
+// clang-format on
+
+// clang-format off
+typedef struct SpvReflectPrvFunction {
+  uint32_t                        id;
+  uint32_t                        callee_count;
+  uint32_t*                       callees;
+  struct SpvReflectPrvFunction**  callee_ptrs;
+  uint32_t                        accessed_ptr_count;
+  uint32_t*                       accessed_ptrs;
+} SpvReflectPrvFunction;
+// clang-format on
+
+// clang-format off
+typedef struct SpvReflectPrvAccessChain {
+  uint32_t                        result_id;
+  uint32_t                        result_type_id;
+  //
+  // Pointing to the base of a composite object.
+  // Generally the id of descriptor block variable
+  uint32_t                        base_id;
+  //
+  // From spec:
+  //   The first index in Indexes will select the
+  //   top-level member/element/component/element
+  //   of the base composite
+  uint32_t                        index_count;
+  uint32_t*                       indexes;
+} SpvReflectPrvAccessChain;
+// clang-format on
+
+// clang-format off
+typedef struct SpvReflectPrvParser {
+  size_t                          spirv_word_count;
+  uint32_t*                       spirv_code;
+  uint32_t                        string_count;
+  SpvReflectPrvString*            strings;
+  SpvSourceLanguage               source_language;
+  uint32_t                        source_language_version;
+  uint32_t                        source_file_id;
+  const char*                     source_embedded;
+  size_t                          node_count;
+  SpvReflectPrvNode*              nodes;
+  uint32_t                        entry_point_count;
+  uint32_t                        capability_count;
+  uint32_t                        function_count;
+  SpvReflectPrvFunction*          functions;
+  uint32_t                        access_chain_count;
+  SpvReflectPrvAccessChain*       access_chains;
+
+  uint32_t                        type_count;
+  uint32_t                        descriptor_count;
+  uint32_t                        push_constant_count;
+} SpvReflectPrvParser;
+// clang-format on
+
+static uint32_t Max(uint32_t a, uint32_t b) { return a > b ? a : b; }
+
+static uint32_t RoundUp(uint32_t value, uint32_t multiple) {
+    assert(multiple && ((multiple & (multiple - 1)) == 0));
+    return (value + multiple - 1) & ~(multiple - 1);
+}
+
+#define IsNull(ptr) (ptr == NULL)
+
+#define IsNotNull(ptr) (ptr != NULL)
+
+#define SafeFree(ptr)     \
+    {                     \
+        free((void*)ptr); \
+        ptr = NULL;       \
+    }
+
+static int SortCompareUint32(const void* a, const void* b) {
+    const uint32_t* p_a = (const uint32_t*)a;
+    const uint32_t* p_b = (const uint32_t*)b;
+
+    return (int)*p_a - (int)*p_b;
+}
+
+//
+// De-duplicates a sorted array and returns the new size.
+//
+// Note: The array doesn't actually need to be sorted, just
+// arranged into "runs" so that all the entries with one
+// value are adjacent.
+//
+static size_t DedupSortedUint32(uint32_t* arr, size_t size) {
+    if (size == 0) {
+        return 0;
+    }
+    size_t dedup_idx = 0;
+    for (size_t i = 0; i < size; ++i) {
+        if (arr[dedup_idx] != arr[i]) {
+            ++dedup_idx;
+            arr[dedup_idx] = arr[i];
+        }
+    }
+    return dedup_idx + 1;
+}
+
+static bool SearchSortedUint32(const uint32_t* arr, size_t size, uint32_t target) {
+    size_t lo = 0;
+    size_t hi = size;
+    while (lo < hi) {
+        size_t mid = (hi - lo) / 2 + lo;
+        if (arr[mid] == target) {
+            return true;
+        } else if (arr[mid] < target) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return false;
+}
+
+static SpvReflectResult IntersectSortedUint32(const uint32_t* p_arr0, size_t arr0_size, const uint32_t* p_arr1, size_t arr1_size,
+                                              uint32_t** pp_res, size_t* res_size) {
+    *pp_res = NULL;
+    *res_size = 0;
+    if (IsNull(p_arr0) || IsNull(p_arr1)) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    const uint32_t* arr0_end = p_arr0 + arr0_size;
+    const uint32_t* arr1_end = p_arr1 + arr1_size;
+
+    const uint32_t* idx0 = p_arr0;
+    const uint32_t* idx1 = p_arr1;
+    while (idx0 != arr0_end && idx1 != arr1_end) {
+        if (*idx0 < *idx1) {
+            ++idx0;
+        } else if (*idx0 > *idx1) {
+            ++idx1;
+        } else {
+            ++*res_size;
+            ++idx0;
+            ++idx1;
+        }
+    }
+
+    if (*res_size > 0) {
+        *pp_res = (uint32_t*)calloc(*res_size, sizeof(**pp_res));
+        if (IsNull(*pp_res)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+        uint32_t* idxr = *pp_res;
+        idx0 = p_arr0;
+        idx1 = p_arr1;
+        while (idx0 != arr0_end && idx1 != arr1_end) {
+            if (*idx0 < *idx1) {
+                ++idx0;
+            } else if (*idx0 > *idx1) {
+                ++idx1;
+            } else {
+                *(idxr++) = *idx0;
+                ++idx0;
+                ++idx1;
+            }
+        }
+    }
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static bool InRange(const SpvReflectPrvParser* p_parser, uint32_t index) {
+    bool in_range = false;
+    if (IsNotNull(p_parser)) {
+        in_range = (index < p_parser->spirv_word_count);
+    }
+    return in_range;
+}
+
+static SpvReflectResult ReadU32(SpvReflectPrvParser* p_parser, uint32_t word_offset, uint32_t* p_value) {
+    assert(IsNotNull(p_parser));
+    assert(IsNotNull(p_parser->spirv_code));
+    assert(InRange(p_parser, word_offset));
+    SpvReflectResult result = SPV_REFLECT_RESULT_ERROR_SPIRV_UNEXPECTED_EOF;
+    if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && InRange(p_parser, word_offset)) {
+        *p_value = *(p_parser->spirv_code + word_offset);
+        result = SPV_REFLECT_RESULT_SUCCESS;
+    }
+    return result;
+}
+
+#define CHECKED_READU32(parser, word_offset, value)                                                  \
+    {                                                                                                \
+        SpvReflectResult checked_readu32_result = ReadU32(parser, word_offset, (uint32_t*)&(value)); \
+        if (checked_readu32_result != SPV_REFLECT_RESULT_SUCCESS) {                                  \
+            return checked_readu32_result;                                                           \
+        }                                                                                            \
+    }
+
+#define CHECKED_READU32_CAST(parser, word_offset, cast_to_type, value)                                                       \
+    {                                                                                                                        \
+        uint32_t checked_readu32_cast_u32 = UINT32_MAX;                                                                      \
+        SpvReflectResult checked_readu32_cast_result = ReadU32(parser, word_offset, (uint32_t*)&(checked_readu32_cast_u32)); \
+        if (checked_readu32_cast_result != SPV_REFLECT_RESULT_SUCCESS) {                                                     \
+            return checked_readu32_cast_result;                                                                              \
+        }                                                                                                                    \
+        value = (cast_to_type)checked_readu32_cast_u32;                                                                      \
+    }
+
+#define IF_READU32(result, parser, word_offset, value)              \
+    if ((result) == SPV_REFLECT_RESULT_SUCCESS) {                   \
+        result = ReadU32(parser, word_offset, (uint32_t*)&(value)); \
+    }
+
+#define IF_READU32_CAST(result, parser, word_offset, cast_to_type, value) \
+    if ((result) == SPV_REFLECT_RESULT_SUCCESS) {                         \
+        uint32_t if_readu32_cast_u32 = UINT32_MAX;                        \
+        result = ReadU32(parser, word_offset, &if_readu32_cast_u32);      \
+        if ((result) == SPV_REFLECT_RESULT_SUCCESS) {                     \
+            value = (cast_to_type)if_readu32_cast_u32;                    \
+        }                                                                 \
+    }
+
+static SpvReflectResult ReadStr(SpvReflectPrvParser* p_parser, uint32_t word_offset, uint32_t word_index, uint32_t word_count,
+                                uint32_t* p_buf_size, char* p_buf) {
+    uint32_t limit = (word_offset + word_count);
+    assert(IsNotNull(p_parser));
+    assert(IsNotNull(p_parser->spirv_code));
+    assert(InRange(p_parser, limit));
+    SpvReflectResult result = SPV_REFLECT_RESULT_ERROR_SPIRV_UNEXPECTED_EOF;
+    if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && InRange(p_parser, limit)) {
+        const char* c_str = (const char*)(p_parser->spirv_code + word_offset + word_index);
+        uint32_t n = word_count * SPIRV_WORD_SIZE;
+        uint32_t length_with_terminator = 0;
+        for (uint32_t i = 0; i < n; ++i) {
+            char c = *(c_str + i);
+            if (c == 0) {
+                length_with_terminator = i + 1;
+                break;
+            }
+        }
+
+        if (length_with_terminator > 0) {
+            result = SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+            if (IsNotNull(p_buf_size) && IsNotNull(p_buf)) {
+                result = SPV_REFLECT_RESULT_ERROR_RANGE_EXCEEDED;
+                if (length_with_terminator <= *p_buf_size) {
+                    memset(p_buf, 0, *p_buf_size);
+                    memcpy(p_buf, c_str, length_with_terminator);
+                    result = SPV_REFLECT_RESULT_SUCCESS;
+                }
+            } else {
+                if (IsNotNull(p_buf_size)) {
+                    *p_buf_size = length_with_terminator;
+                    result = SPV_REFLECT_RESULT_SUCCESS;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+static SpvReflectDecorationFlags ApplyDecorations(const SpvReflectPrvDecorations* p_decoration_fields) {
+    SpvReflectDecorationFlags decorations = SPV_REFLECT_DECORATION_NONE;
+    if (p_decoration_fields->is_relaxed_precision) {
+        decorations |= SPV_REFLECT_DECORATION_RELAXED_PRECISION;
+    }
+    if (p_decoration_fields->is_block) {
+        decorations |= SPV_REFLECT_DECORATION_BLOCK;
+    }
+    if (p_decoration_fields->is_buffer_block) {
+        decorations |= SPV_REFLECT_DECORATION_BUFFER_BLOCK;
+    }
+    if (p_decoration_fields->is_row_major) {
+        decorations |= SPV_REFLECT_DECORATION_ROW_MAJOR;
+    }
+    if (p_decoration_fields->is_column_major) {
+        decorations |= SPV_REFLECT_DECORATION_COLUMN_MAJOR;
+    }
+    if (p_decoration_fields->is_built_in) {
+        decorations |= SPV_REFLECT_DECORATION_BUILT_IN;
+    }
+    if (p_decoration_fields->is_noperspective) {
+        decorations |= SPV_REFLECT_DECORATION_NOPERSPECTIVE;
+    }
+    if (p_decoration_fields->is_flat) {
+        decorations |= SPV_REFLECT_DECORATION_FLAT;
+    }
+    if (p_decoration_fields->is_non_writable) {
+        decorations |= SPV_REFLECT_DECORATION_NON_WRITABLE;
+    }
+    if (p_decoration_fields->is_non_readable) {
+        decorations |= SPV_REFLECT_DECORATION_NON_READABLE;
+    }
+    return decorations;
+}
+
+static void ApplyNumericTraits(const SpvReflectTypeDescription* p_type, SpvReflectNumericTraits* p_numeric_traits) {
+    memcpy(p_numeric_traits, &p_type->traits.numeric, sizeof(p_type->traits.numeric));
+}
+
+static void ApplyArrayTraits(const SpvReflectTypeDescription* p_type, SpvReflectArrayTraits* p_array_traits) {
+    memcpy(p_array_traits, &p_type->traits.array, sizeof(p_type->traits.array));
+}
+
+static SpvReflectPrvNode* FindNode(SpvReflectPrvParser* p_parser, uint32_t result_id) {
+    SpvReflectPrvNode* p_node = NULL;
+    for (size_t i = 0; i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_elem = &(p_parser->nodes[i]);
+        if (p_elem->result_id == result_id) {
+            p_node = p_elem;
+            break;
+        }
+    }
+    return p_node;
+}
+
+static SpvReflectTypeDescription* FindType(SpvReflectShaderModule* p_module, uint32_t type_id) {
+    SpvReflectTypeDescription* p_type = NULL;
+    for (size_t i = 0; i < p_module->_internal->type_description_count; ++i) {
+        SpvReflectTypeDescription* p_elem = &(p_module->_internal->type_descriptions[i]);
+        if (p_elem->id == type_id) {
+            p_type = p_elem;
+            break;
+        }
+    }
+    return p_type;
+}
+
+static SpvReflectResult CreateParser(size_t size, void* p_code, SpvReflectPrvParser* p_parser) {
+    if (p_code == NULL) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    if (size < SPIRV_MINIMUM_FILE_SIZE) {
+        return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_CODE_SIZE;
+    }
+    if ((size % 4) != 0) {
+        return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_CODE_SIZE;
+    }
+
+    p_parser->spirv_word_count = size / SPIRV_WORD_SIZE;
+    p_parser->spirv_code = (uint32_t*)p_code;
+
+    if (p_parser->spirv_code[0] != SpvMagicNumber) {
+        return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_MAGIC_NUMBER;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static void DestroyParser(SpvReflectPrvParser* p_parser) {
+    if (!IsNull(p_parser->nodes)) {
+        // Free nodes
+        for (size_t i = 0; i < p_parser->node_count; ++i) {
+            SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+            if (IsNotNull(p_node->member_names)) {
+                SafeFree(p_node->member_names);
+            }
+            if (IsNotNull(p_node->member_decorations)) {
+                SafeFree(p_node->member_decorations);
+            }
+        }
+
+        // Free functions
+        for (size_t i = 0; i < p_parser->function_count; ++i) {
+            SafeFree(p_parser->functions[i].callees);
+            SafeFree(p_parser->functions[i].callee_ptrs);
+            SafeFree(p_parser->functions[i].accessed_ptrs);
+        }
+
+        // Free access chains
+        for (uint32_t i = 0; i < p_parser->access_chain_count; ++i) {
+            SafeFree(p_parser->access_chains[i].indexes);
+        }
+
+        SafeFree(p_parser->nodes);
+        SafeFree(p_parser->strings);
+        SafeFree(p_parser->source_embedded);
+        SafeFree(p_parser->functions);
+        SafeFree(p_parser->access_chains);
+        p_parser->node_count = 0;
+    }
+}
+
+static SpvReflectResult ParseNodes(SpvReflectPrvParser* p_parser) {
+    assert(IsNotNull(p_parser));
+    assert(IsNotNull(p_parser->spirv_code));
+
+    uint32_t* p_spirv = p_parser->spirv_code;
+    uint32_t spirv_word_index = SPIRV_STARTING_WORD_INDEX;
+
+    // Count nodes
+    uint32_t node_count = 0;
+    while (spirv_word_index < p_parser->spirv_word_count) {
+        uint32_t word = p_spirv[spirv_word_index];
+        SpvOp op = (SpvOp)(word & 0xFFFF);
+        uint32_t node_word_count = (word >> 16) & 0xFFFF;
+        if (node_word_count == 0) {
+            return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_INSTRUCTION;
+        }
+        if (op == SpvOpAccessChain) {
+            ++(p_parser->access_chain_count);
+        }
+        spirv_word_index += node_word_count;
+        ++node_count;
+    }
+
+    if (node_count == 0) {
+        return SPV_REFLECT_RESULT_ERROR_SPIRV_UNEXPECTED_EOF;
+    }
+
+    // Allocate nodes
+    p_parser->node_count = node_count;
+    p_parser->nodes = (SpvReflectPrvNode*)calloc(p_parser->node_count, sizeof(*(p_parser->nodes)));
+    if (IsNull(p_parser->nodes)) {
+        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
+    // Mark all nodes with an invalid state
+    for (uint32_t i = 0; i < node_count; ++i) {
+        p_parser->nodes[i].op = (SpvOp)INVALID_VALUE;
+        p_parser->nodes[i].storage_class = (SpvStorageClass)INVALID_VALUE;
+        p_parser->nodes[i].decorations.set.value = (uint32_t)INVALID_VALUE;
+        p_parser->nodes[i].decorations.binding.value = (uint32_t)INVALID_VALUE;
+        p_parser->nodes[i].decorations.location.value = (uint32_t)INVALID_VALUE;
+        p_parser->nodes[i].decorations.component.value = (uint32_t)INVALID_VALUE;
+        p_parser->nodes[i].decorations.offset.value = (uint32_t)INVALID_VALUE;
+        p_parser->nodes[i].decorations.uav_counter_buffer.value = (uint32_t)INVALID_VALUE;
+        p_parser->nodes[i].decorations.built_in = (SpvBuiltIn)INVALID_VALUE;
+    }
+    // Mark source file id node
+    p_parser->source_file_id = (uint32_t)INVALID_VALUE;
+    p_parser->source_embedded = NULL;
+
+    // Function node
+    uint32_t function_node = (uint32_t)INVALID_VALUE;
+
+    // Allocate access chain
+    if (p_parser->access_chain_count > 0) {
+        p_parser->access_chains =
+            (SpvReflectPrvAccessChain*)calloc(p_parser->access_chain_count, sizeof(*(p_parser->access_chains)));
+        if (IsNull(p_parser->access_chains)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+    }
+
+    // Parse nodes
+    uint32_t node_index = 0;
+    uint32_t access_chain_index = 0;
+    spirv_word_index = SPIRV_STARTING_WORD_INDEX;
+    while (spirv_word_index < p_parser->spirv_word_count) {
+        uint32_t word = p_spirv[spirv_word_index];
+        SpvOp op = (SpvOp)(word & 0xFFFF);
+        uint32_t node_word_count = (word >> 16) & 0xFFFF;
+
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[node_index]);
+        p_node->op = op;
+        p_node->word_offset = spirv_word_index;
+        p_node->word_count = node_word_count;
+
+        switch (p_node->op) {
+            default:
+                break;
+
+            case SpvOpString: {
+                ++(p_parser->string_count);
+            } break;
+
+            case SpvOpSource: {
+                CHECKED_READU32_CAST(p_parser, p_node->word_offset + 1, SpvSourceLanguage, p_parser->source_language);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_parser->source_language_version);
+                if (p_node->word_count >= 4) {
+                    CHECKED_READU32(p_parser, p_node->word_offset + 3, p_parser->source_file_id);
+                }
+                if (p_node->word_count >= 5) {
+                    const char* p_source = (const char*)(p_parser->spirv_code + p_node->word_offset + 4);
+
+                    const size_t source_len = strlen(p_source);
+                    char* p_source_temp = (char*)calloc(source_len + 1, sizeof(char));
+
+                    if (IsNull(p_source_temp)) {
+                        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+                    }
+
+#ifdef _WIN32
+                    strcpy_s(p_source_temp, source_len + 1, p_source);
+#else
+                    strcpy(p_source_temp, p_source);
+#endif
+
+                    SafeFree(p_parser->source_embedded);
+                    p_parser->source_embedded = p_source_temp;
+                }
+            } break;
+
+            case SpvOpSourceContinued: {
+                const char* p_source = (const char*)(p_parser->spirv_code + p_node->word_offset + 1);
+
+                const size_t source_len = strlen(p_source);
+                const size_t embedded_source_len = strlen(p_parser->source_embedded);
+                char* p_continued_source = (char*)calloc(source_len + embedded_source_len + 1, sizeof(char));
+
+                if (IsNull(p_continued_source)) {
+                    return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+                }
+
+#ifdef _WIN32
+                strcpy_s(p_continued_source, embedded_source_len + 1, p_parser->source_embedded);
+                strcat_s(p_continued_source, embedded_source_len + source_len + 1, p_source);
+#else
+                strcpy(p_continued_source, p_parser->source_embedded);
+                strcat(p_continued_source, p_source);
+#endif
+
+                SafeFree(p_parser->source_embedded);
+                p_parser->source_embedded = p_continued_source;
+            } break;
+
+            case SpvOpEntryPoint: {
+                ++(p_parser->entry_point_count);
+            } break;
+
+            case SpvOpCapability: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->capability);
+                ++(p_parser->capability_count);
+            } break;
+
+            case SpvOpName:
+            case SpvOpMemberName: {
+                uint32_t member_offset = (p_node->op == SpvOpMemberName) ? 1 : 0;
+                uint32_t name_start = p_node->word_offset + member_offset + 2;
+                p_node->name = (const char*)(p_parser->spirv_code + name_start);
+            } break;
+
+            case SpvOpTypeStruct: {
+                p_node->member_count = p_node->word_count - 2;
+                FALLTHROUGH;
+            }  // Fall through
+            case SpvOpTypeVoid:
+            case SpvOpTypeBool:
+            case SpvOpTypeInt:
+            case SpvOpTypeFloat:
+            case SpvOpTypeVector:
+            case SpvOpTypeMatrix:
+            case SpvOpTypeSampler:
+            case SpvOpTypeOpaque:
+            case SpvOpTypeFunction:
+            case SpvOpTypeEvent:
+            case SpvOpTypeDeviceEvent:
+            case SpvOpTypeReserveId:
+            case SpvOpTypeQueue:
+            case SpvOpTypePipe:
+            case SpvOpTypeAccelerationStructureKHR:
+            case SpvOpTypeRayQueryKHR: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_id);
+                p_node->is_type = true;
+            } break;
+
+            case SpvOpTypeImage: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->image_traits.sampled_type_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 3, p_node->image_traits.dim);
+                CHECKED_READU32(p_parser, p_node->word_offset + 4, p_node->image_traits.depth);
+                CHECKED_READU32(p_parser, p_node->word_offset + 5, p_node->image_traits.arrayed);
+                CHECKED_READU32(p_parser, p_node->word_offset + 6, p_node->image_traits.ms);
+                CHECKED_READU32(p_parser, p_node->word_offset + 7, p_node->image_traits.sampled);
+                CHECKED_READU32(p_parser, p_node->word_offset + 8, p_node->image_traits.image_format);
+                p_node->is_type = true;
+            } break;
+
+            case SpvOpTypeSampledImage: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->image_type_id);
+                p_node->is_type = true;
+            } break;
+
+            case SpvOpTypeArray: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->array_traits.element_type_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 3, p_node->array_traits.length_id);
+                p_node->is_type = true;
+            } break;
+
+            case SpvOpTypeRuntimeArray: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->array_traits.element_type_id);
+                p_node->is_type = true;
+            } break;
+
+            case SpvOpTypePointer: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->storage_class);
+                CHECKED_READU32(p_parser, p_node->word_offset + 3, p_node->type_id);
+                p_node->is_type = true;
+            } break;
+
+            case SpvOpTypeForwardPointer: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->storage_class);
+                p_node->is_type = true;
+            } break;
+
+            case SpvOpConstantTrue:
+            case SpvOpConstantFalse:
+            case SpvOpConstant:
+            case SpvOpConstantComposite:
+            case SpvOpConstantSampler:
+            case SpvOpConstantNull: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_type_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->result_id);
+            } break;
+
+            case SpvOpSpecConstantTrue:
+            case SpvOpSpecConstantFalse:
+            case SpvOpSpecConstant:
+            case SpvOpSpecConstantComposite:
+            case SpvOpSpecConstantOp: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_type_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->result_id);
+            } break;
+
+            case SpvOpVariable: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->type_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->result_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 3, p_node->storage_class);
+            } break;
+
+            case SpvOpLoad: {
+                // Only load enough so OpDecorate can reference the node, skip the remaining operands.
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_node->result_type_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->result_id);
+            } break;
+
+            case SpvOpAccessChain: {
+                SpvReflectPrvAccessChain* p_access_chain = &(p_parser->access_chains[access_chain_index]);
+                CHECKED_READU32(p_parser, p_node->word_offset + 1, p_access_chain->result_type_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_access_chain->result_id);
+                CHECKED_READU32(p_parser, p_node->word_offset + 3, p_access_chain->base_id);
+                //
+                // SPIRV_ACCESS_CHAIN_INDEX_OFFSET (4) is the number of words up until the first index:
+                //   [Node, Result Type Id, Result Id, Base Id, <Indexes>]
+                //
+                p_access_chain->index_count = (node_word_count - SPIRV_ACCESS_CHAIN_INDEX_OFFSET);
+                if (p_access_chain->index_count > 0) {
+                    p_access_chain->indexes = (uint32_t*)calloc(p_access_chain->index_count, sizeof(*(p_access_chain->indexes)));
+                    if (IsNull(p_access_chain->indexes)) {
+                        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+                    }
+                    // Parse any index values for access chain
+                    for (uint32_t index_index = 0; index_index < p_access_chain->index_count; ++index_index) {
+                        // Read index id
+                        uint32_t index_id = 0;
+                        CHECKED_READU32(p_parser, p_node->word_offset + SPIRV_ACCESS_CHAIN_INDEX_OFFSET + index_index, index_id);
+                        // Find OpConstant node that contains index value
+                        SpvReflectPrvNode* p_index_value_node = FindNode(p_parser, index_id);
+                        if ((p_index_value_node != NULL) && (p_index_value_node->op == SpvOpConstant)) {
+                            // Read index value
+                            uint32_t index_value = UINT32_MAX;
+                            CHECKED_READU32(p_parser, p_index_value_node->word_offset + 3, index_value);
+                            assert(index_value != UINT32_MAX);
+                            // Write index value to array
+                            p_access_chain->indexes[index_index] = index_value;
+                        }
+                    }
+                }
+                ++access_chain_index;
+            } break;
+
+            case SpvOpFunction: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_node->result_id);
+                // Count function definitions, not function declarations.  To determine
+                // the difference, set an in-function variable, and then if an OpLabel
+                // is reached before the end of the function increment the function
+                // count.
+                function_node = node_index;
+            } break;
+
+            case SpvOpLabel: {
+                if (function_node != (uint32_t)INVALID_VALUE) {
+                    SpvReflectPrvNode* p_func_node = &(p_parser->nodes[function_node]);
+                    CHECKED_READU32(p_parser, p_func_node->word_offset + 2, p_func_node->result_id);
+                    ++(p_parser->function_count);
+                }
+                FALLTHROUGH;
+            }  // Fall through
+
+            case SpvOpFunctionEnd: {
+                function_node = (uint32_t)INVALID_VALUE;
+            } break;
+        }
+
+        if (p_node->is_type) {
+            ++(p_parser->type_count);
+        }
+
+        spirv_word_index += node_word_count;
+        ++node_index;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseStrings(SpvReflectPrvParser* p_parser) {
+    assert(IsNotNull(p_parser));
+    assert(IsNotNull(p_parser->spirv_code));
+    assert(IsNotNull(p_parser->nodes));
+
+    // Early out
+    if (p_parser->string_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && IsNotNull(p_parser->nodes)) {
+        // Allocate string storage
+        p_parser->strings = (SpvReflectPrvString*)calloc(p_parser->string_count, sizeof(*(p_parser->strings)));
+
+        uint32_t string_index = 0;
+        for (size_t i = 0; i < p_parser->node_count; ++i) {
+            SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+            if (p_node->op != SpvOpString) {
+                continue;
+            }
+
+            // Paranoid check against string count
+            assert(string_index < p_parser->string_count);
+            if (string_index >= p_parser->string_count) {
+                return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+            }
+
+            // Result id
+            SpvReflectPrvString* p_string = &(p_parser->strings[string_index]);
+            CHECKED_READU32(p_parser, p_node->word_offset + 1, p_string->result_id);
+
+            // String
+            uint32_t string_start = p_node->word_offset + 2;
+            p_string->string = (const char*)(p_parser->spirv_code + string_start);
+
+            // Increment string index
+            ++string_index;
+        }
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseSource(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module) {
+    assert(IsNotNull(p_parser));
+    assert(IsNotNull(p_parser->spirv_code));
+
+    if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code)) {
+        // Source file
+        if (IsNotNull(p_parser->strings)) {
+            for (uint32_t i = 0; i < p_parser->string_count; ++i) {
+                SpvReflectPrvString* p_string = &(p_parser->strings[i]);
+                if (p_string->result_id == p_parser->source_file_id) {
+                    p_module->source_file = p_string->string;
+                    break;
+                }
+            }
+        }
+
+        // Source code
+        if (IsNotNull(p_parser->source_embedded)) {
+            const size_t source_len = strlen(p_parser->source_embedded);
+            char* p_source = (char*)calloc(source_len + 1, sizeof(char));
+
+            if (IsNull(p_source)) {
+                return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+            }
+
+#ifdef _WIN32
+            strcpy_s(p_source, source_len + 1, p_parser->source_embedded);
+#else
+            strcpy(p_source, p_parser->source_embedded);
+#endif
+
+            p_module->source_source = p_source;
+        }
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseFunction(SpvReflectPrvParser* p_parser, SpvReflectPrvNode* p_func_node, SpvReflectPrvFunction* p_func,
+                                      size_t first_label_index) {
+    p_func->id = p_func_node->result_id;
+
+    p_func->callee_count = 0;
+    p_func->accessed_ptr_count = 0;
+
+    for (size_t i = first_label_index; i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+        if (p_node->op == SpvOpFunctionEnd) {
+            break;
+        }
+        switch (p_node->op) {
+            case SpvOpFunctionCall: {
+                ++(p_func->callee_count);
+            } break;
+            case SpvOpLoad:
+            case SpvOpAccessChain:
+            case SpvOpInBoundsAccessChain:
+            case SpvOpPtrAccessChain:
+            case SpvOpArrayLength:
+            case SpvOpGenericPtrMemSemantics:
+            case SpvOpInBoundsPtrAccessChain:
+            case SpvOpStore:
+            case SpvOpImageTexelPointer: {
+                ++(p_func->accessed_ptr_count);
+            } break;
+            case SpvOpCopyMemory:
+            case SpvOpCopyMemorySized: {
+                p_func->accessed_ptr_count += 2;
+            } break;
+            default:
+                break;
+        }
+    }
+
+    if (p_func->callee_count > 0) {
+        p_func->callees = (uint32_t*)calloc(p_func->callee_count, sizeof(*(p_func->callees)));
+        if (IsNull(p_func->callees)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+    }
+
+    if (p_func->accessed_ptr_count > 0) {
+        p_func->accessed_ptrs = (uint32_t*)calloc(p_func->accessed_ptr_count, sizeof(*(p_func->accessed_ptrs)));
+        if (IsNull(p_func->accessed_ptrs)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+    }
+
+    p_func->callee_count = 0;
+    p_func->accessed_ptr_count = 0;
+    for (size_t i = first_label_index; i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+        if (p_node->op == SpvOpFunctionEnd) {
+            break;
+        }
+        switch (p_node->op) {
+            case SpvOpFunctionCall: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 3, p_func->callees[p_func->callee_count]);
+                (++p_func->callee_count);
+            } break;
+            case SpvOpLoad:
+            case SpvOpAccessChain:
+            case SpvOpInBoundsAccessChain:
+            case SpvOpPtrAccessChain:
+            case SpvOpArrayLength:
+            case SpvOpGenericPtrMemSemantics:
+            case SpvOpInBoundsPtrAccessChain:
+            case SpvOpImageTexelPointer: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 3, p_func->accessed_ptrs[p_func->accessed_ptr_count]);
+                (++p_func->accessed_ptr_count);
+            } break;
+            case SpvOpStore: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_func->accessed_ptrs[p_func->accessed_ptr_count]);
+                (++p_func->accessed_ptr_count);
+            } break;
+            case SpvOpCopyMemory:
+            case SpvOpCopyMemorySized: {
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, p_func->accessed_ptrs[p_func->accessed_ptr_count]);
+                (++p_func->accessed_ptr_count);
+                CHECKED_READU32(p_parser, p_node->word_offset + 3, p_func->accessed_ptrs[p_func->accessed_ptr_count]);
+                (++p_func->accessed_ptr_count);
+            } break;
+            default:
+                break;
+        }
+    }
+
+    if (p_func->callee_count > 0) {
+        qsort(p_func->callees, p_func->callee_count, sizeof(*(p_func->callees)), SortCompareUint32);
+    }
+    p_func->callee_count = (uint32_t)DedupSortedUint32(p_func->callees, p_func->callee_count);
+
+    if (p_func->accessed_ptr_count > 0) {
+        qsort(p_func->accessed_ptrs, p_func->accessed_ptr_count, sizeof(*(p_func->accessed_ptrs)), SortCompareUint32);
+    }
+    p_func->accessed_ptr_count = (uint32_t)DedupSortedUint32(p_func->accessed_ptrs, p_func->accessed_ptr_count);
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static int SortCompareFunctions(const void* a, const void* b) {
+    const SpvReflectPrvFunction* af = (const SpvReflectPrvFunction*)a;
+    const SpvReflectPrvFunction* bf = (const SpvReflectPrvFunction*)b;
+    return (int)af->id - (int)bf->id;
+}
+
+static SpvReflectResult ParseFunctions(SpvReflectPrvParser* p_parser) {
+    assert(IsNotNull(p_parser));
+    assert(IsNotNull(p_parser->spirv_code));
+    assert(IsNotNull(p_parser->nodes));
+
+    if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && IsNotNull(p_parser->nodes)) {
+        if (p_parser->function_count == 0) {
+            return SPV_REFLECT_RESULT_SUCCESS;
+        }
+
+        p_parser->functions = (SpvReflectPrvFunction*)calloc(p_parser->function_count, sizeof(*(p_parser->functions)));
+        if (IsNull(p_parser->functions)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+
+        size_t function_index = 0;
+        for (size_t i = 0; i < p_parser->node_count; ++i) {
+            SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+            if (p_node->op != SpvOpFunction) {
+                continue;
+            }
+
+            // Skip over function declarations that aren't definitions
+            bool func_definition = false;
+            // Intentionally reuse i to avoid iterating over these nodes more than
+            // once
+            for (; i < p_parser->node_count; ++i) {
+                if (p_parser->nodes[i].op == SpvOpLabel) {
+                    func_definition = true;
+                    break;
+                }
+                if (p_parser->nodes[i].op == SpvOpFunctionEnd) {
+                    break;
+                }
+            }
+            if (!func_definition) {
+                continue;
+            }
+
+            SpvReflectPrvFunction* p_function = &(p_parser->functions[function_index]);
+
+            SpvReflectResult result = ParseFunction(p_parser, p_node, p_function, i);
+            if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                return result;
+            }
+
+            ++function_index;
+        }
+
+        qsort(p_parser->functions, p_parser->function_count, sizeof(*(p_parser->functions)), SortCompareFunctions);
+
+        // Once they're sorted, link the functions with pointers to improve graph
+        // traversal efficiency
+        for (size_t i = 0; i < p_parser->function_count; ++i) {
+            SpvReflectPrvFunction* p_func = &(p_parser->functions[i]);
+            if (p_func->callee_count == 0) {
+                continue;
+            }
+            p_func->callee_ptrs = (SpvReflectPrvFunction**)calloc(p_func->callee_count, sizeof(*(p_func->callee_ptrs)));
+            for (size_t j = 0, k = 0; j < p_func->callee_count; ++j) {
+                while (p_parser->functions[k].id != p_func->callees[j]) {
+                    ++k;
+                    if (k >= p_parser->function_count) {
+                        // Invalid called function ID somewhere
+                        return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                    }
+                }
+                p_func->callee_ptrs[j] = &(p_parser->functions[k]);
+            }
+        }
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseMemberCounts(SpvReflectPrvParser* p_parser) {
+    assert(IsNotNull(p_parser));
+    assert(IsNotNull(p_parser->spirv_code));
+    assert(IsNotNull(p_parser->nodes));
+
+    if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && IsNotNull(p_parser->nodes)) {
+        for (size_t i = 0; i < p_parser->node_count; ++i) {
+            SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+            if ((p_node->op != SpvOpMemberName) && (p_node->op != SpvOpMemberDecorate)) {
+                continue;
+            }
+
+            uint32_t target_id = 0;
+            uint32_t member_index = (uint32_t)INVALID_VALUE;
+            CHECKED_READU32(p_parser, p_node->word_offset + 1, target_id);
+            CHECKED_READU32(p_parser, p_node->word_offset + 2, member_index);
+            SpvReflectPrvNode* p_target_node = FindNode(p_parser, target_id);
+            // Not all nodes get parsed, so FindNode returning NULL is expected.
+            if (IsNull(p_target_node)) {
+                continue;
+            }
+
+            if (member_index == INVALID_VALUE) {
+                return SPV_REFLECT_RESULT_ERROR_RANGE_EXCEEDED;
+            }
+
+            p_target_node->member_count = Max(p_target_node->member_count, member_index + 1);
+        }
+
+        for (uint32_t i = 0; i < p_parser->node_count; ++i) {
+            SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+            if (p_node->member_count == 0) {
+                continue;
+            }
+
+            p_node->member_names = (const char**)calloc(p_node->member_count, sizeof(*(p_node->member_names)));
+            if (IsNull(p_node->member_names)) {
+                return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+            }
+
+            p_node->member_decorations =
+                (SpvReflectPrvDecorations*)calloc(p_node->member_count, sizeof(*(p_node->member_decorations)));
+            if (IsNull(p_node->member_decorations)) {
+                return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+            }
+        }
+    }
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseNames(SpvReflectPrvParser* p_parser) {
+    assert(IsNotNull(p_parser));
+    assert(IsNotNull(p_parser->spirv_code));
+    assert(IsNotNull(p_parser->nodes));
+
+    if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && IsNotNull(p_parser->nodes)) {
+        for (size_t i = 0; i < p_parser->node_count; ++i) {
+            SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+            if ((p_node->op != SpvOpName) && (p_node->op != SpvOpMemberName)) {
+                continue;
+            }
+
+            uint32_t target_id = 0;
+            CHECKED_READU32(p_parser, p_node->word_offset + 1, target_id);
+            SpvReflectPrvNode* p_target_node = FindNode(p_parser, target_id);
+            // Not all nodes get parsed, so FindNode returning NULL is expected.
+            if (IsNull(p_target_node)) {
+                continue;
+            }
+
+            const char** pp_target_name = &(p_target_node->name);
+            if (p_node->op == SpvOpMemberName) {
+                uint32_t member_index = UINT32_MAX;
+                CHECKED_READU32(p_parser, p_node->word_offset + 2, member_index);
+                pp_target_name = &(p_target_node->member_names[member_index]);
+            }
+
+            *pp_target_name = p_node->name;
+        }
+    }
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseDecorations(SpvReflectPrvParser* p_parser) {
+    for (uint32_t i = 0; i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+
+        if (((uint32_t)p_node->op != (uint32_t)SpvOpDecorate) && ((uint32_t)p_node->op != (uint32_t)SpvOpMemberDecorate) &&
+            ((uint32_t)p_node->op != (uint32_t)SpvReflectOpDecorateId) &&
+            ((uint32_t)p_node->op != (uint32_t)SpvReflectOpDecorateStringGOOGLE) &&
+            ((uint32_t)p_node->op != (uint32_t)SpvReflectOpMemberDecorateStringGOOGLE)) {
+            continue;
+        }
+
+        // Need to adjust the read offset if this is a member decoration
+        uint32_t member_offset = 0;
+        if (p_node->op == SpvOpMemberDecorate) {
+            member_offset = 1;
+        }
+
+        // Get decoration
+        uint32_t decoration = (uint32_t)INVALID_VALUE;
+        CHECKED_READU32(p_parser, p_node->word_offset + member_offset + 2, decoration);
+
+        // Filter out the decoration that do not affect reflection, otherwise
+        // there will be random crashes because the nodes aren't found.
+        bool skip = false;
+        switch (decoration) {
+            default: {
+                skip = true;
+            } break;
+            case SpvDecorationRelaxedPrecision:
+            case SpvDecorationBlock:
+            case SpvDecorationBufferBlock:
+            case SpvDecorationColMajor:
+            case SpvDecorationRowMajor:
+            case SpvDecorationArrayStride:
+            case SpvDecorationMatrixStride:
+            case SpvDecorationBuiltIn:
+            case SpvDecorationNoPerspective:
+            case SpvDecorationFlat:
+            case SpvDecorationNonWritable:
+            case SpvDecorationNonReadable:
+            case SpvDecorationLocation:
+            case SpvDecorationComponent:
+            case SpvDecorationBinding:
+            case SpvDecorationDescriptorSet:
+            case SpvDecorationOffset:
+            case SpvDecorationInputAttachmentIndex:
+            case SpvReflectDecorationHlslCounterBufferGOOGLE:
+            case SpvReflectDecorationHlslSemanticGOOGLE: {
+                skip = false;
+            } break;
+        }
+        if (skip) {
+            continue;
+        }
+
+        // Find target target node
+        uint32_t target_id = 0;
+        CHECKED_READU32(p_parser, p_node->word_offset + 1, target_id);
+        SpvReflectPrvNode* p_target_node = FindNode(p_parser, target_id);
+        if (IsNull(p_target_node)) {
+            if ((p_node->op == (uint32_t)SpvOpDecorate) && (decoration == SpvDecorationRelaxedPrecision)) {
+                // Many OPs can be decorated that we don't care about. Ignore those.
+                // See https://github.com/KhronosGroup/SPIRV-Reflect/issues/134
+                continue;
+            }
+            return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+        }
+        // Get decorations
+        SpvReflectPrvDecorations* p_target_decorations = &(p_target_node->decorations);
+        // Update pointer if this is a member member decoration
+        if (p_node->op == SpvOpMemberDecorate) {
+            uint32_t member_index = (uint32_t)INVALID_VALUE;
+            CHECKED_READU32(p_parser, p_node->word_offset + 2, member_index);
+            p_target_decorations = &(p_target_node->member_decorations[member_index]);
+        }
+
+        switch (decoration) {
+            default:
+                break;
+
+            case SpvDecorationRelaxedPrecision: {
+                p_target_decorations->is_relaxed_precision = true;
+            } break;
+
+            case SpvDecorationBlock: {
+                p_target_decorations->is_block = true;
+            } break;
+
+            case SpvDecorationBufferBlock: {
+                p_target_decorations->is_buffer_block = true;
+            } break;
+
+            case SpvDecorationColMajor: {
+                p_target_decorations->is_column_major = true;
+            } break;
+
+            case SpvDecorationRowMajor: {
+                p_target_decorations->is_row_major = true;
+            } break;
+
+            case SpvDecorationArrayStride: {
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                CHECKED_READU32(p_parser, word_offset, p_target_decorations->array_stride);
+            } break;
+
+            case SpvDecorationMatrixStride: {
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                CHECKED_READU32(p_parser, word_offset, p_target_decorations->matrix_stride);
+            } break;
+
+            case SpvDecorationBuiltIn: {
+                p_target_decorations->is_built_in = true;
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                CHECKED_READU32_CAST(p_parser, word_offset, SpvBuiltIn, p_target_decorations->built_in);
+            } break;
+
+            case SpvDecorationNoPerspective: {
+                p_target_decorations->is_noperspective = true;
+            } break;
+
+            case SpvDecorationFlat: {
+                p_target_decorations->is_flat = true;
+            } break;
+
+            case SpvDecorationNonWritable: {
+                p_target_decorations->is_non_writable = true;
+            } break;
+
+            case SpvDecorationNonReadable: {
+                p_target_decorations->is_non_readable = true;
+            } break;
+
+            case SpvDecorationLocation: {
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                CHECKED_READU32(p_parser, word_offset, p_target_decorations->location.value);
+                p_target_decorations->location.word_offset = word_offset;
+            } break;
+
+            case SpvDecorationComponent: {
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                CHECKED_READU32(p_parser, word_offset, p_target_decorations->component.value);
+                p_target_decorations->component.word_offset = word_offset;
+            } break;
+
+            case SpvDecorationBinding: {
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                CHECKED_READU32(p_parser, word_offset, p_target_decorations->binding.value);
+                p_target_decorations->binding.word_offset = word_offset;
+            } break;
+
+            case SpvDecorationDescriptorSet: {
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                CHECKED_READU32(p_parser, word_offset, p_target_decorations->set.value);
+                p_target_decorations->set.word_offset = word_offset;
+            } break;
+
+            case SpvDecorationOffset: {
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                CHECKED_READU32(p_parser, word_offset, p_target_decorations->offset.value);
+                p_target_decorations->offset.word_offset = word_offset;
+            } break;
+
+            case SpvDecorationInputAttachmentIndex: {
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                CHECKED_READU32(p_parser, word_offset, p_target_decorations->input_attachment_index.value);
+                p_target_decorations->input_attachment_index.word_offset = word_offset;
+            } break;
+
+            case SpvReflectDecorationHlslCounterBufferGOOGLE: {
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                CHECKED_READU32(p_parser, word_offset, p_target_decorations->uav_counter_buffer.value);
+                p_target_decorations->uav_counter_buffer.word_offset = word_offset;
+            } break;
+
+            case SpvReflectDecorationHlslSemanticGOOGLE: {
+                uint32_t word_offset = p_node->word_offset + member_offset + 3;
+                p_target_decorations->semantic.value = (const char*)(p_parser->spirv_code + word_offset);
+                p_target_decorations->semantic.word_offset = word_offset;
+            } break;
+        }
+    }
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult EnumerateAllUniforms(SpvReflectShaderModule* p_module, size_t* p_uniform_count, uint32_t** pp_uniforms) {
+    *p_uniform_count = p_module->descriptor_binding_count;
+    if (*p_uniform_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+    *pp_uniforms = (uint32_t*)calloc(*p_uniform_count, sizeof(**pp_uniforms));
+
+    if (IsNull(*pp_uniforms)) {
+        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
+
+    for (size_t i = 0; i < *p_uniform_count; ++i) {
+        (*pp_uniforms)[i] = p_module->descriptor_bindings[i].spirv_id;
+    }
+    qsort(*pp_uniforms, *p_uniform_count, sizeof(**pp_uniforms), SortCompareUint32);
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseType(SpvReflectPrvParser* p_parser, SpvReflectPrvNode* p_node,
+                                  SpvReflectPrvDecorations* p_struct_member_decorations, SpvReflectShaderModule* p_module,
+                                  SpvReflectTypeDescription* p_type) {
+    SpvReflectResult result = SPV_REFLECT_RESULT_SUCCESS;
+
+    if (p_node->member_count > 0) {
+        p_type->member_count = p_node->member_count;
+        p_type->members = (SpvReflectTypeDescription*)calloc(p_type->member_count, sizeof(*(p_type->members)));
+        if (IsNotNull(p_type->members)) {
+            // Mark all members types with an invalid state
+            for (size_t i = 0; i < p_type->members->member_count; ++i) {
+                SpvReflectTypeDescription* p_member_type = &(p_type->members[i]);
+                p_member_type->id = (uint32_t)INVALID_VALUE;
+                p_member_type->op = (SpvOp)INVALID_VALUE;
+                p_member_type->storage_class = (SpvStorageClass)INVALID_VALUE;
+            }
+        } else {
+            result = SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+    }
+
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        // Since the parse descends on type information, these will get overwritten
+        // if not guarded against assignment. Only assign if the id is invalid.
+        if (p_type->id == INVALID_VALUE) {
+            p_type->id = p_node->result_id;
+            p_type->op = p_node->op;
+            p_type->decoration_flags = 0;
+        }
+        // Top level types need to pick up decorations from all types below it.
+        // Issue and fix here: https://github.com/chaoticbob/SPIRV-Reflect/issues/64
+        p_type->decoration_flags = ApplyDecorations(&p_node->decorations);
+
+        switch (p_node->op) {
+            default:
+                break;
+            case SpvOpTypeVoid:
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_VOID;
+                break;
+
+            case SpvOpTypeBool:
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_BOOL;
+                break;
+
+            case SpvOpTypeInt: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_INT;
+                IF_READU32(result, p_parser, p_node->word_offset + 2, p_type->traits.numeric.scalar.width);
+                IF_READU32(result, p_parser, p_node->word_offset + 3, p_type->traits.numeric.scalar.signedness);
+            } break;
+
+            case SpvOpTypeFloat: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_FLOAT;
+                IF_READU32(result, p_parser, p_node->word_offset + 2, p_type->traits.numeric.scalar.width);
+            } break;
+
+            case SpvOpTypeVector: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_VECTOR;
+                uint32_t component_type_id = (uint32_t)INVALID_VALUE;
+                IF_READU32(result, p_parser, p_node->word_offset + 2, component_type_id);
+                IF_READU32(result, p_parser, p_node->word_offset + 3, p_type->traits.numeric.vector.component_count);
+                // Parse component type
+                SpvReflectPrvNode* p_next_node = FindNode(p_parser, component_type_id);
+                if (IsNotNull(p_next_node)) {
+                    result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
+                } else {
+                    result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                    SPV_REFLECT_ASSERT(false);
+                }
+            } break;
+
+            case SpvOpTypeMatrix: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_MATRIX;
+                uint32_t column_type_id = (uint32_t)INVALID_VALUE;
+                IF_READU32(result, p_parser, p_node->word_offset + 2, column_type_id);
+                IF_READU32(result, p_parser, p_node->word_offset + 3, p_type->traits.numeric.matrix.column_count);
+                SpvReflectPrvNode* p_next_node = FindNode(p_parser, column_type_id);
+                if (IsNotNull(p_next_node)) {
+                    result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
+                } else {
+                    result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                    SPV_REFLECT_ASSERT(false);
+                }
+                p_type->traits.numeric.matrix.row_count = p_type->traits.numeric.vector.component_count;
+                p_type->traits.numeric.matrix.stride = p_node->decorations.matrix_stride;
+                // NOTE: Matrix stride is decorated using OpMemberDecoreate - not OpDecoreate.
+                if (IsNotNull(p_struct_member_decorations)) {
+                    p_type->traits.numeric.matrix.stride = p_struct_member_decorations->matrix_stride;
+                }
+            } break;
+
+            case SpvOpTypeImage: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_EXTERNAL_IMAGE;
+                uint32_t sampled_type_id = (uint32_t)INVALID_VALUE;
+                IF_READU32(result, p_parser, p_node->word_offset + 2, sampled_type_id);
+                SpvReflectPrvNode* p_next_node = FindNode(p_parser, sampled_type_id);
+                if (IsNotNull(p_next_node)) {
+                    result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
+                } else {
+                    result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                }
+                IF_READU32_CAST(result, p_parser, p_node->word_offset + 3, SpvDim, p_type->traits.image.dim);
+                IF_READU32(result, p_parser, p_node->word_offset + 4, p_type->traits.image.depth);
+                IF_READU32(result, p_parser, p_node->word_offset + 5, p_type->traits.image.arrayed);
+                IF_READU32(result, p_parser, p_node->word_offset + 6, p_type->traits.image.ms);
+                IF_READU32(result, p_parser, p_node->word_offset + 7, p_type->traits.image.sampled);
+                IF_READU32_CAST(result, p_parser, p_node->word_offset + 8, SpvImageFormat, p_type->traits.image.image_format);
+            } break;
+
+            case SpvOpTypeSampler: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_EXTERNAL_SAMPLER;
+            } break;
+
+            case SpvOpTypeSampledImage: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_EXTERNAL_SAMPLED_IMAGE;
+                uint32_t image_type_id = (uint32_t)INVALID_VALUE;
+                IF_READU32(result, p_parser, p_node->word_offset + 2, image_type_id);
+                SpvReflectPrvNode* p_next_node = FindNode(p_parser, image_type_id);
+                if (IsNotNull(p_next_node)) {
+                    result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
+                } else {
+                    result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                    SPV_REFLECT_ASSERT(false);
+                }
+            } break;
+
+            case SpvOpTypeArray: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_ARRAY;
+                if (result == SPV_REFLECT_RESULT_SUCCESS) {
+                    uint32_t element_type_id = (uint32_t)INVALID_VALUE;
+                    uint32_t length_id = (uint32_t)INVALID_VALUE;
+                    IF_READU32(result, p_parser, p_node->word_offset + 2, element_type_id);
+                    IF_READU32(result, p_parser, p_node->word_offset + 3, length_id);
+                    // NOTE: Array stride is decorated using OpDecorate instead of
+                    //       OpMemberDecorate, even if the array is apart of a struct.
+                    p_type->traits.array.stride = p_node->decorations.array_stride;
+                    // Get length for current dimension
+                    SpvReflectPrvNode* p_length_node = FindNode(p_parser, length_id);
+                    if (IsNotNull(p_length_node)) {
+                        uint32_t dim_index = p_type->traits.array.dims_count;
+                        if (p_length_node->op == SpvOpSpecConstant || p_length_node->op == SpvOpSpecConstantOp) {
+                            p_type->traits.array.dims[dim_index] = 0xFFFFFFFF;
+                            p_type->traits.array.spec_constant_op_ids[dim_index] = length_id;
+                            p_type->traits.array.dims_count += 1;
+                        } else {
+                            uint32_t length = 0;
+                            IF_READU32(result, p_parser, p_length_node->word_offset + 3, length);
+                            if (result == SPV_REFLECT_RESULT_SUCCESS) {
+                                // Write the array dim and increment the count and offset
+                                p_type->traits.array.dims[dim_index] = length;
+                                p_type->traits.array.spec_constant_op_ids[dim_index] = 0xFFFFFFFF;
+                                p_type->traits.array.dims_count += 1;
+                            } else {
+                                result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                                SPV_REFLECT_ASSERT(false);
+                            }
+                        }
+                        // Parse next dimension or element type
+                        SpvReflectPrvNode* p_next_node = FindNode(p_parser, element_type_id);
+                        if (IsNotNull(p_next_node)) {
+                            result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
+                        }
+                    } else {
+                        result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                        SPV_REFLECT_ASSERT(false);
+                    }
+                }
+            } break;
+
+            case SpvOpTypeRuntimeArray: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_ARRAY;
+                uint32_t element_type_id = (uint32_t)INVALID_VALUE;
+                IF_READU32(result, p_parser, p_node->word_offset + 2, element_type_id);
+                p_type->traits.array.stride = p_node->decorations.array_stride;
+                uint32_t dim_index = p_type->traits.array.dims_count;
+                p_type->traits.array.dims[dim_index] = 0;
+                p_type->traits.array.spec_constant_op_ids[dim_index] = 0;
+                p_type->traits.array.dims_count += 1;
+                // Parse next dimension or element type
+                SpvReflectPrvNode* p_next_node = FindNode(p_parser, element_type_id);
+                if (IsNotNull(p_next_node)) {
+                    result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
+                } else {
+                    result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                    SPV_REFLECT_ASSERT(false);
+                }
+            } break;
+
+            case SpvOpTypeStruct: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_STRUCT;
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_EXTERNAL_BLOCK;
+                uint32_t word_index = 2;
+                uint32_t member_index = 0;
+                for (; word_index < p_node->word_count; ++word_index, ++member_index) {
+                    uint32_t member_id = (uint32_t)INVALID_VALUE;
+                    IF_READU32(result, p_parser, p_node->word_offset + word_index, member_id);
+                    // Find member node
+                    SpvReflectPrvNode* p_member_node = FindNode(p_parser, member_id);
+                    if (IsNull(p_member_node)) {
+                        result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                        SPV_REFLECT_ASSERT(false);
+                        break;
+                    }
+
+                    // Member decorations
+                    SpvReflectPrvDecorations* p_member_decorations = &p_node->member_decorations[member_index];
+
+                    assert(member_index < p_type->member_count);
+                    // Parse member type
+                    SpvReflectTypeDescription* p_member_type = &(p_type->members[member_index]);
+                    p_member_type->id = member_id;
+                    p_member_type->op = p_member_node->op;
+                    result = ParseType(p_parser, p_member_node, p_member_decorations, p_module, p_member_type);
+                    if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                        break;
+                    }
+                    // This looks wrong
+                    // p_member_type->type_name = p_member_node->name;
+                    p_member_type->struct_member_name = p_node->member_names[member_index];
+                }
+            } break;
+
+            case SpvOpTypeOpaque:
+                break;
+
+            case SpvOpTypePointer: {
+                IF_READU32_CAST(result, p_parser, p_node->word_offset + 2, SpvStorageClass, p_type->storage_class);
+                uint32_t type_id = (uint32_t)INVALID_VALUE;
+                IF_READU32(result, p_parser, p_node->word_offset + 3, type_id);
+                // Parse type
+                SpvReflectPrvNode* p_next_node = FindNode(p_parser, type_id);
+                if (IsNotNull(p_next_node)) {
+                    result = ParseType(p_parser, p_next_node, NULL, p_module, p_type);
+                } else {
+                    result = SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                    SPV_REFLECT_ASSERT(false);
+                }
+            } break;
+
+            case SpvOpTypeAccelerationStructureKHR: {
+                p_type->type_flags |= SPV_REFLECT_TYPE_FLAG_EXTERNAL_ACCELERATION_STRUCTURE;
+            } break;
+        }
+
+        if (result == SPV_REFLECT_RESULT_SUCCESS) {
+            // Names get assigned on the way down. Guard against names
+            // get overwritten on the way up.
+            if (IsNull(p_type->type_name)) {
+                p_type->type_name = p_node->name;
+            }
+        }
+    }
+
+    return result;
+}
+
+static SpvReflectResult ParseTypes(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module) {
+    if (p_parser->type_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    p_module->_internal->type_description_count = p_parser->type_count;
+    p_module->_internal->type_descriptions = (SpvReflectTypeDescription*)calloc(p_module->_internal->type_description_count,
+                                                                                sizeof(*(p_module->_internal->type_descriptions)));
+    if (IsNull(p_module->_internal->type_descriptions)) {
+        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
+
+    // Mark all types with an invalid state
+    for (size_t i = 0; i < p_module->_internal->type_description_count; ++i) {
+        SpvReflectTypeDescription* p_type = &(p_module->_internal->type_descriptions[i]);
+        p_type->id = (uint32_t)INVALID_VALUE;
+        p_type->op = (SpvOp)INVALID_VALUE;
+        p_type->storage_class = (SpvStorageClass)INVALID_VALUE;
+    }
+
+    size_t type_index = 0;
+    for (size_t i = 0; i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+        if (!p_node->is_type) {
+            continue;
+        }
+
+        SpvReflectTypeDescription* p_type = &(p_module->_internal->type_descriptions[type_index]);
+        SpvReflectResult result = ParseType(p_parser, p_node, NULL, p_module, p_type);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            return result;
+        }
+        ++type_index;
+    }
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseCapabilities(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module) {
+    if (p_parser->capability_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    p_module->capability_count = p_parser->capability_count;
+    p_module->capabilities = (SpvReflectCapability*)calloc(p_module->capability_count, sizeof(*(p_module->capabilities)));
+    if (IsNull(p_module->capabilities)) {
+        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
+
+    // Mark all types with an invalid state
+    for (size_t i = 0; i < p_module->capability_count; ++i) {
+        SpvReflectCapability* p_cap = &(p_module->capabilities[i]);
+        p_cap->value = SpvCapabilityMax;
+        p_cap->word_offset = (uint32_t)INVALID_VALUE;
+    }
+
+    size_t capability_index = 0;
+    for (size_t i = 0; i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+        if (SpvOpCapability != p_node->op) {
+            continue;
+        }
+
+        SpvReflectCapability* p_cap = &(p_module->capabilities[capability_index]);
+        p_cap->value = p_node->capability;
+        p_cap->word_offset = p_node->word_offset + 1;
+        ++capability_index;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static int SortCompareDescriptorBinding(const void* a, const void* b) {
+    const SpvReflectDescriptorBinding* p_elem_a = (const SpvReflectDescriptorBinding*)a;
+    const SpvReflectDescriptorBinding* p_elem_b = (const SpvReflectDescriptorBinding*)b;
+    int value = (int)(p_elem_a->binding) - (int)(p_elem_b->binding);
+    if (value == 0) {
+        // use spirv-id as a tiebreaker to ensure a stable ordering, as they're guaranteed
+        // unique.
+        assert(p_elem_a->spirv_id != p_elem_b->spirv_id);
+        value = (int)(p_elem_a->spirv_id) - (int)(p_elem_b->spirv_id);
+    }
+    return value;
+}
+
+static SpvReflectResult ParseDescriptorBindings(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module) {
+    p_module->descriptor_binding_count = 0;
+    for (size_t i = 0; i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+        if ((p_node->op != SpvOpVariable) ||
+            ((p_node->storage_class != SpvStorageClassUniform) && (p_node->storage_class != SpvStorageClassStorageBuffer) &&
+             (p_node->storage_class != SpvStorageClassUniformConstant))) {
+            continue;
+        }
+        if ((p_node->decorations.set.value == INVALID_VALUE) || (p_node->decorations.binding.value == INVALID_VALUE)) {
+            continue;
+        }
+
+        p_module->descriptor_binding_count += 1;
+    }
+
+    if (p_module->descriptor_binding_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    p_module->descriptor_bindings =
+        (SpvReflectDescriptorBinding*)calloc(p_module->descriptor_binding_count, sizeof(*(p_module->descriptor_bindings)));
+    if (IsNull(p_module->descriptor_bindings)) {
+        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
+
+    // Mark all types with an invalid state
+    for (uint32_t descriptor_index = 0; descriptor_index < p_module->descriptor_binding_count; ++descriptor_index) {
+        SpvReflectDescriptorBinding* p_descriptor = &(p_module->descriptor_bindings[descriptor_index]);
+        p_descriptor->binding = (uint32_t)INVALID_VALUE;
+        p_descriptor->input_attachment_index = (uint32_t)INVALID_VALUE;
+        p_descriptor->set = (uint32_t)INVALID_VALUE;
+        p_descriptor->descriptor_type = (SpvReflectDescriptorType)INVALID_VALUE;
+        p_descriptor->uav_counter_id = (uint32_t)INVALID_VALUE;
+    }
+
+    size_t descriptor_index = 0;
+    for (size_t i = 0; i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+        if ((p_node->op != SpvOpVariable) ||
+            ((p_node->storage_class != SpvStorageClassUniform) && (p_node->storage_class != SpvStorageClassStorageBuffer) &&
+             (p_node->storage_class != SpvStorageClassUniformConstant))) {
+            continue;
+        }
+        if ((p_node->decorations.set.value == INVALID_VALUE) || (p_node->decorations.binding.value == INVALID_VALUE)) {
+            continue;
+        }
+
+        SpvReflectTypeDescription* p_type = FindType(p_module, p_node->type_id);
+        if (IsNull(p_type)) {
+            return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+        }
+        // If the type is a pointer, resolve it. We need to retain the storage class
+        // from the pointer so that we can use it to deduce deescriptor types.
+        SpvStorageClass pointer_storage_class = SpvStorageClassMax;
+        if (p_type->op == SpvOpTypePointer) {
+            pointer_storage_class = p_type->storage_class;
+            // Find the type's node
+            SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
+            if (IsNull(p_type_node)) {
+                return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+            }
+            // Should be the resolved type
+            p_type = FindType(p_module, p_type_node->type_id);
+            if (IsNull(p_type)) {
+                return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+            }
+        }
+
+        SpvReflectDescriptorBinding* p_descriptor = &p_module->descriptor_bindings[descriptor_index];
+        p_descriptor->spirv_id = p_node->result_id;
+        p_descriptor->name = p_node->name;
+        p_descriptor->binding = p_node->decorations.binding.value;
+        p_descriptor->input_attachment_index = p_node->decorations.input_attachment_index.value;
+        p_descriptor->set = p_node->decorations.set.value;
+        p_descriptor->count = 1;
+        p_descriptor->uav_counter_id = p_node->decorations.uav_counter_buffer.value;
+        p_descriptor->type_description = p_type;
+        p_descriptor->decoration_flags = ApplyDecorations(&p_node->decorations);
+
+        // If this is in the StorageBuffer storage class, it's for sure a storage
+        // buffer descriptor. We need to handle this case earlier because in SPIR-V
+        // there are two ways to indicate a storage buffer:
+        // 1) Uniform storage class + BufferBlock decoration, or
+        // 2) StorageBuffer storage class + Buffer decoration.
+        // The 1) way is deprecated since SPIR-V v1.3. But the Buffer decoration is
+        // also used together with Uniform storage class to mean uniform buffer..
+        // We'll handle the pre-v1.3 cases in ParseDescriptorType().
+        if (pointer_storage_class == SpvStorageClassStorageBuffer) {
+            p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        }
+
+        // Copy image traits
+        if ((p_type->type_flags & SPV_REFLECT_TYPE_FLAG_EXTERNAL_MASK) == SPV_REFLECT_TYPE_FLAG_EXTERNAL_IMAGE) {
+            memcpy(&p_descriptor->image, &p_type->traits.image, sizeof(p_descriptor->image));
+        }
+
+        // This is a workaround for: https://github.com/KhronosGroup/glslang/issues/1096
+        {
+            const uint32_t resource_mask = SPV_REFLECT_TYPE_FLAG_EXTERNAL_SAMPLED_IMAGE | SPV_REFLECT_TYPE_FLAG_EXTERNAL_IMAGE;
+            if ((p_type->type_flags & resource_mask) == resource_mask) {
+                memcpy(&p_descriptor->image, &p_type->traits.image, sizeof(p_descriptor->image));
+            }
+        }
+
+        // Copy array traits
+        if (p_type->traits.array.dims_count > 0) {
+            p_descriptor->array.dims_count = p_type->traits.array.dims_count;
+            for (uint32_t dim_index = 0; dim_index < p_type->traits.array.dims_count; ++dim_index) {
+                uint32_t dim_value = p_type->traits.array.dims[dim_index];
+                p_descriptor->array.dims[dim_index] = dim_value;
+                p_descriptor->count *= dim_value;
+            }
+        }
+
+        // Count
+
+        p_descriptor->word_offset.binding = p_node->decorations.binding.word_offset;
+        p_descriptor->word_offset.set = p_node->decorations.set.word_offset;
+
+        ++descriptor_index;
+    }
+
+    if (p_module->descriptor_binding_count > 0) {
+        qsort(p_module->descriptor_bindings, p_module->descriptor_binding_count, sizeof(*(p_module->descriptor_bindings)),
+              SortCompareDescriptorBinding);
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseDescriptorType(SpvReflectShaderModule* p_module) {
+    if (p_module->descriptor_binding_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    for (uint32_t descriptor_index = 0; descriptor_index < p_module->descriptor_binding_count; ++descriptor_index) {
+        SpvReflectDescriptorBinding* p_descriptor = &(p_module->descriptor_bindings[descriptor_index]);
+        SpvReflectTypeDescription* p_type = p_descriptor->type_description;
+
+        if ((int)p_descriptor->descriptor_type == (int)INVALID_VALUE) {
+            switch (p_type->type_flags & SPV_REFLECT_TYPE_FLAG_EXTERNAL_MASK) {
+                default:
+                    assert(false && "unknown type flag");
+                    break;
+
+                case SPV_REFLECT_TYPE_FLAG_EXTERNAL_IMAGE: {
+                    if (p_descriptor->image.dim == SpvDimBuffer) {
+                        switch (p_descriptor->image.sampled) {
+                            default:
+                                assert(false && "unknown texel buffer sampled value");
+                                break;
+                            case IMAGE_SAMPLED:
+                                p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+                                break;
+                            case IMAGE_STORAGE:
+                                p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+                                break;
+                        }
+                    } else if (p_descriptor->image.dim == SpvDimSubpassData) {
+                        p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+                    } else {
+                        switch (p_descriptor->image.sampled) {
+                            default:
+                                assert(false && "unknown image sampled value");
+                                break;
+                            case IMAGE_SAMPLED:
+                                p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+                                break;
+                            case IMAGE_STORAGE:
+                                p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+                                break;
+                        }
+                    }
+                } break;
+
+                case SPV_REFLECT_TYPE_FLAG_EXTERNAL_SAMPLER: {
+                    p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLER;
+                } break;
+
+                case (SPV_REFLECT_TYPE_FLAG_EXTERNAL_SAMPLED_IMAGE | SPV_REFLECT_TYPE_FLAG_EXTERNAL_IMAGE): {
+                    // This is a workaround for: https://github.com/KhronosGroup/glslang/issues/1096
+                    if (p_descriptor->image.dim == SpvDimBuffer) {
+                        switch (p_descriptor->image.sampled) {
+                            default:
+                                assert(false && "unknown texel buffer sampled value");
+                                break;
+                            case IMAGE_SAMPLED:
+                                p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+                                break;
+                            case IMAGE_STORAGE:
+                                p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+                                break;
+                        }
+                    } else {
+                        p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+                    }
+                } break;
+
+                case SPV_REFLECT_TYPE_FLAG_EXTERNAL_BLOCK: {
+                    if (p_type->decoration_flags & SPV_REFLECT_DECORATION_BLOCK) {
+                        p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+                    } else if (p_type->decoration_flags & SPV_REFLECT_DECORATION_BUFFER_BLOCK) {
+                        p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                    } else {
+                        assert(false && "unknown struct");
+                    }
+                } break;
+
+                case SPV_REFLECT_TYPE_FLAG_EXTERNAL_ACCELERATION_STRUCTURE: {
+                    p_descriptor->descriptor_type = SPV_REFLECT_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
+                } break;
+            }
+        }
+
+        switch (p_descriptor->descriptor_type) {
+            case SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLER:
+                p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_SAMPLER;
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+                p_descriptor->resource_type =
+                    (SpvReflectResourceType)(SPV_REFLECT_RESOURCE_FLAG_SAMPLER | SPV_REFLECT_RESOURCE_FLAG_SRV);
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+                p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_SRV;
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+                p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_UAV;
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+                p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_SRV;
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_UAV;
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+                p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_CBV;
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+                p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_CBV;
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+                p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_UAV;
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+                p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_UAV;
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+                break;
+            case SPV_REFLECT_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+                p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_SRV;
+                break;
+        }
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseUAVCounterBindings(SpvReflectShaderModule* p_module) {
+    char name[MAX_NODE_NAME_LENGTH];
+    const char* k_count_tag = "@count";
+
+    for (uint32_t descriptor_index = 0; descriptor_index < p_module->descriptor_binding_count; ++descriptor_index) {
+        SpvReflectDescriptorBinding* p_descriptor = &(p_module->descriptor_bindings[descriptor_index]);
+
+        if (p_descriptor->descriptor_type != SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+            continue;
+        }
+
+        SpvReflectDescriptorBinding* p_counter_descriptor = NULL;
+        // Use UAV counter buffer id if present...
+        if (p_descriptor->uav_counter_id != UINT32_MAX) {
+            for (uint32_t counter_descriptor_index = 0; counter_descriptor_index < p_module->descriptor_binding_count;
+                 ++counter_descriptor_index) {
+                SpvReflectDescriptorBinding* p_test_counter_descriptor = &(p_module->descriptor_bindings[counter_descriptor_index]);
+                if (p_test_counter_descriptor->descriptor_type != SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+                    continue;
+                }
+                if (p_descriptor->uav_counter_id == p_test_counter_descriptor->spirv_id) {
+                    p_counter_descriptor = p_test_counter_descriptor;
+                    break;
+                }
+            }
+        }
+        // ...otherwise use old @count convention.
+        else {
+            const size_t descriptor_name_length = p_descriptor->name ? strlen(p_descriptor->name) : 0;
+
+            memset(name, 0, MAX_NODE_NAME_LENGTH);
+            memcpy(name, p_descriptor->name, descriptor_name_length);
+#if defined(_WIN32)
+            strcat_s(name, MAX_NODE_NAME_LENGTH, k_count_tag);
+#else
+            strcat(name, k_count_tag);
+#endif
+
+            for (uint32_t counter_descriptor_index = 0; counter_descriptor_index < p_module->descriptor_binding_count;
+                 ++counter_descriptor_index) {
+                SpvReflectDescriptorBinding* p_test_counter_descriptor = &(p_module->descriptor_bindings[counter_descriptor_index]);
+                if (p_test_counter_descriptor->descriptor_type != SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+                    continue;
+                }
+                if (p_test_counter_descriptor->name && strcmp(name, p_test_counter_descriptor->name) == 0) {
+                    p_counter_descriptor = p_test_counter_descriptor;
+                    break;
+                }
+            }
+        }
+
+        if (p_counter_descriptor != NULL) {
+            p_descriptor->uav_counter_binding = p_counter_descriptor;
+        }
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseDescriptorBlockVariable(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module,
+                                                     SpvReflectTypeDescription* p_type, SpvReflectBlockVariable* p_var) {
+    bool has_non_writable = false;
+
+    if (IsNotNull(p_type->members) && (p_type->member_count > 0)) {
+        p_var->member_count = p_type->member_count;
+        p_var->members = (SpvReflectBlockVariable*)calloc(p_var->member_count, sizeof(*p_var->members));
+        if (IsNull(p_var->members)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+
+        SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
+        if (IsNull(p_type_node)) {
+            return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+        }
+        // Resolve to element type if current type is array or run time array
+        while (p_type_node->op == SpvOpTypeArray || p_type_node->op == SpvOpTypeRuntimeArray) {
+            if (p_type_node->op == SpvOpTypeArray) {
+                p_type_node = FindNode(p_parser, p_type_node->array_traits.element_type_id);
+            } else {
+                // Element type description
+                SpvReflectTypeDescription* p_type_temp = FindType(p_module, p_type_node->array_traits.element_type_id);
+                if (IsNull(p_type_temp)) {
+                    return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                }
+                // Element type node
+                p_type_node = FindNode(p_parser, p_type_temp->id);
+            }
+            if (IsNull(p_type_node)) {
+                return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+            }
+        }
+
+        // Parse members
+        for (uint32_t member_index = 0; member_index < p_type->member_count; ++member_index) {
+            SpvReflectTypeDescription* p_member_type = &p_type->members[member_index];
+            SpvReflectBlockVariable* p_member_var = &p_var->members[member_index];
+            bool is_struct = (p_member_type->type_flags & SPV_REFLECT_TYPE_FLAG_STRUCT) == SPV_REFLECT_TYPE_FLAG_STRUCT;
+            if (is_struct) {
+                SpvReflectResult result = ParseDescriptorBlockVariable(p_parser, p_module, p_member_type, p_member_var);
+                if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                    return result;
+                }
+            }
+
+            p_member_var->name = p_type_node->member_names[member_index];
+            p_member_var->offset = p_type_node->member_decorations[member_index].offset.value;
+            p_member_var->decoration_flags = ApplyDecorations(&p_type_node->member_decorations[member_index]);
+            p_member_var->flags |= SPV_REFLECT_VARIABLE_FLAGS_UNUSED;
+            if (!has_non_writable && (p_member_var->decoration_flags & SPV_REFLECT_DECORATION_NON_WRITABLE)) {
+                has_non_writable = true;
+            }
+            ApplyNumericTraits(p_member_type, &p_member_var->numeric);
+            if (p_member_type->op == SpvOpTypeArray) {
+                ApplyArrayTraits(p_member_type, &p_member_var->array);
+            }
+
+            p_member_var->word_offset.offset = p_type_node->member_decorations[member_index].offset.word_offset;
+            p_member_var->type_description = p_member_type;
+        }
+    }
+
+    p_var->name = p_type->type_name;
+    p_var->type_description = p_type;
+    if (has_non_writable) {
+        p_var->decoration_flags |= SPV_REFLECT_DECORATION_NON_WRITABLE;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseDescriptorBlockVariableSizes(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module,
+                                                          bool is_parent_root, bool is_parent_aos, bool is_parent_rta,
+                                                          SpvReflectBlockVariable* p_var) {
+    if (p_var->member_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    // Absolute offsets
+    for (uint32_t member_index = 0; member_index < p_var->member_count; ++member_index) {
+        SpvReflectBlockVariable* p_member_var = &p_var->members[member_index];
+        if (is_parent_root) {
+            p_member_var->absolute_offset = p_member_var->offset;
+        } else {
+            p_member_var->absolute_offset = is_parent_aos ? 0 : p_member_var->offset + p_var->absolute_offset;
+        }
+    }
+
+    // Size
+    for (uint32_t member_index = 0; member_index < p_var->member_count; ++member_index) {
+        SpvReflectBlockVariable* p_member_var = &p_var->members[member_index];
+        SpvReflectTypeDescription* p_member_type = p_member_var->type_description;
+
+        switch (p_member_type->op) {
+            case SpvOpTypeBool: {
+                p_member_var->size = SPIRV_WORD_SIZE;
+            } break;
+
+            case SpvOpTypeInt:
+            case SpvOpTypeFloat: {
+                p_member_var->size = p_member_type->traits.numeric.scalar.width / SPIRV_BYTE_WIDTH;
+            } break;
+
+            case SpvOpTypeVector: {
+                uint32_t size = p_member_type->traits.numeric.vector.component_count *
+                                (p_member_type->traits.numeric.scalar.width / SPIRV_BYTE_WIDTH);
+                p_member_var->size = size;
+            } break;
+
+            case SpvOpTypeMatrix: {
+                if (p_member_var->decoration_flags & SPV_REFLECT_DECORATION_COLUMN_MAJOR) {
+                    p_member_var->size = p_member_var->numeric.matrix.column_count * p_member_var->numeric.matrix.stride;
+                } else if (p_member_var->decoration_flags & SPV_REFLECT_DECORATION_ROW_MAJOR) {
+                    p_member_var->size = p_member_var->numeric.matrix.row_count * p_member_var->numeric.matrix.stride;
+                }
+            } break;
+
+            case SpvOpTypeArray: {
+                // If array of structs, parse members first...
+                bool is_struct = (p_member_type->type_flags & SPV_REFLECT_TYPE_FLAG_STRUCT) == SPV_REFLECT_TYPE_FLAG_STRUCT;
+                if (is_struct) {
+                    SpvReflectResult result =
+                        ParseDescriptorBlockVariableSizes(p_parser, p_module, false, true, is_parent_rta, p_member_var);
+                    if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                        return result;
+                    }
+                }
+                // ...then array
+                uint32_t element_count = (p_member_var->array.dims_count > 0 ? 1 : 0);
+                for (uint32_t i = 0; i < p_member_var->array.dims_count; ++i) {
+                    element_count *= p_member_var->array.dims[i];
+                }
+                p_member_var->size = element_count * p_member_var->array.stride;
+            } break;
+
+            case SpvOpTypeRuntimeArray: {
+                bool is_struct = (p_member_type->type_flags & SPV_REFLECT_TYPE_FLAG_STRUCT) == SPV_REFLECT_TYPE_FLAG_STRUCT;
+                if (is_struct) {
+                    SpvReflectResult result =
+                        ParseDescriptorBlockVariableSizes(p_parser, p_module, false, true, true, p_member_var);
+                    if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                        return result;
+                    }
+                }
+            } break;
+
+            case SpvOpTypeStruct: {
+                SpvReflectResult result =
+                    ParseDescriptorBlockVariableSizes(p_parser, p_module, false, is_parent_aos, is_parent_rta, p_member_var);
+                if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                    return result;
+                }
+            } break;
+
+            default:
+                break;
+        }
+    }
+
+    // Parse padded size using offset difference for all member except for the last entry...
+    for (uint32_t member_index = 0; member_index < (p_var->member_count - 1); ++member_index) {
+        SpvReflectBlockVariable* p_member_var = &p_var->members[member_index];
+        SpvReflectBlockVariable* p_next_member_var = &p_var->members[member_index + 1];
+        p_member_var->padded_size = p_next_member_var->offset - p_member_var->offset;
+        if (p_member_var->size > p_member_var->padded_size) {
+            p_member_var->size = p_member_var->padded_size;
+        }
+        if (is_parent_rta) {
+            p_member_var->padded_size = p_member_var->size;
+        }
+    }
+    // ...last entry just gets rounded up to near multiple of SPIRV_DATA_ALIGNMENT, which is 16 and
+    // subtract the offset.
+    if (p_var->member_count > 0) {
+        SpvReflectBlockVariable* p_member_var = &p_var->members[p_var->member_count - 1];
+        p_member_var->padded_size = RoundUp(p_member_var->offset + p_member_var->size, SPIRV_DATA_ALIGNMENT) - p_member_var->offset;
+        if (p_member_var->size > p_member_var->padded_size) {
+            p_member_var->size = p_member_var->padded_size;
+        }
+        if (is_parent_rta) {
+            p_member_var->padded_size = p_member_var->size;
+        }
+    }
+
+    // @TODO validate this with assertion
+    p_var->size = p_var->members[p_var->member_count - 1].offset + p_var->members[p_var->member_count - 1].padded_size;
+    p_var->padded_size = p_var->size;
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static void MarkSelfAndAllMemberVarsAsUsed(SpvReflectBlockVariable* p_var) {
+    // Clear the current variable's UNUSED flag
+    p_var->flags &= ~SPV_REFLECT_VARIABLE_FLAGS_UNUSED;
+
+    SpvOp op_type = p_var->type_description->op;
+    switch (op_type) {
+        default:
+            break;
+
+        case SpvOpTypeArray: {
+        } break;
+
+        case SpvOpTypeStruct: {
+            for (uint32_t i = 0; i < p_var->member_count; ++i) {
+                SpvReflectBlockVariable* p_member_var = &p_var->members[i];
+                MarkSelfAndAllMemberVarsAsUsed(p_member_var);
+            }
+        } break;
+    }
+}
+
+static SpvReflectResult ParseDescriptorBlockVariableUsage(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module,
+                                                          SpvReflectPrvAccessChain* p_access_chain, uint32_t index_index,
+                                                          SpvOp override_op_type, SpvReflectBlockVariable* p_var) {
+    (void)p_parser;
+    (void)p_access_chain;
+    (void)p_var;
+
+    // Clear the current variable's UNUSED flag
+    p_var->flags &= ~SPV_REFLECT_VARIABLE_FLAGS_UNUSED;
+
+    // Parsing arrays requires overriding the op type for
+    // for the lowest dim's element type.
+    SpvOp op_type = p_var->type_description->op;
+    if (override_op_type != (SpvOp)INVALID_VALUE) {
+        op_type = override_op_type;
+    }
+
+    switch (op_type) {
+        default:
+            break;
+
+        case SpvOpTypeArray: {
+            // Parse through array's type hierarchy to find the actual/non-array element type
+            SpvReflectTypeDescription* p_type = p_var->type_description;
+            while ((p_type->op == SpvOpTypeArray) && (index_index < p_access_chain->index_count)) {
+                // Find the array element type id
+                SpvReflectPrvNode* p_node = FindNode(p_parser, p_type->id);
+                if (p_node == NULL) {
+                    return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                }
+                uint32_t element_type_id = p_node->array_traits.element_type_id;
+                // Get the array element type
+                p_type = FindType(p_module, element_type_id);
+                if (p_type == NULL) {
+                    return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+                }
+                // Next access chain index
+                index_index += 1;
+            }
+
+            // Only continue parsing if there's remaining indices in the access
+            // chain. If the end of the access chain has been reached then all
+            // remaining variables (including those in struct hierarchies)
+            // are considered USED.
+            //
+            // See: https://github.com/KhronosGroup/SPIRV-Reflect/issues/78
+            //
+            if (index_index < p_access_chain->index_count) {
+                // Parse current var again with a type override and advanced index index
+                SpvReflectResult result =
+                    ParseDescriptorBlockVariableUsage(p_parser, p_module, p_access_chain, index_index, p_type->op, p_var);
+                if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                    return result;
+                }
+            } else {
+                // Clear UNUSED flag for remaining variables
+                MarkSelfAndAllMemberVarsAsUsed(p_var);
+            }
+        } break;
+
+        case SpvOpTypeStruct: {
+            assert(p_var->member_count > 0);
+            if (p_var->member_count == 0) {
+                return SPV_REFLECT_RESULT_ERROR_SPIRV_UNEXPECTED_BLOCK_DATA;
+            }
+
+            // The access chain can have zero indexes, if used for a runtime array
+            if (p_access_chain->index_count == 0) {
+                return SPV_REFLECT_RESULT_SUCCESS;
+            }
+
+            // Get member variable at the access's chain current index
+            uint32_t index = p_access_chain->indexes[index_index];
+            if (index >= p_var->member_count) {
+                return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_BLOCK_MEMBER_REFERENCE;
+            }
+            SpvReflectBlockVariable* p_member_var = &p_var->members[index];
+
+            // Next access chain index
+            index_index += 1;
+
+            // Only continue parsing if there's remaining indices in the access
+            // chain. If the end of the access chain has been reach then all
+            // remaining variables (including those in struct hierarchies)
+            // are considered USED.
+            //
+            // See: https://github.com/KhronosGroup/SPIRV-Reflect/issues/78
+            //
+            if (index_index < p_access_chain->index_count) {
+                SpvReflectResult result = ParseDescriptorBlockVariableUsage(p_parser, p_module, p_access_chain, index_index,
+                                                                            (SpvOp)INVALID_VALUE, p_member_var);
+                if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                    return result;
+                }
+            } else {
+                // Clear UNUSED flag for remaining variables
+                MarkSelfAndAllMemberVarsAsUsed(p_member_var);
+            }
+            // SpvReflectBlockVariable* p_member_var = &p_var->members[index];
+            // if (index_index < p_access_chain->index_count) {
+            //   SpvReflectResult result = ParseDescriptorBlockVariableUsage(
+            //     p_parser,
+            //     p_module,
+            //     p_access_chain,
+            //     index_index + 1,
+            //     (SpvOp)INVALID_VALUE,
+            //     p_member_var);
+            //   if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            //     return result;
+            //   }
+            // }
+        } break;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseDescriptorBlocks(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module) {
+    if (p_module->descriptor_binding_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    for (uint32_t descriptor_index = 0; descriptor_index < p_module->descriptor_binding_count; ++descriptor_index) {
+        SpvReflectDescriptorBinding* p_descriptor = &(p_module->descriptor_bindings[descriptor_index]);
+        SpvReflectTypeDescription* p_type = p_descriptor->type_description;
+        if ((p_descriptor->descriptor_type != SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER) &&
+            (p_descriptor->descriptor_type != SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER)) {
+            continue;
+        }
+
+        // Mark UNUSED
+        p_descriptor->block.flags |= SPV_REFLECT_VARIABLE_FLAGS_UNUSED;
+        // Parse descriptor block
+        SpvReflectResult result = ParseDescriptorBlockVariable(p_parser, p_module, p_type, &p_descriptor->block);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            return result;
+        }
+
+        for (uint32_t access_chain_index = 0; access_chain_index < p_parser->access_chain_count; ++access_chain_index) {
+            SpvReflectPrvAccessChain* p_access_chain = &(p_parser->access_chains[access_chain_index]);
+            // Skip any access chains that aren't touching this descriptor block
+            if (p_descriptor->spirv_id != p_access_chain->base_id) {
+                continue;
+            }
+            result = ParseDescriptorBlockVariableUsage(p_parser, p_module, p_access_chain, 0, (SpvOp)INVALID_VALUE,
+                                                       &p_descriptor->block);
+            if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                return result;
+            }
+        }
+
+        p_descriptor->block.name = p_descriptor->name;
+
+        bool is_parent_rta = (p_descriptor->descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+        result = ParseDescriptorBlockVariableSizes(p_parser, p_module, true, false, is_parent_rta, &p_descriptor->block);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            return result;
+        }
+
+        if (is_parent_rta) {
+            p_descriptor->block.size = 0;
+            p_descriptor->block.padded_size = 0;
+        }
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseFormat(const SpvReflectTypeDescription* p_type, SpvReflectFormat* p_format) {
+    SpvReflectResult result = SPV_REFLECT_RESULT_ERROR_INTERNAL_ERROR;
+    bool signedness = (p_type->traits.numeric.scalar.signedness != 0);
+    uint32_t bit_width = p_type->traits.numeric.scalar.width;
+    if (p_type->type_flags & SPV_REFLECT_TYPE_FLAG_VECTOR) {
+        uint32_t component_count = p_type->traits.numeric.vector.component_count;
+        if (p_type->type_flags & SPV_REFLECT_TYPE_FLAG_FLOAT) {
+            switch (bit_width) {
+                case 32: {
+                    switch (component_count) {
+                        case 2:
+                            *p_format = SPV_REFLECT_FORMAT_R32G32_SFLOAT;
+                            break;
+                        case 3:
+                            *p_format = SPV_REFLECT_FORMAT_R32G32B32_SFLOAT;
+                            break;
+                        case 4:
+                            *p_format = SPV_REFLECT_FORMAT_R32G32B32A32_SFLOAT;
+                            break;
+                    }
+                } break;
+
+                case 64: {
+                    switch (component_count) {
+                        case 2:
+                            *p_format = SPV_REFLECT_FORMAT_R64G64_SFLOAT;
+                            break;
+                        case 3:
+                            *p_format = SPV_REFLECT_FORMAT_R64G64B64_SFLOAT;
+                            break;
+                        case 4:
+                            *p_format = SPV_REFLECT_FORMAT_R64G64B64A64_SFLOAT;
+                            break;
+                    }
+                }
+            }
+            result = SPV_REFLECT_RESULT_SUCCESS;
+        } else if (p_type->type_flags & (SPV_REFLECT_TYPE_FLAG_INT | SPV_REFLECT_TYPE_FLAG_BOOL)) {
+            switch (bit_width) {
+                case 32: {
+                    switch (component_count) {
+                        case 2:
+                            *p_format = signedness ? SPV_REFLECT_FORMAT_R32G32_SINT : SPV_REFLECT_FORMAT_R32G32_UINT;
+                            break;
+                        case 3:
+                            *p_format = signedness ? SPV_REFLECT_FORMAT_R32G32B32_SINT : SPV_REFLECT_FORMAT_R32G32B32_UINT;
+                            break;
+                        case 4:
+                            *p_format = signedness ? SPV_REFLECT_FORMAT_R32G32B32A32_SINT : SPV_REFLECT_FORMAT_R32G32B32A32_UINT;
+                            break;
+                    }
+                } break;
+
+                case 64: {
+                    switch (component_count) {
+                        case 2:
+                            *p_format = signedness ? SPV_REFLECT_FORMAT_R64G64_SINT : SPV_REFLECT_FORMAT_R64G64_UINT;
+                            break;
+                        case 3:
+                            *p_format = signedness ? SPV_REFLECT_FORMAT_R64G64B64_SINT : SPV_REFLECT_FORMAT_R64G64B64_UINT;
+                            break;
+                        case 4:
+                            *p_format = signedness ? SPV_REFLECT_FORMAT_R64G64B64A64_SINT : SPV_REFLECT_FORMAT_R64G64B64A64_UINT;
+                            break;
+                    }
+                }
+            }
+            result = SPV_REFLECT_RESULT_SUCCESS;
+        }
+    } else if (p_type->type_flags & SPV_REFLECT_TYPE_FLAG_FLOAT) {
+        switch (bit_width) {
+            case 32:
+                *p_format = SPV_REFLECT_FORMAT_R32_SFLOAT;
+                break;
+            case 64:
+                *p_format = SPV_REFLECT_FORMAT_R64_SFLOAT;
+                break;
+        }
+        result = SPV_REFLECT_RESULT_SUCCESS;
+    } else if (p_type->type_flags & (SPV_REFLECT_TYPE_FLAG_INT | SPV_REFLECT_TYPE_FLAG_BOOL)) {
+        switch (bit_width) {
+            case 32:
+                *p_format = signedness ? SPV_REFLECT_FORMAT_R32_SINT : SPV_REFLECT_FORMAT_R32_UINT;
+                break;
+                break;
+            case 64:
+                *p_format = signedness ? SPV_REFLECT_FORMAT_R64_SINT : SPV_REFLECT_FORMAT_R64_UINT;
+                break;
+        }
+        result = SPV_REFLECT_RESULT_SUCCESS;
+    } else if (p_type->type_flags & SPV_REFLECT_TYPE_FLAG_STRUCT) {
+        *p_format = SPV_REFLECT_FORMAT_UNDEFINED;
+        result = SPV_REFLECT_RESULT_SUCCESS;
+    }
+    return result;
+}
+
+static SpvReflectResult ParseInterfaceVariable(SpvReflectPrvParser* p_parser,
+                                               const SpvReflectPrvDecorations* p_var_node_decorations,
+                                               const SpvReflectPrvDecorations* p_type_node_decorations,
+                                               SpvReflectShaderModule* p_module, SpvReflectTypeDescription* p_type,
+                                               SpvReflectInterfaceVariable* p_var, bool* p_has_built_in) {
+    SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
+    if (IsNull(p_type_node)) {
+        return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+    }
+
+    if (p_type->member_count > 0) {
+        p_var->member_count = p_type->member_count;
+        p_var->members = (SpvReflectInterfaceVariable*)calloc(p_var->member_count, sizeof(*p_var->members));
+        if (IsNull(p_var->members)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+
+        for (uint32_t member_index = 0; member_index < p_type_node->member_count; ++member_index) {
+            SpvReflectPrvDecorations* p_member_decorations = &p_type_node->member_decorations[member_index];
+            SpvReflectTypeDescription* p_member_type = &p_type->members[member_index];
+            SpvReflectInterfaceVariable* p_member_var = &p_var->members[member_index];
+            p_member_var->storage_class = p_var->storage_class;
+            SpvReflectResult result =
+                ParseInterfaceVariable(p_parser, NULL, p_member_decorations, p_module, p_member_type, p_member_var, p_has_built_in);
+            if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                SPV_REFLECT_ASSERT(false);
+                return result;
+            }
+        }
+    }
+
+    p_var->name = p_type_node->name;
+    p_var->decoration_flags = ApplyDecorations(p_type_node_decorations);
+    if (p_var_node_decorations != NULL) {
+        p_var->decoration_flags |= ApplyDecorations(p_var_node_decorations);
+    } else {
+        // Apply values to struct members
+        p_var->location = p_type_node_decorations->location.value;
+        p_var->component = p_type_node_decorations->component.value;
+    }
+    p_var->built_in = p_type_node_decorations->built_in;
+    ApplyNumericTraits(p_type, &p_var->numeric);
+    if (p_type->op == SpvOpTypeArray) {
+        ApplyArrayTraits(p_type, &p_var->array);
+    }
+
+    p_var->type_description = p_type;
+
+    *p_has_built_in |= p_type_node_decorations->is_built_in;
+
+    // Only parse format for interface variables that are input or output
+    if ((p_var->storage_class == SpvStorageClassInput) || (p_var->storage_class == SpvStorageClassOutput)) {
+        SpvReflectResult result = ParseFormat(p_var->type_description, &p_var->format);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            SPV_REFLECT_ASSERT(false);
+            return result;
+        }
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseInterfaceVariables(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module,
+                                                SpvReflectEntryPoint* p_entry, uint32_t interface_variable_count,
+                                                uint32_t* p_interface_variable_ids) {
+    if (interface_variable_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    p_entry->interface_variable_count = interface_variable_count;
+    p_entry->input_variable_count = 0;
+    p_entry->output_variable_count = 0;
+    for (size_t i = 0; i < interface_variable_count; ++i) {
+        uint32_t var_result_id = *(p_interface_variable_ids + i);
+        SpvReflectPrvNode* p_node = FindNode(p_parser, var_result_id);
+        if (IsNull(p_node)) {
+            return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+        }
+
+        if (p_node->storage_class == SpvStorageClassInput) {
+            p_entry->input_variable_count += 1;
+        } else if (p_node->storage_class == SpvStorageClassOutput) {
+            p_entry->output_variable_count += 1;
+        }
+    }
+
+    if (p_entry->input_variable_count > 0) {
+        p_entry->input_variables =
+            (SpvReflectInterfaceVariable**)calloc(p_entry->input_variable_count, sizeof(*(p_entry->input_variables)));
+        if (IsNull(p_entry->input_variables)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+    }
+
+    if (p_entry->output_variable_count > 0) {
+        p_entry->output_variables =
+            (SpvReflectInterfaceVariable**)calloc(p_entry->output_variable_count, sizeof(*(p_entry->output_variables)));
+        if (IsNull(p_entry->output_variables)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+    }
+
+    if (p_entry->interface_variable_count > 0) {
+        p_entry->interface_variables =
+            (SpvReflectInterfaceVariable*)calloc(p_entry->interface_variable_count, sizeof(*(p_entry->interface_variables)));
+        if (IsNull(p_entry->interface_variables)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+    }
+
+    size_t input_index = 0;
+    size_t output_index = 0;
+    for (size_t i = 0; i < interface_variable_count; ++i) {
+        uint32_t var_result_id = *(p_interface_variable_ids + i);
+        SpvReflectPrvNode* p_node = FindNode(p_parser, var_result_id);
+        if (IsNull(p_node)) {
+            return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+        }
+
+        SpvReflectTypeDescription* p_type = FindType(p_module, p_node->type_id);
+        if (IsNull(p_node)) {
+            return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+        }
+        // If the type is a pointer, resolve it
+        if (p_type->op == SpvOpTypePointer) {
+            // Find the type's node
+            SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
+            if (IsNull(p_type_node)) {
+                return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+            }
+            // Should be the resolved type
+            p_type = FindType(p_module, p_type_node->type_id);
+            if (IsNull(p_type)) {
+                return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+            }
+        }
+
+        SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
+        if (IsNull(p_type_node)) {
+            return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+        }
+
+        SpvReflectInterfaceVariable* p_var = &(p_entry->interface_variables[i]);
+        p_var->storage_class = p_node->storage_class;
+
+        bool has_built_in = p_node->decorations.is_built_in;
+        SpvReflectResult result = ParseInterfaceVariable(p_parser, &p_node->decorations, &p_type_node->decorations, p_module,
+                                                         p_type, p_var, &has_built_in);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            SPV_REFLECT_ASSERT(false);
+            return result;
+        }
+
+        // Input and output variables
+        if (p_var->storage_class == SpvStorageClassInput) {
+            p_entry->input_variables[input_index] = p_var;
+            ++input_index;
+        } else if (p_node->storage_class == SpvStorageClassOutput) {
+            p_entry->output_variables[output_index] = p_var;
+            ++output_index;
+        }
+
+        // SPIR-V result id
+        p_var->spirv_id = p_node->result_id;
+        // Name
+        p_var->name = p_node->name;
+        // Semantic
+        p_var->semantic = p_node->decorations.semantic.value;
+
+        // Decorate with built-in if any member is built-in
+        if (has_built_in) {
+            p_var->decoration_flags |= SPV_REFLECT_DECORATION_BUILT_IN;
+        }
+
+        // Location is decorated on OpVariable node, not the type node.
+        p_var->location = p_node->decorations.location.value;
+        p_var->component = p_node->decorations.component.value;
+        p_var->word_offset.location = p_node->decorations.location.word_offset;
+
+        // Built in
+        if (p_node->decorations.is_built_in) {
+            p_var->built_in = p_node->decorations.built_in;
+        }
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult EnumerateAllPushConstants(SpvReflectShaderModule* p_module, size_t* p_push_constant_count,
+                                                  uint32_t** p_push_constants) {
+    *p_push_constant_count = p_module->push_constant_block_count;
+    if (*p_push_constant_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+    *p_push_constants = (uint32_t*)calloc(*p_push_constant_count, sizeof(**p_push_constants));
+
+    if (IsNull(*p_push_constants)) {
+        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
+
+    for (size_t i = 0; i < *p_push_constant_count; ++i) {
+        (*p_push_constants)[i] = p_module->push_constant_blocks[i].spirv_id;
+    }
+    qsort(*p_push_constants, *p_push_constant_count, sizeof(**p_push_constants), SortCompareUint32);
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult TraverseCallGraph(SpvReflectPrvParser* p_parser, SpvReflectPrvFunction* p_func, size_t* p_func_count,
+                                          uint32_t* p_func_ids, uint32_t depth) {
+    if (depth > p_parser->function_count) {
+        // Vulkan does not permit recursion (Vulkan spec Appendix A):
+        //   "Recursion: The static function-call graph for an entry point must not
+        //    contain cycles."
+        return SPV_REFLECT_RESULT_ERROR_SPIRV_RECURSION;
+    }
+    if (IsNotNull(p_func_ids)) {
+        p_func_ids[(*p_func_count)++] = p_func->id;
+    } else {
+        ++*p_func_count;
+    }
+    for (size_t i = 0; i < p_func->callee_count; ++i) {
+        SpvReflectResult result = TraverseCallGraph(p_parser, p_func->callee_ptrs[i], p_func_count, p_func_ids, depth + 1);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            return result;
+        }
+    }
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseStaticallyUsedResources(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module,
+                                                     SpvReflectEntryPoint* p_entry, size_t uniform_count, uint32_t* uniforms,
+                                                     size_t push_constant_count, uint32_t* push_constants) {
+    // Find function with the right id
+    SpvReflectPrvFunction* p_func = NULL;
+    for (size_t i = 0; i < p_parser->function_count; ++i) {
+        if (p_parser->functions[i].id == p_entry->id) {
+            p_func = &(p_parser->functions[i]);
+            break;
+        }
+    }
+    if (p_func == NULL) {
+        return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+    }
+
+    size_t called_function_count = 0;
+    SpvReflectResult result = TraverseCallGraph(p_parser, p_func, &called_function_count, NULL, 0);
+    if (result != SPV_REFLECT_RESULT_SUCCESS) {
+        return result;
+    }
+
+    uint32_t* p_called_functions = NULL;
+    if (called_function_count > 0) {
+        p_called_functions = (uint32_t*)calloc(called_function_count, sizeof(*p_called_functions));
+        if (IsNull(p_called_functions)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+    }
+
+    called_function_count = 0;
+    result = TraverseCallGraph(p_parser, p_func, &called_function_count, p_called_functions, 0);
+    if (result != SPV_REFLECT_RESULT_SUCCESS) {
+        return result;
+    }
+
+    if (called_function_count > 0) {
+        qsort(p_called_functions, called_function_count, sizeof(*p_called_functions), SortCompareUint32);
+    }
+    called_function_count = DedupSortedUint32(p_called_functions, called_function_count);
+
+    uint32_t used_variable_count = 0;
+    for (size_t i = 0, j = 0; i < called_function_count; ++i) {
+        // No need to bounds check j because a missing ID issue would have been
+        // found during TraverseCallGraph
+        while (p_parser->functions[j].id != p_called_functions[i]) {
+            ++j;
+        }
+        used_variable_count += p_parser->functions[j].accessed_ptr_count;
+    }
+    uint32_t* used_variables = NULL;
+    if (used_variable_count > 0) {
+        used_variables = (uint32_t*)calloc(used_variable_count, sizeof(*used_variables));
+        if (IsNull(used_variables)) {
+            SafeFree(p_called_functions);
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+    }
+    used_variable_count = 0;
+    for (size_t i = 0, j = 0; i < called_function_count; ++i) {
+        while (p_parser->functions[j].id != p_called_functions[i]) {
+            ++j;
+        }
+
+        memcpy(&used_variables[used_variable_count], p_parser->functions[j].accessed_ptrs,
+               p_parser->functions[j].accessed_ptr_count * sizeof(*used_variables));
+        used_variable_count += p_parser->functions[j].accessed_ptr_count;
+    }
+    SafeFree(p_called_functions);
+
+    if (used_variable_count > 0) {
+        qsort(used_variables, used_variable_count, sizeof(*used_variables), SortCompareUint32);
+    }
+    used_variable_count = (uint32_t)DedupSortedUint32(used_variables, used_variable_count);
+
+    // Do set intersection to find the used uniform and push constants
+    size_t used_uniform_count = 0;
+    //
+    SpvReflectResult result0 = IntersectSortedUint32(used_variables, used_variable_count, uniforms, uniform_count,
+                                                     &p_entry->used_uniforms, &used_uniform_count);
+
+    size_t used_push_constant_count = 0;
+    //
+    SpvReflectResult result1 = IntersectSortedUint32(used_variables, used_variable_count, push_constants, push_constant_count,
+                                                     &p_entry->used_push_constants, &used_push_constant_count);
+
+    for (uint32_t j = 0; j < p_module->descriptor_binding_count; ++j) {
+        SpvReflectDescriptorBinding* p_binding = &p_module->descriptor_bindings[j];
+        bool found = SearchSortedUint32(used_variables, used_variable_count, p_binding->spirv_id);
+        if (found) {
+            p_binding->accessed = 1;
+        }
+    }
+
+    SafeFree(used_variables);
+    if (result0 != SPV_REFLECT_RESULT_SUCCESS) {
+        return result0;
+    }
+    if (result1 != SPV_REFLECT_RESULT_SUCCESS) {
+        return result1;
+    }
+
+    p_entry->used_uniform_count = (uint32_t)used_uniform_count;
+    p_entry->used_push_constant_count = (uint32_t)used_push_constant_count;
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseEntryPoints(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module) {
+    if (p_parser->entry_point_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    p_module->entry_point_count = p_parser->entry_point_count;
+    p_module->entry_points = (SpvReflectEntryPoint*)calloc(p_module->entry_point_count, sizeof(*(p_module->entry_points)));
+    if (IsNull(p_module->entry_points)) {
+        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
+
+    SpvReflectResult result;
+    size_t uniform_count = 0;
+    uint32_t* uniforms = NULL;
+    if ((result = EnumerateAllUniforms(p_module, &uniform_count, &uniforms)) != SPV_REFLECT_RESULT_SUCCESS) {
+        return result;
+    }
+    size_t push_constant_count = 0;
+    uint32_t* push_constants = NULL;
+    if ((result = EnumerateAllPushConstants(p_module, &push_constant_count, &push_constants)) != SPV_REFLECT_RESULT_SUCCESS) {
+        return result;
+    }
+
+    size_t entry_point_index = 0;
+    for (size_t i = 0; entry_point_index < p_parser->entry_point_count && i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+        if (p_node->op != SpvOpEntryPoint) {
+            continue;
+        }
+
+        SpvReflectEntryPoint* p_entry_point = &(p_module->entry_points[entry_point_index]);
+        CHECKED_READU32_CAST(p_parser, p_node->word_offset + 1, SpvExecutionModel, p_entry_point->spirv_execution_model);
+        CHECKED_READU32(p_parser, p_node->word_offset + 2, p_entry_point->id);
+
+        switch (p_entry_point->spirv_execution_model) {
+            default:
+                break;
+            case SpvExecutionModelVertex:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_VERTEX_BIT;
+                break;
+            case SpvExecutionModelTessellationControl:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
+                break;
+            case SpvExecutionModelTessellationEvaluation:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
+                break;
+            case SpvExecutionModelGeometry:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_GEOMETRY_BIT;
+                break;
+            case SpvExecutionModelFragment:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_FRAGMENT_BIT;
+                break;
+            case SpvExecutionModelGLCompute:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_COMPUTE_BIT;
+                break;
+            case SpvExecutionModelTaskNV:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_TASK_BIT_NV;
+                break;
+            case SpvExecutionModelTaskEXT:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_TASK_BIT_EXT;
+                break;
+            case SpvExecutionModelMeshNV:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_MESH_BIT_NV;
+                break;
+            case SpvExecutionModelMeshEXT:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_MESH_BIT_EXT;
+                break;
+            case SpvExecutionModelRayGenerationKHR:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_RAYGEN_BIT_KHR;
+                break;
+            case SpvExecutionModelIntersectionKHR:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_INTERSECTION_BIT_KHR;
+                break;
+            case SpvExecutionModelAnyHitKHR:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_ANY_HIT_BIT_KHR;
+                break;
+            case SpvExecutionModelClosestHitKHR:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
+                break;
+            case SpvExecutionModelMissKHR:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_MISS_BIT_KHR;
+                break;
+            case SpvExecutionModelCallableKHR:
+                p_entry_point->shader_stage = SPV_REFLECT_SHADER_STAGE_CALLABLE_BIT_KHR;
+                break;
+        }
+
+        ++entry_point_index;
+
+        // Name length is required to calculate next operand
+        uint32_t name_start_word_offset = 3;
+        uint32_t name_length_with_terminator = 0;
+        result = ReadStr(p_parser, p_node->word_offset + name_start_word_offset, 0, p_node->word_count,
+                         &name_length_with_terminator, NULL);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            return result;
+        }
+        p_entry_point->name = (const char*)(p_parser->spirv_code + p_node->word_offset + name_start_word_offset);
+
+        uint32_t name_word_count = RoundUp(name_length_with_terminator, SPIRV_WORD_SIZE) / SPIRV_WORD_SIZE;
+        uint32_t interface_variable_count = (p_node->word_count - (name_start_word_offset + name_word_count));
+        uint32_t* p_interface_variables = NULL;
+        if (interface_variable_count > 0) {
+            p_interface_variables = (uint32_t*)calloc(interface_variable_count, sizeof(*(p_interface_variables)));
+            if (IsNull(p_interface_variables)) {
+                return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+            }
+        }
+
+        for (uint32_t var_index = 0; var_index < interface_variable_count; ++var_index) {
+            uint32_t var_result_id = (uint32_t)INVALID_VALUE;
+            uint32_t offset = name_start_word_offset + name_word_count + var_index;
+            CHECKED_READU32(p_parser, p_node->word_offset + offset, var_result_id);
+            p_interface_variables[var_index] = var_result_id;
+        }
+
+        result = ParseInterfaceVariables(p_parser, p_module, p_entry_point, interface_variable_count, p_interface_variables);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            return result;
+        }
+        SafeFree(p_interface_variables);
+
+        result = ParseStaticallyUsedResources(p_parser, p_module, p_entry_point, uniform_count, uniforms, push_constant_count,
+                                              push_constants);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            return result;
+        }
+    }
+
+    SafeFree(uniforms);
+    SafeFree(push_constants);
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseExecutionModes(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module) {
+    assert(IsNotNull(p_parser));
+    assert(IsNotNull(p_parser->nodes));
+    assert(IsNotNull(p_module));
+
+    if (IsNotNull(p_parser) && IsNotNull(p_parser->spirv_code) && IsNotNull(p_parser->nodes)) {
+        for (size_t node_idx = 0; node_idx < p_parser->node_count; ++node_idx) {
+            SpvReflectPrvNode* p_node = &(p_parser->nodes[node_idx]);
+            if (p_node->op != SpvOpExecutionMode) {
+                continue;
+            }
+
+            // Read entry point id
+            uint32_t entry_point_id = 0;
+            CHECKED_READU32(p_parser, p_node->word_offset + 1, entry_point_id);
+
+            // Find entry point
+            SpvReflectEntryPoint* p_entry_point = NULL;
+            for (size_t entry_point_idx = 0; entry_point_idx < p_module->entry_point_count; ++entry_point_idx) {
+                if (p_module->entry_points[entry_point_idx].id == entry_point_id) {
+                    p_entry_point = &p_module->entry_points[entry_point_idx];
+                    break;
+                }
+            }
+            // Bail if entry point is null
+            if (IsNull(p_entry_point)) {
+                return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ENTRY_POINT;
+            }
+
+            // Read execution mode
+            uint32_t execution_mode = (uint32_t)INVALID_VALUE;
+            CHECKED_READU32(p_parser, p_node->word_offset + 2, execution_mode);
+
+            // Parse execution mode
+            switch (execution_mode) {
+                default: {
+                    return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_EXECUTION_MODE;
+                } break;
+
+                case SpvExecutionModeInvocations: {
+                    CHECKED_READU32(p_parser, p_node->word_offset + 3, p_entry_point->invocations);
+                } break;
+
+                case SpvExecutionModeSpacingEqual:
+                case SpvExecutionModeSpacingFractionalEven:
+                case SpvExecutionModeSpacingFractionalOdd:
+                case SpvExecutionModeVertexOrderCw:
+                case SpvExecutionModeVertexOrderCcw:
+                case SpvExecutionModePixelCenterInteger:
+                case SpvExecutionModeOriginUpperLeft:
+                case SpvExecutionModeOriginLowerLeft:
+                case SpvExecutionModeEarlyFragmentTests:
+                case SpvExecutionModePointMode:
+                case SpvExecutionModeXfb:
+                case SpvExecutionModeDepthReplacing:
+                case SpvExecutionModeDepthGreater:
+                case SpvExecutionModeDepthLess:
+                case SpvExecutionModeDepthUnchanged:
+                    break;
+
+                case SpvExecutionModeLocalSize: {
+                    CHECKED_READU32(p_parser, p_node->word_offset + 3, p_entry_point->local_size.x);
+                    CHECKED_READU32(p_parser, p_node->word_offset + 4, p_entry_point->local_size.y);
+                    CHECKED_READU32(p_parser, p_node->word_offset + 5, p_entry_point->local_size.z);
+                } break;
+
+                case SpvExecutionModeLocalSizeHint:
+                case SpvExecutionModeInputPoints:
+                case SpvExecutionModeInputLines:
+                case SpvExecutionModeInputLinesAdjacency:
+                case SpvExecutionModeTriangles:
+                case SpvExecutionModeInputTrianglesAdjacency:
+                case SpvExecutionModeQuads:
+                case SpvExecutionModeIsolines:
+                case SpvExecutionModeOutputVertices: {
+                    CHECKED_READU32(p_parser, p_node->word_offset + 3, p_entry_point->output_vertices);
+                } break;
+
+                case SpvExecutionModeOutputPoints:
+                case SpvExecutionModeOutputLineStrip:
+                case SpvExecutionModeOutputTriangleStrip:
+                case SpvExecutionModeVecTypeHint:
+                case SpvExecutionModeContractionOff:
+                case SpvExecutionModeInitializer:
+                case SpvExecutionModeFinalizer:
+                case SpvExecutionModeSubgroupSize:
+                case SpvExecutionModeSubgroupsPerWorkgroup:
+                case SpvExecutionModeSubgroupsPerWorkgroupId:
+                case SpvExecutionModeLocalSizeId:
+                case SpvExecutionModeLocalSizeHintId:
+                case SpvExecutionModePostDepthCoverage:
+                case SpvExecutionModeDenormPreserve:
+                case SpvExecutionModeDenormFlushToZero:
+                case SpvExecutionModeSignedZeroInfNanPreserve:
+                case SpvExecutionModeRoundingModeRTE:
+                case SpvExecutionModeRoundingModeRTZ:
+                case SpvExecutionModeStencilRefReplacingEXT:
+                case SpvExecutionModeOutputLinesNV:
+                case SpvExecutionModeOutputPrimitivesNV:
+                case SpvExecutionModeOutputTrianglesNV:
+                    break;
+            }
+            p_entry_point->execution_mode_count++;
+        }
+        uint32_t* indices = (uint32_t*)calloc(p_module->entry_point_count, sizeof(indices));
+        if (IsNull(indices)) {
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+        for (size_t entry_point_idx = 0; entry_point_idx < p_module->entry_point_count; ++entry_point_idx) {
+            SpvReflectEntryPoint* p_entry_point = &p_module->entry_points[entry_point_idx];
+            if (p_entry_point->execution_mode_count > 0) {
+                p_entry_point->execution_modes =
+                    (SpvExecutionMode*)calloc(p_entry_point->execution_mode_count, sizeof(*p_entry_point->execution_modes));
+                if (IsNull(p_entry_point->execution_modes)) {
+                    SafeFree(indices);
+                    return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+                }
+            }
+        }
+
+        for (size_t node_idx = 0; node_idx < p_parser->node_count; ++node_idx) {
+            SpvReflectPrvNode* p_node = &(p_parser->nodes[node_idx]);
+            if (p_node->op != SpvOpExecutionMode) {
+                continue;
+            }
+
+            // Read entry point id
+            uint32_t entry_point_id = 0;
+            CHECKED_READU32(p_parser, p_node->word_offset + 1, entry_point_id);
+
+            // Find entry point
+            SpvReflectEntryPoint* p_entry_point = NULL;
+            uint32_t* idx = NULL;
+            for (size_t entry_point_idx = 0; entry_point_idx < p_module->entry_point_count; ++entry_point_idx) {
+                if (p_module->entry_points[entry_point_idx].id == entry_point_id) {
+                    p_entry_point = &p_module->entry_points[entry_point_idx];
+                    idx = &indices[entry_point_idx];
+                    break;
+                }
+            }
+
+            // Read execution mode
+            uint32_t execution_mode = (uint32_t)INVALID_VALUE;
+            CHECKED_READU32(p_parser, p_node->word_offset + 2, execution_mode);
+            p_entry_point->execution_modes[(*idx)++] = (SpvExecutionMode)execution_mode;
+        }
+        SafeFree(indices);
+    }
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParsePushConstantBlocks(SpvReflectPrvParser* p_parser, SpvReflectShaderModule* p_module) {
+    for (size_t i = 0; i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+        if ((p_node->op != SpvOpVariable) || (p_node->storage_class != SpvStorageClassPushConstant)) {
+            continue;
+        }
+
+        p_module->push_constant_block_count += 1;
+    }
+
+    if (p_module->push_constant_block_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    p_module->push_constant_blocks =
+        (SpvReflectBlockVariable*)calloc(p_module->push_constant_block_count, sizeof(*p_module->push_constant_blocks));
+    if (IsNull(p_module->push_constant_blocks)) {
+        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
+
+    uint32_t push_constant_index = 0;
+    for (size_t i = 0; i < p_parser->node_count; ++i) {
+        SpvReflectPrvNode* p_node = &(p_parser->nodes[i]);
+        if ((p_node->op != SpvOpVariable) || (p_node->storage_class != SpvStorageClassPushConstant)) {
+            continue;
+        }
+
+        SpvReflectTypeDescription* p_type = FindType(p_module, p_node->type_id);
+        if (IsNull(p_node)) {
+            return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+        }
+        // If the type is a pointer, resolve it
+        if (p_type->op == SpvOpTypePointer) {
+            // Find the type's node
+            SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
+            if (IsNull(p_type_node)) {
+                return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+            }
+            // Should be the resolved type
+            p_type = FindType(p_module, p_type_node->type_id);
+            if (IsNull(p_type)) {
+                return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+            }
+        }
+
+        SpvReflectPrvNode* p_type_node = FindNode(p_parser, p_type->id);
+        if (IsNull(p_type_node)) {
+            return SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE;
+        }
+
+        SpvReflectBlockVariable* p_push_constant = &p_module->push_constant_blocks[push_constant_index];
+        p_push_constant->spirv_id = p_node->result_id;
+        SpvReflectResult result = ParseDescriptorBlockVariable(p_parser, p_module, p_type, p_push_constant);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            return result;
+        }
+
+        for (uint32_t access_chain_index = 0; access_chain_index < p_parser->access_chain_count; ++access_chain_index) {
+            SpvReflectPrvAccessChain* p_access_chain = &(p_parser->access_chains[access_chain_index]);
+            // Skip any access chains that aren't touching this push constant block
+            if (p_push_constant->spirv_id != p_access_chain->base_id) {
+                continue;
+            }
+            result =
+                ParseDescriptorBlockVariableUsage(p_parser, p_module, p_access_chain, 0, (SpvOp)INVALID_VALUE, p_push_constant);
+            if (result != SPV_REFLECT_RESULT_SUCCESS) {
+                return result;
+            }
+        }
+
+        p_push_constant->name = p_node->name;
+        result = ParseDescriptorBlockVariableSizes(p_parser, p_module, true, false, false, p_push_constant);
+        if (result != SPV_REFLECT_RESULT_SUCCESS) {
+            return result;
+        }
+
+        ++push_constant_index;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static int SortCompareDescriptorSet(const void* a, const void* b) {
+    const SpvReflectDescriptorSet* p_elem_a = (const SpvReflectDescriptorSet*)a;
+    const SpvReflectDescriptorSet* p_elem_b = (const SpvReflectDescriptorSet*)b;
+    int value = (int)(p_elem_a->set) - (int)(p_elem_b->set);
+    // We should never see duplicate descriptor set numbers in a shader; if so, a tiebreaker
+    // would be needed here.
+    assert(value != 0);
+    return value;
+}
+
+static SpvReflectResult ParseEntrypointDescriptorSets(SpvReflectShaderModule* p_module) {
+    // Update the entry point's sets
+    for (uint32_t i = 0; i < p_module->entry_point_count; ++i) {
+        SpvReflectEntryPoint* p_entry = &p_module->entry_points[i];
+        for (uint32_t j = 0; j < p_entry->descriptor_set_count; ++j) {
+            SafeFree(p_entry->descriptor_sets[j].bindings);
+        }
+        SafeFree(p_entry->descriptor_sets);
+        p_entry->descriptor_set_count = 0;
+        for (uint32_t j = 0; j < p_module->descriptor_set_count; ++j) {
+            const SpvReflectDescriptorSet* p_set = &p_module->descriptor_sets[j];
+            for (uint32_t k = 0; k < p_set->binding_count; ++k) {
+                bool found = SearchSortedUint32(p_entry->used_uniforms, p_entry->used_uniform_count, p_set->bindings[k]->spirv_id);
+                if (found) {
+                    ++p_entry->descriptor_set_count;
+                    break;
+                }
+            }
+        }
+
+        p_entry->descriptor_sets = NULL;
+        if (p_entry->descriptor_set_count > 0) {
+            p_entry->descriptor_sets =
+                (SpvReflectDescriptorSet*)calloc(p_entry->descriptor_set_count, sizeof(*p_entry->descriptor_sets));
+            if (IsNull(p_entry->descriptor_sets)) {
+                return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+            }
+        }
+        p_entry->descriptor_set_count = 0;
+        for (uint32_t j = 0; j < p_module->descriptor_set_count; ++j) {
+            const SpvReflectDescriptorSet* p_set = &p_module->descriptor_sets[j];
+            uint32_t count = 0;
+            for (uint32_t k = 0; k < p_set->binding_count; ++k) {
+                bool found = SearchSortedUint32(p_entry->used_uniforms, p_entry->used_uniform_count, p_set->bindings[k]->spirv_id);
+                if (found) {
+                    ++count;
+                }
+            }
+            if (count == 0) {
+                continue;
+            }
+            SpvReflectDescriptorSet* p_entry_set = &p_entry->descriptor_sets[p_entry->descriptor_set_count++];
+            p_entry_set->set = p_set->set;
+            p_entry_set->bindings = (SpvReflectDescriptorBinding**)calloc(count, sizeof(*p_entry_set->bindings));
+            if (IsNull(p_entry_set->bindings)) {
+                return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+            }
+            for (uint32_t k = 0; k < p_set->binding_count; ++k) {
+                bool found = SearchSortedUint32(p_entry->used_uniforms, p_entry->used_uniform_count, p_set->bindings[k]->spirv_id);
+                if (found) {
+                    p_entry_set->bindings[p_entry_set->binding_count++] = p_set->bindings[k];
+                }
+            }
+        }
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult ParseDescriptorSets(SpvReflectShaderModule* p_module) {
+    // Count the descriptors in each set
+    for (uint32_t i = 0; i < p_module->descriptor_binding_count; ++i) {
+        SpvReflectDescriptorBinding* p_descriptor = &(p_module->descriptor_bindings[i]);
+
+        // Look for a target set using the descriptor's set number
+        SpvReflectDescriptorSet* p_target_set = NULL;
+        for (uint32_t j = 0; j < SPV_REFLECT_MAX_DESCRIPTOR_SETS; ++j) {
+            SpvReflectDescriptorSet* p_set = &p_module->descriptor_sets[j];
+            if (p_set->set == p_descriptor->set) {
+                p_target_set = p_set;
+                break;
+            }
+        }
+
+        // If a target set isn't found, find the first available one.
+        if (IsNull(p_target_set)) {
+            for (uint32_t j = 0; j < SPV_REFLECT_MAX_DESCRIPTOR_SETS; ++j) {
+                SpvReflectDescriptorSet* p_set = &p_module->descriptor_sets[j];
+                if (p_set->set == (uint32_t)INVALID_VALUE) {
+                    p_target_set = p_set;
+                    p_target_set->set = p_descriptor->set;
+                    break;
+                }
+            }
+        }
+
+        if (IsNull(p_target_set)) {
+            return SPV_REFLECT_RESULT_ERROR_INTERNAL_ERROR;
+        }
+
+        p_target_set->binding_count += 1;
+    }
+
+    // Count the descriptor sets
+    for (uint32_t i = 0; i < SPV_REFLECT_MAX_DESCRIPTOR_SETS; ++i) {
+        const SpvReflectDescriptorSet* p_set = &p_module->descriptor_sets[i];
+        if (p_set->set != (uint32_t)INVALID_VALUE) {
+            p_module->descriptor_set_count += 1;
+        }
+    }
+
+    // Sort the descriptor sets based on numbers
+    if (p_module->descriptor_set_count > 0) {
+        qsort(p_module->descriptor_sets, p_module->descriptor_set_count, sizeof(*(p_module->descriptor_sets)),
+              SortCompareDescriptorSet);
+    }
+
+    // Build descriptor pointer array
+    for (uint32_t i = 0; i < p_module->descriptor_set_count; ++i) {
+        SpvReflectDescriptorSet* p_set = &(p_module->descriptor_sets[i]);
+        p_set->bindings = (SpvReflectDescriptorBinding**)calloc(p_set->binding_count, sizeof(*(p_set->bindings)));
+
+        uint32_t descriptor_index = 0;
+        for (uint32_t j = 0; j < p_module->descriptor_binding_count; ++j) {
+            SpvReflectDescriptorBinding* p_descriptor = &(p_module->descriptor_bindings[j]);
+            if (p_descriptor->set == p_set->set) {
+                assert(descriptor_index < p_set->binding_count);
+                p_set->bindings[descriptor_index] = p_descriptor;
+                ++descriptor_index;
+            }
+        }
+    }
+
+    return ParseEntrypointDescriptorSets(p_module);
+}
+
+static SpvReflectResult DisambiguateStorageBufferSrvUav(SpvReflectShaderModule* p_module) {
+    if (p_module->descriptor_binding_count == 0) {
+        return SPV_REFLECT_RESULT_SUCCESS;
+    }
+
+    for (uint32_t descriptor_index = 0; descriptor_index < p_module->descriptor_binding_count; ++descriptor_index) {
+        SpvReflectDescriptorBinding* p_descriptor = &(p_module->descriptor_bindings[descriptor_index]);
+        // Skip everything that isn't a STORAGE_BUFFER descriptor
+        if (p_descriptor->descriptor_type != SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER) {
+            continue;
+        }
+
+        //
+        // Vulkan doesn't disambiguate between SRVs and UAVs so they
+        // come back as STORAGE_BUFFER. The block parsing process will
+        // mark a block as non-writable should any member of the block
+        // or its descendants are non-writable.
+        //
+        if (p_descriptor->block.decoration_flags & SPV_REFLECT_DECORATION_NON_WRITABLE) {
+            p_descriptor->resource_type = SPV_REFLECT_RESOURCE_FLAG_SRV;
+        }
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+static SpvReflectResult SynchronizeDescriptorSets(SpvReflectShaderModule* p_module) {
+    // Free and reset all descriptor set numbers
+    for (uint32_t i = 0; i < SPV_REFLECT_MAX_DESCRIPTOR_SETS; ++i) {
+        SpvReflectDescriptorSet* p_set = &p_module->descriptor_sets[i];
+        SafeFree(p_set->bindings);
+        p_set->binding_count = 0;
+        p_set->set = (uint32_t)INVALID_VALUE;
+    }
+    // Set descriptor set count to zero
+    p_module->descriptor_set_count = 0;
+
+    SpvReflectResult result = ParseDescriptorSets(p_module);
+    return result;
+}
+
+static SpvReflectResult CreateShaderModule(uint32_t flags, size_t size, const void* p_code, SpvReflectShaderModule* p_module) {
+    // Initialize all module fields to zero
+    memset(p_module, 0, sizeof(*p_module));
+
+    // Allocate module internals
+#ifdef __cplusplus
+    p_module->_internal = (SpvReflectShaderModule::Internal*)calloc(1, sizeof(*(p_module->_internal)));
+#else
+    p_module->_internal = calloc(1, sizeof(*(p_module->_internal)));
+#endif
+    if (IsNull(p_module->_internal)) {
+        return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+    }
+    // Copy flags
+    p_module->_internal->module_flags = flags;
+    // Figure out if we need to copy the SPIR-V code or not
+    if (flags & SPV_REFLECT_MODULE_FLAG_NO_COPY) {
+        // Set internal size and pointer to args passed in
+        p_module->_internal->spirv_size = size;
+#if defined(__cplusplus)
+        p_module->_internal->spirv_code = const_cast<uint32_t*>(static_cast<const uint32_t*>(p_code));  // cast that const away
+#else
+        p_module->_internal->spirv_code = (void*)p_code;  // cast that const away
+#endif
+        p_module->_internal->spirv_word_count = (uint32_t)(size / SPIRV_WORD_SIZE);
+    } else {
+        // Allocate SPIR-V code storage
+        p_module->_internal->spirv_size = size;
+        p_module->_internal->spirv_code = (uint32_t*)calloc(1, p_module->_internal->spirv_size);
+        p_module->_internal->spirv_word_count = (uint32_t)(size / SPIRV_WORD_SIZE);
+        if (IsNull(p_module->_internal->spirv_code)) {
+            SafeFree(p_module->_internal);
+            return SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED;
+        }
+        // Copy SPIR-V to code storage
+        memcpy(p_module->_internal->spirv_code, p_code, size);
+    }
+
+    // Initialize everything to zero
+    SpvReflectPrvParser parser;
+    memset(&parser, 0, sizeof(SpvReflectPrvParser));
+
+    // Create parser
+    SpvReflectResult result = CreateParser(p_module->_internal->spirv_size, p_module->_internal->spirv_code, &parser);
+
+    // Generator
+    {
+        const uint32_t* p_ptr = (const uint32_t*)p_module->_internal->spirv_code;
+        p_module->generator = (SpvReflectGenerator)((*(p_ptr + 2) & 0xFFFF0000) >> 16);
+    }
+
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseNodes(&parser);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseStrings(&parser);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseSource(&parser, p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseFunctions(&parser);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseMemberCounts(&parser);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseNames(&parser);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseDecorations(&parser);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+
+    // Start of reflection data parsing
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        p_module->source_language = parser.source_language;
+        p_module->source_language_version = parser.source_language_version;
+
+        // Zero out descriptor set data
+        p_module->descriptor_set_count = 0;
+        memset(p_module->descriptor_sets, 0, SPV_REFLECT_MAX_DESCRIPTOR_SETS * sizeof(*p_module->descriptor_sets));
+        // Initialize descriptor set numbers
+        for (uint32_t set_number = 0; set_number < SPV_REFLECT_MAX_DESCRIPTOR_SETS; ++set_number) {
+            p_module->descriptor_sets[set_number].set = (uint32_t)INVALID_VALUE;
+        }
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseTypes(&parser, p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseDescriptorBindings(&parser, p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseDescriptorType(p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseUAVCounterBindings(p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseDescriptorBlocks(&parser, p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParsePushConstantBlocks(&parser, p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseEntryPoints(&parser, p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseCapabilities(&parser, p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS && p_module->entry_point_count > 0) {
+        SpvReflectEntryPoint* p_entry = &(p_module->entry_points[0]);
+        p_module->entry_point_name = p_entry->name;
+        p_module->entry_point_id = p_entry->id;
+        p_module->spirv_execution_model = p_entry->spirv_execution_model;
+        p_module->shader_stage = p_entry->shader_stage;
+        p_module->input_variable_count = p_entry->input_variable_count;
+        p_module->input_variables = p_entry->input_variables;
+        p_module->output_variable_count = p_entry->output_variable_count;
+        p_module->output_variables = p_entry->output_variables;
+        p_module->interface_variable_count = p_entry->interface_variable_count;
+        p_module->interface_variables = p_entry->interface_variables;
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = DisambiguateStorageBufferSrvUav(p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = SynchronizeDescriptorSets(p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+    if (result == SPV_REFLECT_RESULT_SUCCESS) {
+        result = ParseExecutionModes(&parser, p_module);
+        SPV_REFLECT_ASSERT(result == SPV_REFLECT_RESULT_SUCCESS);
+    }
+
+    // Destroy module if parse was not successful
+    if (result != SPV_REFLECT_RESULT_SUCCESS) {
+        spvReflectDestroyShaderModule(p_module);
+    }
+
+    DestroyParser(&parser);
+
+    return result;
+}
+
+SpvReflectResult spvReflectCreateShaderModule(size_t size, const void* p_code, SpvReflectShaderModule* p_module) {
+    return CreateShaderModule(0, size, p_code, p_module);
+}
+
+SpvReflectResult spvReflectCreateShaderModule2(uint32_t flags, size_t size, const void* p_code, SpvReflectShaderModule* p_module) {
+    return CreateShaderModule(flags, size, p_code, p_module);
+}
+
+SpvReflectResult spvReflectGetShaderModule(size_t size, const void* p_code, SpvReflectShaderModule* p_module) {
+    return spvReflectCreateShaderModule(size, p_code, p_module);
+}
+
+static void SafeFreeTypes(SpvReflectTypeDescription* p_type) {
+    if (IsNull(p_type)) {
+        return;
+    }
+
+    if (IsNotNull(p_type->members)) {
+        for (size_t i = 0; i < p_type->member_count; ++i) {
+            SpvReflectTypeDescription* p_member = &p_type->members[i];
+            SafeFreeTypes(p_member);
+        }
+
+        SafeFree(p_type->members);
+        p_type->members = NULL;
+    }
+}
+
+static void SafeFreeBlockVariables(SpvReflectBlockVariable* p_block) {
+    if (IsNull(p_block)) {
+        return;
+    }
+
+    if (IsNotNull(p_block->members)) {
+        for (size_t i = 0; i < p_block->member_count; ++i) {
+            SpvReflectBlockVariable* p_member = &p_block->members[i];
+            SafeFreeBlockVariables(p_member);
+        }
+
+        SafeFree(p_block->members);
+        p_block->members = NULL;
+    }
+}
+
+static void SafeFreeInterfaceVariable(SpvReflectInterfaceVariable* p_interface) {
+    if (IsNull(p_interface)) {
+        return;
+    }
+
+    if (IsNotNull(p_interface->members)) {
+        for (size_t i = 0; i < p_interface->member_count; ++i) {
+            SpvReflectInterfaceVariable* p_member = &p_interface->members[i];
+            SafeFreeInterfaceVariable(p_member);
+        }
+
+        SafeFree(p_interface->members);
+        p_interface->members = NULL;
+    }
+}
+
+void spvReflectDestroyShaderModule(SpvReflectShaderModule* p_module) {
+    if (IsNull(p_module->_internal)) {
+        return;
+    }
+
+    SafeFree(p_module->source_source);
+
+    // Descriptor set bindings
+    for (size_t i = 0; i < p_module->descriptor_set_count; ++i) {
+        SpvReflectDescriptorSet* p_set = &p_module->descriptor_sets[i];
+        free(p_set->bindings);
+    }
+
+    // Descriptor binding blocks
+    for (size_t i = 0; i < p_module->descriptor_binding_count; ++i) {
+        SpvReflectDescriptorBinding* p_descriptor = &p_module->descriptor_bindings[i];
+        SafeFreeBlockVariables(&p_descriptor->block);
+    }
+    SafeFree(p_module->descriptor_bindings);
+
+    // Entry points
+    for (size_t i = 0; i < p_module->entry_point_count; ++i) {
+        SpvReflectEntryPoint* p_entry = &p_module->entry_points[i];
+        for (size_t j = 0; j < p_entry->interface_variable_count; j++) {
+            SafeFreeInterfaceVariable(&p_entry->interface_variables[j]);
+        }
+        for (uint32_t j = 0; j < p_entry->descriptor_set_count; ++j) {
+            SafeFree(p_entry->descriptor_sets[j].bindings);
+        }
+        SafeFree(p_entry->descriptor_sets);
+        SafeFree(p_entry->input_variables);
+        SafeFree(p_entry->output_variables);
+        SafeFree(p_entry->interface_variables);
+        SafeFree(p_entry->used_uniforms);
+        SafeFree(p_entry->used_push_constants);
+        SafeFree(p_entry->execution_modes);
+    }
+    SafeFree(p_module->capabilities);
+    SafeFree(p_module->entry_points);
+
+    // Push constants
+    for (size_t i = 0; i < p_module->push_constant_block_count; ++i) {
+        SafeFreeBlockVariables(&p_module->push_constant_blocks[i]);
+    }
+    SafeFree(p_module->push_constant_blocks);
+
+    // Type infos
+    for (size_t i = 0; i < p_module->_internal->type_description_count; ++i) {
+        SpvReflectTypeDescription* p_type = &p_module->_internal->type_descriptions[i];
+        if (IsNotNull(p_type->members)) {
+            SafeFreeTypes(p_type);
+        }
+        SafeFree(p_type->members);
+    }
+    SafeFree(p_module->_internal->type_descriptions);
+
+    // Free SPIR-V code if there was a copy
+    if ((p_module->_internal->module_flags & SPV_REFLECT_MODULE_FLAG_NO_COPY) == 0) {
+        SafeFree(p_module->_internal->spirv_code);
+    }
+    // Free internal
+    SafeFree(p_module->_internal);
+}
+
+uint32_t spvReflectGetCodeSize(const SpvReflectShaderModule* p_module) {
+    if (IsNull(p_module)) {
+        return 0;
+    }
+
+    return (uint32_t)(p_module->_internal->spirv_size);
+}
+
+const uint32_t* spvReflectGetCode(const SpvReflectShaderModule* p_module) {
+    if (IsNull(p_module)) {
+        return NULL;
+    }
+
+    return p_module->_internal->spirv_code;
+}
+
+const SpvReflectEntryPoint* spvReflectGetEntryPoint(const SpvReflectShaderModule* p_module, const char* entry_point) {
+    if (IsNull(p_module) || IsNull(entry_point)) {
+        return NULL;
+    }
+
+    for (uint32_t i = 0; i < p_module->entry_point_count; ++i) {
+        if (strcmp(p_module->entry_points[i].name, entry_point) == 0) {
+            return &p_module->entry_points[i];
+        }
+    }
+    return NULL;
+}
+
+SpvReflectResult spvReflectEnumerateDescriptorBindings(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                       SpvReflectDescriptorBinding** pp_bindings) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    if (IsNotNull(pp_bindings)) {
+        if (*p_count != p_module->descriptor_binding_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+
+        for (uint32_t index = 0; index < *p_count; ++index) {
+            SpvReflectDescriptorBinding* p_bindings = (SpvReflectDescriptorBinding*)&p_module->descriptor_bindings[index];
+            pp_bindings[index] = p_bindings;
+        }
+    } else {
+        *p_count = p_module->descriptor_binding_count;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectEnumerateEntryPointDescriptorBindings(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                                 uint32_t* p_count, SpvReflectDescriptorBinding** pp_bindings) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+    if (IsNull(p_entry)) {
+        return SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+    }
+
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < p_module->descriptor_binding_count; ++i) {
+        bool found =
+            SearchSortedUint32(p_entry->used_uniforms, p_entry->used_uniform_count, p_module->descriptor_bindings[i].spirv_id);
+        if (found) {
+            if (IsNotNull(pp_bindings)) {
+                if (count >= *p_count) {
+                    return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+                }
+                pp_bindings[count++] = (SpvReflectDescriptorBinding*)&p_module->descriptor_bindings[i];
+            } else {
+                ++count;
+            }
+        }
+    }
+    if (IsNotNull(pp_bindings)) {
+        if (count != *p_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+    } else {
+        *p_count = count;
+    }
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectEnumerateDescriptorSets(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                   SpvReflectDescriptorSet** pp_sets) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    if (IsNotNull(pp_sets)) {
+        if (*p_count != p_module->descriptor_set_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+
+        for (uint32_t index = 0; index < *p_count; ++index) {
+            SpvReflectDescriptorSet* p_set = (SpvReflectDescriptorSet*)&p_module->descriptor_sets[index];
+            pp_sets[index] = p_set;
+        }
+    } else {
+        *p_count = p_module->descriptor_set_count;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectEnumerateEntryPointDescriptorSets(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                             uint32_t* p_count, SpvReflectDescriptorSet** pp_sets) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+    if (IsNull(p_entry)) {
+        return SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+    }
+
+    if (IsNotNull(pp_sets)) {
+        if (*p_count != p_entry->descriptor_set_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+
+        for (uint32_t index = 0; index < *p_count; ++index) {
+            SpvReflectDescriptorSet* p_set = (SpvReflectDescriptorSet*)&p_entry->descriptor_sets[index];
+            pp_sets[index] = p_set;
+        }
+    } else {
+        *p_count = p_entry->descriptor_set_count;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectEnumerateInterfaceVariables(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                       SpvReflectInterfaceVariable** pp_variables) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    if (IsNotNull(pp_variables)) {
+        if (*p_count != p_module->interface_variable_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+
+        for (uint32_t index = 0; index < *p_count; ++index) {
+            SpvReflectInterfaceVariable* p_var = &p_module->interface_variables[index];
+            pp_variables[index] = p_var;
+        }
+    } else {
+        *p_count = p_module->interface_variable_count;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectEnumerateEntryPointInterfaceVariables(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                                 uint32_t* p_count, SpvReflectInterfaceVariable** pp_variables) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+    if (IsNull(p_entry)) {
+        return SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+    }
+
+    if (IsNotNull(pp_variables)) {
+        if (*p_count != p_entry->interface_variable_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+
+        for (uint32_t index = 0; index < *p_count; ++index) {
+            SpvReflectInterfaceVariable* p_var = &p_entry->interface_variables[index];
+            pp_variables[index] = p_var;
+        }
+    } else {
+        *p_count = p_entry->interface_variable_count;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectEnumerateInputVariables(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                   SpvReflectInterfaceVariable** pp_variables) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    if (IsNotNull(pp_variables)) {
+        if (*p_count != p_module->input_variable_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+
+        for (uint32_t index = 0; index < *p_count; ++index) {
+            SpvReflectInterfaceVariable* p_var = p_module->input_variables[index];
+            pp_variables[index] = p_var;
+        }
+    } else {
+        *p_count = p_module->input_variable_count;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectEnumerateEntryPointInputVariables(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                             uint32_t* p_count, SpvReflectInterfaceVariable** pp_variables) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+    if (IsNull(p_entry)) {
+        return SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+    }
+
+    if (IsNotNull(pp_variables)) {
+        if (*p_count != p_entry->input_variable_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+
+        for (uint32_t index = 0; index < *p_count; ++index) {
+            SpvReflectInterfaceVariable* p_var = p_entry->input_variables[index];
+            pp_variables[index] = p_var;
+        }
+    } else {
+        *p_count = p_entry->input_variable_count;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectEnumerateOutputVariables(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                    SpvReflectInterfaceVariable** pp_variables) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    if (IsNotNull(pp_variables)) {
+        if (*p_count != p_module->output_variable_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+
+        for (uint32_t index = 0; index < *p_count; ++index) {
+            SpvReflectInterfaceVariable* p_var = p_module->output_variables[index];
+            pp_variables[index] = p_var;
+        }
+    } else {
+        *p_count = p_module->output_variable_count;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectEnumerateEntryPointOutputVariables(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                              uint32_t* p_count, SpvReflectInterfaceVariable** pp_variables) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+    if (IsNull(p_entry)) {
+        return SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+    }
+
+    if (IsNotNull(pp_variables)) {
+        if (*p_count != p_entry->output_variable_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+
+        for (uint32_t index = 0; index < *p_count; ++index) {
+            SpvReflectInterfaceVariable* p_var = p_entry->output_variables[index];
+            pp_variables[index] = p_var;
+        }
+    } else {
+        *p_count = p_entry->output_variable_count;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectEnumeratePushConstantBlocks(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                       SpvReflectBlockVariable** pp_blocks) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    if (pp_blocks != NULL) {
+        if (*p_count != p_module->push_constant_block_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+
+        for (uint32_t index = 0; index < *p_count; ++index) {
+            SpvReflectBlockVariable* p_push_constant_blocks = (SpvReflectBlockVariable*)&p_module->push_constant_blocks[index];
+            pp_blocks[index] = p_push_constant_blocks;
+        }
+    } else {
+        *p_count = p_module->push_constant_block_count;
+    }
+
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+SpvReflectResult spvReflectEnumeratePushConstants(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                  SpvReflectBlockVariable** pp_blocks) {
+    return spvReflectEnumeratePushConstantBlocks(p_module, p_count, pp_blocks);
+}
+
+SpvReflectResult spvReflectEnumerateEntryPointPushConstantBlocks(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                                 uint32_t* p_count, SpvReflectBlockVariable** pp_blocks) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_count)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+    if (IsNull(p_entry)) {
+        return SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+    }
+
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < p_module->push_constant_block_count; ++i) {
+        bool found = SearchSortedUint32(p_entry->used_push_constants, p_entry->used_push_constant_count,
+                                        p_module->push_constant_blocks[i].spirv_id);
+        if (found) {
+            if (IsNotNull(pp_blocks)) {
+                if (count >= *p_count) {
+                    return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+                }
+                pp_blocks[count++] = (SpvReflectBlockVariable*)&p_module->push_constant_blocks[i];
+            } else {
+                ++count;
+            }
+        }
+    }
+    if (IsNotNull(pp_blocks)) {
+        if (count != *p_count) {
+            return SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH;
+        }
+    } else {
+        *p_count = count;
+    }
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+const SpvReflectDescriptorBinding* spvReflectGetDescriptorBinding(const SpvReflectShaderModule* p_module, uint32_t binding_number,
+                                                                  uint32_t set_number, SpvReflectResult* p_result) {
+    const SpvReflectDescriptorBinding* p_descriptor = NULL;
+    if (IsNotNull(p_module)) {
+        for (uint32_t index = 0; index < p_module->descriptor_binding_count; ++index) {
+            const SpvReflectDescriptorBinding* p_potential = &p_module->descriptor_bindings[index];
+            if ((p_potential->binding == binding_number) && (p_potential->set == set_number)) {
+                p_descriptor = p_potential;
+                break;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_descriptor)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_descriptor;
+}
+
+const SpvReflectDescriptorBinding* spvReflectGetEntryPointDescriptorBinding(const SpvReflectShaderModule* p_module,
+                                                                            const char* entry_point, uint32_t binding_number,
+                                                                            uint32_t set_number, SpvReflectResult* p_result) {
+    const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+    if (IsNull(p_entry)) {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+        }
+        return NULL;
+    }
+    const SpvReflectDescriptorBinding* p_descriptor = NULL;
+    if (IsNotNull(p_module)) {
+        for (uint32_t index = 0; index < p_module->descriptor_binding_count; ++index) {
+            const SpvReflectDescriptorBinding* p_potential = &p_module->descriptor_bindings[index];
+            bool found = SearchSortedUint32(p_entry->used_uniforms, p_entry->used_uniform_count, p_potential->spirv_id);
+            if ((p_potential->binding == binding_number) && (p_potential->set == set_number) && found) {
+                p_descriptor = p_potential;
+                break;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_descriptor)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_descriptor;
+}
+
+const SpvReflectDescriptorSet* spvReflectGetDescriptorSet(const SpvReflectShaderModule* p_module, uint32_t set_number,
+                                                          SpvReflectResult* p_result) {
+    const SpvReflectDescriptorSet* p_set = NULL;
+    if (IsNotNull(p_module)) {
+        for (uint32_t index = 0; index < p_module->descriptor_set_count; ++index) {
+            const SpvReflectDescriptorSet* p_potential = &p_module->descriptor_sets[index];
+            if (p_potential->set == set_number) {
+                p_set = p_potential;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_set)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_set;
+}
+
+const SpvReflectDescriptorSet* spvReflectGetEntryPointDescriptorSet(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                                    uint32_t set_number, SpvReflectResult* p_result) {
+    const SpvReflectDescriptorSet* p_set = NULL;
+    if (IsNotNull(p_module)) {
+        const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+        if (IsNull(p_entry)) {
+            if (IsNotNull(p_result)) {
+                *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+            }
+            return NULL;
+        }
+        for (uint32_t index = 0; index < p_entry->descriptor_set_count; ++index) {
+            const SpvReflectDescriptorSet* p_potential = &p_entry->descriptor_sets[index];
+            if (p_potential->set == set_number) {
+                p_set = p_potential;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_set)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_set;
+}
+
+const SpvReflectInterfaceVariable* spvReflectGetInputVariableByLocation(const SpvReflectShaderModule* p_module, uint32_t location,
+                                                                        SpvReflectResult* p_result) {
+    if (location == INVALID_VALUE) {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+        }
+        return NULL;
+    }
+    const SpvReflectInterfaceVariable* p_var = NULL;
+    if (IsNotNull(p_module)) {
+        for (uint32_t index = 0; index < p_module->input_variable_count; ++index) {
+            const SpvReflectInterfaceVariable* p_potential = p_module->input_variables[index];
+            if (p_potential->location == location) {
+                p_var = p_potential;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_var)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_var;
+}
+const SpvReflectInterfaceVariable* spvReflectGetInputVariable(const SpvReflectShaderModule* p_module, uint32_t location,
+                                                              SpvReflectResult* p_result) {
+    return spvReflectGetInputVariableByLocation(p_module, location, p_result);
+}
+
+const SpvReflectInterfaceVariable* spvReflectGetEntryPointInputVariableByLocation(const SpvReflectShaderModule* p_module,
+                                                                                  const char* entry_point, uint32_t location,
+                                                                                  SpvReflectResult* p_result) {
+    if (location == INVALID_VALUE) {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+        }
+        return NULL;
+    }
+
+    const SpvReflectInterfaceVariable* p_var = NULL;
+    if (IsNotNull(p_module)) {
+        const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+        if (IsNull(p_entry)) {
+            if (IsNotNull(p_result)) {
+                *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+            }
+            return NULL;
+        }
+        for (uint32_t index = 0; index < p_entry->input_variable_count; ++index) {
+            const SpvReflectInterfaceVariable* p_potential = p_entry->input_variables[index];
+            if (p_potential->location == location) {
+                p_var = p_potential;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_var)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_var;
+}
+
+const SpvReflectInterfaceVariable* spvReflectGetInputVariableBySemantic(const SpvReflectShaderModule* p_module,
+                                                                        const char* semantic, SpvReflectResult* p_result) {
+    if (IsNull(semantic)) {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+        }
+        return NULL;
+    }
+    if (semantic[0] == '\0') {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+        }
+        return NULL;
+    }
+    const SpvReflectInterfaceVariable* p_var = NULL;
+    if (IsNotNull(p_module)) {
+        for (uint32_t index = 0; index < p_module->input_variable_count; ++index) {
+            const SpvReflectInterfaceVariable* p_potential = p_module->input_variables[index];
+            if (p_potential->semantic != NULL && strcmp(p_potential->semantic, semantic) == 0) {
+                p_var = p_potential;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_var)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_var;
+}
+
+const SpvReflectInterfaceVariable* spvReflectGetEntryPointInputVariableBySemantic(const SpvReflectShaderModule* p_module,
+                                                                                  const char* entry_point, const char* semantic,
+                                                                                  SpvReflectResult* p_result) {
+    if (IsNull(semantic)) {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+        }
+        return NULL;
+    }
+    if (semantic[0] == '\0') {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+        }
+        return NULL;
+    }
+    const SpvReflectInterfaceVariable* p_var = NULL;
+    if (IsNotNull(p_module)) {
+        const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+        if (IsNull(p_entry)) {
+            if (IsNotNull(p_result)) {
+                *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+            }
+            return NULL;
+        }
+        for (uint32_t index = 0; index < p_entry->input_variable_count; ++index) {
+            const SpvReflectInterfaceVariable* p_potential = p_entry->input_variables[index];
+            if (p_potential->semantic != NULL && strcmp(p_potential->semantic, semantic) == 0) {
+                p_var = p_potential;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_var)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_var;
+}
+
+const SpvReflectInterfaceVariable* spvReflectGetOutputVariableByLocation(const SpvReflectShaderModule* p_module, uint32_t location,
+                                                                         SpvReflectResult* p_result) {
+    if (location == INVALID_VALUE) {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+        }
+        return NULL;
+    }
+    const SpvReflectInterfaceVariable* p_var = NULL;
+    if (IsNotNull(p_module)) {
+        for (uint32_t index = 0; index < p_module->output_variable_count; ++index) {
+            const SpvReflectInterfaceVariable* p_potential = p_module->output_variables[index];
+            if (p_potential->location == location) {
+                p_var = p_potential;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_var)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_var;
+}
+const SpvReflectInterfaceVariable* spvReflectGetOutputVariable(const SpvReflectShaderModule* p_module, uint32_t location,
+                                                               SpvReflectResult* p_result) {
+    return spvReflectGetOutputVariableByLocation(p_module, location, p_result);
+}
+
+const SpvReflectInterfaceVariable* spvReflectGetEntryPointOutputVariableByLocation(const SpvReflectShaderModule* p_module,
+                                                                                   const char* entry_point, uint32_t location,
+                                                                                   SpvReflectResult* p_result) {
+    if (location == INVALID_VALUE) {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+        }
+        return NULL;
+    }
+
+    const SpvReflectInterfaceVariable* p_var = NULL;
+    if (IsNotNull(p_module)) {
+        const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+        if (IsNull(p_entry)) {
+            if (IsNotNull(p_result)) {
+                *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+            }
+            return NULL;
+        }
+        for (uint32_t index = 0; index < p_entry->output_variable_count; ++index) {
+            const SpvReflectInterfaceVariable* p_potential = p_entry->output_variables[index];
+            if (p_potential->location == location) {
+                p_var = p_potential;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_var)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_var;
+}
+
+const SpvReflectInterfaceVariable* spvReflectGetOutputVariableBySemantic(const SpvReflectShaderModule* p_module,
+                                                                         const char* semantic, SpvReflectResult* p_result) {
+    if (IsNull(semantic)) {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+        }
+        return NULL;
+    }
+    if (semantic[0] == '\0') {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+        }
+        return NULL;
+    }
+    const SpvReflectInterfaceVariable* p_var = NULL;
+    if (IsNotNull(p_module)) {
+        for (uint32_t index = 0; index < p_module->output_variable_count; ++index) {
+            const SpvReflectInterfaceVariable* p_potential = p_module->output_variables[index];
+            if (p_potential->semantic != NULL && strcmp(p_potential->semantic, semantic) == 0) {
+                p_var = p_potential;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_var)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_var;
+}
+
+const SpvReflectInterfaceVariable* spvReflectGetEntryPointOutputVariableBySemantic(const SpvReflectShaderModule* p_module,
+                                                                                   const char* entry_point, const char* semantic,
+                                                                                   SpvReflectResult* p_result) {
+    if (IsNull(semantic)) {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+        }
+        return NULL;
+    }
+    if (semantic[0] == '\0') {
+        if (IsNotNull(p_result)) {
+            *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+        }
+        return NULL;
+    }
+    const SpvReflectInterfaceVariable* p_var = NULL;
+    if (IsNotNull(p_module)) {
+        const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+        if (IsNull(p_entry)) {
+            if (IsNotNull(p_result)) {
+                *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+            }
+            return NULL;
+        }
+        for (uint32_t index = 0; index < p_entry->output_variable_count; ++index) {
+            const SpvReflectInterfaceVariable* p_potential = p_entry->output_variables[index];
+            if (p_potential->semantic != NULL && strcmp(p_potential->semantic, semantic) == 0) {
+                p_var = p_potential;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_var)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_var;
+}
+
+const SpvReflectBlockVariable* spvReflectGetPushConstantBlock(const SpvReflectShaderModule* p_module, uint32_t index,
+                                                              SpvReflectResult* p_result) {
+    const SpvReflectBlockVariable* p_push_constant = NULL;
+    if (IsNotNull(p_module)) {
+        if (index < p_module->push_constant_block_count) {
+            p_push_constant = &p_module->push_constant_blocks[index];
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_push_constant)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_push_constant;
+}
+const SpvReflectBlockVariable* spvReflectGetPushConstant(const SpvReflectShaderModule* p_module, uint32_t index,
+                                                         SpvReflectResult* p_result) {
+    return spvReflectGetPushConstantBlock(p_module, index, p_result);
+}
+
+const SpvReflectBlockVariable* spvReflectGetEntryPointPushConstantBlock(const SpvReflectShaderModule* p_module,
+                                                                        const char* entry_point, SpvReflectResult* p_result) {
+    const SpvReflectBlockVariable* p_push_constant = NULL;
+    if (IsNotNull(p_module)) {
+        const SpvReflectEntryPoint* p_entry = spvReflectGetEntryPoint(p_module, entry_point);
+        if (IsNull(p_entry)) {
+            if (IsNotNull(p_result)) {
+                *p_result = SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+            }
+            return NULL;
+        }
+        for (uint32_t i = 0; i < p_module->push_constant_block_count; ++i) {
+            bool found = SearchSortedUint32(p_entry->used_push_constants, p_entry->used_push_constant_count,
+                                            p_module->push_constant_blocks[i].spirv_id);
+            if (found) {
+                p_push_constant = &p_module->push_constant_blocks[i];
+                break;
+            }
+        }
+    }
+    if (IsNotNull(p_result)) {
+        *p_result = IsNotNull(p_push_constant)
+                        ? SPV_REFLECT_RESULT_SUCCESS
+                        : (IsNull(p_module) ? SPV_REFLECT_RESULT_ERROR_NULL_POINTER : SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND);
+    }
+    return p_push_constant;
+}
+
+SpvReflectResult spvReflectChangeDescriptorBindingNumbers(SpvReflectShaderModule* p_module,
+                                                          const SpvReflectDescriptorBinding* p_binding, uint32_t new_binding_number,
+                                                          uint32_t new_set_binding) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_binding)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+
+    SpvReflectDescriptorBinding* p_target_descriptor = NULL;
+    for (uint32_t index = 0; index < p_module->descriptor_binding_count; ++index) {
+        if (&p_module->descriptor_bindings[index] == p_binding) {
+            p_target_descriptor = &p_module->descriptor_bindings[index];
+            break;
+        }
+    }
+
+    if (IsNotNull(p_target_descriptor)) {
+        if (p_target_descriptor->word_offset.binding > (p_module->_internal->spirv_word_count - 1)) {
+            return SPV_REFLECT_RESULT_ERROR_RANGE_EXCEEDED;
+        }
+        // Binding number
+        if (new_binding_number != (uint32_t)SPV_REFLECT_BINDING_NUMBER_DONT_CHANGE) {
+            uint32_t* p_code = p_module->_internal->spirv_code + p_target_descriptor->word_offset.binding;
+            *p_code = new_binding_number;
+            p_target_descriptor->binding = new_binding_number;
+        }
+        // Set number
+        if (new_set_binding != (uint32_t)SPV_REFLECT_SET_NUMBER_DONT_CHANGE) {
+            uint32_t* p_code = p_module->_internal->spirv_code + p_target_descriptor->word_offset.set;
+            *p_code = new_set_binding;
+            p_target_descriptor->set = new_set_binding;
+        }
+    }
+
+    SpvReflectResult result = SPV_REFLECT_RESULT_SUCCESS;
+    if (new_set_binding != (uint32_t)SPV_REFLECT_SET_NUMBER_DONT_CHANGE) {
+        result = SynchronizeDescriptorSets(p_module);
+    }
+    return result;
+}
+SpvReflectResult spvReflectChangeDescriptorBindingNumber(SpvReflectShaderModule* p_module,
+                                                         const SpvReflectDescriptorBinding* p_descriptor_binding,
+                                                         uint32_t new_binding_number, uint32_t optional_new_set_number) {
+    return spvReflectChangeDescriptorBindingNumbers(p_module, p_descriptor_binding, new_binding_number, optional_new_set_number);
+}
+
+SpvReflectResult spvReflectChangeDescriptorSetNumber(SpvReflectShaderModule* p_module, const SpvReflectDescriptorSet* p_set,
+                                                     uint32_t new_set_number) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_set)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    SpvReflectDescriptorSet* p_target_set = NULL;
+    for (uint32_t index = 0; index < SPV_REFLECT_MAX_DESCRIPTOR_SETS; ++index) {
+        // The descriptor sets for specific entry points might not be in this set,
+        // so just match on set index.
+        if (p_module->descriptor_sets[index].set == p_set->set) {
+            p_target_set = (SpvReflectDescriptorSet*)p_set;
+            break;
+        }
+    }
+
+    SpvReflectResult result = SPV_REFLECT_RESULT_SUCCESS;
+    if (IsNotNull(p_target_set) && new_set_number != (uint32_t)SPV_REFLECT_SET_NUMBER_DONT_CHANGE) {
+        for (uint32_t index = 0; index < p_target_set->binding_count; ++index) {
+            SpvReflectDescriptorBinding* p_descriptor = p_target_set->bindings[index];
+            if (p_descriptor->word_offset.set > (p_module->_internal->spirv_word_count - 1)) {
+                return SPV_REFLECT_RESULT_ERROR_RANGE_EXCEEDED;
+            }
+
+            uint32_t* p_code = p_module->_internal->spirv_code + p_descriptor->word_offset.set;
+            *p_code = new_set_number;
+            p_descriptor->set = new_set_number;
+        }
+
+        result = SynchronizeDescriptorSets(p_module);
+    }
+
+    return result;
+}
+
+static SpvReflectResult ChangeVariableLocation(SpvReflectShaderModule* p_module, SpvReflectInterfaceVariable* p_variable,
+                                               uint32_t new_location) {
+    if (p_variable->word_offset.location > (p_module->_internal->spirv_word_count - 1)) {
+        return SPV_REFLECT_RESULT_ERROR_RANGE_EXCEEDED;
+    }
+    uint32_t* p_code = p_module->_internal->spirv_code + p_variable->word_offset.location;
+    *p_code = new_location;
+    p_variable->location = new_location;
+    return SPV_REFLECT_RESULT_SUCCESS;
+}
+
+SpvReflectResult spvReflectChangeInputVariableLocation(SpvReflectShaderModule* p_module,
+                                                       const SpvReflectInterfaceVariable* p_input_variable, uint32_t new_location) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_input_variable)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    for (uint32_t index = 0; index < p_module->input_variable_count; ++index) {
+        if (p_module->input_variables[index] == p_input_variable) {
+            return ChangeVariableLocation(p_module, p_module->input_variables[index], new_location);
+        }
+    }
+    return SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+}
+
+SpvReflectResult spvReflectChangeOutputVariableLocation(SpvReflectShaderModule* p_module,
+                                                        const SpvReflectInterfaceVariable* p_output_variable,
+                                                        uint32_t new_location) {
+    if (IsNull(p_module)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    if (IsNull(p_output_variable)) {
+        return SPV_REFLECT_RESULT_ERROR_NULL_POINTER;
+    }
+    for (uint32_t index = 0; index < p_module->output_variable_count; ++index) {
+        if (p_module->output_variables[index] == p_output_variable) {
+            return ChangeVariableLocation(p_module, p_module->output_variables[index], new_location);
+        }
+    }
+    return SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND;
+}
+
+const char* spvReflectSourceLanguage(SpvSourceLanguage source_lang) {
+    switch (source_lang) {
+        case SpvSourceLanguageUnknown:
+            return "Unknown";
+        case SpvSourceLanguageESSL:
+            return "ESSL";
+        case SpvSourceLanguageGLSL:
+            return "GLSL";
+        case SpvSourceLanguageOpenCL_C:
+            return "OpenCL_C";
+        case SpvSourceLanguageOpenCL_CPP:
+            return "OpenCL_CPP";
+        case SpvSourceLanguageHLSL:
+            return "HLSL";
+        case SpvSourceLanguageCPP_for_OpenCL:
+            return "CPP_for_OpenCL";
+        case SpvSourceLanguageSYCL:
+            return "SYCL";
+        case SpvSourceLanguageMax:
+            break;
+    }
+    return "";
+}
+
+const char* spvReflectBlockVariableTypeName(const SpvReflectBlockVariable* p_var) {
+    if (p_var == NULL) {
+        return NULL;
+    }
+    return p_var->type_description->type_name;
+}

--- a/tests/spirv_hopper/external/spirv_reflect.h
+++ b/tests/spirv_hopper/external/spirv_reflect.h
@@ -1,0 +1,1903 @@
+/*
+ Copyright 2017-2022 Google Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/*
+
+VERSION HISTORY
+
+  1.0   (2018-03-27) Initial public release
+
+*/
+
+/*!
+
+ @file spirv_reflect.h
+
+*/
+#ifndef SPIRV_REFLECT_H
+#define SPIRV_REFLECT_H
+
+#if defined(SPIRV_REFLECT_USE_SYSTEM_SPIRV_H)
+#include <spirv/unified1/spirv.h>
+#else
+#include "./include/spirv/unified1/spirv.h"
+#endif
+
+#include <stdint.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#define SPV_REFLECT_DEPRECATED(msg_str) __declspec(deprecated("This symbol is deprecated. Details: " msg_str))
+#elif defined(__clang__)
+#define SPV_REFLECT_DEPRECATED(msg_str) __attribute__((deprecated(msg_str)))
+#elif defined(__GNUC__)
+#if GCC_VERSION >= 40500
+#define SPV_REFLECT_DEPRECATED(msg_str) __attribute__((deprecated(msg_str)))
+#else
+#define SPV_REFLECT_DEPRECATED(msg_str) __attribute__((deprecated))
+#endif
+#else
+#define SPV_REFLECT_DEPRECATED(msg_str)
+#endif
+
+/*! @enum SpvReflectResult
+
+*/
+typedef enum SpvReflectResult {
+    SPV_REFLECT_RESULT_SUCCESS,
+    SPV_REFLECT_RESULT_NOT_READY,
+    SPV_REFLECT_RESULT_ERROR_PARSE_FAILED,
+    SPV_REFLECT_RESULT_ERROR_ALLOC_FAILED,
+    SPV_REFLECT_RESULT_ERROR_RANGE_EXCEEDED,
+    SPV_REFLECT_RESULT_ERROR_NULL_POINTER,
+    SPV_REFLECT_RESULT_ERROR_INTERNAL_ERROR,
+    SPV_REFLECT_RESULT_ERROR_COUNT_MISMATCH,
+    SPV_REFLECT_RESULT_ERROR_ELEMENT_NOT_FOUND,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_CODE_SIZE,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_MAGIC_NUMBER,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_UNEXPECTED_EOF,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ID_REFERENCE,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_SET_NUMBER_OVERFLOW,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_STORAGE_CLASS,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_RECURSION,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_INSTRUCTION,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_UNEXPECTED_BLOCK_DATA,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_BLOCK_MEMBER_REFERENCE,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_ENTRY_POINT,
+    SPV_REFLECT_RESULT_ERROR_SPIRV_INVALID_EXECUTION_MODE,
+} SpvReflectResult;
+
+/*! @enum SpvReflectModuleFlagBits
+
+SPV_REFLECT_MODULE_FLAG_NO_COPY - Disables copying of SPIR-V code
+  when a SPIRV-Reflect shader module is created. It is the
+  responsibility of the calling program to ensure that the pointer
+  remains valid and the memory it's pointing to is not freed while
+  SPIRV-Reflect operations are taking place. Freeing the backing
+  memory will cause undefined behavior or most likely a crash.
+  This is flag is intended for cases where the memory overhead of
+  storing the copied SPIR-V is undesirable.
+
+*/
+typedef enum SpvReflectModuleFlagBits {
+    SPV_REFLECT_MODULE_FLAG_NONE = 0x00000000,
+    SPV_REFLECT_MODULE_FLAG_NO_COPY = 0x00000001,
+} SpvReflectModuleFlagBits;
+
+typedef uint32_t SpvReflectModuleFlags;
+
+/*! @enum SpvReflectTypeFlagBits
+
+*/
+typedef enum SpvReflectTypeFlagBits {
+    SPV_REFLECT_TYPE_FLAG_UNDEFINED = 0x00000000,
+    SPV_REFLECT_TYPE_FLAG_VOID = 0x00000001,
+    SPV_REFLECT_TYPE_FLAG_BOOL = 0x00000002,
+    SPV_REFLECT_TYPE_FLAG_INT = 0x00000004,
+    SPV_REFLECT_TYPE_FLAG_FLOAT = 0x00000008,
+    SPV_REFLECT_TYPE_FLAG_VECTOR = 0x00000100,
+    SPV_REFLECT_TYPE_FLAG_MATRIX = 0x00000200,
+    SPV_REFLECT_TYPE_FLAG_EXTERNAL_IMAGE = 0x00010000,
+    SPV_REFLECT_TYPE_FLAG_EXTERNAL_SAMPLER = 0x00020000,
+    SPV_REFLECT_TYPE_FLAG_EXTERNAL_SAMPLED_IMAGE = 0x00040000,
+    SPV_REFLECT_TYPE_FLAG_EXTERNAL_BLOCK = 0x00080000,
+    SPV_REFLECT_TYPE_FLAG_EXTERNAL_ACCELERATION_STRUCTURE = 0x00100000,
+    SPV_REFLECT_TYPE_FLAG_EXTERNAL_MASK = 0x00FF0000,
+    SPV_REFLECT_TYPE_FLAG_STRUCT = 0x10000000,
+    SPV_REFLECT_TYPE_FLAG_ARRAY = 0x20000000,
+} SpvReflectTypeFlagBits;
+
+typedef uint32_t SpvReflectTypeFlags;
+
+/*! @enum SpvReflectDecorationBits
+
+NOTE: HLSL row_major and column_major decorations are reversed
+      in SPIR-V. Meaning that matrices declrations with row_major
+      will get reflected as column_major and vice versa. The
+      row and column decorations get appied during the compilation.
+      SPIRV-Reflect reads the data as is and does not make any
+      attempt to correct it to match what's in the source.
+
+*/
+typedef enum SpvReflectDecorationFlagBits {
+    SPV_REFLECT_DECORATION_NONE = 0x00000000,
+    SPV_REFLECT_DECORATION_BLOCK = 0x00000001,
+    SPV_REFLECT_DECORATION_BUFFER_BLOCK = 0x00000002,
+    SPV_REFLECT_DECORATION_ROW_MAJOR = 0x00000004,
+    SPV_REFLECT_DECORATION_COLUMN_MAJOR = 0x00000008,
+    SPV_REFLECT_DECORATION_BUILT_IN = 0x00000010,
+    SPV_REFLECT_DECORATION_NOPERSPECTIVE = 0x00000020,
+    SPV_REFLECT_DECORATION_FLAT = 0x00000040,
+    SPV_REFLECT_DECORATION_NON_WRITABLE = 0x00000080,
+    SPV_REFLECT_DECORATION_RELAXED_PRECISION = 0x00000100,
+    SPV_REFLECT_DECORATION_NON_READABLE = 0x00000200,
+} SpvReflectDecorationFlagBits;
+
+typedef uint32_t SpvReflectDecorationFlags;
+
+/*! @enum SpvReflectResourceType
+
+*/
+typedef enum SpvReflectResourceType {
+    SPV_REFLECT_RESOURCE_FLAG_UNDEFINED = 0x00000000,
+    SPV_REFLECT_RESOURCE_FLAG_SAMPLER = 0x00000001,
+    SPV_REFLECT_RESOURCE_FLAG_CBV = 0x00000002,
+    SPV_REFLECT_RESOURCE_FLAG_SRV = 0x00000004,
+    SPV_REFLECT_RESOURCE_FLAG_UAV = 0x00000008,
+} SpvReflectResourceType;
+
+/*! @enum SpvReflectFormat
+
+*/
+typedef enum SpvReflectFormat {
+    SPV_REFLECT_FORMAT_UNDEFINED = 0,              // = VK_FORMAT_UNDEFINED
+    SPV_REFLECT_FORMAT_R32_UINT = 98,              // = VK_FORMAT_R32_UINT
+    SPV_REFLECT_FORMAT_R32_SINT = 99,              // = VK_FORMAT_R32_SINT
+    SPV_REFLECT_FORMAT_R32_SFLOAT = 100,           // = VK_FORMAT_R32_SFLOAT
+    SPV_REFLECT_FORMAT_R32G32_UINT = 101,          // = VK_FORMAT_R32G32_UINT
+    SPV_REFLECT_FORMAT_R32G32_SINT = 102,          // = VK_FORMAT_R32G32_SINT
+    SPV_REFLECT_FORMAT_R32G32_SFLOAT = 103,        // = VK_FORMAT_R32G32_SFLOAT
+    SPV_REFLECT_FORMAT_R32G32B32_UINT = 104,       // = VK_FORMAT_R32G32B32_UINT
+    SPV_REFLECT_FORMAT_R32G32B32_SINT = 105,       // = VK_FORMAT_R32G32B32_SINT
+    SPV_REFLECT_FORMAT_R32G32B32_SFLOAT = 106,     // = VK_FORMAT_R32G32B32_SFLOAT
+    SPV_REFLECT_FORMAT_R32G32B32A32_UINT = 107,    // = VK_FORMAT_R32G32B32A32_UINT
+    SPV_REFLECT_FORMAT_R32G32B32A32_SINT = 108,    // = VK_FORMAT_R32G32B32A32_SINT
+    SPV_REFLECT_FORMAT_R32G32B32A32_SFLOAT = 109,  // = VK_FORMAT_R32G32B32A32_SFLOAT
+    SPV_REFLECT_FORMAT_R64_UINT = 110,             // = VK_FORMAT_R64_UINT
+    SPV_REFLECT_FORMAT_R64_SINT = 111,             // = VK_FORMAT_R64_SINT
+    SPV_REFLECT_FORMAT_R64_SFLOAT = 112,           // = VK_FORMAT_R64_SFLOAT
+    SPV_REFLECT_FORMAT_R64G64_UINT = 113,          // = VK_FORMAT_R64G64_UINT
+    SPV_REFLECT_FORMAT_R64G64_SINT = 114,          // = VK_FORMAT_R64G64_SINT
+    SPV_REFLECT_FORMAT_R64G64_SFLOAT = 115,        // = VK_FORMAT_R64G64_SFLOAT
+    SPV_REFLECT_FORMAT_R64G64B64_UINT = 116,       // = VK_FORMAT_R64G64B64_UINT
+    SPV_REFLECT_FORMAT_R64G64B64_SINT = 117,       // = VK_FORMAT_R64G64B64_SINT
+    SPV_REFLECT_FORMAT_R64G64B64_SFLOAT = 118,     // = VK_FORMAT_R64G64B64_SFLOAT
+    SPV_REFLECT_FORMAT_R64G64B64A64_UINT = 119,    // = VK_FORMAT_R64G64B64A64_UINT
+    SPV_REFLECT_FORMAT_R64G64B64A64_SINT = 120,    // = VK_FORMAT_R64G64B64A64_SINT
+    SPV_REFLECT_FORMAT_R64G64B64A64_SFLOAT = 121,  // = VK_FORMAT_R64G64B64A64_SFLOAT
+} SpvReflectFormat;
+
+/*! @enum SpvReflectVariableFlagBits
+
+*/
+enum SpvReflectVariableFlagBits {
+    SPV_REFLECT_VARIABLE_FLAGS_NONE = 0x00000000,
+    SPV_REFLECT_VARIABLE_FLAGS_UNUSED = 0x00000001,
+};
+
+typedef uint32_t SpvReflectVariableFlags;
+
+/*! @enum SpvReflectDescriptorType
+
+*/
+typedef enum SpvReflectDescriptorType {
+    SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLER = 0,                             // = VK_DESCRIPTOR_TYPE_SAMPLER
+    SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = 1,              // = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
+    SPV_REFLECT_DESCRIPTOR_TYPE_SAMPLED_IMAGE = 2,                       // = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE
+    SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_IMAGE = 3,                       // = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
+    SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER = 4,                // = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER
+    SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER = 5,                // = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER
+    SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER = 6,                      // = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER
+    SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER = 7,                      // = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+    SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC = 8,              // = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC
+    SPV_REFLECT_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC = 9,              // = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC
+    SPV_REFLECT_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = 10,                   // = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT
+    SPV_REFLECT_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR = 1000150000  // = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR
+} SpvReflectDescriptorType;
+
+/*! @enum SpvReflectShaderStageFlagBits
+
+*/
+typedef enum SpvReflectShaderStageFlagBits {
+    SPV_REFLECT_SHADER_STAGE_VERTEX_BIT = 0x00000001,                              // = VK_SHADER_STAGE_VERTEX_BIT
+    SPV_REFLECT_SHADER_STAGE_TESSELLATION_CONTROL_BIT = 0x00000002,                // = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT
+    SPV_REFLECT_SHADER_STAGE_TESSELLATION_EVALUATION_BIT = 0x00000004,             // = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT
+    SPV_REFLECT_SHADER_STAGE_GEOMETRY_BIT = 0x00000008,                            // = VK_SHADER_STAGE_GEOMETRY_BIT
+    SPV_REFLECT_SHADER_STAGE_FRAGMENT_BIT = 0x00000010,                            // = VK_SHADER_STAGE_FRAGMENT_BIT
+    SPV_REFLECT_SHADER_STAGE_COMPUTE_BIT = 0x00000020,                             // = VK_SHADER_STAGE_COMPUTE_BIT
+    SPV_REFLECT_SHADER_STAGE_TASK_BIT_NV = 0x00000040,                             // = VK_SHADER_STAGE_TASK_BIT_NV
+    SPV_REFLECT_SHADER_STAGE_TASK_BIT_EXT = SPV_REFLECT_SHADER_STAGE_TASK_BIT_NV,  // = VK_SHADER_STAGE_CALLABLE_BIT_EXT
+    SPV_REFLECT_SHADER_STAGE_MESH_BIT_NV = 0x00000080,                             // = VK_SHADER_STAGE_MESH_BIT_NV
+    SPV_REFLECT_SHADER_STAGE_MESH_BIT_EXT = SPV_REFLECT_SHADER_STAGE_MESH_BIT_NV,  // = VK_SHADER_STAGE_CALLABLE_BIT_EXT
+    SPV_REFLECT_SHADER_STAGE_RAYGEN_BIT_KHR = 0x00000100,                          // = VK_SHADER_STAGE_RAYGEN_BIT_KHR
+    SPV_REFLECT_SHADER_STAGE_ANY_HIT_BIT_KHR = 0x00000200,                         // = VK_SHADER_STAGE_ANY_HIT_BIT_KHR
+    SPV_REFLECT_SHADER_STAGE_CLOSEST_HIT_BIT_KHR = 0x00000400,                     // = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR
+    SPV_REFLECT_SHADER_STAGE_MISS_BIT_KHR = 0x00000800,                            // = VK_SHADER_STAGE_MISS_BIT_KHR
+    SPV_REFLECT_SHADER_STAGE_INTERSECTION_BIT_KHR = 0x00001000,                    // = VK_SHADER_STAGE_INTERSECTION_BIT_KHR
+    SPV_REFLECT_SHADER_STAGE_CALLABLE_BIT_KHR = 0x00002000,                        // = VK_SHADER_STAGE_CALLABLE_BIT_KHR
+
+} SpvReflectShaderStageFlagBits;
+
+/*! @enum SpvReflectGenerator
+
+*/
+typedef enum SpvReflectGenerator {
+    SPV_REFLECT_GENERATOR_KHRONOS_LLVM_SPIRV_TRANSLATOR = 6,
+    SPV_REFLECT_GENERATOR_KHRONOS_SPIRV_TOOLS_ASSEMBLER = 7,
+    SPV_REFLECT_GENERATOR_KHRONOS_GLSLANG_REFERENCE_FRONT_END = 8,
+    SPV_REFLECT_GENERATOR_GOOGLE_SHADERC_OVER_GLSLANG = 13,
+    SPV_REFLECT_GENERATOR_GOOGLE_SPIREGG = 14,
+    SPV_REFLECT_GENERATOR_GOOGLE_RSPIRV = 15,
+    SPV_REFLECT_GENERATOR_X_LEGEND_MESA_MESAIR_SPIRV_TRANSLATOR = 16,
+    SPV_REFLECT_GENERATOR_KHRONOS_SPIRV_TOOLS_LINKER = 17,
+    SPV_REFLECT_GENERATOR_WINE_VKD3D_SHADER_COMPILER = 18,
+    SPV_REFLECT_GENERATOR_CLAY_CLAY_SHADER_COMPILER = 19,
+} SpvReflectGenerator;
+
+enum {
+    SPV_REFLECT_MAX_ARRAY_DIMS = 32,
+    SPV_REFLECT_MAX_DESCRIPTOR_SETS = 64,
+};
+
+enum { SPV_REFLECT_BINDING_NUMBER_DONT_CHANGE = ~0, SPV_REFLECT_SET_NUMBER_DONT_CHANGE = ~0 };
+
+typedef struct SpvReflectNumericTraits {
+    struct Scalar {
+        uint32_t width;
+        uint32_t signedness;
+    } scalar;
+
+    struct Vector {
+        uint32_t component_count;
+    } vector;
+
+    struct Matrix {
+        uint32_t column_count;
+        uint32_t row_count;
+        uint32_t stride;  // Measured in bytes
+    } matrix;
+} SpvReflectNumericTraits;
+
+typedef struct SpvReflectImageTraits {
+    SpvDim dim;
+    uint32_t depth;
+    uint32_t arrayed;
+    uint32_t ms;  // 0: single-sampled; 1: multisampled
+    uint32_t sampled;
+    SpvImageFormat image_format;
+} SpvReflectImageTraits;
+
+typedef struct SpvReflectArrayTraits {
+    uint32_t dims_count;
+    // Each entry is: 0xFFFFFFFF for a specialization constant dimension,
+    // 0 for a runtime array dimension, and the array length otherwise.
+    uint32_t dims[SPV_REFLECT_MAX_ARRAY_DIMS];
+    // Stores Ids for dimensions that are specialization constants
+    uint32_t spec_constant_op_ids[SPV_REFLECT_MAX_ARRAY_DIMS];
+    uint32_t stride;  // Measured in bytes
+} SpvReflectArrayTraits;
+
+typedef struct SpvReflectBindingArrayTraits {
+    uint32_t dims_count;
+    uint32_t dims[SPV_REFLECT_MAX_ARRAY_DIMS];
+} SpvReflectBindingArrayTraits;
+
+/*! @struct SpvReflectTypeDescription
+
+*/
+typedef struct SpvReflectTypeDescription {
+    uint32_t id;
+    SpvOp op;
+    const char* type_name;
+    const char* struct_member_name;
+    SpvStorageClass storage_class;
+    SpvReflectTypeFlags type_flags;
+    SpvReflectDecorationFlags decoration_flags;
+
+    struct Traits {
+        SpvReflectNumericTraits numeric;
+        SpvReflectImageTraits image;
+        SpvReflectArrayTraits array;
+    } traits;
+
+    uint32_t member_count;
+    struct SpvReflectTypeDescription* members;
+} SpvReflectTypeDescription;
+
+/*! @struct SpvReflectInterfaceVariable
+
+*/
+typedef struct SpvReflectInterfaceVariable {
+    uint32_t spirv_id;
+    const char* name;
+    uint32_t location;
+    uint32_t component;
+    SpvStorageClass storage_class;
+    const char* semantic;
+    SpvReflectDecorationFlags decoration_flags;
+    SpvBuiltIn built_in;
+    SpvReflectNumericTraits numeric;
+    SpvReflectArrayTraits array;
+
+    uint32_t member_count;
+    struct SpvReflectInterfaceVariable* members;
+
+    SpvReflectFormat format;
+
+    // NOTE: SPIR-V shares type references for variables
+    //       that have the same underlying type. This means
+    //       that the same type name will appear for multiple
+    //       variables.
+    SpvReflectTypeDescription* type_description;
+
+    struct {
+        uint32_t location;
+    } word_offset;
+} SpvReflectInterfaceVariable;
+
+/*! @struct SpvReflectBlockVariable
+
+*/
+typedef struct SpvReflectBlockVariable {
+    uint32_t spirv_id;
+    const char* name;
+    uint32_t offset;           // Measured in bytes
+    uint32_t absolute_offset;  // Measured in bytes
+    uint32_t size;             // Measured in bytes
+    uint32_t padded_size;      // Measured in bytes
+    SpvReflectDecorationFlags decoration_flags;
+    SpvReflectNumericTraits numeric;
+    SpvReflectArrayTraits array;
+    SpvReflectVariableFlags flags;
+
+    uint32_t member_count;
+    struct SpvReflectBlockVariable* members;
+
+    SpvReflectTypeDescription* type_description;
+
+    struct {
+        uint32_t offset;
+    } word_offset;
+
+} SpvReflectBlockVariable;
+
+/*! @struct SpvReflectDescriptorBinding
+
+*/
+typedef struct SpvReflectDescriptorBinding {
+    uint32_t spirv_id;
+    const char* name;
+    uint32_t binding;
+    uint32_t input_attachment_index;
+    uint32_t set;
+    SpvReflectDescriptorType descriptor_type;
+    SpvReflectResourceType resource_type;
+    SpvReflectImageTraits image;
+    SpvReflectBlockVariable block;
+    SpvReflectBindingArrayTraits array;
+    uint32_t count;
+    uint32_t accessed;
+    uint32_t uav_counter_id;
+    struct SpvReflectDescriptorBinding* uav_counter_binding;
+
+    SpvReflectTypeDescription* type_description;
+
+    struct {
+        uint32_t binding;
+        uint32_t set;
+    } word_offset;
+
+    SpvReflectDecorationFlags decoration_flags;
+} SpvReflectDescriptorBinding;
+
+/*! @struct SpvReflectDescriptorSet
+
+*/
+typedef struct SpvReflectDescriptorSet {
+    uint32_t set;
+    uint32_t binding_count;
+    SpvReflectDescriptorBinding** bindings;
+} SpvReflectDescriptorSet;
+
+/*! @struct SpvReflectEntryPoint
+
+ */
+typedef struct SpvReflectEntryPoint {
+    const char* name;
+    uint32_t id;
+
+    SpvExecutionModel spirv_execution_model;
+    SpvReflectShaderStageFlagBits shader_stage;
+
+    uint32_t input_variable_count;
+    SpvReflectInterfaceVariable** input_variables;
+    uint32_t output_variable_count;
+    SpvReflectInterfaceVariable** output_variables;
+    uint32_t interface_variable_count;
+    SpvReflectInterfaceVariable* interface_variables;
+
+    uint32_t descriptor_set_count;
+    SpvReflectDescriptorSet* descriptor_sets;
+
+    uint32_t used_uniform_count;
+    uint32_t* used_uniforms;
+    uint32_t used_push_constant_count;
+    uint32_t* used_push_constants;
+
+    uint32_t execution_mode_count;
+    SpvExecutionMode* execution_modes;
+
+    struct LocalSize {
+        uint32_t x;
+        uint32_t y;
+        uint32_t z;
+    } local_size;
+    uint32_t invocations;      // valid for geometry
+    uint32_t output_vertices;  // valid for geometry, tesselation
+} SpvReflectEntryPoint;
+
+/*! @struct SpvReflectCapability
+
+*/
+typedef struct SpvReflectCapability {
+    SpvCapability value;
+    uint32_t word_offset;
+} SpvReflectCapability;
+
+/*! @struct SpvReflectShaderModule
+
+*/
+typedef struct SpvReflectShaderModule {
+    SpvReflectGenerator generator;
+    const char* entry_point_name;
+    uint32_t entry_point_id;
+    uint32_t entry_point_count;
+    SpvReflectEntryPoint* entry_points;
+    SpvSourceLanguage source_language;
+    uint32_t source_language_version;
+    const char* source_file;
+    const char* source_source;
+    uint32_t capability_count;
+    SpvReflectCapability* capabilities;
+    SpvExecutionModel spirv_execution_model;                                   // Uses value(s) from first entry point
+    SpvReflectShaderStageFlagBits shader_stage;                                // Uses value(s) from first entry point
+    uint32_t descriptor_binding_count;                                         // Uses value(s) from first entry point
+    SpvReflectDescriptorBinding* descriptor_bindings;                          // Uses value(s) from first entry point
+    uint32_t descriptor_set_count;                                             // Uses value(s) from first entry point
+    SpvReflectDescriptorSet descriptor_sets[SPV_REFLECT_MAX_DESCRIPTOR_SETS];  // Uses value(s) from first entry point
+    uint32_t input_variable_count;                                             // Uses value(s) from first entry point
+    SpvReflectInterfaceVariable** input_variables;                             // Uses value(s) from first entry point
+    uint32_t output_variable_count;                                            // Uses value(s) from first entry point
+    SpvReflectInterfaceVariable** output_variables;                            // Uses value(s) from first entry point
+    uint32_t interface_variable_count;                                         // Uses value(s) from first entry point
+    SpvReflectInterfaceVariable* interface_variables;                          // Uses value(s) from first entry point
+    uint32_t push_constant_block_count;                                        // Uses value(s) from first entry point
+    SpvReflectBlockVariable* push_constant_blocks;                             // Uses value(s) from first entry point
+
+    struct Internal {
+        SpvReflectModuleFlags module_flags;
+        size_t spirv_size;
+        uint32_t* spirv_code;
+        uint32_t spirv_word_count;
+
+        size_t type_description_count;
+        SpvReflectTypeDescription* type_descriptions;
+    } * _internal;
+
+} SpvReflectShaderModule;
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*! @fn spvReflectCreateShaderModule
+
+ @param  size      Size in bytes of SPIR-V code.
+ @param  p_code    Pointer to SPIR-V code.
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @return           SPV_REFLECT_RESULT_SUCCESS on success.
+
+*/
+SpvReflectResult spvReflectCreateShaderModule(size_t size, const void* p_code, SpvReflectShaderModule* p_module);
+
+/*! @fn spvReflectCreateShaderModule2
+
+ @param  flags     Flags for module creations.
+ @param  size      Size in bytes of SPIR-V code.
+ @param  p_code    Pointer to SPIR-V code.
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @return           SPV_REFLECT_RESULT_SUCCESS on success.
+
+*/
+SpvReflectResult spvReflectCreateShaderModule2(SpvReflectModuleFlags flags, size_t size, const void* p_code,
+                                               SpvReflectShaderModule* p_module);
+
+SPV_REFLECT_DEPRECATED("renamed to spvReflectCreateShaderModule")
+SpvReflectResult spvReflectGetShaderModule(size_t size, const void* p_code, SpvReflectShaderModule* p_module);
+
+/*! @fn spvReflectDestroyShaderModule
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+
+*/
+void spvReflectDestroyShaderModule(SpvReflectShaderModule* p_module);
+
+/*! @fn spvReflectGetCodeSize
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @return           Returns the size of the SPIR-V in bytes
+
+*/
+uint32_t spvReflectGetCodeSize(const SpvReflectShaderModule* p_module);
+
+/*! @fn spvReflectGetCode
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @return           Returns a const pointer to the compiled SPIR-V bytecode.
+
+*/
+const uint32_t* spvReflectGetCode(const SpvReflectShaderModule* p_module);
+
+/*! @fn spvReflectGetEntryPoint
+
+ @param  p_module     Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point  Name of the requested entry point.
+ @return              Returns a const pointer to the requested entry point,
+                      or NULL if it's not found.
+*/
+const SpvReflectEntryPoint* spvReflectGetEntryPoint(const SpvReflectShaderModule* p_module, const char* entry_point);
+
+/*! @fn spvReflectEnumerateDescriptorBindings
+
+ @param  p_module     Pointer to an instance of SpvReflectShaderModule.
+ @param  p_count      If pp_bindings is NULL, the module's descriptor binding
+                      count (across all descriptor sets) will be stored here.
+                      If pp_bindings is not NULL, *p_count must contain the
+                      module's descriptor binding count.
+ @param  pp_bindings  If NULL, the module's total descriptor binding count
+                      will be written to *p_count.
+                      If non-NULL, pp_bindings must point to an array with
+                      *p_count entries, where pointers to the module's
+                      descriptor bindings will be written. The caller must not
+                      free the binding pointers written to this array.
+ @return              If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                      Otherwise, the error code indicates the cause of the
+                      failure.
+
+*/
+SpvReflectResult spvReflectEnumerateDescriptorBindings(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                       SpvReflectDescriptorBinding** pp_bindings);
+
+/*! @fn spvReflectEnumerateEntryPointDescriptorBindings
+ @brief  Creates a listing of all descriptor bindings that are used in the
+         static call tree of the given entry point.
+ @param  p_module     Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point  The name of the entry point to get the descriptor bindings for.
+ @param  p_count      If pp_bindings is NULL, the entry point's descriptor binding
+                      count (across all descriptor sets) will be stored here.
+                      If pp_bindings is not NULL, *p_count must contain the
+                      entry points's descriptor binding count.
+ @param  pp_bindings  If NULL, the entry point's total descriptor binding count
+                      will be written to *p_count.
+                      If non-NULL, pp_bindings must point to an array with
+                      *p_count entries, where pointers to the entry point's
+                      descriptor bindings will be written. The caller must not
+                      free the binding pointers written to this array.
+ @return              If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                      Otherwise, the error code indicates the cause of the
+                      failure.
+
+*/
+SpvReflectResult spvReflectEnumerateEntryPointDescriptorBindings(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                                 uint32_t* p_count, SpvReflectDescriptorBinding** pp_bindings);
+
+/*! @fn spvReflectEnumerateDescriptorSets
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @param  p_count   If pp_sets is NULL, the module's descriptor set
+                   count will be stored here.
+                   If pp_sets is not NULL, *p_count must contain the
+                   module's descriptor set count.
+ @param  pp_sets   If NULL, the module's total descriptor set count
+                   will be written to *p_count.
+                   If non-NULL, pp_sets must point to an array with
+                   *p_count entries, where pointers to the module's
+                   descriptor sets will be written. The caller must not
+                   free the descriptor set pointers written to this array.
+ @return           If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                   Otherwise, the error code indicates the cause of the
+                   failure.
+
+*/
+SpvReflectResult spvReflectEnumerateDescriptorSets(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                   SpvReflectDescriptorSet** pp_sets);
+
+/*! @fn spvReflectEnumerateEntryPointDescriptorSets
+ @brief  Creates a listing of all descriptor sets and their bindings that are
+         used in the static call tree of a given entry point.
+ @param  p_module    Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point The name of the entry point to get the descriptor bindings for.
+ @param  p_count     If pp_sets is NULL, the module's descriptor set
+                     count will be stored here.
+                     If pp_sets is not NULL, *p_count must contain the
+                     module's descriptor set count.
+ @param  pp_sets     If NULL, the module's total descriptor set count
+                     will be written to *p_count.
+                     If non-NULL, pp_sets must point to an array with
+                     *p_count entries, where pointers to the module's
+                     descriptor sets will be written. The caller must not
+                     free the descriptor set pointers written to this array.
+ @return             If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                     Otherwise, the error code indicates the cause of the
+                     failure.
+
+*/
+SpvReflectResult spvReflectEnumerateEntryPointDescriptorSets(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                             uint32_t* p_count, SpvReflectDescriptorSet** pp_sets);
+
+/*! @fn spvReflectEnumerateInterfaceVariables
+ @brief  If the module contains multiple entry points, this will only get
+         the interface variables for the first one.
+ @param  p_module      Pointer to an instance of SpvReflectShaderModule.
+ @param  p_count       If pp_variables is NULL, the module's interface variable
+                       count will be stored here.
+                       If pp_variables is not NULL, *p_count must contain
+                       the module's interface variable count.
+ @param  pp_variables  If NULL, the module's interface variable count will be
+                       written to *p_count.
+                       If non-NULL, pp_variables must point to an array with
+                       *p_count entries, where pointers to the module's
+                       interface variables will be written. The caller must not
+                       free the interface variables written to this array.
+ @return               If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                       Otherwise, the error code indicates the cause of the
+                       failure.
+
+*/
+SpvReflectResult spvReflectEnumerateInterfaceVariables(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                       SpvReflectInterfaceVariable** pp_variables);
+
+/*! @fn spvReflectEnumerateEntryPointInterfaceVariables
+ @brief  Enumerate the interface variables for a given entry point.
+ @param  entry_point The name of the entry point to get the interface variables for.
+ @param  p_module      Pointer to an instance of SpvReflectShaderModule.
+ @param  p_count       If pp_variables is NULL, the entry point's interface variable
+                       count will be stored here.
+                       If pp_variables is not NULL, *p_count must contain
+                       the entry point's interface variable count.
+ @param  pp_variables  If NULL, the entry point's interface variable count will be
+                       written to *p_count.
+                       If non-NULL, pp_variables must point to an array with
+                       *p_count entries, where pointers to the entry point's
+                       interface variables will be written. The caller must not
+                       free the interface variables written to this array.
+ @return               If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                       Otherwise, the error code indicates the cause of the
+                       failure.
+
+*/
+SpvReflectResult spvReflectEnumerateEntryPointInterfaceVariables(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                                 uint32_t* p_count, SpvReflectInterfaceVariable** pp_variables);
+
+/*! @fn spvReflectEnumerateInputVariables
+ @brief  If the module contains multiple entry points, this will only get
+         the input variables for the first one.
+ @param  p_module      Pointer to an instance of SpvReflectShaderModule.
+ @param  p_count       If pp_variables is NULL, the module's input variable
+                       count will be stored here.
+                       If pp_variables is not NULL, *p_count must contain
+                       the module's input variable count.
+ @param  pp_variables  If NULL, the module's input variable count will be
+                       written to *p_count.
+                       If non-NULL, pp_variables must point to an array with
+                       *p_count entries, where pointers to the module's
+                       input variables will be written. The caller must not
+                       free the interface variables written to this array.
+ @return               If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                       Otherwise, the error code indicates the cause of the
+                       failure.
+
+*/
+SpvReflectResult spvReflectEnumerateInputVariables(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                   SpvReflectInterfaceVariable** pp_variables);
+
+/*! @fn spvReflectEnumerateEntryPointInputVariables
+ @brief  Enumerate the input variables for a given entry point.
+ @param  entry_point The name of the entry point to get the input variables for.
+ @param  p_module      Pointer to an instance of SpvReflectShaderModule.
+ @param  p_count       If pp_variables is NULL, the entry point's input variable
+                       count will be stored here.
+                       If pp_variables is not NULL, *p_count must contain
+                       the entry point's input variable count.
+ @param  pp_variables  If NULL, the entry point's input variable count will be
+                       written to *p_count.
+                       If non-NULL, pp_variables must point to an array with
+                       *p_count entries, where pointers to the entry point's
+                       input variables will be written. The caller must not
+                       free the interface variables written to this array.
+ @return               If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                       Otherwise, the error code indicates the cause of the
+                       failure.
+
+*/
+SpvReflectResult spvReflectEnumerateEntryPointInputVariables(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                             uint32_t* p_count, SpvReflectInterfaceVariable** pp_variables);
+
+/*! @fn spvReflectEnumerateOutputVariables
+ @brief  Note: If the module contains multiple entry points, this will only get
+         the output variables for the first one.
+ @param  p_module      Pointer to an instance of SpvReflectShaderModule.
+ @param  p_count       If pp_variables is NULL, the module's output variable
+                       count will be stored here.
+                       If pp_variables is not NULL, *p_count must contain
+                       the module's output variable count.
+ @param  pp_variables  If NULL, the module's output variable count will be
+                       written to *p_count.
+                       If non-NULL, pp_variables must point to an array with
+                       *p_count entries, where pointers to the module's
+                       output variables will be written. The caller must not
+                       free the interface variables written to this array.
+ @return               If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                       Otherwise, the error code indicates the cause of the
+                       failure.
+
+*/
+SpvReflectResult spvReflectEnumerateOutputVariables(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                    SpvReflectInterfaceVariable** pp_variables);
+
+/*! @fn spvReflectEnumerateEntryPointOutputVariables
+ @brief  Enumerate the output variables for a given entry point.
+ @param  p_module      Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point   The name of the entry point to get the output variables for.
+ @param  p_count       If pp_variables is NULL, the entry point's output variable
+                       count will be stored here.
+                       If pp_variables is not NULL, *p_count must contain
+                       the entry point's output variable count.
+ @param  pp_variables  If NULL, the entry point's output variable count will be
+                       written to *p_count.
+                       If non-NULL, pp_variables must point to an array with
+                       *p_count entries, where pointers to the entry point's
+                       output variables will be written. The caller must not
+                       free the interface variables written to this array.
+ @return               If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                       Otherwise, the error code indicates the cause of the
+                       failure.
+
+*/
+SpvReflectResult spvReflectEnumerateEntryPointOutputVariables(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                              uint32_t* p_count, SpvReflectInterfaceVariable** pp_variables);
+
+/*! @fn spvReflectEnumeratePushConstantBlocks
+ @brief  Note: If the module contains multiple entry points, this will only get
+         the push constant blocks for the first one.
+ @param  p_module   Pointer to an instance of SpvReflectShaderModule.
+ @param  p_count    If pp_blocks is NULL, the module's push constant
+                    block count will be stored here.
+                    If pp_blocks is not NULL, *p_count must
+                    contain the module's push constant block count.
+ @param  pp_blocks  If NULL, the module's push constant block count
+                    will be written to *p_count.
+                    If non-NULL, pp_blocks must point to an
+                    array with *p_count entries, where pointers to
+                    the module's push constant blocks will be written.
+                    The caller must not free the block variables written
+                    to this array.
+ @return            If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                    Otherwise, the error code indicates the cause of the
+                    failure.
+
+*/
+SpvReflectResult spvReflectEnumeratePushConstantBlocks(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                       SpvReflectBlockVariable** pp_blocks);
+SPV_REFLECT_DEPRECATED("renamed to spvReflectEnumeratePushConstantBlocks")
+SpvReflectResult spvReflectEnumeratePushConstants(const SpvReflectShaderModule* p_module, uint32_t* p_count,
+                                                  SpvReflectBlockVariable** pp_blocks);
+
+/*! @fn spvReflectEnumerateEntryPointPushConstantBlocks
+ @brief  Enumerate the push constant blocks used in the static call tree of a
+         given entry point.
+ @param  p_module   Pointer to an instance of SpvReflectShaderModule.
+ @param  p_count    If pp_blocks is NULL, the entry point's push constant
+                    block count will be stored here.
+                    If pp_blocks is not NULL, *p_count must
+                    contain the entry point's push constant block count.
+ @param  pp_blocks  If NULL, the entry point's push constant block count
+                    will be written to *p_count.
+                    If non-NULL, pp_blocks must point to an
+                    array with *p_count entries, where pointers to
+                    the entry point's push constant blocks will be written.
+                    The caller must not free the block variables written
+                    to this array.
+ @return            If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                    Otherwise, the error code indicates the cause of the
+                    failure.
+
+*/
+SpvReflectResult spvReflectEnumerateEntryPointPushConstantBlocks(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                                 uint32_t* p_count, SpvReflectBlockVariable** pp_blocks);
+
+/*! @fn spvReflectGetDescriptorBinding
+
+ @param  p_module        Pointer to an instance of SpvReflectShaderModule.
+ @param  binding_number  The "binding" value of the requested descriptor
+                         binding.
+ @param  set_number      The "set" value of the requested descriptor binding.
+ @param  p_result        If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                         written to *p_result. Otherwise, a error code
+                         indicating the cause of the failure will be stored
+                         here.
+ @return                 If the module contains a descriptor binding that
+                         matches the provided [binding_number, set_number]
+                         values, a pointer to that binding is returned. The
+                         caller must not free this pointer.
+                         If no match can be found, or if an unrelated error
+                         occurs, the return value will be NULL. Detailed
+                         error results are written to *pResult.
+@note                    If the module contains multiple desriptor bindings
+                         with the same set and binding numbers, there are
+                         no guarantees about which binding will be returned.
+
+*/
+const SpvReflectDescriptorBinding* spvReflectGetDescriptorBinding(const SpvReflectShaderModule* p_module, uint32_t binding_number,
+                                                                  uint32_t set_number, SpvReflectResult* p_result);
+
+/*! @fn spvReflectGetEntryPointDescriptorBinding
+ @brief  Get the descriptor binding with the given binding number and set
+         number that is used in the static call tree of a certain entry
+         point.
+ @param  p_module        Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point     The entry point to get the binding from.
+ @param  binding_number  The "binding" value of the requested descriptor
+                         binding.
+ @param  set_number      The "set" value of the requested descriptor binding.
+ @param  p_result        If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                         written to *p_result. Otherwise, a error code
+                         indicating the cause of the failure will be stored
+                         here.
+ @return                 If the entry point contains a descriptor binding that
+                         matches the provided [binding_number, set_number]
+                         values, a pointer to that binding is returned. The
+                         caller must not free this pointer.
+                         If no match can be found, or if an unrelated error
+                         occurs, the return value will be NULL. Detailed
+                         error results are written to *pResult.
+@note                    If the entry point contains multiple desriptor bindings
+                         with the same set and binding numbers, there are
+                         no guarantees about which binding will be returned.
+
+*/
+const SpvReflectDescriptorBinding* spvReflectGetEntryPointDescriptorBinding(const SpvReflectShaderModule* p_module,
+                                                                            const char* entry_point, uint32_t binding_number,
+                                                                            uint32_t set_number, SpvReflectResult* p_result);
+
+/*! @fn spvReflectGetDescriptorSet
+
+ @param  p_module    Pointer to an instance of SpvReflectShaderModule.
+ @param  set_number  The "set" value of the requested descriptor set.
+ @param  p_result    If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                     written to *p_result. Otherwise, a error code
+                     indicating the cause of the failure will be stored
+                     here.
+ @return             If the module contains a descriptor set with the
+                     provided set_number, a pointer to that set is
+                     returned. The caller must not free this pointer.
+                     If no match can be found, or if an unrelated error
+                     occurs, the return value will be NULL. Detailed
+                     error results are written to *pResult.
+
+*/
+const SpvReflectDescriptorSet* spvReflectGetDescriptorSet(const SpvReflectShaderModule* p_module, uint32_t set_number,
+                                                          SpvReflectResult* p_result);
+
+/*! @fn spvReflectGetEntryPointDescriptorSet
+
+ @param  p_module    Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point The entry point to get the descriptor set from.
+ @param  set_number  The "set" value of the requested descriptor set.
+ @param  p_result    If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                     written to *p_result. Otherwise, a error code
+                     indicating the cause of the failure will be stored
+                     here.
+ @return             If the entry point contains a descriptor set with the
+                     provided set_number, a pointer to that set is
+                     returned. The caller must not free this pointer.
+                     If no match can be found, or if an unrelated error
+                     occurs, the return value will be NULL. Detailed
+                     error results are written to *pResult.
+
+*/
+const SpvReflectDescriptorSet* spvReflectGetEntryPointDescriptorSet(const SpvReflectShaderModule* p_module, const char* entry_point,
+                                                                    uint32_t set_number, SpvReflectResult* p_result);
+
+/* @fn spvReflectGetInputVariableByLocation
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @param  location  The "location" value of the requested input variable.
+                   A location of 0xFFFFFFFF will always return NULL
+                   with *p_result == ELEMENT_NOT_FOUND.
+ @param  p_result  If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                   written to *p_result. Otherwise, a error code
+                   indicating the cause of the failure will be stored
+                   here.
+ @return           If the module contains an input interface variable
+                   with the provided location value, a pointer to that
+                   variable is returned. The caller must not free this
+                   pointer.
+                   If no match can be found, or if an unrelated error
+                   occurs, the return value will be NULL. Detailed
+                   error results are written to *pResult.
+@note
+
+*/
+const SpvReflectInterfaceVariable* spvReflectGetInputVariableByLocation(const SpvReflectShaderModule* p_module, uint32_t location,
+                                                                        SpvReflectResult* p_result);
+SPV_REFLECT_DEPRECATED("renamed to spvReflectGetInputVariableByLocation")
+const SpvReflectInterfaceVariable* spvReflectGetInputVariable(const SpvReflectShaderModule* p_module, uint32_t location,
+                                                              SpvReflectResult* p_result);
+
+/* @fn spvReflectGetEntryPointInputVariableByLocation
+
+ @param  p_module    Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point The entry point to get the input variable from.
+ @param  location    The "location" value of the requested input variable.
+                     A location of 0xFFFFFFFF will always return NULL
+                     with *p_result == ELEMENT_NOT_FOUND.
+ @param  p_result    If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                     written to *p_result. Otherwise, a error code
+                     indicating the cause of the failure will be stored
+                     here.
+ @return             If the entry point contains an input interface variable
+                     with the provided location value, a pointer to that
+                     variable is returned. The caller must not free this
+                     pointer.
+                     If no match can be found, or if an unrelated error
+                     occurs, the return value will be NULL. Detailed
+                     error results are written to *pResult.
+@note
+
+*/
+const SpvReflectInterfaceVariable* spvReflectGetEntryPointInputVariableByLocation(const SpvReflectShaderModule* p_module,
+                                                                                  const char* entry_point, uint32_t location,
+                                                                                  SpvReflectResult* p_result);
+
+/* @fn spvReflectGetInputVariableBySemantic
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @param  semantic  The "semantic" value of the requested input variable.
+                   A semantic of NULL will return NULL.
+                   A semantic of "" will always return NULL with
+                   *p_result == ELEMENT_NOT_FOUND.
+ @param  p_result  If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                   written to *p_result. Otherwise, a error code
+                   indicating the cause of the failure will be stored
+                   here.
+ @return           If the module contains an input interface variable
+                   with the provided semantic, a pointer to that
+                   variable is returned. The caller must not free this
+                   pointer.
+                   If no match can be found, or if an unrelated error
+                   occurs, the return value will be NULL. Detailed
+                   error results are written to *pResult.
+@note
+
+*/
+const SpvReflectInterfaceVariable* spvReflectGetInputVariableBySemantic(const SpvReflectShaderModule* p_module,
+                                                                        const char* semantic, SpvReflectResult* p_result);
+
+/* @fn spvReflectGetEntryPointInputVariableBySemantic
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point The entry point to get the input variable from.
+ @param  semantic  The "semantic" value of the requested input variable.
+                   A semantic of NULL will return NULL.
+                   A semantic of "" will always return NULL with
+                   *p_result == ELEMENT_NOT_FOUND.
+ @param  p_result  If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                   written to *p_result. Otherwise, a error code
+                   indicating the cause of the failure will be stored
+                   here.
+ @return           If the entry point contains an input interface variable
+                   with the provided semantic, a pointer to that
+                   variable is returned. The caller must not free this
+                   pointer.
+                   If no match can be found, or if an unrelated error
+                   occurs, the return value will be NULL. Detailed
+                   error results are written to *pResult.
+@note
+
+*/
+const SpvReflectInterfaceVariable* spvReflectGetEntryPointInputVariableBySemantic(const SpvReflectShaderModule* p_module,
+                                                                                  const char* entry_point, const char* semantic,
+                                                                                  SpvReflectResult* p_result);
+
+/* @fn spvReflectGetOutputVariableByLocation
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @param  location  The "location" value of the requested output variable.
+                   A location of 0xFFFFFFFF will always return NULL
+                   with *p_result == ELEMENT_NOT_FOUND.
+ @param  p_result  If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                   written to *p_result. Otherwise, a error code
+                   indicating the cause of the failure will be stored
+                   here.
+ @return           If the module contains an output interface variable
+                   with the provided location value, a pointer to that
+                   variable is returned. The caller must not free this
+                   pointer.
+                   If no match can be found, or if an unrelated error
+                   occurs, the return value will be NULL. Detailed
+                   error results are written to *pResult.
+@note
+
+*/
+const SpvReflectInterfaceVariable* spvReflectGetOutputVariableByLocation(const SpvReflectShaderModule* p_module, uint32_t location,
+                                                                         SpvReflectResult* p_result);
+SPV_REFLECT_DEPRECATED("renamed to spvReflectGetOutputVariableByLocation")
+const SpvReflectInterfaceVariable* spvReflectGetOutputVariable(const SpvReflectShaderModule* p_module, uint32_t location,
+                                                               SpvReflectResult* p_result);
+
+/* @fn spvReflectGetEntryPointOutputVariableByLocation
+
+ @param  p_module     Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point  The entry point to get the output variable from.
+ @param  location     The "location" value of the requested output variable.
+                      A location of 0xFFFFFFFF will always return NULL
+                      with *p_result == ELEMENT_NOT_FOUND.
+ @param  p_result     If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                      written to *p_result. Otherwise, a error code
+                      indicating the cause of the failure will be stored
+                      here.
+ @return              If the entry point contains an output interface variable
+                      with the provided location value, a pointer to that
+                      variable is returned. The caller must not free this
+                      pointer.
+                      If no match can be found, or if an unrelated error
+                      occurs, the return value will be NULL. Detailed
+                      error results are written to *pResult.
+@note
+
+*/
+const SpvReflectInterfaceVariable* spvReflectGetEntryPointOutputVariableByLocation(const SpvReflectShaderModule* p_module,
+                                                                                   const char* entry_point, uint32_t location,
+                                                                                   SpvReflectResult* p_result);
+
+/* @fn spvReflectGetOutputVariableBySemantic
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @param  semantic  The "semantic" value of the requested output variable.
+                   A semantic of NULL will return NULL.
+                   A semantic of "" will always return NULL with
+                   *p_result == ELEMENT_NOT_FOUND.
+ @param  p_result  If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                   written to *p_result. Otherwise, a error code
+                   indicating the cause of the failure will be stored
+                   here.
+ @return           If the module contains an output interface variable
+                   with the provided semantic, a pointer to that
+                   variable is returned. The caller must not free this
+                   pointer.
+                   If no match can be found, or if an unrelated error
+                   occurs, the return value will be NULL. Detailed
+                   error results are written to *pResult.
+@note
+
+*/
+const SpvReflectInterfaceVariable* spvReflectGetOutputVariableBySemantic(const SpvReflectShaderModule* p_module,
+                                                                         const char* semantic, SpvReflectResult* p_result);
+
+/* @fn spvReflectGetEntryPointOutputVariableBySemantic
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point  The entry point to get the output variable from.
+ @param  semantic  The "semantic" value of the requested output variable.
+                   A semantic of NULL will return NULL.
+                   A semantic of "" will always return NULL with
+                   *p_result == ELEMENT_NOT_FOUND.
+ @param  p_result  If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                   written to *p_result. Otherwise, a error code
+                   indicating the cause of the failure will be stored
+                   here.
+ @return           If the entry point contains an output interface variable
+                   with the provided semantic, a pointer to that
+                   variable is returned. The caller must not free this
+                   pointer.
+                   If no match can be found, or if an unrelated error
+                   occurs, the return value will be NULL. Detailed
+                   error results are written to *pResult.
+@note
+
+*/
+const SpvReflectInterfaceVariable* spvReflectGetEntryPointOutputVariableBySemantic(const SpvReflectShaderModule* p_module,
+                                                                                   const char* entry_point, const char* semantic,
+                                                                                   SpvReflectResult* p_result);
+
+/*! @fn spvReflectGetPushConstantBlock
+
+ @param  p_module  Pointer to an instance of SpvReflectShaderModule.
+ @param  index     The index of the desired block within the module's
+                   array of push constant blocks.
+ @param  p_result  If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                   written to *p_result. Otherwise, a error code
+                   indicating the cause of the failure will be stored
+                   here.
+ @return           If the provided index is within range, a pointer to
+                   the corresponding push constant block is returned.
+                   The caller must not free this pointer.
+                   If no match can be found, or if an unrelated error
+                   occurs, the return value will be NULL. Detailed
+                   error results are written to *pResult.
+
+*/
+const SpvReflectBlockVariable* spvReflectGetPushConstantBlock(const SpvReflectShaderModule* p_module, uint32_t index,
+                                                              SpvReflectResult* p_result);
+SPV_REFLECT_DEPRECATED("renamed to spvReflectGetPushConstantBlock")
+const SpvReflectBlockVariable* spvReflectGetPushConstant(const SpvReflectShaderModule* p_module, uint32_t index,
+                                                         SpvReflectResult* p_result);
+
+/*! @fn spvReflectGetEntryPointPushConstantBlock
+ @brief  Get the push constant block corresponding to the given entry point.
+         As by the Vulkan specification there can be no more than one push
+         constant block used by a given entry point, so if there is one it will
+         be returned, otherwise NULL will be returned.
+ @param  p_module     Pointer to an instance of SpvReflectShaderModule.
+ @param  entry_point  The entry point to get the push constant block from.
+ @param  p_result     If successful, SPV_REFLECT_RESULT_SUCCESS will be
+                      written to *p_result. Otherwise, a error code
+                      indicating the cause of the failure will be stored
+                      here.
+ @return              If the provided index is within range, a pointer to
+                      the corresponding push constant block is returned.
+                      The caller must not free this pointer.
+                      If no match can be found, or if an unrelated error
+                      occurs, the return value will be NULL. Detailed
+                      error results are written to *pResult.
+
+*/
+const SpvReflectBlockVariable* spvReflectGetEntryPointPushConstantBlock(const SpvReflectShaderModule* p_module,
+                                                                        const char* entry_point, SpvReflectResult* p_result);
+
+/*! @fn spvReflectChangeDescriptorBindingNumbers
+ @brief  Assign new set and/or binding numbers to a descriptor binding.
+         In addition to updating the reflection data, this function modifies
+         the underlying SPIR-V bytecode. The updated code can be retrieved
+         with spvReflectGetCode().  If the binding is used in multiple
+         entry points within the module, it will be changed in all of them.
+ @param  p_module            Pointer to an instance of SpvReflectShaderModule.
+ @param  p_binding           Pointer to the descriptor binding to modify.
+ @param  new_binding_number  The new binding number to assign to the
+                             provided descriptor binding.
+                             To leave the binding number unchanged, pass
+                             SPV_REFLECT_BINDING_NUMBER_DONT_CHANGE.
+ @param  new_set_number      The new set number to assign to the
+                             provided descriptor binding. Successfully changing
+                             a descriptor binding's set number invalidates all
+                             existing SpvReflectDescriptorBinding and
+                             SpvReflectDescriptorSet pointers from this module.
+                             To leave the set number unchanged, pass
+                             SPV_REFLECT_SET_NUMBER_DONT_CHANGE.
+ @return                     If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                             Otherwise, the error code indicates the cause of
+                             the failure.
+*/
+SpvReflectResult spvReflectChangeDescriptorBindingNumbers(SpvReflectShaderModule* p_module,
+                                                          const SpvReflectDescriptorBinding* p_binding, uint32_t new_binding_number,
+                                                          uint32_t new_set_number);
+SPV_REFLECT_DEPRECATED("Renamed to spvReflectChangeDescriptorBindingNumbers")
+SpvReflectResult spvReflectChangeDescriptorBindingNumber(SpvReflectShaderModule* p_module,
+                                                         const SpvReflectDescriptorBinding* p_descriptor_binding,
+                                                         uint32_t new_binding_number, uint32_t optional_new_set_number);
+
+/*! @fn spvReflectChangeDescriptorSetNumber
+ @brief  Assign a new set number to an entire descriptor set (including
+         all descriptor bindings in that set).
+         In addition to updating the reflection data, this function modifies
+         the underlying SPIR-V bytecode. The updated code can be retrieved
+         with spvReflectGetCode().  If the descriptor set is used in
+         multiple entry points within the module, it will be modified in all
+         of them.
+ @param  p_module        Pointer to an instance of SpvReflectShaderModule.
+ @param  p_set           Pointer to the descriptor binding to modify.
+ @param  new_set_number  The new set number to assign to the
+                         provided descriptor set, and all its descriptor
+                         bindings. Successfully changing a descriptor
+                         binding's set number invalidates all existing
+                         SpvReflectDescriptorBinding and
+                         SpvReflectDescriptorSet pointers from this module.
+                         To leave the set number unchanged, pass
+                         SPV_REFLECT_SET_NUMBER_DONT_CHANGE.
+ @return                 If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                         Otherwise, the error code indicates the cause of
+                         the failure.
+*/
+SpvReflectResult spvReflectChangeDescriptorSetNumber(SpvReflectShaderModule* p_module, const SpvReflectDescriptorSet* p_set,
+                                                     uint32_t new_set_number);
+
+/*! @fn spvReflectChangeInputVariableLocation
+ @brief  Assign a new location to an input interface variable.
+         In addition to updating the reflection data, this function modifies
+         the underlying SPIR-V bytecode. The updated code can be retrieved
+         with spvReflectGetCode().
+         It is the caller's responsibility to avoid assigning the same
+         location to multiple input variables.  If the input variable is used
+         by multiple entry points in the module, it will be changed in all of
+         them.
+ @param  p_module          Pointer to an instance of SpvReflectShaderModule.
+ @param  p_input_variable  Pointer to the input variable to update.
+ @param  new_location      The new location to assign to p_input_variable.
+ @return                   If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                           Otherwise, the error code indicates the cause of
+                           the failure.
+
+*/
+SpvReflectResult spvReflectChangeInputVariableLocation(SpvReflectShaderModule* p_module,
+                                                       const SpvReflectInterfaceVariable* p_input_variable, uint32_t new_location);
+
+/*! @fn spvReflectChangeOutputVariableLocation
+ @brief  Assign a new location to an output interface variable.
+         In addition to updating the reflection data, this function modifies
+         the underlying SPIR-V bytecode. The updated code can be retrieved
+         with spvReflectGetCode().
+         It is the caller's responsibility to avoid assigning the same
+         location to multiple output variables.  If the output variable is used
+         by multiple entry points in the module, it will be changed in all of
+         them.
+ @param  p_module          Pointer to an instance of SpvReflectShaderModule.
+ @param  p_output_variable Pointer to the output variable to update.
+ @param  new_location      The new location to assign to p_output_variable.
+ @return                   If successful, returns SPV_REFLECT_RESULT_SUCCESS.
+                           Otherwise, the error code indicates the cause of
+                           the failure.
+
+*/
+SpvReflectResult spvReflectChangeOutputVariableLocation(SpvReflectShaderModule* p_module,
+                                                        const SpvReflectInterfaceVariable* p_output_variable,
+                                                        uint32_t new_location);
+
+/*! @fn spvReflectSourceLanguage
+
+ @param  source_lang  The source language code.
+ @return Returns string of source language specified in \a source_lang.
+         The caller must not free the memory associated with this string.
+*/
+const char* spvReflectSourceLanguage(SpvSourceLanguage source_lang);
+
+/*! @fn spvReflectBlockVariableTypeName
+
+ @param  p_var Pointer to block variable.
+ @return Returns string of block variable's type description type name
+         or NULL if p_var is NULL.
+*/
+const char* spvReflectBlockVariableTypeName(const SpvReflectBlockVariable* p_var);
+
+#if defined(__cplusplus)
+};
+#endif
+
+#if defined(__cplusplus)
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace spv_reflect {
+
+/*! \class ShaderModule
+
+*/
+class ShaderModule {
+  public:
+    ShaderModule();
+    ShaderModule(size_t size, const void* p_code, SpvReflectModuleFlags flags = SPV_REFLECT_MODULE_FLAG_NONE);
+    ShaderModule(const std::vector<uint8_t>& code, SpvReflectModuleFlags flags = SPV_REFLECT_MODULE_FLAG_NONE);
+    ShaderModule(const std::vector<uint32_t>& code, SpvReflectModuleFlags flags = SPV_REFLECT_MODULE_FLAG_NONE);
+    ~ShaderModule();
+
+    ShaderModule(ShaderModule&& other);
+    ShaderModule& operator=(ShaderModule&& other);
+
+    SpvReflectResult GetResult() const;
+
+    const SpvReflectShaderModule& GetShaderModule() const;
+
+    uint32_t GetCodeSize() const;
+    const uint32_t* GetCode() const;
+
+    const char* GetEntryPointName() const;
+
+    const char* GetSourceFile() const;
+
+    uint32_t GetEntryPointCount() const;
+    const char* GetEntryPointName(uint32_t index) const;
+    SpvReflectShaderStageFlagBits GetEntryPointShaderStage(uint32_t index) const;
+
+    SpvReflectShaderStageFlagBits GetShaderStage() const;
+    SPV_REFLECT_DEPRECATED("Renamed to GetShaderStage")
+    SpvReflectShaderStageFlagBits GetVulkanShaderStage() const { return GetShaderStage(); }
+
+    SpvReflectResult EnumerateDescriptorBindings(uint32_t* p_count, SpvReflectDescriptorBinding** pp_bindings) const;
+    SpvReflectResult EnumerateEntryPointDescriptorBindings(const char* entry_point, uint32_t* p_count,
+                                                           SpvReflectDescriptorBinding** pp_bindings) const;
+    SpvReflectResult EnumerateDescriptorSets(uint32_t* p_count, SpvReflectDescriptorSet** pp_sets) const;
+    SpvReflectResult EnumerateEntryPointDescriptorSets(const char* entry_point, uint32_t* p_count,
+                                                       SpvReflectDescriptorSet** pp_sets) const;
+    SpvReflectResult EnumerateInterfaceVariables(uint32_t* p_count, SpvReflectInterfaceVariable** pp_variables) const;
+    SpvReflectResult EnumerateEntryPointInterfaceVariables(const char* entry_point, uint32_t* p_count,
+                                                           SpvReflectInterfaceVariable** pp_variables) const;
+    SpvReflectResult EnumerateInputVariables(uint32_t* p_count, SpvReflectInterfaceVariable** pp_variables) const;
+    SpvReflectResult EnumerateEntryPointInputVariables(const char* entry_point, uint32_t* p_count,
+                                                       SpvReflectInterfaceVariable** pp_variables) const;
+    SpvReflectResult EnumerateOutputVariables(uint32_t* p_count, SpvReflectInterfaceVariable** pp_variables) const;
+    SpvReflectResult EnumerateEntryPointOutputVariables(const char* entry_point, uint32_t* p_count,
+                                                        SpvReflectInterfaceVariable** pp_variables) const;
+    SpvReflectResult EnumeratePushConstantBlocks(uint32_t* p_count, SpvReflectBlockVariable** pp_blocks) const;
+    SpvReflectResult EnumerateEntryPointPushConstantBlocks(const char* entry_point, uint32_t* p_count,
+                                                           SpvReflectBlockVariable** pp_blocks) const;
+    SPV_REFLECT_DEPRECATED("Renamed to EnumeratePushConstantBlocks")
+    SpvReflectResult EnumeratePushConstants(uint32_t* p_count, SpvReflectBlockVariable** pp_blocks) const {
+        return EnumeratePushConstantBlocks(p_count, pp_blocks);
+    }
+
+    const SpvReflectDescriptorBinding* GetDescriptorBinding(uint32_t binding_number, uint32_t set_number,
+                                                            SpvReflectResult* p_result = nullptr) const;
+    const SpvReflectDescriptorBinding* GetEntryPointDescriptorBinding(const char* entry_point, uint32_t binding_number,
+                                                                      uint32_t set_number,
+                                                                      SpvReflectResult* p_result = nullptr) const;
+    const SpvReflectDescriptorSet* GetDescriptorSet(uint32_t set_number, SpvReflectResult* p_result = nullptr) const;
+    const SpvReflectDescriptorSet* GetEntryPointDescriptorSet(const char* entry_point, uint32_t set_number,
+                                                              SpvReflectResult* p_result = nullptr) const;
+    const SpvReflectInterfaceVariable* GetInputVariableByLocation(uint32_t location, SpvReflectResult* p_result = nullptr) const;
+    SPV_REFLECT_DEPRECATED("Renamed to GetInputVariableByLocation")
+    const SpvReflectInterfaceVariable* GetInputVariable(uint32_t location, SpvReflectResult* p_result = nullptr) const {
+        return GetInputVariableByLocation(location, p_result);
+    }
+    const SpvReflectInterfaceVariable* GetEntryPointInputVariableByLocation(const char* entry_point, uint32_t location,
+                                                                            SpvReflectResult* p_result = nullptr) const;
+    const SpvReflectInterfaceVariable* GetInputVariableBySemantic(const char* semantic, SpvReflectResult* p_result = nullptr) const;
+    const SpvReflectInterfaceVariable* GetEntryPointInputVariableBySemantic(const char* entry_point, const char* semantic,
+                                                                            SpvReflectResult* p_result = nullptr) const;
+    const SpvReflectInterfaceVariable* GetOutputVariableByLocation(uint32_t location, SpvReflectResult* p_result = nullptr) const;
+    SPV_REFLECT_DEPRECATED("Renamed to GetOutputVariableByLocation")
+    const SpvReflectInterfaceVariable* GetOutputVariable(uint32_t location, SpvReflectResult* p_result = nullptr) const {
+        return GetOutputVariableByLocation(location, p_result);
+    }
+    const SpvReflectInterfaceVariable* GetEntryPointOutputVariableByLocation(const char* entry_point, uint32_t location,
+                                                                             SpvReflectResult* p_result = nullptr) const;
+    const SpvReflectInterfaceVariable* GetOutputVariableBySemantic(const char* semantic,
+                                                                   SpvReflectResult* p_result = nullptr) const;
+    const SpvReflectInterfaceVariable* GetEntryPointOutputVariableBySemantic(const char* entry_point, const char* semantic,
+                                                                             SpvReflectResult* p_result = nullptr) const;
+    const SpvReflectBlockVariable* GetPushConstantBlock(uint32_t index, SpvReflectResult* p_result = nullptr) const;
+    SPV_REFLECT_DEPRECATED("Renamed to GetPushConstantBlock")
+    const SpvReflectBlockVariable* GetPushConstant(uint32_t index, SpvReflectResult* p_result = nullptr) const {
+        return GetPushConstantBlock(index, p_result);
+    }
+    const SpvReflectBlockVariable* GetEntryPointPushConstantBlock(const char* entry_point,
+                                                                  SpvReflectResult* p_result = nullptr) const;
+
+    SpvReflectResult ChangeDescriptorBindingNumbers(const SpvReflectDescriptorBinding* p_binding,
+                                                    uint32_t new_binding_number = SPV_REFLECT_BINDING_NUMBER_DONT_CHANGE,
+                                                    uint32_t optional_new_set_number = SPV_REFLECT_SET_NUMBER_DONT_CHANGE);
+    SPV_REFLECT_DEPRECATED("Renamed to ChangeDescriptorBindingNumbers")
+    SpvReflectResult ChangeDescriptorBindingNumber(const SpvReflectDescriptorBinding* p_binding,
+                                                   uint32_t new_binding_number = SPV_REFLECT_BINDING_NUMBER_DONT_CHANGE,
+                                                   uint32_t new_set_number = SPV_REFLECT_SET_NUMBER_DONT_CHANGE) {
+        return ChangeDescriptorBindingNumbers(p_binding, new_binding_number, new_set_number);
+    }
+    SpvReflectResult ChangeDescriptorSetNumber(const SpvReflectDescriptorSet* p_set,
+                                               uint32_t new_set_number = SPV_REFLECT_SET_NUMBER_DONT_CHANGE);
+    SpvReflectResult ChangeInputVariableLocation(const SpvReflectInterfaceVariable* p_input_variable, uint32_t new_location);
+    SpvReflectResult ChangeOutputVariableLocation(const SpvReflectInterfaceVariable* p_output_variable, uint32_t new_location);
+
+  private:
+    // Make noncopyable
+    ShaderModule(const ShaderModule&);
+    ShaderModule& operator=(const ShaderModule&);
+
+  private:
+    mutable SpvReflectResult m_result = SPV_REFLECT_RESULT_NOT_READY;
+    SpvReflectShaderModule m_module = {};
+};
+
+// =================================================================================================
+// ShaderModule
+// =================================================================================================
+
+/*! @fn ShaderModule
+
+*/
+inline ShaderModule::ShaderModule() {}
+
+/*! @fn ShaderModule
+
+  @param  size
+  @param  p_code
+
+*/
+inline ShaderModule::ShaderModule(size_t size, const void* p_code, SpvReflectModuleFlags flags) {
+    m_result = spvReflectCreateShaderModule2(flags, size, p_code, &m_module);
+}
+
+/*! @fn ShaderModule
+
+  @param  code
+
+*/
+inline ShaderModule::ShaderModule(const std::vector<uint8_t>& code, SpvReflectModuleFlags flags) {
+    m_result = spvReflectCreateShaderModule2(flags, code.size(), code.data(), &m_module);
+}
+
+/*! @fn ShaderModule
+
+  @param  code
+
+*/
+inline ShaderModule::ShaderModule(const std::vector<uint32_t>& code, SpvReflectModuleFlags flags) {
+    m_result = spvReflectCreateShaderModule2(flags, code.size() * sizeof(uint32_t), code.data(), &m_module);
+}
+
+/*! @fn  ~ShaderModule
+
+*/
+inline ShaderModule::~ShaderModule() { spvReflectDestroyShaderModule(&m_module); }
+
+inline ShaderModule::ShaderModule(ShaderModule&& other) { *this = std::move(other); }
+
+inline ShaderModule& ShaderModule::operator=(ShaderModule&& other) {
+    m_result = std::move(other.m_result);
+    m_module = std::move(other.m_module);
+
+    other.m_module = {};
+    return *this;
+}
+
+/*! @fn GetResult
+
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::GetResult() const { return m_result; }
+
+/*! @fn GetShaderModule
+
+  @return
+
+*/
+inline const SpvReflectShaderModule& ShaderModule::GetShaderModule() const { return m_module; }
+
+/*! @fn GetCodeSize
+
+  @return
+
+  */
+inline uint32_t ShaderModule::GetCodeSize() const { return spvReflectGetCodeSize(&m_module); }
+
+/*! @fn GetCode
+
+  @return
+
+*/
+inline const uint32_t* ShaderModule::GetCode() const { return spvReflectGetCode(&m_module); }
+
+/*! @fn GetEntryPoint
+
+  @return Returns entry point
+
+*/
+inline const char* ShaderModule::GetEntryPointName() const { return this->GetEntryPointName(0); }
+
+/*! @fn GetEntryPoint
+
+  @return Returns entry point
+
+*/
+inline const char* ShaderModule::GetSourceFile() const { return m_module.source_file; }
+
+/*! @fn GetEntryPointCount
+
+  @param
+  @return
+*/
+inline uint32_t ShaderModule::GetEntryPointCount() const { return m_module.entry_point_count; }
+
+/*! @fn GetEntryPointName
+
+  @param index
+  @return
+*/
+inline const char* ShaderModule::GetEntryPointName(uint32_t index) const { return m_module.entry_points[index].name; }
+
+/*! @fn GetEntryPointShaderStage
+
+  @param index
+  @return Returns the shader stage for the entry point at \b index
+*/
+inline SpvReflectShaderStageFlagBits ShaderModule::GetEntryPointShaderStage(uint32_t index) const {
+    return m_module.entry_points[index].shader_stage;
+}
+
+/*! @fn GetShaderStage
+
+  @return Returns shader stage for the first entry point
+
+*/
+inline SpvReflectShaderStageFlagBits ShaderModule::GetShaderStage() const { return m_module.shader_stage; }
+
+/*! @fn EnumerateDescriptorBindings
+
+  @param  count
+  @param  p_binding_numbers
+  @param  pp_bindings
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateDescriptorBindings(uint32_t* p_count,
+                                                                  SpvReflectDescriptorBinding** pp_bindings) const {
+    m_result = spvReflectEnumerateDescriptorBindings(&m_module, p_count, pp_bindings);
+    return m_result;
+}
+
+/*! @fn EnumerateEntryPointDescriptorBindings
+
+  @param  entry_point
+  @param  count
+  @param  pp_bindings
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateEntryPointDescriptorBindings(const char* entry_point, uint32_t* p_count,
+                                                                            SpvReflectDescriptorBinding** pp_bindings) const {
+    m_result = spvReflectEnumerateEntryPointDescriptorBindings(&m_module, entry_point, p_count, pp_bindings);
+    return m_result;
+}
+
+/*! @fn EnumerateDescriptorSets
+
+  @param  count
+  @param  pp_sets
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateDescriptorSets(uint32_t* p_count, SpvReflectDescriptorSet** pp_sets) const {
+    m_result = spvReflectEnumerateDescriptorSets(&m_module, p_count, pp_sets);
+    return m_result;
+}
+
+/*! @fn EnumerateEntryPointDescriptorSets
+
+  @param  entry_point
+  @param  count
+  @param  pp_sets
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateEntryPointDescriptorSets(const char* entry_point, uint32_t* p_count,
+                                                                        SpvReflectDescriptorSet** pp_sets) const {
+    m_result = spvReflectEnumerateEntryPointDescriptorSets(&m_module, entry_point, p_count, pp_sets);
+    return m_result;
+}
+
+/*! @fn EnumerateInterfaceVariables
+
+  @param  count
+  @param  pp_variables
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateInterfaceVariables(uint32_t* p_count,
+                                                                  SpvReflectInterfaceVariable** pp_variables) const {
+    m_result = spvReflectEnumerateInterfaceVariables(&m_module, p_count, pp_variables);
+    return m_result;
+}
+
+/*! @fn EnumerateEntryPointInterfaceVariables
+
+  @param  entry_point
+  @param  count
+  @param  pp_variables
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateEntryPointInterfaceVariables(const char* entry_point, uint32_t* p_count,
+                                                                            SpvReflectInterfaceVariable** pp_variables) const {
+    m_result = spvReflectEnumerateEntryPointInterfaceVariables(&m_module, entry_point, p_count, pp_variables);
+    return m_result;
+}
+
+/*! @fn EnumerateInputVariables
+
+  @param  count
+  @param  pp_variables
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateInputVariables(uint32_t* p_count, SpvReflectInterfaceVariable** pp_variables) const {
+    m_result = spvReflectEnumerateInputVariables(&m_module, p_count, pp_variables);
+    return m_result;
+}
+
+/*! @fn EnumerateEntryPointInputVariables
+
+  @param  entry_point
+  @param  count
+  @param  pp_variables
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateEntryPointInputVariables(const char* entry_point, uint32_t* p_count,
+                                                                        SpvReflectInterfaceVariable** pp_variables) const {
+    m_result = spvReflectEnumerateEntryPointInputVariables(&m_module, entry_point, p_count, pp_variables);
+    return m_result;
+}
+
+/*! @fn EnumerateOutputVariables
+
+  @param  count
+  @param  pp_variables
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateOutputVariables(uint32_t* p_count,
+                                                               SpvReflectInterfaceVariable** pp_variables) const {
+    m_result = spvReflectEnumerateOutputVariables(&m_module, p_count, pp_variables);
+    return m_result;
+}
+
+/*! @fn EnumerateEntryPointOutputVariables
+
+  @param  entry_point
+  @param  count
+  @param  pp_variables
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateEntryPointOutputVariables(const char* entry_point, uint32_t* p_count,
+                                                                         SpvReflectInterfaceVariable** pp_variables) const {
+    m_result = spvReflectEnumerateEntryPointOutputVariables(&m_module, entry_point, p_count, pp_variables);
+    return m_result;
+}
+
+/*! @fn EnumeratePushConstantBlocks
+
+  @param  count
+  @param  pp_blocks
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumeratePushConstantBlocks(uint32_t* p_count, SpvReflectBlockVariable** pp_blocks) const {
+    m_result = spvReflectEnumeratePushConstantBlocks(&m_module, p_count, pp_blocks);
+    return m_result;
+}
+
+/*! @fn EnumerateEntryPointPushConstantBlocks
+
+  @param  entry_point
+  @param  count
+  @param  pp_blocks
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::EnumerateEntryPointPushConstantBlocks(const char* entry_point, uint32_t* p_count,
+                                                                            SpvReflectBlockVariable** pp_blocks) const {
+    m_result = spvReflectEnumerateEntryPointPushConstantBlocks(&m_module, entry_point, p_count, pp_blocks);
+    return m_result;
+}
+
+/*! @fn GetDescriptorBinding
+
+  @param  binding_number
+  @param  set_number
+  @param  p_result
+  @return
+
+*/
+inline const SpvReflectDescriptorBinding* ShaderModule::GetDescriptorBinding(uint32_t binding_number, uint32_t set_number,
+                                                                             SpvReflectResult* p_result) const {
+    return spvReflectGetDescriptorBinding(&m_module, binding_number, set_number, p_result);
+}
+
+/*! @fn GetEntryPointDescriptorBinding
+
+  @param  entry_point
+  @param  binding_number
+  @param  set_number
+  @param  p_result
+  @return
+
+*/
+inline const SpvReflectDescriptorBinding* ShaderModule::GetEntryPointDescriptorBinding(const char* entry_point,
+                                                                                       uint32_t binding_number, uint32_t set_number,
+                                                                                       SpvReflectResult* p_result) const {
+    return spvReflectGetEntryPointDescriptorBinding(&m_module, entry_point, binding_number, set_number, p_result);
+}
+
+/*! @fn GetDescriptorSet
+
+  @param  set_number
+  @param  p_result
+  @return
+
+*/
+inline const SpvReflectDescriptorSet* ShaderModule::GetDescriptorSet(uint32_t set_number, SpvReflectResult* p_result) const {
+    return spvReflectGetDescriptorSet(&m_module, set_number, p_result);
+}
+
+/*! @fn GetEntryPointDescriptorSet
+
+  @param  entry_point
+  @param  set_number
+  @param  p_result
+  @return
+
+*/
+inline const SpvReflectDescriptorSet* ShaderModule::GetEntryPointDescriptorSet(const char* entry_point, uint32_t set_number,
+                                                                               SpvReflectResult* p_result) const {
+    return spvReflectGetEntryPointDescriptorSet(&m_module, entry_point, set_number, p_result);
+}
+
+/*! @fn GetInputVariable
+
+  @param  location
+  @param  p_result
+  @return
+
+*/
+inline const SpvReflectInterfaceVariable* ShaderModule::GetInputVariableByLocation(uint32_t location,
+                                                                                   SpvReflectResult* p_result) const {
+    return spvReflectGetInputVariableByLocation(&m_module, location, p_result);
+}
+inline const SpvReflectInterfaceVariable* ShaderModule::GetInputVariableBySemantic(const char* semantic,
+                                                                                   SpvReflectResult* p_result) const {
+    return spvReflectGetInputVariableBySemantic(&m_module, semantic, p_result);
+}
+
+/*! @fn GetEntryPointInputVariable
+
+  @param  entry_point
+  @param  location
+  @param  p_result
+  @return
+
+*/
+inline const SpvReflectInterfaceVariable* ShaderModule::GetEntryPointInputVariableByLocation(const char* entry_point,
+                                                                                             uint32_t location,
+                                                                                             SpvReflectResult* p_result) const {
+    return spvReflectGetEntryPointInputVariableByLocation(&m_module, entry_point, location, p_result);
+}
+inline const SpvReflectInterfaceVariable* ShaderModule::GetEntryPointInputVariableBySemantic(const char* entry_point,
+                                                                                             const char* semantic,
+                                                                                             SpvReflectResult* p_result) const {
+    return spvReflectGetEntryPointInputVariableBySemantic(&m_module, entry_point, semantic, p_result);
+}
+
+/*! @fn GetOutputVariable
+
+  @param  location
+  @param  p_result
+  @return
+
+*/
+inline const SpvReflectInterfaceVariable* ShaderModule::GetOutputVariableByLocation(uint32_t location,
+                                                                                    SpvReflectResult* p_result) const {
+    return spvReflectGetOutputVariableByLocation(&m_module, location, p_result);
+}
+inline const SpvReflectInterfaceVariable* ShaderModule::GetOutputVariableBySemantic(const char* semantic,
+                                                                                    SpvReflectResult* p_result) const {
+    return spvReflectGetOutputVariableBySemantic(&m_module, semantic, p_result);
+}
+
+/*! @fn GetEntryPointOutputVariable
+
+  @param  entry_point
+  @param  location
+  @param  p_result
+  @return
+
+*/
+inline const SpvReflectInterfaceVariable* ShaderModule::GetEntryPointOutputVariableByLocation(const char* entry_point,
+                                                                                              uint32_t location,
+                                                                                              SpvReflectResult* p_result) const {
+    return spvReflectGetEntryPointOutputVariableByLocation(&m_module, entry_point, location, p_result);
+}
+inline const SpvReflectInterfaceVariable* ShaderModule::GetEntryPointOutputVariableBySemantic(const char* entry_point,
+                                                                                              const char* semantic,
+                                                                                              SpvReflectResult* p_result) const {
+    return spvReflectGetEntryPointOutputVariableBySemantic(&m_module, entry_point, semantic, p_result);
+}
+
+/*! @fn GetPushConstant
+
+  @param  index
+  @param  p_result
+  @return
+
+*/
+inline const SpvReflectBlockVariable* ShaderModule::GetPushConstantBlock(uint32_t index, SpvReflectResult* p_result) const {
+    return spvReflectGetPushConstantBlock(&m_module, index, p_result);
+}
+
+/*! @fn GetEntryPointPushConstant
+
+  @param  entry_point
+  @param  index
+  @param  p_result
+  @return
+
+*/
+inline const SpvReflectBlockVariable* ShaderModule::GetEntryPointPushConstantBlock(const char* entry_point,
+                                                                                   SpvReflectResult* p_result) const {
+    return spvReflectGetEntryPointPushConstantBlock(&m_module, entry_point, p_result);
+}
+
+/*! @fn ChangeDescriptorBindingNumbers
+
+  @param  p_binding
+  @param  new_binding_number
+  @param  new_set_number
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::ChangeDescriptorBindingNumbers(const SpvReflectDescriptorBinding* p_binding,
+                                                                     uint32_t new_binding_number, uint32_t new_set_number) {
+    return spvReflectChangeDescriptorBindingNumbers(&m_module, p_binding, new_binding_number, new_set_number);
+}
+
+/*! @fn ChangeDescriptorSetNumber
+
+  @param  p_set
+  @param  new_set_number
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::ChangeDescriptorSetNumber(const SpvReflectDescriptorSet* p_set, uint32_t new_set_number) {
+    return spvReflectChangeDescriptorSetNumber(&m_module, p_set, new_set_number);
+}
+
+/*! @fn ChangeInputVariableLocation
+
+  @param  p_input_variable
+  @param  new_location
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::ChangeInputVariableLocation(const SpvReflectInterfaceVariable* p_input_variable,
+                                                                  uint32_t new_location) {
+    return spvReflectChangeInputVariableLocation(&m_module, p_input_variable, new_location);
+}
+
+/*! @fn ChangeOutputVariableLocation
+
+  @param  p_input_variable
+  @param  new_location
+  @return
+
+*/
+inline SpvReflectResult ShaderModule::ChangeOutputVariableLocation(const SpvReflectInterfaceVariable* p_output_variable,
+                                                                   uint32_t new_location) {
+    return spvReflectChangeOutputVariableLocation(&m_module, p_output_variable, new_location);
+}
+
+}  // namespace spv_reflect
+#endif  // defined(__cplusplus)
+#endif  // SPIRV_REFLECT_H

--- a/tests/spirv_hopper/main.cpp
+++ b/tests/spirv_hopper/main.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <fstream>
+#include <string>
+#include <iostream>
+#include <filesystem>
+
+#include "spirv_hopper.h"
+#include "vulkan_object.h"
+#include "glslang/SPIRV/GlslangToSpv.h"
+
+static bool IsValidSPIRV(size_t file_size, const char* spirv_data) {
+    if (file_size < 4) {
+        return false;
+    } else if (0x03 == spirv_data[0] && 0x02 == spirv_data[1] && 0x23 == spirv_data[2] && 0x07 == spirv_data[3]) {
+        return true;  // Little Endianness
+    } else if (0x07 == spirv_data[0] && 0x23 == spirv_data[1] && 0x02 == spirv_data[2] && 0x03 == spirv_data[3]) {
+        return true;  // Big Endianness
+    } else {
+        return false;
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::cout << "Error:\n\tUsage: ./spirv-hopper [file | directory]\n";
+        return EXIT_FAILURE;
+    } else if (!std::filesystem::exists(argv[1])) {
+        std::cout << "Error: " << argv[1] << " Does not exists\n";
+        return EXIT_FAILURE;
+    }
+
+    std::vector<std::filesystem::path> file_list;
+    std::vector<std::filesystem::path> failed_files;
+
+    if (!std::filesystem::is_directory(argv[1])) {
+        file_list.push_back(argv[1]);
+    } else {
+        for (auto const& dir_entry : std::filesystem::recursive_directory_iterator(argv[1])) {
+            if (std::filesystem::is_regular_file(dir_entry)) {
+                file_list.push_back(dir_entry.path());
+            }
+        }
+    }
+
+    const size_t files_list_count = file_list.size();
+    size_t files_ran_count = 1;
+    std::cout << "Found " << files_list_count << " files\n";
+
+    // Main execution loop
+    {
+        // Single VkInstance scope for every shader
+        VulkanInstance vk;
+        glslang::InitializeProcess();
+
+        for (const auto& file : file_list) {
+            std::ifstream spirv_file(file, std::ios::binary);
+            if (!spirv_file.good()) {
+                std::cout << "Error: Unable to open the file " << file << "\n";
+                failed_files.push_back(file);
+                continue;
+            }
+            spirv_file.seekg(0, spirv_file.end);
+            const size_t file_size = static_cast<size_t>(spirv_file.tellg());
+            spirv_file.seekg(0, spirv_file.beg);
+
+            std::vector<char> spirv_data(file_size);
+            spirv_file.read(spirv_data.data(), static_cast<std::streamsize>(file_size));
+            spirv_file.close();
+
+            if (!IsValidSPIRV(file_size, spirv_data.data())) {
+                std::cout << "Warning: File " << file << " is not a valid SPIR-V File - skipping\n";
+                failed_files.push_back(file);
+            } else {
+                vk.is_valid = true;
+                Hopper hopper(vk, file_size, spirv_data.data());
+
+                std::cout << "[" << files_ran_count++ << "|" << files_list_count << "] Running " << file << "\n";
+
+                if (!hopper.Run() || !vk.is_valid) {
+                    failed_files.push_back(file);
+                }
+            }
+        }
+        glslang::FinalizeProcess();
+    }
+
+    if (!failed_files.empty()) {
+        std::cout << "\nRESULT: Failure!\n";
+        std::cout << "\nThe following tests failed:\n";
+        for (const auto& file : failed_files) {
+            std::cout << "\t" << file << "\n";
+        }
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "\nRESULT: Success!\n";
+}

--- a/tests/spirv_hopper/pass_through_shaders.cpp
+++ b/tests/spirv_hopper/pass_through_shaders.cpp
@@ -1,0 +1,408 @@
+
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "spirv_hopper.h"
+#include "glslang/SPIRV/GlslangToSpv.h"
+#include <iostream>
+
+static constexpr bool IsFloatFormat(SpvReflectFormat format) {
+    switch (format) {
+        case SPV_REFLECT_FORMAT_R32_SFLOAT:
+        case SPV_REFLECT_FORMAT_R32G32_SFLOAT:
+        case SPV_REFLECT_FORMAT_R32G32B32_SFLOAT:
+        case SPV_REFLECT_FORMAT_R32G32B32A32_SFLOAT:
+        case SPV_REFLECT_FORMAT_R64_SFLOAT:
+        case SPV_REFLECT_FORMAT_R64G64_SFLOAT:
+        case SPV_REFLECT_FORMAT_R64G64B64_SFLOAT:
+        case SPV_REFLECT_FORMAT_R64G64B64A64_SFLOAT:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// Can't pass the variable as members in structs can't get information
+// But need the variable format to know which Numeric Type it is (float vs uint vs int)
+std::string Hopper::GetTypeDescription(SpvReflectTypeDescription& description, SpvReflectFormat format) {
+    std::string type;
+    if (description.op == SpvOp::SpvOpTypeArray) {
+        // An array input has a <type> output from the shader
+        // SPIRV Reflect does not store the type of the array so the type
+        // must be determined by the description
+        if ((description.traits.numeric.matrix.column_count > 0) && (description.traits.numeric.matrix.row_count > 0)) {
+            description.op = SpvOp::SpvOpTypeMatrix;
+        } else if (description.traits.numeric.vector.component_count > 0) {
+            description.op = SpvOp::SpvOpTypeVector;
+        } else {
+            // either a float, bool, or int. Must be inferred from format
+            if (description.type_flags & SpvReflectTypeFlagBits::SPV_REFLECT_TYPE_FLAG_FLOAT) {
+                description.op = SpvOp::SpvOpTypeFloat;
+            } else if (description.type_flags & SpvReflectTypeFlagBits::SPV_REFLECT_TYPE_FLAG_INT) {
+                description.op = SpvOp::SpvOpTypeInt;
+            }
+        }
+    }
+
+    switch (description.op) {
+        case SpvOp::SpvOpTypeBool: {
+            type += "bool";
+            break;
+        }
+        case SpvOp::SpvOpTypeFloat: {
+            type += "float";
+            break;
+        }
+        case SpvOp::SpvOpTypeInt: {
+            if (description.traits.numeric.scalar.signedness == 0) {
+                type += "u";
+            }
+            type += "int";
+            break;
+        }
+        case SpvOp::SpvOpTypeVector: {
+            if (!IsFloatFormat(format)) {
+                type += (description.traits.numeric.scalar.signedness == 0) ? "u" : "i";
+            }
+            type += "vec";
+            const uint32_t component_count = description.traits.numeric.vector.component_count;
+            type += std::to_string(component_count);
+            break;
+        }
+        case SpvOp::SpvOpTypeMatrix: {
+            type += "mat";
+            const uint32_t column_count = description.traits.numeric.matrix.column_count;
+            const uint32_t row_count = description.traits.numeric.matrix.row_count;
+            if (column_count == row_count) {
+                type += std::to_string(column_count);
+            } else {
+                type += std::to_string(column_count) + "x" + std::to_string(row_count);
+            }
+            break;
+        }
+        default:
+            // Has a custom type (ex. struct)
+            if (description.type_name != nullptr) {
+                return description.type_name;
+            }
+            type += "UNKNOWN_TYPE";  // Unsupported type
+            break;
+    }
+    return type;
+}
+
+std::string Hopper::DefineCustomStruct(SpvReflectInterfaceVariable& variable) {
+    SpvReflectTypeDescription& description = *variable.type_description;
+    std::string shader = "struct ";
+    shader += (description.type_name) ? description.type_name : "UNKNOWN_TYPE";
+    shader += " {\n";
+    for (uint32_t i = 0; i < description.member_count; i++) {
+        shader += "\t";
+        shader += GetTypeDescription(description.members[i], variable.members[i].format);
+        shader += " ";
+        shader += (description.members[i].struct_member_name) ? description.members[i].struct_member_name
+                                                              : "UNKNOWN_TYPE_MEMBER_" + std::to_string(i);
+        for (uint32_t j = 0; j < description.members[i].traits.array.dims_count; j++) {
+            shader += "[" + std::to_string(description.members[i].traits.array.dims[j]) + "]";
+        }
+        shader += ";\n";
+    }
+    shader += "};\n";
+    return shader;
+}
+
+bool Hopper::CreatePassThroughVertex() {
+    std::string shader = "#version 450\n";
+    for (auto variable : input_variables) {
+        if (IsBuiltinType(variable) == true) {
+            continue;
+        } else if ((shader_stage == VK_SHADER_STAGE_GEOMETRY_BIT && variable->format == SPV_REFLECT_FORMAT_UNDEFINED)) {
+            // TODO - Figure out why some Geometry shaders can these bogus variables
+            continue;
+        }
+
+        // Need to define struct to match
+        if (variable->type_description->op == SpvOp::SpvOpTypeStruct) {
+            shader += DefineCustomStruct(*variable);
+        }
+
+        // over 3 is invalid, means not set, zero is default implicit value
+        const uint32_t component = (variable->component > 3) ? 0 : variable->component;
+
+        shader += "layout(location = ";
+        shader += std::to_string(variable->location);
+        if (component > 0) {
+            shader += ", component = " + std::to_string(component);
+        }
+        shader += ") out ";
+        shader += GetTypeDescription(*variable->type_description, variable->format);
+        shader += " ";
+        // Names might not be valid GLSL names, so just give unique name
+        shader += "var_" + std::to_string(variable->location) + "_" + std::to_string(component);
+
+        // Vertex output into Gemometry are not actually arrays
+        if (shader_stage != VK_SHADER_STAGE_GEOMETRY_BIT) {
+            for (uint32_t i = 0; i < variable->array.dims_count; i++) {
+                shader += "[" + std::to_string(variable->array.dims[i]) + "]";
+            }
+        }
+        shader += ";\n";
+    }
+
+    shader += "void main() { gl_Position = vec4(1.0); }";
+    return BuildPassThroughShader(shader, VK_SHADER_STAGE_VERTEX_BIT);
+}
+
+bool Hopper::CreatePassThroughVertexNoInterface() {
+    std::string shader = "#version 450\nvoid main() { }";
+    return BuildPassThroughShader(shader, VK_SHADER_STAGE_VERTEX_BIT);
+}
+
+// TODO - The CreatePassThrough*() function share a lot, could make a common
+bool Hopper::CreatePassThroughTessellationEval() {
+    std::string shader = "#version 450\n";
+    const size_t patchIndex = shader.size();
+    shader += "layout(triangles, equal_spacing, cw) in;\n";
+
+    for (auto variable : output_variables) {
+        if (IsBuiltinType(variable) == true) {
+            continue;
+        }
+
+        // Need to define struct to match
+        if (variable->type_description->op == SpvOp::SpvOpTypeStruct) {
+            shader += DefineCustomStruct(*variable);
+        }
+
+        // over 3 is invalid, means not set, zero is default implicit value
+        const uint32_t component = (variable->component > 3) ? 0 : variable->component;
+
+        shader += "layout(location = ";
+        shader += std::to_string(variable->location);
+        if (component > 0) {
+            shader += ", component = " + std::to_string(component);
+        }
+        shader += ") in ";
+        if (variable->type_description->type_name != nullptr) {
+            std::string patch = DefineCustomStruct(*variable);
+            shader.insert(patchIndex, patch);
+        }
+        shader += GetTypeDescription(*variable->type_description, variable->format);
+        shader += " ";
+        shader += "var_" + std::to_string(variable->location) + "_" + std::to_string(component);
+        shader += "[]";
+        shader += ";\n";
+    }
+    shader += "void main() { gl_Position = vec4(1.0); }";
+    return BuildPassThroughShader(shader, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT);
+}
+
+bool Hopper::CreatePassThroughTessellationControl() {
+    std::string shader = "#version 450\n";
+    const size_t patchIndex = shader.size();
+    shader += "layout(vertices = 3) out;\n";
+
+    for (auto variable : input_variables) {
+        if (IsBuiltinType(variable) == true) {
+            continue;
+        }
+
+        // Need to define struct to match
+        if (variable->type_description->op == SpvOp::SpvOpTypeStruct) {
+            shader += DefineCustomStruct(*variable);
+        }
+
+        // over 3 is invalid, means not set, zero is default implicit value
+        const uint32_t component = (variable->component > 3) ? 0 : variable->component;
+
+        shader += "layout(location = ";
+        shader += std::to_string(variable->location);
+        if (component > 0) {
+            shader += ", component = " + std::to_string(component);
+        }
+        shader += ") out ";
+        if (variable->type_description->type_name != nullptr) {
+            std::string patch = DefineCustomStruct(*variable);
+            shader.insert(patchIndex, patch);
+        }
+        shader += GetTypeDescription(*variable->type_description, variable->format);
+        shader += " ";
+        shader += "var_" + std::to_string(variable->location) + "_" + std::to_string(component);
+        shader += "[]";
+        shader += ";\n";
+    }
+    shader += "void main() { }";
+    return BuildPassThroughShader(shader, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT);
+}
+
+static TBuiltInResource InitResources() {
+    TBuiltInResource resources;
+    resources.maxLights = 32;
+    resources.maxClipPlanes = 6;
+    resources.maxTextureUnits = 32;
+    resources.maxTextureCoords = 32;
+    resources.maxVertexAttribs = 64;
+    resources.maxVertexUniformComponents = 4096;
+    resources.maxVaryingFloats = 64;
+    resources.maxVertexTextureImageUnits = 32;
+    resources.maxCombinedTextureImageUnits = 80;
+    resources.maxTextureImageUnits = 32;
+    resources.maxFragmentUniformComponents = 4096;
+    resources.maxDrawBuffers = 32;
+    resources.maxVertexUniformVectors = 128;
+    resources.maxVaryingVectors = 8;
+    resources.maxFragmentUniformVectors = 16;
+    resources.maxVertexOutputVectors = 16;
+    resources.maxFragmentInputVectors = 15;
+    resources.minProgramTexelOffset = -8;
+    resources.maxProgramTexelOffset = 7;
+    resources.maxClipDistances = 8;
+    resources.maxComputeWorkGroupCountX = 65535;
+    resources.maxComputeWorkGroupCountY = 65535;
+    resources.maxComputeWorkGroupCountZ = 65535;
+    resources.maxComputeWorkGroupSizeX = 1024;
+    resources.maxComputeWorkGroupSizeY = 1024;
+    resources.maxComputeWorkGroupSizeZ = 64;
+    resources.maxComputeUniformComponents = 1024;
+    resources.maxComputeTextureImageUnits = 16;
+    resources.maxComputeImageUniforms = 8;
+    resources.maxComputeAtomicCounters = 8;
+    resources.maxComputeAtomicCounterBuffers = 1;
+    resources.maxVaryingComponents = 60;
+    resources.maxVertexOutputComponents = 64;
+    resources.maxGeometryInputComponents = 64;
+    resources.maxGeometryOutputComponents = 128;
+    resources.maxFragmentInputComponents = 128;
+    resources.maxImageUnits = 8;
+    resources.maxCombinedImageUnitsAndFragmentOutputs = 8;
+    resources.maxCombinedShaderOutputResources = 8;
+    resources.maxImageSamples = 0;
+    resources.maxVertexImageUniforms = 0;
+    resources.maxTessControlImageUniforms = 0;
+    resources.maxTessEvaluationImageUniforms = 0;
+    resources.maxGeometryImageUniforms = 0;
+    resources.maxFragmentImageUniforms = 8;
+    resources.maxCombinedImageUniforms = 8;
+    resources.maxGeometryTextureImageUnits = 16;
+    resources.maxGeometryOutputVertices = 256;
+    resources.maxGeometryTotalOutputComponents = 1024;
+    resources.maxGeometryUniformComponents = 1024;
+    resources.maxGeometryVaryingComponents = 64;
+    resources.maxTessControlInputComponents = 128;
+    resources.maxTessControlOutputComponents = 128;
+    resources.maxTessControlTextureImageUnits = 16;
+    resources.maxTessControlUniformComponents = 1024;
+    resources.maxTessControlTotalOutputComponents = 4096;
+    resources.maxTessEvaluationInputComponents = 128;
+    resources.maxTessEvaluationOutputComponents = 128;
+    resources.maxTessEvaluationTextureImageUnits = 16;
+    resources.maxTessEvaluationUniformComponents = 1024;
+    resources.maxTessPatchComponents = 120;
+    resources.maxPatchVertices = 32;
+    resources.maxTessGenLevel = 64;
+    resources.maxViewports = 16;
+    resources.maxVertexAtomicCounters = 0;
+    resources.maxTessControlAtomicCounters = 0;
+    resources.maxTessEvaluationAtomicCounters = 0;
+    resources.maxGeometryAtomicCounters = 0;
+    resources.maxFragmentAtomicCounters = 8;
+    resources.maxCombinedAtomicCounters = 8;
+    resources.maxAtomicCounterBindings = 1;
+    resources.maxVertexAtomicCounterBuffers = 0;
+    resources.maxTessControlAtomicCounterBuffers = 0;
+    resources.maxTessEvaluationAtomicCounterBuffers = 0;
+    resources.maxGeometryAtomicCounterBuffers = 0;
+    resources.maxFragmentAtomicCounterBuffers = 1;
+    resources.maxCombinedAtomicCounterBuffers = 1;
+    resources.maxAtomicCounterBufferSize = 16384;
+    resources.maxTransformFeedbackBuffers = 4;
+    resources.maxTransformFeedbackInterleavedComponents = 64;
+    resources.maxCullDistances = 8;
+    resources.maxCombinedClipAndCullDistances = 8;
+    resources.maxSamples = 4;
+    resources.maxMeshOutputVerticesNV = 256;
+    resources.maxMeshOutputPrimitivesNV = 512;
+    resources.maxMeshWorkGroupSizeX_NV = 32;
+    resources.maxMeshWorkGroupSizeY_NV = 1;
+    resources.maxMeshWorkGroupSizeZ_NV = 1;
+    resources.maxTaskWorkGroupSizeX_NV = 32;
+    resources.maxTaskWorkGroupSizeY_NV = 1;
+    resources.maxTaskWorkGroupSizeZ_NV = 1;
+    resources.maxMeshViewCountNV = 4;
+    resources.maxMeshOutputVerticesEXT = 256;
+    resources.maxMeshOutputPrimitivesEXT = 512;
+    resources.maxMeshWorkGroupSizeX_EXT = 32;
+    resources.maxMeshWorkGroupSizeY_EXT = 1;
+    resources.maxMeshWorkGroupSizeZ_EXT = 1;
+    resources.maxTaskWorkGroupSizeX_EXT = 32;
+    resources.maxTaskWorkGroupSizeY_EXT = 1;
+    resources.maxTaskWorkGroupSizeZ_EXT = 1;
+    resources.maxMeshViewCountEXT = 4;
+    resources.maxDualSourceDrawBuffersEXT = 1;
+    resources.limits.nonInductiveForLoops = 1;
+    resources.limits.whileLoops = 1;
+    resources.limits.doWhileLoops = 1;
+    resources.limits.generalUniformIndexing = 1;
+    resources.limits.generalAttributeMatrixVectorIndexing = 1;
+    resources.limits.generalVaryingIndexing = 1;
+    resources.limits.generalSamplerIndexing = 1;
+    resources.limits.generalVariableIndexing = 1;
+    resources.limits.generalConstantMatrixVectorIndexing = 1;
+
+    return resources;
+}
+static const TBuiltInResource DefaultTBuiltInResource = InitResources();
+
+bool Hopper::BuildPassThroughShader(std::string& source, VkShaderStageFlagBits stage) {
+    glslang::TProgram program;
+
+    EShLanguage glsl_stage = EShLangVertex;
+    switch (stage) {
+        case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
+            glsl_stage = EShLangTessControl;
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
+            glsl_stage = EShLangTessEvaluation;
+            break;
+        default:
+            break;
+    }
+
+    // TODO - smart pointer, also in VkTestFramework::GLSLtoSPV
+    glslang::TShader* shader = new glslang::TShader(glsl_stage);
+    shader->setEnvTarget(glslang::EshTargetSpv, glslang::EShTargetSpv_1_6);
+    shader->setEnvClient(glslang::EShClientVulkan, glslang::EShTargetVulkan_1_3);
+
+    const char* shader_strings = source.c_str();
+    const int shader_length = static_cast<int>(source.length());
+    shader->setStringsWithLengths(&shader_strings, &shader_length, 1);
+    EShMessages messages = EShMsgDefault;
+    if (!shader->parse(&DefaultTBuiltInResource, 110, false, messages)) {
+        std::cout << shader->getInfoLog() << "\n";
+        std::cout << source << "\n";
+        return false;
+    }
+
+    program.addShader(shader);
+    if (!program.link(messages)) {
+        std::cout << shader->getInfoLog() << "\n";
+        std::cout << source << "\n";
+        return false;
+    }
+
+    glslang::SpvOptions spv_options;
+    std::vector<uint32_t> spirv;
+    glslang::GlslangToSpv(*program.getIntermediate(glsl_stage), spirv, &spv_options);
+
+    delete shader;
+
+    return CreateShaderStage(spirv.size() * sizeof(uint32_t), spirv.data(), stage);
+}

--- a/tests/spirv_hopper/spirv_hopper.cpp
+++ b/tests/spirv_hopper/spirv_hopper.cpp
@@ -1,0 +1,470 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <iostream>
+#include "spirv_hopper.h"
+#include <unordered_map>
+#include "vulkan_object.h"
+
+#include "generated/lvt_function_pointers.h"
+#include "generated/vk_typemap_helper.h"
+
+#define REFLECT_SUCCESS(err)                                          \
+    {                                                                 \
+        const SpvReflectResult result = err;                          \
+        if (result != SpvReflectResult::SPV_REFLECT_RESULT_SUCCESS) { \
+            return false;                                             \
+        }                                                             \
+    }
+
+#define VK_SUCCESS(err)              \
+    {                                \
+        const VkResult result = err; \
+        if (result != VK_SUCCESS) {  \
+            return false;            \
+        }                            \
+    }
+
+Hopper::Hopper(VulkanInstance& vk, size_t file_size, const void* spirv_data)
+    : vk(vk), file_size(file_size), spirv_data(spirv_data) {}
+
+Hopper::~Hopper() {
+    for (const auto& shader_module : shader_modules) {
+        if (shader_module != VK_NULL_HANDLE) {
+            vk::DestroyShaderModule(vk.device, shader_module, nullptr);
+        }
+    }
+    if (render_pass != VK_NULL_HANDLE) {
+        vk::DestroyRenderPass(vk.device, render_pass, nullptr);
+    }
+    if (pipeline_layout != VK_NULL_HANDLE) {
+        vk::DestroyPipelineLayout(vk.device, pipeline_layout, nullptr);
+    }
+    if (pipeline != VK_NULL_HANDLE) {
+        vk::DestroyPipeline(vk.device, pipeline, nullptr);
+    }
+
+    spvReflectDestroyShaderModule(&module);
+}
+
+bool Hopper::Reflect() {
+    REFLECT_SUCCESS(spvReflectCreateShaderModule2(SPV_REFLECT_MODULE_FLAG_NO_COPY, file_size, spirv_data, &module));
+
+    if (module.entry_point_count == 0) {
+        std::cout << "WARNING: No entrypoint, no way to test\n";
+        return true;
+    } else if (module.entry_point_count > 1) {
+        uint32_t shader_stage_set = 0x0;
+        for (uint32_t i = 0; i < module.entry_point_count; i++) {
+            if (shader_stage_set & module.entry_points[i].shader_stage) {
+                std::cout << "Warning: Can't handle duplicate Execution Modes in moudle, might have duplciated objects\n";
+            }
+            shader_stage_set |= module.entry_points[i].shader_stage;
+        }
+        // TODO - Just take first entry point for now
+        std::cout << "WARNING: Only the first entry point modules is used\n";
+    }
+    entry_point = module.entry_points[0];
+    shader_stage = static_cast<VkShaderStageFlagBits>(module.shader_stage);
+
+    uint32_t count = 0;
+    REFLECT_SUCCESS(spvReflectEnumerateInputVariables(&module, &count, nullptr));
+    input_variables.resize(count);
+    REFLECT_SUCCESS(spvReflectEnumerateInputVariables(&module, &count, input_variables.data()));
+
+    REFLECT_SUCCESS(spvReflectEnumerateOutputVariables(&module, &count, nullptr));
+    output_variables.resize(count);
+    REFLECT_SUCCESS(spvReflectEnumerateOutputVariables(&module, &count, output_variables.data()));
+
+    REFLECT_SUCCESS(spvReflectEnumeratePushConstantBlocks(&module, &count, nullptr));
+    push_constants.resize(count);
+    REFLECT_SUCCESS(spvReflectEnumeratePushConstantBlocks(&module, &count, push_constants.data()));
+
+    REFLECT_SUCCESS(spvReflectEnumerateDescriptorSets(&module, &count, nullptr));
+    descriptor_sets.resize(count);
+    REFLECT_SUCCESS(spvReflectEnumerateDescriptorSets(&module, &count, descriptor_sets.data()));
+    return true;
+}
+
+bool Hopper::CreatePipelineLayout() {
+    // get the VkDescriptorSetLayouts
+    std::vector<VkDescriptorSetLayout> layouts;
+    struct DescriptorSetLayoutData {
+        uint32_t set;
+        VkDescriptorSetLayoutCreateInfo ds_create_info;
+        std::vector<VkDescriptorSetLayoutBinding> bindings;
+    };
+
+    std::vector<DescriptorSetLayoutData> set_layouts(descriptor_sets.size(), DescriptorSetLayoutData{});
+    for (uint32_t set_id = 0; set_id < descriptor_sets.size(); set_id++) {
+        const SpvReflectDescriptorSet& reflect_set = *(descriptor_sets[set_id]);
+        DescriptorSetLayoutData& layout = set_layouts[set_id];
+
+        // There can be a template descriptor where 2 variables share the same slot, but will be duplicated here
+        // <binding, index into bindings to grab again>
+        std::unordered_map<uint32_t, uint32_t> used_bindings;
+
+        for (uint32_t i = 0; i < reflect_set.binding_count; i++) {
+            const SpvReflectDescriptorBinding& reflect = *(reflect_set.bindings[i]);
+            VkDescriptorSetLayoutBinding new_binding;
+
+            new_binding.descriptorType = static_cast<VkDescriptorType>(reflect.descriptor_type);
+            new_binding.binding = reflect.binding;
+            new_binding.descriptorCount = 1;
+            for (uint32_t dim_id = 0; dim_id < reflect.array.dims_count; dim_id++) {
+                const uint32_t dim = reflect.array.dims[dim_id];
+                // an OpTypeRuntimeArray will have a zero dim
+                // https://github.com/KhronosGroup/SPIRV-Reflect/issues/177
+                if (dim != 0) {
+                    new_binding.descriptorCount *= reflect.array.dims[dim_id];
+                }
+            }
+            new_binding.stageFlags = shader_stage;
+            new_binding.pImmutableSamplers = nullptr;
+
+            if (auto used = used_bindings.find(new_binding.binding); used != used_bindings.end()) {
+                VkDescriptorSetLayoutBinding& other_binding = layout.bindings[used->second];
+                if ((other_binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER &&
+                     new_binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) ||
+                    (other_binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE &&
+                     new_binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER)) {
+                    // COMBINED images in HLSL can actually be seperated types sharing same slot
+                    other_binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+                } else {
+                    // templated descriptor - nothing to do for now
+                }
+                continue;  // prevent duplicated bindings index
+            }
+
+            if (new_binding.descriptorType == VkDescriptorType::VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) {
+                input_attachments.push_back(&reflect);
+            }
+            layout.bindings.push_back(new_binding);
+            used_bindings[new_binding.binding] = static_cast<uint32_t>(layout.bindings.size() - 1);
+        }
+        layout.set = reflect_set.set;
+        layout.ds_create_info = LvlInitStruct<VkDescriptorSetLayoutCreateInfo>();
+        layout.ds_create_info.bindingCount = static_cast<uint32_t>(layout.bindings.size());
+        layout.ds_create_info.pBindings = layout.bindings.data();
+    }
+
+    uint32_t id = 0;
+    for (const DescriptorSetLayoutData& set_layout : set_layouts) {
+        while (set_layout.set > id) {
+            id++;
+            VkDescriptorSetLayout layout = VK_NULL_HANDLE;
+            VK_SUCCESS(vk::CreateDescriptorSetLayout(vk.device, &set_layout.ds_create_info, nullptr, &layout));
+            layouts.push_back(layout);
+        }
+        VkDescriptorSetLayout layout = VK_NULL_HANDLE;
+        VK_SUCCESS(vk::CreateDescriptorSetLayout(vk.device, &set_layout.ds_create_info, nullptr, &layout));
+        layouts.push_back(layout);
+        id++;
+    }
+
+    // Get the push constants
+    std::vector<VkPushConstantRange> push_constant_ranges;
+    for (uint32_t i = 0; i < push_constants.size(); i++) {
+        VkPushConstantRange range = {};
+        range.stageFlags = static_cast<VkShaderStageFlagBits>(shader_stage);
+        range.size = push_constants[i]->size;
+        range.offset = push_constants[i]->offset;
+        push_constant_ranges.push_back(range);
+    }
+
+    // Create the pipeline layout
+    {
+        auto pipeline_layout_info = LvlInitStruct<VkPipelineLayoutCreateInfo>();
+        pipeline_layout_info.flags = 0;
+        pipeline_layout_info.pSetLayouts = layouts.data();
+        pipeline_layout_info.setLayoutCount = static_cast<uint32_t>(layouts.size());
+        pipeline_layout_info.pPushConstantRanges = push_constant_ranges.data();
+        pipeline_layout_info.pushConstantRangeCount = static_cast<uint32_t>(push_constant_ranges.size());
+        VK_SUCCESS(vk::CreatePipelineLayout(vk.device, &pipeline_layout_info, nullptr, &pipeline_layout));
+    }
+
+    // cleanup
+    for (VkDescriptorSetLayout& layout : layouts) {
+        vk::DestroyDescriptorSetLayout(vk.device, layout, nullptr);
+    }
+    return true;
+}
+
+// Some Builtins like 'gl_in' of tessellation shaders are structs and so the gl_* identifiers are reserved. Can't assume all
+// structs are Builtins.
+bool Hopper::IsBuiltinType(SpvReflectInterfaceVariable* variable) {
+    return (variable->built_in >= 0 || (variable->name && std::string(variable->name).find("gl_") == 0));
+}
+
+bool Hopper::CreateShaderStage(size_t code_size, const void* code, VkShaderStageFlagBits stage, const char* name) {
+    auto shader_module_info = LvlInitStruct<VkShaderModuleCreateInfo>();
+    shader_module_info.flags = 0;
+    shader_module_info.pCode = reinterpret_cast<const uint32_t*>(code);
+    shader_module_info.codeSize = code_size;
+    VkShaderModule shader_module;
+    VK_SUCCESS(vk::CreateShaderModule(vk.device, &shader_module_info, nullptr, &shader_module));
+    shader_modules.push_back(shader_module);
+
+    auto shader_stage_info = LvlInitStruct<VkPipelineShaderStageCreateInfo>();
+    shader_stage_info.flags = 0;
+    shader_stage_info.stage = stage;
+    shader_stage_info.module = shader_module;
+    shader_stage_info.pName = name;
+    shader_stage_info.pSpecializationInfo = nullptr;
+    shader_stages_info.push_back(shader_stage_info);
+    return true;
+}
+
+static uint32_t DescriptionLocationsConsumed(SpvReflectTypeDescription& description) {
+    const uint32_t scalar_bytes = description.traits.numeric.scalar.width / 8;
+    const uint32_t bytes_in_location = 16;
+    uint32_t vector_location_consumed = 1;
+    uint32_t column_count = 1;
+
+    // SpvOpTypeVector
+    if (description.traits.numeric.vector.component_count > 0) {
+        uint32_t vector_length = description.traits.numeric.vector.component_count;
+        vector_location_consumed = (vector_length * scalar_bytes > bytes_in_location) ? 2 : 1;
+    }
+    // SpvOpTypeMatrix
+    if ((description.traits.numeric.matrix.column_count > 0) && (description.traits.numeric.matrix.row_count > 0)) {
+        column_count = description.traits.numeric.matrix.column_count;
+    }
+
+    return vector_location_consumed * column_count;
+}
+
+bool Hopper::CreateVertexAttributeDescriptions(SpvReflectInterfaceVariable& variable) {
+    bool success = true;
+    SpvReflectTypeDescription& description = *variable.type_description;
+    if (variable.member_count > 0) {
+        if (description.op == SpvOp::SpvOpTypeArray) {
+            // SPIRV-Reflect can't handle array-of-structs currently
+            return false;
+        }
+
+        // Walk down struct
+        for (uint32_t i = 0; i < variable.member_count; i++) {
+            success &= CreateVertexAttributeDescriptions(variable.members[i]);
+        }
+    } else {
+        uint32_t array_elements = 1;
+        for (uint32_t i = 0; i < description.traits.array.dims_count; i++) {
+            array_elements *= description.traits.array.dims[i];
+        }
+
+        const uint32_t locations = DescriptionLocationsConsumed(description) * array_elements;
+
+        const bool is_block_location = (variable.location == 0);
+        const uint32_t start_location = is_block_location ? block_location : variable.location;
+
+        if (is_block_location) {
+            block_location += locations;
+        }
+
+        for (uint32_t i = 0; i < locations; i++) {
+            // The only things we need are the location and format for each Vertex Input
+            // binding and offset values don't matter
+            vertex_input_attributes.push_back({start_location + i, 0, static_cast<VkFormat>(variable.format), 0});
+        }
+    }
+    return success;
+}
+
+bool Hopper::CreateGraphicsPipeline() {
+    // Create pass through shaders for stages at need one
+    bool success = true;
+    switch (shader_stage) {
+        case VK_SHADER_STAGE_GEOMETRY_BIT:
+        case VK_SHADER_STAGE_FRAGMENT_BIT:
+            success &= CreatePassThroughVertex();
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
+            success &= CreatePassThroughVertexNoInterface();
+            success &= CreatePassThroughTessellationControl();
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
+            success &= CreatePassThroughVertexNoInterface();
+            success &= CreatePassThroughTessellationEval();
+            break;
+        default:
+            break;
+    }
+    if (!success) return false;
+
+    uint32_t attachment_count = 0;
+    // VkPipelineColorBlendStateCreateInfo
+    {
+        if (shader_stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
+            std::vector<uint32_t> fragment_attachments;
+            for (uint32_t i = 0; i < output_variables.size(); i++) {
+                attachment_count = std::max(attachment_count, output_variables[i]->location);
+            }
+            // locations are 0 indexed so increment by 1
+            attachment_count += 1;
+        }
+
+        color_attachment_references.resize(attachment_count);
+        color_blend_attachments.resize(attachment_count);
+        for (uint32_t i = 0; i < attachment_count; i++) {
+            color_attachment_references[i].attachment = 0;
+            color_attachment_references[i].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+            color_blend_attachments[i].blendEnable = VK_FALSE;
+            color_blend_attachments[i].colorWriteMask =
+                VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+        }
+
+        vk.color_blend_state.attachmentCount = static_cast<uint32_t>(color_blend_attachments.size());
+        vk.color_blend_state.pAttachments = color_blend_attachments.data();
+    }
+
+    // VkPipelineVertexInputStateCreateInfo
+    {
+        vk.vertex_input_state.vertexAttributeDescriptionCount = 0;
+        vk.vertex_input_state.pVertexAttributeDescriptions = nullptr;
+
+        if (shader_stage == VK_SHADER_STAGE_VERTEX_BIT) {
+            for (uint32_t i = 0; i < input_variables.size(); i++) {
+                SpvReflectInterfaceVariable* input_variable = input_variables[i];
+                // built in types (gl_VertexIndex, etc) are not part of the vertex input
+                // Any negative value means it is not part of the SpvBuiltIn
+                if (IsBuiltinType(input_variable) == true) {
+                    continue;
+                }
+
+                // Locations can either be set on the Struct or the first level members.
+                // It is not valid to have Locations decorations on nested struct blocks.
+                // Since the value is "zero" for not being set, simpler to just know here where it is decorated.
+                // No decoration == "zero" implicitly (which is the default)
+                block_location = input_variable->location;
+
+                success = CreateVertexAttributeDescriptions(*input_variable);
+                if (!success) return false;
+            }
+
+            vk.vertex_input_state.vertexAttributeDescriptionCount = static_cast<uint32_t>(vertex_input_attributes.size());
+            vk.vertex_input_state.pVertexAttributeDescriptions = vertex_input_attributes.data();
+        }
+    }
+
+    // VkPipelineInputAssemblyStateCreateInfo
+    {
+        vk.input_assembly_state.topology = ((shader_stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT) ||
+                                            (shader_stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT))
+                                               ? VK_PRIMITIVE_TOPOLOGY_PATCH_LIST
+                                               : VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    }
+
+    // Subpass and Renderpass
+    {
+        // Find all the attachments and create a Framebuffer and RenderPass
+        VkSubpassDescription subpass_dscription = {};
+        subpass_dscription.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_dscription.colorAttachmentCount = attachment_count;
+        subpass_dscription.pColorAttachments = color_attachment_references.data();
+
+        // Create dummy input attachments if the shader requires input attachments.
+        std::vector<VkAttachmentReference> input_attachment_reference;
+        std::vector<VkAttachmentDescription> input_attachment_description;
+        for (uint32_t i = 0; i < input_attachments.size(); i++) {
+            // input_attachment_reference.push_back({input_attachments[i].input_attachment_index, VK_IMAGE_LAYOUT_GENERAL});
+            input_attachment_reference.push_back({0, VK_IMAGE_LAYOUT_GENERAL});
+        }
+        subpass_dscription.inputAttachmentCount = static_cast<uint32_t>(input_attachment_reference.size());
+        subpass_dscription.pInputAttachments = input_attachment_reference.data();
+
+        auto render_pass_info = LvlInitStruct<VkRenderPassCreateInfo>();
+        render_pass_info.flags = 0;
+        render_pass_info.attachmentCount = 1;
+        render_pass_info.pAttachments = &vk.basic_attachment_description;
+        render_pass_info.subpassCount = 1;
+        render_pass_info.pSubpasses = &subpass_dscription;
+        render_pass_info.dependencyCount = 0;
+        render_pass_info.pDependencies = nullptr;
+        VK_SUCCESS(vk::CreateRenderPass(vk.device, &render_pass_info, nullptr, &render_pass));
+    }
+
+    auto pipeline_info = LvlInitStruct<VkGraphicsPipelineCreateInfo>();
+    pipeline_info.flags = 0;
+    pipeline_info.stageCount = static_cast<uint32_t>(shader_stages_info.size());
+    pipeline_info.pStages = shader_stages_info.data();
+    pipeline_info.pVertexInputState = &vk.vertex_input_state;
+    pipeline_info.pInputAssemblyState = &vk.input_assembly_state;
+    pipeline_info.pTessellationState = &vk.tessellation_state;
+    pipeline_info.pViewportState = &vk.viewport_input_state;
+    pipeline_info.pRasterizationState = &vk.rasterization_state;
+    pipeline_info.pMultisampleState = &vk.multisample_state;
+    pipeline_info.pDepthStencilState = nullptr;
+    pipeline_info.pColorBlendState = &vk.color_blend_state;
+    pipeline_info.pDynamicState = nullptr;
+    pipeline_info.layout = pipeline_layout;
+    pipeline_info.renderPass = render_pass;
+    pipeline_info.subpass = 0;
+    pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
+
+    VK_SUCCESS(vk::CreateGraphicsPipelines(vk.device, VK_NULL_HANDLE, 1, &pipeline_info, nullptr, &pipeline));
+    return success;
+}
+
+bool Hopper::CreateComputePipeline() {
+    auto pipeline_info = LvlInitStruct<VkComputePipelineCreateInfo>();
+    pipeline_info.flags = 0;
+    pipeline_info.stage = shader_stages_info[0];
+    pipeline_info.layout = pipeline_layout;
+    pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
+
+    VK_SUCCESS(vk::CreateComputePipelines(vk.device, VK_NULL_HANDLE, 1, &pipeline_info, nullptr, &pipeline));
+    return true;
+}
+
+bool Hopper::Run() {
+    if (!Reflect()) return false;
+    if (!CreatePipelineLayout()) return false;
+    // Create shader module for shader we are testing
+    if (!CreateShaderStage(file_size, spirv_data, shader_stage, entry_point.name)) return false;
+
+    bool success = true;
+    switch (shader_stage) {
+        case VK_SHADER_STAGE_VERTEX_BIT:
+        case VK_SHADER_STAGE_GEOMETRY_BIT:
+        case VK_SHADER_STAGE_FRAGMENT_BIT:
+            success = CreateGraphicsPipeline();
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
+        case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
+            break;
+        case VK_SHADER_STAGE_COMPUTE_BIT:
+            success = CreateComputePipeline();
+            break;
+        case VK_SHADER_STAGE_TASK_BIT_EXT:
+        case VK_SHADER_STAGE_MESH_BIT_EXT:
+            std::cout << "Currently Mesh/Task stages not supported\n";
+            break;
+        case VK_SHADER_STAGE_RAYGEN_BIT_KHR:
+        case VK_SHADER_STAGE_ANY_HIT_BIT_KHR:
+        case VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR:
+        case VK_SHADER_STAGE_MISS_BIT_KHR:
+        case VK_SHADER_STAGE_INTERSECTION_BIT_KHR:
+        case VK_SHADER_STAGE_CALLABLE_BIT_KHR:
+            std::cout << "Currently Ray Tracing stages not supported\n";
+            break;
+        case VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI:
+        case VK_SHADER_STAGE_CLUSTER_CULLING_BIT_HUAWEI:
+            std::cout << "Currently Subpass Shading stages not supported\n";
+            break;
+        default:
+            std::cout << "Shader stage not found\n";
+            return false;
+            break;
+    }
+
+    return success;
+}

--- a/tests/spirv_hopper/spirv_hopper.h
+++ b/tests/spirv_hopper/spirv_hopper.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+#include <vulkan/vulkan_core.h>
+#include <vector>
+#include "external/spirv_reflect.h"
+
+struct VulkanInstance;
+
+class Hopper {
+  public:
+    Hopper(VulkanInstance& vk, size_t file_size, const void* spirv_data);
+    ~Hopper();
+
+    bool Run();
+
+  private:
+    VulkanInstance& vk;
+
+    size_t file_size;
+    const void* spirv_data;
+
+    bool Reflect();
+    bool CreateShaderStage(size_t code_size, const void* code, VkShaderStageFlagBits stage, const char* name = "main");
+    bool CreatePipelineLayout();
+    bool CreateVertexAttributeDescriptions(SpvReflectInterfaceVariable& variable);
+    bool CreateGraphicsPipeline();
+    bool CreateComputePipeline();
+
+    // For Pass Through shaders
+    bool IsBuiltinType(SpvReflectInterfaceVariable* variable);
+    std::string GetTypeDescription(SpvReflectTypeDescription& description, SpvReflectFormat format);
+    std::string DefineCustomStruct(SpvReflectInterfaceVariable& variable);
+    bool BuildPassThroughShader(std::string& source, VkShaderStageFlagBits stage);
+    bool CreatePassThroughVertex();
+    bool CreatePassThroughVertexNoInterface();
+    bool CreatePassThroughTessellationEval();
+    bool CreatePassThroughTessellationControl();
+
+    SpvReflectShaderModule module;
+
+    SpvReflectEntryPoint entry_point;
+    VkShaderStageFlagBits shader_stage;
+
+    std::vector<SpvReflectInterfaceVariable*> input_variables;
+    std::vector<SpvReflectInterfaceVariable*> output_variables;
+    std::vector<SpvReflectDescriptorSet*> descriptor_sets;
+    std::vector<SpvReflectBlockVariable*> push_constants;
+    std::vector<const SpvReflectDescriptorBinding*> input_attachments;
+
+    std::vector<VkAttachmentReference> color_attachment_references;
+    std::vector<VkPipelineColorBlendAttachmentState> color_blend_attachments;
+    std::vector<VkVertexInputAttributeDescription> vertex_input_attributes;
+
+    std::vector<VkShaderModule> shader_modules;
+    std::vector<VkPipelineShaderStageCreateInfo> shader_stages_info;
+
+    VkRenderPass render_pass = VK_NULL_HANDLE;
+    VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
+    VkPipeline pipeline = VK_NULL_HANDLE;
+
+    uint32_t block_location;
+};

--- a/tests/spirv_hopper/vulkan_object.cpp
+++ b/tests/spirv_hopper/vulkan_object.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "vulkan_object.h"
+#include <vector>
+#include <iostream>
+
+#include "generated/lvt_function_pointers.h"
+#include "generated/vk_typemap_helper.h"
+
+// Extensions not allowed to use if promoted
+// TODO - Generate these
+#include <array>
+#include <string.h>
+static std::array<const char *, 3> ignore_extensions{
+    "VK_AMD_negative_viewport_height",
+    "VK_EXT_buffer_device_address",
+    "VK_KHR_portability_subset",
+};
+
+static bool IsExtensionForPromoted(const char *vk_extension) {
+    for (const auto &extension : ignore_extensions) {
+        if (strcmp(extension, vk_extension) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilMessengerCallback(VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT,
+                                                          const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
+                                                          void *is_valid) {
+    // Allow us to catch some VUs that are really not a 'failure'
+    if (
+        // These are the fragmentDensityMap feature VUs (VUID-VkDeviceCreateInfo-fragmentDensityMap-*)
+        // We need to enable the EXT and KHR extensions as there are 2 seperate capabilities we might find
+        (callback_data->messageIdNumber == static_cast<int32_t>(0x8dec816a)) ||
+        (callback_data->messageIdNumber == static_cast<int32_t>(0x449ecae8)) ||
+        (callback_data->messageIdNumber == static_cast<int32_t>(0x6baba20a)) ||
+        // geom/tessellation shaders might not be writting to a PointSize
+        // even though shaderTessellationAndGeometryPointSize is set
+        (callback_data->messageIdNumber == static_cast<int32_t>(0x64e29d24))) {
+        // Ignored
+    } else if (callback_data->messageIdNumber == static_cast<int32_t>(0x4e2c336f)) {
+        // TODO - When parsing Geometry shaders, the BuiltIn block might not be the default
+        // block used in the Vertex Shader
+        std::cerr << callback_data->pMessage << "\n";
+    } else if (callback_data->messageIdNumber == static_cast<int32_t>(0x2a1bf17f)) {
+        // spirv-val failed error message, don't quit, issue with SPIR-V or spirv-val
+        // Usually the SPIR-V is just missing the OpCapability for what it is using
+        std::cerr << callback_data->pMessage << "\n";
+    } else {
+        std::cerr << callback_data->pMessage << "\n";
+        *(static_cast<bool *>(is_valid)) = false;
+    }
+    return VK_FALSE;
+}
+
+VulkanInstance::VulkanInstance() {
+    // Instance Creation
+    vk::InitCore("vulkan");
+    {
+        auto debug_utils_create_info = LvlInitStruct<VkDebugUtilsMessengerCreateInfoEXT>();
+        debug_utils_create_info.flags = 0;
+        debug_utils_create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+        debug_utils_create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+        debug_utils_create_info.pfnUserCallback = DebugUtilMessengerCallback;
+        debug_utils_create_info.pUserData = &is_valid;
+
+        std::vector<const char *> instance_extensions;
+        uint32_t count = 0;
+        vk::EnumerateInstanceExtensionProperties(nullptr, &count, nullptr);
+        std::vector<VkExtensionProperties> extensions(count);
+        vk::EnumerateInstanceExtensionProperties(nullptr, &count, extensions.data());
+        for (uint32_t i = 0; i < count; i++) {
+            instance_extensions.push_back(extensions[i].extensionName);
+        }
+
+        VkApplicationInfo app_info;
+        app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+        app_info.pNext = nullptr;
+        // Use latest version of Vulkan incase the shader use newest SPIR-V version
+        app_info.apiVersion = VK_API_VERSION_1_3;
+        app_info.pApplicationName = "SPIRV-Hopper";
+        app_info.applicationVersion = 1;
+        app_info.pEngineName = "SPIRV-Hopper";
+        app_info.engineVersion = 1;
+
+        VkInstanceCreateInfo instance_info;
+        instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+        instance_info.pNext = &debug_utils_create_info;
+        instance_info.flags = 0;
+        instance_info.pApplicationInfo = &app_info;
+        instance_info.enabledLayerCount = 0;
+        instance_info.ppEnabledLayerNames = nullptr;
+        instance_info.enabledExtensionCount = static_cast<uint32_t>(instance_extensions.size());
+        instance_info.ppEnabledExtensionNames = instance_extensions.data();
+        vk::CreateInstance(&instance_info, nullptr, &instance);
+
+        auto vkCreateDebugUtilsMessengerEXT = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
+            vk::GetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT"));
+        vkCreateDebugUtilsMessengerEXT(instance, &debug_utils_create_info, nullptr, &debug_utils_messenger);
+    }
+
+    // Physical Device
+    {
+        // Grab first GPU
+        uint32_t count = 0;
+        vk::EnumeratePhysicalDevices(instance, &count, nullptr);
+        std::vector<VkPhysicalDevice> physical_devices(count);
+        vk::EnumeratePhysicalDevices(instance, &count, physical_devices.data());
+        gpu = physical_devices[0];
+
+        vk::GetPhysicalDeviceProperties(gpu, &properties);
+        vk::GetPhysicalDeviceMemoryProperties(gpu, &memory_properties);
+    }
+
+    // Query so downstrem layers don't blow up
+    {
+        uint32_t count = 0;
+        vk::GetPhysicalDeviceQueueFamilyProperties(gpu, &count, nullptr);
+        std::vector<VkQueueFamilyProperties> queue_families(count);
+        vk::GetPhysicalDeviceQueueFamilyProperties(gpu, &count, queue_families.data());
+    }
+
+    // Logical Device Creation
+    {
+        std::vector<const char *> device_extensions;
+        std::vector<VkExtensionProperties> extensions;
+        {
+            uint32_t count = 0;
+            vk::EnumerateDeviceExtensionProperties(gpu, nullptr, &count, nullptr);
+            extensions.resize(count);
+            vk::EnumerateDeviceExtensionProperties(gpu, nullptr, &count, extensions.data());
+            for (uint32_t i = 0; i < count; i++) {
+                // TODO - Generate these
+                if (!IsExtensionForPromoted(extensions[i].extensionName)) {
+                    device_extensions.push_back(extensions[i].extensionName);
+                }
+            }
+        }
+
+        // TODO - Generate these
+        // Currently assumes using MockICD and profiles so all of these are enabled
+        auto physical_device_ray_tracing_pipeline_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+        auto physical_device_fragment_shader_interlock_features =
+            LvlInitStruct<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(&physical_device_ray_tracing_pipeline_features);
+        auto physical_device_shader_atomic_float_features =
+            LvlInitStruct<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(&physical_device_fragment_shader_interlock_features);
+        auto physical_device_shader_atomic_float2_features =
+            LvlInitStruct<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(&physical_device_shader_atomic_float_features);
+        auto physical_device_workgroup_memory_explicit_layout_features =
+            LvlInitStruct<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(&physical_device_shader_atomic_float2_features);
+        auto physical_device_ray_query_features =
+            LvlInitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&physical_device_workgroup_memory_explicit_layout_features);
+        auto physical_device_ray_tracing_maintenance1_features =
+            LvlInitStruct<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(&physical_device_ray_query_features);
+        auto physical_device_fragment_shading_rate_features =
+            LvlInitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(&physical_device_ray_tracing_maintenance1_features);
+        auto physical_device_fragment_shader_barycentric_features =
+            LvlInitStruct<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR>(&physical_device_fragment_shading_rate_features);
+        auto physical_device_transform_feedback_features =
+            LvlInitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(&physical_device_fragment_shader_barycentric_features);
+        auto physical_device_shader_image_atomic_int64_features =
+            LvlInitStruct<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(&physical_device_transform_feedback_features);
+        auto physical_device_fragment_density_map_features =
+            LvlInitStruct<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(&physical_device_shader_image_atomic_int64_features);
+        auto physical_device_vulkan11_features =
+            LvlInitStruct<VkPhysicalDeviceVulkan11Features>(&physical_device_fragment_density_map_features);
+        auto physical_device_vulkan12_features =
+            LvlInitStruct<VkPhysicalDeviceVulkan12Features>(&physical_device_vulkan11_features);
+        auto physical_device_vulkan13_features =
+            LvlInitStruct<VkPhysicalDeviceVulkan13Features>(&physical_device_vulkan12_features);
+        auto physical_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&physical_device_vulkan13_features);
+        vk::GetPhysicalDeviceFeatures2(gpu, &physical_features2);
+
+        // Don't actually need a queue, so just grab the first one
+        auto queue_info = LvlInitStruct<VkDeviceQueueCreateInfo>();
+        queue_info.flags = 0;
+        queue_info.queueFamilyIndex = 0;
+        queue_info.queueCount = 1;
+        float queue_priority = 1.0f;
+        queue_info.pQueuePriorities = &queue_priority;
+
+        auto device_info = LvlInitStruct<VkDeviceCreateInfo>(&physical_features2);
+        device_info.flags = 0;
+        device_info.pQueueCreateInfos = &queue_info;
+        device_info.queueCreateInfoCount = 1;
+        device_info.enabledLayerCount = 0;
+        device_info.ppEnabledLayerNames = nullptr;
+        device_info.enabledExtensionCount = static_cast<uint32_t>(device_extensions.size());
+        device_info.ppEnabledExtensionNames = device_extensions.data();
+        device_info.pEnabledFeatures = nullptr;
+
+        vk::CreateDevice(gpu, &device_info, nullptr, &device);
+    }
+}
+
+VulkanInstance::~VulkanInstance() {
+    if (device != VK_NULL_HANDLE) {
+        vk::DestroyDevice(device, nullptr);
+    }
+    if (debug_utils_messenger != VK_NULL_HANDLE) {
+        auto vkDestroyDebugUtilsMessengerEXT = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
+            vk::GetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT"));
+        vkDestroyDebugUtilsMessengerEXT(instance, debug_utils_messenger, nullptr);
+    }
+    if (instance != VK_NULL_HANDLE) {
+        vk::DestroyInstance(instance, nullptr);
+    }
+}

--- a/tests/spirv_hopper/vulkan_object.h
+++ b/tests/spirv_hopper/vulkan_object.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+#include <vulkan/vulkan_core.h>
+
+// Holds all Vulkan objects for the entire run
+struct VulkanInstance {
+  public:
+    VulkanInstance();
+    ~VulkanInstance();
+
+    VkInstance instance = VK_NULL_HANDLE;
+    VkPhysicalDevice gpu = VK_NULL_HANDLE;
+    VkDevice device = VK_NULL_HANDLE;
+
+    VkDebugUtilsMessengerEXT debug_utils_messenger = VK_NULL_HANDLE;
+
+    // Any Validation Errors caught
+    bool is_valid = true;
+
+    VkPhysicalDeviceProperties properties;
+    VkPhysicalDeviceMemoryProperties memory_properties;
+
+    // Require possible changes, but only need to define once
+    VkPipelineInputAssemblyStateCreateInfo input_assembly_state{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+                                                                nullptr, 0, VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, VK_FALSE};
+    VkPipelineColorBlendStateCreateInfo color_blend_state{VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+                                                          nullptr,
+                                                          0,
+                                                          VK_FALSE,
+                                                          VK_LOGIC_OP_CLEAR,
+                                                          0,
+                                                          nullptr,
+                                                          {0.0f, 0.0f, 0.0f, 0.0f}};
+    VkPipelineVertexInputStateCreateInfo vertex_input_state{
+        VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO, nullptr, 0, 1, &vertex_input_binding, 0, nullptr};
+    VkAttachmentDescription basic_attachment_description = {0,
+                                                            VK_FORMAT_R8G8B8A8_UNORM,
+                                                            VK_SAMPLE_COUNT_1_BIT,
+                                                            VK_ATTACHMENT_LOAD_OP_CLEAR,
+                                                            VK_ATTACHMENT_STORE_OP_STORE,
+                                                            VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                                            VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                                            VK_IMAGE_LAYOUT_UNDEFINED,
+                                                            VK_IMAGE_LAYOUT_GENERAL};
+
+    // Objects that are the same as they don't effect the shader run
+    constexpr static VkViewport viewport{0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f};
+    constexpr static VkRect2D scissor{{0, 0}, {1, 1}};
+    constexpr static VkPipelineViewportStateCreateInfo viewport_input_state{
+        VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO, nullptr, 0, 1, &viewport, 1, &scissor};
+    constexpr static VkPipelineRasterizationStateCreateInfo rasterization_state{
+        VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+        nullptr,
+        0,
+        VK_FALSE,
+        VK_FALSE,
+        VK_POLYGON_MODE_FILL,
+        VK_CULL_MODE_NONE,
+        VK_FRONT_FACE_CLOCKWISE,
+        VK_FALSE,
+        1.0f,
+        0.0f,
+        0.0f,
+        1.0f};
+    constexpr static VkPipelineMultisampleStateCreateInfo multisample_state{
+        VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+        nullptr,
+        0,
+        VK_SAMPLE_COUNT_1_BIT,
+        VK_FALSE,
+        0.0f,
+        nullptr,
+        VK_FALSE,
+        VK_FALSE};
+    constexpr static VkPipelineTessellationStateCreateInfo tessellation_state{
+        VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO, nullptr, 0, 1};
+    constexpr static VkVertexInputBindingDescription vertex_input_binding = {0, 16, VK_VERTEX_INPUT_RATE_VERTEX};
+};


### PR DESCRIPTION
Adds a new `SPIRV-Hopper` test harness

I have ran this on a lot of shaders generated from various places, and it now passes them all

As more shaders are added, this can be updated, but this is in good enough shape to start using for CI once merged