### PR TITLE
Add downstream interface tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,55 @@
+# Copyright (c) 2023-2023 The Khronos Group Inc.
+# Copyright (c) 2023-2023 RasterGrid Kft.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: VVL Downstream Interfaces
+
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  # github.head_ref is only defined on pull_request
+  # Fallback to the run ID, which is guaranteed to be both unique and defined for the run.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id  }}
+  cancel-in-progress: true
+
+on:
+    push:
+    pull_request:
+        branches:
+            - main
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: lukka/get-cmake@latest
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: downstream_test_ccache
+      - name: Configure Downstream Interface Test
+        run: |
+          cmake -S tests/downstream -B tests/downstream/build
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
+          CMAKE_GENERATOR: Ninja
+      - name: Build Downstream Interface Test
+        run: cmake --build tests/downstream/build

--- a/tests/downstream/CMakeLists.txt
+++ b/tests/downstream/CMakeLists.txt
@@ -1,0 +1,116 @@
+# ~~~
+# Copyright (c) 2023-2023 The Khronos Group Inc.
+# Copyright (c) 2023-2023 RasterGrid Kft.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+project(VVL_CUSTOM_FRAMEWORK LANGUAGES CXX)
+
+cmake_minimum_required(VERSION 3.17.2)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(VVL_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../../")
+set(VVL_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/vvl/build")
+set(VVL_UPDATE_DEPS_DIR "${CMAKE_CURRENT_BINARY_DIR}/vvl/external")
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E rm -rf ${VVL_BINARY_DIR})
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -S ${VVL_SOURCE_DIR} -B ${VVL_BINARY_DIR}
+        -D BUILD_TESTS=ON -G "Ninja" -D CMAKE_BUILD_TYPE=Debug -D UPDATE_DEPS=ON -D UPDATE_DEPS_DIR=${VVL_UPDATE_DEPS_DIR}
+)
+execute_process(COMMAND ${CMAKE_COMMAND} --build ${VVL_BINARY_DIR} --clean-first --target VkLayer_utils)
+
+list(APPEND CMAKE_PREFIX_PATH "${VVL_UPDATE_DEPS_DIR}/glslang/build/install")
+list(APPEND CMAKE_PREFIX_PATH "${VVL_UPDATE_DEPS_DIR}/Vulkan-Headers/build/install")
+list(APPEND CMAKE_PREFIX_PATH "${VVL_UPDATE_DEPS_DIR}/SPIRV-Headers/build/install")
+list(APPEND CMAKE_PREFIX_PATH "${VVL_UPDATE_DEPS_DIR}/SPIRV-Tools/build/install")
+list(APPEND CMAKE_PREFIX_PATH "${VVL_UPDATE_DEPS_DIR}/googletest/build/install")
+
+find_package(VulkanHeaders REQUIRED CONFIG)
+
+find_package(Python3 REQUIRED QUIET)
+
+add_custom_target(test_api_specific_generator_interfaces ALL
+    COMMAND Python3::Interpreter ${CMAKE_CURRENT_SOURCE_DIR}/test_api_specific_generator_interfaces.py)
+
+add_executable(custom_test_framework)
+
+target_compile_definitions(custom_test_framework PRIVATE VK_ENABLE_BETA_EXTENSIONS)
+target_compile_definitions(custom_test_framework PRIVATE VVL_TESTS_USE_CMAKE)
+target_compile_definitions(custom_test_framework PRIVATE VVL_TESTS_USE_CUSTOM_TEST_FRAMEWORK)
+
+target_include_directories(custom_test_framework PRIVATE
+    .
+    ../../layers
+    ../../layers/vulkan
+    ../framework)
+
+find_package(GTest REQUIRED CONFIG QUIET)
+find_package(glslang REQUIRED CONFIG QUIET)
+
+target_sources(custom_test_framework PRIVATE
+    framework/custom_test_framework.h
+    framework/custom_test_framework.cpp
+    ../framework/layer_validation_tests.h
+    ../framework/layer_validation_tests.cpp
+    ../framework/test_common.h
+    ../framework/error_monitor.cpp
+    ../framework/error_monitor.h
+    ../framework/render.cpp
+    ../framework/render.h
+    ../framework/binding.h
+    ../framework/binding.cpp
+    ../framework/test_framework.cpp)
+
+target_link_directories(custom_test_framework PRIVATE ${VVL_BINARY_DIR}/layers)
+
+# Represents all SPIRV libraries we need
+add_library(VVL-SPIRV-LIBS INTERFACE)
+
+find_package(SPIRV-Headers REQUIRED CONFIG QUIET)
+target_link_libraries(VVL-SPIRV-LIBS INTERFACE SPIRV-Headers::SPIRV-Headers)
+
+find_package(SPIRV-Tools-opt REQUIRED CONFIG QUIET)
+target_link_libraries(VVL-SPIRV-LIBS INTERFACE SPIRV-Tools-opt)
+
+find_package(SPIRV-Tools REQUIRED CONFIG QUIET)
+
+# See https://github.com/KhronosGroup/SPIRV-Tools/issues/3909 for background on this.
+# The targets available from SPIRV-Tools change depending on how SPIRV_TOOLS_BUILD_STATIC is set.
+# Try to handle all possible combinations so that we work with externally built packages.
+if (TARGET SPIRV-Tools)
+    target_link_libraries(VVL-SPIRV-LIBS INTERFACE SPIRV-Tools)
+elseif(TARGET SPIRV-Tools-static)
+    target_link_libraries(VVL-SPIRV-LIBS INTERFACE SPIRV-Tools-static)
+elseif(TARGET SPIRV-Tools-shared)
+    target_link_libraries(VVL-SPIRV-LIBS INTERFACE SPIRV-Tools-shared)
+else()
+    message(FATAL_ERROR "Cannot determine SPIRV-Tools target name")
+endif()
+
+target_link_libraries(custom_test_framework
+    VkLayer_utils
+    Vulkan::Headers
+    glslang::glslang
+    glslang::OGLCompiler
+    glslang::OSDependent
+    glslang::MachineIndependent
+    glslang::GenericCodeGen
+    glslang::HLSL
+    glslang::SPIRV
+    glslang::SPVRemapper
+    VVL-SPIRV-LIBS
+    GTest::gtest
+    GTest::gtest_main)

