### PR TITLE
layers: Move cc_shader.h to proper util

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -135,7 +135,6 @@ core_validation_sources = [
   "layers/core_checks/cc_ray_tracing.cpp",
   "layers/core_checks/cc_render_pass.cpp",
   "layers/core_checks/cc_shader.cpp",
-  "layers/core_checks/cc_shader.h",
   "layers/core_checks/cc_synchronization.cpp",
   "layers/core_checks/cc_video.cpp",
   "layers/core_checks/cc_wsi.cpp",
@@ -212,6 +211,8 @@ core_validation_sources = [
   "layers/sync/sync_vuid_maps.h",
   "layers/sync/sync_validation.cpp",
   "layers/sync/sync_validation.h",
+  "layers/utils/shader_utils.cpp",
+  "layers/utils/shader_utils.h",
 ]
 
 object_lifetimes_sources = [

--- a/build-android/jni/Android.mk
+++ b/build-android/jni/Android.mk
@@ -148,6 +148,7 @@ LOCAL_SRC_FILES += $(SRC_DIR)/layers/vulkan/generated/vk_safe_struct_vendor.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/state_tracker/image_layout_map.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/containers/subresource_adapter.cpp
 LOCAL_SRC_FILES += $(SRC_DIR)/layers/external/vma/vma.cpp
+LOCAL_SRC_FILES += $(SRC_DIR)/layers/utils/shader_utils.cpp
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/$(SRC_DIR)/layers \
                     $(LOCAL_PATH)/$(SRC_DIR)/layers/vulkan
 LOCAL_CPPFLAGS += -isystem $(VULKAN_INCLUDE)

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -231,7 +231,6 @@ target_sources(vvl PRIVATE
     core_checks/cc_ray_tracing.cpp
     core_checks/cc_render_pass.cpp
     core_checks/cc_shader.cpp
-    core_checks/cc_shader.h
     core_checks/cc_synchronization.cpp
     core_checks/cc_video.cpp
     core_checks/cc_wsi.cpp
@@ -341,6 +340,8 @@ target_sources(vvl PRIVATE
     sync/sync_vuid_maps.h
     thread_tracker/thread_safety_validation.cpp
     thread_tracker/thread_safety_validation.h
+    utils/shader_utils.cpp
+    utils/shader_utils.h
     layer_options.cpp
     vk_layer_settings_ext.h
 )

--- a/layers/best_practices/bp_descriptor.cpp
+++ b/layers/best_practices/bp_descriptor.cpp
@@ -19,7 +19,6 @@
 
 #include "best_practices/best_practices_validation.h"
 #include "best_practices/best_practices_error_enums.h"
-#include "core_checks/cc_shader.h"
 
 bool BestPractices::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                           VkDescriptorSet* pDescriptorSets, void* ads_state_data) const {

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -19,7 +19,6 @@
 
 #include "best_practices/best_practices_validation.h"
 #include "best_practices/best_practices_error_enums.h"
-#include "core_checks/cc_shader.h"
 
 static inline bool FormatHasFullThroughputBlendingArm(VkFormat format) {
     switch (format) {

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -30,6 +30,7 @@
 #include "generated/vk_enum_string_helper.h"
 #include "generated/chassis.h"
 #include "core_validation.h"
+#include "utils/shader_utils.h"
 
 bool CoreChecks::ValidateDeviceQueueFamily(uint32_t queue_family, const char *cmd_name, const char *parameter_name,
                                            const char *error_code, bool optional = false) const {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -23,7 +23,6 @@
 #include "state_tracker/state_tracker.h"
 #include "state_tracker/image_layout_map.h"
 #include "gpu_validation/gpu_validation.h"
-#include "cc_shader.h"
 #include "error_message/core_error_location.h"
 #include "containers/qfo_transfer.h"
 #include "state_tracker/cmd_buffer_state.h"

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -16,10 +16,10 @@
  */
 
 #include "gpu_validation/debug_printf.h"
-#include "spirv-tools/optimizer.hpp"
 #include "spirv-tools/instrument.hpp"
 #include <iostream>
 #include "generated/layer_chassis_dispatch.h"
+#include "utils/shader_utils.h"
 
 // Perform initializations that can be done at Create Device time.
 void DebugPrintf::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {

--- a/layers/gpu_validation/gpu_utils.cpp
+++ b/layers/gpu_validation/gpu_utils.cpp
@@ -17,11 +17,9 @@
 
 #include "gpu_validation/gpu_utils.h"
 #include "sync/sync_utils.h"
-#include "spirv-tools/libspirv.h"
-#include "spirv-tools/optimizer.hpp"
 #include "spirv-tools/instrument.hpp"
 #include "vma/vma.h"
-#include <spirv/unified1/spirv.hpp>
+
 #include <algorithm>
 #include <regex>
 

--- a/layers/gpu_validation/gpu_utils.h
+++ b/layers/gpu_validation/gpu_utils.h
@@ -16,7 +16,6 @@
  */
 #pragma once
 #include "generated/chassis.h"
-#include "core_checks/cc_shader.h"
 #include "state_tracker/cmd_buffer_state.h"
 #include "state_tracker/state_tracker.h"
 #include "vma/vma.h"

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 
-#include <climits>
 #include <cmath>
 #include "utils/cast_utils.h"
+#include "utils/shader_utils.h"
 #include "gpu_validation/gpu_validation.h"
-#include "spirv-tools/optimizer.hpp"
 #include "spirv-tools/instrument.hpp"
 #include "generated/layer_chassis_dispatch.h"
 #include "gpu_vuids.h"

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -27,7 +27,7 @@
 
 #include "generated/chassis.h"
 #include "state_tracker/state_tracker.h"
-#include "core_checks/cc_shader.h"
+#include "utils/shader_utils.h"
 #include "sync/sync_utils.h"
 #include "state_tracker/cmd_buffer_state.h"
 

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -1,0 +1,72 @@
+/* Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (C) 2015-2023 Google Inc.
+ * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "shader_utils.h"
+
+#include "state_tracker/device_state.h"
+#include "generated/vk_extension_helper.h"
+
+spv_target_env PickSpirvEnv(const APIVersion& api_version, bool spirv_1_4) {
+    if (api_version >= VK_API_VERSION_1_3) {
+        return SPV_ENV_VULKAN_1_3;
+    } else if (api_version >= VK_API_VERSION_1_2) {
+        return SPV_ENV_VULKAN_1_2;
+    } else if (api_version >= VK_API_VERSION_1_1) {
+        if (spirv_1_4) {
+            return SPV_ENV_VULKAN_1_1_SPIRV_1_4;
+        } else {
+            return SPV_ENV_VULKAN_1_1;
+        }
+    }
+    return SPV_ENV_VULKAN_1_0;
+}
+
+// Some Vulkan extensions/features are just all done in spirv-val behind optional settings
+void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
+                            spvtools::ValidatorOptions &options) {
+    // VK_KHR_relaxed_block_layout never had a feature bit so just enabling the extension allows relaxed layout
+    // Was promotoed in Vulkan 1.1 so anyone using Vulkan 1.1 also gets this for free
+    if (IsExtEnabled(device_extensions.vk_khr_relaxed_block_layout)) {
+        // --relax-block-layout
+        options.SetRelaxBlockLayout(true);
+    }
+
+    // The rest of the settings are controlled from a feature bit, which are set correctly in the state tracking. Regardless of
+    // Vulkan version used, the feature bit is needed (also described in the spec).
+
+    if (enabled_features.core12.uniformBufferStandardLayout == VK_TRUE) {
+        // --uniform-buffer-standard-layout
+        options.SetUniformBufferStandardLayout(true);
+    }
+    if (enabled_features.core12.scalarBlockLayout == VK_TRUE) {
+        // --scalar-block-layout
+        options.SetScalarBlockLayout(true);
+    }
+    if (enabled_features.workgroup_memory_explicit_layout_features.workgroupMemoryExplicitLayoutScalarBlockLayout) {
+        // --workgroup-scalar-block-layout
+        options.SetWorkgroupScalarBlockLayout(true);
+    }
+    if (enabled_features.core13.maintenance4) {
+        // --allow-localsizeid
+        options.SetAllowLocalSizeId(true);
+    }
+
+    // Faster validation without friendly names.
+    options.SetFriendlyNames(false);
+}

--- a/layers/utils/shader_utils.h
+++ b/layers/utils/shader_utils.h
@@ -20,15 +20,17 @@
 
 #pragma once
 
-#include <cstdlib>
-
 #include "vulkan/vulkan.h"
-#include <generated/spirv_tools_commit_id.h>
-#include "state_tracker/shader_module.h"
 #include "utils/vk_layer_utils.h"
+#include "generated/spirv_tools_commit_id.h"
+
+#include <spirv/unified1/spirv.hpp>
+#include <spirv-tools/libspirv.h>
+#include <spirv-tools/optimizer.hpp>
 
 struct DeviceFeatures;
 struct DeviceExtensions;
+class APIVersion;
 
 class ValidationCache {
   public:
@@ -145,7 +147,7 @@ class ValidationCache {
     mutable std::shared_mutex lock_;
 };
 
-spv_target_env PickSpirvEnv(APIVersion api_version, bool spirv_1_4);
+spv_target_env PickSpirvEnv(const APIVersion& api_version, bool spirv_1_4);
 
 void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
                             spvtools::ValidatorOptions &options);


### PR DESCRIPTION
currently we have things from `gpu_av`(and BP will to in future) trying to access code in `core_checks/cc_shader.cpp` which is just structurally wrong

Created a proper util file to hold the various shader related things not specific to core checks