### PR TITLE
Add alphaToCoverageEnabled VUs

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -114,6 +114,7 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDraw-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDraw-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDraw-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDraw-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDraw-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDraw-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDraw-firstAttachment-07476";
@@ -269,6 +270,7 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawMultiEXT-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawMultiEXT-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawMultiEXT-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawMultiEXT-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawMultiEXT-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawMultiEXT-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawMultiEXT-firstAttachment-07476";
@@ -425,6 +427,7 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawIndexed-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawIndexed-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawIndexed-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawIndexed-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawIndexed-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawIndexed-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawIndexed-firstAttachment-07476";
@@ -581,6 +584,7 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawMultiIndexedEXT-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawMultiIndexedEXT-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawMultiIndexedEXT-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawMultiIndexedEXT-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawMultiIndexedEXT-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawMultiIndexedEXT-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawMultiIndexedEXT-firstAttachment-07476";
@@ -738,6 +742,7 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawIndirect-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawIndirect-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawIndirect-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawIndirect-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawIndirect-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawIndirect-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawIndirect-firstAttachment-07476";
@@ -896,6 +901,7 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawIndexedIndirect-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawIndexedIndirect-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawIndexedIndirect-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawIndexedIndirect-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawIndexedIndirect-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawIndexedIndirect-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawIndexedIndirect-firstAttachment-07476";
@@ -1138,6 +1144,7 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawIndirectCount-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawIndirectCount-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawIndirectCount-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawIndirectCount-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawIndirectCount-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawIndirectCount-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawIndirectCount-firstAttachment-07476";
@@ -1299,6 +1306,7 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawIndexedIndirectCount-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawIndexedIndirectCount-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawIndexedIndirectCount-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawIndexedIndirectCount-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawIndexedIndirectCount-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawIndexedIndirectCount-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawIndexedIndirectCount-firstAttachment-07476";
@@ -1609,6 +1617,7 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawMeshTasksNV-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawMeshTasksNV-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawMeshTasksNV-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawMeshTasksNV-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawMeshTasksNV-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawMeshTasksNV-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawMeshTasksNV-firstAttachment-07476";
@@ -1758,6 +1767,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawMeshTasksIndirectNV-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawMeshTasksIndirectNV-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawMeshTasksIndirectNV-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawMeshTasksIndirectNV-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawMeshTasksIndirectNV-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawMeshTasksIndirectNV-firstAttachment-07476";
@@ -1910,6 +1920,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawMeshTasksIndirectCountNV-firstAttachment-07476";
@@ -2056,6 +2067,7 @@ struct DispatchVuidsCmdDrawMeshTasksEXT: DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawMeshTasksEXT-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawMeshTasksEXT-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawMeshTasksEXT-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawMeshTasksEXT-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawMeshTasksEXT-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawMeshTasksEXT-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawMeshTasksEXT-firstAttachment-07476";
@@ -2205,6 +2217,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectEXT: DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawMeshTasksIndirectEXT-firstAttachment-07476";
@@ -2357,6 +2370,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountEXT : DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-firstAttachment-07476";
@@ -2514,6 +2528,7 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         dynamic_rasterization_samples_07622      = "VUID-vkCmdDrawIndirectByteCountEXT-None-07622";
         dynamic_sample_mask_07623                = "VUID-vkCmdDrawIndirectByteCountEXT-None-07623";
         dynamic_alpha_to_coverage_enable_07624   = "VUID-vkCmdDrawIndirectByteCountEXT-None-07624";
+        dynamic_alpha_to_coverage_component_08919 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08919";
         dynamic_alpha_to_one_enable_07625        = "VUID-vkCmdDrawIndirectByteCountEXT-None-07625";
         dynamic_logic_op_enable_07626            = "VUID-vkCmdDrawIndirectByteCountEXT-None-07626";
         dynamic_color_blend_enable_07476         = "VUID-vkCmdDrawIndirectByteCountEXT-firstAttachment-07476";

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2544,7 +2544,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &last_boun
             ValidatePipelineRenderpassDraw(last_bound_state, cmd_type);
         }
 
