### PR TITLE
layers: Prevent crash for physicalStorageBuffer interface

### DIFF
--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -441,7 +441,7 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE &produ
 
     for (const auto &interface_slot : producer_entrypoint.output_interface_slots) {
         auto &slot = slot_map[interface_slot.first.Location()][interface_slot.first.Component()];
-        if (interface_slot.second->nested_struct) {
+        if (interface_slot.second->nested_struct || interface_slot.second->physical_storage_buffer) {
             return skip;  // TODO workaround
         }
         slot.output = interface_slot.second;
@@ -450,7 +450,7 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const SHADER_MODULE_STATE &produ
     }
     for (const auto &interface_slot : consumer_entrypoint.input_interface_slots) {
         auto &slot = slot_map[interface_slot.first.Location()][interface_slot.first.Component()];
-        if (interface_slot.second->nested_struct) {
+        if (interface_slot.second->nested_struct || interface_slot.second->physical_storage_buffer) {
             return skip;  // TODO workaround
         }
         slot.input = interface_slot.second;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1565,6 +1565,11 @@ std::vector<InterfaceSlot> StageInteraceVariable::GetInterfaceSlots(StageInterac
 
                 // Info needed to test type matching later
                 const Instruction* numerical_type = module_state.GetBaseTypeInstruction(member_id);
+                // TODO 5374 - Handle PhysicalStorageBuffer interfaces
+                if (!numerical_type) {
+                    variable.physical_storage_buffer = true;
+                    break;
+                }
                 const uint32_t numerical_type_opcode = numerical_type->Opcode();
                 // TODO - Handle nested structs
                 if (numerical_type_opcode == spv::OpTypeStruct) {
@@ -1679,6 +1684,7 @@ StageInteraceVariable::StageInteraceVariable(const SHADER_MODULE_STATE& module_s
       base_type(FindBaseType(*this, module_state)),
       is_builtin(IsBuiltin(*this, module_state)),
       nested_struct(false),
+      physical_storage_buffer(false),
       interface_slots(GetInterfaceSlots(*this, module_state)),
       builtin_block(GetBuiltinBlock(*this, module_state)),
       total_builtin_components(GetBuiltinComponents(*this, module_state)) {}

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -255,6 +255,7 @@ struct StageInteraceVariable : public VariableBase {
     const Instruction &base_type;
     const bool is_builtin;
     bool nested_struct;
+    bool physical_storage_buffer;
 
     const std::vector<InterfaceSlot> interface_slots;  // Only for User Defined variables
     const std::vector<uint32_t> builtin_block;

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -1440,3 +1440,150 @@ TEST_F(PositiveShaderInterface, PackingInsideArray) {
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 }
+
+TEST_F(PositiveShaderInterface, PhysicalStorageBufferGlslang3) {
+    TEST_DESCRIPTION("Taken from glslang spv.bufferhandle3.frag test");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required";
+    }
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    auto features12 = LvlInitStruct<VkPhysicalDeviceVulkan12Features>();
+    GetPhysicalDeviceFeatures2(features12);
+    if (VK_TRUE != features12.bufferDeviceAddress) {
+        GTEST_SKIP() << "bufferDeviceAddress not supported and is required";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features12));
+
+    char const *fsSource = R"glsl(
+        #version 450
+        #extension GL_EXT_buffer_reference : enable
+
+        layout(buffer_reference, std430) buffer t3 {
+            int h;
+        };
+
+        layout(set = 1, binding = 2, buffer_reference, std430) buffer t4 {
+            layout(offset = 0)  int j;
+            t3 k;
+        } x;
+
+        layout(set = 0, binding = 0, std430) buffer t5 {
+            t4 m;
+        } s5;
+
+        layout(location = 0) flat in t4 k;
+
+        t4 foo(t4 y) { return y; }
+        void main() {}
+    )glsl";
+
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
+}
+
+TEST_F(PositiveShaderInterface, PhysicalStorageBufferGlslang6) {
+    TEST_DESCRIPTION("Taken from glslang spv.bufferhandle6.frag test");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required";
+    }
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    auto features12 = LvlInitStruct<VkPhysicalDeviceVulkan12Features>();
+    GetPhysicalDeviceFeatures2(features12);
+    if (VK_TRUE != features12.bufferDeviceAddress) {
+        GTEST_SKIP() << "bufferDeviceAddress not supported and is required";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features12));
+
+    char const *fsSource = R"glsl(
+        #version 450 core
+        #extension GL_EXT_buffer_reference : enable
+        layout (push_constant, std430) uniform Block { int identity[32]; } pc;
+        layout(r32ui, set = 3, binding = 0) uniform uimage2D image0_0;
+        layout(buffer_reference) buffer T1;
+        layout(set = 3, binding = 1, buffer_reference) buffer T1 {
+        layout(offset = 0) int a[2]; // stride = 4 for std430, 16 for std140
+        layout(offset = 32) int b;
+        layout(offset = 48) T1  c[2]; // stride = 8 for std430, 16 for std140
+        layout(offset = 80) T1  d;
+        } x;
+        void main() {}
+    )glsl";
+
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
+}
+
+TEST_F(PositiveShaderInterface, PhysicalStorageBuffer) {
+    TEST_DESCRIPTION("Regression shaders from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5349");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
+        GTEST_SKIP() << "At least Vulkan version 1.2 is required";
+    }
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+
+    auto features12 = LvlInitStruct<VkPhysicalDeviceVulkan12Features>();
+    GetPhysicalDeviceFeatures2(features12);
+    if (VK_TRUE != features12.bufferDeviceAddress) {
+        GTEST_SKIP() << "bufferDeviceAddress not supported and is required";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features12));
+
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    char const *vsSource = R"glsl(
+        #version 450
+        #extension GL_EXT_buffer_reference_uvec2 : enable
+
+        layout(set=0, binding=0) layout(buffer_reference, std430) buffer dataBuffer {
+            highp int value1;
+            highp int value2;
+        };
+
+        layout(location=0) out dataBuffer outgoingPtr;
+        void main() {
+            outgoingPtr = dataBuffer(uvec2(2.0));
+        }
+    )glsl";
+
+    char const *fsSource = R"glsl(
+        #version 450
+        #extension GL_EXT_buffer_reference_uvec2 : enable
+
+        layout(set=0, binding=0) layout(buffer_reference, std430) buffer dataBuffer {
+            highp int value1;
+            highp int value2;
+        };
+
+        layout(location=0) in dataBuffer incomingPtr;
+        layout(location=0) out highp vec4 fragColor;
+        void main() {
+            highp ivec2 v = ivec2(incomingPtr.value1, incomingPtr.value2);
+            fragColor = vec4(float(v.x)/255.0,float(v.y)/255.0, float(v.x+v.y)/255.0,1.0);
+        }
+    )glsl";
+
+    VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+}


### PR DESCRIPTION
Already have an issue #5374 

Found with `spirv-hopper` some shaders were crashing, added unit tests (since CI flow with spirv-hopper not fully setup)