### PR TITLE
layers: Avoid warnings from std::tolower

### DIFF
--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -34,11 +34,11 @@ void DebugPrintf::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
     output_buffer_size = *size_string ? atoi(size_string) : 1024;
 
     std::string verbose_string = getLayerOption("khronos_validation.printf_verbose");
-    transform(verbose_string.begin(), verbose_string.end(), verbose_string.begin(), ::tolower);
+    vvl::ToLower(verbose_string);
     verbose = !verbose_string.compare("true");
 
     std::string stdout_string = getLayerOption("khronos_validation.printf_to_stdout");
-    transform(stdout_string.begin(), stdout_string.end(), stdout_string.begin(), ::tolower);
+    vvl::ToLower(stdout_string);
     use_stdout = !stdout_string.compare("true");
     if (getenv("DEBUG_PRINTF_TO_STDOUT")) use_stdout = true;
 

--- a/layers/gpu_validation/gpu_utils.h
+++ b/layers/gpu_validation/gpu_utils.h
@@ -179,7 +179,7 @@ class GpuAssistedBase : public ValidationStateTracker {
     }
     bool GpuGetOption(const char *option, bool default_value) {
         std::string option_string = getLayerOption(option);
-        transform(option_string.begin(), option_string.end(), option_string.begin(), ::tolower);
+        vvl::ToLower(option_string);
         return !option_string.empty() ? !option_string.compare("true") : default_value;
     }
 

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -354,7 +354,7 @@ static bool SetBool(const std::string &config_string, const std::string &env_str
         setting = config_string;
     }
     if (!setting.empty()) {
-        transform(setting.begin(), setting.end(), setting.begin(), ::tolower);
+        vvl::ToLower(setting);
         if (setting == "true") {
             result = true;
         } else {
@@ -376,7 +376,7 @@ static std::string GetConfigValue(const char *setting) {
 
 static std::string GetEnvVarValue(const char *setting) {
     std::string env_var = setting;
-    std::transform(env_var.begin(), env_var.end(), env_var.begin(), ::toupper);
+    vvl::ToUpper(env_var);
     return GetEnvironment((std::string("VK_LAYER_") + env_var).c_str());
 }
 

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -773,4 +773,20 @@ static constexpr bool HasNonShaderTileImageAccessFlags(VkAccessFlags2 in_flags) 
     return ((in_flags & ~kShaderTileImageAllowedAccessFlags) != 0);
 }
 
+namespace vvl {
+
+static inline void ToLower(std::string &str) {
+    // std::tolower() returns int which can cause compiler warnings
+    transform(str.begin(), str.end(), str.begin(),
+              [](char c) { return static_cast<char>(std::tolower(c)); });
+}
+
+static inline void ToUpper(std::string &str) {
+    // std::toupper() returns int which can cause compiler warnings
+    transform(str.begin(), str.end(), str.begin(),
+              [](char c) { return static_cast<char>(std::toupper(c)); });
+}
+
+}  // namespace vvl
+
 #endif

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -27,6 +27,7 @@
 
 #include "generated/vk_format_utils.h"
 #include "generated/vk_extension_helper.h"
+#include "utils/vk_layer_utils.h"
 #include "vk_layer_settings_ext.h"
 #include "layer_validation_tests.h"
 
@@ -160,7 +161,7 @@ VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
 
 inline void CheckDisableCoreValidation(VkValidationFeaturesEXT &features) {
     auto disable = GetEnvironment("VK_LAYER_TESTS_DISABLE_CORE_VALIDATION");
-    std::transform(disable.begin(), disable.end(), disable.begin(), ::tolower);
+    vvl::ToLower(disable);
     if (disable == "false" || disable == "0" || disable == "FALSE") {       // default is to change nothing, unless flag is correctly specified
         features.disabledValidationFeatureCount = 0;                        // remove all disables to get all validation messages
     }
@@ -168,7 +169,7 @@ inline void CheckDisableCoreValidation(VkValidationFeaturesEXT &features) {
 
 void *VkRenderFramework::SetupValidationSettings(void *first_pnext) {
     auto validation = GetEnvironment("VK_LAYER_TESTS_VALIDATION_FEATURES");
-    std::transform(validation.begin(), validation.end(), validation.begin(), ::tolower);
+    vvl::ToLower(validation);
     VkValidationFeaturesEXT *features = LvlFindModInChain<VkValidationFeaturesEXT>(first_pnext);
     if (features) {
         CheckDisableCoreValidation(*features);

--- a/tests/negative/arm_best_practices.cpp
+++ b/tests/negative/arm_best_practices.cpp
@@ -331,7 +331,7 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
     // create a non-sparse index buffer
     std::vector<uint16_t> nonsparse_indices;
     nonsparse_indices.resize(128);
-    std::generate(nonsparse_indices.begin(), nonsparse_indices.end(), [n = 0]() mutable { return ++n; });
+    std::generate(nonsparse_indices.begin(), nonsparse_indices.end(), [n = uint16_t(0)]() mutable { return ++n; });
 
     // another example of non-sparsity where the number of indices is also very small
     std::vector<uint16_t> nonsparse_indices_2 = {0, 1, 2, 3, 4, 5, 6, 7};
@@ -342,7 +342,7 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
     // another example of non-sparsity, all the indices are the same value (42)
     std::vector<uint16_t> nonsparse_indices_4 = {};
     nonsparse_indices_4.resize(128);
-    std::fill(nonsparse_indices_4.begin(), nonsparse_indices_4.end(), 42);
+    std::fill(nonsparse_indices_4.begin(), nonsparse_indices_4.end(), uint16_t(42));
 
     std::vector<uint16_t> sparse_indices = nonsparse_indices;
     // The buffer (0, 1, 2, ..., n) is completely un-sparse. However, if n < 0xFFFF, by adding 0xFFFF at the end, we


### PR DESCRIPTION
Using this function with std::transform on a std::string can result in truncation from int to char warnings with some compilers.