### PR TITLE
layers: VK_IMAGE_COMPRESSION_DEFAULT_EXT flag fix

### DIFF
--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -585,7 +585,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                 (VK_IMAGE_COMPRESSION_DEFAULT_EXT | VK_IMAGE_COMPRESSION_FIXED_RATE_DEFAULT_EXT |
                  VK_IMAGE_COMPRESSION_FIXED_RATE_EXPLICIT_EXT | VK_IMAGE_COMPRESSION_DISABLED_EXT);
             skip |= ValidateFlags("vkCreateImage", "VkImageCompressionControlEXT::flags", "VkImageCompressionFlagsEXT",
-                                  AllVkImageCompressionFlagBitsEXT, image_compression_control->flags, kRequiredSingleBit,
+                                  AllVkImageCompressionFlagBitsEXT, image_compression_control->flags, kOptionalSingleBit,
                                   "VUID-VkImageCompressionControlEXT-flags-06747");
 
             if (image_compression_control->flags == VK_IMAGE_COMPRESSION_FIXED_RATE_EXPLICIT_EXT &&

--- a/tests/positive/image.cpp
+++ b/tests/positive/image.cpp
@@ -714,6 +714,24 @@ TEST_F(PositiveImage, ImageCompressionControl) {
     image_ci.tiling = VK_IMAGE_TILING_LINEAR;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
+    // Create with disabled image compression
+    {
+        auto compressionControl = LvlInitStruct<VkImageCompressionControlEXT>();
+        compressionControl.flags = VK_IMAGE_COMPRESSION_DISABLED_EXT;
+        image_ci.pNext = &compressionControl;
+
+        vk_testing::Image image(*m_device, image_ci);
+    }
+
+    // Create with default image compression, without fixed rate
+    {
+        auto compressionControl = LvlInitStruct<VkImageCompressionControlEXT>();
+        compressionControl.flags = VK_IMAGE_COMPRESSION_DEFAULT_EXT;
+        image_ci.pNext = &compressionControl;
+
+        vk_testing::Image image(*m_device, image_ci);
+    }
+
     // Create with fixed rate compression image
     {
         auto compressionControl = LvlInitStruct<VkImageCompressionControlEXT>();


### PR DESCRIPTION
VL falsely marks flag VK_IMAGE_COMPRESSION_DEFAULT_EXT as invalid. The value of this enum is 0 and ValidateFlags function used to check if flags are properly set has 'flag_type' parameter set to kRequiredSingleBit which doesnt allows 0 as flag value.

Changing flag_type to kOptionalSingleBit resolves issue.

This fixes issue #5971 