### PR TITLE
layers: Do not use std::move with std::initiailzer_list

### DIFF
--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -138,8 +138,8 @@ class small_vector {
     small_vector(std::initializer_list<T> list) : size_(0), capacity_(N) {
         DebugUpdateWorkingStore();
         reserve(list.size());
-        for (auto &obj : list) {
-            emplace_back(std::move(obj));
+        for (const auto &obj : list) {
+            emplace_back(obj);
         }
     }
 


### PR DESCRIPTION
Elements of std::initializer_list are constants and applying std::move to such elements does not produce movable object `&&` but `const &&`. At least with current version of C++ copy is needed. The original code was correct (move does not have effect) but it signaled wrong intent.