### PR TITLE
layers: Move SPIRV_MODULE_STATE creation to PreRecord

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2477,6 +2477,27 @@ static ValidationCache *GetValidationCacheInfo(VkShaderModuleCreateInfo const *p
     return nullptr;
 }
 
+void CoreChecks::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
+                                                 const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
+                                                 void *csm_state_data) {
+    // Normally would validate in PreCallValidate, but need a non-const function to update csm_state
+    // This is on the stack, we don't have to worry about threading hazards and this could be moved and used const_cast
+    ValidationStateTracker::PreCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, csm_state_data);
+    create_shader_module_api_state *csm_state = static_cast<create_shader_module_api_state *>(csm_state_data);
+    // TODO - Move SPIR-V only validation from a pipeline check to here
+    csm_state->valid_spirv = true;
+}
+
+void CoreChecks::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT *pCreateInfos,
+                                               const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
+                                               void *csm_state_data) {
+    ValidationStateTracker::PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders,
+                                                          csm_state_data);
+    create_shader_module_api_state *csm_state = static_cast<create_shader_module_api_state *>(csm_state_data);
+    // TODO - Move SPIR-V only validation from a pipeline check to here
+    csm_state->valid_spirv = true;
+}
+
 bool CoreChecks::PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                                    const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule) const {
     bool skip = false;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -867,6 +867,12 @@ class CoreChecks : public ValidationStateTracker {
                                                      VkShaderModuleIdentifierEXT* pIdentifier) const override;
     bool PreCallValidateGetShaderModuleCreateInfoIdentifierEXT(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                                                VkShaderModuleIdentifierEXT* pIdentifier) const override;
+    void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
+                                         const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
+                                         void* csm_state_data) override;
+    void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
+                                       const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
+                                       void* csm_state_data) override;
     bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule) const override;
     bool ValidatePipelineShaderStage(const PIPELINE_STATE& pipeline, const PipelineStageState& stage_state) const;

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -129,13 +129,20 @@ bool DebugPrintf::InstrumentShader(const vvl::span<const uint32_t> &input, std::
 void DebugPrintf::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                                   const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                                   void *csm_state_data) {
-    create_shader_module_api_state *csm_state = reinterpret_cast<create_shader_module_api_state *>(csm_state_data);
+    ValidationStateTracker::PreCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, csm_state_data);
+    create_shader_module_api_state *csm_state = static_cast<create_shader_module_api_state *>(csm_state_data);
     const bool pass = InstrumentShader(vvl::make_span(pCreateInfo->pCode, pCreateInfo->codeSize / sizeof(uint32_t)),
                                        csm_state->instrumented_pgm, &csm_state->unique_shader_id);
     if (pass) {
         csm_state->instrumented_create_info.pCode = csm_state->instrumented_pgm.data();
         csm_state->instrumented_create_info.codeSize = csm_state->instrumented_pgm.size() * sizeof(uint32_t);
     }
+}
+
+void DebugPrintf::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
+                                                const VkShaderCreateInfoEXT *pCreateInfos, const VkAllocationCallbacks *pAllocator,
+                                                VkShaderEXT *pShaders, void *csm_state_data) {
+    // TODO - Add VK_EXT_shader_object support
 }
 
 vartype vartype_lookup(char intype) {

--- a/layers/gpu_validation/debug_printf.h
+++ b/layers/gpu_validation/debug_printf.h
@@ -93,6 +93,9 @@ class DebugPrintf : public GpuAssistedBase {
     void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                          void* csm_state_data) override;
+    void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
+                                       const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
+                                       void* csm_state_data) override;
     std::vector<DPFSubstring> ParseFormatString(const std::string& format_string);
     std::string FindFormatString(vvl::span<const uint32_t> pgm, uint32_t string_id);
     void AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, DPFBufferInfo& buffer_info,

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -1008,14 +1008,20 @@ bool GpuAssisted::InstrumentShader(const vvl::span<const uint32_t> &input, std::
 void GpuAssisted::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                                   const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                                   void *csm_state_data) {
-    create_shader_module_api_state *csm_state = reinterpret_cast<create_shader_module_api_state *>(csm_state_data);
+    ValidationStateTracker::PreCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, csm_state_data);
+    create_shader_module_api_state *csm_state = static_cast<create_shader_module_api_state *>(csm_state_data);
     const bool pass = InstrumentShader(vvl::make_span(pCreateInfo->pCode, pCreateInfo->codeSize / sizeof(uint32_t)),
                                        csm_state->instrumented_pgm, &csm_state->unique_shader_id);
     if (pass) {
         csm_state->instrumented_create_info.pCode = csm_state->instrumented_pgm.data();
         csm_state->instrumented_create_info.codeSize = csm_state->instrumented_pgm.size() * sizeof(uint32_t);
     }
