### PR TITLE
scripts: Restore the -o option on generate_source

### DIFF
--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -328,6 +328,7 @@ def main(argv):
     parser.add_argument('--generated-version', help='sets the header version used to generate the repo')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--target', nargs='+', help='only generate file names passed in')
+    group.add_argument('-o', help='Create target and related files in specified directory.', dest='output_directory')
     group.add_argument('-i', '--incremental', action='store_true', help='only update repo files that change')
     group.add_argument('-v', '--verify', action='store_true', help='verify repo files match generator output')
     args = parser.parse_args(argv)
@@ -357,6 +358,9 @@ def main(argv):
     else:
         # generate directly in the repo
         gen_dir = repo_dir
+
+    if args.output_directory is not None:
+      gen_dir = args.output_directory;
 
     registry = os.path.abspath(os.path.join(args.registry,  'vk.xml'))
     grammar = os.path.abspath(os.path.join(args.grammar, 'spirv.core.grammar.json'))


### PR DESCRIPTION
The old script had a way to specify a custom output directory for generated files. The recent refactoring removed this option.

This option is important if your CI runs on a read-only version of the repository, and generated files/intermediates are written to a different folder before being processed (Bazel-like build).