### PR TITLE
Improve message for 02251

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -218,9 +218,17 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         if (!LvlFindInChain<VkExternalFormatANDROID>(pCreateInfo->pNext)) {
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
             skip |= LogError(device, "VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251",
-                             "vkCreateImage(): Format %s is not supported for this combination of parameters and "
-                             "VkGetPhysicalDeviceImageFormatProperties returned back %s.",
-                             string_VkFormat(pCreateInfo->format), string_VkResult(result));
+                             "vkCreateImage(): The following parameters -\n"
+                             "format (%s)\n"
+                             "type (%s)\n"
+                             "tiling (%s)\n"
+                             "usage (%s)\n"
+                             "flags (%s)\n"
+                             "returned a non-success result (%s) when calling VkGetPhysicalDeviceImageFormatProperties (which "
+                             "makes all things undefined).",
+                             string_VkFormat(pCreateInfo->format), string_VkImageType(pCreateInfo->imageType),
+                             string_VkImageTiling(pCreateInfo->tiling), string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
+                             string_VkImageCreateFlags(pCreateInfo->flags).c_str(), string_VkResult(result));
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -217,6 +217,9 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         if (!LvlFindInChain<VkExternalFormatANDROID>(pCreateInfo->pNext)) {
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
+            const char *dispatchFunction = IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)
+                                               ? "VkGetPhysicalDeviceImageFormatProperties2"
+                                               : "VkGetPhysicalDeviceImageFormatProperties";
             skip |= LogError(device, "VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251",
                              "vkCreateImage(): The following parameters -\n"
                              "format (%s)\n"
@@ -224,11 +227,10 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                              "tiling (%s)\n"
                              "usage (%s)\n"
                              "flags (%s)\n"
-                             "returned a non-success result (%s) when calling VkGetPhysicalDeviceImageFormatProperties (which "
-                             "makes all things undefined).",
+                             "returned (%s) when calling %s.",
                              string_VkFormat(pCreateInfo->format), string_VkImageType(pCreateInfo->imageType),
                              string_VkImageTiling(pCreateInfo->tiling), string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
-                             string_VkImageCreateFlags(pCreateInfo->flags).c_str(), string_VkResult(result));
+                             string_VkImageCreateFlags(pCreateInfo->flags).c_str(), string_VkResult(result), dispatchFunction);
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -6322,3 +6322,22 @@ TEST_F(NegativeImage, ComputeImageLayout11) {
     m_commandBuffer->QueueCommandBuffer(false);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeImage, GetPhysicalDeviceImageFormatProperties) {
+    TEST_DESCRIPTION("fail a call to GetPhysicalDeviceImageFormatProperties");
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    // VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 is a hardcoded format that is known to fail in MockICD
+    if (!IsPlatform(kMockICD)) {
+        GTEST_SKIP() << "Test only supported by MockICD";
+    }
+    if (!ImageFormatAndFeaturesSupported(gpu(), VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, VK_IMAGE_TILING_OPTIMAL,
+                                         VK_IMAGE_USAGE_STORAGE_BIT)) {
+        GTEST_SKIP() << "Required formats/features not supported";
+    }
+
+    VkImageObj image(m_device);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251");
+    image.Init(128, 128, 1, VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, VK_IMAGE_USAGE_STORAGE_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6134

If you take a deep look you find `02251` VU indeed is just a VERY complex way of saying `vkGetPhysicalDeviceImageFormatProperties` must be `VK_SUCCESS`

This improves it and adds a test (didn't have one because its hard to guarantee the result to be non-success)

> Validation Error: [ VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251 ] Object 0: handle = 0x56229a852780, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xbebcae79 | vkCreateImage(): The following parameters -
format (VK_FORMAT_E5B9G9R9_UFLOAT_PACK32)
type (VK_IMAGE_TYPE_2D)
tiling (VK_IMAGE_TILING_OPTIMAL)
usage (VK_IMAGE_USAGE_STORAGE_BIT)
flags (VkImageCreateFlags(0))
returned a non-success result (VK_ERROR_FORMAT_NOT_SUPPORTED) when calling VkGetPhysicalDeviceImageFormatProperties (which makes all things undefined). The Vulkan spec states: Each of the following values (as described in Image Creation Limits) must not be undefined : imageCreateMaxMipLevels, imageCreateMaxArrayLayers, imageCreateMaxExtent, and imageCreateSampleCounts (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251)`