### PR TITLE
build: Redo API parameterization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ cmake_minimum_required(VERSION 3.17.2)
 
 project(VVL LANGUAGES CXX)
 
+# This variable enables downstream users to customize the target API
+# variant (e.g. Vulkan SC)
+set(API_TYPE "vulkan")
+
 add_subdirectory(scripts)
 
 set(VVL_CPP_STANDARD 17 CACHE STRING "Set the C++ standard to build against.")

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -16,9 +16,8 @@
 # limitations under the License.
 # ~~~
 
-# These variables enable downstream users to customize the CMake targets
+# This variable enables downstream users to customize the CMake targets
 # based on the target API variant (e.g. Vulkan SC)
-set(API_TYPE "vulkan")
 set(LAYER_NAME "VkLayer_khronos_validation")
 
 add_library(VkLayer_utils STATIC)

--- a/layers/vulkan/generated/object_tracker.cpp
+++ b/layers/vulkan/generated/object_tracker.cpp
@@ -34,8 +34,8 @@ bool ObjectLifetimes::ReportUndestroyedInstanceObjects(VkInstance instance) cons
     bool skip = false;
     const std::string error_code = "VUID-vkDestroyInstance-instance-00629";
     skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeSurfaceKHR, error_code);
-    // No destroy API -- do not report: skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDisplayKHR, error_code);
-    // No destroy API -- do not report: skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDisplayModeKHR, error_code);
+    // No destroy API or implicitly freed/destroyed -- do not report: skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDisplayKHR, error_code);
+    // No destroy API or implicitly freed/destroyed -- do not report: skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDisplayModeKHR, error_code);
     skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDebugReportCallbackEXT, error_code);
     skip |= ReportLeakedInstanceObjects(instance, kVulkanObjectTypeDebugUtilsMessengerEXT, error_code);
     return skip;

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -40,6 +40,8 @@ if (UPDATE_DEPS)
     endif()
     list(APPEND update_dep_command "--config")
     list(APPEND update_dep_command "${_build_type}")
+    list(APPEND update_dep_command "--api")
+    list(APPEND update_dep_command "${API_TYPE}")
 
     set(UPDATE_DEPS_DIR_SUFFIX "${_build_type}")
     if (ANDROID)

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -66,7 +66,7 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, targetF
 
     # These set fields that are needed by both OutputGenerator and BaseGenerator,
     # but are uniform and don't need to be set at a per-generated file level
-    from generators.base_generator import (SetOutputDirectory, SetTargetApiName)
+    from generators.base_generator import (SetOutputDirectory, SetTargetApiName, SetMergedApiNames)
     SetOutputDirectory(directory)
     SetTargetApiName(api)
 
