### PR TITLE
SPIRV-Hopper cleanup

### DIFF
--- a/tests/spirv_hopper/pass_through_shaders.cpp
+++ b/tests/spirv_hopper/pass_through_shaders.cpp
@@ -93,7 +93,7 @@ std::string Hopper::GetTypeDescription(SpvReflectTypeDescription& description, S
             if (description.type_name != nullptr) {
                 return description.type_name;
             }
-            type += "UNKNOWN_TYPE";  // Unsupported type
+            type += "UNKNOWN_STRUCT_" + std::to_string(description.id);  // Unsupported type
             break;
     }
     return type;
@@ -102,14 +102,14 @@ std::string Hopper::GetTypeDescription(SpvReflectTypeDescription& description, S
 std::string Hopper::DefineCustomStruct(SpvReflectInterfaceVariable& variable) {
     SpvReflectTypeDescription& description = *variable.type_description;
     std::string shader = "struct ";
-    shader += (description.type_name) ? description.type_name : "UNKNOWN_TYPE";
+    shader += (description.type_name) ? description.type_name : "UNKNOWN_STRUCT_" + std::to_string(description.id);
     shader += " {\n";
     for (uint32_t i = 0; i < description.member_count; i++) {
         shader += "\t";
         shader += GetTypeDescription(description.members[i], variable.members[i].format);
         shader += " ";
         shader += (description.members[i].struct_member_name) ? description.members[i].struct_member_name
-                                                              : "UNKNOWN_TYPE_MEMBER_" + std::to_string(i);
+                                                              : "UNKNOWN_MEMBER_" + std::to_string(i);
         for (uint32_t j = 0; j < description.members[i].traits.array.dims_count; j++) {
             shader += "[" + std::to_string(description.members[i].traits.array.dims[j]) + "]";
         }

--- a/tests/spirv_hopper/spirv_hopper.cpp
+++ b/tests/spirv_hopper/spirv_hopper.cpp
@@ -366,10 +366,10 @@ bool Hopper::CreateGraphicsPipeline() {
     // Subpass and Renderpass
     {
         // Find all the attachments and create a Framebuffer and RenderPass
-        VkSubpassDescription subpass_dscription = {};
-        subpass_dscription.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-        subpass_dscription.colorAttachmentCount = attachment_count;
-        subpass_dscription.pColorAttachments = color_attachment_references.data();
+        VkSubpassDescription subpass_description = {};
+        subpass_description.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_description.colorAttachmentCount = attachment_count;
+        subpass_description.pColorAttachments = color_attachment_references.data();
 
         // Create dummy input attachments if the shader requires input attachments.
         std::vector<VkAttachmentReference> input_attachment_reference;
@@ -378,15 +378,15 @@ bool Hopper::CreateGraphicsPipeline() {
             // input_attachment_reference.push_back({input_attachments[i].input_attachment_index, VK_IMAGE_LAYOUT_GENERAL});
             input_attachment_reference.push_back({0, VK_IMAGE_LAYOUT_GENERAL});
         }
-        subpass_dscription.inputAttachmentCount = static_cast<uint32_t>(input_attachment_reference.size());
-        subpass_dscription.pInputAttachments = input_attachment_reference.data();
+        subpass_description.inputAttachmentCount = static_cast<uint32_t>(input_attachment_reference.size());
+        subpass_description.pInputAttachments = input_attachment_reference.data();
 
         auto render_pass_info = LvlInitStruct<VkRenderPassCreateInfo>();
         render_pass_info.flags = 0;
         render_pass_info.attachmentCount = 1;
         render_pass_info.pAttachments = &vk.basic_attachment_description;
         render_pass_info.subpassCount = 1;
-        render_pass_info.pSubpasses = &subpass_dscription;
+        render_pass_info.pSubpasses = &subpass_description;
         render_pass_info.dependencyCount = 0;
         render_pass_info.pDependencies = nullptr;
         VK_SUCCESS(vk::CreateRenderPass(vk.device, &render_pass_info, nullptr, &render_pass));
@@ -423,23 +423,19 @@ bool Hopper::CreateGraphicsMeshPipeline() {
 
     // Renderpass
     {
-        color_attachment_references.resize(1);
-        color_attachment_references[0].attachment = 0;
-        color_attachment_references[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
         // Find all the attachments and create a Framebuffer and RenderPass
-        VkSubpassDescription subpass_dscription = {};
-        subpass_dscription.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-        subpass_dscription.colorAttachmentCount = 1;
-        subpass_dscription.pColorAttachments = color_attachment_references.data();
-        subpass_dscription.inputAttachmentCount = 0;  // inputAttachment only allowed in Frag
-        subpass_dscription.pResolveAttachments = nullptr;
-        subpass_dscription.pDepthStencilAttachment = nullptr;
+        VkSubpassDescription subpass_description = {};
+        subpass_description.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+        subpass_description.colorAttachmentCount = 0;
+        subpass_description.inputAttachmentCount = 0;  // inputAttachment only allowed in Frag
+        subpass_description.pResolveAttachments = nullptr;
+        subpass_description.pDepthStencilAttachment = nullptr;
         auto render_pass_info = LvlInitStruct<VkRenderPassCreateInfo>();
         render_pass_info.flags = 0;
         render_pass_info.attachmentCount = 1;
         render_pass_info.pAttachments = &vk.basic_attachment_description;
         render_pass_info.subpassCount = 1;
-        render_pass_info.pSubpasses = &subpass_dscription;
+        render_pass_info.pSubpasses = &subpass_description;
         render_pass_info.dependencyCount = 0;
         render_pass_info.pDependencies = nullptr;
         VK_SUCCESS(vk::CreateRenderPass(vk.device, &render_pass_info, nullptr, &render_pass));
@@ -452,8 +448,8 @@ bool Hopper::CreateGraphicsMeshPipeline() {
     pipeline_info.pVertexInputState = nullptr;
     pipeline_info.pInputAssemblyState = nullptr;
     pipeline_info.pTessellationState = nullptr;
-    pipeline_info.pViewportState = nullptr;
-    pipeline_info.pRasterizationState = nullptr;
+    pipeline_info.pViewportState = &vk.viewport_input_state;
+    pipeline_info.pRasterizationState = &vk.rasterization_state;
     pipeline_info.pMultisampleState = &vk.multisample_state;
     pipeline_info.pDepthStencilState = nullptr;
     pipeline_info.pColorBlendState = nullptr;

--- a/tests/spirv_hopper/spirv_hopper.cpp
+++ b/tests/spirv_hopper/spirv_hopper.cpp
@@ -76,21 +76,21 @@ bool Hopper::Reflect() {
     shader_stage = static_cast<VkShaderStageFlagBits>(module.shader_stage);
 
     uint32_t count = 0;
-    REFLECT_SUCCESS(spvReflectEnumerateInputVariables(&module, &count, nullptr));
+    REFLECT_SUCCESS(spvReflectEnumerateEntryPointInputVariables(&module, entry_point.name, &count, nullptr));
     input_variables.resize(count);
-    REFLECT_SUCCESS(spvReflectEnumerateInputVariables(&module, &count, input_variables.data()));
+    REFLECT_SUCCESS(spvReflectEnumerateEntryPointInputVariables(&module, entry_point.name, &count, input_variables.data()));
 
-    REFLECT_SUCCESS(spvReflectEnumerateOutputVariables(&module, &count, nullptr));
+    REFLECT_SUCCESS(spvReflectEnumerateEntryPointOutputVariables(&module, entry_point.name, &count, nullptr));
     output_variables.resize(count);
-    REFLECT_SUCCESS(spvReflectEnumerateOutputVariables(&module, &count, output_variables.data()));
+    REFLECT_SUCCESS(spvReflectEnumerateEntryPointOutputVariables(&module, entry_point.name, &count, output_variables.data()));
 
-    REFLECT_SUCCESS(spvReflectEnumeratePushConstantBlocks(&module, &count, nullptr));
+    REFLECT_SUCCESS(spvReflectEnumerateEntryPointPushConstantBlocks(&module, entry_point.name, &count, nullptr));
     push_constants.resize(count);
-    REFLECT_SUCCESS(spvReflectEnumeratePushConstantBlocks(&module, &count, push_constants.data()));
+    REFLECT_SUCCESS(spvReflectEnumerateEntryPointPushConstantBlocks(&module, entry_point.name, &count, push_constants.data()));
 
-    REFLECT_SUCCESS(spvReflectEnumerateDescriptorSets(&module, &count, nullptr));
+    REFLECT_SUCCESS(spvReflectEnumerateEntryPointDescriptorSets(&module, entry_point.name, &count, nullptr));
     descriptor_sets.resize(count);
-    REFLECT_SUCCESS(spvReflectEnumerateDescriptorSets(&module, &count, descriptor_sets.data()));
+    REFLECT_SUCCESS(spvReflectEnumerateEntryPointDescriptorSets(&module, entry_point.name, &count, descriptor_sets.data()));
     return true;
 }
 


### PR DESCRIPTION
Adds a few misc things for SPIRV-Hopper

- Per-EntryPoint enumeration (for future support to handle multi-entry point shaders)
- Handle case where multiple structs are not known for passthrough shader
- Set `pRasterizationState` as it was hitting a Validation Error otherwise