--- a/tests/downstream/api_specific_generator_interfaces.py
+++ b/tests/downstream/api_specific_generator_interfaces.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023-2023 The Khronos Group Inc.
+# Copyright (c) 2023-2023 RasterGrid Kft.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from generators.vulkan_object import Version
+
+class TestDiffRule:
+    def __init__(self, method, contains, matches_when_replaced_with):
+        self.method = method
+        self.contains = contains
+        self.matches_when_replaced_with = matches_when_replaced_with
+
+
+# API-specific interfaces across the generators that need testing
+# and custom test implementations provided for each
+class APISpecificInterfaces:
+
+    # Dictionary of source diff rules to verify the effects of the
+    # API-specific interfaces
+    gen_src_diff_rules: dict[str, list[TestDiffRule]] = {}
+
+    @staticmethod
+    def addGenSrcDiffRule(filename: str, rule: TestDiffRule):
+        if not filename in APISpecificInterfaces.gen_src_diff_rules:
+            APISpecificInterfaces.gen_src_diff_rules[filename] = []
+        APISpecificInterfaces.gen_src_diff_rules[filename].append(rule)
+
+
+    class generators:
+        # BaseGenerator
+        class base_generator:
+            @staticmethod
+            def createApiVersion(targetApiName: str, name: str, number: str) -> Version:
+                nameApi = name.replace('VK_', 'VK{NameApi}_API_')
+                nameString = '"' + name.replace('VK_', 'VK{NameString}_') + '"'
+
+                APISpecificInterfaces.addGenSrcDiffRule('vk_extension_helper.h', TestDiffRule(
+                    'base_generator.APISpecific.createApiVersion',
+                    '{NameString}', ''))
+
+                APISpecificInterfaces.addGenSrcDiffRule('stateless_validation_helper.cpp', TestDiffRule(
+                    'base_generator.APISpecific.createApiVersion',
+                    '{NameApi}', ''))
+
+                return Version(name, nameString, nameApi, number)
+
+
+        # EnumFlagBitsOutputGenerator
+        class enum_flag_bits_generator:
+            @staticmethod
+            def genManualConstants(targetApiName: str) -> list[str]:
+                APISpecificInterfaces.addGenSrcDiffRule('enum_flag_bits.h', TestDiffRule(
+                    'enum_flag_bits_generator.APISpecific.genManualConstants',
+                    '{Foo}{Bar}', ''))
+
+                return ['{Foo}', '{Bar}']
+
+
+        # ExtensionHelperOutputGenerator
+        class extension_helper_generator:
+            @staticmethod
+            def genAPIVersionSource(targetApiName: str) -> str:
+                modified_result = '{FooBarAPIVersionSource}'
+                APISpecificInterfaces.addGenSrcDiffRule('vk_extension_helper.h', TestDiffRule(
+                    'extension_helper_generator.APISpecific.genAPIVersionSource',
+                    modified_result,
+                    APISpecificInterfaces.generators.extension_helper_generator.original_genAPIVersionSource(targetApiName)))
+                return modified_result
+
+            @staticmethod
+            def getVersionFieldNameDict(targetApiName: str) -> dict[str, str]:
+                orig_result = APISpecificInterfaces.generators.extension_helper_generator.original_getVersionFieldNameDict(targetApiName)
+                modified_result = {}
+                for key in orig_result:
+                    modified_result[key] = '{FooBar' + orig_result[key] + 'VersionField}'
+
+                    APISpecificInterfaces.addGenSrcDiffRule('vk_extension_helper.h', TestDiffRule(
+                        'extension_helper_generator.APISpecific.getVersionFieldNameDict',
+                        modified_result[key], orig_result[key]))
+
+                return modified_result
+
+            @staticmethod
+            def getPromotedExtensionArrayName(targetApiName: str, scope: str) -> dict[str, str]:
+                orig_result = APISpecificInterfaces.generators.extension_helper_generator.original_getPromotedExtensionArrayName(targetApiName, scope)
+                modified_result = {}
+                for key in orig_result:
+                    modified_result[key] = '{FooBar' + orig_result[key] + 'PromotedVar}'
+
+                    APISpecificInterfaces.addGenSrcDiffRule('vk_extension_helper.h', TestDiffRule(
+                        'extension_helper_generator.APISpecific.getPromotedExtensionArrayName',
+                        modified_result[key], orig_result[key]))
+
+                return modified_result
+
+
+        # LayerChassisOutputGenerator
+        class layer_chassis_generator:
+            @staticmethod
+            def getValidationLayerList(targetApiName: str) -> list[dict[str, str]]:
+                orig_result = APISpecificInterfaces.generators.layer_chassis_generator.original_getValidationLayerList(targetApiName)
+                modified_result = []
+                for layer in orig_result:
+                    modified_result.append({
+                        'include': '{FooBar' + layer['include'] + 'IncludePath}',
+                        'class': '{FooBar' + layer['class'] + 'LayerClass}' if layer['class'] != 'ThreadSafety' else layer['class'],
+                        'enabled': '{FooBar' + layer['enabled'] + 'EnabledCondition}'
+                    })
+
+                    for key in ['include', 'class', 'enabled']:
+                        APISpecificInterfaces.addGenSrcDiffRule('chassis.cpp', TestDiffRule(
+                            'layer_chassis_generator.APISpecific.getValidationLayerList',
+                            modified_result[-1][key], layer[key]))
+
+                return modified_result
+
+
+            @staticmethod
+            def getInstanceExtensionList(targetApiName: str) -> list[str]:
+                orig_result = APISpecificInterfaces.generators.layer_chassis_generator.original_getInstanceExtensionList(targetApiName)
+                modified_result = []
+                for ext in orig_result:
+                    modified_result.append('{FooBar' + ext + 'InstanceExtension}')
+
+                    APISpecificInterfaces.addGenSrcDiffRule('chassis.cpp', TestDiffRule(
+                        'layer_chassis_generator.APISpecific.getInstanceExtensionList',
+                        modified_result[-1].upper(), ext.upper()))
+
+                return modified_result
+
+
+            @staticmethod
+            def getDeviceExtensionList(targetApiName: str) -> list[str]:
+                orig_result = APISpecificInterfaces.generators.layer_chassis_generator.original_getDeviceExtensionList(targetApiName)
+                modified_result = []
+                for ext in orig_result:
+                    modified_result.append('{FooBar' + ext + 'DeviceExtension}')
+
+                    APISpecificInterfaces.addGenSrcDiffRule('chassis.cpp', TestDiffRule(
+                        'layer_chassis_generator.APISpecific.getDeviceExtensionList',
+                        modified_result[-1].upper(), ext.upper()))
+
+                return modified_result
+
+
+            @staticmethod
+            def genInitObjectDispatchVectorSource(targetApiName: str) -> str:
+                modified_result = '{FooBarInitObjectDispatchVectorSource}'
+                APISpecificInterfaces.addGenSrcDiffRule('chassis_dispatch_helper.h', TestDiffRule(
+                    'layer_chassis_generator.APISpecific.genInitObjectDispatchVectorSource',
+                    modified_result,
+                    APISpecificInterfaces.generators.layer_chassis_generator.original_genInitObjectDispatchVectorSource(targetApiName)))
+
+                return modified_result
+
+
+        # ObjectTrackerOutputGenerator
+        class object_tracker_generator:
+            @staticmethod
+            def getUndestroyedObjectVUID(targetApiName: str, scope: str) -> str:
+                modified_result = '{FooBar' + scope + 'UndestroyedObjectVUID}'
+                APISpecificInterfaces.addGenSrcDiffRule('object_tracker.cpp', TestDiffRule(
+                    'object_tracker_generator.APISpecific.getUndestroyedObjectVUID',
+                    modified_result,
+                    APISpecificInterfaces.generators.object_tracker_generator.original_getUndestroyedObjectVUID(targetApiName, scope)))
+                return modified_result
+
+
+            @staticmethod
+            def IsImplicitlyDestroyed(targetApiName: str, handleType: str) -> bool:
+                orig_implicitly_destroyed = {
+                    'VkDisplayKHR': 'instance',
+                    'VkDisplayModeKHR': 'instance'
+                }
+
+                modified_implicitly_destroyed = {
+                    'VkSurfaceKHR': 'instance',
+                    'VkCommandBuffer': 'device',
+                    'VkImage': 'device',
+                    'VkBufferView': 'device'
+                }
+
+                if handleType in orig_implicitly_destroyed:
+                    scope = orig_implicitly_destroyed[handleType]
+                elif handleType in modified_implicitly_destroyed:
+                    scope = modified_implicitly_destroyed[handleType]
+                else:
+                    scope = 'invalid'
+
+                base_src_line = f'skip |= ReportLeaked{scope.capitalize()}Objects({scope}, kVulkanObjectType{handleType[2:]}, error_code);'
+                comment_prefix = '// No destroy API or implicitly freed/destroyed -- do not report: '
+
+                if handleType in orig_implicitly_destroyed and handleType not in modified_implicitly_destroyed:
+                    APISpecificInterfaces.addGenSrcDiffRule('object_tracker.cpp', TestDiffRule(
+                        'object_tracker_generator.APISpecific.IsImplicitlyDestroyed',
+                        '    ' + base_src_line,
+                        '    ' + comment_prefix + base_src_line))
+                if handleType not in orig_implicitly_destroyed and handleType in modified_implicitly_destroyed:
+                    APISpecificInterfaces.addGenSrcDiffRule('object_tracker.cpp', TestDiffRule(
+                        'object_tracker_generator.APISpecific.IsImplicitlyDestroyed',
+                        '    ' + comment_prefix + base_src_line,
+                        '    ' + base_src_line))
+
+                return handleType in modified_implicitly_destroyed
+
+
+            @staticmethod
+            def AreAllocVUIDsEnabled(targetApiName: str) -> bool:
+                # Unfortunately we cannot do anything better currently but to mimic the caller to get the original VUIDs
+                import inspect
+                caller_frame = inspect.currentframe().f_back
+                caller_instance = caller_frame.f_locals['self']
+                param = caller_frame.f_locals['param']
+
+                def mimic_caller(self, param, allocType: str) -> str:
+                    lookup_string = '%s-%s' %(param.name, allocType)
+                    vuid = self.manual_vuids.get(lookup_string, None)
+                    if vuid is not None:
+                        return vuid
+                    lookup_string = '%s-%s-%s' %(param.type, param.name, allocType)
+                    vuid = self.manual_vuids.get(lookup_string, None)
+                    if vuid is not None:
+                        return vuid
+                    return "kVUIDUndefined"
+
+                orig_compatalloc_vuid = mimic_caller(caller_instance, param, 'compatalloc')
+                orig_nullalloc_vuid = mimic_caller(caller_instance, param, 'nullalloc')
+
+                # The ValidateDestroyObject call for these objects is manually written
+                manual_validate_destroy_object_types = {
+                    'VkInstance',
+                    'VkDevice',
+                    'VkDescriptorPool'
+                    'VkDescriptorSet',
+                    'VkCommandPool',
+                    'VkCommandBuffer',
+                    'VkSwapchainKHR'
+                }
+
+                was_modified = True
+                was_modified = was_modified and param.type not in manual_validate_destroy_object_types
+                was_modified = was_modified and (orig_compatalloc_vuid != 'kVUIDUndefined' or orig_nullalloc_vuid != 'kVUIDUndefined')
+
+                if was_modified:
+                    APISpecificInterfaces.addGenSrcDiffRule('object_tracker.cpp', TestDiffRule(
+                        'object_tracker_generator.APISpecific.AreAllocVUIDsEnabled',
+                        f'ValidateDestroyObject({param.name}, kVulkanObjectType{param.type[2:]}, pAllocator, kVUIDUndefined, kVUIDUndefined)',
+                        f'ValidateDestroyObject({param.name}, kVulkanObjectType{param.type[2:]}, pAllocator, {orig_compatalloc_vuid}, {orig_nullalloc_vuid})'))
+
+                return False
+
+
+        # StatelessValidationHelperOutputGenerator
+        class stateless_validation_helper_generator:
+            @staticmethod
+            def genCustomValidation(targetApiName: str, funcName: str, member) -> list[str]:
+                if member.type == 'uint32_t' and member.name == 'engineVersion':
+                    APISpecificInterfaces.addGenSrcDiffRule('stateless_validation_helper.cpp', TestDiffRule(
+                        'stateless_validation_helper_generator.APISpecific.genCustomValidation',
+                        '{Foo}{Bar}{Custom}{Validation}', ''))
+                    lines = ['{Foo}', '{Bar}', '{Custom}', '{Validation}']
+                    return lines
+                else:
+                    return None

