### PR TITLE
Label framebuffer VUID correctly for non Imageless Framebuffers

### DIFF
--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -219,6 +219,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/framework/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/positive/descriptors.cpp \
                    $(SRC_DIR)/tests/positive/dynamic_state.cpp \
                    $(SRC_DIR)/tests/positive/image.cpp \
+                   $(SRC_DIR)/tests/positive/imageless_framebuffer.cpp \
                    $(SRC_DIR)/tests/positive/gpu_av.cpp \
                    $(SRC_DIR)/tests/positive/instance.cpp \
                    $(SRC_DIR)/tests/positive/layer_utils.cpp \

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -961,8 +961,8 @@ bool ObjectLifetimes::PreCallValidateCreateFramebuffer(VkDevice device, const Vk
                                "VUID-VkFramebufferCreateInfo-renderPass-parameter", "VUID-VkFramebufferCreateInfo-commonparent");
         if ((pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
             for (uint32_t index1 = 0; index1 < pCreateInfo->attachmentCount; ++index1) {
-                skip |= ValidateObject(pCreateInfo->pAttachments[index1], kVulkanObjectTypeImageView, true, kVUIDUndefined,
-                                       "VUID-VkFramebufferCreateInfo-commonparent");
+                skip |= ValidateObject(pCreateInfo->pAttachments[index1], kVulkanObjectTypeImageView, true,
+                                       "VUID-VkFramebufferCreateInfo-flags-02778", "VUID-VkFramebufferCreateInfo-commonparent");
             }
         }
     }

--- a/layers/stateless/sl_framebuffer.cpp
+++ b/layers/stateless/sl_framebuffer.cpp
@@ -25,7 +25,7 @@ bool StatelessValidation::manual_PreCallValidateCreateFramebuffer(VkDevice devic
     bool skip = false;
     if ((pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
         skip |= ValidateArray("vkCreateFramebuffer", "attachmentCount", "pAttachments", pCreateInfo->attachmentCount,
-                              &pCreateInfo->pAttachments, false, true, kVUIDUndefined, kVUIDUndefined);
+                              &pCreateInfo->pAttachments, false, true, kVUIDUndefined, "VUID-VkFramebufferCreateInfo-flags-02778");
     }
     return skip;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     positive/gpu_av.cpp
     positive/graphics_library.cpp
     positive/image.cpp
+    positive/imageless_framebuffer.cpp
     positive/instance.cpp
     positive/layer_utils.cpp
     positive/memory.cpp

--- a/tests/negative/imageless_framebuffer.cpp
+++ b/tests/negative/imageless_framebuffer.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
 class NegativeImagelessFramebuffer : public VkLayerTest {};

--- a/tests/positive/imageless_framebuffer.cpp
+++ b/tests/positive/imageless_framebuffer.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+
+class PositiveImagelessFramebuffer : public VkLayerTest {};
+
+TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
+    TEST_DESCRIPTION("Create an imageless framebuffer");
+
+    AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    auto imageless_features = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
+    GetPhysicalDeviceFeatures2(imageless_features);
+    if (!imageless_features.imagelessFramebuffer) {
+        GTEST_SKIP() << "imagelessFramebuffer not supported.";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    uint32_t attachment_width = 512;
+    uint32_t attachment_height = 512;
+    VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+
+    // Create a renderPass with a single attachment
+    VkAttachmentDescription attachment_description = {};
+    attachment_description.format = format;
+    attachment_description.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment_description.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    attachment_description.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+    VkAttachmentReference attachment_reference = {};
+    attachment_reference.layout = VK_IMAGE_LAYOUT_GENERAL;
+    VkSubpassDescription subpass = {};
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments = &attachment_reference;
+    auto rp_ci = LvlInitStruct<VkRenderPassCreateInfo>();
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass;
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &attachment_description;
+    vk_testing::RenderPass render_pass(*m_device, rp_ci);
+
+    auto fb_attachment_image_info = LvlInitStruct<VkFramebufferAttachmentImageInfoKHR>();
+    fb_attachment_image_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    fb_attachment_image_info.width = attachment_width;
+    fb_attachment_image_info.height = attachment_height;
+    fb_attachment_image_info.layerCount = 1;
+    fb_attachment_image_info.viewFormatCount = 1;
+    fb_attachment_image_info.pViewFormats = &format;
+    auto fb_attachment_ci = LvlInitStruct<VkFramebufferAttachmentsCreateInfoKHR>();
+    fb_attachment_ci.attachmentImageInfoCount = 1;
+    fb_attachment_ci.pAttachmentImageInfos = &fb_attachment_image_info;
+    auto fb_ci = LvlInitStruct<VkFramebufferCreateInfo>(&fb_attachment_ci);
+    fb_ci.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR;
+    fb_ci.width = attachment_width;
+    fb_ci.height = attachment_height;
+    fb_ci.layers = 1;
+    fb_ci.renderPass = render_pass.handle();
+    fb_ci.attachmentCount = 1;
+
+    fb_ci.pAttachments  = nullptr;
+    vk_testing::Framebuffer framebuffer_null(*m_device, fb_ci);
+
+    VkImageView image_views[2] = {
+    m_renderTargets[0]->targetView(VK_FORMAT_B8G8R8A8_UNORM),
+    CastToHandle<VkImageView, uintptr_t>(0xbaadbeef)
+    };
+    fb_ci.pAttachments = image_views;
+    vk_testing::Framebuffer framebuffer_bad_image_view(*m_device, fb_ci);
+}


### PR DESCRIPTION
Adds ` VUID-VkFramebufferCreateInfo-flags-02778` for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5842

In adding the test, noticed we were actually getting a `VUID_Undefined`. I realize both Stateless and Object Tracker were actually doing the validation and it never made it to core