### PR TITLE
layers: Remove false positive for dynamic vertex input

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2675,7 +2675,8 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &last_boun
     }
 
     // Verify vertex binding
-    if (pipeline.vertex_input_state) {
+    // TODO #5954 - Add proper dynamic support
+    if (pipeline.vertex_input_state && !pipeline.IsDynamic(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT)) {
         for (size_t i = 0; i < pipeline.vertex_input_state->binding_descriptions.size(); i++) {
             const auto vertex_binding = pipeline.vertex_input_state->binding_descriptions[i].binding;
             if (current_vtx_bfr_binding_info.size() < (vertex_binding + 1)) {
@@ -2747,8 +2748,8 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &last_boun
             } else {
                 const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
                 skip |= LogError(objlist, vuid.vertex_binding_attribute_02721,
-                                 "%s: binding #%" PRIu32 " in pVertexAttributeDescriptions[%" PRIu32 "] is an invalid values.",
-                                 caller, vertex_binding, i);
+                                 "%s: pVertexAttributeDescriptions[%" PRIu32 "].binding (%" PRIu32 ") is an invalid value.", caller,
+                                 vertex_binding, i);
             }
         }
     }

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -750,6 +750,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
             const bool has_dynamic_exclusive_scissor_nv = vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV);
             const bool has_dynamic_viewport_with_count = vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
             const bool has_dynamic_scissor_with_count = vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
+            const bool has_dynamic_vertex_input = vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
 
             // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
 
@@ -808,7 +809,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(VkDevice
                 skip |= ValidatePipelineInputAssemblyStateCreateInfo(*create_info.pInputAssemblyState, i);
             }
 
-            if (!(active_shaders & VK_SHADER_STAGE_MESH_BIT_EXT) && (create_info.pVertexInputState != nullptr)) {
+            if (!has_dynamic_vertex_input && !(active_shaders & VK_SHADER_STAGE_MESH_BIT_EXT) &&
+                (create_info.pVertexInputState != nullptr)) {
                 auto const &vertex_input_state = create_info.pVertexInputState;
 
                 skip |= ValidatePipelineVertexInputStateCreateInfo(*vertex_input_state, i);

--- a/tests/negative/vertex_input.cpp
+++ b/tests/negative/vertex_input.cpp
@@ -887,10 +887,6 @@ TEST_F(NegativeVertexInput, Attribute64bitInputAttribute) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    VkBufferObj vtx_buf;
-    auto info = vtx_buf.create_info(1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
-    vtx_buf.init(*m_device, info);
-
     char const *vsSource = R"glsl(
         #version 450 core
         layout(location = 0) in float pos; // 32-bit
@@ -930,10 +926,6 @@ TEST_F(NegativeVertexInput, Attribute64bitShaderInput) {
     if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
-
-    VkBufferObj vtx_buf;
-    auto info = vtx_buf.create_info(1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
-    vtx_buf.init(*m_device, info);
 
     char const *vsSource = R"glsl(
         #version 450 core
@@ -976,10 +968,6 @@ TEST_F(NegativeVertexInput, Attribute64bitUnusedComponent) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    VkBufferObj vtx_buf;
-    auto info = vtx_buf.create_info(1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
-    vtx_buf.init(*m_device, info);
-
     char const *vsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
@@ -1020,10 +1008,6 @@ TEST_F(NegativeVertexInput, Attribute64bitMissingComponent) {
     if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
-
-    VkBufferObj vtx_buf;
-    auto info = vtx_buf.create_info(1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
-    vtx_buf.init(*m_device, info);
 
     char const *vsSource = R"glsl(
         #version 450 core

--- a/tests/positive/dynamic_state.cpp
+++ b/tests/positive/dynamic_state.cpp
@@ -130,6 +130,15 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXT) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
+    // Fill with bad data as should be ignored with dynamic state
+    VkVertexInputBindingDescription input_binding = {5, 7, VK_VERTEX_INPUT_RATE_VERTEX};
+    VkVertexInputAttributeDescription input_attrib = {5, 7, VK_FORMAT_UNDEFINED, 9};
+    auto vi_ci = LvlInitStruct<VkPipelineVertexInputStateCreateInfo>();
+    vi_ci.pVertexBindingDescriptions = &input_binding;
+    vi_ci.vertexBindingDescriptionCount = 1;
+    vi_ci.pVertexAttributeDescriptions = &input_attrib;
+    vi_ci.vertexAttributeDescriptionCount = 1;
+
     CreatePipelineHelper pipe(*this);
     pipe.InitInfo();
     const VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VERTEX_INPUT_EXT};
@@ -138,7 +147,7 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXT) {
     dyn_state_ci.pDynamicStates = dyn_states;
     pipe.dyn_state_ci_ = dyn_state_ci;
     pipe.InitState();
-    pipe.gp_ci_.pVertexInputState = nullptr;
+    pipe.gp_ci_.pVertexInputState = &vi_ci;  // ignored
     pipe.CreateGraphicsPipeline();
 
     VkVertexInputBindingDescription2EXT binding = LvlInitStruct<VkVertexInputBindingDescription2EXT>();
@@ -152,8 +161,14 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXT) {
     attribute.format = VK_FORMAT_R32_SFLOAT;
     attribute.offset = 0;
 
+    VkBufferObj vtx_buf;
+    auto info = vtx_buf.create_info(1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
+    vtx_buf.init(*m_device, info);
+    VkDeviceSize offset = 0;
+
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
+    vk::CmdBindVertexBuffers(m_commandBuffer->handle(), 0, 1, &vtx_buf.handle(), &offset);
     vk::CmdSetVertexInputEXT(m_commandBuffer->handle(), 1, &binding, 1, &attribute);
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdDraw(m_commandBuffer->handle(), 1, 0, 0, 0);
@@ -212,8 +227,14 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXTStride) {
     attribute.format = VK_FORMAT_R32_SFLOAT;
     attribute.offset = 0;
 
+    VkBufferObj vtx_buf;
+    auto info = vtx_buf.create_info(1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
+    vtx_buf.init(*m_device, info);
+    VkDeviceSize offset = 0;
+
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
+    vk::CmdBindVertexBuffers(m_commandBuffer->handle(), 0, 1, &vtx_buf.handle(), &offset);
     vk::CmdSetVertexInputEXT(m_commandBuffer->handle(), 1, &binding, 1, &attribute);
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdDraw(m_commandBuffer->handle(), 1, 0, 0, 0);


### PR DESCRIPTION
Related (but not fixes) for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5954

This for the moment prevents false positives if using `VK_DYNAMIC_STATE_VERTEX_INPUT_EXT`

There is a lot more care that is needed in the vertex input logic then I realized, rather slowly fix it up, add many more tests before removing this dynamic state check