### PR TITLE
scripts: Use python file built-in helper

### DIFF
--- a/layers/vulkan/generated/spirv_grammar_helper.cpp
+++ b/layers/vulkan/generated/spirv_grammar_helper.cpp
@@ -1,5 +1,5 @@
 // *** THIS FILE IS GENERATED - DO NOT EDIT ***
-// See spirv_gramar_generator.py for modifications
+// See spirv_grammar_generator.py for modifications
 
 
 /***************************************************************************

--- a/layers/vulkan/generated/spirv_grammar_helper.h
+++ b/layers/vulkan/generated/spirv_grammar_helper.h
@@ -1,5 +1,5 @@
 // *** THIS FILE IS GENERATED - DO NOT EDIT ***
-// See spirv_gramar_generator.py for modifications
+// See spirv_grammar_generator.py for modifications
 
 
 /***************************************************************************

--- a/layers/vulkan/generated/vk_dispatch_table_helper.h
+++ b/layers/vulkan/generated/vk_dispatch_table_helper.h
@@ -1,6 +1,6 @@
 #pragma once
 // *** THIS FILE IS GENERATED - DO NOT EDIT ***
-// See dispatch_helper_generator.py for modifications
+// See dispatch_table_helper_generator.py for modifications
 
 /*
  * Copyright (c) 2015-2023 The Khronos Group Inc.

--- a/scripts/generators/best_practices_generator.py
+++ b/scripts/generators/best_practices_generator.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import sys,os
 from generator import *
 from common_codegen import *
 
@@ -87,7 +87,7 @@ class BestPracticesOutputGenerator(OutputGenerator):
 
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See best_practices_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         self.otwrite('both', file_comment)
         # Copyright Statement
         copyright = ''

--- a/scripts/generators/command_validation_generator.py
+++ b/scripts/generators/command_validation_generator.py
@@ -78,7 +78,7 @@ class CommandValidationOutputGenerator(OutputGenerator):
 
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See command_validation_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         write(file_comment, file=self.outFile)
         # Copyright Statement
         copyright = ''

--- a/scripts/generators/dispatch_table_helper_generator.py
+++ b/scripts/generators/dispatch_table_helper_generator.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import sys,os
 from generator import *
 from common_codegen import *
 
@@ -48,7 +48,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         write("#pragma once", file=self.outFile)
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See dispatch_helper_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         write(file_comment, file=self.outFile)
         # Copyright Notice
         copyright =  '/*\n'

--- a/scripts/generators/dynamic_state_generator.py
+++ b/scripts/generators/dynamic_state_generator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import sys,os
 from generator import *
 from common_codegen import *
 
@@ -41,7 +41,7 @@ class DynamicStateOutputGenerator(OutputGenerator):
 
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See dynamic_state_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         write(file_comment, file=self.outFile)
         # Copyright Statement
         copyright = ''

--- a/scripts/generators/external_revision_generator.py
+++ b/scripts/generators/external_revision_generator.py
@@ -17,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import argparse
 import hashlib
 import subprocess
@@ -28,7 +29,7 @@ def generate(symbol_name, commit_id, output_header_file):
     with open(output_header_file, "w", newline='\n') as header_file:
          # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See external_revision_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         header_file.write(file_comment)
         # Copyright Notice
         copyright = ''

--- a/scripts/generators/format_utils_generator.py
+++ b/scripts/generators/format_utils_generator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import sys,os
 from generator import *
 from common_codegen import *
 
@@ -62,7 +62,7 @@ class FormatUtilsOutputGenerator(OutputGenerator):
 
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See format_utils_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         write(file_comment, file=self.outFile)
         # Copyright Statement
         copyright = ''

--- a/scripts/generators/helper_file_generator.py
+++ b/scripts/generators/helper_file_generator.py
@@ -18,7 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re,sys
+import re,sys,os
 import xml.etree.ElementTree as etree
 from generator import *
 from collections import namedtuple
@@ -138,7 +138,7 @@ static inline APIVersion NormalizeApiVersion(APIVersion specified_version) {
         self.helper_file_type = genOpts.helper_file_type
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See helper_file_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         write(file_comment, file=self.outFile)
         # Copyright Notice
         copyright = ''

--- a/scripts/generators/layer_dispatch_table_generator.py
+++ b/scripts/generators/layer_dispatch_table_generator.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import sys,os
 from generator import *
 from collections import namedtuple
 from common_codegen import *
@@ -56,7 +56,7 @@ class LayerDispatchTableOutputGenerator(OutputGenerator):
 
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See layer_dispatch_table_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         write(file_comment, file=self.outFile)
 
         # Copyright Notice

--- a/scripts/generators/lvt_file_generator.py
+++ b/scripts/generators/lvt_file_generator.py
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import sys,os
 from generator import *
 from collections import namedtuple
 from common_codegen import *
@@ -129,7 +129,7 @@ class LvtFileOutputGenerator(OutputGenerator):
 
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See lvt_file_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         write(file_comment, file=self.outFile)
         # Copyright Notice
         copyright =  '/*\n'

--- a/scripts/generators/object_tracker_generator.py
+++ b/scripts/generators/object_tracker_generator.py
@@ -340,7 +340,7 @@ class ObjectTrackerOutputGenerator(OutputGenerator):
 
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See object_tracker_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         self.otwrite('both', file_comment)
         # Copyright Statement
         copyright = ''

--- a/scripts/generators/parameter_validation_generator.py
+++ b/scripts/generators/parameter_validation_generator.py
@@ -309,8 +309,9 @@ class ParameterValidationOutputGenerator(OutputGenerator):
         from datetime import datetime
         curr_year = datetime.now().year
         year = f'{start_year}-{curr_year}' if start_year is not None else curr_year
+        file_name = os.path.basename(__file__)
         return f'''/* *** THIS FILE IS GENERATED - DO NOT EDIT! ***
- * See parameter_validation_generator.py for modifications
+ * See {file_name} for modifications
  *
  * Copyright (c) {year} The Khronos Group Inc.
  * Copyright (c) {year} LunarG, Inc.

--- a/scripts/generators/spirv_grammar_generator.py
+++ b/scripts/generators/spirv_grammar_generator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re,sys,json
+import re,sys,json,os
 from generator import *
 from common_codegen import *
 
@@ -80,7 +80,7 @@ class SpirvGrammarHelperOutputGenerator(OutputGenerator):
 
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See spirv_gramar_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         write(file_comment, file=self.outFile)
         # Copyright Statement
         copyright = ''

--- a/scripts/generators/spirv_validation_generator.py
+++ b/scripts/generators/spirv_validation_generator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import sys,os
 from generator import *
 from common_codegen import *
 
@@ -132,7 +132,7 @@ class SpirvValidationHelperOutputGenerator(OutputGenerator):
         OutputGenerator.beginFile(self, genOpts)
         # File Comment
         file_comment = '// *** THIS FILE IS GENERATED - DO NOT EDIT ***\n'
-        file_comment += '// See spirv_validation_generator.py for modifications\n'
+        file_comment += '// See {} for modifications\n'.format(os.path.basename(__file__))
         write(file_comment, file=self.outFile)
         # Copyright Statement
         copyright = ''


### PR DESCRIPTION
Use `os.path.basename(__file__)` to print out file name, prevent needless typo errors (which we had some)