### PR TITLE
layers: Turn off VK_KHR_cooperative_matrix

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -816,6 +816,9 @@ bool CoreChecks::ValidateCooperativeMatrix(const SPIRV_MODULE_STATE &module_stat
     return skip;
 }
 
+// Turned off due to backward breaking SPIRV-Headers
+// see https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6225
+#if 0
 // Validate SPV_KHR_cooperative_matrix behavior that can't be statically validated
 // in SPIRV-Tools (e.g. due to specialization constant usage).
 bool CoreChecks::ValidateCooperativeMatrixKHR(const SPIRV_MODULE_STATE &module_state,
@@ -1103,9 +1106,9 @@ bool CoreChecks::ValidateCooperativeMatrixKHR(const SPIRV_MODULE_STATE &module_s
                 break;
         }
     }
-
     return skip;
 }
+#endif
 
 bool CoreChecks::ValidateShaderResolveQCOM(const SPIRV_MODULE_STATE &module_state, VkShaderStageFlagBits stage,
                                            const PIPELINE_STATE &pipeline) const {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -889,8 +889,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateMemoryScope(const SPIRV_MODULE_STATE& module_state, const Instruction& insn) const;
     bool ValidateCooperativeMatrix(const SPIRV_MODULE_STATE& module_state,
                                    safe_VkPipelineShaderStageCreateInfo const* create_info) const;
-    bool ValidateCooperativeMatrixKHR(const SPIRV_MODULE_STATE& module_state,
-                                      safe_VkPipelineShaderStageCreateInfo const* create_info, const uint32_t local_size_x) const;
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6225
+    // bool ValidateCooperativeMatrixKHR(const SPIRV_MODULE_STATE& module_state,
+    //                                   safe_VkPipelineShaderStageCreateInfo const* create_info, const uint32_t local_size_x) const;
     bool ValidateShaderResolveQCOM(const SPIRV_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
                                    const PIPELINE_STATE& pipeline) const;
     bool ValidateShaderSubgroupSizeControl(const SPIRV_MODULE_STATE& module_state, VkShaderStageFlagBits stage,


### PR DESCRIPTION
Due to CI issues with SPIRV-Tools and old NDK versions (https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6231#issuecomment-1659869849)  decided to just remove the code from building as we are still waiting for glslang support to land anyway (https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6176)