### PR TITLE
Add Not Active query check and label unassigned Query VUIDs

### DIFF
--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -848,6 +848,20 @@ bool CoreChecks::ValidateQueryPoolIndex(const QUERY_POOL_STATE &query_pool_state
     return skip;
 }
 
+bool CoreChecks::ValidateQueryPoolNotActive(const CMD_BUFFER_STATE &cb_state, VkQueryPool queryPool, uint32_t firstQuery,
+                                            uint32_t queryCount, const char *func_name, const char *vuid) const {
+    bool skip = false;
+    for (uint32_t i = 0; i < queryCount; i++) {
+        const uint32_t slot = firstQuery + i;
+        QueryObject query_obj = {queryPool, slot};
+        if (cb_state.activeQueries.count(query_obj)) {
+            const LogObjectList objlist(cb_state.commandBuffer(), queryPool);
+            skip |= LogError(objlist, vuid, "%s: Query index %" PRIu32 " is still active.", func_name, slot);
+        }
+    }
+    return skip;
+}
+
 bool CoreChecks::PreCallValidateCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                                   uint32_t queryCount) const {
     if (disabled[query_validation]) return false;
@@ -859,7 +873,8 @@ bool CoreChecks::PreCallValidateCmdResetQueryPool(VkCommandBuffer commandBuffer,
     const auto &query_pool_state = *Get<QUERY_POOL_STATE>(queryPool);
     skip |= ValidateQueryPoolIndex(query_pool_state, firstQuery, queryCount, "VkCmdResetQueryPool()",
                                    "VUID-vkCmdResetQueryPool-firstQuery-00796", "VUID-vkCmdResetQueryPool-firstQuery-00797");
-
+    skip |= ValidateQueryPoolNotActive(*cb_state, queryPool, firstQuery, queryCount, "vkCmdResetQueryPool()",
+                                       "VUID-vkCmdResetQueryPool-None-02841");
     return skip;
 }
 
@@ -932,6 +947,8 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandB
     skip |= ValidateQueryPoolIndex(query_pool_state, firstQuery, queryCount, "vkCmdCopyQueryPoolResults()",
                                    "VUID-vkCmdCopyQueryPoolResults-firstQuery-00820",
                                    "VUID-vkCmdCopyQueryPoolResults-firstQuery-00821");
+    skip |= ValidateQueryPoolNotActive(*cb_state, queryPool, firstQuery, queryCount, "vkCmdCopyQueryPoolResults()",
+                                       "VUID-vkCmdCopyQueryPoolResults-None-07429");
 
     if (query_pool_state.createInfo.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
         skip |= ValidatePerformanceQueryResults("vkCmdCopyQueryPoolResults", query_pool_state, firstQuery, queryCount, flags);

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -848,8 +848,8 @@ bool CoreChecks::ValidateQueryPoolIndex(const QUERY_POOL_STATE &query_pool_state
     return skip;
 }
 
-bool CoreChecks::ValidateQueryPoolNotActive(const CMD_BUFFER_STATE &cb_state, VkQueryPool queryPool, uint32_t firstQuery,
-                                            uint32_t queryCount, const char *func_name, const char *vuid) const {
+bool CoreChecks::ValidateQueriesNotActive(const CMD_BUFFER_STATE &cb_state, VkQueryPool queryPool, uint32_t firstQuery,
+                                          uint32_t queryCount, const char *func_name, const char *vuid) const {
     bool skip = false;
     for (uint32_t i = 0; i < queryCount; i++) {
         const uint32_t slot = firstQuery + i;
@@ -873,8 +873,8 @@ bool CoreChecks::PreCallValidateCmdResetQueryPool(VkCommandBuffer commandBuffer,
     const auto &query_pool_state = *Get<QUERY_POOL_STATE>(queryPool);
     skip |= ValidateQueryPoolIndex(query_pool_state, firstQuery, queryCount, "VkCmdResetQueryPool()",
                                    "VUID-vkCmdResetQueryPool-firstQuery-00796", "VUID-vkCmdResetQueryPool-firstQuery-00797");
-    skip |= ValidateQueryPoolNotActive(*cb_state, queryPool, firstQuery, queryCount, "vkCmdResetQueryPool()",
-                                       "VUID-vkCmdResetQueryPool-None-02841");
+    skip |= ValidateQueriesNotActive(*cb_state, queryPool, firstQuery, queryCount, "vkCmdResetQueryPool()",
+                                     "VUID-vkCmdResetQueryPool-None-02841");
     return skip;
 }
 
@@ -947,8 +947,8 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandB
     skip |= ValidateQueryPoolIndex(query_pool_state, firstQuery, queryCount, "vkCmdCopyQueryPoolResults()",
                                    "VUID-vkCmdCopyQueryPoolResults-firstQuery-00820",
                                    "VUID-vkCmdCopyQueryPoolResults-firstQuery-00821");
-    skip |= ValidateQueryPoolNotActive(*cb_state, queryPool, firstQuery, queryCount, "vkCmdCopyQueryPoolResults()",
-                                       "VUID-vkCmdCopyQueryPoolResults-None-07429");
+    skip |= ValidateQueriesNotActive(*cb_state, queryPool, firstQuery, queryCount, "vkCmdCopyQueryPoolResults()",
+                                     "VUID-vkCmdCopyQueryPoolResults-None-07429");
 
     if (query_pool_state.createInfo.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
         skip |= ValidatePerformanceQueryResults("vkCmdCopyQueryPoolResults", query_pool_state, firstQuery, queryCount, flags);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -558,9 +558,6 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos, const char* api_name) const;
     bool ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
                                                                  const char* api_name) const;
-    static bool ValidateCopyQueryPoolResults(const CMD_BUFFER_STATE& cb_state, VkQueryPool queryPool, uint32_t firstQuery,
-                                             uint32_t queryCount, uint32_t perfPass, VkQueryResultFlags flags,
-                                             QueryMap* localQueryToStateMap);
     static bool VerifyQueryIsReset(const CMD_BUFFER_STATE& cb_state, const QueryObject& query_obj, const CMD_TYPE cmd_type,
                                    VkQueryPool& firstPerfQueryPool, uint32_t perfPass, QueryMap* localQueryToStateMap);
     static bool ValidatePerformanceQuery(const CMD_BUFFER_STATE& cb_state, const QueryObject& query_obj, const CMD_TYPE cmd_type,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1707,6 +1707,8 @@ class CoreChecks : public ValidationStateTracker {
     void PreCallRecordCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot) override;
     bool ValidateQueryPoolIndex(const QUERY_POOL_STATE& query_pool_state, uint32_t firstQuery, uint32_t queryCount,
                                 const char* func_name, const char* first_vuid, const char* sum_vuid) const;
+    bool ValidateQueryPoolNotActive(const CMD_BUFFER_STATE& cb_state, VkQueryPool queryPool, uint32_t firstQuery,
+                                    uint32_t queryCount, const char* func_name, const char* vuid) const;
     bool PreCallValidateCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                           uint32_t queryCount) const override;
     bool PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1707,8 +1707,8 @@ class CoreChecks : public ValidationStateTracker {
     void PreCallRecordCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot) override;
     bool ValidateQueryPoolIndex(const QUERY_POOL_STATE& query_pool_state, uint32_t firstQuery, uint32_t queryCount,
                                 const char* func_name, const char* first_vuid, const char* sum_vuid) const;
-    bool ValidateQueryPoolNotActive(const CMD_BUFFER_STATE& cb_state, VkQueryPool queryPool, uint32_t firstQuery,
-                                    uint32_t queryCount, const char* func_name, const char* vuid) const;
+    bool ValidateQueriesNotActive(const CMD_BUFFER_STATE& cb_state, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
+                                  const char* func_name, const char* vuid) const;
     bool PreCallValidateCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                           uint32_t queryCount) const override;
     bool PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,

--- a/layers/error_message/validation_error_enums.h
+++ b/layers/error_message/validation_error_enums.h
@@ -29,8 +29,6 @@
 [[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidEvent = "UNASSIGNED-CoreValidation-DrawState-InvalidEvent";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidImageAspect = "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidImageLayout = "UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout";
-[[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidQuery = "UNASSIGNED-CoreValidation-DrawState-InvalidQuery";
-[[maybe_unused]] static const char *kVUID_Core_DrawState_QueryNotReset = "UNASSIGNED-CoreValidation-DrawState-QueryNotReset";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidRenderpass = "UNASSIGNED-CoreValidation-DrawState-InvalidRenderpass";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_InvalidSecondaryCommandBuffer = "UNASSIGNED-CoreValidation-DrawState-InvalidSecondaryCommandBuffer";
 [[maybe_unused]] static const char *kVUID_Core_DrawState_NoEndCommandBuffer = "UNASSIGNED-CoreValidation-DrawState-NoEndCommandBuffer";


### PR DESCRIPTION
As a first step for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6107

This labels the VUIDs for the 2 UNASSIGNED VUs for queries

Also adds `VUID-vkCmdResetQueryPool-None-02841` and `VUID-vkCmdCopyQueryPoolResults-None-07429`