### PR TITLE
layers: Add unimplementable VUIDs from extensions

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -621,10 +621,8 @@ bool CoreChecks::PreCallValidateCmdSetDepthBounds(VkCommandBuffer commandBuffer,
     bool skip = false;
     skip |= ValidateExtendedDynamicState(*cb_state, CMD_SETDEPTHBOUNDS, VK_TRUE, nullptr, nullptr);
 
-    // The extension was not created with a feature bit whichs prevents displaying the 2 variations of the VUIDs
     if (!IsExtEnabled(device_extensions.vk_ext_depth_range_unrestricted)) {
         if (!(minDepthBounds >= 0.0) || !(minDepthBounds <= 1.0)) {
-            // Also VUID-vkCmdSetDepthBounds-minDepthBounds-00600
             skip |= LogError(commandBuffer, "VUID-vkCmdSetDepthBounds-minDepthBounds-02508",
                              "vkCmdSetDepthBounds(): VK_EXT_depth_range_unrestricted extension is not enabled and minDepthBounds "
                              "(=%f) is not within the [0.0, 1.0] range.",
@@ -632,7 +630,6 @@ bool CoreChecks::PreCallValidateCmdSetDepthBounds(VkCommandBuffer commandBuffer,
         }
 
         if (!(maxDepthBounds >= 0.0) || !(maxDepthBounds <= 1.0)) {
-            // Also VUID-vkCmdSetDepthBounds-maxDepthBounds-00601
             skip |= LogError(commandBuffer, "VUID-vkCmdSetDepthBounds-maxDepthBounds-02509",
                              "vkCmdSetDepthBounds(): VK_EXT_depth_range_unrestricted extension is not enabled and maxDepthBounds "
                              "(=%f) is not within the [0.0, 1.0] range.",

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -728,10 +728,8 @@ bool CoreChecks::ValidateClearDepthStencilValue(VkCommandBuffer commandBuffer, V
                                                 const char *apiName) const {
     bool skip = false;
 
-    // The extension was not created with a feature bit whichs prevents displaying the 2 variations of the VUIDs
     if (!IsExtEnabled(device_extensions.vk_ext_depth_range_unrestricted)) {
         if (!(clearValue.depth >= 0.0) || !(clearValue.depth <= 1.0)) {
-            // Also VUID-VkClearDepthStencilValue-depth-00022
             skip |= LogError(commandBuffer, "VUID-VkClearDepthStencilValue-depth-02506",
                              "%s: VK_EXT_depth_range_unrestricted extension is not enabled and VkClearDepthStencilValue::depth "
                              "(=%f) is not within the [0.0, 1.0] range.",

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -1258,12 +1258,10 @@ bool CoreChecks::ValidateGraphicsPipelineRasterizationState(const PIPELINE_STATE
                                 pipeline.create_index);
                         }
 
-                        // The extension was not created with a feature bit whichs prevents displaying the 2 variations of the VUIDs
                         if (!IsExtEnabled(device_extensions.vk_ext_depth_range_unrestricted) &&
                             !pipeline.IsDynamic(VK_DYNAMIC_STATE_DEPTH_BOUNDS)) {
                             const float minDepthBounds = ds_state->minDepthBounds;
                             const float maxDepthBounds = ds_state->maxDepthBounds;
-                            // Also VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00755
                             if (!(minDepthBounds >= 0.0) || !(minDepthBounds <= 1.0)) {
                                 skip |= LogError(
                                     device, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-02510",

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -1926,7 +1926,6 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(RenderPassCreateVersion rp_ve
                                 pCreateInfo->pAttachments[subpass.pColorAttachments[last_sample_count_attachment].attachment]
                                     .samples;
                             if (current_sample_count != last_sample_count) {
-                                // Also VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06869
                                 const char *vuid = use_rp2 ? "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872"
                                                            : "VUID-VkSubpassDescription-pColorAttachments-06868";
                                 skip |= LogError(

--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -23,4 +23,17 @@ const char* unimplementable_validation[] = {
     // sparseAddressSpaceSize can't be tracked in a layer
     // https://gitlab.khronos.org/vulkan/vulkan/-/issues/2403
     "VUID-vkCreateBuffer-flags-00911",
+
+    // Some of the early extensions were not created with a feature bit. This means if the extension is used, we considered it
+    // "enabled". This becomes a problem as some coniditional VUIDs depend on the Extension to be enabled, this means we are left
+    // with 2 variations of the VUIDs, but only one is not possible to ever get to.
+    // The following are a list of these:
+    "VUID-vkCmdSetDepthBounds-minDepthBounds-00600",                       // VUID-vkCmdSetDepthBounds-minDepthBounds-02508
+    "VUID-vkCmdSetDepthBounds-maxDepthBounds-00601",                       // VUID-vkCmdSetDepthBounds-maxDepthBounds-02509
+    "VUID-VkClearDepthStencilValue-depth-00022",                           // VUID-VkClearDepthStencilValue-depth-02506
+    "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06869",  // VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872
+    "VUID-VkViewport-minDepth-02540",                                      // VUID-VkViewport-minDepth-01234
+    "VUID-VkViewport-maxDepth-02541",                                      // VUID-VkViewport-maxDepth-01235
+    "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00755",              // VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-02510
+    "VUID-vkCmdFillBuffer-apiVersion-07894",                               // VUID-vkCmdFillBuffer-commandBuffer-00030
 };

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -1374,11 +1374,9 @@ bool StatelessValidation::manual_PreCallValidateViewport(const VkViewport &viewp
         }
     }
 
-    // The extension was not created with a feature bit whichs prevents displaying the 2 variations of the VUIDs
     if (!IsExtEnabled(device_extensions.vk_ext_depth_range_unrestricted)) {
         // minDepth
         if (!(viewport.minDepth >= 0.0) || !(viewport.minDepth <= 1.0)) {
-            // Also VUID-VkViewport-minDepth-02540
             skip |= LogError(object, "VUID-VkViewport-minDepth-01234",
                              "%s: VK_EXT_depth_range_unrestricted extension is not enabled and %s.minDepth (=%f) is not within the "
                              "[0.0, 1.0] range.",
@@ -1387,7 +1385,6 @@ bool StatelessValidation::manual_PreCallValidateViewport(const VkViewport &viewp
 
         // maxDepth
         if (!(viewport.maxDepth >= 0.0) || !(viewport.maxDepth <= 1.0)) {
-            // Also VUID-VkViewport-maxDepth-02541
             skip |= LogError(object, "VUID-VkViewport-maxDepth-01235",
                              "%s: VK_EXT_depth_range_unrestricted extension is not enabled and %s.maxDepth (=%f) is not within the "
                              "[0.0, 1.0] range.",


### PR DESCRIPTION
Now that we have a proper place to put these, I moved all these old VUIDs from old extensions that are not able to be hit ever, but currently are marked as "todo" from our stats script