### PR TITLE
layers: Improve Query state code

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -362,10 +362,10 @@ bool CoreChecks::PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer) 
             report_data->FormatHandle(commandBuffer).c_str());
     }
 
-    for (const auto &query : cb_state.activeQueries) {
+    for (const auto &query_obj : cb_state.activeQueries) {
         skip |= LogError(commandBuffer, "VUID-vkEndCommandBuffer-commandBuffer-00061",
                          "vkEndCommandBuffer(): Ending command buffer with in progress query: %s, query %d.",
-                         report_data->FormatHandle(query.pool).c_str(), query.query);
+                         report_data->FormatHandle(query_obj.pool).c_str(), query_obj.slot);
     }
     if (cb_state.conditional_rendering_active) {
         skip |= LogError(commandBuffer, "VUID-vkEndCommandBuffer-None-01978",

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -644,8 +644,8 @@ void CoreChecks::PreCallRecordCmdWriteAccelerationStructuresPropertiesKHR(VkComm
         if (!do_validate) return false;
         bool skip = false;
         for (uint32_t i = 0; i < accelerationStructureCount; i++) {
-            QueryObject query = {{queryPool, firstQuery + i}, perfPass};
-            skip |= VerifyQueryIsReset(cb_state_arg, query, cmd_type, firstPerfQueryPool, perfPass, localQueryToStateMap);
+            QueryObject query_obj = {queryPool, firstQuery + i, perfPass};
+            skip |= VerifyQueryIsReset(cb_state_arg, query_obj, cmd_type, firstPerfQueryPool, perfPass, localQueryToStateMap);
         }
         return skip;
     });

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1446,7 +1446,7 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator) const override;
     bool PreCallValidateDestroyQueryPool(VkDevice device, VkQueryPool queryPool,
                                          const VkAllocationCallbacks* pAllocator) const override;
