### PR TITLE
layers: Disable buffer_address_map updates

### DIFF
--- a/tests/negative/ray_tracing.cpp
+++ b/tests/negative/ray_tracing.cpp
@@ -1076,7 +1076,7 @@ TEST_F(NegativeRayTracing, CopyMemoryToAsBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeRayTracing, ArrayOOBRayTracingShaders) {
+TEST_F(NegativeRayTracing, DISABLED_ArrayOOBRayTracingShaders) {
     TEST_DESCRIPTION(
         "Core validation: Verify detection of out-of-bounds descriptor array indexing and use of uninitialized descriptors for "
         "ray tracing shaders.");
@@ -1217,7 +1217,7 @@ TEST_F(NegativeRayTracing, CreateAccelerationStructureKHRReplayFeature) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
+TEST_F(NegativeRayTracing, DISABLED_CmdTraceRaysKHR) {
     TEST_DESCRIPTION("Validate vkCmdTraceRaysKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1623,7 +1623,7 @@ TEST_F(NegativeRayTracing, AccelerationStructureVersionInfoKHR) {
     }
 }
 
-TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
+TEST_F(NegativeRayTracing, DISABLED_CmdBuildAccelerationStructuresKHR) {
     TEST_DESCRIPTION("Validate acceleration structure building.");
 
     AddOptionalExtensions(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME);
@@ -2197,7 +2197,7 @@ TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
     }
 }
 
-TEST_F(NegativeRayTracing, ObjInUseCmdBuildAccelerationStructureKHR) {
+TEST_F(NegativeRayTracing, DISABLED_ObjInUseCmdBuildAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate acceleration structure building tracks the objects used.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2298,7 +2298,7 @@ TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
     vk::DestroyAccelerationStructureKHR(device(), as, nullptr);
 }
 
-TEST_F(NegativeRayTracing, UpdateAccelerationStructureKHR) {
+TEST_F(NegativeRayTracing, DISABLED_UpdateAccelerationStructureKHR) {
     TEST_DESCRIPTION("Test for updating an acceleration structure without a srcAccelerationStructure");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2334,7 +2334,7 @@ TEST_F(NegativeRayTracing, UpdateAccelerationStructureKHR) {
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
+TEST_F(NegativeRayTracing, DISABLED_BuffersAndBufferDeviceAddressesMapping) {
     TEST_DESCRIPTION(
         "Test that buffers and buffer device addresses mapping is correctly handled."
         "Bound multiple buffers to the same memory so that they have the same buffer device address."
@@ -2435,7 +2435,7 @@ TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
     }
 }
 
-TEST_F(NegativeRayTracing, WriteAccelerationStructuresProperties) {
+TEST_F(NegativeRayTracing, DISABLE_WriteAccelerationStructuresProperties) {
     TEST_DESCRIPTION("Test queryType validation in vkCmdWriteAccelerationStructuresPropertiesKHR");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2541,7 +2541,7 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresProperties) {
     }
 }
 
-TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1) {
+TEST_F(NegativeRayTracing, DISABLE_WriteAccelerationStructuresPropertiesMaintenance1) {
     TEST_DESCRIPTION("Test queryType validation in vkCmdWriteAccelerationStructuresPropertiesKHR");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/negative/ray_tracing_pipeline.cpp
+++ b/tests/negative/ray_tracing_pipeline.cpp
@@ -882,7 +882,7 @@ TEST_F(NegativeRayTracing, GetCaptureReplayShaderGroupHandlesKHR) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeRayTracing, DeferredOp) {
+TEST_F(NegativeRayTracing, DISABLED_DeferredOp) {
     TEST_DESCRIPTION(
         "Test that objects created with deferred operations are recorded once the operation has successfully completed.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -990,7 +990,7 @@ TEST_F(NegativeRayTracing, DeferredOp) {
     vk::DestroyPipeline(m_device->handle(), library, nullptr);
 }
 
-TEST_F(NegativeRayTracing, BindPoint) {
+TEST_F(NegativeRayTracing, DISABLED_BindPoint) {
     TEST_DESCRIPTION("Bind a graphics pipeline in the ray-tracing bind point");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);

--- a/tests/positive/ray_tracing.cpp
+++ b/tests/positive/ray_tracing.cpp
@@ -53,7 +53,7 @@ TEST_F(PositiveRayTracing, GetAccelerationStructureBuildSizes) {
                                               &max_primitives_count, &build_sizes_info);
 }
 
-TEST_F(PositiveRayTracing, AccelerationStructureReference) {
+TEST_F(PositiveRayTracing, DISABLE_AccelerationStructureReference) {
     TEST_DESCRIPTION("Test device side accelerationStructureReference");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -130,7 +130,7 @@ TEST_F(PositiveRayTracing, HostAccelerationStructureReference) {
     top_level_build_geometry.BuildHost(instance(), *m_device);
 }
 
-TEST_F(PositiveRayTracing, StridedDeviceAddressRegion) {
+TEST_F(PositiveRayTracing, DISABLED_StridedDeviceAddressRegion) {
     TEST_DESCRIPTION("Test different valid VkStridedDeviceAddressRegionKHR");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -415,7 +415,7 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(PositiveRayTracing, BuildAccelerationStructuresList) {
+TEST_F(PositiveRayTracing, DISABLE_BuildAccelerationStructuresList) {
     TEST_DESCRIPTION("Build a list of destination acceleration structures, then do an update build on that same list");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);


### PR DESCRIPTION
Disable tests failing as a consequence of that

(This PR will not be merged, I just want CI. This is related to ongoing perf investigation on buffer_address_map slowness)