### PR TITLE
layers: Fix `vkGetBufferDeviceAddress` state recording bug

### DIFF
--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -357,6 +357,7 @@ class small_vector {
     inline const_iterator cend() const { return GetWorkingStore() + size_; }
     inline const_iterator end() const { return GetWorkingStore() + size_; }
     inline size_type size() const { return size_; }
+    auto capacity() const { return capacity_; }
 
     inline pointer data() { return GetWorkingStore(); }
     inline const_pointer data() const { return GetWorkingStore(); }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -314,6 +314,29 @@ void ValidationStateTracker::PreCallRecordCmdBlitImage2(VkCommandBuffer commandB
                                 Get<IMAGE_STATE>(pBlitImageInfo->dstImage));
 }
 
+struct BufferAddressInfillUpdateOps {
+    using Map = typename ValidationStateTracker::BufferAddressRangeMap;
+    using Iterator = typename Map::iterator;
+    using Value = typename Map::value_type;
+    using Mapped = typename Map::mapped_type;
+    using Range = typename Map::key_type;
+    void infill(Map &map, const Iterator &pos, const Range &infill_range) const {
+        map.insert(pos, Value(infill_range, insert_value));
+    }
+    void update(const Iterator &pos) const {
+        auto &current_buffer_list = pos->second;
+        assert(!current_buffer_list.empty());
+        const auto buffer_found_it = std::find(current_buffer_list.begin(), current_buffer_list.end(), insert_value[0]);
+        if (buffer_found_it == current_buffer_list.end()) {
+            if (current_buffer_list.capacity() <= (current_buffer_list.size() + 1)) {
+                current_buffer_list.reserve(current_buffer_list.capacity() * 2);
+            }
+            current_buffer_list.emplace_back(insert_value[0]);
+        }
+    }
+    const Mapped &insert_value;
+};
+
 void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
                                                         const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer,
                                                         VkResult result) {
@@ -338,14 +361,8 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
             buffer_state->deviceAddress = opaque_capture_address->opaqueCaptureAddress;
             const auto address_range = buffer_state->DeviceAddressRange();
 
-            buffer_address_map_.split_and_merge_insert(
-                {address_range, {buffer_state}}, [](auto &current_buffer_list, const auto &new_buffer) {
-                    assert(!current_buffer_list.empty());
-                    const auto buffer_found_it = std::find(current_buffer_list.begin(), current_buffer_list.end(), new_buffer[0]);
-                    if (buffer_found_it == current_buffer_list.end()) {
-                        current_buffer_list.emplace_back(new_buffer[0]);
-                    }
-                });
+            BufferAddressInfillUpdateOps ops{{buffer_state}};
+            sparse_container::infill_update_range(buffer_address_map_, address_range, ops);
         }
 
         const VkBufferUsageFlags descriptor_buffer_usages =
@@ -5693,14 +5710,8 @@ void ValidationStateTracker::RecordGetBufferDeviceAddress(const VkBufferDeviceAd
         buffer_state->deviceAddress = address;
         const auto address_range = buffer_state->DeviceAddressRange();
 
-        buffer_address_map_.split_and_merge_insert(
-            {address_range, {buffer_state}}, [](auto &current_buffer_list, const auto &new_buffer) {
-                assert(!current_buffer_list.empty());
-                const auto buffer_found_it = std::find(current_buffer_list.begin(), current_buffer_list.end(), new_buffer[0]);
-                if (buffer_found_it == current_buffer_list.end()) {
-                    current_buffer_list.emplace_back(new_buffer[0]);
-                }
-            });
+        BufferAddressInfillUpdateOps ops{{buffer_state}};
+        sparse_container::infill_update_range(buffer_address_map_, address_range, ops);
     }
 }
 

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1607,6 +1607,9 @@ class ValidationStateTracker : public ValidationObject {
 
     mutable VideoProfileDesc::Cache video_profile_cache_;
 
+    using BufferAddressMapStore = small_vector<std::shared_ptr<BUFFER_STATE>, 1, size_t>;
+    using BufferAddressRangeMap = sparse_container::range_map<VkDeviceAddress, BufferAddressMapStore>;
+
   protected:
     // tracks which queue family index were used when creating the device for quick lookup
     vvl::unordered_set<uint32_t> queue_family_index_set;
@@ -1619,7 +1622,7 @@ class ValidationStateTracker : public ValidationObject {
     };
     std::vector<DeviceQueueInfo> device_queue_info_list;
     // If vkGetBufferDeviceAddress is called, keep track of buffer <-> address mapping.
-    sparse_container::range_map<VkDeviceAddress, small_vector<std::shared_ptr<BUFFER_STATE>, 1, size_t>> buffer_address_map_;
+    BufferAddressRangeMap buffer_address_map_;
     mutable std::shared_mutex buffer_address_lock_;
 
     vl_concurrent_unordered_map<uint64_t, VkFormatFeatureFlags2KHR> ahb_ext_formats_map;

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -8196,7 +8196,8 @@ void QueueBatchContext::ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag) 
         ApplyPredicatedWait(predicate);
     }
 
