### PR TITLE
cmake: Fix MSVC warning 4459

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,6 @@ elseif(MSVC)
         /wd4324 # padding
         /wd4458 # hiding class member
         /wd4457 # hiding function parameter
-        /wd4459 # hiding global parameter
         /wd4702 # unreachable code
         /wd4389 # signed/unsigned mismatch
     )

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -18,29 +18,30 @@
 
 #include "stateless/stateless_validation.h"
 #include "generated/enum_flag_bits.h"
-
-struct SampleOrderInfo {
-    VkShadingRatePaletteEntryNV shadingRate;
-    uint32_t width;
-    uint32_t height;
-};
-
-// All palette entries with more than one pixel per fragment
-static SampleOrderInfo sample_order_infos[] = {
-    {VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_1X2_PIXELS_NV, 1, 2},
-    {VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_2X1_PIXELS_NV, 2, 1},
-    {VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_2X2_PIXELS_NV, 2, 2},
-    {VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_4X2_PIXELS_NV, 4, 2},
-    {VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_2X4_PIXELS_NV, 2, 4},
-    {VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_4X4_PIXELS_NV, 4, 4},
-};
+#include <array>
 
 bool StatelessValidation::ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV *order) const {
     bool skip = false;
 
-    SampleOrderInfo *sample_order_info;
+    struct SampleOrderInfo {
+        VkShadingRatePaletteEntryNV shadingRate;
+        uint32_t width;
+        uint32_t height;
+    };
+
+    // All palette entries with more than one pixel per fragment
+    constexpr std::array sample_order_infos = {
+        SampleOrderInfo{VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_1X2_PIXELS_NV, 1, 2},
+        SampleOrderInfo{VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_2X1_PIXELS_NV, 2, 1},
+        SampleOrderInfo{VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_2X2_PIXELS_NV, 2, 2},
+        SampleOrderInfo{VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_4X2_PIXELS_NV, 4, 2},
+        SampleOrderInfo{VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_2X4_PIXELS_NV, 2, 4},
+        SampleOrderInfo{VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_4X4_PIXELS_NV, 4, 4},
+    };
+
+    const SampleOrderInfo *sample_order_info;
     uint32_t info_idx = 0;
-    for (sample_order_info = nullptr; info_idx < ARRAY_SIZE(sample_order_infos); ++info_idx) {
+    for (sample_order_info = nullptr; info_idx < sample_order_infos.size(); ++info_idx) {
         if (sample_order_infos[info_idx].shadingRate == order->shadingRate) {
             sample_order_info = &sample_order_infos[info_idx];
             break;

--- a/layers/utils/vk_layer_extension_utils.cpp
+++ b/layers/utils/vk_layer_extension_utils.cpp
@@ -15,26 +15,18 @@
  * limitations under the License.
  */
 
-#include <string.h>
+#include <cstring>
 #include "vk_layer_extension_utils.h"
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
-
-/*
- * This file contains utility functions for layers
- */
-
-VkResult util_GetExtensionProperties(const uint32_t count, const VkExtensionProperties *layer_extensions,
-                                                     uint32_t *pCount, VkExtensionProperties *pProperties) {
-    uint32_t copy_size;
-
-    if (pProperties == NULL || layer_extensions == NULL) {
+VkResult util_GetExtensionProperties(const uint32_t count, const VkExtensionProperties *layer_extensions, uint32_t *pCount,
+                                     VkExtensionProperties *pProperties) {
+    if (pProperties == nullptr || layer_extensions == nullptr) {
         *pCount = count;
         return VK_SUCCESS;
     }
 
-    copy_size = *pCount < count ? *pCount : count;
-    memcpy(pProperties, layer_extensions, copy_size * sizeof(VkExtensionProperties));
+    const uint32_t copy_size = *pCount < count ? *pCount : count;
+    std::memcpy(pProperties, layer_extensions, copy_size * sizeof(VkExtensionProperties));
     *pCount = copy_size;
     if (copy_size < count) {
         return VK_INCOMPLETE;
@@ -44,16 +36,14 @@ VkResult util_GetExtensionProperties(const uint32_t count, const VkExtensionProp
 }
 
 VkResult util_GetLayerProperties(const uint32_t count, const VkLayerProperties *layer_properties, uint32_t *pCount,
-                                                 VkLayerProperties *pProperties) {
-    uint32_t copy_size;
-
-    if (pProperties == NULL || layer_properties == NULL) {
+                                 VkLayerProperties *pProperties) {
+    if (pProperties == nullptr || layer_properties == nullptr) {
         *pCount = count;
         return VK_SUCCESS;
     }
 
-    copy_size = *pCount < count ? *pCount : count;
-    memcpy(pProperties, layer_properties, copy_size * sizeof(VkLayerProperties));
+    const uint32_t copy_size = *pCount < count ? *pCount : count;
+    std::memcpy(pProperties, layer_properties, copy_size * sizeof(VkLayerProperties));
     *pCount = copy_size;
     if (copy_size < count) {
         return VK_INCOMPLETE;

--- a/layers/utils/vk_layer_extension_utils.h
+++ b/layers/utils/vk_layer_extension_utils.h
@@ -18,17 +18,8 @@
 
 #include "vulkan/vulkan_core.h"
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
-
-/*
- * This file contains static functions for the generated layers
- */
-extern "C" {
-
 VkResult util_GetExtensionProperties(const uint32_t count, const VkExtensionProperties *layer_extensions, uint32_t *pCount,
                                      VkExtensionProperties *pProperties);
 
 VkResult util_GetLayerProperties(const uint32_t count, const VkLayerProperties *layer_properties, uint32_t *pCount,
                                  VkLayerProperties *pProperties);
-
-}  // extern "C"

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -22,7 +22,8 @@
  */
 
 
-#include <string.h>
+#include <array>
+#include <cstring>
 #include <mutex>
 
 #include "chassis.h"
@@ -55,16 +56,16 @@ bool wrap_handles = true;
 // This header file must be included after the above validation object class definitions
 #include "chassis_dispatch_helper.h"
 
-static const VkExtensionProperties instance_extensions[] = {
-    {VK_EXT_DEBUG_REPORT_EXTENSION_NAME, VK_EXT_DEBUG_REPORT_SPEC_VERSION},
-    {VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_SPEC_VERSION},
-    {VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME, VK_EXT_VALIDATION_FEATURES_SPEC_VERSION},
+static constexpr std::array kInstanceExtensions = {
+    VkExtensionProperties{VK_EXT_DEBUG_REPORT_EXTENSION_NAME, VK_EXT_DEBUG_REPORT_SPEC_VERSION},
+    VkExtensionProperties{VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_SPEC_VERSION},
+    VkExtensionProperties{VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME, VK_EXT_VALIDATION_FEATURES_SPEC_VERSION},
 };
 
-static const VkExtensionProperties device_extensions[] = {
-    {VK_EXT_VALIDATION_CACHE_EXTENSION_NAME, VK_EXT_VALIDATION_CACHE_SPEC_VERSION},
-    {VK_EXT_DEBUG_MARKER_EXTENSION_NAME, VK_EXT_DEBUG_MARKER_SPEC_VERSION},
-    {VK_EXT_TOOLING_INFO_EXTENSION_NAME, VK_EXT_TOOLING_INFO_SPEC_VERSION},
+static constexpr std::array kDeviceExtensions = {
+    VkExtensionProperties{VK_EXT_VALIDATION_CACHE_EXTENSION_NAME, VK_EXT_VALIDATION_CACHE_SPEC_VERSION},
+    VkExtensionProperties{VK_EXT_DEBUG_MARKER_EXTENSION_NAME, VK_EXT_DEBUG_MARKER_SPEC_VERSION},
+    VkExtensionProperties{VK_EXT_TOOLING_INFO_EXTENSION_NAME, VK_EXT_TOOLING_INFO_SPEC_VERSION},
 };
 
 static std::vector<ValidationObject*> CreateObjectDispatch(const CHECK_ENABLED &enables, const CHECK_DISABLED &disables) {
@@ -301,15 +302,19 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceLayerProperties(VkPhysicalDevice p
 
 VKAPI_ATTR VkResult VKAPI_CALL EnumerateInstanceExtensionProperties(const char *pLayerName, uint32_t *pCount,
                                                                     VkExtensionProperties *pProperties) {
-    if (pLayerName && !strcmp(pLayerName, global_layer.layerName))
-        return util_GetExtensionProperties(ARRAY_SIZE(instance_extensions), instance_extensions, pCount, pProperties);
+    if (pLayerName && !strcmp(pLayerName, global_layer.layerName)) {
+        return util_GetExtensionProperties(static_cast<uint32_t>(kInstanceExtensions.size()), kInstanceExtensions.data(), pCount, pProperties);
+    }
 
     return VK_ERROR_LAYER_NOT_PRESENT;
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevice physicalDevice, const char *pLayerName,
                                                                   uint32_t *pCount, VkExtensionProperties *pProperties) {
-    if (pLayerName && !strcmp(pLayerName, global_layer.layerName)) return util_GetExtensionProperties(ARRAY_SIZE(device_extensions), device_extensions, pCount, pProperties);
+    if (pLayerName && !strcmp(pLayerName, global_layer.layerName)) {
+        return util_GetExtensionProperties(static_cast<uint32_t>(kDeviceExtensions.size()), kDeviceExtensions.data(), pCount, pProperties);
+    }
+
     assert(physicalDevice);
     auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
     return layer_data->instance_dispatch_table.EnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pCount, pProperties);


### PR DESCRIPTION
The main issue is the globals instance_extensions and device_extensions defined in chassis.cpp

This name is already used by ValidationObject which is what is causing the warning.
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4459?view=msvc-170

This commit also removes the usage of ARRAY_SIZE in favor of std::array and removes extern "C" usage that didn't need to exist.