### PR TITLE
layers: Disable calls to ComputeScratchSize (temporary CTS fix)

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -302,6 +302,8 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
             // acceleration structure's memory if build mode is update, or other scratch buffers' memory.
             // Here validation is pessimistic: if one buffer associated to pInfos[other_info_j].scratchData.deviceAddress has an
             // overlap, an error will be logged.
+// Issue 6040
+#if 0
             if (auto other_scratches = GetBuffersByAddress(pInfos[other_info_j].scratchData.deviceAddress);
                 !other_scratches.empty()) {
                 using BUFFER_STATE_PTR = ValidationStateTracker::BUFFER_STATE_PTR;
@@ -534,6 +536,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
                     *this, other_scratches, "vkCmdBuildAccelerationStructuresKHR()", address_name_ss.str(),
                     pInfos[other_info_j].scratchData.deviceAddress);
             }
+#endif
 
             // skip comparing to self pInfos[info_i]
             if (other_info_j != info_i) {

--- a/tests/negative/ray_tracing.cpp
+++ b/tests/negative/ray_tracing.cpp
@@ -1933,7 +1933,8 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
+// Issue 6040
+TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
     TEST_DESCRIPTION(
         "Validate acceleration structure building when source/destination acceleration structures and scratch buffers overlap.");
 


### PR DESCRIPTION
Temporary fix for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6040
Will soon work on a true fix