### PR TITLE
cmake: Fix MSVC warning 4754

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,6 @@ elseif(MSVC)
         /wd4459 # hiding global parameter
         /wd4702 # unreachable code
         /wd4389 # signed/unsigned mismatch
-        /wd4754 # conversion rules for arithmetic operations
     )
 
     # Enforce stricter ISO C++

--- a/layers/core_checks/cc_shader.cpp
+++ b/layers/core_checks/cc_shader.cpp
@@ -3168,7 +3168,7 @@ bool CoreChecks::ValidateComputeWorkGroupSizes(const SHADER_MODULE_STATE &module
     }
 
     uint32_t limit = phys_dev_props.limits.maxComputeWorkGroupInvocations;
-    uint64_t invocations = local_size_x * local_size_y;
+    uint64_t invocations = static_cast<uint64_t>(local_size_x) * static_cast<uint64_t>(local_size_y);
     // Prevent overflow.
     bool fail = false;
     if (invocations > vvl::kU32Max || invocations > limit) {
@@ -3346,7 +3346,7 @@ bool CoreChecks::ValidateTaskMeshWorkGroupSizes(const SHADER_MODULE_STATE &modul
                          string_SpvExecutionModel(entrypoint.execution_model), local_size_z, max_local_size_z);
     }
 
-    uint64_t invocations = local_size_x * local_size_y;
+    uint64_t invocations = static_cast<uint64_t>(local_size_x) * static_cast<uint64_t>(local_size_y);
     // Prevent overflow.
     bool fail = false;
     if (invocations > vvl::kU32Max || invocations > max_workgroup_size) {


### PR DESCRIPTION
This warning is actually very useful and pointed out a real issue with the code.

See the compiler docs for a detailed walkthrough:
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4754?view=msvc-170