### PR TITLE
layers: Fix VUID churn for VK_EXT_shader_object

### DIFF
--- a/layers/stateless/sl_shader_object.cpp
+++ b/layers/stateless/sl_shader_object.cpp
@@ -61,21 +61,20 @@ bool StatelessValidation::manual_PreCallValidateCreateShadersEXT(VkDevice device
                 "].flags (%s) contains VK_SHADER_CREATE_LINK_STAGE_BIT_EXT bit, but pCreateInfos[%" PRIu32 "].stage is %s.",
                 i, string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(), i, string_VkShaderStageFlagBits(createInfo.stage));
         }
-        if (createInfo.stage != VK_SHADER_STAGE_COMPUTE_BIT) {
-            if ((createInfo.flags &
-                 (VK_SHADER_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT | VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT)) != 0) {
-                skip |= LogError(
-                    device, "VUID-VkShaderCreateInfoEXT-flags-08413",
-                    "vkCreateShadersEXT(): pCreateInfos[%" PRIu32 "].flags are %s, but pCreateInfos[%" PRIu32 "].stage is %s.", i,
-                    string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(), i, string_VkShaderStageFlagBits(createInfo.stage));
-            }
-            if ((createInfo.flags & VK_SHADER_CREATE_DISPATCH_BASE_BIT_EXT) != 0) {
-                skip |=
-                    LogError(device, "VUID-VkShaderCreateInfoEXT-flags-08485",
+        if (((createInfo.flags & VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT) != 0) &&
+            ((createInfo.stage & (VK_SHADER_STAGE_MESH_BIT_EXT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_COMPUTE_BIT)) ==
+             0)) {
+            skip |= LogError(
+                device, "VUID-VkShaderCreateInfoEXT-flags-08992",
+                "vkCreateShadersEXT(): pCreateInfos[%" PRIu32 "].flags (%s), but pCreateInfos[%" PRIu32 "].stage is %s.", i,
+                string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(), i, string_VkShaderStageFlagBits(createInfo.stage));
+        }
+        if ((createInfo.stage != VK_SHADER_STAGE_COMPUTE_BIT) &&
+            ((createInfo.flags & VK_SHADER_CREATE_DISPATCH_BASE_BIT_EXT) != 0)) {
+            skip |= LogError(device, "VUID-VkShaderCreateInfoEXT-flags-08485",
                              "vkCreateShadersEXT(): pCreateInfos[%" PRIu32
                              "].flags include VK_SHADER_CREATE_DISPATCH_BASE_BIT_EXT, but pCreateInfos[%" PRIu32 "].stage is %s.",
                              i, i, string_VkShaderStageFlagBits(createInfo.stage));
-            }
         }
         if (createInfo.stage != VK_SHADER_STAGE_FRAGMENT_BIT) {
             if ((createInfo.flags & VK_SHADER_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_EXT) != 0) {
@@ -154,20 +153,6 @@ bool StatelessValidation::manual_PreCallValidateCreateShadersEXT(VkDevice device
                 skip |= LogError(device, "VUID-VkShaderCreateInfoEXT-nextStage-08436",
                                  "vkCreateShadersEXT(): pCreateInfos[%" PRIu32
                                  "].stage is VK_SHADER_STAGE_MESH_BIT_EXT, but pCreateInfos[%" PRIu32 "].nextStage is %s.",
-                                 i, i, string_VkShaderStageFlags(createInfo.nextStage).c_str());
-            }
-        } else if (createInfo.stage == VK_SHADER_STAGE_TASK_BIT_NV) {
-            if ((createInfo.nextStage & ~VK_SHADER_STAGE_MESH_BIT_NV) != 0) {
-                skip |= LogError(device, "VUID-VkShaderCreateInfoEXT-nextStage-08437",
-                                 "vkCreateShadersEXT(): pCreateInfos[%" PRIu32
-                                 "].stage is VK_SHADER_STAGE_TASK_BIT_NV, but pCreateInfos[%" PRIu32 "].nextStage is %s.",
-                                 i, i, string_VkShaderStageFlags(createInfo.nextStage).c_str());
-            }
-        } else if (createInfo.stage == VK_SHADER_STAGE_MESH_BIT_NV) {
-            if ((createInfo.nextStage & ~VK_SHADER_STAGE_FRAGMENT_BIT) != 0) {
-                skip |= LogError(device, "VUID-VkShaderCreateInfoEXT-nextStage-08438",
-                                 "vkCreateShadersEXT(): pCreateInfos[%" PRIu32
-                                 "].stage is VK_SHADER_STAGE_MESH_BIT_NV, but pCreateInfos[%" PRIu32 "].nextStage is %s.",
                                  i, i, string_VkShaderStageFlags(createInfo.nextStage).c_str());
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_ALL_GRAPHICS || createInfo.stage == VK_SHADER_STAGE_ALL) {

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -61,7 +61,7 @@ TEST_F(NegativeShaderObject, LinkedComputeShader) {
 TEST_F(NegativeShaderObject, InvalidFlags) {
     TEST_DESCRIPTION("Create shader with invalid flags.");
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderCreateInfoEXT-flags-08413");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderCreateInfoEXT-flags-08992");
 
     InitBasicShaderObject();
     if (::testing::Test::IsSkipped()) return;
@@ -69,7 +69,7 @@ TEST_F(NegativeShaderObject, InvalidFlags) {
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
     VkShaderCreateInfoEXT createInfo = LvlInitStruct<VkShaderCreateInfoEXT>();
-    createInfo.flags = VK_SHADER_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT;
+    createInfo.flags = VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT;
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);


### PR DESCRIPTION
Related Spec change https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6031

@ziga-lunarg seems that `VUID-VkShaderCreateInfoEXT-flags-08413` was recently changed to `VUID-VkShaderCreateInfoEXT-flags-08992` with the logic as well