### PR TITLE
layers: Fix 64-bit vertex input logic

### DIFF
--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -138,12 +138,12 @@ bool CoreChecks::ValidateInterfaceVertexInput(const PIPELINE_STATE &pipeline, co
                     // Unlike 32-bit, the components for 64-bit inputs have to match exactly
                     const uint32_t attribute_components = FormatComponentCount(attribute_format);
                     const uint32_t input_components = module_state.GetNumComponentsInBaseType(shader_input);
-                    if (attribute_components != input_components) {
+                    if (attribute_components < input_components) {
                         skip |= LogError(module_state.handle(), "UNASSIGNED-VkGraphicsPipelineCreateInfo-Component-64bit",
                                          "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attribute at location %" PRIu32
                                          " is a %" PRIu32 "-wide 64-bit format (%s) but vertex shader input is %" PRIu32
                                          "-wide 64-bit type (%s), 64-bit vertex input don't have default values and require "
-                                         "matching components.",
+                                         "components to match what is used in the shader.",
                                          pipeline.create_index, location, attribute_components, string_VkFormat(attribute_format),
                                          input_components, module_state.DescribeType(var_base_type_id).c_str());
                     }

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -1103,47 +1103,6 @@ TEST_F(NegativeVertexInput, Attribute64bitUnusedComponent) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeVertexInput, Attribute64bitMissingComponent) {
-    TEST_DESCRIPTION("Shader uses f64vec2, but provides too many component with R64G64B64A64");
-
-    ASSERT_NO_FATAL_FAILURE(Init());
-    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    if (!m_device->phy().features().shaderFloat64) {
-        GTEST_SKIP() << "Device does not support 64bit vertex attributes";
-    }
-
-    const VkFormat format = VK_FORMAT_R64G64B64A64_SFLOAT;
-    VkFormatProperties format_props = m_device->format_properties(format);
-    if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
-        GTEST_SKIP() << "Format not supported for Vertex Buffer";
-    }
-
-    char const *vsSource = R"glsl(
-        #version 450 core
-        #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
-        layout(location = 0) in f64vec2 pos;
-        void main() {}
-    )glsl";
-    VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
-
-    CreatePipelineHelper pipe(*this);
-    pipe.InitInfo();
-    VkVertexInputBindingDescription input_binding = {0, 32, VK_VERTEX_INPUT_RATE_VERTEX};
-    VkVertexInputAttributeDescription input_attribs = {0, 0, format, 0};
-
-    pipe.vi_ci_.vertexBindingDescriptionCount = 1;
-    pipe.vi_ci_.pVertexBindingDescriptions = &input_binding;
-    pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
-    pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
-    pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-VkGraphicsPipelineCreateInfo-Component-64bit");
-    pipe.CreateGraphicsPipeline();
-    m_errorMonitor->VerifyFound();
-}
-
 TEST_F(NegativeVertexInput, AttributeStructTypeBlockLocation64bit) {
     TEST_DESCRIPTION("Input is OpTypeStruct where the Block has the Location with 64-bit Vertex format");
 

--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -576,3 +576,42 @@ TEST_F(PositiveVertexInput, AttributeStructTypeBlockLocation64bit) {
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
+
+TEST_F(PositiveVertexInput, Attribute64bitMissingComponent) {
+    TEST_DESCRIPTION("Shader uses f64vec2, but provides too many component with R64G64B64A64, which is valid");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    if (!m_device->phy().features().shaderFloat64) {
+        GTEST_SKIP() << "Device does not support 64bit vertex attributes";
+    }
+
+    const VkFormat format = VK_FORMAT_R64G64B64A64_SFLOAT;
+    VkFormatProperties format_props = m_device->format_properties(format);
+    if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
+        GTEST_SKIP() << "Format not supported for Vertex Buffer";
+    }
+
+    char const *vsSource = R"glsl(
+        #version 450 core
+        #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
+        layout(location = 0) in f64vec2 pos;
+        void main() {}
+    )glsl";
+    VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitInfo();
+    VkVertexInputBindingDescription input_binding = {0, 32, VK_VERTEX_INPUT_RATE_VERTEX};
+    VkVertexInputAttributeDescription input_attribs = {0, 0, format, 0};
+
+    pipe.vi_ci_.vertexBindingDescriptionCount = 1;
+    pipe.vi_ci_.pVertexBindingDescriptions = &input_binding;
+    pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
+    pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
+    pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
+    pipe.InitState();
+
+    pipe.CreateGraphicsPipeline();
+}


### PR DESCRIPTION
Discussed in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6008

This is illegal

> format = `R64`    | shader = `(location = 0) in f64vec2`

but this is actually legal

> format = `R64G64` | shader = `(location = 0) in float64_t`

So fixed the logic and moved test to positive

(new VUID will come in a spec update soon)