-    bool ValidatePerformanceQueryResults(const char* cmd_name, const QUERY_POOL_STATE* query_pool_state, uint32_t firstQuery,
+    bool ValidatePerformanceQueryResults(const char* cmd_name, const QUERY_POOL_STATE& query_pool_state, uint32_t firstQuery,
                                          uint32_t queryCount, VkQueryResultFlags flags) const;
     bool ValidateGetQueryPoolPerformanceResults(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, void* pData,
                                                 VkDeviceSize stride, VkQueryResultFlags flags, const char* apiName) const;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -393,17 +393,17 @@ bool CMD_BUFFER_STATE::UpdatesQuery(const QueryObject &query_obj) const {
 static bool SetQueryStateMulti(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, uint32_t perfPass, QueryState value,
                                QueryMap *localQueryToStateMap) {
     for (uint32_t i = 0; i < queryCount; i++) {
-        QueryObject object = QueryObject(QueryObject(queryPool, firstQuery + i), perfPass);
-        (*localQueryToStateMap)[object] = value;
+        QueryObject query_obj = {queryPool, firstQuery + i, perfPass};
+        (*localQueryToStateMap)[query_obj] = value;
     }
     return false;
 }
 
 void CMD_BUFFER_STATE::EndQueries(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {
     for (uint32_t slot = firstQuery; slot < (firstQuery + queryCount); slot++) {
-        QueryObject query = {queryPool, slot};
-        activeQueries.erase(query);
-        updatedQueries.insert(query);
+        QueryObject query_obj = {queryPool, slot};
+        activeQueries.erase(query_obj);
+        updatedQueries.insert(query_obj);
     }
     queryUpdates.emplace_back([queryPool, firstQuery, queryCount](CMD_BUFFER_STATE &cb_state_arg, bool do_validate,
                                                                   VkQueryPool &firstPerfQueryPool, uint32_t perfQueryPass,
@@ -414,9 +414,9 @@ void CMD_BUFFER_STATE::EndQueries(VkQueryPool queryPool, uint32_t firstQuery, ui
 
 void CMD_BUFFER_STATE::ResetQueryPool(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {
     for (uint32_t slot = firstQuery; slot < (firstQuery + queryCount); slot++) {
-        QueryObject query = {queryPool, slot};
-        resetQueries.insert(query);
-        updatedQueries.insert(query);
+        QueryObject query_obj = {queryPool, slot};
+        resetQueries.insert(query_obj);
+        updatedQueries.insert(query_obj);
     }
 
     queryUpdates.emplace_back([queryPool, firstQuery, queryCount](CMD_BUFFER_STATE &cb_state_arg, bool do_validate,
@@ -1470,8 +1470,8 @@ void CMD_BUFFER_STATE::RecordWriteTimestamp(CMD_TYPE cmd_type, VkPipelineStageFl
         auto pool_state = dev_data->Get<QUERY_POOL_STATE>(queryPool);
         AddChild(pool_state);
     }
-    QueryObject query = {queryPool, slot};
-    EndQuery(query);
+    QueryObject query_obj = {queryPool, slot};
+    EndQuery(query_obj);
 }
 
 void CMD_BUFFER_STATE::Submit(uint32_t perf_submit_pass) {
@@ -1484,7 +1484,7 @@ void CMD_BUFFER_STATE::Submit(uint32_t perf_submit_pass) {
 
     for (const auto &query_state_pair : local_query_to_state_map) {
         auto query_pool_state = dev_data->Get<QUERY_POOL_STATE>(query_state_pair.first.pool);
-        query_pool_state->SetQueryState(query_state_pair.first.query, query_state_pair.first.perf_pass, query_state_pair.second);
+        query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass, query_state_pair.second);
     }
 
     for (const auto &function : eventUpdates) {
@@ -1523,7 +1523,7 @@ void CMD_BUFFER_STATE::Retire(uint32_t perf_submit_pass, const std::function<boo
         if (query_state_pair.second == QUERYSTATE_ENDED && !is_query_updated_after(query_state_pair.first)) {
             auto query_pool_state = dev_data->Get<QUERY_POOL_STATE>(query_state_pair.first.pool);
             if (query_pool_state) {
-                query_pool_state->SetQueryState(query_state_pair.first.query, query_state_pair.first.perf_pass,
+                query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass,
                                                 QUERYSTATE_AVAILABLE);
             }
         }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3424,13 +3424,13 @@ void ValidationStateTracker::PostCallRecordCmdBeginQuery(VkCommandBuffer command
         num_queries = std::max(num_queries, bits);
     }
     for (uint32_t i = 0; i < num_queries; ++i) {
-        QueryObject query = {queryPool, slot};
+        QueryObject query_obj = {queryPool, slot};
         cb_state->RecordCmd(CMD_BEGINQUERY);
         if (!disabled[query_validation]) {
-            cb_state->BeginQuery(query);
+            cb_state->BeginQuery(query_obj);
         }
         if (!disabled[command_buffer_state]) {
-            auto pool_state = Get<QUERY_POOL_STATE>(query.pool);
+            auto pool_state = Get<QUERY_POOL_STATE>(queryPool);
             cb_state->AddChild(pool_state);
         }
     }
@@ -3453,7 +3453,7 @@ void ValidationStateTracker::PostCallRecordCmdEndQuery(VkCommandBuffer commandBu
             cb_state->EndQuery(query_obj);
         }
         if (!disabled[command_buffer_state]) {
-            auto pool_state = Get<QUERY_POOL_STATE>(query_obj.pool);
+            auto pool_state = Get<QUERY_POOL_STATE>(queryPool);
             cb_state->AddChild(pool_state);
         }
     }
@@ -4639,7 +4639,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceDisplayPlaneProperti
 }
 
 void ValidationStateTracker::PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
-                                                                   uint32_t query, VkQueryControlFlags flags, uint32_t index) {
+                                                                   uint32_t slot, VkQueryControlFlags flags, uint32_t index) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     uint32_t num_queries = 1;
     // If render pass instance has multiview enabled, query uses N consecutive query indices
@@ -4649,14 +4649,14 @@ void ValidationStateTracker::PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuff
     }
 
     for (uint32_t i = 0; i < num_queries; ++i) {
-        QueryObject query_obj = {queryPool, query, index + i};
+        QueryObject query_obj = {queryPool, slot, 0, true, index + i};
         cb_state->RecordCmd(CMD_BEGINQUERYINDEXEDEXT);
         cb_state->BeginQuery(query_obj);
     }
 }
 
 void ValidationStateTracker::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool,
-                                                                 uint32_t query, uint32_t index) {
+                                                                 uint32_t slot, uint32_t index) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     uint32_t num_queries = 1;
     // If render pass instance has multiview enabled, query uses N consecutive query indices
@@ -4666,7 +4666,7 @@ void ValidationStateTracker::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer
     }
 
     for (uint32_t i = 0; i < num_queries; ++i) {
-        QueryObject query_obj = {queryPool, query, index + i};
+        QueryObject query_obj = {queryPool, slot, 0, true, index + i};
         cb_state->RecordCmd(CMD_ENDQUERYINDEXEDEXT);
         cb_state->EndQuery(query_obj);
     }


### PR DESCRIPTION
The first thing this does is make `ValidatePerformanceQueryResults` use a const ref

Then I went through and notices a lot of cleanup needed around `QueryObject`

- Make all uses of `QueryObject` be consistent with name of `query_obj`
- We used `slot` in half the functions, I agree it makes reading the code easier, but went through and made it same everywhere
-  Removed a `QueryObject` constructor never being used
- Combined `QueryObject` constructors because it was confusing because they both wanted to use `uint32_t` parameters, so just combined into a single constructor