### PR TITLE
layers: Fix shader components counting

### DIFF
--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -690,12 +690,14 @@ EntryPoint::EntryPoint(const SHADER_MODULE_STATE& module_state, const Instructio
                         if (!max_input_slot || slot.slot > max_input_slot->slot) {
                             max_input_slot = &slot;
                             max_input_slot_variable = &variable;
+                            user_input_components++;
                         }
                     } else if (variable.storage_class == spv::StorageClassOutput) {
                         output_interface_slots[slot] = &variable;
                         if (!max_output_slot || slot.slot > max_output_slot->slot) {
                             max_output_slot = &slot;
                             max_output_slot_variable = &variable;
+                            user_output_components++;
                         }
                     }
                 }

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -388,6 +388,8 @@ struct EntryPoint {
     const InterfaceSlot *max_output_slot = nullptr;
     uint32_t builtin_input_components = 0;
     uint32_t builtin_output_components = 0;
+    uint32_t user_input_components = 0;
+    uint32_t user_output_components = 0;
 
     // Mark if a BuiltIn is written to
     bool written_builtin_point_size{false};

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -490,13 +490,14 @@ TEST_F(NegativeGeometryTessellation, MaxTessellationControlInputOutputComponents
                 break;
             }
             case 1: {
-                // in and out component limit
-                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                // in and out component/location limit
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
+                                              "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
             }
             case 2: {
-                // in and out component limit
+                // in and out location limit
                 constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
@@ -609,13 +610,14 @@ TEST_F(NegativeGeometryTessellation, MaxTessellationEvaluationInputOutputCompone
                 break;
             }
             case 1: {
-                // in and out component limit
-                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                // in and out component/location limit
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
+                                              "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
             }
             case 2: {
-                // in and out component limit
+                // in and out location limit
                 constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
@@ -718,13 +720,14 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInputOutputComponents) {
                 break;
             }
             case 1: {
-                // in and out component limit
-                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                // in and out component/location limit
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
+                                              "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
             }
             case 2: {
-                // in and out component limit
+                // in and out location limit
                 constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;

--- a/tests/unit/shader_interface.cpp
+++ b/tests/unit/shader_interface.cpp
@@ -219,11 +219,12 @@ TEST_F(NegativeShaderInterface, MaxVertexOutputComponents) {
             }
             case 1: {
                 // component and location limit (maxVertexOutputComponents)
-                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-Location-06272");
+                constexpr std::array vuids = {"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"};
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vuids);
                 break;
             }
             case 2: {
-                // just component limit (maxVertexOutputComponents)
+                // just location limit (maxVertexOutputComponents)
                 CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-Location-06272");
                 break;
             }
@@ -235,7 +236,7 @@ TEST_F(NegativeShaderInterface, MaxVertexOutputComponents) {
 }
 
 TEST_F(NegativeShaderInterface, MaxComponentsBlocks) {
-    TEST_DESCRIPTION("Test if the max componenets checks are done properly when in a single block");
+    TEST_DESCRIPTION("Test if the max components checks are done properly when in a single block");
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -288,7 +289,8 @@ TEST_F(NegativeShaderInterface, MaxComponentsBlocks) {
 
     // 1 for maxVertexOutputComponents and 1 for maxFragmentInputComponents
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                      vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
+                                      vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272",
+                                                     "VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
 }
 
 TEST_F(NegativeShaderInterface, MaxFragmentInputComponents) {
@@ -343,7 +345,7 @@ TEST_F(NegativeShaderInterface, MaxFragmentInputComponents) {
             }
             case 1: {
                 // (maxFragmentInputComponents)
-                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-Location-06272");
+                CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, vector<string>{"VUID-RuntimeSpirv-Location-06272", "VUID-RuntimeSpirv-Location-06272"});
                 break;
             }
             case 2:


### PR DESCRIPTION
I'm suspecting that in function `ValidateShaderStageInputOutputLimits` in `cc_shader.cpp` determining total input/output components are not correct.

Values are taken from `Entrypoint` variable which contain data about last input and last output variable declared in shader.
That values are assigned in `EntryPoint` constructor (shader_module.cpp) by searching through `StageInteraceVariable` struct for `InterfaceSlot` with highest value of slot (Location * 4 + Component)
That method works good when variables declared in shader occupy whole location space (4 components). The issue arises when in shader variable declaration occupy less than 4 components (e.g. float).
Example:
part of shader code:
```
layout(location=0) in float vin0; // occupy location 0, component 0
layout(location=1) in vec4 vin1; // occupy location 1, components 0-3
```
max slot index = 7 (**amount of components = 8**)
After swapping locations for this variables:
```
layout(location=0) in vec4 vin0; // occupy location 0, components 0-3
layout(location=1) in float vin1; // occupy location 1, component 0
```
max slot index = 4 (**amount of components = 5**)
Difference comes from equation `slot = Location * 4 + Component`
For same variables but layered differently max slot index is changed, so I suppose that can't be used as total input/output component value.

Shaders which are used by tests inside Validation Layers have always declare `vec4` variable (and sometimes last variable as `float` to intentionally exceed limits). This cases cannot reproduce issue that I was presented.

I propose solution which is similar to count buildin components.