### PR TITLE
layers: Separate SHADER_MODULE_STATE and SPIRV_MODULE_STATE

### DIFF
--- a/layers/gpu_validation/gpu_utils.h
+++ b/layers/gpu_validation/gpu_utils.h
@@ -220,7 +220,7 @@ class GpuAssistedBase : public ValidationStateTracker {
     VkPhysicalDeviceFeatures supported_features{};
     VkPhysicalDeviceFeatures desired_features{};
     uint32_t adjusted_max_desc_sets = 0;
-    uint32_t unique_shader_module_id = 0;
+    uint32_t unique_shader_module_id = 1;  // zero represents no shader module found
     uint32_t output_buffer_size = 0;
     VkDescriptorSetLayout debug_desc_layout = VK_NULL_HANDLE;
     VkDescriptorSetLayout dummy_desc_layout = VK_NULL_HANDLE;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -39,7 +39,7 @@ class Descriptor;
 class ValidationStateTracker;
 class CMD_BUFFER_STATE;
 class RENDER_PASS_STATE;
-struct SPIRV_MODULE_STATE;
+struct SHADER_MODULE_STATE;
 class PIPELINE_STATE;
 
 enum DescriptorReqBits {
@@ -84,12 +84,14 @@ inline bool operator<(const DescriptorRequirement &a, const DescriptorRequiremen
 typedef std::map<uint32_t, DescriptorRequirement> BindingVariableMap;
 
 struct PipelineStageState {
-    std::shared_ptr<const SPIRV_MODULE_STATE> module_state;
+    // We use this over a SPIRV_MODULE_STATE because there are times we need to create empty objects
+    std::shared_ptr<const SHADER_MODULE_STATE> module_state;
     const safe_VkPipelineShaderStageCreateInfo *create_info;
+    // If null, means it is an empty object, no SPIR-V backing it
     std::shared_ptr<const EntryPoint> entrypoint;
 
     PipelineStageState(const safe_VkPipelineShaderStageCreateInfo *create_info,
-                       std::shared_ptr<const SPIRV_MODULE_STATE> &module_state, std::shared_ptr<const EntryPoint> &entrypoint);
+                       std::shared_ptr<const SHADER_MODULE_STATE> &module_state);
 };
 
 class PIPELINE_CACHE_STATE : public BASE_NODE {
@@ -296,7 +298,7 @@ class PIPELINE_STATE : public BASE_NODE {
         return {};
     }
 
-    std::shared_ptr<const SPIRV_MODULE_STATE> GetSubStateShader(VkShaderStageFlagBits state) const;
+    std::shared_ptr<const SHADER_MODULE_STATE> GetSubStateShader(VkShaderStageFlagBits state) const;
 
     template <VkGraphicsPipelineLibraryFlagBitsEXT type_flag>
     static inline typename SubStateTraits<type_flag>::type GetLibSubState(const ValidationStateTracker &state,

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -23,7 +23,7 @@
 // Graphics pipeline sub-state as defined by VK_KHR_graphics_pipeline_library
 //
 class RENDER_PASS_STATE;
-struct SPIRV_MODULE_STATE;
+struct SHADER_MODULE_STATE;
 
 template <typename CreateInfoType>
 static inline VkGraphicsPipelineLibraryFlagsEXT GetGraphicsLibType(const CreateInfoType &create_info) {
@@ -81,11 +81,11 @@ struct PreRasterState : public PipelineSubState {
     std::shared_ptr<const RENDER_PASS_STATE> rp_state;
     uint32_t subpass = 0;
 
-    std::shared_ptr<const SPIRV_MODULE_STATE> tessc_shader, tesse_shader;
+    std::shared_ptr<const SHADER_MODULE_STATE> tessc_shader, tesse_shader;
     const safe_VkPipelineShaderStageCreateInfo *tessc_shader_ci = nullptr, *tesse_shader_ci = nullptr;
     const safe_VkPipelineTessellationStateCreateInfo *tess_create_info = nullptr;
 
-    std::shared_ptr<const SPIRV_MODULE_STATE> vertex_shader, geometry_shader, task_shader, mesh_shader;
+    std::shared_ptr<const SHADER_MODULE_STATE> vertex_shader, geometry_shader, task_shader, mesh_shader;
     const safe_VkPipelineShaderStageCreateInfo *vertex_shader_ci = nullptr, *geometry_shader_ci = nullptr,
                                                *task_shader_ci = nullptr, *mesh_shader_ci = nullptr;
 };
@@ -131,7 +131,7 @@ struct FragmentShaderState : public PipelineSubState {
     std::unique_ptr<const safe_VkPipelineMultisampleStateCreateInfo> ms_state;
     std::unique_ptr<const safe_VkPipelineDepthStencilStateCreateInfo> ds_state;
 
-    std::shared_ptr<const SPIRV_MODULE_STATE> fragment_shader;
+    std::shared_ptr<const SHADER_MODULE_STATE> fragment_shader;
     std::unique_ptr<const safe_VkPipelineShaderStageCreateInfo> fragment_shader_ci;
 
   private:

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -66,6 +66,8 @@ class EVENT_STATE;
 class SWAPCHAIN_NODE;
 class SURFACE_STATE;
 class UPDATE_TEMPLATE_STATE;
+struct SHADER_MODULE_STATE;
+struct SHADER_OBJECT_STATE;
 
 // These versions allow functions that are the same to share the same logic but can use different VUs
 // The common case are functions that were missing the pNext in Vulkan 1.0 and added via extension
@@ -257,8 +259,6 @@ static inline VkDeviceSize GetBufferSizeFromCopyImage(const RegionType& region, 
     return buffer_size;
 }
 
-struct SPIRV_MODULE_STATE;
-
 VALSTATETRACK_STATE_OBJECT(VkQueue, QUEUE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkRenderPass, RENDER_PASS_STATE)
@@ -272,7 +272,8 @@ VALSTATETRACK_STATE_OBJECT(VkPipelineCache, PIPELINE_CACHE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkPipeline, PIPELINE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkDeviceMemory, DEVICE_MEMORY_STATE)
 VALSTATETRACK_STATE_OBJECT(VkFramebuffer, FRAMEBUFFER_STATE)
-VALSTATETRACK_STATE_OBJECT(VkShaderModule, SPIRV_MODULE_STATE)
+VALSTATETRACK_STATE_OBJECT(VkShaderModule, SHADER_MODULE_STATE)
+VALSTATETRACK_STATE_OBJECT(VkShaderEXT, SHADER_OBJECT_STATE)
 VALSTATETRACK_STATE_OBJECT(VkDescriptorUpdateTemplate, UPDATE_TEMPLATE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkSwapchainKHR, SWAPCHAIN_NODE)
 VALSTATETRACK_STATE_OBJECT(VkDescriptorPool, DESCRIPTOR_POOL_STATE)
@@ -846,14 +847,16 @@ class ValidationStateTracker : public ValidationObject {
                                        const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore, VkResult result) override;
     void PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator) override;
 
-    std::shared_ptr<SPIRV_MODULE_STATE> CreateShaderModuleState(const VkShaderModuleCreateInfo& create_info,
-                                                                 uint32_t unique_shader_id,
-                                                                 VkShaderModule handle = VK_NULL_HANDLE) const;
+    std::shared_ptr<SHADER_MODULE_STATE> CreateShaderModuleState(const VkShaderModuleCreateInfo& create_info, VkShaderModule handle,
+                                                                 uint32_t unique_shader_id) const;
     void PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                           const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule, VkResult result,
                                           void* csm_state) override;
     void PreCallRecordDestroyShaderModule(VkDevice device, VkShaderModule shaderModule,
                                           const VkAllocationCallbacks* pAllocator) override;
+    void PostCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
+                                        const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders, VkResult result) override;
+    void PreCallRecordDestroyShaderEXT(VkDevice device, VkShaderEXT shader, const VkAllocationCallbacks* pAllocator) override;
     void PreCallRecordDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
                                         const VkAllocationCallbacks* pAllocator) override;
     void PostCallRecordCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,
@@ -1487,7 +1490,7 @@ class ValidationStateTracker : public ValidationObject {
         }
     }
 
-    inline std::shared_ptr<SPIRV_MODULE_STATE> GetShaderModuleStateFromIdentifier(const VkShaderModuleIdentifierEXT& ident) {
+    inline std::shared_ptr<SHADER_MODULE_STATE> GetShaderModuleStateFromIdentifier(const VkShaderModuleIdentifierEXT& ident) {
         ReadLockGuard guard(shader_identifier_map_lock_);
         if (const auto itr = shader_identifier_map_.find(ident); itr != shader_identifier_map_.cend()) {
             return itr->second;
@@ -1495,7 +1498,7 @@ class ValidationStateTracker : public ValidationObject {
         return {};
     }
 
-    inline std::shared_ptr<SPIRV_MODULE_STATE> GetShaderModuleStateFromIdentifier(
+    inline std::shared_ptr<SHADER_MODULE_STATE> GetShaderModuleStateFromIdentifier(
         const VkPipelineShaderStageModuleIdentifierCreateInfoEXT& shader_stage_id) const {
         if (shader_stage_id.pIdentifier) {
             auto shader_id = LvlInitStruct<VkShaderModuleIdentifierEXT>();
@@ -1639,7 +1642,7 @@ class ValidationStateTracker : public ValidationObject {
     std::atomic<VkDeviceSize> samplerDescriptorBufferAddressSpaceSize = {0u};
 
     // Keep track of identifier -> state
-    vvl::unordered_map<VkShaderModuleIdentifierEXT, std::shared_ptr<SPIRV_MODULE_STATE>> shader_identifier_map_;
+    vvl::unordered_map<VkShaderModuleIdentifierEXT, std::shared_ptr<SHADER_MODULE_STATE>> shader_identifier_map_;
     mutable std::shared_mutex shader_identifier_map_lock_;
 
     // If vkGetMemoryFdKHR is called, keep track of fd handle -> allocation info
@@ -1674,7 +1677,8 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkPipeline, PIPELINE_STATE, pipeline_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkDeviceMemory, DEVICE_MEMORY_STATE, mem_obj_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkFramebuffer, FRAMEBUFFER_STATE, frame_buffer_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkShaderModule, SPIRV_MODULE_STATE, shader_module_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkShaderModule, SHADER_MODULE_STATE, shader_module_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkShaderEXT, SHADER_OBJECT_STATE, shader_object_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorUpdateTemplate, UPDATE_TEMPLATE_STATE, desc_template_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkSwapchainKHR, SWAPCHAIN_NODE, swapchain_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorPool, DESCRIPTOR_POOL_STATE, descriptor_pool_map_)


### PR DESCRIPTION
Follow up for https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6187 (cc @ziga-lunarg)

This breaks up the logic between a `SPIRV_MODULE_STATE` (which parses and holds the SPIR-V) and a `SHADER_MODULE_STATE` (and future `SHADER_OBJECT_STATE`) struct which is a thin wrapper around the SPIR-V

There is a lot of "fun" quirks around `SHADER_MODULE_STATE` and `VK_EXT_shader_module_identifier` / `VK_EXT_graphics_pipeline_library`, but luckily these extensions don't interact with `VK_EXT_shader_object`

This PR just separates the StateTracking objects, a follow up PR will adjust the GPU-AV to properly use `SPIRV_MODULE_STATE`