### PR TITLE
layers: Fix skip in shader tile image validation

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2104,7 +2104,7 @@ bool CoreChecks::ValidateShaderTileImage(const SPIRV_MODULE_STATE &module_state,
                                          const PIPELINE_STATE &pipeline, const VkShaderStageFlagBits stage) const {
     bool skip = false;
 
-    if ((stage != VK_SHADER_STAGE_FRAGMENT_BIT) && !IsExtEnabled(device_extensions.vk_ext_shader_tile_image)) {
+    if ((stage != VK_SHADER_STAGE_FRAGMENT_BIT) || !IsExtEnabled(device_extensions.vk_ext_shader_tile_image)) {
         return skip;
     }
 


### PR DESCRIPTION
VK_EXT_shader_tile_image validation should be skip if stage is not fragment OR if the extension is not enabled