### PR TITLE
layers: Fix attachment feedback EXT state tracking

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5483,6 +5483,12 @@ void ValidationStateTracker::PostCallRecordCmdSetColorWriteEnableEXT(VkCommandBu
     cb_state->dynamic_state_value.color_write_enable_attachment_count = attachmentCount;
 }
 
+void ValidationStateTracker::PostCallRecordCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer,
+                                                                                 VkImageAspectFlags aspectMask) {
+    auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
+    cb_state->RecordStateCmd(CMD_SETATTACHMENTFEEDBACKLOOPENABLEEXT, CB_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
+}
+
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 void ValidationStateTracker::PostCallRecordAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
                                                                              VkResult result) {

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1166,6 +1166,7 @@ class ValidationStateTracker : public ValidationObject {
                                             const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions) override;
     void PostCallRecordCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                  const VkBool32* pColorWriteEnables) override;
+    void PostCallRecordCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer, VkImageAspectFlags aspectMask) override;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     void PostCallRecordAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain, VkResult result) override;
     void PostCallRecordReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain, VkResult result) override;

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -549,6 +549,12 @@ TEST_F(PositiveDynamicState, AttachmentFeedbackLoopEnable) {
 
     m_commandBuffer->begin();
     vk::CmdSetAttachmentFeedbackLoopEnableEXT(m_commandBuffer->handle(), VK_IMAGE_ASPECT_COLOR_BIT);
+
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(*m_commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
+    vk::CmdDraw(*m_commandBuffer, 3, 1, 0, 0);
+    m_commandBuffer->EndRenderPass();
+
     m_commandBuffer->end();
 }
 


### PR DESCRIPTION
Fix state tracking for vkCmdSetAttachmentFeedbackLoopEnableEXT.

Fixes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6092.