### PR TITLE
android: Generate valid APK from CMake binaries

### DIFF
--- a/tests/android/CMakeLists.txt
+++ b/tests/android/CMakeLists.txt
@@ -62,11 +62,7 @@ target_link_options(android_glue PUBLIC -u ANativeActivity_onCreate)
 
 target_link_libraries(vk_layer_validation_tests PRIVATE android_glue)
 
-# 'VulkanLayerValidationTests.so' needed for Android.mk backcompat
-set_target_properties(vk_layer_validation_tests PROPERTIES
-    OUTPUT_NAME "VulkanLayerValidationTests"
-    PREFIX ""
-)
+set_target_properties(vk_layer_validation_tests PROPERTIES OUTPUT_NAME "VulkanLayerValidationTests")
 
 install(TARGETS vk_layer_validation_tests DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -72,6 +72,9 @@ int fopen_s(FILE **pFile, const char *filename, const char *mode) {
 
 #endif
 
+#if !defined(VK_USE_PLATFORM_ANDROID_KHR)
+// NOTE: Android doesn't use environment variables like desktop does!
+//
 // Certain VK_* environment variables accept lists.
 // Return a vector of std::string containing each member in the list.
 //
@@ -176,12 +179,15 @@ static void CheckEnvironmentVariables() {
         std::exit(EXIT_FAILURE);
     }
 }
+#endif
 
 // Set up environment for GLSL compiler
 // Must be done once per process
 void TestEnvironment::SetUp() {
+#if !defined(VK_USE_PLATFORM_ANDROID_KHR)
     // Helps ensure common developer environment variables are set correctly
     CheckEnvironmentVariables();
+#endif
 
     // Initialize GLSL to SPV compiler utility
     glslang::InitializeProcess();


### PR DESCRIPTION
APK generated from this script successfully ran on a Pixel 3!

Fixes to make this happen:

- The name of test binary was wrong.

- Added logic to copy libc++_shared.so

- CMake build doesn't use test_framework_android.cpp and failed due to lack of environment variables.