-    if (queue_id == GetQueueId() || any_queue) {
+    // SwapChain acquire QBC's have no queue, but also, events are always empty.
+    if (queue_state_ && (queue_id == GetQueueId() || any_queue)) {
         events_context_.ApplyTaggedWait(GetQueueFlags(), tag);
     }
 }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1617,47 +1617,35 @@ SyncStageAccessFlags SyncStageAccess::AccessScope(VkPipelineStageFlags2KHR stage
     return AccessScopeByStage(stages) & AccessScopeByAccess(accesses);
 }
 
+// The semantics of the InfillUpdateOps of infill_update_range are slightly different than for the UpdateMemoryAccessState Action
+// operations, as this simplifies the generic traversal.  So we wrap them in a semantics Adapter to get the same effect.
+template <typename Action>
+struct ActionToOpsAdapter {
+    using Map = ResourceAccessRangeMap;
+    using Range = typename Map::key_type;
+    using Iterator = typename Map::iterator;
+    using IndexType = typename Map::index_type;
+
+    void infill(Map &accesses, const Iterator &pos, const Range &infill_range) const {
+        // Combine Infill and update operations to make the generic implementation simpler
+        Iterator infill = action.Infill(&accesses, pos, infill_range);
+        if (infill == accesses.end()) return;  // Allow action to 'pass' on filling in the blanks
+
+        // Need to apply the action to the Infill.  'infill_update_range' expect ops.infill to be completely done with
+        // the infill_range, where as Action::Infill assumes the caller will apply the action() logic to the infill_range
+        for (; infill != pos; ++infill) {
+            assert(infill != accesses.end());
+            action(infill);
+        }
+    }
+    void update(const Iterator &pos) const { action(pos); }
+    const Action &action;
+};
+
 template <typename Action>
 void UpdateMemoryAccessState(ResourceAccessRangeMap *accesses, const ResourceAccessRange &range, const Action &action) {
-    // TODO: Optimization for operations that do a pure overwrite (i.e. WRITE usages which rewrite the state, vs READ usages
-    //       that do incrementalupdates
-    assert(accesses);
-    if (range.empty()) return;
-    auto pos = accesses->lower_bound(range);
-    if (pos == accesses->end() || !pos->first.intersects(range)) {
-        // The range is empty, fill it with a default value.
-        pos = action.Infill(accesses, pos, range);
-    } else if (range.begin < pos->first.begin) {
-        // Leading empty space, infill
-        pos = action.Infill(accesses, pos, ResourceAccessRange(range.begin, pos->first.begin));
-    } else if (pos->first.begin < range.begin) {
-        // Trim the beginning if needed
-        pos = accesses->split(pos, range.begin, sparse_container::split_op_keep_both());
-        ++pos;
-    }
-
-    const auto the_end = accesses->end();
-    while ((pos != the_end) && pos->first.intersects(range)) {
-        if (pos->first.end > range.end) {
-            pos = accesses->split(pos, range.end, sparse_container::split_op_keep_both());
-        }
-
-        pos = action(accesses, pos);
-        if (pos == the_end) break;
-
-        auto next = pos;
-        ++next;
-
-        // Do gap infill or infill to end of range, if needed.
-        if (pos->first.end < range.end) {
-            VkDeviceSize limit = (next == the_end) ? range.end : std::min(range.end, next->first.begin);
-            ResourceAccessRange new_range(pos->first.end, limit);
-            if (new_range.non_empty()) {
-                next = action.Infill(accesses, next, new_range);
-            }
-        }
-        pos = next;
-    }
+    ActionToOpsAdapter<Action> ops{action};
+    infill_update_range(*accesses, range, ops);
 }
 
 // Give a comparable interface for range generators and ranges
@@ -1692,10 +1680,9 @@ struct UpdateMemoryAccessStateFunctor {
         return accesses->lower_bound(range);
     }
 
