### PR TITLE
layers: Add support for concurrent blocking operations

### DIFF
--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -32,6 +32,8 @@
 #include "layer_options.h"
 #include "layer_chassis_dispatch.h"
 
+thread_local WriteLockGuard* ValidationObject::record_guard{};
+
 small_unordered_map<void*, ValidationObject*, 2> layer_data_map;
 
 // Global unique object identifier.

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -3787,11 +3787,18 @@ class ValidationObject {
 
         // If the Record phase calls a function that blocks, we might need to release
         // the lock that protects Record itself in order to avoid mutual waiting.
-        WriteLockGuard* record_guard = nullptr;
+        static thread_local WriteLockGuard* record_guard;
 
         // Should be used instead of WriteLock() if the Record phase wants to release
         // its lock during the blocking operation.
         void GetWriteLockForBlockingOperation(WriteLockGuard& write_lock) {
+
+            // This assert detects recursive calls. It is here mostly for documentation purposes
+            // because WriteLock() also triggers errors during recursion.
+            // Recursion is not allowed since record_guard is a thread-local variable and it can
+            // reference only one frame of the callstack.
+            assert(record_guard == nullptr);
+
             write_lock = WriteLock();
             // Initialize record_guard only when Record is actually protected by the
             // mutex. It's not the case when fine grained locking is enabled.


### PR DESCRIPTION
Fixes the bug in my previous PR that it did not take into account multiple concurrent waiters (I tested only with a single one).

The test reproduces the issues with concurrent waiters and the test passes with this fix, also the client reports that long-standing issue finally works: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4968#issuecomment-1641676594


