### PR TITLE
tests: Split and fix RasterizationLine tests

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -615,6 +615,8 @@ class NegativeDynamicState : public DynamicStateTest {
     void ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic_state, const char *vuid);
     // VK_EXT_extended_dynamic_state3 - Create a pipeline with dynamic state, but the feature disabled
     void ExtendedDynamicState3PipelineFeatureDisabled(VkDynamicState dynamic_state, const char *vuid);
+    // VK_EXT_line_rasterization - Init with LineRasterization features off
+    void InitLineRasterizationFeatureDisabled();
 };
 class PositiveDynamicState : public DynamicStateTest {
   public:


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6020

1. splits tests up
2. Adds missing VUID from undefined values being set