### PR TITLE
layers: Check out of bounds access in syncval

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1991,6 +1991,10 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
             continue;
         }
         for (const auto &variable : stage_state.entrypoint->resource_interface_variables) {
+            if (variable.decorations.set >= per_sets->size()) {
+                // This should be caught by Core validation, but if core checks are disabled SyncVal should not crash.
+                continue;
+            }
             const auto *descriptor_set = (*per_sets)[variable.decorations.set].bound_descriptor_set.get();
             if (!descriptor_set) continue;
             auto binding = descriptor_set->GetBinding(variable.decorations.binding);
@@ -2129,6 +2133,10 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
             continue;
         }
         for (const auto &variable : stage_state.entrypoint->resource_interface_variables) {
+            if (variable.decorations.set >= per_sets->size()) {
+                // This should be caught by Core validation, but if core checks are disabled SyncVal should not crash.
+                continue;
+            }
             const auto *descriptor_set = (*per_sets)[variable.decorations.set].bound_descriptor_set.get();
             if (!descriptor_set) continue;
             auto binding = descriptor_set->GetBinding(variable.decorations.binding);


### PR DESCRIPTION
This can happen when core checks are disabled or when corresponding checks not implemented.

There are core validation checks for set-not-bound error for `vkCmdBindDescriptorSets` API.
That functionality is not implemented yet for `vkCmdBindDescriptorBuffers` + `vkCmdSetDescriptorBufferOffsets` API.
That is why, even with core checks enabled, we still need to do preventing checks in SyncVal.

Addresses https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6112