-    ValidationStateTracker::PreCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, csm_state_data);
+}
+
+void GpuAssisted::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
+                                                const VkShaderCreateInfoEXT *pCreateInfos, const VkAllocationCallbacks *pAllocator,
+                                                VkShaderEXT *pShaders, void *csm_state_data) {
+    // TODO - Add VK_EXT_shader_object support
 }
 
 // Generate the part of the message describing the violation.

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -218,6 +218,9 @@ class GpuAssisted : public GpuAssistedBase {
     void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                          void* csm_state_data) override;
+    void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
+                                       const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
+                                       void* csm_state_data) override;
     void AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, GpuAssistedBufferInfo& buffer_info,
                                     uint32_t operation_index, uint32_t* const debug_output_buffer,
                                     const std::vector<GpuAssistedDescSetState>& descriptor_sets);

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -51,12 +51,13 @@ PIPELINE_STATE::StageStateVec PIPELINE_STATE::GetStageStates(const ValidationSta
                     const auto shader_ci = LvlFindInChain<VkShaderModuleCreateInfo>(stage_ci.pNext);
                     const uint32_t unique_shader_id = (csm_states) ? (*csm_states)[stage].unique_shader_id : 0;
                     if (shader_ci) {
-                        module_state = state_data.CreateShaderModuleState(*shader_ci, VK_NULL_HANDLE, unique_shader_id);
+                        // don't need to worry about GroupDecoration in GPL
+                        auto spirv_module = std::make_unique<SPIRV_MODULE_STATE>(shader_ci->codeSize, shader_ci->pCode);
+                        module_state =
+                            std::make_shared<SHADER_MODULE_STATE>(VK_NULL_HANDLE, std::move(spirv_module), unique_shader_id);
                     } else {
-                        // shader_module_identifier could legally provide a null module handle
-                        VkShaderModuleCreateInfo dummy_module_ci = LvlInitStruct<VkShaderModuleCreateInfo>();
-                        dummy_module_ci.pCode = &unique_shader_id;  // Ensure tripping invalid spirv
-                        module_state = state_data.CreateShaderModuleState(dummy_module_ci, VK_NULL_HANDLE, unique_shader_id);
+                        // VK_EXT_shader_module_identifier could legally provide a null module handle
+                        module_state = std::make_shared<SHADER_MODULE_STATE>(unique_shader_id);
                     }
                 }
 

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -78,7 +78,9 @@ PreRasterState::PreRasterState(const PIPELINE_STATE &p, const ValidationStateTra
                 // module is part of a library and the state must be created
                 const auto shader_ci = LvlFindInChain<VkShaderModuleCreateInfo>(create_info.pStages[i].pNext);
                 if (shader_ci) {
-                    module_state = state_data.CreateShaderModuleState(*shader_ci, VK_NULL_HANDLE, 0);
+                    // don't need to worry about GroupDecoration in GPL
+                    auto spirv_module = std::make_unique<SPIRV_MODULE_STATE>(shader_ci->codeSize, shader_ci->pCode);
+                    module_state = std::make_shared<SHADER_MODULE_STATE>(VK_NULL_HANDLE, std::move(spirv_module), 0);
                 }
             }
 
