### PR TITLE
ci: Update Vulkan-Loader library unloading option

### DIFF
--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -140,9 +140,6 @@ def BuildLoader():
     cmake_cmd = f'cmake -S {SRC_DIR} -B {BUILD_DIR}'
     cmake_cmd += ' -D UPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release'
 
-    # This enables better stack traces from tools like leak sanitizer by using the loader feature which prevents unloading of libraries at shutdown.
-    cmake_cmd += ' -D LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING=ON'
-
     # GitHub actions runs our test as admin on Windows
     if IsGHA() and IsWindows():
         cmake_cmd += ' -D LOADER_USE_UNSAFE_FILE_SEARCH=ON'
@@ -224,6 +221,9 @@ def RunVVLTests():
         lvt_env['LD_LIBRARY_PATH'] = os.path.join(CI_INSTALL_DIR, 'lib')
         lvt_env['VK_LAYER_PATH'] = os.path.join(CI_INSTALL_DIR, 'share/vulkan/explicit_layer.d')
         lvt_env['VK_DRIVER_FILES'] = os.path.join(CI_INSTALL_DIR, 'share/vulkan/icd.d/VkICD_mock_icd.json')
+
+    # This enables better stack traces from tools like leak sanitizer by using the loader feature which prevents unloading of libraries at shutdown.
+    lvt_env['VK_LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING'] = '1'
 
     # Useful for debugging
     # lvt_env['VK_LOADER_DEBUG'] = 'error,warn,info'


### PR DESCRIPTION
The loader recently updated how the dynamic library unloading behavior is enabled, from a build option to an environment variable set at startup. this commit updates common_ci.py to respect that change.