### PR TITLE
layers: Guarantee there is an active renderpass

### DIFF
--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -112,7 +112,7 @@ bool BestPractices::ClearAttachmentsIsFullClear(const bp_state::CommandBuffer& c
     // If we have a rect which covers the entire frame buffer, we have a LOAD_OP_CLEAR-like command.
     for (uint32_t i = 0; i < rectCount; i++) {
         auto& rect = pRects[i];
-        auto& render_area = cmd.activeRenderPassBeginInfo.renderArea;
+        auto& render_area = cmd.active_render_pass_begin_info.renderArea;
         if (rect.rect.extent.width == render_area.extent.width && rect.rect.extent.height == render_area.extent.height) {
             return true;
         }

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -485,10 +485,10 @@ void BestPractices::RecordCmdBeginRenderingCommon(VkCommandBuffer commandBuffer)
                         }
                     }
                 }
-                for (uint32_t i = 0; i < cmd_state->activeRenderPassBeginInfo.clearValueCount; ++i) {
+                for (uint32_t i = 0; i < cmd_state->active_render_pass_begin_info.clearValueCount; ++i) {
                     const auto& attachment = rp->createInfo.pAttachments[i];
                     if (attachment.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
-                        const auto& clear_color = cmd_state->activeRenderPassBeginInfo.pClearValues[i].color;
+                        const auto& clear_color = cmd_state->active_render_pass_begin_info.pClearValues[i].color;
                         RecordClearColor(attachment.format, clear_color);
                     }
                 }

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -341,7 +341,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                 if (sample_locations && sample_locations->sampleLocationsEnable == VK_TRUE &&
                     !pipeline_state.IsDynamic(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT)) {
                     const VkRenderPassSampleLocationsBeginInfoEXT *sample_locations_begin_info =
-                        LvlFindInChain<VkRenderPassSampleLocationsBeginInfoEXT>(cb_state->activeRenderPassBeginInfo.pNext);
+                        LvlFindInChain<VkRenderPassSampleLocationsBeginInfoEXT>(cb_state->active_render_pass_begin_info.pNext);
                     bool found = false;
                     if (sample_locations_begin_info) {
                         for (uint32_t i = 0; i < sample_locations_begin_info->postSubpassSampleLocationsCount; ++i) {

--- a/layers/error_message/validation_error_enums.h
+++ b/layers/error_message/validation_error_enums.h
@@ -33,7 +33,6 @@
 [[maybe_unused]] static const char *kVUID_Core_DrawState_QueryNotReset = "UNASSIGNED-CoreValidation-DrawState-QueryNotReset";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidRenderpass = "UNASSIGNED-CoreValidation-DrawState-InvalidRenderpass";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidSecondaryCommandBuffer = "UNASSIGNED-CoreValidation-DrawState-InvalidSecondaryCommandBuffer";
-[[maybe_unused]] static const char *kVUID_Core_DrawState_NoActiveRenderpass = "UNASSIGNED-CoreValidation-DrawState-NoActiveRenderpass";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_NoEndCommandBuffer = "UNASSIGNED-CoreValidation-DrawState-NoEndCommandBuffer";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_QueueForwardProgress = "UNASSIGNED-CoreValidation-DrawState-QueueForwardProgress";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidImageView = "UNASSIGNED-CoreValidation-DrawState-InvalidImageView";

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -252,7 +252,6 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
         }
     } dynamic_state_value;
 
-    std::string begin_rendering_func_name;
     // Currently storing "lastBound" objects on per-CB basis
     //  long-term may want to create caches of "lastBound" states and could have
     //  each individual CMD_NODE referencing its own "lastBound" state
@@ -304,15 +303,18 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
 
     uint32_t initial_device_mask;
 
-    safe_VkRenderPassBeginInfo activeRenderPassBeginInfo;
+    // The RenderPass created from vkCmdBeginRenderPass or vkCmdBeginRendering
     std::shared_ptr<RENDER_PASS_STATE> activeRenderPass;
+    // Used for both type of renderPass
+    vvl::unordered_set<uint32_t> active_color_attachments_index;
+    uint32_t active_render_pass_device_mask;
+    // only when not using dynamic rendering
+    safe_VkRenderPassBeginInfo active_render_pass_begin_info;
     std::shared_ptr<std::vector<SUBPASS_INFO>> active_subpasses;
     std::shared_ptr<std::vector<IMAGE_VIEW_STATE *>> active_attachments;
     std::set<std::shared_ptr<IMAGE_VIEW_STATE>> attachments_view_states;
-    vvl::unordered_set<uint32_t> active_color_attachments_index;
 
     VkSubpassContents activeSubpassContents;
-    uint32_t active_render_pass_device_mask;
     uint32_t GetActiveSubpass() const { return active_subpass_; }
     void SetActiveSubpass(uint32_t subpass);
     std::optional<VkSampleCountFlagBits> GetActiveSubpassRasterizationSampleCount() const { return active_subpass_sample_count_; }
@@ -482,6 +484,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     void EndRenderPass(CMD_TYPE cmd_type);
 
     void BeginRendering(CMD_TYPE cmd_type, const VkRenderingInfo *pRenderingInfo);
+    void EndRendering(CMD_TYPE cmd_type);
 
     void BeginVideoCoding(const VkVideoBeginCodingInfoKHR *pBeginInfo);
     void EndVideoCoding(const VkVideoEndCodingInfoKHR *pEndCodingInfo);

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3714,12 +3714,6 @@ void ValidationStateTracker::PostCallRecordCmdEndConditionalRenderingEXT(VkComma
     cb_state->conditional_rendering_subpass = 0;
 }
 
-void ValidationStateTracker::RecordCmdEndRenderingRenderPassState(VkCommandBuffer commandBuffer) {
-    auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
-    cb_state->activeRenderPass = nullptr;
-    cb_state->active_color_attachments_index.clear();
-}
-
 void ValidationStateTracker::PreCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBuffer,
                                                                const VkRenderingInfoKHR *pRenderingInfo) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
@@ -3732,11 +3726,13 @@ void ValidationStateTracker::PreCallRecordCmdBeginRendering(VkCommandBuffer comm
 }
 
 void ValidationStateTracker::PreCallRecordCmdEndRenderingKHR(VkCommandBuffer commandBuffer) {
-    RecordCmdEndRenderingRenderPassState(commandBuffer);
+    auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
+    cb_state->EndRendering(CMD_ENDRENDERING);
 }
 
 void ValidationStateTracker::PreCallRecordCmdEndRendering(VkCommandBuffer commandBuffer) {
-    RecordCmdEndRenderingRenderPassState(commandBuffer);
+    auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
+    cb_state->EndRendering(CMD_ENDRENDERINGKHR);
 }
 
 void ValidationStateTracker::PreCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1321,7 +1321,6 @@ class ValidationStateTracker : public ValidationObject {
     void RecordCreateDescriptorUpdateTemplateState(const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
                                                    VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate);
     void RecordMappedMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void** ppData);
-    void RecordCmdEndRenderingRenderPassState(VkCommandBuffer commandBuffer);
     void RecordVulkanSurface(VkSurfaceKHR* pSurface);
     void PreRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout);
     void PostRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout, VkResult result);

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2024,8 +2024,8 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         const auto &subresource_range = img_view_state->normalized_subresource_range;
 
                         if (sync_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
-                            const VkExtent3D extent = CastTo3D(cb_state_->activeRenderPassBeginInfo.renderArea.extent);
-                            const VkOffset3D offset = CastTo3D(cb_state_->activeRenderPassBeginInfo.renderArea.offset);
+                            const VkExtent3D extent = CastTo3D(cb_state_->active_render_pass_begin_info.renderArea.extent);
+                            const VkOffset3D offset = CastTo3D(cb_state_->active_render_pass_begin_info.renderArea.offset);
                             // Input attachments are subject to raster ordering rules
                             hazard =
                                 current_context_->DetectHazard(*img_state, sync_index, subresource_range, SyncOrdering::kRaster,
@@ -2155,8 +2155,8 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                         }
                         const auto *img_state = GetImageViewImageState(img_view_state);
                         if (sync_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
-                            const VkExtent3D extent = CastTo3D(cb_state_->activeRenderPassBeginInfo.renderArea.extent);
-                            const VkOffset3D offset = CastTo3D(cb_state_->activeRenderPassBeginInfo.renderArea.offset);
+                            const VkExtent3D extent = CastTo3D(cb_state_->active_render_pass_begin_info.renderArea.extent);
+                            const VkOffset3D offset = CastTo3D(cb_state_->active_render_pass_begin_info.renderArea.offset);
                             current_context_->UpdateAccessState(*img_state, sync_index, SyncOrdering::kRaster,
                                                                 img_view_state->normalized_subresource_range, offset, extent, tag);
                         } else {

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -2266,19 +2266,19 @@ void VkCommandBufferObj::NextSubpass(VkSubpassContents contents) { vk::CmdNextSu
 void VkCommandBufferObj::EndRenderPass() { vk::CmdEndRenderPass(handle()); }
 
 void VkCommandBufferObj::BeginRendering(const VkRenderingInfoKHR &renderingInfo) {
-    PFN_vkCmdBeginRenderingKHR vkCmdBeginRenderingKHR =
-        (PFN_vkCmdBeginRenderingKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdBeginRenderingKHR");
-    assert(vkCmdBeginRenderingKHR != nullptr);
-
-    vkCmdBeginRenderingKHR(handle(), &renderingInfo);
+    if (vk::CmdBeginRenderingKHR) {
+        vk::CmdBeginRenderingKHR(handle(), &renderingInfo);
+    } else {
+        vk::CmdBeginRendering(handle(), &renderingInfo);
+    }
 }
 
 void VkCommandBufferObj::EndRendering() {
-    PFN_vkCmdEndRenderingKHR vkCmdEndRenderingKHR =
-        (PFN_vkCmdEndRenderingKHR)vk::GetDeviceProcAddr(m_device->device(), "vkCmdEndRenderingKHR");
-    assert(vkCmdEndRenderingKHR != nullptr);
-
-    vkCmdEndRenderingKHR(handle());
+    if (vk::CmdEndRenderingKHR) {
+        vk::CmdEndRenderingKHR(handle());
+    } else {
+        vk::CmdEndRendering(handle());
+    }
 }
 
 void VkCommandBufferObj::BeginVideoCoding(const VkVideoBeginCodingInfoKHR &beginInfo) {

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -2617,7 +2617,7 @@ TEST_F(NegativeDynamicRendering, WithBarrier) {
     begin_rendering_info.renderArea = clear_rect.rect;
     begin_rendering_info.layerCount = 1;
 
-    vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
+    m_commandBuffer->BeginRendering(begin_rendering_info);
 
     VkBufferObj buffer;
     VkMemoryPropertyFlags mem_reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
@@ -2642,7 +2642,7 @@ TEST_F(NegativeDynamicRendering, WithBarrier) {
                            nullptr, 0, nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
-    vk::CmdEndRendering(m_commandBuffer->handle());
+    m_commandBuffer->EndRendering();
     m_commandBuffer->end();
 }
 
@@ -2689,7 +2689,7 @@ TEST_F(NegativeDynamicRendering, WithoutShaderTileImageAndBarrier) {
     begin_rendering_info.renderArea = clear_rect.rect;
     begin_rendering_info.layerCount = 1;
 
-    vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
+    m_commandBuffer->BeginRendering(begin_rendering_info);
 
     auto memory_barrier_2 = LvlInitStruct<VkMemoryBarrier2KHR>();
     memory_barrier_2.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -2720,7 +2720,7 @@ TEST_F(NegativeDynamicRendering, WithoutShaderTileImageAndBarrier) {
                            nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
-    vk::CmdEndRendering(m_commandBuffer->handle());
+    m_commandBuffer->EndRendering();
     m_commandBuffer->end();
 }
 
@@ -2763,7 +2763,7 @@ TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
     begin_rendering_info.renderArea = clear_rect.rect;
     begin_rendering_info.layerCount = 1;
 
-    vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
+    m_commandBuffer->BeginRendering(begin_rendering_info);
 
     auto memory_barrier_2 = LvlInitStruct<VkMemoryBarrier2KHR>();
     memory_barrier_2.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -2887,7 +2887,7 @@ TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
                            nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
-    vk::CmdEndRendering(m_commandBuffer->handle());
+    m_commandBuffer->EndRendering();
     m_commandBuffer->end();
 }
 
@@ -6392,11 +6392,11 @@ TEST_F(NegativeDynamicRendering, BeginRenderingDisabled) {
 
     if (vulkan_13) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginRendering-dynamicRendering-06446");
-        vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
+        m_commandBuffer->BeginRendering(begin_rendering_info);
         m_errorMonitor->VerifyFound();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndRendering-None-06161");
         m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
-        vk::CmdEndRendering(m_commandBuffer->handle());
+        m_commandBuffer->EndRendering();
         m_errorMonitor->VerifyFound();
         m_commandBuffer->EndRenderPass();
     }

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -199,10 +199,10 @@ TEST_F(PositiveDynamicRendering, BeginQuery) {
 
     m_commandBuffer->begin();
 
-    vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
+    m_commandBuffer->BeginRendering(begin_rendering_info);
     vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 0, 0);
     vk::CmdEndQuery(m_commandBuffer->handle(), query_pool.handle(), 0);
-    vk::CmdEndRendering(m_commandBuffer->handle());
+    m_commandBuffer->EndRendering();
 
     m_commandBuffer->end();
 }
@@ -968,18 +968,18 @@ TEST_F(PositiveDynamicRendering, WithShaderTileImageAndBarrier) {
     dependency_info.imageMemoryBarrierCount = 0;
     dependency_info.pImageMemoryBarriers = VK_NULL_HANDLE;
 
-    vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
+    m_commandBuffer->BeginRendering(begin_rendering_info);
     vk::CmdPipelineBarrier2(m_commandBuffer->handle(), &dependency_info);
-    vk::CmdEndRendering(m_commandBuffer->handle());
+    m_commandBuffer->EndRendering();
 
     auto memory_barrier = LvlInitStruct<VkMemoryBarrier>();
     memory_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     memory_barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
-    vk::CmdBeginRendering(m_commandBuffer->handle(), &begin_rendering_info);
+    m_commandBuffer->BeginRendering(begin_rendering_info);
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_DEPENDENCY_BY_REGION_BIT, 1, &memory_barrier, 0,
                            nullptr, 0, nullptr);
-    vk::CmdEndRendering(m_commandBuffer->handle());
+    m_commandBuffer->EndRendering();
     m_commandBuffer->end();
 }
 

--- a/tests/unit/renderpass.cpp
+++ b/tests/unit/renderpass.cpp
@@ -4653,3 +4653,26 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSeparateDepthStencil) {
         }
     }
 }
+
+TEST_F(NegativeRenderPass, BeginInfoWithoutRenderPass) {
+    TEST_DESCRIPTION("call VkRenderPassBeginInfo with invalid renderpass");
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassBeginInfo-renderPass-parameter");
+    m_renderPassBeginInfo.renderPass = CastFromUint64<VkRenderPass>(0xFFFFEEEE);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}
+
+TEST_F(NegativeRenderPass, EndWithoutRenderPass) {
+    TEST_DESCRIPTION("call vkCmdEndRenderPass never starting a renderpass");
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndRenderPass-renderpass");
+    m_commandBuffer->EndRenderPass();
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -1309,3 +1309,22 @@ TEST_F(NegativeSubpass, SubpassInputWithoutFormat) {
     pipe.CreateVKPipeline(pl.handle(), rp.handle());
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeSubpass, NextSubpassNoRenderPass) {
+    TEST_DESCRIPTION("call next subpass outside a renderpass");
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdNextSubpass-renderpass");
+    vk::CmdNextSubpass(m_commandBuffer->handle(), VK_SUBPASS_CONTENTS_INLINE);
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    m_commandBuffer->EndRenderPass();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdNextSubpass-renderpass");
+    vk::CmdNextSubpass(m_commandBuffer->handle(), VK_SUBPASS_CONTENTS_INLINE);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5863

We have all these `if (activeRenderPass) {` which don't make sense because there is a bunch of implicit VUs in `ValidateCmd` that check if we are in a renderpass or not.

I went through and all the command that require to be in renderPass, I wrote a test (to confirm it won't crash) and then removed the redundant checks so now it is clear if we actually need to check for renderPass

some small house cleaning was done along the way