### PR TITLE
tests: Remove unused IsPlatform checks

### DIFF
--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -86,24 +86,14 @@ class VkDepthStencilObj;
 typedef enum {
     kGalaxyS10,
     kPixel3,
-    kPixelC,
-    kNexusPlayer,
-    kShieldTV,
     kShieldTVb,
-    kPixel3aXL,
-    kPixel2XL,
     kMockICD,
 } PlatformType;
 
 const std::unordered_map<PlatformType, std::string, std::hash<int>> vk_gpu_table = {
     {kGalaxyS10, "Mali-G76"},
     {kPixel3, "Adreno (TM) 630"},
-    {kPixelC, "NVIDIA Tegra X1"},
-    {kNexusPlayer, "PowerVR Rogue G6430"},
-    {kShieldTV, "NVIDIA Tegra X1 (nvgpu)"},
     {kShieldTVb, "NVIDIA Tegra X1 (rev B) (nvgpu)"},
-    {kPixel3aXL, "Adreno (TM) 615"},
-    {kPixel2XL, "Adreno (TM) 540"},
     {kMockICD, "Vulkan Mock Device"},
 };
 struct SurfaceContext {

--- a/tests/negative/android_hardware_buffer.cpp
+++ b/tests/negative/android_hardware_buffer.cpp
@@ -187,7 +187,7 @@ TEST_F(NegativeAndroidHardwareBuffer, GpuDataBuffer) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on this device";
     }
 
@@ -234,7 +234,7 @@ TEST_F(NegativeAndroidHardwareBuffer, AllocationSize) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on this device";
     }
 
@@ -293,7 +293,7 @@ TEST_F(NegativeAndroidHardwareBuffer, DedicatedUsageColor) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on this device";
     }
 
@@ -361,7 +361,7 @@ TEST_F(NegativeAndroidHardwareBuffer, DedicatedUsageDS) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on this device";
     }
 
@@ -439,7 +439,7 @@ TEST_F(NegativeAndroidHardwareBuffer, MipmapChain) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on this device";
     }
 
@@ -509,7 +509,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ImageDimensions) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on this device";
     }
 
@@ -577,7 +577,7 @@ TEST_F(NegativeAndroidHardwareBuffer, UnknownFormat) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on this device";
     }
 
@@ -642,7 +642,7 @@ TEST_F(NegativeAndroidHardwareBuffer, GpuUsage) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on this device";
     }
 
@@ -729,7 +729,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportMemoryAllocate) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on this device";
     }
 

--- a/tests/negative/arm_best_practices.cpp
+++ b/tests/negative/arm_best_practices.cpp
@@ -189,7 +189,7 @@ TEST_F(VkArmBestPracticesLayerTest, ManySmallIndexedDrawcalls) {
     InitBestPracticesFramework(kEnableArmValidation);
     InitState();
 
-    if (IsPlatform(kNexusPlayer) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         return;
     }
 
@@ -621,9 +621,6 @@ TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {
     InitBestPracticesFramework(kEnableArmValidation);
     InitState();
 
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test crashes on the NexusPlayer platform";
-    }
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
     m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);

