### PR TITLE
layers: Fix null image view state dereferencing

### DIFF
--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -4121,6 +4121,9 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
                 const VkImageView *image_views = pCreateInfo->pAttachments;
                 for (uint32_t i = 0; i < pCreateInfo->attachmentCount; ++i) {
                     auto view_state = Get<IMAGE_VIEW_STATE>(image_views[i]);
+                    if (!view_state) {
+                        continue;
+                    }
                     auto &ivci = view_state->create_info;
                     auto &subresource_range = view_state->normalized_subresource_range;
                     if (ivci.format != rpci->pAttachments[i].format) {

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -387,14 +387,18 @@ FRAMEBUFFER_STATE::FRAMEBUFFER_STATE(VkFramebuffer fb, const VkFramebufferCreate
 
 void FRAMEBUFFER_STATE::LinkChildNodes() {
     // Connect child node(s), which cannot safely be done in the constructor.
-    for (auto &a : attachments_view_state) {
-        a->AddParent(this);
+    for (auto &view : attachments_view_state) {
+        if (view) {
+            view->AddParent(this);
+        }
     }
 }
 
 void FRAMEBUFFER_STATE::Destroy() {
     for (auto &view : attachments_view_state) {
-        view->RemoveParent(this);
+        if (view) {
+            view->RemoveParent(this);
+        }
     }
     attachments_view_state.clear();
     BASE_NODE::Destroy();


### PR DESCRIPTION
The test introduced here leads to null image view states that would cause null pointers dereferencing in `CoreChecks::PreCallValidateCreateFramebuffer`, `FRAMEBUFFER_STATE::LinkChildNodes()` and `FRAMEBUFFER_STATE::Destroy()`. 
Before adding null checks, just bumping the Vulkan API version for this test from 1.0 to 1.1 would cause image view states to not be null.
Null checks are added to prevent crashes.

Internal discussion: https://chat.google.com/room/AAAAOXVAYGg/cGoDLJK09hI