@@ -77,146 +77,191 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, targetF
     generators = {
         'thread_safety_counter_definitions.h' : {
             'generator' : ThreadSafetyOutputGenerator,
+            'genCombined': True,
         },
         'thread_safety_counter_instances.h' : {
             'generator' : ThreadSafetyOutputGenerator,
+            'genCombined': True,
         },
         'thread_safety_counter_bodies.h' : {
             'generator' : ThreadSafetyOutputGenerator,
+            'genCombined': True,
         },
         'thread_safety_commands.h' : {
             'generator' : ThreadSafetyOutputGenerator,
+            'genCombined': True,
         },
         'thread_safety.cpp' : {
             'generator' : ThreadSafetyOutputGenerator,
+            'genCombined': True,
         },
         'stateless_validation_helper.h' : {
             'generator' : StatelessValidationHelperOutputGenerator,
+            'genCombined': False,
             'options' : [valid_usage_file],
         },
         'stateless_validation_helper.cpp' : {
             'generator' : StatelessValidationHelperOutputGenerator,
+            'genCombined': False,
             'options' : [valid_usage_file],
         },
         'enum_flag_bits.h' : {
             'generator' : EnumFlagBitsOutputGenerator,
+            'genCombined': False,
         },
         'valid_enum_values.h' : {
             'generator' : ValidEnumValuesOutputGenerator,
+            'genCombined': False,
         },
         'valid_enum_values.cpp' : {
             'generator' : ValidEnumValuesOutputGenerator,
+            'genCombined': False,
         },
         'object_tracker.h' : {
             'generator' : ObjectTrackerOutputGenerator,
+            'genCombined': True,
             'options' : [valid_usage_file],
         },
         'object_tracker.cpp' : {
             'generator' : ObjectTrackerOutputGenerator,
+            'genCombined': True,
             'options' : [valid_usage_file],
         },
         'vk_dispatch_table_helper.h' : {
             'generator' : DispatchTableHelperOutputGenerator,
+            'genCombined': True,
         },
         'vk_function_pointers.h' : {
             'generator' : FunctionPointersOutputGenerator,
+            'genCombined': True,
         },
         'vk_function_pointers.cpp' : {
             'generator' : FunctionPointersOutputGenerator,
+            'genCombined': True,
         },
         'vk_layer_dispatch_table.h' : {
             'generator' : LayerDispatchTableOutputGenerator,
+            'genCombined': True,
         },
         'vk_enum_string_helper.h' : {
             'generator' : EnumStringHelperOutputGenerator,
+            'genCombined': True,
         },
         'vk_safe_struct.h' : {
             'generator' : SafeStructOutputGenerator,
+            'genCombined': True,
         },
         'vk_safe_struct_utils.cpp' : {
             'generator' : SafeStructOutputGenerator,
+            'genCombined': True,
         },
         'vk_safe_struct_core.cpp' : {
             'generator' : SafeStructOutputGenerator,
+            'genCombined': True,
         },
         'vk_safe_struct_khr.cpp' : {
             'generator' : SafeStructOutputGenerator,
+            'genCombined': True,
         },
         'vk_safe_struct_ext.cpp' : {
             'generator' : SafeStructOutputGenerator,
+            'genCombined': True,
         },
         'vk_safe_struct_vendor.cpp' : {
             'generator' : SafeStructOutputGenerator,
+            'genCombined': True,
         },
         'vk_object_types.h' : {
             'generator' : ObjectTypesOutputGenerator,
+            'genCombined': True,
         },
         'vk_extension_helper.h' : {
             'generator' : ExtensionHelperOutputGenerator,
+            'genCombined': True,
         },
         'vk_typemap_helper.h' : {
             'generator' : TypemapHelperOutputGenerator,
+            'genCombined': True,
         },
         'chassis.h' : {
             'generator' : LayerChassisOutputGenerator,
+            'genCombined': True,
         },
         'chassis.cpp' : {
             'generator' : LayerChassisOutputGenerator,
+            'genCombined': False,
         },
         'chassis_dispatch_helper.h' : {
             'generator' : LayerChassisOutputGenerator,
+            'genCombined': True,
         },
         'layer_chassis_dispatch.h' : {
             'generator' : LayerChassisDispatchOutputGenerator,
+            'genCombined': True,
         },
         'layer_chassis_dispatch.cpp' : {
             'generator' : LayerChassisDispatchOutputGenerator,
+            'genCombined': True,
         },
         'best_practices.h' : {
             'generator' : BestPracticesOutputGenerator,
+            'genCombined': True,
         },
         'best_practices.cpp' : {
             'generator' : BestPracticesOutputGenerator,
+            'genCombined': True,
         },
         'sync_validation_types.h' : {
             'generator' : SyncValidationOutputGenerator,
+            'genCombined': False,
         },
         'sync_validation_types.cpp' : {
             'generator' : SyncValidationOutputGenerator,
+            'genCombined': False,
         },
         'spirv_validation_helper.cpp' : {
             'generator' : SpirvValidationHelperOutputGenerator,
+            'genCombined': False,
         },
         'spirv_grammar_helper.h' : {
             'generator' : SpirvGrammarHelperOutputGenerator,
+            'genCombined': False,
             'options' : [grammar],
         },
         'spirv_grammar_helper.cpp' : {
             'generator' : SpirvGrammarHelperOutputGenerator,
+            'genCombined': False,
             'options' : [grammar],
         },
         'spirv_tools_commit_id.h' : {
+            'genCombined': False,
             'generator' : SpirvToolCommitIdOutputGenerator,
         },
         'command_validation.h' : {
             'generator' : CommandValidationOutputGenerator,
+            'genCombined': True,
             'options' : [valid_usage_file],
         },
         'command_validation.cpp' : {
             'generator' : CommandValidationOutputGenerator,
+            'genCombined': True,
             'options' : [valid_usage_file],
         },
         'dynamic_state_helper.h' : {
             'generator' : DynamicStateOutputGenerator,
+            'genCombined': False,
         },
         'dynamic_state_helper.cpp' : {
             'generator' : DynamicStateOutputGenerator,
+            'genCombined': False,
         },
         'vk_format_utils.h' : {
             'generator' : FormatUtilsOutputGenerator,
+            'genCombined': True,
         },
         'vk_format_utils.cpp' : {
             'generator' : FormatUtilsOutputGenerator,
+            'genCombined': True,
         },
     }
 
@@ -235,6 +280,17 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, targetF
         generatorOptions = generators[target]['options'] if 'options' in generators[target] else []
         generator = targetGenerator(*generatorOptions)
 
+        # This code and the 'genCombined' generator metadata is used by downstream
+        # users to generate code with all Vulkan APIs merged into the target API variant
+        # (e.g. Vulkan SC) when needed. The constructed apiList is also used to filter
+        # out non-applicable extensions later below.
+        apiList = [api]
+        if api != 'vulkan' and generators[target]['genCombined']:
+            SetMergedApiNames('vulkan')
+            apiList.append('vulkan')
+        else:
+            SetMergedApiNames(None)
+
         baseOptions = BaseGeneratorOptions(customFileName = target)
 
         # Create the registry object with the specified generator and generator