--- a/tests/downstream/framework/custom_test_framework.cpp
+++ b/tests/downstream/framework/custom_test_framework.cpp
@@ -1,0 +1,34 @@
+/***************************************************************************
+ *
+ * Copyright (c) 2023-2023 The Khronos Group Inc.
+ * Copyright (c) 2023-2023 RasterGrid Kft.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+#include "layer_validation_tests.h"
+
+#include <type_traits>
+
+// Test that using a custom framework enables us to define our own main
+// function and that the custom framework class is added as the base class
+// of VkLayerTest
+int main(int argc, char **argv) {
+    // VkLayerTest must be a subclass of VkCustomRenderFramework
+    static_assert(std::is_base_of<VkCustomRenderFramework, VkLayerTest>::value);
+
+    // VkCustomRenderFramework must be a subclass of VkRenderFramework
+    static_assert(std::is_base_of<VkRenderFramework, VkCustomRenderFramework>::value);
+
+    return 0;
+}

--- a/tests/downstream/framework/custom_test_framework.h
+++ b/tests/downstream/framework/custom_test_framework.h
@@ -1,0 +1,25 @@
+/***************************************************************************
+ *
+ * Copyright (c) 2023-2023 The Khronos Group Inc.
+ * Copyright (c) 2023-2023 RasterGrid Kft.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+#pragma once
+
+#include "render.h"
+
+// Test custom framework injection support by defining the base class for
+// VkLayerTest in the framework/custom_test_framework.h header
+class VkCustomRenderFramework : public VkRenderFramework {};
+using VkLayerTestBase = VkCustomRenderFramework;

--- a/tests/downstream/test_api_specific_generator_interfaces.py
+++ b/tests/downstream/test_api_specific_generator_interfaces.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023-2023 The Khronos Group Inc.
+# Copyright (c) 2023-2023 RasterGrid Kft.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import inspect
+import functools
+import pathlib
+import importlib
+import difflib
+
+class Test:
+    def __init__(self):
+        self.has_error = False
+
+        # Get script directory name
+        dirname = os.path.dirname(os.path.abspath(__file__))
+
+        # Change working directory to the directory where the script is located
+        os.chdir(dirname)
+
+        registry_dir = os.path.join(dirname, 'build/vvl/external/Vulkan-Headers/registry')
+        grammar_dir = os.path.join(dirname, 'build/vvl/external/SPIRV-Headers/include/spirv/unified1')
+
+        registry_file = os.path.join(registry_dir, 'vk.xml')
+        grammar_file = os.path.join(grammar_dir, 'spirv.core.grammar.json')
+
+        # Also add the registry and script directories to the python package search path
+        sys.path.insert(0, registry_dir)
+        sys.path.insert(1, os.path.join(pathlib.Path(dirname).parent.parent.absolute(), 'scripts'))
+
+        from api_specific_generator_interfaces import APISpecificInterfaces
+
+        # Test that the APISpecific generators have the desired interfaces and patch them
+        # with the test implementations
+        for package_name in APISpecificInterfaces.generators.__dict__.keys():
+            if package_name.startswith('__'):
+                continue
+
+            package = getattr(APISpecificInterfaces.generators, package_name)
+
+            try:
+                module = importlib.import_module(f'generators.{package_name}')
+            except:
+                self.error(f'Generator package "{package_name}" not found.')
+                continue
+
+            try:
+                cls = getattr(module, 'APISpecific')
+            except:
+                self.error(f'No APISpecific class found in generator package "{package_name}".')
+                continue
+
+            method_names = [x for x in package.__dict__.keys() if not x.startswith('__') and not x.startswith('verify_')]
+            for method_name in method_names:
+                try:
+                    method = getattr(cls, method_name)
+                except:
+                    self.error(f'Method "{package_name}.APISpecific.{method_name}" not found.')
+                    continue
+
+                test_method = getattr(package, method_name)
+
+                # Test signature
+                if inspect.signature(method) != inspect.signature(test_method):
+                    self.error(f'Method "{package_name}.APISpecific.{method_name}" signature mismatch.')
+
+                # Test that the interface only returns something when using the 'vulkan' target API name
+                for targetApiName in ['vulkan', 'vulkanvariant1',  'vulkanvariant2']:
+                    for param_name, param_data in inspect.signature(method).parameters.items():
+                        if param_name == 'targetApiName':
+                            bound_method = functools.partial(method, targetApiName)
+                        else:
+                            bound_method = functools.partial(bound_method, param_data.annotation())
+                    try:
+                        result = bound_method()
+                        if targetApiName != 'vulkan':
+                            if result is not None:
+                                self.error(f'Method "{package_name}.APISpecific.{method_name}" does not return None for non-Vulkan target API.')
+                    except:
+                        # Some functions have additional requirements on their inputs
+                        pass
+
+                setattr(cls, method_name, test_method)
+                setattr(package, f'original_{method_name}', method)
+
+        if self.has_error:
+            exit(1)
+
+        # Load source generator function
+        RunGenerators = getattr(importlib.import_module('generate_source'), 'RunGenerators')
+
+        # Create directory for generated files
+        gen_dir = os.path.join(dirname, 'build/generated')
+        ref_gen_dir = os.path.join(pathlib.Path(dirname).parent.parent.absolute(), 'layers/vulkan/generated')
+        if not pathlib.Path(gen_dir).is_dir():
+            os.mkdir(gen_dir)
+
+        # Run generators
+        RunGenerators('vulkan', registry_file, grammar_file, gen_dir, None)
+
+        # Verify output
+        contents = {}
+        ref_contents = {}
+        for filename in APISpecificInterfaces.gen_src_diff_rules.keys():
+            # Load generated file
+            file = open(f'{gen_dir}/{filename}', mode='r')
+            contents[filename] = file.read()
+            file.close()
+
+            # Load reference generated file
+            file = open(f'{ref_gen_dir}/{filename}', mode='r')
+            ref_contents[filename] = file.read()
+            file.close()
+
+        # Check contains rules
+        methods_with_no_effects = {}
+        for filename, rules in APISpecificInterfaces.gen_src_diff_rules.items():
+            for rule in rules:
+                if not rule.contains in contents[filename]:
+                    self.error(f'Could not find "{rule.contains}" in "{filename}".')
+                    if not rule.method in methods_with_no_effects:
+                        methods_with_no_effects[rule.method] = set()
+                    methods_with_no_effects[rule.method].add(filename)
+
+        for method_name, filenames in methods_with_no_effects.items():
+            self.error(f'Effect of method "{method_name}" is not observable in the generated file(s): {filenames}.')
+
+        # Apply replacement rules
+        for filename, rules in APISpecificInterfaces.gen_src_diff_rules.items():
+            for rule in rules:
+                contents[filename] = contents[filename].replace(rule.contains, rule.matches_when_replaced_with)
+
+        # Compare contents:
+        for filename in APISpecificInterfaces.gen_src_diff_rules.keys():
+            if contents[filename] != ref_contents[filename]:
+                self.error(f'Effect of API-specific test methods are different than expected in the generated file "{filename}":\n' +
+                            ''.join(difflib.unified_diff(
+                                [x + '\n' for x in ref_contents[filename].split('\n')],
+                                [x + '\n' for x in contents[filename].split('\n')])))
+
+        if self.has_error:
+            exit(1)
+
+
+    def error(self, msg: str):
+        print(f'ERROR: {msg}')
+        self.has_error = True
+
+    def fatal(self, msg: str):
+        print(f'ERROR: {msg}')
+        exit(1)
+
+
+if __name__ == '__main__':
+    Test()


### PR DESCRIPTION
This is a proposal to add tests for the downstream interfaces of VVL used to be able to implement and maintain downstream forks of VVL targeting other Vulkan API variants.