### PR TITLE
android: Allow usage of c++_static when running tests

### DIFF
--- a/tests/android/CMakeLists.txt
+++ b/tests/android/CMakeLists.txt
@@ -15,27 +15,20 @@
 # limitations under the License.
 # ~~~
 
-# "CMAKE_ANDROID_STL_TYPE specifies the C++ STL implementation to be used. Earlier NDK releases
-# supported a range of different options, but projects should now use either c++_shared or c++_static.
-# Only use the latter if your application consists of a single shared library."- Professional CMake
+# NOTE: This can be removed when the minimum API level we support is 28.
 #
-# Here is the problem we encountered when building tests with c++_static:
+# Our unit tests on Android repeatedly close/open the vulkan validation layers.
+# This causes issues with issues with thread_local variables.
 #
-# https://developer.android.com/ndk/guides/cpp-support recommends using
-# c++_shared for applications that use more than one shared library.
-# If multiple libraries using c++_static are loaded several copies of
-# the globals will be present in the C++ runtime. This also happens
-# if the same library is dlopen/dlclosed several times, as when running
-# the Layer Validation Tests. Some of the c++ runtime globals are
-# thread_local, so each copy consumes a TLS key. There are only 128 TLS
-# keys allowed on android, and the unit tests can hit this because of
-# repeatedly loading and unloading VVL.
+# To run our tests on more devices without issue we can inform the linker to not unload VVL at runtime.
+# This will prevent VVL from being unloaded by dlclose which will avoid the issue.
 #
-# The drawback to using c++_shared is that the layer library can no longer
-# be installed manually, but must be installed in an APK. It is still
-# common practice to load layer libraries manually.
+# https://github.com/android/ndk/issues/360
+# https://github.com/android/ndk/issues/360#issuecomment-339107521
+# https://github.com/android/ndk/releases/tag/r26-beta1
 if ("${CMAKE_ANDROID_STL_TYPE}" MATCHES "static")
-    message(FATAL_ERROR "Cannot build tests with ${CMAKE_ANDROID_STL_TYPE}!")
+    # nodelete : Marks that vvl shouldn't be unloaded at runtime. 
+    target_link_options(vvl PRIVATE -Wl,-z,nodelete)
 endif()
 
 set_directory_properties(PROPERTIES "COMPILE_OPTIONS" "") # Disable compiler warnings


### PR DESCRIPTION
Instruct linker to ignore dlclose for VVL

Links to relevant documentation:
https://github.com/android/ndk/issues/360
https://github.com/android/ndk/issues/360#issuecomment-339107521
https://github.com/android/ndk/releases/tag/r26-beta1