### PR TITLE
tests: Fix PositiveCommand.ThreadedCommandBuffersWithLabels

### DIFF
--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -258,8 +258,7 @@ def RunVVLTests():
     lvt_cmd = os.path.join(TEST_INSTALL_DIR, 'bin', 'vk_layer_validation_tests')
 
     # The following test fail with thread sanitization enabled.
-    failing_tsan_tests = '-PositiveCommand.ThreadedCommandBuffersWithLabels'
-    failing_tsan_tests += ':VkPositiveLayerTest.QueueThreading'
+    failing_tsan_tests = '-VkPositiveLayerTest.QueueThreading'
     failing_tsan_tests += ':NegativeCommand.SecondaryCommandBufferRerecordedExplicitReset'
     failing_tsan_tests += ':NegativeCommand.SecondaryCommandBufferRerecordedNoReset'
     failing_tsan_tests += ':NegativeSyncVal.CopyOptimalImageHazards'

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -1031,7 +1031,9 @@ class ThreadTimeoutHelper {
   private:
     void OnThreadDone();
 
+    std::mutex active_thread_mutex_;
     int active_threads_;
+
     std::condition_variable cv_;
     std::mutex mutex_;
 };


### PR DESCRIPTION
Fixes the following error reported by TSAN:

```
==================
WARNING: ThreadSanitizer: double lock of a mutex (pid=62035)
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x53908)
    #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749 (vk_layer_validation_tests+0x120aa4a)
    #2 std::mutex::lock() /usr/include/c++/11/bits/std_mutex.h:100 (vk_layer_validation_tests+0x120ace6)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/11/bits/std_mutex.h:229 (vk_layer_validation_tests+0x120ed40)
    #4 ThreadTimeoutHelper::OnThreadDone() /home/juan/projects/vvl/tests/framework/layer_validation_tests.cpp:195 (vk_layer_validation_tests+0x11dfd3e)
    #5 ThreadTimeoutHelper::Guard::~Guard() /home/juan/projects/vvl/tests/positive/../framework/layer_validation_tests.h:1022 (vk_layer_validation_tests+0x13636ae)
    #6 operator() /home/juan/projects/vvl/tests/positive/command.cpp:804 (vk_layer_validation_tests+0x1354b42)
    #7 __invoke_impl<void, PositiveCommand_ThreadedCommandBuffersWithLabels_Test::TestBody()::<lambda(int)>, int> /usr/include/c++/11/bits/invoke.h:61 (vk_layer_validation_tests+0x1363155)
    #8 __invoke<PositiveCommand_ThreadedCommandBuffersWithLabels_Test::TestBody()::<lambda(int)>, int> /usr/include/c++/11/bits/invoke.h:96 (vk_layer_validation_tests+0x136309a)
    #9 _M_invoke<0, 1> /usr/include/c++/11/bits/std_thread.h:253 (vk_layer_validation_tests+0x1362fa6)
    #10 operator() /usr/include/c++/11/bits/std_thread.h:260 (vk_layer_validation_tests+0x1362f32)
    #11 _M_run /usr/include/c++/11/bits/std_thread.h:211 (vk_layer_validation_tests+0x1362ee8)
    #12 <null> <null> (libstdc++.so.6+0xdc2b2)

  Location is stack of main thread.

  Location is global '<null>' at 0x000000000000 ([stack]+0x00000002c978)

  Mutex M3863 (0x7fffffffd978) created at:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x53908)
    #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749 (vk_layer_validation_tests+0x120aa4a)
    #2 std::mutex::lock() /usr/include/c++/11/bits/std_mutex.h:100 (vk_layer_validation_tests+0x120ace6)
    #3 std::unique_lock<std::mutex>::lock() /usr/include/c++/11/bits/unique_lock.h:139 (vk_layer_validation_tests+0x1217615)
    #4 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/include/c++/11/bits/unique_lock.h:69 (vk_layer_validation_tests+0x120e37c)
    #5 ThreadTimeoutHelper::WaitForThreads(int) /home/juan/projects/vvl/tests/framework/layer_validation_tests.cpp:188 (vk_layer_validation_tests+0x11dfc61)
    #6 PositiveCommand_ThreadedCommandBuffersWithLabels_Test::TestBody() /home/juan/projects/vvl/tests/positive/command.cpp:808 (vk_layer_validation_tests+0x1355078)
    #7 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/juan/projects/vvl/external/Debug/googletest/googletest/src/gtest.cc:2621 (vk_layer_validation_tests+0x2732450)
    #8 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/juan/projects/vvl/external/Debug/googletest/googletest/src/gtest.cc:2657 (vk_layer_validation_tests+0x2728583)
    #9 testing::Test::Run() /home/juan/projects/vvl/external/Debug/googletest/googletest/src/gtest.cc:2696 (vk_layer_validation_tests+0x26fb14d)
    #10 testing::TestInfo::Run() /home/juan/projects/vvl/external/Debug/googletest/googletest/src/gtest.cc:2845 (vk_layer_validation_tests+0x26fbf80)
    #11 testing::TestSuite::Run() /home/juan/projects/vvl/external/Debug/googletest/googletest/src/gtest.cc:3004 (vk_layer_validation_tests+0x26fccab)
    #12 testing::internal::UnitTestImpl::RunAllTests() /home/juan/projects/vvl/external/Debug/googletest/googletest/src/gtest.cc:5890 (vk_layer_validation_tests+0x270f47e)
    #13 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/juan/projects/vvl/external/Debug/googletest/googletest/src/gtest.cc:2621 (vk_layer_validation_tests+0x2733b67)
    #14 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/juan/projects/vvl/external/Debug/googletest/googletest/src/gtest.cc:2657 (vk_layer_validation_tests+0x2729d76)
    #15 testing::UnitTest::Run() /home/juan/projects/vvl/external/Debug/googletest/googletest/src/gtest.cc:5455 (vk_layer_validation_tests+0x270d3a9)
    #16 RUN_ALL_TESTS() /home/juan/projects/vvl/external/Debug/googletest/build/install/include/gtest/gtest.h:2314 (vk_layer_validation_tests+0x120b7d9)
    #17 main /home/juan/projects/vvl/tests/framework/layer_validation_tests.cpp:3789 (vk_layer_validation_tests+0x11ff77a)

SUMMARY: ThreadSanitizer: double lock of a mutex /usr/include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749 in __gthread_mutex_lock
```