### PR TITLE
build: Apply Robinhood setting to tests

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -78,7 +78,7 @@ target_include_directories(VkLayer_utils PUBLIC . ${API_TYPE})
 find_package(robin_hood CONFIG)
 option(USE_ROBIN_HOOD_HASHING "robin_hood provides faster versions of std::unordered_map and std::unordered_set" ${robin_hood_FOUND})
 if (USE_ROBIN_HOOD_HASHING)
-    target_link_libraries(VkLayer_utils PRIVATE robin_hood::robin_hood)
+    target_link_libraries(VkLayer_utils PUBLIC robin_hood::robin_hood)
     target_compile_definitions(robin_hood::robin_hood INTERFACE USE_ROBIN_HOOD_HASHING)
 endif()
 


### PR DESCRIPTION
When building the repo with both tests enabled and Link Time Optimization, the tests do not have USE_ROBIN_HOOD_HASHING defined. This causes an ODR violation in vk_layer_validation_tests and VkLayer_device_profile_api because they both link to VkLayer_utils statically which *does* define USE_ROBIN_HOOD_HASHING.

Fixing this requires all components linking to robin_hood, which required moving `find_package(robin_hood CONFIG)` to the top level CMakeLists.txt so that the package is visible.

Fixes #6052 