### PR TITLE
layers: Remove manual logic for extensions with 2 properties

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1619,8 +1619,7 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
                                    &phys_dev_props->subgroup_size_control_props);
     GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_qcom_image_processing, &phys_dev_props->image_processing_props);
     GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_descriptor_buffer, &phys_dev_props->descriptor_buffer_props);
-    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_descriptor_buffer_density,
-                                   &phys_dev_props->descriptor_buffer_density_props);
+    GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_descriptor_buffer, &phys_dev_props->descriptor_buffer_density_props);
     if (api_version >= VK_API_VERSION_1_1) {
         GetPhysicalDeviceExtProperties(physical_device, &phys_dev_props->subgroup_props);
     }

--- a/layers/vulkan/generated/vk_extension_helper.h
+++ b/layers/vulkan/generated/vk_extension_helper.h
@@ -155,7 +155,6 @@ struct InstanceExtensions {
     ExtEnabled vk_qnx_screen_surface{kNotEnabled};
     ExtEnabled vk_google_surfaceless_query{kNotEnabled};
     ExtEnabled vk_lunarg_direct_driver_loading{kNotEnabled};
-    ExtEnabled vk_ext_descriptor_buffer_density{kNotEnabled};
 
     struct InstanceReq {
         const ExtEnabled InstanceExtensions::* enabled;
@@ -704,7 +703,6 @@ struct DeviceExtensions : public InstanceExtensions {
     ExtEnabled vk_khr_ray_tracing_pipeline{kNotEnabled};
     ExtEnabled vk_khr_ray_query{kNotEnabled};
     ExtEnabled vk_ext_mesh_shader{kNotEnabled};
-    ExtEnabled vk_ext_descriptor_buffer_density{kNotEnabled};
 
     struct DeviceReq {
         const ExtEnabled DeviceExtensions::* enabled;

--- a/scripts/generators/extension_helper_generator.py
+++ b/scripts/generators/extension_helper_generator.py
@@ -213,8 +213,6 @@ struct InstanceExtensions {
     ExtEnabled vk_feature_version_1_3{kNotEnabled};
 ''')
         out.extend([f'    ExtEnabled {ext.name.lower()}{{kNotEnabled}};\n' for ext in self.vk.extensions.values() if ext.instance])
-        # TODO Issue 4841 -  It looks like framework is not ready for two properties structs per extension (like VK_EXT_descriptor_buffer have). Workarounding.
-        out.append('    ExtEnabled vk_ext_descriptor_buffer_density{kNotEnabled};\n')
 
         out.append('''
     struct InstanceReq {
@@ -334,8 +332,6 @@ struct DeviceExtensions : public InstanceExtensions {
     ExtEnabled vk_feature_version_1_3{kNotEnabled};
 ''')
         out.extend([f'    ExtEnabled {ext.name.lower()}{{kNotEnabled}};\n' for ext in self.vk.extensions.values() if ext.device])
-        # TODO Issue 4841 -  It looks like framework is not ready for two properties structs per extension (like VK_EXT_descriptor_buffer have). Workarounding.
-        out.append('    ExtEnabled vk_ext_descriptor_buffer_density{kNotEnabled};\n')
 
         out.append('''
     struct DeviceReq {


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4841

The new scripts don't need to have a workaround for extensions with 2 properties