@@ -173,7 +175,9 @@ void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const Validatio
                 // module is part of a library and the state must be created
                 const auto shader_ci = LvlFindInChain<VkShaderModuleCreateInfo>(create_info.pStages[i].pNext);
                 if (shader_ci) {
-                    module_state = state_data.CreateShaderModuleState(*shader_ci, VK_NULL_HANDLE, 0);
+                    // don't need to worry about GroupDecoration in GPL
+                    auto spirv_module = std::make_unique<SPIRV_MODULE_STATE>(shader_ci->codeSize, shader_ci->pCode);
+                    module_state = std::make_shared<SHADER_MODULE_STATE>(VK_NULL_HANDLE, std::move(spirv_module), 0);
                 }
             }
 

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -6184,15 +6184,18 @@ class ValidationObject {
             PreCallRecordCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout);
         };
 
-        // Enable the CreateShaderModule API to take an extra argument for state preservation and paramter modification
-        virtual bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule, void* csm_state) const {
-            return PreCallValidateCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule);
-        };
+        // Enable the CreateShaderModule/CreateShaderEXT API to take an extra argument for state preservation and paramter modification
         virtual void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule, void* csm_state) {
             PreCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule);
         };
         virtual void PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule, VkResult result, void* csm_state) {
             PostCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, result);
+        };
+        virtual void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders, void* csm_state) {
+            PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders);
+        };
+        virtual void PostCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders, VkResult result, void* csm_state) {
+            PostCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, result);
         };
 
         // Allow AllocateDescriptorSets to use some local stack storage for performance purposes

--- a/layers/vulkan/generated/chassis_dispatch_helper.h
+++ b/layers/vulkan/generated/chassis_dispatch_helper.h
@@ -1545,9 +1545,6 @@ typedef enum InterceptId{
     InterceptIdPreCallValidateCmdOpticalFlowExecuteNV,
     InterceptIdPreCallRecordCmdOpticalFlowExecuteNV,
     InterceptIdPostCallRecordCmdOpticalFlowExecuteNV,
-    InterceptIdPreCallValidateCreateShadersEXT,
-    InterceptIdPreCallRecordCreateShadersEXT,
-    InterceptIdPostCallRecordCreateShadersEXT,
     InterceptIdPreCallValidateDestroyShaderEXT,
     InterceptIdPreCallRecordDestroyShaderEXT,
     InterceptIdPostCallRecordDestroyShaderEXT,
@@ -3280,9 +3277,6 @@ void ValidationObject::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCmdOpticalFlowExecuteNV);
     BUILD_DISPATCH_VECTOR(PreCallRecordCmdOpticalFlowExecuteNV);
     BUILD_DISPATCH_VECTOR(PostCallRecordCmdOpticalFlowExecuteNV);
-    BUILD_DISPATCH_VECTOR(PreCallValidateCreateShadersEXT);
-    BUILD_DISPATCH_VECTOR(PreCallRecordCreateShadersEXT);
-    BUILD_DISPATCH_VECTOR(PostCallRecordCreateShadersEXT);
     BUILD_DISPATCH_VECTOR(PreCallValidateDestroyShaderEXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordDestroyShaderEXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordDestroyShaderEXT);


### PR DESCRIPTION
This reworks the chassis for `vkCreateShaderModule` and `vkCreateShadersEXT` so it can after

1. Validate the SPIR-V without needing pipeline state (to solve issues like https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2835)
2. Easier to add support for `VK_EXT_shader_object` in both Validation and GPU-AV (making separate PR as needs many tests added)

Overview of flow

![spirv](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/115671160/f152727a-8bfb-4beb-b092-10da0c07384a)
