### PR TITLE
ci: Add to TSAN blacklist

### DIFF
--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -257,15 +257,17 @@ def RunVVLTests():
 
     lvt_cmd = os.path.join(TEST_INSTALL_DIR, 'bin', 'vk_layer_validation_tests')
 
-    # The following test fail with thread sanitization enabled.
+    # The following test(s) fail with thread sanitization enabled.
     failing_tsan_tests = '-VkPositiveLayerTest.QueueThreading'
     failing_tsan_tests += ':NegativeCommand.SecondaryCommandBufferRerecordedExplicitReset'
     failing_tsan_tests += ':NegativeCommand.SecondaryCommandBufferRerecordedNoReset'
     failing_tsan_tests += ':NegativeSyncVal.CopyOptimalImageHazards'
     failing_tsan_tests += ':NegativeViewportInheritance.BasicUsage'
     failing_tsan_tests += ':NegativeViewportInheritance.MultiViewport'
-    # NOTE: This test fails sporadically. Make sure to run multiple times.
+    # NOTE: These test(s) fails sporadically.
+    # These need extra care to prevent a regression in the future.
     failing_tsan_tests += ':PositiveSyncObject.WaitTimelineSemThreadRace'
+    failing_tsan_tests += ':PositiveQuery.ResetQueryPoolFromDifferentCB'
 
     RunShellCmd(lvt_cmd + f" --gtest_filter={failing_tsan_tests}", env=lvt_env)
 


### PR DESCRIPTION
PositiveQuery.ResetQueryPoolFromDifferentCB sporadically fails.

See failed run for reference:
https://github.com/KhronosGroup/Vulkan-ValidationLayers/actions/runs/5484689187/jobs/9992567221

<details>

```
[ RUN      ] PositiveQuery.ResetQueryPoolFromDifferentCB
==================
WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=8499)
  Cycle in lock order graph: M283862531850684912 (0x000000000000) => M287802992546052168 (0x000000000000) => M283862531850684912

  Mutex M287802992546052168 acquired here while holding mutex M283862531850684912 in thread T384:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x53908)
    #1 std::_Function_handler<bool (QueryObject const&), QUEUE_STATE::ThreadFunc()::{lambda(QueryObject const&)#1}>::_M_invoke(std::_Any_data const&, QueryObject const&) <null> (libVkLayer_khronos_validation.so+0x205ff1f)
    #2 CMD_BUFFER_STATE::Retire(unsigned int, std::function<bool (QueryObject const&)> const&) <null> (libVkLayer_khronos_validation.so+0x1f92818)
    #3 QUEUE_STATE::ThreadFunc() <null> (libVkLayer_khronos_validation.so+0x2062f50)
    #4 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (QUEUE_STATE::*)(), QUEUE_STATE*> > >::_M_run() <null> (libVkLayer_khronos_validation.so+0x2068c51)
    #5 <null> <null> (libstdc++.so.6+0xdc2b2)

    Hint: use TSAN_OPTIONS=second_deadlock_stack=1 to get more informative warning message

  Mutex M283862531850684912 acquired here while holding mutex M287802992546052168 in thread T384:
    #0 pthread_rwlock_wrlock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1368 (libtsan.so.0+0x3f778)
    #1 CMD_BUFFER_STATE::Destroy() <null> (libVkLayer_khronos_validation.so+0x1faa1e5)
    #2 CMD_BUFFER_STATE::~CMD_BUFFER_STATE() <null> (libVkLayer_khronos_validation.so+0x149de12)
    #3 CORE_CMD_BUFFER_STATE::~CORE_CMD_BUFFER_STATE() <null> (libVkLayer_khronos_validation.so+0x17d1a04)
    #4 std::_Sp_counted_ptr_inplace<CORE_CMD_BUFFER_STATE, std::allocator<CORE_CMD_BUFFER_STATE>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() <null> (libVkLayer_khronos_validation.so+0x17c8145)
    #5 QUEUE_STATE::ThreadFunc() <null> (libVkLayer_khronos_validation.so+0x2063a44)
    #6 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (QUEUE_STATE::*)(), QUEUE_STATE*> > >::_M_run() <null> (libVkLayer_khronos_validation.so+0x2068c51)
    #7 <null> <null> (libstdc++.so.6+0xdc2b2)

  Thread T43 (tid=8912, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:969 (libtsan.so.0+0x605b8)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xdc388)
    #2 ValidationStateTracker::PreCallRecordQueueSubmit(VkQueue_T*, unsigned int, VkSubmitInfo const*, VkFence_T*) <null> (libVkLayer_khronos_validation.so+0x20e363e)
    #3 vulkan_layer_chassis::QueueSubmit(VkQueue_T*, unsigned int, VkSubmitInfo const*, VkFence_T*) <null> (libVkLayer_khronos_validation.so+0x1893079)
    #4 vkQueueSubmit <null> (libvulkan.so+0x58b56)
    #5 PositiveQuery_ResetQueryPoolFromDifferentCB_Test::TestBody() <null> (vk_layer_validation_tests+0xcbfa9b)
    #6 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (vk_layer_validation_tests+0x16127be)
    #7 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (vk_layer_validation_tests+0x1607d00)
    #8 testing::Test::Run() <null> (vk_layer_validation_tests+0x15d7195)
    #9 testing::TestInfo::Run() <null> (vk_layer_validation_tests+0x15d7fc8)
    #10 testing::TestSuite::Run() <null> (vk_layer_validation_tests+0x15d8dcf)
    #11 testing::internal::UnitTestImpl::RunAllTests() <null> (vk_layer_validation_tests+0x15eb72d)
    #12 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) <null> (vk_layer_validation_tests+0x1614005)
    #13 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) <null> (vk_layer_validation_tests+0x1609736)
    #14 testing::UnitTest::Run() <null> (vk_layer_validation_tests+0x15e9621)
    #15 main <null> (vk_layer_validation_tests+0x4fc606)

SUMMARY: ThreadSanitizer: lock-order-inversion (potential deadlock) (/home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build/install/lib/libVkLayer_khronos_validation.so+0x205ff1f) in std::_Function_handler<bool (QueryObject const&), QUEUE_STATE::ThreadFunc()::{lambda(QueryObject const&)#1}>::_M_invoke(std::_Any_data const&, QueryObject const&)
```

</details>