### PR TITLE
sync: Fix semaphore wait timeout

### DIFF
--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -508,7 +508,9 @@ void SEMAPHORE_STATE::NotifyAndWait(uint64_t payload) {
     if (scope_ == kSyncScopeInternal) {
         Notify(payload);
         auto waiter = Wait(payload);
+        dev_data_.BeginBlockingOperation();
         auto result = waiter.wait_until(GetCondWaitTimeout());
+        dev_data_.EndBlockingOperation();
         if (result != std::future_status::ready) {
             dev_data_.LogError(Handle(), "UNASSIGNED-VkSemaphore-state-timeout",
                                "Timeout waiting for timeline semaphore state to update. This is most likely a validation bug."

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -4557,7 +4557,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValue(
     }
     VkResult result = DispatchGetSemaphoreCounterValue(device, semaphore, pValue);
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordGetSemaphoreCounterValue]) {
-        auto lock = intercept->WriteLock();
+        WriteLockGuard lock;
+        intercept->GetWriteLockForBlockingOperation(lock);
         intercept->PostCallRecordGetSemaphoreCounterValue(device, semaphore, pValue, result);
     }
     return result;
@@ -4580,7 +4581,8 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphores(
     }
     VkResult result = DispatchWaitSemaphores(device, pWaitInfo, timeout);
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordWaitSemaphores]) {
-        auto lock = intercept->WriteLock();
+        WriteLockGuard lock;
+        intercept->GetWriteLockForBlockingOperation(lock);
         intercept->PostCallRecordWaitSemaphores(device, pWaitInfo, timeout, result);
     }
     return result;
@@ -7901,7 +7903,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValueKHR(
     }
     VkResult result = DispatchGetSemaphoreCounterValueKHR(device, semaphore, pValue);
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordGetSemaphoreCounterValueKHR]) {
-        auto lock = intercept->WriteLock();
+        WriteLockGuard lock;
+        intercept->GetWriteLockForBlockingOperation(lock);
         intercept->PostCallRecordGetSemaphoreCounterValueKHR(device, semaphore, pValue, result);
     }
     return result;
@@ -7924,7 +7927,8 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphoresKHR(
     }
     VkResult result = DispatchWaitSemaphoresKHR(device, pWaitInfo, timeout);
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordWaitSemaphoresKHR]) {
-        auto lock = intercept->WriteLock();
+        WriteLockGuard lock;
+        intercept->GetWriteLockForBlockingOperation(lock);
         intercept->PostCallRecordWaitSemaphoresKHR(device, pWaitInfo, timeout, result);
     }
     return result;

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -3785,6 +3785,33 @@ class ValidationObject {
             return WriteLockGuard(validation_object_mutex);
         }
 
+        // If the Record phase calls a function that blocks, we might need to release
+        // the lock that protects Record itself in order to avoid mutual waiting.
+        WriteLockGuard* record_guard = nullptr;
+
+        // Should be used instead of WriteLock() if the Record phase wants to release
+        // its lock during the blocking operation.
+        void GetWriteLockForBlockingOperation(WriteLockGuard& write_lock) {
+            write_lock = WriteLock();
+            // Initialize record_guard only when Record is actually protected by the
+            // mutex. It's not the case when fine grained locking is enabled.
+            record_guard = write_lock.owns_lock() ? &write_lock : nullptr;
+        }
+
+        // The following Begin/End methods should be called during the Record phase
+        // around blocking operation that causes mutual waiting (deadlock).
+        void BeginBlockingOperation() {
+            if (record_guard) {
+                record_guard->unlock();
+            }
+        }
+        void EndBlockingOperation() {
+            if (record_guard) {
+                record_guard->lock();
+                record_guard = nullptr;
+            }
+        }
+
         ValidationObject* GetValidationObject(std::vector<ValidationObject*>& object_dispatch, LayerObjectTypeId object_type) {
             for (auto validation_object : object_dispatch) {
                 if (validation_object->container_type == object_type) {


### PR DESCRIPTION
Fixes `vkWaitSemaphores` timeouts while waiting for `vkSignalSemaphore` https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4968#issuecomment-1613006858

Also fixes the same issue but for `vkGetSemaphoreCounterValue` <-> `vkSignalSemaphore` combination.

Potentially fixes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4968

The root cause is that some commands perform blocking operations inside `Record` (ex. vkWaitSemaphores can't return until a signal is processed). `Record` calls themselves are protected by a mutex (except the case of fine grained locking). If the waiting condition of the blocked thread depends on another thread executing `Record` to update some state, this creates a deadlock. During a blocking operation, there's no need to keep the validation object locked (blocked thread can't modify state), so we can pass exclusive ownership to other threads. After the wait is completed, the lock is re-acquired again.

Validation objects that use fine grained locking do not have this issue. That's why repro case is implemented for SyncVal which does not use fine grained locking.
