### PR TITLE
layers: Label new Vertex 64-bit VUIDs

### DIFF
--- a/layers/core_checks/cc_shader.cpp
+++ b/layers/core_checks/cc_shader.cpp
@@ -104,17 +104,17 @@ bool CoreChecks::ValidateViAgainstVsInputs(const PIPELINE_STATE &pipeline, const
                                  pipeline.create_index, string_VkFormat(attribute_format), location,
                                  module_state.DescribeType(input_base_type_id).c_str());
             } else {
-                // 64-bit can't be used if the other is not also 64-bit.
+                // 64-bit can't be used if both the Vertex Attribute AND Shader Input Variable are both not 64-bit.
                 const bool attribute64 = FormatIs64bit(attribute_format);
                 const bool input64 = module_state.GetBaseTypeInstruction(input_base_type_id)->GetBitWidth() == 64;
                 if (attribute64 && !input64) {
-                    skip |= LogError(module_state.vk_shader_module(), "UNASSIGNED-VkGraphicsPipelineCreateInfo-Attribute-64bit",
+                    skip |= LogError(module_state.vk_shader_module(), "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08929",
                                      "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attribute at location %" PRIu32
                                      " is a 64-bit format (%s) but vertex shader input is 32-bit type (%s)",
                                      pipeline.create_index, location, string_VkFormat(attribute_format),
                                      module_state.DescribeType(input_base_type_id).c_str());
                 } else if (!attribute64 && input64) {
-                    skip |= LogError(module_state.vk_shader_module(), "UNASSIGNED-VkGraphicsPipelineCreateInfo-Input-64bit",
+                    skip |= LogError(module_state.vk_shader_module(), "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08930",
                                      "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attribute at location %" PRIu32
                                      " is a not a 64-bit format (%s) but vertex shader input is 64-bit type (%s)",
                                      pipeline.create_index, location, string_VkFormat(attribute_format),

--- a/tests/negative/vertex_input.cpp
+++ b/tests/negative/vertex_input.cpp
@@ -910,7 +910,7 @@ TEST_F(NegativeVertexInput, Attribute64bitInputAttribute) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.InitState();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-VkGraphicsPipelineCreateInfo-Attribute-64bit");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08929");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -955,7 +955,7 @@ TEST_F(NegativeVertexInput, Attribute64bitShaderInput) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.InitState();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-VkGraphicsPipelineCreateInfo-Input-64bit");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08930");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
The 1.3.253 spec introduced 2 of the VUs I added in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5757

This just gives them the proper VUID