### PR TITLE
layers: Move Viewport and Scissor to DynamicState

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -583,12 +583,12 @@ class CoreChecks::ViewportScissorInheritanceTracker {
             viewport_trashed_by_[n] = primary_state->trashedViewportMask & bit ? kTrashedByPrimary : kNotTrashed;
             scissor_trashed_by_[n] = primary_state->trashedScissorMask & bit ? kTrashedByPrimary : kNotTrashed;
             if (viewport_mask_ & bit) {
-                viewports_to_inherit_[n] = primary_state->dynamicViewports[n];
+                viewports_to_inherit_[n] = primary_state->dynamic_state_value.viewports[n];
             }
         }
 
-        viewport_count_to_inherit_ = primary_state->viewportWithCountCount;
-        scissor_count_to_inherit_ = primary_state->scissorWithCountCount;
+        viewport_count_to_inherit_ = primary_state->dynamic_state_value.viewport_count;
+        scissor_count_to_inherit_ = primary_state->dynamic_state_value.scissor_count;
         viewport_count_trashed_by_ = primary_state->trashedViewportCount ? kTrashedByPrimary : kNotTrashed;
         scissor_count_trashed_by_ = primary_state->trashedScissorCount ? kTrashedByPrimary : kNotTrashed;
         return false;
@@ -622,18 +622,18 @@ class CoreChecks::ViewportScissorInheritanceTracker {
         for (uint32_t n = 0; n < kMaxViewports; ++n) {
             uint32_t bit = uint32_t(1) << n;
             if ((secondary_state->viewportMask | secondary_state->viewportWithCountMask) & bit) {
-                viewports_to_inherit_[n] = secondary_state->dynamicViewports[n];
+                viewports_to_inherit_[n] = secondary_state->dynamic_state_value.viewports[n];
                 viewport_trashed_by_[n] = kNotTrashed;
             }
             if ((secondary_state->scissorMask | secondary_state->scissorWithCountMask) & bit) {
                 scissor_trashed_by_[n] = kNotTrashed;
             }
-            if (secondary_state->viewportWithCountCount != 0) {
-                viewport_count_to_inherit_ = secondary_state->viewportWithCountCount;
+            if (secondary_state->dynamic_state_value.viewport_count != 0) {
+                viewport_count_to_inherit_ = secondary_state->dynamic_state_value.viewport_count;
                 viewport_count_trashed_by_ = kNotTrashed;
             }
-            if (secondary_state->scissorWithCountCount != 0) {
-                scissor_count_to_inherit_ = secondary_state->scissorWithCountCount;
+            if (secondary_state->dynamic_state_value.scissor_count != 0) {
+                scissor_count_to_inherit_ = secondary_state->dynamic_state_value.scissor_count;
                 scissor_count_trashed_by_ = kNotTrashed;
             }
             // Order of above vs below matters here.

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2568,7 +2568,7 @@ bool CoreChecks::ValidateGraphicsPipelineShaderDynamicState(const PIPELINE_STATE
         const VkShaderStageFlagBits stage = stage_state.create_info->stage;
         if (stage == VK_SHADER_STAGE_VERTEX_BIT || stage == VK_SHADER_STAGE_GEOMETRY_BIT || stage == VK_SHADER_STAGE_MESH_BIT_EXT) {
             if (!phys_dev_ext_props.fragment_shading_rate_props.primitiveFragmentShadingRateWithMultipleViewports &&
-                pipeline.IsDynamic(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT) && cb_state.viewportWithCountCount != 1) {
+                pipeline.IsDynamic(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT) && cb_state.dynamic_state_value.viewport_count != 1) {
                 if (stage_state.entrypoint && stage_state.entrypoint->written_builtin_primitive_shading_rate_khr) {
                     skip |= LogError(
                         stage_state.module_state.get()->vk_shader_module(), vuid.viewport_count_primitive_shading_rate_04552,

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -143,10 +143,8 @@ void CMD_BUFFER_STATE::ResetCBState() {
     pipelineStaticScissorCount = 0;
     viewportMask = 0;
     viewportWithCountMask = 0;
-    viewportWithCountCount = 0;
     scissorMask = 0;
     scissorWithCountMask = 0;
-    scissorWithCountCount = 0;
     trashedViewportMask = 0;
     trashedScissorMask = 0;
     trashedViewportCount = false;

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -224,10 +224,22 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
         std::bitset<32> color_write_mask_attachments;      // VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT
         std::bitset<32> color_blend_advanced_attachments;  // VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT
 
+        // VK_DYNAMIC_STATE_VIEWPORT
+        std::vector<VkViewport> viewports;
+        // and VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT
+        uint32_t viewport_count;
+        // VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT
+        uint32_t scissor_count;
+
         // When the Command Buffer resets, the value most things in this struct don't matter because if they are read without
         // setting the state, it will fail in ValidateDynamicStateIsSet() for us. Some values (ex. the bitset) are tracking in
         // replacement for static_status/dynamic_status so this needs to reset along with those
         void reset() {
+            // There are special because the Secondary CB Inheritance is tracking these defaults
+            viewport_count = 0;
+            scissor_count = 0;
+
+            viewports.clear();
             discard_rectangles.reset();
             color_blend_enable_attachments.reset();
             color_blend_equation_attachments.reset();
@@ -272,14 +284,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
 
     uint32_t viewportMask;
     uint32_t viewportWithCountMask;
-    uint32_t viewportWithCountCount;
     uint32_t scissorMask;
     uint32_t scissorWithCountMask;
-    uint32_t scissorWithCountCount;
-
-    // Dynamic viewports set in this command buffer; if bit j of viewportMask is set then dynamicViewports[j] is valid, but the
-    // converse need not be true.
-    std::vector<VkViewport> dynamicViewports;
 
     // Bits set when binding graphics pipeline defining corresponding static state, or executing any secondary command buffer.
     // Bits unset by calling a corresponding vkCmdSet[State] cmd.

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -2840,9 +2840,9 @@ void ValidationStateTracker::PostCallRecordCmdSetViewport(VkCommandBuffer comman
     cb_state->viewportMask |= bits;
     cb_state->trashedViewportMask &= ~bits;
 
-    cb_state->dynamicViewports.resize(std::max(size_t(firstViewport + viewportCount), cb_state->dynamicViewports.size()));
+    cb_state->dynamic_state_value.viewports.resize(firstViewport + viewportCount);
     for (size_t i = 0; i < viewportCount; ++i) {
-        cb_state->dynamicViewports[firstViewport + i] = pViewports[i];
+        cb_state->dynamic_state_value.viewports[firstViewport + i] = pViewports[i];
     }
 }
 
@@ -5193,12 +5193,12 @@ void ValidationStateTracker::RecordCmdSetViewportWithCount(VkCommandBuffer comma
     uint32_t bits = (1u << viewportCount) - 1u;
     cb_state->viewportWithCountMask |= bits;
     cb_state->trashedViewportMask &= ~bits;
-    cb_state->viewportWithCountCount = viewportCount;
+    cb_state->dynamic_state_value.viewport_count = viewportCount;
     cb_state->trashedViewportCount = false;
 
-    cb_state->dynamicViewports.resize(std::max(size_t(viewportCount), cb_state->dynamicViewports.size()));
+    cb_state->dynamic_state_value.viewports.resize(viewportCount);
     for (size_t i = 0; i < viewportCount; ++i) {
-        cb_state->dynamicViewports[i] = pViewports[i];
+        cb_state->dynamic_state_value.viewports[i] = pViewports[i];
     }
 }
 
@@ -5219,7 +5219,7 @@ void ValidationStateTracker::RecordCmdSetScissorWithCount(VkCommandBuffer comman
     uint32_t bits = (1u << scissorCount) - 1u;
     cb_state->scissorWithCountMask |= bits;
     cb_state->trashedScissorMask &= ~bits;
-    cb_state->scissorWithCountCount = scissorCount;
+    cb_state->dynamic_state_value.scissor_count = scissorCount;
     cb_state->trashedScissorCount = false;
 }
 


### PR DESCRIPTION
There seems to be a need to clean up the Viewport/Scissor dynamic state Secondary Command Buffer Inheritance logic, but for now, the goal is to move all dynamic state value data into the `DynamicStateValue` struct so it is in a single location