### PR TITLE
layers: Move Dynamic State helper to LastBoundState

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2797,7 +2797,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &last_boun
                     subpass_num_samples |= static_cast<unsigned>(render_pass_info->pAttachments[attachment].samples);
                 }
 
-                const VkSampleCountFlagBits rasterization_samples = cb_state.GetRasterizationSamples(pipeline);
+                const VkSampleCountFlagBits rasterization_samples = last_bound_state.GetRasterizationSamples();
                 if (!(IsExtEnabled(device_extensions.vk_amd_mixed_attachment_samples) ||
                       IsExtEnabled(device_extensions.vk_nv_framebuffer_mixed_samples) ||
                       enabled_features.multisampled_render_to_single_sampled_features.multisampledRenderToSingleSampled) &&
@@ -3245,7 +3245,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LAST_BOUND_STATE &l
             }
         }
     } else if (!enabled_features.multisampled_render_to_single_sampled_features.multisampledRenderToSingleSampled) {
-        const VkSampleCountFlagBits rasterization_samples = cb_state.GetRasterizationSamples(pipeline);
+        const VkSampleCountFlagBits rasterization_samples = last_bound_state.GetRasterizationSamples();
         for (uint32_t i = 0; i < rendering_info.colorAttachmentCount; ++i) {
             if (rendering_info.pColorAttachments[i].imageView == VK_NULL_HANDLE) {
                 continue;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1548,17 +1548,3 @@ void CMD_BUFFER_STATE::UnbindResources() {
     // Pipeline and descriptor sets
     lastBound[BindPoint_Graphics].Reset();
 }
-
-// Need to think about dynamic state when grabbing state
-bool CMD_BUFFER_STATE::RasterizationDisabled() const {
-    auto pipeline = lastBound[BindPoint_Graphics].pipeline_state;
-    if (pipeline) {
-        if (pipeline->IsDynamic(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT)) {
-            return rasterization_disabled;
-        } else {
-            return pipeline->RasterizationDisabled();
-        }
-    }
-
-    return false;
-}

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -215,6 +215,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
         VkLineRasterizationModeEXT line_rasterization_mode;
         // VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT
         bool stippled_line_enable;
+        // VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE
+        bool rasterizer_discard_enable;
 
         uint32_t color_write_enable_attachment_count;
 
@@ -293,8 +295,6 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     bool usedDynamicScissorCount;
 
     uint32_t initial_device_mask;
-
-    bool rasterization_disabled = false;
 
     safe_VkRenderPassBeginInfo activeRenderPassBeginInfo;
     std::shared_ptr<RENDER_PASS_STATE> activeRenderPass;
@@ -568,21 +568,6 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
         return false;
     }
 
-    // For given pipeline, return number of MSAA samples, or one if MSAA disabled
-    VkSampleCountFlagBits GetRasterizationSamples(const PIPELINE_STATE &pipeline) const {
-        VkSampleCountFlagBits rasterization_samples = VK_SAMPLE_COUNT_1_BIT;
-        if (pipeline.IsDynamic(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT)) {
-            rasterization_samples = dynamic_state_value.rasterization_samples;
-        } else {
-            const auto ms_state = pipeline.MultisampleState();
-            if (ms_state) {
-                rasterization_samples = ms_state->rasterizationSamples;
-            }
-        }
-        return rasterization_samples;
-    }
-
-    bool RasterizationDisabled() const;
     inline void BindPipeline(LvlBindPoint bind_point, PIPELINE_STATE *pipe_state) {
         lastBound[bind_point].pipeline_state = pipe_state;
     }

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -903,3 +903,23 @@ VkStencilOpState LAST_BOUND_STATE::GetStencilOpStateBack() const {
     }
     return back;
 }
+
+VkSampleCountFlagBits LAST_BOUND_STATE::GetRasterizationSamples() const {
+    // For given pipeline, return number of MSAA samples, or one if MSAA disabled
+    VkSampleCountFlagBits rasterization_samples = VK_SAMPLE_COUNT_1_BIT;
+    if (pipeline_state->IsDynamic(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT)) {
+        rasterization_samples = cb_state.dynamic_state_value.rasterization_samples;
+    } else {
+        const auto ms_state = pipeline_state->MultisampleState();
+        if (ms_state) {
+            rasterization_samples = ms_state->rasterizationSamples;
+        }
+    }
+    return rasterization_samples;
+}
+
+bool LAST_BOUND_STATE::IsRasterizationDisabled() const {
+    return pipeline_state->IsDynamic(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT)
+               ? cb_state.dynamic_state_value.rasterizer_discard_enable
+               : pipeline_state->RasterizationDisabled();
+}

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -823,6 +823,8 @@ struct LAST_BOUND_STATE {
     bool IsStencilTestEnable() const;
     VkStencilOpState GetStencilOpStateFront() const;
     VkStencilOpState GetStencilOpStateBack() const;
+    VkSampleCountFlagBits GetRasterizationSamples() const;
+    bool IsRasterizationDisabled() const;
 };
 
 static inline bool IsBoundSetCompat(uint32_t set, const LAST_BOUND_STATE &last_bound,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5418,7 +5418,7 @@ void ValidationStateTracker::RecordCmdSetRasterizerDiscardEnable(VkCommandBuffer
                                                                  CMD_TYPE cmd_type) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     cb_state->RecordStateCmd(cmd_type, CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE);
-    cb_state->rasterization_disabled = rasterizerDiscardEnable == VK_TRUE;
+    cb_state->dynamic_state_value.rasterizer_discard_enable = (rasterizerDiscardEnable == VK_TRUE);
 }
 
 void ValidationStateTracker::PostCallRecordCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer,


### PR DESCRIPTION
Moving 2 functions found in `CMD_BUFFER_STATE` that are better placed in `LAST_BOUND_STATE` as that is the new go-to location as it contains the pipeline and command buffer state together