### PR TITLE
layers: Handle OpUndef used for Image Accesses

### DIFF
--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -583,8 +583,8 @@ ImageAccess::ImageAccess(const SHADER_MODULE_STATE& module_state, const Instruct
     }
 
     // With the OpLoad find the OpVariable for the Image
-    assert(image_load);
-    if (image_load->Opcode() == spv::OpFunctionParameter) {
+    if (!image_load || image_load->Opcode() != spv::OpLoad) {
+        // TODO - This can be OpUndef, need to get spec clarification how this is handled
         no_function_jump = false;
         return;  // TODO 5614 - Handle function jumps
     }
@@ -617,7 +617,7 @@ ImageAccess::ImageAccess(const SHADER_MODULE_STATE& module_state, const Instruct
 
     // If there is a OpSampledImage, take the other OpLoad and find the OpVariable for the Sampler
     if (sampler_load) {
-        if (sampler_load->Opcode() == spv::OpFunctionParameter) {
+        if (sampler_load->Opcode() != spv::OpLoad) {
             no_function_jump = false;
             return;  // TODO 5614 - Handle function jumps
         }


### PR DESCRIPTION
Using `SPIRV-Hopper` I found a shader using `OpUndef` instead of a `OpLoad` in a `OpSampledImage`

I adjusted the logic to not just check if it is `OpFunctionParameter` but, if it is not the `OpLoad` I would expect, we just exit (as there might be other instructions this can be as well)

There is a lot left to this part of the code, but the goal of the PR is to not assert if someone's shader has a valid `OpUndef`