### PR TITLE
tests: Add --print-vu for viewing new VU messages

### DIFF
--- a/docs/creating_tests.md
+++ b/docs/creating_tests.md
@@ -220,6 +220,14 @@ m_errorMonitor->VerifyFound();
 ```
 Here it is obvious that the `aspectMask` parameter is the cause of 02271.
 
+### Viewing VU Messages
+
+When `SetDesiredFailureMsg` is used, nothing is displayed if the test is successful. To see the messages regardless use `--print-vu`
+
+```bash
+./tests/vk_layer_validation_tests --print-vu --gtest_filter=Tests
+```
+
 ## Device Profiles API
 
 There are times a test writer will want to test a case where an implementation returns a certain support for a format feature or limit. Instead of just hoping to find a device that supports a certain case, there is the Device Profiles API layer. This layer will allow a test writer to inject certain values for format features and/or limits.

--- a/tests/framework/error_monitor.cpp
+++ b/tests/framework/error_monitor.cpp
@@ -66,7 +66,7 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugCallback(VkDebugUtilsMessageSeverityF
 }
 #endif
 
-ErrorMonitor::ErrorMonitor() {
+ErrorMonitor::ErrorMonitor(bool print_all_errors) : print_all_errors_(print_all_errors) {
     MonitorReset();
     ExpectSuccess(kErrorBit);
 #if !defined(VK_USE_PLATFORM_ANDROID_KHR)
@@ -167,6 +167,9 @@ VkBool32 ErrorMonitor::CheckForDesiredMsg(const char *const msgString) {
     std::string error_string(msgString);
     bool found_expected = false;
 
+    if (print_all_errors_) {
+        std::cout << error_string << "\n\n";
+    }
     if (!IgnoreMessage(error_string)) {
         for (auto desired_msg_it = desired_message_strings_.begin(); desired_msg_it != desired_message_strings_.end();
              ++desired_msg_it) {

--- a/tests/framework/error_monitor.h
+++ b/tests/framework/error_monitor.h
@@ -33,7 +33,7 @@
 // failure was encountered.
 class ErrorMonitor {
   public:
-    ErrorMonitor();
+    ErrorMonitor(bool print_all_errors);
     ~ErrorMonitor() noexcept = default;
 
     void CreateCallback(VkInstance instance) noexcept;
@@ -99,4 +99,5 @@ class ErrorMonitor {
     mutable std::mutex mutex_;
     std::atomic<bool> *bailout_{};
     bool message_found_{};
+    bool print_all_errors_{};
 };

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -219,7 +219,7 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<VkLayerProperties> available_layers_; // allow caching of available layers
     std::vector<VkExtensionProperties> available_extensions_; // allow caching of available instance extensions
 
-    ErrorMonitor monitor_;
+    ErrorMonitor monitor_ = ErrorMonitor(m_print_vu);
     ErrorMonitor *m_errorMonitor = &monitor_;  // TODO: Removing this properly is it's own PR. It's a big change.
 
     VkApplicationInfo app_info_;

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -207,10 +207,15 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
             m_strip_spv = true;
         else if (optionMatch("--canonicalize-SPV", argv[i]))
             m_canonicalize_spv = true;
+        else if (optionMatch("--print-vu", argv[i]))
+            m_print_vu = true;
         else if (optionMatch("--device-index", argv[i]) && ((i + 1) < *argc)) {
             m_phys_device_index = std::atoi(argv[++i]);
         } else if (optionMatch("--help", argv[i]) || optionMatch("-h", argv[i])) {
             printf("\nOther options:\n");
+            printf(
+                "\t--print-vu\n"
+                "\t\tPrints all VUs - help see what new VU will look like.\n");
             printf(
                 "\t--show-images\n"
                 "\t\tDisplay test images in viewer after tests complete.\n");

--- a/tests/framework/test_framework.h
+++ b/tests/framework/test_framework.h
@@ -55,6 +55,7 @@ class VkTestFramework : public ::testing::Test {
     void FreeFileData(char **data);
 
     static inline bool m_canonicalize_spv = false;
+    static inline bool m_print_vu = false;
     static inline bool m_strip_spv = false;
     static inline bool m_do_everything_spv = false;
     static inline int m_phys_device_index = -1;

--- a/tests/framework/test_framework_android.h
+++ b/tests/framework/test_framework_android.h
@@ -38,6 +38,7 @@ class VkTestFramework : public ::testing::Test {
 
     static inline int m_phys_device_index = -1;
     static inline ANativeWindow *window = nullptr;
+    static inline bool m_print_vu = false;
 };
 
 class TestEnvironment : public ::testing::Environment {

--- a/tests/positive/other.cpp
+++ b/tests/positive/other.cpp
@@ -727,7 +727,7 @@ TEST_F(VkPositiveLayerTest, EnumeratePhysicalDeviceGroups) {
         vk::InitInstanceExtension(test_instance, instance_ext_name);
     }
 
-    ErrorMonitor monitor;
+    ErrorMonitor monitor = ErrorMonitor(false);
     monitor.CreateCallback(test_instance);
 
     uint32_t physical_device_group_count = 0;


### PR DESCRIPTION
Closes https://github.com/orgs/KhronosGroup/projects/15/views/1?pane=issue&itemId=22965268

Adds a `--print-vu` to view the VU error messages

This saves people time having to modify the VUID just to recompile and view what a new VU error message looks like for a test