### PR TITLE
tests: Use Create*Test helpers

### DIFF
--- a/tests/negative/buffer.cpp
+++ b/tests/negative/buffer.cpp
@@ -749,11 +749,7 @@ TEST_F(NegativeBuffer, DedicatedAllocationBufferFlags) {
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_create_info.queueFamilyIndexCount = 1;
     buffer_create_info.pQueueFamilyIndices = &queue_family_index;
-
-    VkBuffer buffer;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-pNext-01571");
-    vk::CreateBuffer(m_device->device(), &buffer_create_info, NULL, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-pNext-01571");
 }
 
 TEST_F(NegativeBuffer, FillBufferCmdPoolUnsupported) {
@@ -976,9 +972,5 @@ TEST_F(NegativeBuffer, MaxBufferSize) {
     auto buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = maintenance4_properties.maxBufferSize + 1;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-
-    VkBuffer buffer;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-size-06409");
-    vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-size-06409");
 }

--- a/tests/negative/descriptor_buffer.cpp
+++ b/tests/negative/descriptor_buffer.cpp
@@ -268,33 +268,24 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
             buffCI.queueFamilyIndexCount = 1;
             buffCI.pQueueFamilyIndices = &qfi;
 
-            VkBuffer buffer;
-
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-flags-08099");
             buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-            vk::CreateBuffer(m_device->device(), &buffCI, NULL, &buffer);
-            m_errorMonitor->VerifyFound();
+            CreateBufferTest(*this, &buffCI, "VUID-VkBufferCreateInfo-flags-08099");
 
             buffCI.flags = 0;
 
             if (descriptor_buffer_properties.bufferlessPushDescriptors) {
                 m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-usage-08102");
             }
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-usage-08101");
             buffCI.usage =
                 VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-            vk::CreateBuffer(m_device->device(), &buffCI, NULL, &buffer);
-            m_errorMonitor->VerifyFound();
+            CreateBufferTest(*this, &buffCI, "VUID-VkBufferCreateInfo-usage-08101");
 
             buffCI.pNext = &ocddci;
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-pNext-08100");
             buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-            vk::CreateBuffer(m_device->device(), &buffCI, NULL, &buffer);
-            m_errorMonitor->VerifyFound();
+            CreateBufferTest(*this, &buffCI, "VUID-VkBufferCreateInfo-pNext-08100");
         }
 
         {
-            VkImage temp_image;
             auto image_create_info = LvlInitStruct<VkImageCreateInfo>();
             image_create_info.flags |= VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
             image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -308,16 +299,11 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
             image_create_info.format = VK_FORMAT_D32_SFLOAT;
             image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
             image_create_info.pNext = &ocddci;
-
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-flags-08104");
-            vk::CreateImage(m_device->device(), &image_create_info, nullptr, &temp_image);
-            m_errorMonitor->VerifyFound();
+            CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-08104");
 
             image_create_info.pNext = &ocddci;
             image_create_info.flags &= ~VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-08105");
-            vk::CreateImage(m_device->device(), &image_create_info, nullptr, &temp_image);
-            m_errorMonitor->VerifyFound();
+            CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-pNext-08105");
         }
 
         {
@@ -334,7 +320,6 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
             image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
             vk_testing::Image temp_image(*m_device, image_create_info);
 
-            VkImageView dsv;
             auto dsvci = LvlInitStruct<VkImageViewCreateInfo>();
             dsvci.flags |= VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
             dsvci.image = temp_image.handle();
@@ -344,16 +329,11 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
             dsvci.subresourceRange.baseMipLevel = 0;
             dsvci.subresourceRange.levelCount = 1;
             dsvci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-flags-08106");
-            vk::CreateImageView(m_device->device(), &dsvci, NULL, &dsv);
-            m_errorMonitor->VerifyFound();
+            CreateImageViewTest(*this, &dsvci, "VUID-VkImageViewCreateInfo-flags-08106");
 
             dsvci.pNext = &ocddci;
             dsvci.flags &= ~VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-pNext-08107");
-            vk::CreateImageView(m_device->device(), &dsvci, NULL, &dsv);
-            m_errorMonitor->VerifyFound();
+            CreateImageViewTest(*this, &dsvci, "VUID-VkImageViewCreateInfo-pNext-08107");
         }
 
         if (IsExtensionsEnabled(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME)) {
@@ -383,19 +363,14 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         }
 
         {
-            VkSampler sampler2;
             auto sampler_ci = SafeSaneSamplerCreateInfo();
             sampler_ci.flags |= VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
 
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCreateInfo-flags-08110");
-            vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler2);
-            m_errorMonitor->VerifyFound();
+            CreateSamplerTest(*this, &sampler_ci, "VUID-VkSamplerCreateInfo-flags-08110");
 
             sampler_ci.pNext = &ocddci;
             sampler_ci.flags &= ~VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCreateInfo-pNext-08111");
-            vk::CreateSampler(m_device->device(), &sampler_ci, NULL, &sampler2);
-            m_errorMonitor->VerifyFound();
+            CreateSamplerTest(*this, &sampler_ci, "VUID-VkSamplerCreateInfo-pNext-08111");
         }
     }
 
