### PR TITLE
tests: Move ExternalMemorySync helpers to test file

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -571,38 +571,6 @@ VkExternalMemoryHandleTypeFlagsNV FindSupportedExternalMemoryHandleTypesNV(const
     return supported_types;
 }
 
-VkExternalFenceHandleTypeFlags FindSupportedExternalFenceHandleTypes(VkPhysicalDevice gpu,
-                                                                     VkExternalFenceFeatureFlags requested_features) {
-    VkExternalFenceHandleTypeFlags supported_types = 0;
-    IterateFlags<VkExternalFenceHandleTypeFlagBits>(
-        AllVkExternalFenceHandleTypeFlagBits, [&](VkExternalFenceHandleTypeFlagBits flag) {
-            auto external_info = LvlInitStruct<VkPhysicalDeviceExternalFenceInfo>();
-            external_info.handleType = flag;
-            auto external_properties = LvlInitStruct<VkExternalFenceProperties>();
-            vk::GetPhysicalDeviceExternalFenceProperties(gpu, &external_info, &external_properties);
-            if ((external_properties.externalFenceFeatures & requested_features) == requested_features) {
-                supported_types |= flag;
-            }
-        });
-    return supported_types;
-}
-
-VkExternalSemaphoreHandleTypeFlags FindSupportedExternalSemaphoreHandleTypes(VkPhysicalDevice gpu,
-                                                                             VkExternalSemaphoreFeatureFlags requested_features) {
-    VkExternalSemaphoreHandleTypeFlags supported_types = 0;
-    IterateFlags<VkExternalSemaphoreHandleTypeFlagBits>(
-        AllVkExternalSemaphoreHandleTypeFlagBits, [&](VkExternalSemaphoreHandleTypeFlagBits flag) {
-            auto external_info = LvlInitStruct<VkPhysicalDeviceExternalSemaphoreInfo>();
-            external_info.handleType = flag;
-            auto external_properties = LvlInitStruct<VkExternalSemaphoreProperties>();
-            vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu, &external_info, &external_properties);
-            if ((external_properties.externalSemaphoreFeatures & requested_features) == requested_features) {
-                supported_types |= flag;
-            }
-        });
-    return supported_types;
-}
-
 bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkExternalSemaphoreHandleTypeFlagBits handle_type) {
     constexpr auto export_import_flags =
         VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR | VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR;
@@ -612,50 +580,6 @@ bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkExternalSemaphoreHan
     auto properties = LvlInitStruct<VkExternalSemaphoreProperties>();
     vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu, &info, &properties);
     return (properties.externalSemaphoreFeatures & export_import_flags) == export_import_flags;
-}
-
-VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, const VkBufferCreateInfo &buffer_create_info,
-                                                         VkExternalMemoryHandleTypeFlagBits handle_type) {
-    auto external_info = LvlInitStruct<VkPhysicalDeviceExternalBufferInfo>();
-    external_info.flags = buffer_create_info.flags;
-    external_info.usage = buffer_create_info.usage;
-    external_info.handleType = handle_type;
-    auto external_buffer_properties = LvlInitStruct<VkExternalBufferProperties>();
-    vk::GetPhysicalDeviceExternalBufferProperties(gpu, &external_info, &external_buffer_properties);
-    return external_buffer_properties.externalMemoryProperties.compatibleHandleTypes;
-}
-
-VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, const VkImageCreateInfo &image_create_info,
-                                                         VkExternalMemoryHandleTypeFlagBits handle_type) {
-    auto external_info = LvlInitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
-    external_info.handleType = handle_type;
-    auto image_info = LvlInitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_info);
-    image_info.format = image_create_info.format;
-    image_info.type = image_create_info.imageType;
-    image_info.tiling = image_create_info.tiling;
-    image_info.usage = image_create_info.usage;
-    image_info.flags = image_create_info.flags;
-    auto external_properties = LvlInitStruct<VkExternalImageFormatProperties>();
-    auto image_properties = LvlInitStruct<VkImageFormatProperties2>(&external_properties);
-    if (vk::GetPhysicalDeviceImageFormatProperties2(gpu, &image_info, &image_properties) != VK_SUCCESS) return 0;
-    return external_properties.externalMemoryProperties.compatibleHandleTypes;
-}
-
-VkExternalFenceHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, VkExternalFenceHandleTypeFlagBits handle_type) {
-    auto external_info = LvlInitStruct<VkPhysicalDeviceExternalFenceInfo>();
-    external_info.handleType = handle_type;
-    auto external_properties = LvlInitStruct<VkExternalFenceProperties>();
-    vk::GetPhysicalDeviceExternalFenceProperties(gpu, &external_info, &external_properties);
-    return external_properties.compatibleHandleTypes;
-}
-
-VkExternalSemaphoreHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu,
-                                                            VkExternalSemaphoreHandleTypeFlagBits handle_type) {
-    auto external_info = LvlInitStruct<VkPhysicalDeviceExternalSemaphoreInfo>();
-    external_info.handleType = handle_type;
-    auto external_properties = LvlInitStruct<VkExternalSemaphoreProperties>();
-    vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu, &external_info, &external_properties);
-    return external_properties.compatibleHandleTypes;
 }
 
 void AllocateDisjointMemory(VkDeviceObj *device, PFN_vkGetImageMemoryRequirements2KHR fp, VkImage mp_image,

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -1092,24 +1092,7 @@ VkExternalMemoryHandleTypeFlagsNV FindSupportedExternalMemoryHandleTypesNV(const
 bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkImageCreateInfo &image_create_info,
                                         VkExternalMemoryHandleTypeFlagBits handle_type);
 
-VkExternalFenceHandleTypeFlags FindSupportedExternalFenceHandleTypes(VkPhysicalDevice gpu,
-                                                                     VkExternalFenceFeatureFlags requested_features);
-
-VkExternalSemaphoreHandleTypeFlags FindSupportedExternalSemaphoreHandleTypes(VkPhysicalDevice gpu,
-                                                                             VkExternalSemaphoreFeatureFlags requested_features);
-
 bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkExternalSemaphoreHandleTypeFlagBits handle_type);
-
-VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, const VkBufferCreateInfo &buffer_create_info,
-                                                         VkExternalMemoryHandleTypeFlagBits handle_type);
-
-VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, const VkImageCreateInfo &image_create_info,
-                                                         VkExternalMemoryHandleTypeFlagBits handle_type);
-
-VkExternalFenceHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, VkExternalFenceHandleTypeFlagBits handle_type);
-
-VkExternalSemaphoreHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu,
-                                                            VkExternalSemaphoreHandleTypeFlagBits handle_type);
 
 void SetImageLayout(VkDeviceObj *device, VkImageAspectFlags aspect, VkImage image, VkImageLayout image_layout);
 


### PR DESCRIPTION
Reduces calls in `tests/framework/layer_validation_tests.h` and moves to the test file that is using them