### PR TITLE
cmake: Disable warnings per target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,13 +106,6 @@ elseif(MSVC)
     add_compile_options(
         /W4
         /we5038 # Enable warning about MIL ordering in constructors
-
-        # Disable warnings
-        /wd4324 # padding
-        /wd4458 # hiding class member
-        /wd4457 # hiding function parameter
-        /wd4702 # unreachable code
-        /wd4389 # signed/unsigned mismatch
     )
 
     # Enforce stricter ISO C++

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -126,6 +126,14 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
         -Wno-sign-conversion
         -Wno-implicit-int-conversion
     )
+elseif(MSVC)
+    target_compile_options(VkLayer_utils PRIVATE
+        /wd4324 # padding
+        /wd4458 # hiding class member
+        /wd4457 # hiding function parameter
+        /wd4702 # unreachable code
+        /wd4389 # signed/unsigned mismatch
+    )
 endif()
 
 if (NOT BUILD_LAYERS)
@@ -354,6 +362,14 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(vvl PRIVATE
         -Wno-sign-conversion
         -Wno-implicit-int-conversion
+    )
+elseif(MSVC)
+    target_compile_options(vvl PRIVATE
+        /wd4324 # padding
+        /wd4458 # hiding class member
+        /wd4457 # hiding function parameter
+        /wd4702 # unreachable code
+        /wd4389 # signed/unsigned mismatch
     )
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -165,8 +165,13 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
         )
     endif()
 elseif(MSVC)
-    # Disable some signed/unsigned mismatch warnings.
-    target_compile_options(vk_layer_validation_tests PRIVATE /wd4267)
+    target_compile_options(vk_layer_validation_tests PRIVATE
+        /wd4458 # hiding class member
+        /wd4457 # hiding function parameter
+        /wd4702 # unreachable code
+        /wd4389 # signed/unsigned mismatch
+        /wd4267 # Disable some signed/unsigned mismatch warnings.
+    )
 
     set_target_properties(vk_layer_validation_tests PROPERTIES VS_DEBUGGER_ENVIRONMENT "VK_LAYER_PATH=$<TARGET_FILE_DIR:vvl>")
 

--- a/tests/layers/CMakeLists.txt
+++ b/tests/layers/CMakeLists.txt
@@ -46,6 +46,13 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
             -Wno-implicit-int-conversion
         )
     endif()
+elseif(MSVC)
+    target_compile_options(VkLayer_device_profile_api PRIVATE
+        /wd4458 # hiding class member
+        /wd4457 # hiding function parameter
+        /wd4702 # unreachable code
+        /wd4389 # signed/unsigned mismatch
+    )
 endif()
 
 target_include_directories(VkLayer_device_profile_api PRIVATE .)


### PR DESCRIPTION
This is consistent with how we treat GCC/Clang warnings