### PR TITLE
layers: Fix record_guard misses clean up

### DIFF
--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -4559,8 +4559,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValue(
     }
     VkResult result = DispatchGetSemaphoreCounterValue(device, semaphore, pValue);
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordGetSemaphoreCounterValue]) {
-        WriteLockGuard lock;
-        intercept->GetWriteLockForBlockingOperation(lock);
+        ValidationObject::BlockingOperationGuard lock(intercept);
         intercept->PostCallRecordGetSemaphoreCounterValue(device, semaphore, pValue, result);
     }
     return result;
@@ -4583,8 +4582,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphores(
     }
     VkResult result = DispatchWaitSemaphores(device, pWaitInfo, timeout);
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordWaitSemaphores]) {
-        WriteLockGuard lock;
-        intercept->GetWriteLockForBlockingOperation(lock);
+        ValidationObject::BlockingOperationGuard lock(intercept);
         intercept->PostCallRecordWaitSemaphores(device, pWaitInfo, timeout, result);
     }
     return result;
@@ -7905,8 +7903,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreCounterValueKHR(
     }
     VkResult result = DispatchGetSemaphoreCounterValueKHR(device, semaphore, pValue);
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordGetSemaphoreCounterValueKHR]) {
-        WriteLockGuard lock;
-        intercept->GetWriteLockForBlockingOperation(lock);
+        ValidationObject::BlockingOperationGuard lock(intercept);
         intercept->PostCallRecordGetSemaphoreCounterValueKHR(device, semaphore, pValue, result);
     }
     return result;
@@ -7929,8 +7926,7 @@ VKAPI_ATTR VkResult VKAPI_CALL WaitSemaphoresKHR(
     }
     VkResult result = DispatchWaitSemaphoresKHR(device, pWaitInfo, timeout);
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordWaitSemaphoresKHR]) {
-        WriteLockGuard lock;
-        intercept->GetWriteLockForBlockingOperation(lock);
+        ValidationObject::BlockingOperationGuard lock(intercept);
         intercept->PostCallRecordWaitSemaphoresKHR(device, pWaitInfo, timeout, result);
     }
     return result;


### PR DESCRIPTION
If control flow takes path that does not call `EndBlockingOperation` then `record_guard` stays initialized which triggers assert.

Reset record guard in destructor to ensure clean up always happens.

External semaphores do not call `{Begin/End}BlockingOperation`, and it triggered assert in CTS tests.