### PR TITLE
Remove unused stateless for VkPresentRegionsKHR

### DIFF
--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -227,9 +227,8 @@ bool StatelessValidation::ValidateCmdBindVertexBuffers2(VkCommandBuffer commandB
                     not_null_msg = "pSizes is not NULL";
                 else
                     not_null_msg = "pStrides is not NULL";
-                const char *vuid_breach_msg = "%s: %s, so bindingCount must be greater than 0.";
-                skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", vuid_breach_msg, api_call,
-                                 not_null_msg);
+                skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength",
+                                 "%s: %s, so bindingCount must be greater than 0.", api_call, not_null_msg);
             }
         }
     }

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -227,7 +227,7 @@ bool StatelessValidation::ValidateCmdBindVertexBuffers2(VkCommandBuffer commandB
                     not_null_msg = "pSizes is not NULL";
                 else
                     not_null_msg = "pStrides is not NULL";
-                const char *vuid_breach_msg = "%s: %s, so bindingCount must be greater that 0.";
+                const char *vuid_breach_msg = "%s: %s, so bindingCount must be greater than 0.";
                 skip |= LogError(commandBuffer, "VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", vuid_breach_msg, api_call,
                                  not_null_msg);
             }

--- a/layers/stateless/sl_wsi.cpp
+++ b/layers/stateless/sl_wsi.cpp
@@ -186,14 +186,6 @@ bool StatelessValidation::manual_PreCallValidateQueuePresentKHR(VkQueue queue, c
             skip |= ValidateStructPnext("QueuePresentKHR", "pCreateInfo->pNext->pNext", NULL, present_regions->pNext, 0, NULL,
                                         GeneratedVulkanHeaderVersion, "VUID-VkPresentInfoKHR-pNext-pNext",
                                         "VUID-VkPresentInfoKHR-sType-unique");
-            skip |= ValidateArray("QueuePresentKHR", "pCreateInfo->pNext->swapchainCount", "pCreateInfo->pNext->pRegions",
-                                  present_regions->swapchainCount, &present_regions->pRegions, true, false, kVUIDUndefined,
-                                  kVUIDUndefined);
-            for (uint32_t i = 0; i < present_regions->swapchainCount; ++i) {
-                skip |= ValidateArray("QueuePresentKHR", "pCreateInfo->pNext->pRegions[].rectangleCount",
-                                      "pCreateInfo->pNext->pRegions[].pRectangles", present_regions->pRegions[i].rectangleCount,
-                                      &present_regions->pRegions[i].pRectangles, true, false, kVUIDUndefined, kVUIDUndefined);
-            }
         }
     }
 


### PR DESCRIPTION
There were 2 `ValidateArray` that were not correct, this removes them and adds tests