### PR TITLE
Fix nullptr crash

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -992,7 +992,7 @@ bool CoreChecks::ValidateAccessMask(const LogObjectList &objlist, const Location
         const auto illegal_pipeline_stages = allVkPipelineShaderStageBits2 & ~VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR;
         if (stage_mask & illegal_pipeline_stages) {
             // Select right vuid based on enabled extensions
-            const char *vuid = sync_vuid_maps::GetAccessMaskRayQueryVUIDSelector(loc, device_extensions);
+            const auto &vuid = sync_vuid_maps::GetAccessMaskRayQueryVUIDSelector(loc, device_extensions);
             const auto stages_string = sync_utils::StringPipelineStageFlags(stage_mask);
             std::stringstream msg;
             msg << loc.Message() << " contains pipeline stages " << stages_string << '.';

--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -668,7 +668,7 @@ const std::string &GetBadAccessFlagsVUID(const Location &loc, VkAccessFlags2KHR 
 
 // commonvalidity/access_mask_2_common.adoc
 static const auto &GetLocation2VUIDMap() {
-    static const std::map<Key, const char *> Location2VUID{
+    static const std::map<Key, std::string> Location2VUID{
         {Key(Struct::VkMemoryBarrier2, Field::srcAccessMask), "VUID-VkMemoryBarrier2-srcAccessMask-06256"},
         {Key(Struct::VkMemoryBarrier2, Field::dstAccessMask), "VUID-VkMemoryBarrier2-dstAccessMask-06256"},
         {Key(Struct::VkBufferMemoryBarrier2, Field::srcAccessMask), "VUID-VkBufferMemoryBarrier2-srcAccessMask-06256"},
@@ -680,13 +680,13 @@ static const auto &GetLocation2VUIDMap() {
     return Location2VUID;
 }
 
-const char *GetAccessMaskRayQueryVUIDSelector(const Location &loc, const DeviceExtensions &device_extensions) {
+const std::string &GetAccessMaskRayQueryVUIDSelector(const Location &loc, const DeviceExtensions &device_extensions) {
     const Key key(loc.structure, loc.field);
-    auto it = GetLocation2VUIDMap().find(key);
-    if (it != GetLocation2VUIDMap().end()) {
+    if (auto it = GetLocation2VUIDMap().find(key); it != GetLocation2VUIDMap().end()) {
         return it->second;
     }
-    return nullptr;
+    static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-bad-access-flags");
+    return unhandled;
 }
 
 static const std::vector<Entry> kQueueCapErrors{

--- a/layers/sync/sync_vuid_maps.h
+++ b/layers/sync/sync_vuid_maps.h
@@ -118,6 +118,6 @@ enum class ShaderTileImageError { kShaderTileImageFeatureError, kShaderTileImage
 
 const std::string &GetShaderTileImageVUID(const Location &loc, ShaderTileImageError error);
 
-const char *GetAccessMaskRayQueryVUIDSelector(const Location &loc, const DeviceExtensions &device_extensions);
+const std::string &GetAccessMaskRayQueryVUIDSelector(const Location &loc, const DeviceExtensions &device_extensions);
 
 }  // namespace sync_vuid_maps

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -415,6 +415,22 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(PositiveRayTracing, BarrierSync1NoCrash) {
+    TEST_DESCRIPTION("Regression test for nullptr crash when Sync1 barrier API is used for acceleration structure accesses");
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    // This stage can not be used with ACCELERATION_STRUCTURE_READ access when ray query is disabled, but VVL also should not crash.
+    constexpr VkPipelineStageFlags invalid_src_stage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+
+    auto barrier = LvlInitStruct<VkMemoryBarrier>();
+    barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
+
+    m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreChecks-unhandled-bad-access-flags");
+    m_commandBuffer->begin();
+    m_commandBuffer->PipelineBarrier(invalid_src_stage, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, 1, &barrier, 0, nullptr, 0, nullptr);
+    m_commandBuffer->end();
+}
+
 TEST_F(PositiveRayTracing, BuildAccelerationStructuresList) {
     TEST_DESCRIPTION("Build a list of destination acceleration structures, then do an update build on that same list");
 


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6195

It's similar to other GetVUID helpers to handle situation when VUID is not defined.

Can happen when VU is defined only for Sync2 but we still do the checks for Sync1.
This assumes that rules for compatible subset of Sync2 enums make sense for Sync1 too.