### PR TITLE
layers: Use constant for ObjectUseData alignment

### DIFF
--- a/layers/thread_tracker/thread_safety_validation.h
+++ b/layers/thread_tracker/thread_safety_validation.h
@@ -46,7 +46,13 @@ static_assert(std::is_same<uint64_t, DISTINCT_NONDISPATCHABLE_PHONY_HANDLE>::val
 [[maybe_unused]] static const char *kVUID_Threading_MultipleThreads = "UNASSIGNED-Threading-MultipleThreads";
 [[maybe_unused]] static const char *kVUID_Threading_SingleThreadReuse = "UNASSIGNED-Threading-SingleThreadReuse";
 
-class alignas(get_hardware_destructive_interference_size()) ObjectUseData {
+// Modern CPUs have 64 or 128-byte cache line sizes (Apple M1 has 128-byte cache line size).
+// Use alignment of 64 bytes (instead of 128) to prioritize using less memory and decrease
+// cache pressure.
+inline constexpr size_t kObjectUserDataAlignment = 64;
+static_assert(get_hardware_destructive_interference_size() % kObjectUserDataAlignment == 0);  // sanity check on the build machine
+
+class alignas(kObjectUserDataAlignment) ObjectUseData {
   public:
     class WriteReadCount {
       public:


### PR DESCRIPTION
`get_hardware_destructive_interference_size()` value is specific to build machine and at least in theory no guarantee it's the same as on the user machine.

For threading/sync code it's good to be as specific and unambiguous as possible to simplify the reasoning and validation of the code.

There could be two options here.
1. Use maximum cache line size that we have on the market. Currently it's 128 bytes.
2. Use the most common cache line size of 64 bytes.

The choice here is the 2nd option, it decreases cache pressure which is helpful for Apple devices too.

In case of potential false sharing on devices with 128 cache line size we can use conditional compilation and specify 128 alignment there, but until evidence, prefer a unified solution. Also for regular workloads we don't expect a lot of false sharing (it's a rare event in the CPU instruction stream - twice per high level Vulkan API call), but heavy threaded applications with a lot of Vulkan API calls increase the chance of collisions.