### PR TITLE
scripts: Refactor format utils to use new generate style

### DIFF
--- a/layers/vulkan/generated/vk_format_utils.cpp
+++ b/layers/vulkan/generated/vk_format_utils.cpp
@@ -21,10 +21,10 @@
 ****************************************************************************/
 
 // NOLINTBEGIN
+
 #include "vk_format_utils.h"
 #include "utils/vk_layer_utils.h"
 #include <vector>
-
 
 enum class COMPONENT_TYPE {
     NONE,
@@ -944,7 +944,6 @@ static const vvl::unordered_map<VkFormat, MULTIPLANE_COMPATIBILITY> kVkMultiplan
 };
 // clang-format on
 
-
 // Return true if all components in the format are an SFLOAT
 bool FormatIsSFLOAT(VkFormat format) {
     bool found = false;
@@ -1297,7 +1296,6 @@ bool FormatIsUSCALED(VkFormat format) {
     return found;
 }
 
-
 // Return true if the format is a ASTC_HDR compressed image format
 bool FormatIsCompressed_ASTC_HDR(VkFormat format) {
     bool found = false;
@@ -1457,7 +1455,6 @@ bool FormatIsCompressed(VkFormat format) {
       FormatIsCompressed_PVRTC(format));
 }
 
-
 // Return true if format is a depth OR stencil format
 bool FormatIsDepthOrStencil(VkFormat format) {
     bool found = false;
@@ -1581,7 +1578,6 @@ FORMAT_NUMERICAL_TYPE FormatStencilNumericalType(VkFormat format) {
      }
 }
 
-
 // Return true if format is a packed format
 bool FormatIsPacked(VkFormat format) {
     bool found = false;
@@ -1647,7 +1643,6 @@ bool FormatIsPacked(VkFormat format) {
     }
     return found;
 }
-
 
 // Return true if format requires sampler YCBCR conversion
 // for VK_IMAGE_ASPECT_COLOR_BIT image views
@@ -1751,7 +1746,6 @@ bool FormatIsYChromaSubsampled(VkFormat format) {
     return found;
 }
 
-
 // Will return VK_FORMAT_UNDEFINED if given a plane aspect that doesn't exist for the format
 VkFormat FindMultiplaneCompatibleFormat(VkFormat mp_fmt, VkImageAspectFlags plane_aspect) {
     const uint32_t plane_idx = GetPlaneIndex(plane_aspect);
@@ -1776,7 +1770,6 @@ VkExtent2D FindMultiplaneExtentDivisors(VkFormat mp_fmt, VkImageAspectFlags plan
     divisors.height = it->second.per_plane[plane_idx].height_divisor;
     return divisors;
 }
-
 
 uint32_t FormatComponentCount(VkFormat format) {
     auto format_info = kVkFormatTable.find(format);

--- a/layers/vulkan/generated/vk_format_utils.h
+++ b/layers/vulkan/generated/vk_format_utils.h
@@ -21,13 +21,13 @@
 ****************************************************************************/
 
 // NOLINTBEGIN
+
 #pragma once
 #include <vulkan/vk_layer.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
 static constexpr uint32_t FORMAT_MAX_PLANES = 3;
 static constexpr uint32_t FORMAT_MAX_COMPONENTS = 4;
 
@@ -129,9 +129,7 @@ enum class FORMAT_COMPATIBILITY_CLASS {
     _8BIT_3PLANE_444,
     _96BIT
 };
-
-// Numeric
-// Formats with more then one numeric type (VK_FORMAT_D16_UNORM_S8_UINT) will return false
+// Numeric formats with more then one numeric type (D16_UNORM_S8_UINT) will return false
 bool FormatIsSFLOAT(VkFormat format);
 bool FormatIsSINT(VkFormat format);
 bool FormatIsSNORM(VkFormat format);
@@ -150,7 +148,6 @@ static inline bool FormatIsSampledFloat(VkFormat format) {
             FormatIsUFLOAT(format)  || FormatIsSFLOAT(format)  ||
             FormatIsSRGB(format));
 }
-
 // Compressed
 bool FormatIsCompressed_ASTC_HDR(VkFormat format);
 bool FormatIsCompressed_ASTC_LDR(VkFormat format);
@@ -247,8 +244,8 @@ FORMAT_COMPATIBILITY_CLASS FormatCompatibilityClass(VkFormat format);
 bool FormatElementIsTexel(VkFormat format);
 uint32_t FormatElementSize(VkFormat format, VkImageAspectFlags aspectMask = VK_IMAGE_ASPECT_COLOR_BIT);
 double FormatTexelSize(VkFormat format, VkImageAspectFlags aspectMask = VK_IMAGE_ASPECT_COLOR_BIT);
-// True if Format contains a 64-bit component
 
+// True if Format contains a 64-bit component
 constexpr bool FormatIs64bit(VkFormat format) {
     bool found = false;
     switch (format) {
@@ -280,7 +277,6 @@ bool FormatHasBlue(VkFormat format);
 bool FormatHasAlpha(VkFormat format);
 bool FormatsSameComponentBits(VkFormat format_a, VkFormat format_b);
 
-
 // Utils/misc
 static inline bool FormatIsUndef(VkFormat format) { return (format == VK_FORMAT_UNDEFINED); }
 // "blocked image" are defined in the spec (vkspec.html#blocked-image)
@@ -296,4 +292,5 @@ static inline bool FormatIsColor(VkFormat format) {
 #ifdef __cplusplus
 }
 #endif
+
 // NOLINTEND


### PR DESCRIPTION
Move from the various random functions to a single generate style

```python
if self.filename == 'vk_format_utils.h':
    self.generateHeader()
elif self.filename == 'vk_format_utils.cpp':
    self.generateSource()
```
