### PR TITLE
tests: Add missing max_profile ext/features

### DIFF
--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -227,6 +227,9 @@
                 "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                     "decodeModeSharedExponent": true
                 },
+                "VkPhysicalDeviceShaderObjectFeaturesEXT": {
+                    "shaderObject": true
+                },
                 "VkPhysicalDeviceTransformFeedbackFeaturesEXT": {
                     "transformFeedback": true,
                     "geometryStreams": true
@@ -665,6 +668,11 @@
                 },
                 "VkPhysicalDeviceImageViewMinLodFeaturesEXT": {
                     "minLod": true
+                },
+                "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM": {
+                    "rasterizationOrderColorAttachmentAccess": true,
+                    "rasterizationOrderDepthAttachmentAccess": true,
+                    "rasterizationOrderStencilAttachmentAccess": true
                 },
                 "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT": {
                     "rasterizationOrderColorAttachmentAccess": true,
@@ -1758,6 +1766,7 @@
                 "VK_EXT_shader_demote_to_helper_invocation": 1,
                 "VK_EXT_shader_image_atomic_int64": 1,
                 "VK_EXT_shader_module_identifier": 1,
+                "VK_EXT_shader_object": 1,
                 "VK_EXT_shader_stencil_export": 1,
                 "VK_EXT_shader_subgroup_ballot": 1,
                 "VK_EXT_shader_subgroup_vote": 1,


### PR DESCRIPTION
Adds `VK_ARM_rasterization_order_attachment_access` features (goes with https://github.com/KhronosGroup/Vulkan-Profiles/pull/447)

Adds `VK_EXT_shader_object` as the one test that uses it was not running (and probably will be used in the near future more)