@@ -1533,24 +1508,17 @@ TEST_F(NegativeDescriptorBuffer, SetBufferAddressSpaceLimits) {
 
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = descriptor_buffer_properties.descriptorBufferAddressSpaceSize + 1;
-    VkBuffer buffer = VK_NULL_HANDLE;
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-usage-08097");
     buffer_ci.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
-    vk::CreateBuffer(*m_device, &buffer_ci, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-usage-08097");
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-usage-08098");
     buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-    vk::CreateBuffer(*m_device, &buffer_ci, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-usage-08098");
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-usage-08097");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-usage-08098");
     buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT |
                       VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
-    vk::CreateBuffer(*m_device, &buffer_ci, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-usage-08098");
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5826

--- a/tests/negative/dynamic_state.cpp
+++ b/tests/negative/dynamic_state.cpp
@@ -3240,10 +3240,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0) {
         image_create_info.flags = VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT;
         image_create_info.format = VK_FORMAT_S8_UINT;
-        VkImage temp_image;
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-flags-01533");
-        vk::CreateImage(m_device->device(), &image_create_info, nullptr, &temp_image);
-        m_errorMonitor->VerifyFound();
+        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-01533");
     }
 
     const VkFormat depth_format = FindSupportedDepthStencilFormat(gpu());

--- a/tests/negative/external_memory_sync.cpp
+++ b/tests/negative/external_memory_sync.cpp
@@ -1488,11 +1488,7 @@ TEST_F(NegativeExternalMemorySync, MemoryAndMemoryNV) {
     }
     external_mem_nv.handleTypes = LeastSignificantFlag<VkExternalMemoryFeatureFlagBitsNV>(supported_types_nv);
     external_mem.handleTypes = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(supported_types);
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-00988");
-    VkImage test_image;
-    vk::CreateImage(device(), &ici, nullptr, &test_image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-00988");
 }
 
 TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
@@ -1520,10 +1516,7 @@ TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
     const auto supported_types = FindSupportedExternalMemoryHandleTypes(gpu(), ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (supported_types) {
         external_mem.handleTypes = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(supported_types);
-        VkImage test_image;
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-01443");
-        vk::CreateImage(device(), &ici, nullptr, &test_image);
-        m_errorMonitor->VerifyFound();
+        CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-01443");
     }
     if (IsExtensionsEnabled(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME)) {
         auto external_mem_nv = LvlInitStruct<VkExternalMemoryImageCreateInfoNV>();
@@ -1532,10 +1525,7 @@ TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
         if (supported_types_nv) {
             external_mem_nv.handleTypes = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBitsNV>(supported_types_nv);
             ici.pNext = &external_mem_nv;
-            VkImage test_image;
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-01443");
-            vk::CreateImage(device(), &ici, nullptr, &test_image);
-            m_errorMonitor->VerifyFound();
+            CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-01443");
         }
     }
 }

--- a/tests/negative/fragment_shading_rate.cpp
+++ b/tests/negative/fragment_shading_rate.cpp
@@ -1494,7 +1494,6 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
     image.Init(128, 128, 1, format, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
-    VkImageView imageview;
     VkImageViewCreateInfo createinfo = LvlInitStruct<VkImageViewCreateInfo>();
     createinfo.image = image.handle();
     createinfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -1511,9 +1510,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
     }
 
     // Create a view with the fragment shading rate attachment usage, but that doesn't support it
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-usage-04550");
-    vk::CreateImageView(m_device->device(), &createinfo, NULL, &imageview);
-    m_errorMonitor->VerifyFound();
+    CreateImageViewTest(*this, &createinfo, "VUID-VkImageViewCreateInfo-usage-04550");
 
     auto fsrProperties = LvlInitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
     GetPhysicalDeviceProperties2(fsrProperties);
@@ -1534,10 +1531,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
             createinfo.format = VK_FORMAT_R8_UINT;
             createinfo.subresourceRange.layerCount = 2;
             createinfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-usage-04551");
-            vk::CreateImageView(m_device->device(), &createinfo, NULL, &imageview);
-            m_errorMonitor->VerifyFound();
+            CreateImageViewTest(*this, &createinfo, "VUID-VkImageViewCreateInfo-usage-04551");
         }
     }
 }

