### PR TITLE
layers: Do not check self-dependency in ValidateDependencyInfo

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -110,8 +110,8 @@ config("vulkan_layer_config") {
 
 core_validation_sources = [
   "layers/utils/android_ndk_types.h",
-  "layers/utils/convert_to_renderpass2.cpp",
-  "layers/utils/convert_to_renderpass2.h",
+  "layers/utils/convert_utils.cpp",
+  "layers/utils/convert_utils.h",
   "layers/core_checks/cc_android.cpp",
   "layers/core_checks/cc_buffer.cpp",
   "layers/core_checks/cc_buffer_address.h",

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -245,6 +245,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/framework/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/positive/shader_storage_image.cpp \
                    $(SRC_DIR)/tests/positive/shader_storage_texel.cpp \
                    $(SRC_DIR)/tests/positive/sparse.cpp \
+                   $(SRC_DIR)/tests/positive/subpass.cpp \
                    $(SRC_DIR)/tests/positive/sync_object.cpp \
                    $(SRC_DIR)/tests/positive/tooling.cpp \
                    $(SRC_DIR)/tests/positive/vertex_input.cpp \

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -108,7 +108,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/sync/sync_vuid_maps.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/error_message/core_error_location.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vulkan/generated/sync_validation_types.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/sync/sync_validation.cpp
-LOCAL_SRC_FILES += $(SRC_DIR)/layers/utils/convert_to_renderpass2.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/utils/convert_utils.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vulkan/generated/layer_chassis_dispatch.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vulkan/generated/chassis.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/vulkan/generated/valid_param_values.cpp
@@ -261,7 +261,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/tests/framework/layer_validation_tests.cpp \
                    $(SRC_DIR)/tests/framework/error_monitor.cpp \
                    $(SRC_DIR)/tests/framework/render.cpp \
                    $(SRC_DIR)/tests/framework/ray_tracing_objects.cpp \
-                   $(SRC_DIR)/layers/utils/convert_to_renderpass2.cpp \
+                   $(SRC_DIR)/layers/utils/convert_utils.cpp \
                    $(SRC_DIR)/layers/vulkan/generated/vk_safe_struct_utils.cpp \
                    $(SRC_DIR)/layers/vulkan/generated/vk_safe_struct_core.cpp \
                    $(SRC_DIR)/layers/vulkan/generated/vk_safe_struct_khr.cpp \

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -46,8 +46,8 @@ target_sources(VkLayer_utils PRIVATE
     ${API_TYPE}/generated/vk_extension_helper.h
     ${API_TYPE}/generated/vk_typemap_helper.h
     utils/cast_utils.h
-    utils/convert_to_renderpass2.cpp
-    utils/convert_to_renderpass2.h
+    utils/convert_utils.cpp
+    utils/convert_utils.h
     utils/hash_util.h
     utils/hash_vk_types.h
     utils/vk_layer_extension_utils.cpp

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -26,7 +26,7 @@
 #include "generated/chassis.h"
 #include "core_validation.h"
 #include "sync/sync_utils.h"
-#include "utils/convert_to_renderpass2.h"
+#include "utils/convert_utils.h"
 
 bool CoreChecks::LogInvalidAttachmentMessage(const char *type1_string, const RENDER_PASS_STATE &rp1_state, const char *type2_string,
                                              const RENDER_PASS_STATE &rp2_state, uint32_t primary_attach, uint32_t secondary_attach,

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2429,11 +2429,6 @@ bool CoreChecks::ValidateBarriers(const Location &outer_loc, const CMD_BUFFER_ST
 bool CoreChecks::ValidateDependencyInfo(const LogObjectList &objects, const Location &outer_loc, const CMD_BUFFER_STATE *cb_state,
                                         const VkDependencyInfoKHR *dep_info) const {
     bool skip = false;
-
-    if (cb_state->activeRenderPass) {
-        skip |= ValidateRenderPassPipelineBarriers(outer_loc, cb_state, dep_info);
-        if (skip) return true;  // Early return to avoid redundant errors from below calls
-    }
     for (uint32_t i = 0; i < dep_info->memoryBarrierCount; ++i) {
         const auto &mem_barrier = dep_info->pMemoryBarriers[i];
         auto loc = outer_loc.dot(Struct::VkMemoryBarrier2, Field::pMemoryBarriers, i);

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "state_tracker/render_pass_state.h"
-#include "utils/convert_to_renderpass2.h"
+#include "utils/convert_utils.h"
 #include "state_tracker/image_state.h"
 
 static const VkImageLayout kInvalidLayout = VK_IMAGE_LAYOUT_MAX_ENUM;

--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "stateless/stateless_validation.h"
-#include "utils/convert_to_renderpass2.h"
+#include "utils/convert_utils.h"
 
 bool StatelessValidation::ValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
                                                    const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,

--- a/layers/utils/convert_utils.cpp
+++ b/layers/utils/convert_utils.cpp
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "convert_to_renderpass2.h"
+#include "convert_utils.h"
 
 #include <vector>
 
@@ -221,4 +221,26 @@ safe_VkRenderPassCreateInfo2 ConvertVkRenderPassCreateInfoToV2KHR(const VkRender
         out_struct.pCorrelatedViewMasks = correlated_view_masks;
     }
     return out_struct;
+}
+
+safe_VkImageMemoryBarrier2 ConvertVkImageMemoryBarrierToV2(const VkImageMemoryBarrier& barrier, VkPipelineStageFlags2 srcStageMask,
+                                                           VkPipelineStageFlags2 dstStageMask) {
+    auto barrier2 = LvlInitStruct<VkImageMemoryBarrier2>();
+
+    // As of Vulkan 1.3.153, the VkImageMemoryBarrier2 supports the same pNext structs as VkImageMemoryBarrier
+    // (VkExternalMemoryAcquireUnmodifiedEXT and VkSampleLocationsInfoEXT). It means we can copy entire pNext
+    // chain (as part of safe_VkImageMemoryBarrier2 constructor) without analyzing which pNext structures are supported in V2.
+    barrier2.pNext = barrier.pNext;
+
+    barrier2.srcStageMask = srcStageMask;
+    barrier2.srcAccessMask = barrier.srcAccessMask;
+    barrier2.dstStageMask = dstStageMask;
+    barrier2.dstAccessMask = barrier.dstAccessMask;
+    barrier2.oldLayout = barrier.oldLayout;
+    barrier2.newLayout = barrier.newLayout;
+    barrier2.srcQueueFamilyIndex = barrier.srcQueueFamilyIndex;
+    barrier2.dstQueueFamilyIndex = barrier.dstQueueFamilyIndex;
+    barrier2.image = barrier.image;
+    barrier2.subresourceRange = barrier.subresourceRange;
+    return safe_VkImageMemoryBarrier2(&barrier2);
 }

--- a/layers/utils/convert_utils.h
+++ b/layers/utils/convert_utils.h
@@ -20,3 +20,6 @@
 #include "generated/vk_safe_struct.h"
 
 safe_VkRenderPassCreateInfo2 ConvertVkRenderPassCreateInfoToV2KHR(const VkRenderPassCreateInfo& create_info);
+
+safe_VkImageMemoryBarrier2 ConvertVkImageMemoryBarrierToV2(const VkImageMemoryBarrier& barrier, VkPipelineStageFlags2 srcStageMask,
+                                                           VkPipelineStageFlags2 dstStageMask);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     positive/shader_storage_image.cpp
     positive/shader_storage_texel.cpp
     positive/sparse.cpp
+    positive/subpass.cpp
     positive/sync_object.cpp
     positive/sync_val.cpp
     positive/tooling.cpp

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -31,7 +31,7 @@
 #include "generated/vk_extension_helper.h"
 #include "render.h"
 #include "generated/vk_typemap_helper.h"
-#include "utils/convert_to_renderpass2.h"
+#include "utils/convert_utils.h"
 
 #include <algorithm>
 #include <cmath>

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -766,7 +766,9 @@ class PositiveSparse : public SparseTest {};
 
 class NegativeSubgroup : public VkLayerTest {};
 
-class NegativeSubpass : public VkLayerTest {};
+class SubpassTest : public VkLayerTest {};
+class NegativeSubpass : public SubpassTest {};
+class PositiveSubpass : public SubpassTest {};
 
 class SyncObjectTest : public VkLayerTest {
   protected:

--- a/tests/positive/subpass.cpp
+++ b/tests/positive/subpass.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../framework/layer_validation_tests.h"
+
+TEST_F(PositiveSubpass, SubpassImageBarrier) {
+    TEST_DESCRIPTION("Subpass with image barrier (self-dependency)");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
+        GTEST_SKIP() << "At least Vulkan version 1.3 is required";
+    }
+    auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2Features>();
+    GetPhysicalDeviceFeatures2(sync2_features);
+    if (!sync2_features.synchronization2) {
+        GTEST_SKIP() << "Test requires (unsupported) synchronization2";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+
+    const VkAttachmentDescription attachment = {0,
+                                                VK_FORMAT_R8G8B8A8_UNORM,
+                                                VK_SAMPLE_COUNT_1_BIT,
+                                                VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                                VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                                VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                                VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                                VK_IMAGE_LAYOUT_UNDEFINED,
+                                                VK_IMAGE_LAYOUT_GENERAL};
+    const VkSubpassDependency dependency = {0,
+                                            0,
+                                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                            VK_DEPENDENCY_BY_REGION_BIT};
+    const VkAttachmentReference ref = {0, VK_IMAGE_LAYOUT_GENERAL};
+    const VkSubpassDescription subpass = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 1, &ref, 1, &ref, nullptr, nullptr, 0, nullptr};
+
+    auto rpci = LvlInitStruct<VkRenderPassCreateInfo>();
+    rpci.attachmentCount = 1;
+    rpci.pAttachments = &attachment;
+    rpci.subpassCount = 1;
+    rpci.pSubpasses = &subpass;
+    rpci.dependencyCount = 1;
+    rpci.pDependencies = &dependency;
+    vk_testing::RenderPass render_pass(*m_device, rpci);
+
+    VkImageObj image(m_device);
+    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                       VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
+    VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
+
+    auto fbci = LvlInitStruct<VkFramebufferCreateInfo>();
+    fbci.renderPass = render_pass;
+    fbci.attachmentCount = 1;
+    fbci.pAttachments = &image_view;
+    fbci.width = 32;
+    fbci.height = 32;
+    fbci.layers = 1;
+    vk_testing::Framebuffer framebuffer(*m_device, fbci);
+
+    auto render_pass_begin = LvlInitStruct<VkRenderPassBeginInfo>();
+    render_pass_begin.renderPass = render_pass;
+    render_pass_begin.framebuffer = framebuffer;
+    render_pass_begin.renderArea = VkRect2D{{0, 0}, {32, 32}};
+
+    // VkImageMemoryBarrier
+    auto barrier = LvlInitStruct<VkImageMemoryBarrier>();
+    barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrier.image = image;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.layerCount = 1;
+    barrier.subresourceRange.levelCount = 1;
+
+    // VkDependencyInfo with VkImageMemoryBarrier2
+    const safe_VkImageMemoryBarrier2 safe_barrier2 = ConvertVkImageMemoryBarrierToV2(
+        barrier, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    auto dependency_info = LvlInitStruct<VkDependencyInfo>();
+    dependency_info.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
+    dependency_info.imageMemoryBarrierCount = 1;
+    dependency_info.pImageMemoryBarriers = safe_barrier2.ptr();
+
+    // Test vkCmdPipelineBarrier subpass barrier
+    m_commandBuffer->begin();
+    vk::CmdBeginRenderPass(*m_commandBuffer, &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdPipelineBarrier(*m_commandBuffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1,
+                           &barrier);
+    vk::CmdEndRenderPass(*m_commandBuffer);
+    m_commandBuffer->end();
+
+    // Test vkCmdPipelineBarrier2 subpass barrier
+    m_commandBuffer->begin();
+    vk::CmdBeginRenderPass(*m_commandBuffer, &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdPipelineBarrier2(*m_commandBuffer, &dependency_info);
+    vk::CmdEndRenderPass(*m_commandBuffer);
+    m_commandBuffer->end();
+}

--- a/tests/positive/subpass.cpp
+++ b/tests/positive/subpass.cpp
@@ -117,3 +117,112 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
     vk::CmdEndRenderPass(*m_commandBuffer);
     m_commandBuffer->end();
 }
+
+TEST_F(PositiveSubpass, SubpassWithEventWait) {
+    TEST_DESCRIPTION("Subpass waits for the event set outside of this subpass");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
+        GTEST_SKIP() << "At least Vulkan version 1.3 is required";
+    }
+    auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2Features>();
+    GetPhysicalDeviceFeatures2(sync2_features);
+    if (!sync2_features.synchronization2) {
+        GTEST_SKIP() << "Test requires (unsupported) synchronization2";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+
+    const VkAttachmentDescription attachment = {0,
+                                                VK_FORMAT_R8G8B8A8_UNORM,
+                                                VK_SAMPLE_COUNT_1_BIT,
+                                                VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                                VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                                VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                                VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                                VK_IMAGE_LAYOUT_UNDEFINED,
+                                                VK_IMAGE_LAYOUT_GENERAL};
+    const VkSubpassDependency dependency = {VK_SUBPASS_EXTERNAL,
+                                            0,
+                                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                            0};
+    const VkAttachmentReference ref = {0, VK_IMAGE_LAYOUT_GENERAL};
+    const VkSubpassDescription subpass = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 1, &ref, 1, &ref, nullptr, nullptr, 0, nullptr};
+
+    auto rpci = LvlInitStruct<VkRenderPassCreateInfo>();
+    rpci.attachmentCount = 1;
+    rpci.pAttachments = &attachment;
+    rpci.subpassCount = 1;
+    rpci.pSubpasses = &subpass;
+    rpci.dependencyCount = 1;
+    rpci.pDependencies = &dependency;
+    vk_testing::RenderPass render_pass(*m_device, rpci);
+
+    VkImageObj image(m_device);
+    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                       VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
+    VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
+
+    auto fbci = LvlInitStruct<VkFramebufferCreateInfo>();
+    fbci.renderPass = render_pass;
+    fbci.attachmentCount = 1;
+    fbci.pAttachments = &image_view;
+    fbci.width = 32;
+    fbci.height = 32;
+    fbci.layers = 1;
+    vk_testing::Framebuffer framebuffer(*m_device, fbci);
+
+    auto render_pass_begin = LvlInitStruct<VkRenderPassBeginInfo>();
+    render_pass_begin.renderPass = render_pass;
+    render_pass_begin.framebuffer = framebuffer;
+    render_pass_begin.renderArea = VkRect2D{{0, 0}, {32, 32}};
+
+    // VkImageMemoryBarrier
+    auto barrier = LvlInitStruct<VkImageMemoryBarrier>();
+    barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrier.image = image;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    barrier.subresourceRange.baseArrayLayer = 0;
+    barrier.subresourceRange.baseMipLevel = 0;
+    barrier.subresourceRange.layerCount = 1;
+    barrier.subresourceRange.levelCount = 1;
+
+    // VkDependencyInfo with VkImageMemoryBarrier2
+    const safe_VkImageMemoryBarrier2 safe_barrier2 = ConvertVkImageMemoryBarrierToV2(
+        barrier, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+    auto dependency_info = LvlInitStruct<VkDependencyInfo>();
+    dependency_info.dependencyFlags = 0;
+    dependency_info.imageMemoryBarrierCount = 1;
+    dependency_info.pImageMemoryBarriers = safe_barrier2.ptr();
+
+    // vkCmdWaitEvents inside render pass
+    {
+        VkEventObj event(*m_device);
+        m_commandBuffer->begin();
+        vk::CmdSetEvent(*m_commandBuffer, event, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
+        vk::CmdBeginRenderPass(*m_commandBuffer, &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdWaitEvents(*m_commandBuffer, 1, &event.handle(), VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                          VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, nullptr, 0, nullptr, 1, &barrier);
+        vk::CmdEndRenderPass(*m_commandBuffer);
+        m_commandBuffer->end();
+    }
+
+    // vkCmdWaitEvents2 inside render pass.
+    // It's also a regression test for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4258
+    {
+        VkEventObj event2(*m_device);
+        m_commandBuffer->begin();
+        vk::CmdSetEvent2(*m_commandBuffer, event2, &dependency_info);
+        vk::CmdBeginRenderPass(*m_commandBuffer, &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+        vk::CmdWaitEvents2(*m_commandBuffer, 1, &event2.handle(), &dependency_info);
+        vk::CmdEndRenderPass(*m_commandBuffer);
+        m_commandBuffer->end();
+    }
+}


### PR DESCRIPTION
* Removes duplicated call to `ValidateRenderPassPipelineBarriers`.
* Fixes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4258
* Renames `convert_to_renderpass2` files to `convert_utils` to use it as a general place for conversion routines.

DETAILS:

`ValidateRenderPassPipelineBarriers` is used to validate subpass self-dependencies. It can be called through these code paths:
1. By ValidateCmdPipelineBarrier2
2. By ValidateCmdSetEvent2/ValidateCmdWaitEvents2

In the first case we have two duplicate calls to `ValidateRenderPassPipelineBarriers`. It's called directly by `ValidateCmdPipelineBarrier2`, but also as part of `ValidateDependencyInfo`.

```mermaid
flowchart LR
    ValidateCmdPipelineBarrier2-->ValidateRenderPassPipelineBarriers
    ValidateDependencyInfo-->ValidateRenderPassPipelineBarriers
    ValidateCmdPipelineBarrier2 --> ValidateDependencyInfo
    ValidateCmdSetEvent2 --> ValidateDependencyInfo
    ValidateCmdWaitEvents2 --> ValidateDependencyInfo
```

In the second case a `VkEvent` is not allowed to form a self-dependency inside a subpass (according to spec). Because the code did that anyway it resulted in false-positive error messages (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4258).

The solution is to remove `ValidateRenderPassPipelineBarriers` call from `ValidateDependencyInfo`.

With this fix the self-dependency validation is done by `PreCallValidateCmdPipelineBarrier` and `ValidateCmdPipelineBarrier2` that directly invoke `ValidateRenderPassPipelineBarriers`.