-    Iterator operator()(ResourceAccessRangeMap *accesses, const Iterator &pos) const {
+    void operator()(const Iterator &pos) const {
         auto &access_state = pos->second;
         access_state.Update(usage, ordering_rule, tag);
-        return pos;
     }
 
     UpdateMemoryAccessStateFunctor(const AccessContext &context_, SyncStageAccessIndex usage_, SyncOrdering ordering_rule_,
@@ -1766,7 +1753,7 @@ class ApplyBarrierOpsFunctor {
         return inserted;
     }
 
-    Iterator operator()(ResourceAccessRangeMap *accesses, const Iterator &pos) const {
+    void operator()(const Iterator &pos) const {
         auto &access_state = pos->second;
         for (const auto &op : barrier_ops_) {
             op(&access_state);
@@ -1777,7 +1764,6 @@ class ApplyBarrierOpsFunctor {
             // another walk
             access_state.ApplyPendingBarriers(tag_);
         }
-        return pos;
     }
 
     // A valid tag is required IFF layout_transition is true, as transitions are write ops

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -93,3 +93,103 @@ TEST_F(PositiveBuffer, TexelBufferAlignmentIn13) {
     buff_view_ci.offset = minTexelBufferOffsetAlignment + block_size;
     CreateBufferViewTest(*this, &buff_view_ci, {});
 }
+
+TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressWorstCase) {
+    TEST_DESCRIPTION("Add elements to buffer_address_map, worst case scenario");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "Test requires at least Vulkan 1.1";
+    }
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    auto buffer_addr_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    auto features2 = GetPhysicalDeviceFeatures2(buffer_addr_features);
+    if (!buffer_addr_features.bufferDeviceAddress) {
+        GTEST_SKIP() << "bufferDeviceAddress not supported";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+
+    // Allocate common buffer memory, all buffers will be bound to it so that they have the same starting address
+    auto alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+    alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
+    VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>(&alloc_flags);
+    alloc_info.allocationSize = 100 * 4096 * 4096;
+    vk_testing::DeviceMemory buffer_memory(*m_device, alloc_info);
+
+    // Create buffers. They have the same starting offset, but a growing size.
+    // This is the worst case scenario for adding an element in the current buffer_address_map: inserted range will have to be split
+    // for every range currently in the map.
+    constexpr size_t N = 1400;
+    std::vector<VkBufferObj> buffers(N);
+    auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
+    buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    buffer_ci.size = 4096;
+    buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+
+    VkDeviceAddress ref_address = 0;
+
+    for (size_t i = 0; i < N; ++i) {
+        VkBufferObj &buffer = buffers[i];
+        buffer_ci.size = (i + 1) * 4096;
+        buffer.init_no_mem(*m_device, buffer_ci);
+        vk::BindBufferMemory(device(), buffer.handle(), buffer_memory.handle(), 0);
+        VkDeviceAddress addr = buffer.address(DeviceValidationVersion());
+        if (ref_address == 0) {
+            ref_address = addr;
+        }
+        if (addr != ref_address) {
+            GTEST_SKIP() << "At iteration " << i << ", retrieved buffer address (" << addr << ") != reference address ("
+                         << ref_address << ")";
+        }
+    }
+}
+
+TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressGoodCase) {
+    TEST_DESCRIPTION("Add elements to buffer_address_map, good case scenario");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "Test requires at least Vulkan 1.1";
+    }
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    auto buffer_addr_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    auto features2 = GetPhysicalDeviceFeatures2(buffer_addr_features);
+    if (!buffer_addr_features.bufferDeviceAddress) {
+        GTEST_SKIP() << "bufferDeviceAddress not supported";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+
+    // Allocate common buffer memory, all buffers will be bound to it so that they have the same starting address
+    auto alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+    alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
+    VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>(&alloc_flags);
+    alloc_info.allocationSize = 100 * 4096 * 4096;
+    vk_testing::DeviceMemory buffer_memory(*m_device, alloc_info);
+
+    // Create buffers. They have consecutive device address ranges, so no overlaps: no split will be needed when inserting, it
+    // should be fast.
+    constexpr size_t N = 1400;  // 100 * 4096;
+    std::vector<VkBufferObj> buffers(N);
+    auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
+    buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    buffer_ci.size = 4096;
+    buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+
+    for (size_t i = 0; i < N; ++i) {
+        VkBufferObj &buffer = buffers[i];
+        buffer.init_no_mem(*m_device, buffer_ci);
+        // Consecutive offsets
+        vk::BindBufferMemory(device(), buffer.handle(), buffer_memory.handle(), i * buffer_ci.size);
+        (void)buffer.address(DeviceValidationVersion());
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6056
Also should fix Dan G issue

Adding a buffer to `buffer_address_map_` should now work as expected (in some cases adding a buffer could fail), and be faster. 
