### PR TITLE
Use a single buffer for buffer device address GPU-AV

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -928,6 +928,26 @@
                                                     }
                                                 ]
                                             }
+                                        },
+                                        {
+                                            "key": "max_buffer_device_addresses",
+                                            "label": "Specify the maximum number of buffer device addresses in use at one time",
+                                            "description": "Specify maximum number of buffer device addresses",
+                                            "type": "INT",
+                                            "default": 10000,
+                                            "platforms": [
+                                                "WINDOWS",
+                                                "LINUX"
+                                            ],
+                                            "dependence": {
+                                                "mode": "ALL",
+                                                "settings": [
+                                                    {
+                                                        "key": "validate_gpu_based",
+                                                        "value": "GPU_BASED_GPU_ASSISTED"
+                                                    }
+                                                ]
+                                            }
                                         }
                                     ]
                                 }

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -62,7 +62,6 @@ struct GpuAssistedPreDispatchResources {
 
 struct GpuAssistedBufferInfo {
     GpuAssistedDeviceMemoryBlock output_mem_block;
-    GpuAssistedDeviceMemoryBlock bda_input_mem_block;  // Buffer Device Address input
     GpuAssistedPreDrawResources pre_draw_resources;
     GpuAssistedPreDispatchResources pre_dispatch_resources;
     VkDescriptorSet desc_set;
@@ -71,12 +70,11 @@ struct GpuAssistedBufferInfo {
     bool uses_robustness;
     CMD_TYPE cmd_type;
     uint32_t desc_binding_index;
-    GpuAssistedBufferInfo(GpuAssistedDeviceMemoryBlock output_mem_block, GpuAssistedDeviceMemoryBlock bda_input_mem_block,
-                          GpuAssistedPreDrawResources pre_draw_resources, GpuAssistedPreDispatchResources pre_dispatch_resources,
-                          VkDescriptorSet desc_set, VkDescriptorPool desc_pool, VkPipelineBindPoint pipeline_bind_point,
-                          bool uses_robustness, CMD_TYPE cmd_type, uint32_t desc_binding_index)
+    GpuAssistedBufferInfo(GpuAssistedDeviceMemoryBlock output_mem_block, GpuAssistedPreDrawResources pre_draw_resources,
+                          GpuAssistedPreDispatchResources pre_dispatch_resources, VkDescriptorSet desc_set,
+                          VkDescriptorPool desc_pool, VkPipelineBindPoint pipeline_bind_point, bool uses_robustness,
+                          CMD_TYPE cmd_type, uint32_t desc_binding_index)
         : output_mem_block(output_mem_block),
-          bda_input_mem_block(bda_input_mem_block),
           pre_draw_resources(pre_draw_resources),
           pre_dispatch_resources(pre_dispatch_resources),
           desc_set(desc_set),
@@ -223,6 +221,7 @@ class GpuAssisted : public GpuAssistedBase {
                                     uint32_t operation_index, uint32_t* const debug_output_buffer,
                                     const std::vector<GpuAssistedDescSetState>& descriptor_sets);
     void UpdateInstrumentationBuffer(gpuav_state::CommandBuffer* cb_node);
+    void UpdateBDABuffer(GpuAssistedDeviceMemoryBlock buffer_device_addresses);
 
     void UpdateBoundDescriptors(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint);
 
@@ -340,6 +339,10 @@ class GpuAssisted : public GpuAssistedBase {
     GpuAssistedAccelerationStructureBuildValidationState acceleration_structure_validation_state;
     GpuAssistedPreDrawValidationState pre_draw_validation_state;
     GpuAssistedPreDispatchValidationState pre_dispatch_validation_state;
+    GpuAssistedDeviceMemoryBlock app_buffer_device_addresses{};
+    size_t app_bda_buffer_size{};
+    size_t app_bda_max_addresses{};
+    uint32_t gpuav_bda_buffer_version = 0;
 
     bool buffer_device_address;
 };

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5717,6 +5717,7 @@ void ValidationStateTracker::RecordGetBufferDeviceAddress(const VkBufferDeviceAd
 
         BufferAddressInfillUpdateOps ops{{buffer_state}};
         sparse_container::infill_update_range(buffer_address_map_, address_range, ops);
+        buffer_device_address_ranges_version++;
     }
 }
 

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1604,6 +1604,7 @@ class ValidationStateTracker : public ValidationObject {
     std::vector<QueueFamilyExtensionProperties> queue_family_ext_props;
 
     bool performance_lock_acquired = false;
+    uint32_t buffer_device_address_ranges_version = 0;
 
     mutable VideoProfileDesc::Cache video_profile_cache_;
 

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -98,6 +98,12 @@ khronos_validation.enables =
 # Use VMA linear memory allocations for GPU-AV output buffers
 #khronos_validation.vma_linear_output = true
 
+# Specify the maximum number of buffer device addresses in simultaneous use
+# =====================
+# <LayerIdentifier>.gpuav_max_buffer_device_addresses
+# Specify the maximum number of buffer device addresses to allow GPU-AV allocate resources
+#khronos_validation.gpuav_max_buffer_device_addresses = 10000
+
 # Fine Grained Locking
 # =====================
 # <LayerIdentifier>.fine_grained_locking

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -226,3 +226,130 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOPushDescriptor) {
 
     vk::DestroyPipeline(m_device->device(), pipeline, nullptr);
 }
+
+TEST_F(PositiveGpuAssistedLayer, GpuBufferDeviceAddress) {
+    TEST_DESCRIPTION("Makes sure that writing to a buffer that was created after command buffer record doesn't get OOB error");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    VkValidationFeaturesEXT validation_features = GetValidationFeatures();
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, &validation_features));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    if (!CanEnableGpuAV()) {
+        GTEST_SKIP() << "Requirements for GPU-AV are not met";
+    }
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required";
+    }
+    if (IsDriver(VK_DRIVER_ID_MESA_RADV)) {
+        GTEST_SKIP() << "This test should not be run on the RADV driver.";
+    }
+    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
+        GTEST_SKIP() << "This test should not be run on the AMD proprietary driver.";
+    }
+    auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    VkPhysicalDeviceFeatures2KHR features2 = GetPhysicalDeviceFeatures2(bda_features);
+    if (!bda_features.bufferDeviceAddress) {
+        GTEST_SKIP() << "Buffer Device Address feature not supported";
+    }
+    features2.features.robustBufferAccess = VK_FALSE;
+
+    VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
+    ASSERT_NO_FATAL_FAILURE(InitViewport());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    // Make a uniform buffer to be passed to the shader that contains the pointer and write count
+    uint32_t qfi = 0;
+    auto bci = LvlInitStruct<VkBufferCreateInfo>();
+    bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+    bci.size = 12;  // 64 bit pointer + int
+    bci.queueFamilyIndexCount = 1;
+    bci.pQueueFamilyIndices = &qfi;
+    vk_testing::Buffer buffer0;
+    VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    buffer0.init(*m_device, bci, mem_props);
+
+    VkViewport viewport = m_viewports[0];
+    VkRect2D scissors = m_scissors[0];
+
+    auto submit_info = LvlInitStruct<VkSubmitInfo>();
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &m_commandBuffer->handle();
+
+    auto begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
+    auto hinfo = LvlInitStruct<VkCommandBufferInheritanceInfo>();
+    begin_info.pInheritanceInfo = &hinfo;
+
+    OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
+
+    const VkPipelineLayoutObj pipeline_layout(m_device, {&descriptor_set.layout_});
+    VkDescriptorBufferInfo buffer_test_buffer_info = {};
+    buffer_test_buffer_info.buffer = buffer0.handle();
+    buffer_test_buffer_info.offset = 0;
+    buffer_test_buffer_info.range = sizeof(uint32_t);
+
+    auto descriptor_write = LvlInitStruct<VkWriteDescriptorSet>();
+    descriptor_write.dstSet = descriptor_set.set_;
+    descriptor_write.dstBinding = 0;
+    descriptor_write.descriptorCount = 1;
+    descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    descriptor_write.pBufferInfo = &buffer_test_buffer_info;
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
+
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_buffer_reference : enable
+        layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
+        layout(set = 0, binding = 0) uniform ufoo {
+            bufStruct data;
+            int nWrites;
+        } u_info;
+        layout(buffer_reference, std140) buffer bufStruct {
+            int a[4];
+        };
+        void main() {
+            for (int i=0; i < u_info.nWrites; ++i) {
+                u_info.data.a[i] = 0xdeadca71;
+            }
+        }
+    )glsl";
+    VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, nullptr, "main", true);
+
+    VkPipelineObj pipe(m_device);
+    pipe.AddShader(&vs);
+    pipe.AddDefaultColorAttachment();
+    pipe.DisableRasterization();
+    auto subcase_err = pipe.CreateVKPipeline(pipeline_layout.handle(), renderPass());
+    ASSERT_VK_SUCCESS(subcase_err);
+
+    m_commandBuffer->begin(&begin_info);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
+                              &descriptor_set.set_, 0, nullptr);
+    vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
+    vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissors);
+    vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+    vk::CmdEndRenderPass(m_commandBuffer->handle());
+    m_commandBuffer->end();
+
+    // Make another buffer to write to
+    bci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
+    bci.size = 64;  // Buffer should be 16*4 = 64 bytes
+    vk_testing::Buffer buffer1(*m_device, bci, mem_props, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
+
+    // Get device address of buffer to write to
+    auto pBuffer = buffer1.address();
+
+    auto *data = static_cast<VkDeviceAddress *>(buffer0.memory().map());
+    data[0] = pBuffer;
+    data[1] = 4;
+    buffer0.memory().unmap();
+
+    subcase_err = vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+    ASSERT_VK_SUCCESS(subcase_err);
+    subcase_err = vk::QueueWaitIdle(m_device->m_queue);
+    ASSERT_VK_SUCCESS(subcase_err);
+}


### PR DESCRIPTION
Should be better than 1 buffer per draw, and now accounts for buffers created after draw is recorded