### PR TITLE
ci: Skip PositiveSyncObject.WaitTimelineSemThreadRace

### DIFF
--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -265,6 +265,8 @@ def RunVVLTests():
     failing_tsan_tests += ':NegativeSyncVal.CopyOptimalImageHazards'
     failing_tsan_tests += ':NegativeViewportInheritance.BasicUsage'
     failing_tsan_tests += ':NegativeViewportInheritance.MultiViewport'
+    # NOTE: This test fails sporadically. Make sure to run multiple times.
+    failing_tsan_tests += ':PositiveSyncObject.WaitTimelineSemThreadRace'
 
     RunShellCmd(lvt_cmd + f" --gtest_filter={failing_tsan_tests}", env=lvt_env)
 


### PR DESCRIPTION
This tests fails sporadically with TSAN enabled.

Examples:
https://github.com/KhronosGroup/Vulkan-ValidationLayers/actions/runs/5231916205/jobs/9446352482
https://github.com/KhronosGroup/Vulkan-ValidationLayers/actions/runs/5226531209/jobs/9437280878