### PR TITLE
build: Bump python version to 3.10

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: clang-format version
         run: clang-format --version
       - name: Execute Source Code Format Checking Script

--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -78,7 +78,7 @@ jobs:
           cmakeVersion: 3.17.2
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Install build dependencies
         run: |
           sudo apt-get -qq update
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch }}
@@ -218,7 +218,7 @@ jobs:
         - uses: actions/checkout@v3
         - uses: actions/setup-python@v4
           with:
-            python-version: '3.8'
+            python-version: '3.10'
         - name: Build
           run: python3 scripts/github_ci_android.py --abi arm64-v8a
 
@@ -231,7 +231,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - uses: lukka/get-cmake@latest
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -258,7 +258,7 @@ jobs:
           key: mingw-ccache
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - uses: lukka/get-cmake@latest
       - name: GCC Version
         run: gcc --version # If this fails MINGW is not setup correctly
@@ -284,7 +284,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - uses: lukka/get-cmake@latest
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/BUILD.md
+++ b/BUILD.md
@@ -15,7 +15,7 @@
 1. CMake >= 3.17.2
 2. C++17 compatible toolchain
 3. Git
-4. Python >= 3.8
+4. Python >= 3.10
 
 NOTE: Python is needed for working on generated code, and helping grab dependencies.
 While it's not technically required, it's practically required for most users.

--- a/scripts/generators/vulkan_object.py
+++ b/scripts/generators/vulkan_object.py
@@ -38,8 +38,8 @@ class Extension:
     provisional: bool
     promotedTo: str # ex) VK_VERSION_1_1
     deprecatedBy: str
-    obsoletedBy: str
-    specialUse: List[str]
+    obsoletedBy: (str | None)
+    specialUse: list[str]
 
     # These are here to allow for easy reverse lookups
     # Quotes allow us to forward declare the dataclass


### PR DESCRIPTION
Python 3.10 provide some helpful features around making `VulkanObject` much easier to use

Main two features

1. Can use `list` and `dict` directly without `typing` library
2. Can make fields unions, which is nice to show that some fields might be `None`