### PR TITLE
layers: Add previously unimplementable external memory VUs

### DIFF
--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -20,12 +20,7 @@
 // This file should never be included, but here for searchability and statistics
 
 const char* unimplementable_validation[] = {
-    // TODO - This might be able to be rewritten as how VUID-VkWaylandSurfaceCreateInfoKHR-display-01304 is
-    //
-    // Not possible to validate a "valid" handle for fd
-    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5431#issuecomment-1484167442
-    "VUID-vkGetMemoryFdPropertiesKHR-fd-00673",
-
     // sparseAddressSpaceSize can't be tracked in a layer
     // https://gitlab.khronos.org/vulkan/vulkan/-/issues/2403
-    "VUID-vkCreateBuffer-flags-00911"};
+    "VUID-vkCreateBuffer-flags-00911",
+};

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1368,6 +1368,8 @@ class StatelessValidation : public ValidationObject {
                                                                VkSamplerYcbcrConversion *pYcbcrConversion) const;
 
     bool manual_PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR *pGetFdInfo, int *pFd) const;
+    bool manual_PreCallValidateGetMemoryFdPropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, int fd,
+                                                        VkMemoryFdPropertiesKHR *pMemoryFdProperties) const;
     bool ValidateExternalSemaphoreHandleType(VkSemaphore semaphore, const char *vuid, const char *caller,
                                              VkExternalSemaphoreHandleTypeFlagBits handle_type,
                                              VkExternalSemaphoreHandleTypeFlags allowed_types) const;
@@ -1382,6 +1384,9 @@ class StatelessValidation : public ValidationObject {
     bool manual_PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR *pGetFdInfo, int *pFd) const;
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
+    bool manual_PreCallValidateGetMemoryWin32HandlePropertiesKHR(
+        VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, HANDLE handle,
+        VkMemoryWin32HandlePropertiesKHR *pMemoryWin32HandleProperties) const;
     bool manual_PreCallValidateImportSemaphoreWin32HandleKHR(
         VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR *pImportSemaphoreWin32HandleInfo) const;
     bool manual_PreCallValidateGetSemaphoreWin32HandleKHR(VkDevice device,

--- a/layers/vulkan/generated/parameter_validation.cpp
+++ b/layers/vulkan/generated/parameter_validation.cpp
@@ -12230,6 +12230,7 @@ bool StatelessValidation::PreCallValidateGetMemoryWin32HandlePropertiesKHR(
     {
         skip |= ValidateStructPnext("vkGetMemoryWin32HandlePropertiesKHR", "pMemoryWin32HandleProperties->pNext", nullptr, pMemoryWin32HandleProperties->pNext, 0, nullptr, GeneratedVulkanHeaderVersion, "VUID-VkMemoryWin32HandlePropertiesKHR-pNext-pNext", kVUIDUndefined, false, false);
     }
+    if (!skip) skip |= manual_PreCallValidateGetMemoryWin32HandlePropertiesKHR(device, handleType, handle, pMemoryWin32HandleProperties);
     return skip;
 }
 
@@ -12270,6 +12271,7 @@ bool StatelessValidation::PreCallValidateGetMemoryFdPropertiesKHR(
     {
         skip |= ValidateStructPnext("vkGetMemoryFdPropertiesKHR", "pMemoryFdProperties->pNext", nullptr, pMemoryFdProperties->pNext, 0, nullptr, GeneratedVulkanHeaderVersion, "VUID-VkMemoryFdPropertiesKHR-pNext-pNext", kVUIDUndefined, false, false);
     }
+    if (!skip) skip |= manual_PreCallValidateGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties);
     return skip;
 }
 

--- a/scripts/generators/parameter_validation_generator.py
+++ b/scripts/generators/parameter_validation_generator.py
@@ -229,6 +229,8 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkCmdSetDiscardRectangleEnableEXT',
             'vkCmdSetDiscardRectangleModeEXT',
             'vkCmdSetExclusiveScissorEnableNV',
+            'vkGetMemoryWin32HandlePropertiesKHR',
+            'vkGetMemoryFdPropertiesKHR',
             ]
 
         # Commands to ignore


### PR DESCRIPTION
The wording of these VUs changed in 1.3.251 and they become implementable: 00665 and 00673.
Also added 00674/00666 for completeness.

No positive tests here. It's not trivial to create external non-opaque handles for testing purposes (for example, D3D11 surface). Validation is simple enough so probably not worth efforts.
