### PR TITLE
tests: Add Task/Mesh support for SPIRV-Hopper

### DIFF
--- a/tests/spirv_hopper/pass_through_shaders.cpp
+++ b/tests/spirv_hopper/pass_through_shaders.cpp
@@ -243,6 +243,17 @@ bool Hopper::CreatePassThroughTessellationControl() {
     return BuildPassThroughShader(shader, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT);
 }
 
+bool Hopper::CreatePassThroughMesh() {
+    static const uint32_t simple_mesh_spv[52] = {
+        0x07230203, 0x00010600, 0x00070000, 0x00000005, 0x00000000, 0x00020011, 0x000014A3, 0x0006000A, 0x5F565053,
+        0x5F545845, 0x6873656D, 0x6168735F, 0x00726564, 0x0003000E, 0x00000000, 0x00000001, 0x0005000F, 0x000014F5,
+        0x00000001, 0x6E69616D, 0x00000000, 0x00060010, 0x00000001, 0x00000011, 0x00000001, 0x00000001, 0x00000001,
+        0x00040010, 0x00000001, 0x0000001A, 0x00000003, 0x00040010, 0x00000001, 0x00001496, 0x00000001, 0x00030010,
+        0x00000001, 0x000014B2, 0x00020013, 0x00000002, 0x00030021, 0x00000003, 0x00000002, 0x00050036, 0x00000002,
+        0x00000001, 0x00000000, 0x00000003, 0x000200F8, 0x00000004, 0x000100FD, 0x00010038};
+    return CreateShaderStage(sizeof(simple_mesh_spv), simple_mesh_spv, VK_SHADER_STAGE_MESH_BIT_EXT);
+}
+
 static TBuiltInResource InitResources() {
     TBuiltInResource resources;
     resources.maxLights = 32;

--- a/tests/spirv_hopper/spirv_hopper.h
+++ b/tests/spirv_hopper/spirv_hopper.h
@@ -34,6 +34,7 @@ class Hopper {
     bool CreatePipelineLayout();
     bool CreateVertexAttributeDescriptions(SpvReflectInterfaceVariable& variable);
     bool CreateGraphicsPipeline();
+    bool CreateGraphicsMeshPipeline();
     bool CreateComputePipeline();
 
     // For Pass Through shaders
@@ -45,6 +46,7 @@ class Hopper {
     bool CreatePassThroughVertexNoInterface();
     bool CreatePassThroughTessellationEval();
     bool CreatePassThroughTessellationControl();
+    bool CreatePassThroughMesh();
 
     SpvReflectShaderModule module;
 

--- a/tests/spirv_hopper/vulkan_object.cpp
+++ b/tests/spirv_hopper/vulkan_object.cpp
@@ -150,7 +150,9 @@ VulkanInstance::VulkanInstance() {
 
         // TODO - Generate these
         // Currently assumes using MockICD and profiles so all of these are enabled
-        auto physical_device_ray_tracing_pipeline_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+        auto physical_device_mesh_shader_features = LvlInitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+        auto physical_device_ray_tracing_pipeline_features =
+            LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(&physical_device_mesh_shader_features);
         auto physical_device_fragment_shader_interlock_features =
             LvlInitStruct<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(&physical_device_ray_tracing_pipeline_features);
         auto physical_device_shader_atomic_float_features =


### PR DESCRIPTION
Adds support so Task/Mesh shaders can run with `spirv-hopper`