### PR TITLE
Enable Win32 testing on CI

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -123,11 +123,6 @@ jobs:
         arch: [ amd64, amd64_x86 ] # 64 bit compiler, 64 bit compiler targeting 32 bit
         config: [ debug, release ]
         os: [ windows-latest ]
-        exclude:
-          - arch: amd64_x86
-            config: release
-          - arch: amd64
-            config: debug
 
     steps:
       - uses: actions/checkout@v3
@@ -157,6 +152,8 @@ jobs:
           key: ${{ matrix.os }}-build-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.config }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Build
         run: python3 scripts/github_ci_win_linux.py --build --config ${{ matrix.config }} --cmake='-DUPDATE_DEPS_SKIP_EXISTING_INSTALL=ON'
+      - name: Test Vulkan-ValidationLayers - Max Profile
+        run: python scripts/github_ci_win_linux.py --test
 
   android_cmake:
       runs-on: ubuntu-22.04

--- a/tests/negative/query.cpp
+++ b/tests/negative/query.cpp
@@ -79,6 +79,7 @@ TEST_F(NegativeQuery, PerformanceCreation) {
     // Invalid counter indices
     counterIndices.push_back(counters.size());
     perf_query_pool_ci.counterIndexCount++;
+    perf_query_pool_ci.pCounterIndices = counterIndices.data();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkQueryPoolPerformanceCreateInfoKHR-pCounterIndices-03321");
     query_pool.init(*m_device, query_pool_ci);
     m_errorMonitor->VerifyFound();

--- a/tests/negative/wsi.cpp
+++ b/tests/negative/wsi.cpp
@@ -2772,7 +2772,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionRelease) {
     vk::QueueWaitIdle(m_device->m_queue);
 }
 
-#if defined(VVL_TESTS_ENABLE_EXCLUSIVE_FULLSCREEN) && defined(VK_USE_PLATFORM_WIN32_KHR)
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
 TEST_F(NegativeWsi, AcquireFullScreenExclusiveModeEXT) {
     TEST_DESCRIPTION("Test vkAcquireFullScreenExclusiveModeEXT.");
 
@@ -2785,6 +2785,10 @@ TEST_F(NegativeWsi, AcquireFullScreenExclusiveModeEXT) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    if (!IsPlatform(kMockICD)) {
+        GTEST_SKIP() << "Only run test MockICD due to CI stability";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -2851,8 +2855,8 @@ TEST_F(NegativeWsi, AcquireFullScreenExclusiveModeEXT) {
 }
 #endif
 
-#if defined(VVL_TESTS_ENABLE_EXCLUSIVE_FULLSCREEN) && defined(VK_USE_PLATFORM_WIN32_KHR)
-TEST_F(NegativeWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullscreenEXT) {
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+TEST_F(NegativeWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullScreenEXT) {
     TEST_DESCRIPTION("Test vkAcquireFullScreenExclusiveModeEXT.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -2864,6 +2868,10 @@ TEST_F(NegativeWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullscreenEXT) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    if (!IsPlatform(kMockICD)) {
+        GTEST_SKIP() << "Only run test MockICD due to CI stability";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());

--- a/tests/positive/wsi.cpp
+++ b/tests/positive/wsi.cpp
@@ -173,8 +173,8 @@ TEST_F(PositiveWsi, CreateX11Surface) {
 #endif
 }
 
-#if defined(VVL_TESTS_ENABLE_EXCLUSIVE_FULLSCREEN) && defined(VK_USE_PLATFORM_WIN32_KHR)
-TEST_F(PositiveWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullscreenEXT) {
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+TEST_F(PositiveWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullScreenEXT) {
     TEST_DESCRIPTION("Test vkAcquireFullScreenExclusiveModeEXT.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -186,6 +186,10 @@ TEST_F(PositiveWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullscreenEXT) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    if (!IsPlatform(kMockICD)) {
+        GTEST_SKIP() << "Only run test MockICD due to CI stability";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());


### PR DESCRIPTION
- Fix `NegativeQuery.PerformanceCreation`
- Enables FullScreen testing on MockICD only. Also made naming consistent Fullscreen -> FullScreen to make it easier to run tests.
- Enable CI testing