### PR TITLE
layers: Add missing vkImportSemaphore{Type} VUIDs

### DIFF
--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -44,7 +44,7 @@ bool CoreChecks::PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkIm
     const char *func_name = "vkImportSemaphoreFdKHR";
     auto sem_state = Get<SEMAPHORE_STATE>(info->semaphore);
     if (sem_state) {
-        skip |= ValidateObjectNotInUse(sem_state.get(), func_name, kVUIDUndefined);
+        skip |= ValidateObjectNotInUse(sem_state.get(), func_name, "VUID-vkImportSemaphoreFdKHR-semaphore-01142");
 
         if ((info->flags & VK_SEMAPHORE_IMPORT_TEMPORARY_BIT) != 0 && sem_state->type == VK_SEMAPHORE_TYPE_TIMELINE) {
             skip |= LogError(sem_state->Handle(), "VUID-VkImportSemaphoreFdInfoKHR-flags-03323",
@@ -122,6 +122,7 @@ bool CoreChecks::PreCallValidateImportSemaphoreWin32HandleKHR(VkDevice device,
     const char *func_name = "vkImportSemaphoreWin32HandleKHR";
     auto sem_state = Get<SEMAPHORE_STATE>(info->semaphore);
     if (sem_state) {
+        // Waiting for: https://gitlab.khronos.org/vulkan/vulkan/-/issues/3507
         skip |= ValidateObjectNotInUse(sem_state.get(), func_name, kVUIDUndefined);
 
         if ((info->flags & VK_SEMAPHORE_IMPORT_TEMPORARY_BIT) != 0 && sem_state->type == VK_SEMAPHORE_TYPE_TIMELINE) {
@@ -179,7 +180,7 @@ bool CoreChecks::PreCallValidateImportSemaphoreZirconHandleFUCHSIA(VkDevice devi
     const char *func_name = "vkImportSemaphoreZirconHandleFUCHSIA";
     auto sem_state = Get<SEMAPHORE_STATE>(info->semaphore);
     if (sem_state) {
-        skip |= ValidateObjectNotInUse(sem_state.get(), func_name, kVUIDUndefined);
+        skip |= ValidateObjectNotInUse(sem_state.get(), func_name, "VUID-vkImportSemaphoreZirconHandleFUCHSIA-semaphore-04764");
 
         if (sem_state->type == VK_SEMAPHORE_TYPE_TIMELINE) {
             skip |=


### PR DESCRIPTION
Adds VUIDs (fd and FUCHSIA handles) that it's illegal to import into the semaphore that is in use.