-        if (pipeline.fragment_output_state && pipeline.fragment_output_state->dual_source_blending) {
+        if (pipeline.DualSourceBlending()) {
             uint32_t count =
                 cb_state.activeRenderPass->UsesDynamicRendering()
                     ? cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.colorAttachmentCount
@@ -2560,46 +2560,44 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &last_boun
         }
     }
 
-        bool primitives_generated_query_with_rasterizer_discard =
-            enabled_features.primitives_generated_query_features.primitivesGeneratedQueryWithRasterizerDiscard == VK_TRUE;
-        bool primitives_generated_query_with_non_zero_streams =
-            enabled_features.primitives_generated_query_features.primitivesGeneratedQueryWithNonZeroStreams == VK_TRUE;
-        if (!primitives_generated_query_with_rasterizer_discard || !primitives_generated_query_with_non_zero_streams) {
-            bool primitives_generated_query = false;
-            for (const auto &query : cb_state.activeQueries) {
-                auto query_pool_state = Get<QUERY_POOL_STATE>(query.pool);
-                if (query_pool_state && query_pool_state->createInfo.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
-                    primitives_generated_query = true;
-                    break;
-                }
+    bool primitives_generated_query_with_rasterizer_discard =
+        enabled_features.primitives_generated_query_features.primitivesGeneratedQueryWithRasterizerDiscard == VK_TRUE;
+    bool primitives_generated_query_with_non_zero_streams =
+        enabled_features.primitives_generated_query_features.primitivesGeneratedQueryWithNonZeroStreams == VK_TRUE;
+    if (!primitives_generated_query_with_rasterizer_discard || !primitives_generated_query_with_non_zero_streams) {
+        bool primitives_generated_query = false;
+        for (const auto &query : cb_state.activeQueries) {
+            auto query_pool_state = Get<QUERY_POOL_STATE>(query.pool);
+            if (query_pool_state && query_pool_state->createInfo.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
+                primitives_generated_query = true;
+                break;
             }
-            const auto rp_state = pipeline.RasterizationState();
-            if (primitives_generated_query) {
-                if (!primitives_generated_query_with_rasterizer_discard && rp_state &&
-                    rp_state->rasterizerDiscardEnable == VK_TRUE) {
+        }
+        const auto rp_state = pipeline.RasterizationState();
+        if (primitives_generated_query) {
+            if (!primitives_generated_query_with_rasterizer_discard && rp_state && rp_state->rasterizerDiscardEnable == VK_TRUE) {
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                skip |= LogError(objlist, vuid.primitives_generated_06708,
+                                 "%s: a VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT query is active and pipeline was created with "
+                                 "VkPipelineRasterizationStateCreateInfo::rasterizerDiscardEnable set to VK_TRUE, but  "
+                                 "primitivesGeneratedQueryWithRasterizerDiscard feature is not enabled.",
+                                 caller);
+            }
+            if (!primitives_generated_query_with_non_zero_streams) {
+                const auto rasterization_state_stream_ci =
+                    LvlFindInChain<VkPipelineRasterizationStateStreamCreateInfoEXT>(rp_state->pNext);
+                if (rasterization_state_stream_ci && rasterization_state_stream_ci->rasterizationStream != 0) {
                     const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
-                    skip |= LogError(objlist, vuid.primitives_generated_06708,
-                                     "%s: a VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT query is active and pipeline was created with "
-                                     "VkPipelineRasterizationStateCreateInfo::rasterizerDiscardEnable set to VK_TRUE, but  "
-                                     "primitivesGeneratedQueryWithRasterizerDiscard feature is not enabled.",
-                                     caller);
-                }
-                if (!primitives_generated_query_with_non_zero_streams) {
-                    const auto rasterization_state_stream_ci =
-                        LvlFindInChain<VkPipelineRasterizationStateStreamCreateInfoEXT>(rp_state->pNext);
-                    if (rasterization_state_stream_ci && rasterization_state_stream_ci->rasterizationStream != 0) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
-                        skip |=
-                            LogError(objlist, vuid.primitives_generated_streams_06709,
+                    skip |= LogError(objlist, vuid.primitives_generated_streams_06709,
                                      "%s: a VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT query is active and pipeline was created with "
                                      "VkPipelineRasterizationStateStreamCreateInfoEXT::rasterizationStream set to %" PRIu32
                                      ", but  "
                                      "primitivesGeneratedQueryWithNonZeroStreams feature is not enabled.",
                                      caller, rasterization_state_stream_ci->rasterizationStream);
-                    }
                 }
             }
         }
+    }
 
     // Verify vertex & index buffer for unprotected command buffer.
     // Because vertex & index buffer is read only, it doesn't need to care protected command buffer case.
@@ -2827,6 +2825,25 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &last_boun
 
     if (enabled_features.fragment_shading_rate_features.primitiveFragmentShadingRate) {
         skip |= ValidateGraphicsPipelineShaderDynamicState(pipeline, cb_state, caller, vuid);
+    }
+
+    if (pipeline.IsDynamic(VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT) &&
+        cb_state.dynamic_state_value.alpha_to_coverage_enable) {
+        if (pipeline.fragment_shader_state && pipeline.fragment_shader_state->fragment_shader) {
+            std::shared_ptr<const SHADER_MODULE_STATE> module_state = pipeline.fragment_shader_state->fragment_shader;
+            const safe_VkPipelineShaderStageCreateInfo *stage_ci = pipeline.fragment_shader_state->fragment_shader_ci.get();
+            auto entrypoint = module_state->FindEntrypoint(stage_ci->pName, stage_ci->stage);
+
+            // TODO - DualSource blend has two outputs at location zero, so Index == 0 is the one that's required.
+            // Currently lack support to test each index.
+            if (entrypoint && !entrypoint->has_alpha_to_coverage_variable && !pipeline.DualSourceBlending()) {
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                skip |= LogError(objlist, vuid.dynamic_alpha_to_coverage_component_08919,
+                                 "%s(): vkCmdSetAlphaToCoverageEnableEXT set alphaToCoverageEnable to true but the bound pipeline "
+                                 "fragment shader doesn't declare a variable that covers Location 0, Component 3.",
+                                 caller);
+            }
+        }
     }
 
     return skip;

--- a/layers/core_checks/cc_shader.cpp
+++ b/layers/core_checks/cc_shader.cpp
@@ -32,8 +32,8 @@
 #include "generated/spirv_grammar_helper.h"
 #include "external/xxhash.h"
 
-bool CoreChecks::ValidateViAgainstVsInputs(const PIPELINE_STATE &pipeline, const SHADER_MODULE_STATE &module_state,
-                                           const EntryPoint &entrypoint) const {
+bool CoreChecks::ValidateInterfaceVertexInput(const PIPELINE_STATE &pipeline, const SHADER_MODULE_STATE &module_state,
+                                              const EntryPoint &entrypoint) const {
     bool skip = false;
     safe_VkPipelineVertexInputStateCreateInfo const *vi = pipeline.vertex_input_state->input_state;
 
@@ -139,6 +139,23 @@ bool CoreChecks::ValidateViAgainstVsInputs(const PIPELINE_STATE &pipeline, const
         }
     }
 
+    return skip;
+}
+
+bool CoreChecks::ValidateInterfaceFragmentOutput(const PIPELINE_STATE &pipeline, const SHADER_MODULE_STATE &module_state,
+                                                 const EntryPoint &entrypoint) const {
+    bool skip = false;
+    const auto *ms_state = pipeline.MultisampleState();
+    if (!pipeline.IsDynamic(VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT) && ms_state && ms_state->alphaToCoverageEnable) {
+        // TODO - DualSource blend has two outputs at location zero, so Index == 0 is the one that's required.
+        // Currently lack support to test each index.
+        if (!entrypoint.has_alpha_to_coverage_variable && !pipeline.DualSourceBlending()) {
+            skip |= LogError(module_state.vk_shader_module(), "VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891",
+                             "vkCreateGraphicsPipelines(): alphaToCoverageEnable is set, but pCreateInfos[%" PRIu32
+                             "] fragment shader doesn't declare a variable that covers Location 0, Component 3.",
+                             pipeline.create_index);
+        }
+    }
     return skip;
 }
 
@@ -3249,7 +3266,12 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const PIPELINE_STATE &pipel
 
     if (pipeline.vertex_input_state && vertex_stage && vertex_stage->entrypoint && vertex_stage->module_state->has_valid_spirv &&
         !pipeline.IsDynamic(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT)) {
-        skip |= ValidateViAgainstVsInputs(pipeline, *vertex_stage->module_state.get(), *vertex_stage->entrypoint);
+        skip |= ValidateInterfaceVertexInput(pipeline, *vertex_stage->module_state.get(), *vertex_stage->entrypoint);
+    }
+
+    if (pipeline.fragment_shader_state && fragment_stage && fragment_stage->entrypoint &&
+        fragment_stage->module_state->has_valid_spirv) {
+        skip |= ValidateInterfaceFragmentOutput(pipeline, *fragment_stage->module_state.get(), *fragment_stage->entrypoint);
     }
 
     for (size_t i = 1; i < pipeline.stage_states.size(); i++) {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -133,6 +133,7 @@ struct DrawDispatchVuid {
     const char* dynamic_rasterization_samples_07622 = kVUIDUndefined;
     const char* dynamic_sample_mask_07623 = kVUIDUndefined;
     const char* dynamic_alpha_to_coverage_enable_07624 = kVUIDUndefined;
+    const char* dynamic_alpha_to_coverage_component_08919 = kVUIDUndefined;
     const char* dynamic_alpha_to_one_enable_07625 = kVUIDUndefined;
     const char* dynamic_logic_op_enable_07626 = kVUIDUndefined;
     const char* dynamic_color_blend_enable_07476 = kVUIDUndefined;
@@ -906,8 +907,10 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateAtomicsTypes(const SHADER_MODULE_STATE& module_state) const;
     bool ValidateExecutionModes(const SHADER_MODULE_STATE& module_state, const EntryPoint& entrypoint, VkShaderStageFlagBits stage,
                                 const PIPELINE_STATE& pipeline) const;
-    bool ValidateViAgainstVsInputs(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
-                                   const EntryPoint& entrypoint) const;
+    bool ValidateInterfaceVertexInput(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
+                                      const EntryPoint& entrypoint) const;
+    bool ValidateInterfaceFragmentOutput(const PIPELINE_STATE& pipeline, const SHADER_MODULE_STATE& module_state,
+                                         const EntryPoint& entrypoint) const;
     bool ValidateShaderInputAttachment(const SHADER_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline,
                                        const ResourceInterfaceVariable& variable) const;
     bool ValidateConservativeRasterization(const SHADER_MODULE_STATE& module_state, const EntryPoint& entrypoint,

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -217,6 +217,8 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
         bool stippled_line_enable;
         // VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE
         bool rasterizer_discard_enable;
+        // VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT
+        bool alpha_to_coverage_enable;
 
         uint32_t color_write_enable_attachment_count;
 

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -385,6 +385,13 @@ class PIPELINE_STATE : public BASE_NODE {
         return false;
     }
 
+    bool DualSourceBlending() const {
+        if (fragment_output_state) {
+            return fragment_output_state->dual_source_blending == VK_TRUE;
+        }
+        return false;
+    }
+
     const safe_VkPipelineViewportStateCreateInfo *ViewportState() const {
         // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
         if (pre_raster_state) {

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -697,6 +697,9 @@ EntryPoint::EntryPoint(const SHADER_MODULE_STATE& module_state, const Instructio
                             max_output_slot = &slot;
                             max_output_slot_variable = &variable;
                         }
+                        if (slot.Location() == 0 && slot.Component() == 3) {
+                            has_alpha_to_coverage_variable = true;
+                        }
                     }
                 }
             }

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -396,6 +396,7 @@ struct EntryPoint {
     bool written_builtin_viewport_mask_nv{false};
 
     bool has_passthrough{false};
+    bool has_alpha_to_coverage_variable{false};  // only for Fragment shaders
 
     EntryPoint(const SHADER_MODULE_STATE &module_state, const Instruction &entrypoint_insn, const ImageAccessMap &image_access_map);
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5561,6 +5561,7 @@ void ValidationStateTracker::PostCallRecordCmdSetAlphaToCoverageEnableEXT(VkComm
                                                                           VkBool32 alphaToCoverageEnable) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     cb_state->RecordStateCmd(CMD_SETALPHATOCOVERAGEENABLEEXT, CB_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT);
+    cb_state->dynamic_state_value.alpha_to_coverage_enable = alphaToCoverageEnable;
 }
 
 void ValidationStateTracker::PostCallRecordCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToOneEnable) {

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -330,7 +330,11 @@ class DynamicRenderingTest : public VkLayerTest {
 class NegativeDynamicRendering : public DynamicRenderingTest {};
 class PositiveDynamicRendering : public DynamicRenderingTest {};
 
-class DynamicStateTest : public VkLayerTest {};
+class DynamicStateTest : public VkLayerTest {
+  public:
+    void InitBasicExtendedDynamicState();  // enables VK_EXT_extended_dynamic_state
+    void InitBasicExtendedDynamicState3(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT &features);
+};
 class NegativeDynamicState : public DynamicStateTest {
     // helper functions for tests in this file
   public:
@@ -341,10 +345,7 @@ class NegativeDynamicState : public DynamicStateTest {
     // VK_EXT_line_rasterization - Init with LineRasterization features off
     void InitLineRasterizationFeatureDisabled();
 };
-class PositiveDynamicState : public DynamicStateTest {
-  public:
-    void InitBasicExtendedDynamicState();  // enables VK_EXT_extended_dynamic_state
-};
+class PositiveDynamicState : public DynamicStateTest {};
 
 class ExternalMemorySyncTest : public VkLayerTest {
   public:

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -1037,3 +1037,55 @@ TEST_F(PositiveShaderInterface, NestedStructs) {
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
+
+TEST_F(PositiveShaderInterface, AlphaToCoverageOffsetToAlpha) {
+    TEST_DESCRIPTION("Only set the needed component and nothing else.");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget(0u));
+
+    char const *fsSource = R"glsl(
+        #version 450
+        layout(location=0, component = 3) out float x;
+        void main(){
+            x = 1.0;
+        }
+    )glsl";
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    VkPipelineMultisampleStateCreateInfo ms_state_ci = LvlInitStruct<VkPipelineMultisampleStateCreateInfo>();
+    ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+    ms_state_ci.alphaToCoverageEnable = VK_TRUE;
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+        helper.pipe_ms_state_ci_ = ms_state_ci;
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+}
+
+TEST_F(PositiveShaderInterface, AlphaToCoverageArray) {
+    TEST_DESCRIPTION("Have array out outputs");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget(0u));
+
+    char const *fsSource = R"glsl(
+        #version 450
+        // Just need to declare variable
+        layout(location=0) out vec4 fragData[4];
+        void main() {
+        }
+    )glsl";
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    VkPipelineMultisampleStateCreateInfo ms_state_ci = LvlInitStruct<VkPipelineMultisampleStateCreateInfo>();
+    ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+    ms_state_ci.alphaToCoverageEnable = VK_TRUE;
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+        helper.pipe_ms_state_ci_ = ms_state_ci;
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+}


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5520

this adds `VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891` and `VUID-vkCmdDraw-alphaToCoverageEnable-08919`