### PR TITLE
Fix VUID for CommandBuffers and DescriptorSets

### DIFF
--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -1404,7 +1404,7 @@ bool StatelessValidation::manual_PreCallValidateFreeCommandBuffers(VkDevice devi
     // This is an array of handles, where the elements are allowed to be VK_NULL_HANDLE, and does not require any validation beyond
     // ValidateArray()
     skip |= ValidateArray("vkFreeCommandBuffers", "commandBufferCount", "pCommandBuffers", commandBufferCount, &pCommandBuffers,
-                          true, true, kVUIDUndefined, kVUIDUndefined);
+                          true, true, kVUIDUndefined, "VUID-vkFreeCommandBuffers-pCommandBuffers-00048");
     return skip;
 }
 

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -668,7 +668,7 @@ bool StatelessValidation::manual_PreCallValidateFreeDescriptorSets(VkDevice devi
     // This is an array of handles, where the elements are allowed to be VK_NULL_HANDLE, and does not require any validation beyond
     // ValidateArray()
     return ValidateArray("vkFreeDescriptorSets", "descriptorSetCount", "pDescriptorSets", descriptorSetCount, &pDescriptorSets,
-                         true, true, kVUIDUndefined, kVUIDUndefined);
+                         true, true, kVUIDUndefined, "VUID-vkFreeDescriptorSets-pDescriptorSets-00310");
 }
 
 bool StatelessValidation::ValidateWriteDescriptorSet(const char *vkCallingFunction, const uint32_t descriptorWriteCount,

--- a/layers/vulkan/generated/parameter_validation.cpp
+++ b/layers/vulkan/generated/parameter_validation.cpp
@@ -7783,6 +7783,7 @@ bool StatelessValidation::PreCallValidateFreeCommandBuffers(
     bool skip = false;
     skip |= ValidateRequiredHandle("vkFreeCommandBuffers", "commandPool", commandPool);
     skip |= ValidateArray("vkFreeCommandBuffers", "commandBufferCount", "", commandBufferCount, &pCommandBuffers, true, false, "VUID-vkFreeCommandBuffers-commandBufferCount-arraylength", kVUIDUndefined);
+    if (!skip) skip |= manual_PreCallValidateFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
     return skip;
 }
 

--- a/scripts/generators/parameter_validation_generator.py
+++ b/scripts/generators/parameter_validation_generator.py
@@ -107,6 +107,7 @@ class ParameterValidationOutputGenerator(OutputGenerator):
             'vkFreeDescriptorSets',
             'vkUpdateDescriptorSets',
             'vkBeginCommandBuffer',
+            'vkFreeCommandBuffers',
             'vkCmdSetViewport',
             'vkCmdSetScissor',
             'vkCmdSetLineWidth',

--- a/tests/negative/others.cpp
+++ b/tests/negative/others.cpp
@@ -2060,6 +2060,42 @@ TEST_F(VkLayerTest, ResetEventThenSet) {
     vk::FreeCommandBuffers(m_device->device(), command_pool.handle(), 1, &command_buffer);
 }
 
+TEST_F(VkLayerTest, FreeCommandBuffersNull) {
+    TEST_DESCRIPTION("Can pass NULL for vkFreeCommandBuffers");
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkFreeCommandBuffers-pCommandBuffers-00048");
+    vk::FreeCommandBuffers(m_device->device(), m_commandPool->handle(), 2, nullptr);
+    m_errorMonitor->VerifyFound();
+
+    VkCommandBuffer invalid_cb = CastToHandle<VkCommandBuffer, uintptr_t>(0xbaadbeef);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkFreeCommandBuffers-pCommandBuffers-00048");
+    vk::FreeCommandBuffers(m_device->device(), m_commandPool->handle(), 1, &invalid_cb);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkLayerTest, FreeDescriptorSetsNull) {
+    TEST_DESCRIPTION("Can pass NULL for vkFreeDescriptorSets");
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    VkDescriptorPoolSize ds_type_count = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1};
+    auto ds_pool_ci = LvlInitStruct<VkDescriptorPoolCreateInfo>();
+    ds_pool_ci.maxSets = 1;
+    ds_pool_ci.poolSizeCount = 1;
+    ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+    ds_pool_ci.pPoolSizes = &ds_type_count;
+    vk_testing::DescriptorPool ds_pool(*m_device, ds_pool_ci);
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkFreeDescriptorSets-pDescriptorSets-00310");
+    vk::FreeDescriptorSets(m_device->device(), ds_pool.handle(), 2, nullptr);
+    m_errorMonitor->VerifyFound();
+
+    VkDescriptorSet invalid_set = CastToHandle<VkDescriptorSet, uintptr_t>(0xbaadbeef);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkFreeDescriptorSets-pDescriptorSets-00310");
+    vk::FreeDescriptorSets(m_device->device(), ds_pool.handle(), 1, &invalid_set);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(VkLayerTest, ValidateStride) {
     TEST_DESCRIPTION("Validate Stride.");
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));


### PR DESCRIPTION
Currently we have `kVUIDUndefined` where we should be using the proper VUID

Also `vk::FreeCommandBuffers(m_device->device(), m_commandPool->handle(), 2, nullptr);` was crashing because we were not actually calling into `manual_PreCallValidateFreeCommandBuffers`