--- a/tests/negative/others.cpp
+++ b/tests/negative/others.cpp
@@ -2488,10 +2488,7 @@ TEST_F(VkLayerTest, InvalidImageCreateFlagWithPhysicalDeviceCount) {
         GTEST_SKIP() << "image format is not supported";
     }
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-physicalDeviceCount-01421");
-    VkImage test_image;
-    vk::CreateImage(device(), &ici, nullptr, &test_image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-physicalDeviceCount-01421");
 }
 
 TEST_F(VkLayerTest, Features12AndppEnabledExtensionNames) {
@@ -2676,30 +2673,21 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     ici.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ici.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     ici.pNext = &metal_object_create_info;
-    VkImage image;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-06783");
-    vk::CreateImage(device(), &ici, NULL, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-06783");
 
     auto import_metal_texture_info = LvlInitStruct<VkImportMetalTextureInfoEXT>();
     import_metal_texture_info.plane = VK_IMAGE_ASPECT_COLOR_BIT;
     ici.pNext = &import_metal_texture_info;
     ici.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-06784");
-    vk::CreateImage(device(), &ici, NULL, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-06784");
 
     ici.format = VK_FORMAT_B8G8R8A8_UNORM;
     import_metal_texture_info.plane = VK_IMAGE_ASPECT_PLANE_1_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-06785");
-    vk::CreateImage(device(), &ici, NULL, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-06785");
 
     ici.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
     import_metal_texture_info.plane = VK_IMAGE_ASPECT_PLANE_2_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-06786");
-    vk::CreateImage(device(), &ici, NULL, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-06786");
 
     uint32_t queue_family_index = 0;
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
@@ -2714,15 +2702,11 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     buff_view_ci.buffer = buffer.handle();
     buff_view_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
     buff_view_ci.range = VK_WHOLE_SIZE;
-    VkBufferView buffer_view;
     buff_view_ci.pNext = &metal_object_create_info;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferViewCreateInfo-pNext-06782");
-    vk::CreateBufferView(device(), &buff_view_ci, NULL, &buffer_view);
-    m_errorMonitor->VerifyFound();
+    CreateBufferViewTest(*this, &buff_view_ci, {"VUID-VkBufferViewCreateInfo-pNext-06782"});
 
     VkImageObj image_obj(m_device);
     image_obj.Init(256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
-    VkImageView image_view;
     VkImageViewCreateInfo ivci = LvlInitStruct<VkImageViewCreateInfo>();
     ivci.image = image_obj.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -2732,9 +2716,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     ivci.subresourceRange.levelCount = 1;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     ivci.pNext = &metal_object_create_info;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-pNext-06787");
-    vk::CreateImageView(m_device->device(), &ivci, nullptr, &image_view);
-    m_errorMonitor->VerifyFound();
+    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-pNext-06787");
 
     auto sem_info = LvlInitStruct<VkSemaphoreCreateInfo>();
     sem_info.pNext = &metal_object_create_info;

--- a/tests/negative/protected_memory.cpp
+++ b/tests/negative/protected_memory.cpp
@@ -105,17 +105,13 @@ TEST_F(NegativeProtectedMemory, Submit) {
     vk::CreateCommandPool(device(), &pool_create_info, nullptr, &command_pool);
     m_errorMonitor->VerifyFound();
 
-    VkBuffer buffer;
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.flags = VK_BUFFER_CREATE_PROTECTED_BIT;
     buffer_create_info.size = 4096;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buffer_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-flags-01887");
-    vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-01887");
 
-    VkImage image;
     VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.flags = VK_IMAGE_CREATE_PROTECTED_BIT;
     image_create_info.extent = {64, 64, 1};
@@ -126,9 +122,7 @@ TEST_F(NegativeProtectedMemory, Submit) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.arrayLayers = 1;
     image_create_info.mipLevels = 1;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-flags-01890");
-    vk::CreateImage(device(), &image_create_info, nullptr, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-01890");
 
     // Try to find memory with protected bit in it at all
     VkDeviceMemory memory_protected = VK_NULL_HANDLE;
@@ -203,9 +197,7 @@ TEST_F(NegativeProtectedMemory, Memory) {
     buffer_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     if (sparse_support == true) {
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-None-01888");
-        vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer_protected);
-        m_errorMonitor->VerifyFound();
+        CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-None-01888");
     }
 
     // Create actual protected and unprotected buffers
@@ -228,9 +220,7 @@ TEST_F(NegativeProtectedMemory, Memory) {
     image_create_info.mipLevels = 1;
 
     if (sparse_support == true) {
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-None-01891");
-        vk::CreateImage(device(), &image_create_info, nullptr, &image_protected);
-        m_errorMonitor->VerifyFound();
+        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-None-01891");
     }
 
     // Create actual protected and unprotected images

--- a/tests/negative/sparse.cpp
+++ b/tests/negative/sparse.cpp
@@ -253,13 +253,7 @@ TEST_F(NegativeSparse, ImageUsageBits) {
     image_create_info.queueFamilyIndexCount = 0;
     image_create_info.pQueueFamilyIndices = NULL;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VkImageObj image(m_device);
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-None-01925");
-    VkImage img = image.image();
-    vk::CreateImage(m_device->device(), &image_create_info, nullptr, &img);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-None-01925");
 }
 
 TEST_F(NegativeSparse, MemoryBindOffset) {
@@ -891,22 +885,14 @@ TEST_F(NegativeSparse, BufferFlagsFeature) {
     buffer_create_info.size = 64;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 
-    VkBuffer buffer;
-
     buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-flags-00915");
-    vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-00915");
 
     buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-flags-00916");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-flags-00918");
-    vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-00918");
 
     buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_ALIASED_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-flags-00917");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-flags-00918");
-    vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-00918");
 }

--- a/tests/negative/video.cpp
+++ b/tests/negative/video.cpp
@@ -3979,33 +3979,25 @@ TEST_F(VkVideoLayerTest, CreateBufferInvalidProfileList) {
     VkBufferCreateInfo buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.usage = VK_BUFFER_USAGE_VIDEO_DECODE_SRC_BIT_KHR;
     buffer_ci.size = 2048;
-
-    VkBuffer buffer;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-usage-04813");
-    vk::CreateBuffer(device(), &buffer_ci, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-usage-04813");
 
     VkVideoProfileListInfoKHR video_profiles = LvlInitStruct<VkVideoProfileListInfoKHR>();
     VkVideoProfileInfoKHR profiles[] = {*config.Profile(), *config.Profile()};
     video_profiles.profileCount = 2;
     video_profiles.pProfiles = profiles;
     buffer_ci.pNext = &video_profiles;
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkVideoProfileListInfoKHR-pProfiles-06813");
-    vk::CreateBuffer(device(), &buffer_ci, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_ci, "VUID-VkVideoProfileListInfoKHR-pProfiles-06813");
 
     video_profiles.profileCount = 1;
     video_profiles.pProfiles = config.Profile();
 
+    VkBuffer buffer;
     vk::CreateBuffer(device(), &buffer_ci, nullptr, &buffer);
     vk::DestroyBuffer(device(), buffer, nullptr);
 
     buffer_ci.usage |= VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR;
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferCreateInfo-usage-04814");
-    vk::CreateBuffer(device(), &buffer_ci, nullptr, &buffer);
-    m_errorMonitor->VerifyFound();
+    CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-usage-04814");
 }
 
 TEST_F(VkVideoLayerTest, CreateImageInvalidProfileList) {
@@ -4028,21 +4020,14 @@ TEST_F(VkVideoLayerTest, CreateImageInvalidProfileList) {
     image_ci.tiling = config.PictureFormatProps()->imageTiling;
     image_ci.usage = config.PictureFormatProps()->imageUsageFlags;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
-    VkImage image;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-usage-04815");
-    vk::CreateImage(device(), &image_ci, nullptr, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-usage-04815");
 
     VkVideoProfileListInfoKHR video_profiles = LvlInitStruct<VkVideoProfileListInfoKHR>();
     VkVideoProfileInfoKHR profiles[] = {*config.Profile(), *config.Profile()};
     video_profiles.profileCount = 2;
     video_profiles.pProfiles = profiles;
     image_ci.pNext = &video_profiles;
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkVideoProfileListInfoKHR-pProfiles-06813");
-    vk::CreateImage(device(), &image_ci, nullptr, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &image_ci, "VUID-VkVideoProfileListInfoKHR-pProfiles-06813");
 }
 
 TEST_F(VkVideoLayerTest, CreateImageIncompatibleProfile) {
@@ -4076,12 +4061,8 @@ TEST_F(VkVideoLayerTest, CreateImageIncompatibleProfile) {
     image_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    VkImage image = VK_NULL_HANDLE;
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-pNext-06811");
     image_ci.format = VK_FORMAT_D16_UNORM;
-    vk::CreateImage(m_device->device(), &image_ci, nullptr, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-pNext-06811");
 }
 
 TEST_F(VkVideoLayerTest, CreateImageViewInvalidViewType) {
@@ -4128,10 +4109,7 @@ TEST_F(VkVideoLayerTest, CreateImageViewInvalidViewType) {
     image_view_ci.subresourceRange.layerCount = 6;
 
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageViewCreateInfo-image-01003");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-image-04817");
-    VkImageView image_view = VK_NULL_HANDLE;
-    vk::CreateImageView(m_device->device(), &image_view_ci, nullptr, &image_view);
-    m_errorMonitor->VerifyFound();
+    CreateImageViewTest(*this, &image_view_ci, "VUID-VkImageViewCreateInfo-image-04817");
 }
 
 TEST_F(VkVideoLayerTest, BeginQueryIncompatibleQueueFamily) {

--- a/tests/negative/wsi.cpp
+++ b/tests/negative/wsi.cpp
@@ -223,7 +223,6 @@ TEST_F(NegativeWsi, SwapchainImage) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
-    VkImage image;
     auto image_swapchain_create_info = LvlInitStruct<VkImageSwapchainCreateInfoKHR>();
     image_swapchain_create_info.swapchain = m_swapchain;
 
@@ -246,45 +245,33 @@ TEST_F(NegativeWsi, SwapchainImage) {
     // imageType
     image_create_info = good_create_info;
     image_create_info.imageType = VK_IMAGE_TYPE_3D;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-    vk::CreateImage(device(), &image_create_info, NULL, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &image_create_info, vuid);
 
     // mipLevels
     image_create_info = good_create_info;
     image_create_info.mipLevels = 2;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-    vk::CreateImage(device(), &image_create_info, NULL, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &image_create_info, vuid);
 
     // samples
     image_create_info = good_create_info;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-    vk::CreateImage(device(), &image_create_info, NULL, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &image_create_info, vuid);
 
     // tiling
     image_create_info = good_create_info;
     image_create_info.tiling = VK_IMAGE_TILING_LINEAR;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-    vk::CreateImage(device(), &image_create_info, NULL, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &image_create_info, vuid);
 
     // initialLayout
     image_create_info = good_create_info;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-    vk::CreateImage(device(), &image_create_info, NULL, &image);
-    m_errorMonitor->VerifyFound();
+    CreateImageTest(*this, &image_create_info, vuid);
 
     // flags
     if (m_device->phy().features().sparseBinding) {
         image_create_info = good_create_info;
         image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
-        vk::CreateImage(device(), &image_create_info, NULL, &image);
-        m_errorMonitor->VerifyFound();
+        CreateImageTest(*this, &image_create_info, vuid);
     }
 }
 

--- a/tests/negative/ycbcr.cpp
+++ b/tests/negative/ycbcr.cpp
@@ -153,21 +153,15 @@ TEST_F(NegativeYcbcr, Sampler) {
     // Try to create a Sampler with non-matching filters without feature bit set
     VkSamplerYcbcrConversionInfo sampler_ycbcr_info = LvlInitStruct<VkSamplerYcbcrConversionInfo>();
     sampler_ycbcr_info.conversion = conversion.handle();
-    VkSampler sampler;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.minFilter = VK_FILTER_NEAREST;  // Different than chromaFilter
     sampler_info.magFilter = VK_FILTER_LINEAR;
     sampler_info.pNext = (void *)&sampler_ycbcr_info;
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCreateInfo-minFilter-01645");
-    vk::CreateSampler(device(), &sampler_info, nullptr, &sampler);
-    m_errorMonitor->VerifyFound();
+    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-minFilter-01645");
 
     sampler_info.magFilter = VK_FILTER_NEAREST;
     sampler_info.minFilter = VK_FILTER_LINEAR;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSamplerCreateInfo-minFilter-01645");
-    vk::CreateSampler(device(), &sampler_info, nullptr, &sampler);
-    m_errorMonitor->VerifyFound();
+    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-minFilter-01645");
 }
 
 TEST_F(NegativeYcbcr, Swizzle) {
@@ -307,7 +301,6 @@ TEST_F(NegativeYcbcr, Swizzle) {
     VkSamplerYcbcrConversionInfo conversion_info = LvlInitStruct<VkSamplerYcbcrConversionInfo>();
     conversion_info.conversion = conversion.handle();
 
-    VkImageView image_view;
     VkImageViewCreateInfo image_view_create_info = LvlInitStruct<VkImageViewCreateInfo>(&conversion_info);
     image_view_create_info.image = image.handle();
     image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -318,9 +311,7 @@ TEST_F(NegativeYcbcr, Swizzle) {
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     image_view_create_info.components = identity;
     image_view_create_info.components.r = VK_COMPONENT_SWIZZLE_B;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-pNext-01970");
-    vk::CreateImageView(m_device->device(), &image_view_create_info, nullptr, &image_view);
-    m_errorMonitor->VerifyFound();
+    CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageViewCreateInfo-pNext-01970");
 }
 
 TEST_F(NegativeYcbcr, Formats) {


### PR DESCRIPTION
We have these `CreateBufferTest`/`CreateImageTest` helpers, tried to find all places that weren't using them to reduce code usage