### PR TITLE
layers: Allow using uncached buffer for Debug Printf 

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -750,6 +750,26 @@
                                             }
                                         },
                                         {
+                                            "key": "printf_uncached_buffer",
+                                            "label": "Printf using uncached buffer (ALPHA)",
+                                            "description": "Use VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD(from VK_AMD_device_coherent_memory) to allocate destination buffer. Slower, but useful in case of instrumenting shader causing VK_ERROR_DEVICE_LOST.",
+                                            "type": "BOOL",
+                                            "default": false,
+                                            "platforms": [
+                                                "WINDOWS",
+                                                "LINUX"
+                                            ],
+                                            "dependence": {
+                                                "mode": "ALL",
+                                                "settings": [
+                                                    {
+                                                        "key": "validate_gpu_based",
+                                                        "value": "GPU_BASED_DEBUG_PRINTF"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
                                             "key": "printf_verbose",
                                             "label": "Printf verbose",
                                             "description": "Set the verbosity of debug printf messages",

--- a/layers/gpu_validation/gpu_utils.cpp
+++ b/layers/gpu_validation/gpu_utils.cpp
@@ -192,7 +192,8 @@ static VKAPI_ATTR void VKAPI_CALL gpuVkCmdCopyBuffer(VkCommandBuffer commandBuff
     DispatchCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
 }
 
-VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, bool use_buffer_device_address, VmaAllocator *pAllocator) {
+VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, bool use_buffer_device_address,
+                           bool use_device_coherent_memory, VmaAllocator *pAllocator) {
     VmaVulkanFunctions functions;
     VmaAllocatorCreateInfo allocator_info = {};
     allocator_info.instance = instance;
@@ -201,6 +202,10 @@ VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical_device
 
     if (use_buffer_device_address) {
         allocator_info.flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
+    }
+
+    if (use_device_coherent_memory) {
+        allocator_info.flags |= VMA_ALLOCATOR_CREATE_AMD_DEVICE_COHERENT_MEMORY_BIT;
     }
 
     functions.vkGetInstanceProcAddr = static_cast<PFN_vkGetInstanceProcAddr>(gpuVkGetInstanceProcAddr);
@@ -373,7 +378,8 @@ void GpuAssistedBase::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
     }
     desc_set_bind_index = adjusted_max_desc_sets - 1;
 
-    VkResult result1 = UtilInitializeVma(instance, physical_device, device, force_buffer_device_address, &vmaAllocator);
+    VkResult result1 = UtilInitializeVma(instance, physical_device, device, force_buffer_device_address,
+                                         force_device_coherent_memory, &vmaAllocator);
     assert(result1 == VK_SUCCESS);
     desc_set_manager = std::make_unique<UtilDescriptorSetManager>(device, static_cast<uint32_t>(bindings_.size()));
 

--- a/layers/gpu_validation/gpu_utils.h
+++ b/layers/gpu_validation/gpu_utils.h
@@ -79,7 +79,7 @@ VALSTATETRACK_DERIVED_STATE_OBJECT(VkQueue, gpu_utils_state::Queue, QUEUE_STATE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, gpu_utils_state::CommandBuffer, CMD_BUFFER_STATE)
 
 VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device, bool use_buffer_device_address,
-                           VmaAllocator *pAllocator);
+                           bool use_device_coherent_memory, VmaAllocator *pAllocator);
 
 void UtilGenerateStageMessage(const uint32_t *debug_record, std::string &msg);
 void UtilGenerateCommonMessage(const debug_report_data *report_data, const VkCommandBuffer commandBuffer,
@@ -216,6 +216,7 @@ class GpuAssistedBase : public ValidationStateTracker {
   public:
     bool aborted = false;
     bool force_buffer_device_address;
+    bool force_device_coherent_memory = false;
     PFN_vkSetDeviceLoaderData vkSetDeviceLoaderData;
     const char *setup_vuid;
     VkPhysicalDeviceFeatures supported_features{};

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -53,6 +53,8 @@ const char *SETTING_CUSTOM_STYPE_LIST = "custom_stype_list";
 const char *SETTING_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
 const char *SETTING_FINE_GRAINED_LOCKING = "fine_grained_locking";
 
+const char *SETTING_DEBUG_PRINTF_UNCACHED_BUFFER = "printf_uncached_buffer";
+
 // Set the local disable flag for the appropriate VALIDATION_CHECK_DISABLE enum
 void SetValidationDisable(CHECK_DISABLED &disable_data, const ValidationCheckDisables disable_id) {
     switch (disable_id) {
@@ -373,6 +375,11 @@ static std::string GetConfigValue(const char *setting) {
     return getLayerOption(key.c_str());
 }
 
+static void SetConfigValue(const char *setting, const char* value) {
+    const std::string key(GetSettingKey(setting));
+    return setLayerOption(key.c_str(), value);
+}
+
 static std::string GetEnvVarValue(const char *setting) {
     std::string env_var = setting;
     vvl::ToUpper(env_var);
@@ -438,6 +445,8 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
                 CreateFilterMessageIdList(data, ",", settings_data->message_filter_list);
             } else if (name == SETTING_DUPLICATE_MESSAGE_LIMIT) {
                 *settings_data->duplicate_message_limit = cur_setting.data.value32;
+            } else if ((name == SETTING_DEBUG_PRINTF_UNCACHED_BUFFER) && cur_setting.data.valueBool) {
+                SetConfigValue(SETTING_DEBUG_PRINTF_UNCACHED_BUFFER, "true");
             } else if (name == SETTING_CUSTOM_STYPE_LIST) {
                 if (cur_setting.type == VK_LAYER_SETTING_VALUE_TYPE_STRING_ARRAY_EXT) {
                     std::string data(cur_setting.data.arrayString.pCharArray);

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -280,7 +280,7 @@ class VkGpuAssistedLayerTest : public VkLayerTest {
 
 class NegativeDebugPrintf : public VkLayerTest {
   public:
-    void InitDebugPrintfFramework();
+    void InitDebugPrintfFramework(bool use_uncached_buffer = false);
 
   protected:
 };

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -1182,10 +1182,11 @@ TEST_F(NegativeDebugPrintf, UncachedBuffer) {
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, message);
 
     err = vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
-    ASSERT_TRUE((err == VK_SUCCESS) || (err == VK_ERROR_DEVICE_LOST)) << vk_result_string(err);
+    // Some drivers return VK_TIMEOUT (spec does not allow it).
+    ASSERT_TRUE((err == VK_SUCCESS) || (err == VK_ERROR_DEVICE_LOST) || (err == VK_TIMEOUT)) << vk_result_string(err);
     if (err == VK_SUCCESS) {
         err = vk::QueueWaitIdle(m_device->m_queue);
-        ASSERT_TRUE((err == VK_SUCCESS) || (err == VK_ERROR_DEVICE_LOST)) << vk_result_string(err);
+        ASSERT_TRUE((err == VK_SUCCESS) || (err == VK_ERROR_DEVICE_LOST) || (err == VK_TIMEOUT)) << vk_result_string(err);
     }
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -1101,7 +1101,7 @@ TEST_F(NegativeDebugPrintf, UncachedBuffer) {
 
     // deviceCoherentMemory feature needs to be supported, but if not specified or enabled, Debug Printf will force enable it.
     auto dcm_features = LvlInitStruct<VkPhysicalDeviceCoherentMemoryFeaturesAMD>();
-    auto features2 = GetPhysicalDeviceFeatures2(dcm_features);
+    GetPhysicalDeviceFeatures2(dcm_features);
     if (dcm_features.deviceCoherentMemory == 0) {
         GTEST_SKIP() << "deviceCoherentMemory feature not supported";
     }
@@ -1121,13 +1121,6 @@ TEST_F(NegativeDebugPrintf, UncachedBuffer) {
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
-    // Make a uniform buffer to be passed to the shader that contains the test number
-    uint32_t qfi = 0;
-    VkBufferCreateInfo bci = LvlInitStruct<VkBufferCreateInfo>();
-    bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    bci.size = 8;
-    bci.queueFamilyIndexCount = 1;
-    bci.pQueueFamilyIndices = &qfi;
 
     VkPushConstantRange push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(float) * 4};
 


### PR DESCRIPTION
Adds option to force using AMD_DEVICE_COHERENT_MEMORY for debug printf buffer to print messages even if VK_ERROR_DEVICE_LOST is encountered.

Forcing extension and device feature if not enabled by application.

Added workaround for atomic operations in
uncached memory being in cache anyway.

Added workaround to failing MapMemory after DEVICE_LOST (occurs on AMD): When using uncached buffer, do not unmap buffer until messages are analyzed.

This PR attempts to implement #6101 Tested on AMD and Intel (extension not public yet) using this modified vkcube: https://github.com/dorian-apanel-intel/Vulkan-Tools/commit/e0226930a7958bb4964428691dd1376c3447bca3
