### PR TITLE
layers: Remove CooperativeMatrixKHR until glslang supports

### DIFF
--- a/layers/core_checks/cc_shader.cpp
+++ b/layers/core_checks/cc_shader.cpp
@@ -2619,9 +2619,10 @@ bool CoreChecks::ValidatePipelineShaderStage(const PIPELINE_STATE &pipeline, con
     if (enabled_features.cooperative_matrix_features.cooperativeMatrix) {
         skip |= ValidateCooperativeMatrix(module_state, create_info);
     }
-    if (enabled_features.cooperative_matrix_features_khr.cooperativeMatrix) {
-        skip |= ValidateCooperativeMatrixKHR(module_state, create_info, local_size_x);
-    }
+    // TODO - Add once glslang support lands
+    // if (enabled_features.cooperative_matrix_features_khr.cooperativeMatrix) {
+    //     skip |= ValidateCooperativeMatrixKHR(module_state, create_info, local_size_x);
+    // }
     if (enabled_features.fragment_shading_rate_features.primitiveFragmentShadingRate) {
         skip |= ValidatePrimitiveRateShaderState(pipeline, module_state, entrypoint, stage);
     }

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -2,11 +2,11 @@
     "repos": [
         {
             "name": "glslang",
-            "url": "https://github.com/archimedus/glslang.git",
+            "url": "https://github.com/KhronosGroup/glslang.git",
             "sub_dir": "glslang",
             "build_dir": "glslang/build",
             "install_dir": "glslang/build/install",
-            "commit": "a7260ca8a6a81cddacef5d6b3d80398cd67b94b5",
+            "commit": "4f3ae4b03dc3556f96f55467e139f852831199d0",
             "optional": [
                 "tests"
             ]

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,8 +109,9 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/sampler_positive.cpp
     unit/shader_compute.cpp
     unit/shader_compute_positive.cpp
-    unit/shader_cooperative_matrix.cpp
-    unit/shader_cooperative_matrix_positive.cpp
+    # // TODO - Add once glslang support lands
+    # unit/shader_cooperative_matrix.cpp
+    # unit/shader_cooperative_matrix_positive.cpp
     unit/shader_image_access_positive.cpp
     unit/shader_interface.cpp
     unit/shader_interface_positive.cpp


### PR DESCRIPTION
I accidentally merged a fork of glslang in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6093

but proper glslang support is still in review https://github.com/KhronosGroup/glslang/pull/3248

this branch removes `CooperativeMatrixKHR` temporary if needed