### PR TITLE
android: Require CMake 3.21+ and ndk r24+

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -194,8 +194,6 @@ jobs:
             -D ANDROID_PLATFORM=26 \
             -D CMAKE_ANDROID_ARCH_ABI=${{ matrix.abi }} \
             -D CMAKE_ANDROID_STL_TYPE=${{ matrix.stl_type }} \
-            -D CMAKE_ANDROID_RTTI=YES \
-            -D CMAKE_ANDROID_EXCEPTIONS=YES \
             -D ANDROID_USE_LEGACY_TOOLCHAIN_FILE=NO \
             -D CMAKE_BUILD_TYPE=Debug \
             -D BUILD_TESTS=${{ matrix.build_tests }} \

--- a/layers/android/CMakeLists.txt
+++ b/layers/android/CMakeLists.txt
@@ -15,6 +15,21 @@
 # limitations under the License.
 # ~~~
 
+# https://gitlab.kitware.com/cmake/cmake/issues/18787
+# https://github.com/android-ndk/ndk/issues/463
+# "Users should be able to reliably use the toolchain provided by the NDK r23 or later when using CMake 3.21 or later" - Professional CMake
+if (CMAKE_VERSION VERSION_LESS "3.21")
+    message(FATAL_ERROR "Android build requires at least CMake 3.21!")
+endif()
+
+# Avoid issues with older NDKs which complicate correct CMake builds:
+#
+# Example:
+# The NDK toolchain file in r23 contains a bug which means CMAKE_ANDROID_EXCEPTIONS might not be set correctly in some circumstances, if not set directly by the developer.
+if (ANDROID_NDK_REVISION VERSION_LESS "24")
+    message(FATAL_ERROR "Android build requires at least NDK r25!")
+endif()
+
 message(STATUS "Targeting Android API Level ${CMAKE_SYSTEM_VERSION}")
 
 message(STATUS "Building with Android NDK Version ${ANDROID_NDK_REVISION}")

--- a/scripts/android.py
+++ b/scripts/android.py
@@ -156,8 +156,6 @@ def main():
         cmake_cmd += f' -D CMAKE_ANDROID_STL_TYPE={android_stl}'
 
         cmake_cmd += ' -D ANDROID_PLATFORM=26'
-        cmake_cmd += ' -D CMAKE_ANDROID_RTTI=YES'
-        cmake_cmd += ' -D CMAKE_ANDROID_EXCEPTIONS=YES'
         cmake_cmd += ' -D ANDROID_USE_LEGACY_TOOLCHAIN_FILE=NO'
 
         common_ci.RunShellCmd(cmake_cmd)

--- a/tests/android/CMakeLists.txt
+++ b/tests/android/CMakeLists.txt
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
-if (CMAKE_VERSION VERSION_LESS "3.19")
-    message(FATAL_ERROR "This file utilizes JSON parsing functionality added in 3.19!")
-endif()
 
 # "CMAKE_ANDROID_STL_TYPE specifies the C++ STL implementation to be used. Earlier NDK releases
 # supported a range of different options, but projects should now use either c++_shared or c++_static.


### PR DESCRIPTION
Avoids legacy issues with older versions of these tools.