### PR TITLE
tests: Remove unused VkRenderFramework fields

### DIFF
--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -560,24 +560,6 @@ void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *crea
 
     m_render_target_fmt = GetRenderTargetFormat();
 
-    m_lineWidth = 1.0f;
-
-    m_depthBiasConstantFactor = 0.0f;
-    m_depthBiasClamp = 0.0f;
-    m_depthBiasSlopeFactor = 0.0f;
-
-    m_blendConstants[0] = 1.0f;
-    m_blendConstants[1] = 1.0f;
-    m_blendConstants[2] = 1.0f;
-    m_blendConstants[3] = 1.0f;
-
-    m_minDepthBounds = 0.f;
-    m_maxDepthBounds = 1.f;
-
-    m_compareMask = 0xff;
-    m_writeMask = 0xff;
-    m_reference = 0;
-
     m_commandPool = new VkCommandPoolObj(m_device, m_device->graphics_queue_node_index_, flags);
 
     m_commandBuffer = new VkCommandBufferObj(m_device, m_commandPool);

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -245,16 +245,6 @@ class VkRenderFramework : public VkTestFramework {
 
     std::vector<VkViewport> m_viewports;
     std::vector<VkRect2D> m_scissors;
-    float m_lineWidth;
-    float m_depthBiasConstantFactor;
-    float m_depthBiasClamp;
-    float m_depthBiasSlopeFactor;
-    float m_blendConstants[4];
-    float m_minDepthBounds;
-    float m_maxDepthBounds;
-    uint32_t m_compareMask;
-    uint32_t m_writeMask;
-    uint32_t m_reference;
     bool m_addRenderPassSelfDependency;
     std::vector<VkSubpassDependency> m_additionalSubpassDependencies;
     std::vector<VkClearValue> m_renderPassClearValues;


### PR DESCRIPTION
Talking with @arno-lunarg , we should clean up the `VkRenderFramework` as things like creating a `InitRenderTarget` depends on so many random member variables.

this is a simple first PR to remove the unused variables we are not even using