### PR TITLE
layers: Fix crash with push constants using spec const

### DIFF
--- a/layers/core_checks/cc_shader.cpp
+++ b/layers/core_checks/cc_shader.cpp
@@ -224,6 +224,11 @@ bool CoreChecks::ValidatePushConstantUsage(const PIPELINE_STATE &pipeline, const
                                            const EntryPoint &entrypoint) const {
     bool skip = false;
 
+    // TODO - Workaround for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5911
+    if (module_state.static_data_.has_specialization_constants) {
+        return skip;
+    }
+
     const VkShaderStageFlagBits stage = entrypoint.stage;
     const auto push_constant_variable = entrypoint.push_constant_variable;
     if (!push_constant_variable) {


### PR DESCRIPTION
This is a temporary fix for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5911

It might still produce false positive  for `VUID-VkComputePipelineCreateInfo-layout-07987`, but decide that was **much better** then crashing from an assert.

I plan to put together a proper fix, but that will require a more work as we need more tests as it will be invasive, but want to get things unblocked for now

