### PR TITLE
wip: Add tests from issue 4968

### DIFF
--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -25,7 +25,7 @@ using SemOp = SEMAPHORE_STATE::SemOp;
 // (via being in a PostRecord call) that a fence, semaphore or wait for idle has
 // completed. Hitting it is almost a certainly a bug in this code.
 static std::chrono::time_point<std::chrono::steady_clock> GetCondWaitTimeout() {
-    return std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    return std::chrono::steady_clock::now() + std::chrono::seconds(2);
 }
 
 void CB_SUBMISSION::BeginUse() {


### PR DESCRIPTION
That's the tests provided by @glebov-andrey in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4968 and adjusted to run under VVL test framework.

The tests were further simplified. Currently both of them have 100% repro case on the development windows machine and also fail on the internal CI.

`PositiveGpuAssistedLayer.GetCounterFromSignaledSemaphore`
Fails under **GPU AV** validation.
Fails on **Windows**.
**Passes mock icd** run
No failures detected when it was modified to run under Regular or SyncVal validation.
Comparing to the original test no iterations are needed to reproduce the failure.

`PositiveSyncVal, SignalAndWaitSemaphoreFromHost`
Fails under **SyncVal** validation.
Fails  both on **Linux and Windows**.
**Does NOT pass mock icd** run (with timeout error as on a regular driver).
No failures detected when it was modified to run under Regular or GPU AV validation.
This test still needs iterations. 100'000 runs looks like a minimum limit, in some cases it managed to pass 10'000 runs.

