### PR TITLE
layers: Add write lock to protect timeline modification

### DIFF
--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -488,7 +488,7 @@ void SEMAPHORE_STATE::Retire(QUEUE_STATE *current_queue, uint64_t payload) {
 }
 
 std::shared_future<void> SEMAPHORE_STATE::Wait(uint64_t payload) {
-    auto guard = ReadLock();
+    auto guard = WriteLock();
     if (payload <= completed_.payload) {
         std::promise<void> already_done;
         auto result = already_done.get_future();


### PR DESCRIPTION
Found accidentally while working on a different sync issue. Not sure if we had actual issues because of this.