### PR TITLE
layers: Fix debug label validation

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1743,10 +1743,13 @@ bool CoreChecks::PreCallValidateCmdEndDebugUtilsLabelEXT(VkCommandBuffer command
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
     assert(cb_state);
     bool skip = false;
+
+    if (cb_state->IsPrimary()) {
+        return skip;
+    }
+
     if (cb_state->LabelStackDepth() < 1) {
-        const auto vuid = cb_state->IsPrimary() ? "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912"
-                                                : "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01913";
-        skip |= LogError(commandBuffer, vuid,
+        skip |= LogError(commandBuffer, "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01913",
                          "vkCmdEndDebugUtilsLabelEXT() called without a corresponding vkCmdBeginDebugUtilsLabelEXT first");
     }
     return skip;

--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-// This file list all VUID that are no possible to validate.
+// This file list all VUID that are not possible to validate.
 // This file should never be included, but here for searchability and statistics
 
 const char* unimplementable_validation[] = {
@@ -36,4 +36,7 @@ const char* unimplementable_validation[] = {
     "VUID-VkViewport-maxDepth-02541",                                      // VUID-VkViewport-maxDepth-01235
     "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00755",              // VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-02510
     "VUID-vkCmdFillBuffer-apiVersion-07894",                               // VUID-vkCmdFillBuffer-commandBuffer-00030
-};
+
+    // This VUID cannot be validated at vkCmdEndDebugUtilsLabelEXT time. Needs spec clarification.
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5671
+    "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912"};

--- a/tests/negative/command.cpp
+++ b/tests/negative/command.cpp
@@ -7260,3 +7260,21 @@ TEST_F(NegativeCommand, ClearImageAspectMask) {
     m_errorMonitor->VerifyFound();
     m_commandBuffer->end();
 }
+
+TEST_F(NegativeCommand, DebugLabelSecondaryCommandBuffer) {
+    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    VkCommandBufferObj cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    cb.begin();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01913");
+    vk::CmdEndDebugUtilsLabelEXT(cb);
+    m_errorMonitor->VerifyFound();
+
+    cb.end();
+}

--- a/tests/negative/others.cpp
+++ b/tests/negative/others.cpp
@@ -3166,43 +3166,6 @@ TEST_F(VkLayerTest, InvalidExtEnum) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(VkLayerTest, EndDebugLabelWithNoBegin) {
-    TEST_DESCRIPTION("Call vkCmdEndDebugUtilsLabelEXT without matching vkCmdBeginDebugUtilsLabelEXT");
-
-    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-    ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (!AreRequiredExtensionsEnabled()) {
-        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState());
-    m_commandBuffer->begin();
-    // First verify there is no error in the valid case
-    auto label = LvlInitStruct<VkDebugUtilsLabelEXT>(nullptr, "Test");
-    vk::CmdBeginDebugUtilsLabelEXT(*m_commandBuffer, &label);
-    vk::CmdEndDebugUtilsLabelEXT(*m_commandBuffer);
-
-    // Now call vkCmdEndDebugUtilsLabelEXT without a corresponding begin
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912");
-    vk::CmdEndDebugUtilsLabelEXT(*m_commandBuffer);
-    m_errorMonitor->VerifyFound();
-
-    m_commandBuffer->end();
-
-    // Now test the same scenario for secondary buffers
-    auto cb_info =
-        LvlInitStruct<VkCommandBufferAllocateInfo>(nullptr, m_commandPool->handle(), VK_COMMAND_BUFFER_LEVEL_SECONDARY, 1u);
-    vk_testing::CommandBuffer cb(*m_device, cb_info);
-    cb.begin();
-    vk::CmdBeginDebugUtilsLabelEXT(cb, &label);
-    vk::CmdEndDebugUtilsLabelEXT(cb);
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01913");
-    vk::CmdEndDebugUtilsLabelEXT(cb);
-    m_errorMonitor->VerifyFound();
-
-    cb.end();
-}
-
 TEST_F(VkLayerTest, ExtensionNotEnabled) {
     TEST_DESCRIPTION("Validate that using an API from an unenabled extension returns an error");
 


### PR DESCRIPTION
This VUID cannot be validated in vkCmdEndDebugUtilsLabelEXT

So I'm adding it to the unimplementable_validation.h file.

My plan is to help fix/clear up the specification.

Meanwhile fixing up this false positive and adding positive
testing to prevent a regression.

closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5671