### PR TITLE
Warn if descriptor buffer is enabled with GPU-AV

### DIFF
--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -138,6 +138,11 @@ void GpuAssisted::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
                    "VK_EXT_shader_Object is enabled, but GPU-AV does not currently support validation of shader objects");
     }
 
+    if (IsExtEnabled(device_extensions.vk_ext_descriptor_buffer)) {
+        LogWarning(device, "UNASSIGNED-GPU-Assisted Validation Warning",
+                   "VK_EXT_descriptor_buffer is enabled, but GPU-AV does not currently support validation of descriptor buffers");
+    }
+
     output_buffer_size = sizeof(uint32_t) * (spvtools::kInstMaxOutCnt + spvtools::kDebugOutputDataOffset);
 
     if (validate_descriptor_indexing) {


### PR DESCRIPTION
VK_EXT_descriptor_buffer GPU-AV is a WIP
Warn if it's used with GPU-AV.  #6025