--- a/tests/negative/best_practices.cpp
+++ b/tests/negative/best_practices.cpp
@@ -247,7 +247,7 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTestSecondary) {
     InitBestPracticesFramework();
     InitState();
 
-    if (IsPlatform(PlatformType::kShieldTV) || IsPlatform(PlatformType::kShieldTVb)) {
+    if (IsPlatform(PlatformType::kShieldTVb)) {
         GTEST_SKIP() << "Test CmdClearAttachmentTestSecondary is unstable on ShieldTV";
     }
 
@@ -650,8 +650,7 @@ TEST_F(VkBestPracticesLayerTest, AttachmentShouldNotBeTransient) {
     InitBestPracticesFramework();
     InitState();
 
-    if (IsPlatform(kPixel2XL) || IsPlatform(kPixel3) || IsPlatform(kPixel3aXL) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb) ||
-        IsPlatform(kNexusPlayer)) {
+    if (IsPlatform(kPixel3) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test seems super-picky on Android platforms";
     }
 
@@ -882,7 +881,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     InitBestPracticesFramework();
     InitState();
 
-    if (IsPlatform(PlatformType::kShieldTV) || IsPlatform(PlatformType::kShieldTVb)) {
+    if (IsPlatform(PlatformType::kShieldTVb)) {
         GTEST_SKIP() << "Test CmdClearAttachmentAfterLoadSecondary is unstable on ShieldTV";
     }
 

--- a/tests/negative/descriptors.cpp
+++ b/tests/negative/descriptors.cpp
@@ -3981,9 +3981,6 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenAttachmentsAndDescript
     TEST_DESCRIPTION("Validate if attachments and descriptor set use the same image subresources");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());

--- a/tests/negative/dynamic_state.cpp
+++ b/tests/negative/dynamic_state.cpp
@@ -4573,9 +4573,6 @@ TEST_F(NegativeDynamicState, LineWidth) {
     TEST_DESCRIPTION("Test non-1.0 lineWidth errors when pipeline is created and in vkCmdSetLineWidth");
     VkPhysicalDeviceFeatures features{};
     ASSERT_NO_FATAL_FAILURE(Init(&features));
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const std::array test_cases = {-1.0f, 0.0f, NearestSmaller(1.0f), NearestGreater(1.0f),

--- a/tests/negative/gpu_av.cpp
+++ b/tests/negative/gpu_av.cpp
@@ -71,10 +71,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
         GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
-
     auto maintenance4_features = LvlInitStruct<VkPhysicalDeviceMaintenance4Features>();
     maintenance4_features.maintenance4 = true;
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&maintenance4_features);
@@ -827,7 +823,7 @@ void VkGpuAssistedLayerTest::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDe
     if (IsPlatform(kGalaxyS10)) {
         GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
 
@@ -1745,7 +1741,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
     auto indexing_features = LvlInitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
@@ -1984,9 +1980,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationAbort) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     VkValidationFeaturesEXT validation_features = GetValidationFeatures();
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, &validation_features));
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
@@ -2046,7 +2039,7 @@ TEST_F(VkGpuAssistedLayerTest, DrawingWithUnboundUnusedSet) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -2120,7 +2113,7 @@ TEST_F(VkGpuAssistedLayerTest, DispatchIndirectWorkgroupSize) {
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "GPU-Assisted validation test requires a driver that can draw.";
     }
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
 
@@ -2233,7 +2226,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPL) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
 
@@ -2413,7 +2406,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPLIndependentSets) {
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
     if (!AreRequiredExtensionsEnabled()) {

--- a/tests/negative/others.cpp
+++ b/tests/negative/others.cpp
@@ -118,10 +118,6 @@ TEST_F(VkLayerTest, UnsupportedPnextApiVersion) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
-
     auto phys_dev_props_2 = LvlInitStruct<VkPhysicalDeviceProperties2>();
     auto bad_version_1_1_struct = LvlInitStruct<VkPhysicalDeviceVulkan12Properties>();
     phys_dev_props_2.pNext = &bad_version_1_1_struct;
@@ -2016,9 +2012,6 @@ TEST_F(VkLayerTest, FreeDescriptorSetsNull) {
 TEST_F(VkLayerTest, ValidateStride) {
     TEST_DESCRIPTION("Validate Stride.");
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
-    if (IsPlatform(kPixelC)) {
-        GTEST_SKIP() << "This test should not run on Pixel C";
-    }
 
     uint32_t queue_count;
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);

--- a/tests/negative/pipeline.cpp
+++ b/tests/negative/pipeline.cpp
@@ -257,9 +257,6 @@ TEST_F(VkLayerTest, PipelineRenderpassCompatibility) {
 TEST_F(VkLayerTest, CmdBufferPipelineDestroyed) {
     TEST_DESCRIPTION("Attempt to draw with a command buffer that is invalid due to a pipeline dependency being destroyed.");
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     {

--- a/tests/negative/protected_memory.cpp
+++ b/tests/negative/protected_memory.cpp
@@ -755,7 +755,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "CreateImageView calls crash ShieldTV";
     }
     if (!AreRequiredExtensionsEnabled()) {

--- a/tests/negative/query.cpp
+++ b/tests/negative/query.cpp
@@ -1135,10 +1135,6 @@ TEST_F(NegativeQuery, Sizes) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    if (IsPlatform(kPixel2XL)) {
-        GTEST_SKIP() << "This test should not run on Pixel 2 XL";
-    }
-
     uint32_t queue_count;
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);

--- a/tests/negative/renderpass.cpp
+++ b/tests/negative/renderpass.cpp
@@ -1673,9 +1673,6 @@ TEST_F(NegativeRenderPass, DestroyWhileInUse) {
     TEST_DESCRIPTION("Delete in-use renderPass.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // Create simple renderpass

--- a/tests/negative/shader_push_constants.cpp
+++ b/tests/negative/shader_push_constants.cpp
@@ -360,7 +360,7 @@ TEST_F(NegativeShaderPushConstants, MultipleEntryPoint) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kPixel3) || IsPlatform(kPixel3aXL)) {
+    if (IsPlatform(kPixel3)) {
         GTEST_SKIP() << "Pixel 3 compilers can't compile this valid SPIR-V";
     }
 

--- a/tests/negative/subpass.cpp
+++ b/tests/negative/subpass.cpp
@@ -590,9 +590,6 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
     TEST_DESCRIPTION("Validate subpass input isn't bound to fragment shader or descriptor set");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkImageUsageFlags usage_input =

--- a/tests/negative/sync_object.cpp
+++ b/tests/negative/sync_object.cpp
@@ -252,9 +252,6 @@ TEST_F(NegativeSyncObject, Barriers) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "Vulkan 1.1 required";
     }
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }

--- a/tests/negative/sync_val.cpp
+++ b/tests/negative/sync_val.cpp
@@ -1987,9 +1987,6 @@ TEST_F(NegativeSyncVal, CmdQuery) {
     // CmdCopyQueryPoolResults
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     if ((m_device->queue_props.empty()) || (m_device->queue_props[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
     }
@@ -2270,10 +2267,6 @@ TEST_F(NegativeSyncVal, RenderPassLoadHazardVsInitialLayout) {
 TEST_F(NegativeSyncVal, RenderPassWithWrongDepthStencilInitialLayout) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -2688,9 +2681,6 @@ struct SyncTestPipeline {
 TEST_F(NegativeSyncVal, LayoutTransition) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
 
     CreateRenderPassHelper rp_helper(m_device);
     rp_helper.Init();
@@ -2777,9 +2767,6 @@ TEST_F(NegativeSyncVal, LayoutTransition) {
 TEST_F(NegativeSyncVal, SubpassMultiDep) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
 
     CreateRenderPassHelper rp_helper_positive(m_device);
 
@@ -2922,7 +2909,7 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    if (IsPlatform(kPixel3) || IsPlatform(kPixel3aXL)) {
+    if (IsPlatform(kPixel3)) {
         GTEST_SKIP() << "Temporarily disabling on Pixel 3 and Pixel 3a XL due to driver crash";
     }
 
@@ -5039,9 +5026,6 @@ TEST_F(NegativeSyncVal, QSOBarrierHazard) {
 TEST_F(NegativeSyncVal, QSRenderPass) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework(true));  // Enable QueueSubmit validation
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
 
     CreateRenderPassHelper rp_helper(m_device);
     rp_helper.InitAllAttachmentsToLayoutGeneral();

--- a/tests/positive/android_hardware_buffer.cpp
+++ b/tests/positive/android_hardware_buffer.cpp
@@ -81,7 +81,7 @@ TEST_F(PositiveAndroidHardwareBuffer, DepthStencil) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 

--- a/tests/positive/command.cpp
+++ b/tests/positive/command.cpp
@@ -140,7 +140,7 @@ TEST_F(PositiveCommand, ClearAttachmentsCalledWithoutFbInSecondaryCB) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    if (IsPlatform(PlatformType::kShieldTV) || IsPlatform(PlatformType::kShieldTVb)) {
+    if (IsPlatform(PlatformType::kShieldTVb)) {
         GTEST_SKIP() << "Test is unstable on ShieldTV";
     }
 
@@ -816,7 +816,7 @@ TEST_F(PositiveCommand, ClearAttachmentsDepthStencil) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on this device";
     }
 

--- a/tests/positive/descriptors.cpp
+++ b/tests/positive/descriptors.cpp
@@ -253,9 +253,6 @@ TEST_F(PositiveDescriptors, EmptyDescriptorUpdate) {
     TEST_DESCRIPTION("Update last descriptor in a set that includes an empty binding");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
 
     // Create layout with two uniform buffer descriptors w/ empty binding between them
     OneOffDescriptorSet ds(m_device, {

--- a/tests/positive/gpu_av.cpp
+++ b/tests/positive/gpu_av.cpp
@@ -30,7 +30,7 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOBindDescriptor) {
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -135,7 +135,7 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOPushDescriptor) {
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());

--- a/tests/positive/pipeline.cpp
+++ b/tests/positive/pipeline.cpp
@@ -217,9 +217,6 @@ TEST_F(VkPositiveLayerTest, CreateGraphicsPipelineWithIgnoredPointers) {
     TEST_DESCRIPTION("Create Graphics Pipeline with pointers that must be ignored by layers");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
     m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
@@ -668,9 +665,6 @@ TEST_F(PositivePipeline, AttachmentUnused) {
     TEST_DESCRIPTION("Make sure unused attachments are correctly ignored.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     char const *fsSource = R"glsl(
@@ -799,9 +793,6 @@ TEST_F(PositivePipeline, SampleMaskOverrideCoverageNV) {
 TEST_F(PositivePipeline, RasterizationDiscardEnableTrue) {
     TEST_DESCRIPTION("Ensure it doesn't crash and trigger error msg when rasterizerDiscardEnable = true");
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkAttachmentDescription att[1] = {{}};

--- a/tests/positive/pipeline_topology.cpp
+++ b/tests/positive/pipeline_topology.cpp
@@ -336,9 +336,6 @@ TEST_F(VkPositiveLayerTest, PSOPolygonModeValid) {
     TEST_DESCRIPTION("Verify that using a solid polygon fill mode works correctly.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     std::vector<const char *> device_extension_names;

--- a/tests/positive/protected_memory.cpp
+++ b/tests/positive/protected_memory.cpp
@@ -29,7 +29,7 @@ TEST_F(PositiveProtectedMemory, MixProtectedQueue) {
 
     // NOTE (ncesario): This appears to be failing in the driver on the Shield.
     //      It's clear what is causing this; more investigation is necessary.
-    if (IsPlatform(kShieldTV) || IsPlatform(kShieldTVb)) {
+    if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "Test not supported by Shield TV";
     }
 

--- a/tests/positive/query.cpp
+++ b/tests/positive/query.cpp
@@ -214,9 +214,6 @@ TEST_F(PositiveQuery, QueryAndCopySecondaryCommandBuffers) {
     TEST_DESCRIPTION("Issue a query on a secondary command buffer and copy it on a primary.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     if ((m_device->queue_props.empty()) || (m_device->queue_props[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
     }
@@ -281,9 +278,6 @@ TEST_F(PositiveQuery, QueryAndCopyMultipleCommandBuffers) {
     TEST_DESCRIPTION("Issue a query and copy from it on a second command buffer.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     if ((m_device->queue_props.empty()) || (m_device->queue_props[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
     }

--- a/tests/positive/render_pass.cpp
+++ b/tests/positive/render_pass.cpp
@@ -197,9 +197,6 @@ TEST_F(PositiveRenderPass, BeginTransitionsAttachmentUnused) {
         "Ensure that layout transitions work correctly without errors, when an attachment reference is VK_ATTACHMENT_UNUSED");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
 
     // A renderpass with no attachments
     VkAttachmentReference att_ref = {VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
@@ -437,9 +434,6 @@ TEST_F(PositiveRenderPass, BeginDepthStencilLayoutTransitionFromUndefined) {
 TEST_F(PositiveRenderPass, DestroyPipeline) {
     TEST_DESCRIPTION("Draw using a pipeline whose create renderPass has been destroyed.");
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kNexusPlayer)) {
-        GTEST_SKIP() << "This test should not run on Nexus Player";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkResult err;

--- a/tests/positive/shader_storage_image.cpp
+++ b/tests/positive/shader_storage_image.cpp
@@ -312,7 +312,7 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kPixel3) || IsPlatform(kPixel3aXL)) {
+    if (IsPlatform(kPixel3)) {
         GTEST_SKIP() << "Pixel 3 compilers can't compile this valid SPIR-V";
     }
 


### PR DESCRIPTION
These should in theory not be used anymore, so rather not leave them around for people to copy and paste wrongly