### PR TITLE
Fix VkDescriptorAddressInfoEXT VUs

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -3974,18 +3974,37 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureOpaqueCaptureDescriptorD
     return skip;
 }
 
-bool CoreChecks::ValidateDescriptorAddressInfoEXT(VkDevice device, const VkDescriptorAddressInfoEXT *address_info) const {
+bool CoreChecks::ValidateDescriptorAddressInfoEXT(VkDevice device, const VkDescriptorAddressInfoEXT *address_info,
+                                                  const char *structure) const {
     bool skip = false;
 
-    if ((address_info->address == 0) && !enabled_features.robustness2_features.nullDescriptor) {
-        skip |= LogError(device, "VUID-VkDescriptorAddressInfoEXT-address-08043",
-                         "VkDescriptorAddressInfoEXT: address is 0, but the nullDescriptor feature is not enabled.");
+    if (address_info->range == 0) {
+        skip |= LogError(device, "VUID-VkDescriptorAddressInfoEXT-range-08940",
+                         "vkGetDescriptorEXT: pDescriptorInfo->data.%s->range is zero.", structure);
+    }
+
+    if (address_info->address == 0) {
+        if (!enabled_features.robustness2_features.nullDescriptor) {
+            skip |= LogError(
+                device, "VUID-VkDescriptorAddressInfoEXT-address-08043",
+                "vkGetDescriptorEXT: pDescriptorInfo->data.%s->address is 0, but the nullDescriptor feature is not enabled.",
+                structure);
+        } else if (address_info->range != VK_WHOLE_SIZE) {
+            skip |= LogError(device, "VUID-VkDescriptorAddressInfoEXT-nullDescriptor-08938",
+                             "vkGetDescriptorEXT: pDescriptorInfo->data.%s->range is not VK_WHOLE_SIZE when address is zero.",
+                             structure);
+        }
+    } else {
+        if (address_info->range == VK_WHOLE_SIZE) {
+            skip |= LogError(device, "VUID-VkDescriptorAddressInfoEXT-nullDescriptor-08939",
+                             "vkGetDescriptorEXT: pDescriptorInfo->data.%s->range is VK_WHOLE_SIZE.", structure);
+        }
     }
 
     const auto buffer_states = GetBuffersByAddress(address_info->address);
     if ((address_info->address != 0) && buffer_states.empty()) {
         skip |= LogError(device, "VUID-VkDescriptorAddressInfoEXT-None-08044",
-                         "VkDescriptorAddressInfoEXT: address not 0 or a valid buffer address.");
+                         "vkGetDescriptorEXT: pDescriptorInfo->data.%s->address is not a valid buffer address.", structure);
     } else {
         using BUFFER_STATE_PTR = ValidationStateTracker::BUFFER_STATE_PTR;
         BufferAddressValidation<1> buffer_address_validator = {
@@ -4003,11 +4022,6 @@ bool CoreChecks::ValidateDescriptorAddressInfoEXT(VkDevice device, const VkDescr
 
         skip |= buffer_address_validator.LogErrorsIfNoValidBuffer(*this, buffer_states, "vkCmdBindDescriptorBuffersEXT", "address",
                                                                   address_info->address);
-    }
-
-    if (address_info->range == VK_WHOLE_SIZE) {
-        skip |= LogError(device, "VUID-VkDescriptorAddressInfoEXT-range-08046",
-                         "VkDescriptorAddressInfoEXT: range must not be VK_WHOLE_SIZE.");
     }
 
     return skip;
@@ -4242,22 +4256,22 @@ bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescri
     switch (pDescriptorInfo->type) {
         case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
             if (pDescriptorInfo->data.pUniformTexelBuffer) {
-                skip |= ValidateDescriptorAddressInfoEXT(device, pDescriptorInfo->data.pUniformTexelBuffer);
+                skip |= ValidateDescriptorAddressInfoEXT(device, pDescriptorInfo->data.pUniformTexelBuffer, "pUniformTexelBuffer");
             }
             break;
         case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
             if (pDescriptorInfo->data.pStorageTexelBuffer) {
-                skip |= ValidateDescriptorAddressInfoEXT(device, pDescriptorInfo->data.pStorageTexelBuffer);
+                skip |= ValidateDescriptorAddressInfoEXT(device, pDescriptorInfo->data.pStorageTexelBuffer, "pStorageTexelBuffer");
             }
             break;
         case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
             if (pDescriptorInfo->data.pUniformBuffer) {
-                skip |= ValidateDescriptorAddressInfoEXT(device, pDescriptorInfo->data.pUniformBuffer);
+                skip |= ValidateDescriptorAddressInfoEXT(device, pDescriptorInfo->data.pUniformBuffer, "pUniformBuffer");
             }
             break;
         case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
             if (pDescriptorInfo->data.pStorageBuffer) {
-                skip |= ValidateDescriptorAddressInfoEXT(device, pDescriptorInfo->data.pStorageBuffer);
+                skip |= ValidateDescriptorAddressInfoEXT(device, pDescriptorInfo->data.pStorageBuffer, "pStorageBuffer");
             }
             break;
         default:

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -2283,7 +2283,8 @@ class CoreChecks : public ValidationStateTracker {
                                                                    uint32_t set) const override;
     bool PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
                                                     const VkDescriptorBufferBindingInfoEXT* pBindingInfos) const override;
-    bool ValidateDescriptorAddressInfoEXT(VkDevice device, const VkDescriptorAddressInfoEXT* address_info) const;
+    bool ValidateDescriptorAddressInfoEXT(VkDevice device, const VkDescriptorAddressInfoEXT* address_info,
+                                          const char* structure) const;
     bool PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT* pDescriptorInfo, size_t dataSize,
                                          void* pDescriptor) const override;
 

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -1183,10 +1183,16 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAddressRange) {
     vk::GetDescriptorEXT(m_device->device(), &dgi, descriptor_buffer_properties.uniformBufferDescriptorSize, &buffer);
     m_errorMonitor->VerifyFound();
 
+    dai.range = 0;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorAddressInfoEXT-range-08940");
+    vk::GetDescriptorEXT(m_device->device(), &dgi, descriptor_buffer_properties.uniformBufferDescriptorSize, &buffer);
+    m_errorMonitor->VerifyFound();
+
     dai.range = VK_WHOLE_SIZE;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorAddressInfoEXT-range-08045");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorAddressInfoEXT-range-08046");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorAddressInfoEXT-nullDescriptor-08939");
     vk::GetDescriptorEXT(m_device->device(), &dgi, descriptor_buffer_properties.uniformBufferDescriptorSize, &buffer);
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
These `VK_EXT_descriptor_buffer` VUs were changed in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5929

`VUID-VkDescriptorAddressInfoEXT-range-08046` was split up into

- VUID-VkDescriptorAddressInfoEXT-nullDescriptor-08938
- VUID-VkDescriptorAddressInfoEXT-nullDescriptor-08939
-  VUID-VkDescriptorAddressInfoEXT-range-08940
- 
While at it, broke up the massive `NegativeDescriptorBuffer.DescriptorGetInfo` test we had into more manageable tests that can be debugged easier