@@ -244,9 +300,8 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, targetF
         # Parse the specified registry XML into an ElementTree object
         tree = ElementTree.parse(registry)
 
-        # Filter out non-Vulkan extensions
-        if api == 'vulkan':
-            [exts.remove(e) for exts in tree.findall('extensions') for e in exts.findall('extension') if (sup := e.get('supported')) is not None and baseOptions.apiname not in sup.split(',')]
+        # Filter out extensions that are not on the API list
+        [exts.remove(e) for exts in tree.findall('extensions') for e in exts.findall('extension') if (sup := e.get('supported')) is not None and all(api not in sup.split(',') for api in apiList)]
 
         # Load the XML tree into the registry object
         reg.loadElementTree(tree)

--- a/scripts/generators/enum_flag_bits_generator.py
+++ b/scripts/generators/enum_flag_bits_generator.py
@@ -21,6 +21,23 @@
 import os
 from generators.base_generator import BaseGenerator
 
+# This class is a container for any source code, data, or other behavior that is necessary to
+# customize the generator script for a specific target API variant (e.g. Vulkan SC). As such,
+# all of these API-specific interfaces and their use in the generator script are part of the
+# contract between this repository and its downstream users. Changing or removing any of these
+# interfaces or their use in the generator script will have downstream effects and thus
+# should be avoided unless absolutely necessary.
+class APISpecific:
+    # Generates manual constants
+    @staticmethod
+    def genManualConstants(targetApiName: str) -> list[str]:
+        match targetApiName:
+
+            # Vulkan specific manual constant generation
+            case 'vulkan':
+                return []
+
+
 class EnumFlagBitsOutputGenerator(BaseGenerator):
     def __init__(self):
         BaseGenerator.__init__(self)
@@ -86,6 +103,8 @@ class EnumFlagBitsOutputGenerator(BaseGenerator):
             out.append(f'const {bitmask.flagName} All{bitmask.name} = {"|".join([flag.name for flag in bitmask.flags])}')
             out.append(';\n')
             out.extend([f'#endif //{bitmask.protect}\n'] if bitmask.protect else [])
+
+        out.extend(APISpecific.genManualConstants(self.targetApiName))
 
         out.append('\n')
         out.append('// mask of all the VK_PIPELINE_STAGE_*_SHADER_BIT stages\n')

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -3556,6 +3556,13 @@ void android_main(struct android_app *app) {
 #include <crtdbg.h>
 #endif
 
+// Defining VVL_TESTS_USE_CUSTOM_TEST_FRAMEWORK allows downstream users
+// to inject custom test framework changes. This includes the ability
+// to override the main entry point of the test executable in order to
+// add custom command line arguments and use a custom test environment
+// class. This #ifndef thus makes sure that when the definition is
+// present we do not include the default main entry point.
+#ifndef VVL_TESTS_USE_CUSTOM_TEST_FRAMEWORK
 int main(int argc, char **argv) {
     int result;
 
@@ -3581,3 +3588,4 @@ int main(int argc, char **argv) {
     VkTestFramework::Finish();
     return result;
 }
+#endif

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -41,6 +41,7 @@
 #include <string>
 #include <unordered_set>
 #include <vector>
+#include <condition_variable>
 
 using std::string;
 using std::vector;
@@ -155,9 +156,23 @@ T NearestSmaller(const T from) {
     return std::nextafter(from, negative_direction);
 }
 
+// Defining VVL_TESTS_USE_CUSTOM_TEST_FRAMEWORK allows downstream users
+// to inject custom test framework changes. This includes the ability
+// to override the the base class of the VkLayerTest class so that
+// appropriate test framework customizations can be injected into the
+// class hierarchy at the closest possible place to the base class used
+// by all validation layer tests. Downstream users can provide their
+// own version of custom_test_framework.h to define the appropriate
+// custom base class to use through the VkLayerTestBase type identifier.
+#ifdef VVL_TESTS_USE_CUSTOM_TEST_FRAMEWORK
+#include "framework/custom_test_framework.h"
+#else
+using VkLayerTestBase = VkRenderFramework;
+#endif
+
 // VkLayerTest is the main GTest test class
 // It is the root for all other test class variations
-class VkLayerTest : public VkRenderFramework {
+class VkLayerTest : public VkLayerTestBase {
   public:
     const char *kValidationLayerName = "VK_LAYER_KHRONOS_validation";
     const char *kSynchronization2LayerName = "VK_LAYER_KHRONOS_synchronization2";


### PR DESCRIPTION
This re-does the API-specific parameterization needed to support downstream API variants like Vulkan SC after the generator script rewrites.