### PR TITLE
tests: Remove features checks not needed

### DIFF
--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -108,11 +108,8 @@ TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressWorstCase) {
     }
 
     auto buffer_addr_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(buffer_addr_features);
-    if (!buffer_addr_features.bufferDeviceAddress) {
-        GTEST_SKIP() << "bufferDeviceAddress not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(buffer_addr_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &buffer_addr_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // Allocate common buffer memory, all buffers will be bound to it so that they have the same starting address
     auto alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
@@ -163,11 +160,8 @@ TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressGoodCase) {
     }
 
     auto buffer_addr_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(buffer_addr_features);
-    if (!buffer_addr_features.bufferDeviceAddress) {
-        GTEST_SKIP() << "bufferDeviceAddress not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(buffer_addr_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &buffer_addr_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // Allocate common buffer memory, all buffers will be bound to it so that they have the same starting address
     auto alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -205,9 +205,6 @@ TEST_F(NegativeCommand, Sync2SecondaryCommandbufferAsPrimary) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferSubmitInfo-commandBuffer-03890");
@@ -273,9 +270,6 @@ TEST_F(NegativeCommand, Sync2CommandBufferTwoSubmits) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-CommandBufferSingleSubmitViolation");

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -3761,11 +3761,8 @@ TEST_F(NegativeDescriptors, CreateDescriptorPoolFlags) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkDescriptorPoolSize ds_type_count = {};
@@ -3825,11 +3822,8 @@ TEST_F(NegativeDescriptors, MutableDescriptorPoolsWithPartialOverlap) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
 
     VkDescriptorPoolSize pool_sizes[2] = {};
     pool_sizes[0].type = VK_DESCRIPTOR_TYPE_MUTABLE_EXT;
@@ -3895,11 +3889,8 @@ TEST_F(NegativeDescriptors, CreateDescriptorPoolAllocateFlags) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkDescriptorPoolSize ds_type_count = {};
@@ -4047,11 +4038,8 @@ TEST_F(NegativeDescriptors, WriteMutableDescriptorSet) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     auto mutdesc_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutdesc_features);
-    if (!mutdesc_features.mutableDescriptorType) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutdesc_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutdesc_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkDescriptorPoolSize ds_type_count = {};
@@ -4143,12 +4131,8 @@ TEST_F(NegativeDescriptors, MutableDescriptors) {
     }
 
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "mutableDescriptorType feature is not supported, skipping test";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
-
+    GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     VkDescriptorSetLayoutBinding dsl_binding = {};
     dsl_binding.binding = 0;
     dsl_binding.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
@@ -4221,11 +4205,8 @@ TEST_F(NegativeDescriptors, DescriptorUpdateTemplate) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
     auto mutdesc_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutdesc_features);
-    if (!mutdesc_features.mutableDescriptorType) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutdesc_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutdesc_features));
 
     VkDescriptorPoolSize ds_type_count = {};
     ds_type_count.type = VK_DESCRIPTOR_TYPE_MUTABLE_EXT;
@@ -4300,11 +4281,8 @@ TEST_F(NegativeDescriptors, MutableDescriptorSetLayout) {
     }
 
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_MUTABLE_EXT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
@@ -4958,11 +4936,8 @@ TEST_F(NegativeDescriptors, DescriptorSetLayoutBinding) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
 
     vk_testing::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -5005,9 +4980,6 @@ TEST_F(NegativeDescriptors, BindingDescriptorSetFromHostOnlyPool) {
     }
     auto mutdesc_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
     GetPhysicalDeviceFeatures2(mutdesc_features);
-    if (!mutdesc_features.mutableDescriptorType) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported.";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutdesc_features));
 
     VkDescriptorPoolSize ds_type_count = {};
@@ -5061,12 +5033,8 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "Test requires unsupported mutableDescriptorType feature";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
-
+    GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     {
         VkDescriptorType descriptor_types[] = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER};
 
@@ -5368,11 +5336,8 @@ TEST_F(NegativeDescriptors, UpdatingMutableDescriptors) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "Test requires unsupported mutableDescriptorType feature";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
 
     VkDescriptorType descriptor_types[] = {VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER};
 

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -720,11 +720,8 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
 
     VkDescriptorType descriptor_types[] = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER};
 
@@ -828,17 +825,8 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
     auto acc_struct_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&mutable_descriptor_type_features);
     auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&acc_struct_features);
-    auto features2 = GetPhysicalDeviceFeatures2(bda_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported";
-    }
-    if (acc_struct_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure feature not supported";
-    }
-    if (bda_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress feature not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(bda_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &bda_features));
 
     std::array descriptor_types = {VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR};
 
@@ -1133,12 +1121,8 @@ TEST_F(PositiveDescriptors, MultipleThreadsUsingHostOnlyDescriptorSet) {
     }
 
     auto mutable_descriptor = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor);
-    if (mutable_descriptor.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutable_descriptor);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor));
 
     VkImageObj image1(m_device);
     VkImageObj image2(m_device);

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -2603,11 +2603,6 @@ TEST_F(NegativeDynamicRendering, WithBarrier) {
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2Features>();
     InitBasicDynamicRendering(&sync2_features);
     if (::testing::Test::IsSkipped()) return;
-
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "Test requires (unsupported) synchronization2";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     m_commandBuffer->begin();
@@ -2665,9 +2660,6 @@ TEST_F(NegativeDynamicRendering, WithoutShaderTileImageAndBarrier) {
     auto features2 = GetPhysicalDeviceFeatures2(vk13features);
     if (!vk13features.dynamicRendering) {
         GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
-    }
-    if (!vk13features.synchronization2) {
-        GTEST_SKIP() << "Test requires (unsupported) synchronization2";
     }
 
     if (!shader_tile_image_features.shaderTileImageColorReadAccess && !shader_tile_image_features.shaderTileImageDepthReadAccess &&
@@ -2743,9 +2735,6 @@ TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
     auto features2 = GetPhysicalDeviceFeatures2(vk13features);
     if (!vk13features.dynamicRendering) {
         GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
-    }
-    if (!vk13features.synchronization2) {
-        GTEST_SKIP() << "Test requires (unsupported) synchronization2";
     }
 
     if (!shader_tile_image_features.shaderTileImageColorReadAccess && !shader_tile_image_features.shaderTileImageDepthReadAccess &&
@@ -5278,10 +5267,6 @@ TEST_F(NegativeDynamicRendering, SuspendingRenderPassInstanceQueueSubmit2) {
     auto synchronization2 = LvlInitStruct<VkPhysicalDeviceSynchronization2Features>();
     InitBasicDynamicRendering(&synchronization2);
     if (::testing::Test::IsSkipped()) return;
-
-    if (!synchronization2.synchronization2) {
-        GTEST_SKIP() << "Test requires (unsupported) synchronization2";
-    }
 
     VkCommandPoolObj command_pool(m_device, m_device->graphics_queue_node_index_);
     VkCommandBufferObj cmd_buffer1(m_device, &command_pool);

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -181,10 +181,6 @@ TEST_F(PositiveDynamicRendering, BeginQuery) {
     InitBasicDynamicRendering(&sync2_features);
     if (::testing::Test::IsSkipped()) return;
 
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "Test requires (unsupported) synchronization2";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkRenderingInfoKHR begin_rendering_info = LvlInitStruct<VkRenderingInfoKHR>();
@@ -935,10 +931,6 @@ TEST_F(PositiveDynamicRendering, WithShaderTileImageAndBarrier) {
     auto shader_tile_image_features = LvlInitStruct<VkPhysicalDeviceShaderTileImageFeaturesEXT>(&sync2_features);
     InitBasicDynamicRendering(&shader_tile_image_features);
     if (::testing::Test::IsSkipped()) return;
-
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "Test requires (unsupported) synchronization2";
-    }
     if (!shader_tile_image_features.shaderTileImageColorReadAccess && !shader_tile_image_features.shaderTileImageDepthReadAccess &&
         !shader_tile_image_features.shaderTileImageStencilReadAccess) {
         GTEST_SKIP() << "Test requires (unsupported) shader tile image extension.";

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -4721,10 +4721,6 @@ TEST_F(NegativeDynamicState, DrawNotSetAttachmentFeedbackLoopEnable) {
 
     auto feedback_loop_dynamic_features = LvlInitStruct<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT>();
     GetPhysicalDeviceFeatures2(feedback_loop_dynamic_features);
-    if (!feedback_loop_dynamic_features.attachmentFeedbackLoopDynamicState) {
-        GTEST_SKIP() << "attachmentFeedbackLoopDynamicState is not supported.";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &feedback_loop_dynamic_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -4795,13 +4791,6 @@ TEST_F(NegativeDynamicState, AttachmentFeedbackLoopEnableAspectMask) {
     auto feedback_loop_features =
         LvlInitStruct<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>(&feedback_loop_dynamic_features);
     GetPhysicalDeviceFeatures2(feedback_loop_features);
-    if (!feedback_loop_dynamic_features.attachmentFeedbackLoopDynamicState) {
-        GTEST_SKIP() << "attachmentFeedbackLoopDynamicState is not supported.";
-    }
-    if (!feedback_loop_features.attachmentFeedbackLoopLayout) {
-        GTEST_SKIP() << "attachmentFeedbackLoopLayout is not supported.";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &feedback_loop_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -538,13 +538,6 @@ TEST_F(PositiveDynamicState, AttachmentFeedbackLoopEnable) {
     auto feedback_loop_features =
         LvlInitStruct<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>(&feedback_loop_dynamic_features);
     GetPhysicalDeviceFeatures2(feedback_loop_features);
-    if (!feedback_loop_dynamic_features.attachmentFeedbackLoopDynamicState) {
-        GTEST_SKIP() << "attachmentFeedbackLoopDynamicState is not supported.";
-    }
-    if (!feedback_loop_features.attachmentFeedbackLoopLayout) {
-        GTEST_SKIP() << "attachmentFeedbackLoopLayout is not supported.";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &feedback_loop_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -500,9 +500,6 @@ TEST_F(NegativeExternalMemorySync, TimelineSemaphore) {
 
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     // Check for external semaphore import and export capability
@@ -565,9 +562,6 @@ TEST_F(NegativeExternalMemorySync, SyncFdSemaphore) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // Check for external semaphore import and export capability

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -1015,9 +1015,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
         LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(mesh_shader_supported ? &mesh_shader_features : nullptr);
 
     VkPhysicalDeviceFeatures2KHR features2 = GetPhysicalDeviceFeatures2(bda_features);
-    if (!bda_features.bufferDeviceAddress) {
-        GTEST_SKIP() << "Buffer Device Address feature not supported";
-    }
     features2.features.robustBufferAccess = VK_FALSE;
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
@@ -1409,8 +1406,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndexedIndirectCountDeviceLimitSubmit2) {
     auto features_12 = LvlInitStruct<VkPhysicalDeviceVulkan12Features>(&features_13);
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&features_12);
     GetPhysicalDeviceFeatures2(features2);
-    if (!features_12.drawIndirectCount || !features_13.synchronization2) {
-        GTEST_SKIP() << "drawIndirectCount and synchronization2 both not supported";
+    if (!features_12.drawIndirectCount) {
+        GTEST_SKIP() << "drawIndirectCount not supported";
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -250,9 +250,6 @@ TEST_F(PositiveGpuAssistedLayer, GpuBufferDeviceAddress) {
     }
     auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
     VkPhysicalDeviceFeatures2KHR features2 = GetPhysicalDeviceFeatures2(bda_features);
-    if (!bda_features.bufferDeviceAddress) {
-        GTEST_SKIP() << "Buffer Device Address feature not supported";
-    }
     features2.features.robustBufferAccess = VK_FALSE;
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
@@ -367,12 +364,6 @@ TEST_F(PositiveGpuAssistedLayer, GetCounterFromSignaledSemaphoreAfterSubmit) {
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2Features>();
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>(&sync2_features);
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     auto semaphore_type_info = LvlInitStruct<VkSemaphoreTypeCreateInfo>();
@@ -410,11 +401,8 @@ TEST_F(PositiveGpuAssistedLayer, MutableBuffer) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
     auto mutable_descriptor_type_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
-    if (mutable_descriptor_type_features.mutableDescriptorType == VK_FALSE) {
-        GTEST_SKIP() << "mutableDescriptorType feature not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkPhysicalDeviceProperties properties = {};

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -1416,11 +1416,6 @@ TEST_F(NegativeGraphicsLibrary, PipelineExecutableProperties) {
     auto executable_features = LvlInitStruct<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR>();
     InitBasicGraphicsLibrary(&executable_features);
     if (::testing::Test::IsSkipped()) return;
-
-    if (!executable_features.pipelineExecutableInfo) {
-        GTEST_SKIP() << "pipelineExecutableInfo not supported";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     {

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -1393,9 +1393,6 @@ TEST_F(NegativeImage, ImageLayout) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
@@ -5572,9 +5569,6 @@ TEST_F(NegativeImage, AttachmentFeedbackLoopLayoutFeature) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     VkImageCreateInfo info = vk_testing::Image::create_info();

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -28,12 +28,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
     auto imageless_features = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(imageless_features);
-    if (!imageless_features.imagelessFramebuffer) {
-        GTEST_SKIP() << "imagelessFramebuffer not supported.";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(imageless_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     uint32_t attachmentWidth = 512;
     uint32_t attachmentHeight = 512;
@@ -430,12 +426,8 @@ TEST_F(NegativeImagelessFramebuffer, BasicUsage) {
     if (IsExtensionsEnabled(VK_KHR_MULTIVIEW_EXTENSION_NAME)) {
         imageless_features.pNext = &mv_features;
     }
-    VkPhysicalDeviceFeatures2 features2 = GetPhysicalDeviceFeatures2(imageless_features);
-    if (!imageless_features.imagelessFramebuffer) {
-        GTEST_SKIP() << "imagelessFramebuffer not supported.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
-
+    GetPhysicalDeviceFeatures2(imageless_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     uint32_t attachmentWidth = 512;
@@ -544,11 +536,8 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImageUsageMismatch) {
     }
 
     auto imageless_features = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(imageless_features);
-    if (!imageless_features.imagelessFramebuffer) {
-        GTEST_SKIP() << "imagelessFramebuffer feature not supported.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(imageless_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -693,14 +682,8 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentMultiviewImageLayerCountMismatch)
 
     auto mv_features = LvlInitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>();
     auto imageless_features = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>(&mv_features);
-    auto features2 = GetPhysicalDeviceFeatures2(imageless_features);
-    if (!imageless_features.imagelessFramebuffer) {
-        GTEST_SKIP() << "imagelessFramebuffer feature not supported.";
-    }
-    if (!mv_features.multiview) {
-        GTEST_SKIP() << "multivew feature not supported.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(imageless_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -851,14 +834,8 @@ TEST_F(NegativeImagelessFramebuffer, DepthStencilResolveAttachment) {
 
     auto mv_features = LvlInitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>();
     auto imageless_features = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>(&mv_features);
-    auto features2 = GetPhysicalDeviceFeatures2(imageless_features);
-    if (!imageless_features.imagelessFramebuffer) {
-        GTEST_SKIP() << "imagelessFramebuffer feature not supported.";
-    }
-    if (!mv_features.multiview) {
-        GTEST_SKIP() << "multiview feature not supported.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(imageless_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -1160,12 +1137,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
     auto imageless_features = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(imageless_features);
-    if (!imageless_features.imagelessFramebuffer) {
-        GTEST_SKIP() << "imagelessFramebuffer feature not supported.";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(imageless_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     uint32_t attachmentWidth = 512;
     uint32_t attachmentHeight = 512;
     VkFormat attachmentFormats[1] = {VK_FORMAT_R8G8B8A8_UNORM};

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -22,9 +22,6 @@ TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
 
     auto imageless_features = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
     GetPhysicalDeviceFeatures2(imageless_features);
-    if (!imageless_features.imagelessFramebuffer) {
-        GTEST_SKIP() << "imagelessFramebuffer not supported.";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -88,11 +85,8 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
     auto imageless_framebuffer = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeatures>();
-    auto features2 = GetPhysicalDeviceFeatures2(imageless_framebuffer);
-    if (imageless_framebuffer.imagelessFramebuffer == VK_FALSE) {
-        GTEST_SKIP() << "multiview feature not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(imageless_framebuffer);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_framebuffer));
 
     if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled - requires imageView2DOn3DImage to be VK_TRUE.\n";

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -1622,10 +1622,6 @@ TEST_F(NegativeMemory, BufferDeviceAddressEXT) {
 
     auto buffer_device_address_features = LvlInitStruct<VkPhysicalDeviceBufferAddressFeaturesEXT>();
     GetPhysicalDeviceFeatures2(buffer_device_address_features);
-    if (buffer_device_address_features.bufferDeviceAddressCaptureReplay != VK_TRUE) {
-        GTEST_SKIP() << "bufferDeviceAddressCaptureReplay feature not supported";
-    }
-
     buffer_device_address_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &buffer_device_address_features));
@@ -1715,10 +1711,6 @@ TEST_F(NegativeMemory, BufferDeviceAddressKHR) {
 
     auto buffer_device_address_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
     GetPhysicalDeviceFeatures2(buffer_device_address_features);
-    if (buffer_device_address_features.bufferDeviceAddress != VK_TRUE) {
-        GTEST_SKIP() << "bufferDeviceAddress feature not supported";
-    }
-
     buffer_device_address_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &buffer_device_address_features));

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -264,23 +264,10 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto as_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
     auto rt_pipeline_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    auto as_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&rt_pipeline_features);
     auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&as_features);
     GetPhysicalDeviceFeatures2(bda_features);
-
-    if (as_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure feature is not supported";
-    }
-
-    if (bda_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress feature is not supported";
-    }
-
-    if (rt_pipeline_features.rayTracingPipeline == VK_FALSE) {
-        GTEST_SKIP() << "rayTracingPipeline feature is not supported";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &bda_features));
 
     VkQueueObj *graphics_queue = m_device->GetDefaultQueue();
@@ -662,10 +649,6 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_ZcullDirection)
     if (!dynamic_rendering_features.dynamicRendering) {
         GTEST_SKIP() << "This test requires dynamicRendering";
     }
-    if (!synchronization2_features.synchronization2) {
-        GTEST_SKIP() << "This test requires synchronization2";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -169,9 +169,6 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierBufferDestroyed) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     VkBuffer buffer;
@@ -242,9 +239,6 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierImageDestroyed) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     VkImage image;

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -335,12 +335,9 @@ TEST_F(VkPositiveLayerTest, HostQueryResetSuccess) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features =
-        LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
-    host_query_reset_features.hostQueryReset = VK_TRUE;
-
-    VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
+    auto host_query_reset_features = LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
+    GetPhysicalDeviceFeatures2(host_query_reset_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_query_reset_features));
 
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
@@ -434,8 +431,7 @@ TEST_F(VkPositiveLayerTest, Vulkan12Features) {
     auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
     VkPhysicalDeviceFeatures2 features2 = GetPhysicalDeviceFeatures2(bda_features);
     if (!bda_features.bufferDeviceAddress) {
-        printf("Buffer Device Address feature not supported, skipping test\n");
-        return;
+        GTEST_SKIP() << "Buffer Device Address feature not supported, skipping test";
     }
 
     VkPhysicalDeviceVulkan12Features features12 = LvlInitStruct<VkPhysicalDeviceVulkan12Features>();

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -1042,10 +1042,6 @@ TEST_F(NegativePipelineLayout, SetLayoutFlags) {
 
     auto mut_features = LvlInitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
     GetPhysicalDeviceFeatures2(mut_features);
-    if (!mut_features.mutableDescriptorType) {
-        GTEST_SKIP() << "mutableDescriptorType not supported.";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mut_features));
 
     VkDescriptorSetLayoutBinding layout_binding = {};

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -192,11 +192,8 @@ TEST_F(PositivePipelineTopology, PointSizeStructMemeberWritten) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " required but not supported";
     }
     auto maint4features = LvlInitStruct<VkPhysicalDeviceMaintenance4FeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(maint4features);
-    if (!maint4features.maintenance4) {
-        GTEST_SKIP() << "VkPhysicalDeviceMaintenance4FeaturesKHR::maintenance4 is required but not enabled.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(maint4features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maint4features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const std::string vs_src = R"asm(

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -538,9 +538,6 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
     if (!performance_features.performanceCounterQueryPools) {
         GTEST_SKIP() << "Performance query pools are not supported.";
     }
-    if (!host_query_reset_features.hostQueryReset) {
-        GTEST_SKIP() << "Missing host query reset.";
-    }
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR doens't match up with profile queues";
     }
@@ -766,9 +763,6 @@ TEST_F(NegativeQuery, PerformanceResetAndBegin) {
     if (!performance_features.performanceCounterQueryPools) {
         GTEST_SKIP() << "Performance query pools are not supported.";
     }
-    if (!host_query_reset_features.hostQueryReset) {
-        GTEST_SKIP() << "Missing host query reset.";
-    }
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &performance_features, pool_flags));
@@ -917,12 +911,9 @@ TEST_F(NegativeQuery, HostResetFirstQuery) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features =
-        LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
-    host_query_reset_features.hostQueryReset = VK_TRUE;
-
-    VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
+    auto host_query_reset_features = LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
+    GetPhysicalDeviceFeatures2(host_query_reset_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_query_reset_features));
 
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
@@ -945,12 +936,9 @@ TEST_F(NegativeQuery, HostyResetBadRange) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features =
-        LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
-    host_query_reset_features.hostQueryReset = VK_TRUE;
-
-    VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
+    auto host_query_reset_features = LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
+    GetPhysicalDeviceFeatures2(host_query_reset_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_query_reset_features));
 
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
@@ -974,12 +962,9 @@ TEST_F(NegativeQuery, HostyResetQueryPool) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features =
-        LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
-    host_query_reset_features.hostQueryReset = VK_TRUE;
-
-    VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
+    auto host_query_reset_features = LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
+    GetPhysicalDeviceFeatures2(host_query_reset_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_query_reset_features));
 
     // Create and destroy a query pool.
     VkQueryPool query_pool;
@@ -1007,12 +992,9 @@ TEST_F(NegativeQuery, HostyResetDevice) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features =
-        LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
-    host_query_reset_features.hostQueryReset = VK_TRUE;
-
-    VkPhysicalDeviceFeatures2 pd_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&host_query_reset_features);
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
+    auto host_query_reset_features = LvlInitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
+    GetPhysicalDeviceFeatures2(host_query_reset_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_query_reset_features));
 
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -31,9 +31,6 @@ TEST_F(NegativeRayTracing, BarrierAccessAccelerationStructure) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto mem_barrier = LvlInitStruct<VkMemoryBarrier2>();
@@ -90,9 +87,6 @@ TEST_F(NegativeRayTracing, BarrierAccessMaskAccelerationStructureRayQueryDisable
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto mem_barrier = LvlInitStruct<VkMemoryBarrier2>();
@@ -170,9 +164,6 @@ TEST_F(NegativeRayTracing, BarrierAccessMaskAccelerationStructureRayQueryDisable
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto mem_barrier = LvlInitStruct<VkMemoryBarrier2>();
@@ -253,9 +244,6 @@ TEST_F(NegativeRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto mem_barrier = LvlInitStruct<VkMemoryBarrier2>();
@@ -335,9 +323,6 @@ TEST_F(NegativeRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto mem_barrier = LvlInitStruct<VkMemoryBarrier2>();
@@ -450,19 +435,12 @@ TEST_F(NegativeRayTracing, AccelerationStructureBindings) {
 
     auto accel_struct_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
     auto ray_tracing_pipeline_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(&accel_struct_features);
-    auto features2 = GetPhysicalDeviceFeatures2(ray_tracing_pipeline_features);
-
-    if (!accel_struct_features.accelerationStructure) {
-        GTEST_SKIP() << "accelerationStructure not supported, skipping test";
-    }
-    if (!ray_tracing_pipeline_features.rayTracingPipeline) {
-        GTEST_SKIP() << "rayTracingPipeline not supported, skipping test";
-    }
+    GetPhysicalDeviceFeatures2(ray_tracing_pipeline_features);
 
     auto accel_struct_props = LvlInitStruct<VkPhysicalDeviceAccelerationStructurePropertiesKHR>();
     GetPhysicalDeviceProperties2(accel_struct_props);
 
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_pipeline_features));
 
     // Create one descriptor set layout holding (maxPerStageDescriptorAccelerationStructures + 1) bindings
     // for the same shader stage
@@ -739,13 +717,8 @@ TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure) {
 
     auto as_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
     auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&as_features);
-    auto features2 = GetPhysicalDeviceFeatures2(bda_features);
-
-    if (as_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure feature is not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(bda_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &bda_features));
 
     auto blas_no_mem = rt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(DeviceValidationVersion(), 4096);
     blas_no_mem->SetDeviceBufferInitNoMem(true);
@@ -789,9 +762,6 @@ TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
     auto accel_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&bda_features);
     auto features2 = GetPhysicalDeviceFeatures2(accel_features);
 
-    if (bda_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress feature is not supported";
-    }
     if (accel_features.accelerationStructureHostCommands == VK_FALSE) {
         GTEST_SKIP() << "accelerationStructureHostCommands feature is not supported";
     }
@@ -991,16 +961,13 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructureMemory) {
 
     auto ray_query_features = LvlInitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>();
     auto as_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_query_features);
-    auto features2 = GetPhysicalDeviceFeatures2(as_features);
+    GetPhysicalDeviceFeatures2(as_features);
 
-    if (as_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure feature is not supported";
-    }
     if (as_features.accelerationStructureHostCommands == VK_FALSE) {
         GTEST_SKIP() << "accelerationStructureHostCommands feature is not supported";
     }
 
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &as_features));
 
     // Init a non host visible buffer
     VkBufferObj non_host_visible_buffer;
@@ -1108,10 +1075,6 @@ TEST_F(NegativeRayTracing, CreateAccelerationStructureKHR) {
     auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&bda_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
-    }
-
-    if (ray_query_features.rayQuery == VK_FALSE && ray_tracing_features.rayTracingPipeline == VK_FALSE) {
-        GTEST_SKIP() << "Both of the required features rayQuery and rayTracing are not supported";
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
@@ -1248,10 +1211,6 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
     // Needed for Ray Tracing
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
-    }
-
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
@@ -1531,10 +1490,6 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRFeatureDisabled) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << "not supported, skipping test";
     }
-    if (bda_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress not supported";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     VkBufferCreateInfo buffer_info = LvlInitStruct<VkBufferCreateInfo>();
@@ -1572,9 +1527,6 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRAddress) {
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << "not supported, skipping test";
-    }
-    if (bda_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress not supported";
     }
     if (maintenance1_features.rayTracingPipelineTraceRaysIndirect2 == VK_FALSE) {
         GTEST_SKIP() << "rayTracingPipelineTraceRaysIndirect2 not supported";
@@ -1964,16 +1916,6 @@ TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    if (ray_query_features.rayQuery == VK_FALSE) {
-        GTEST_SKIP() << "rayQuery feature is not supported";
-    }
-    if (accel_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure feature is not supported";
-    }
-    if (bda_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress feature is not supported";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     constexpr size_t build_info_count = 3;
@@ -2266,9 +2208,6 @@ TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
     auto ray_query_features = LvlInitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&ray_tracing_features);
     auto acc_struct_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_query_features);
     GetPhysicalDeviceFeatures2(acc_struct_features);
-    if (ray_query_features.rayQuery == VK_FALSE && ray_tracing_features.rayTracingPipeline == VK_FALSE) {
-        GTEST_SKIP() << "Both of the required features rayQuery and rayTracing are not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &acc_struct_features));
 
     constexpr VkDeviceSize buffer_size = 4096;
@@ -2322,15 +2261,8 @@ TEST_F(NegativeRayTracing, UpdateAccelerationStructureKHR) {
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
     auto buffer_address_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&ray_tracing_features);
     auto acc_structure_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&buffer_address_features);
-    auto features2 = GetPhysicalDeviceFeatures2(acc_structure_features);
-    if (acc_structure_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure feature not supported";
-    }
-    if (buffer_address_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress feature not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(acc_structure_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &acc_structure_features));
 
     m_commandBuffer->begin();
 
@@ -2459,7 +2391,6 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresProperties) {
     auto accel_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
     auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
     auto ray_query_features = LvlInitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
-    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_query_features);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "Test requires at least Vulkan 1.1";
@@ -2468,17 +2399,8 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresProperties) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    GetPhysicalDeviceFeatures2(features2);
-    if (accel_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure not supported";
-    }
-    if (bda_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress not supported";
-    }
-    if (ray_query_features.rayQuery == VK_FALSE) {
-        GTEST_SKIP() << "rayQuery not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(ray_query_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_query_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     const bool rt_maintenance_1 = IsExtensionsEnabled(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
     // On host query with invalid query type
     if (accel_features.accelerationStructureHostCommands == VK_TRUE) {
@@ -2563,7 +2485,6 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1) {
     auto bda_features = LvlInitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
     auto ray_query_features = LvlInitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
     auto ray_tracing_maintenance1 = LvlInitStruct<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(&ray_query_features);
-    auto features2 = LvlInitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_tracing_maintenance1);
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
@@ -2573,20 +2494,8 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    GetPhysicalDeviceFeatures2(features2);
-    if (accel_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure not supported";
-    }
-    if (bda_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress not supported";
-    }
-    if (ray_query_features.rayQuery == VK_FALSE) {
-        GTEST_SKIP() << "rayQuery not supported";
-    }
-    if (ray_tracing_maintenance1.rayTracingMaintenance1 == VK_FALSE) {
-        GTEST_SKIP() << "rayTracingMaintenance1 not supported";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(ray_tracing_maintenance1);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_maintenance1, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // On host query with invalid query type
     if (accel_features.accelerationStructureHostCommands == VK_TRUE) {

--- a/tests/unit/ray_tracing_pipeline.cpp
+++ b/tests/unit/ray_tracing_pipeline.cpp
@@ -24,11 +24,8 @@ TEST_F(NegativeRayTracing, BasicUsage) {
     }
 
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(ray_tracing_features);
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(ray_tracing_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
     const VkPipelineLayoutObj empty_pipeline_layout(m_device, {});
     VkShaderObj rgen_shader(this, kRayTracingNVMinimalGlsl, VK_SHADER_STAGE_RAYGEN_BIT_KHR);
     VkShaderObj ahit_shader(this, kRayTracingNVMinimalGlsl, VK_SHADER_STAGE_ANY_HIT_BIT_KHR);
@@ -186,13 +183,8 @@ TEST_F(NegativeRayTracing, ShaderGroupsKHR) {
     }
 
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(ray_tracing_features);
-
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(ray_tracing_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
 
     const VkPipelineLayoutObj empty_pipeline_layout(m_device, {});
 
@@ -686,11 +678,8 @@ TEST_F(NegativeRayTracing, LibraryFlags) {
     }
 
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(ray_tracing_features);
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(ray_tracing_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
 
     const VkPipelineLayoutObj pipeline_layout(m_device, {});
 
@@ -900,10 +889,6 @@ TEST_F(NegativeRayTracing, DeferredOp) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     const VkPipelineLayoutObj empty_pipeline_layout(m_device, {});
@@ -1037,10 +1022,7 @@ TEST_F(NegativeRayTracing, MaxResources) {
     }
 
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(ray_tracing_features);
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
-    }
+    GetPhysicalDeviceFeatures2(ray_tracing_features);
     if (!ray_tracing_features.rayTraversalPrimitiveCulling) {
         GTEST_SKIP() << "Feature rayTraversalPrimitiveCulling is not supported.";
     }
@@ -1051,7 +1033,7 @@ TEST_F(NegativeRayTracing, MaxResources) {
     props.limits.maxPerStageResources = maxPerStageResources;
     fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
 
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
 
     std::vector<VkDescriptorSetLayoutBinding> layout_bindings = {
         {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, m_device->phy().properties().limits.maxPerStageResources,
@@ -1100,14 +1082,11 @@ TEST_F(NegativeRayTracing, PipelineFlags) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(ray_tracing_features);
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
-    }
+    GetPhysicalDeviceFeatures2(ray_tracing_features);
     if (!ray_tracing_features.rayTraversalPrimitiveCulling) {
         GTEST_SKIP() << "Feature rayTraversalPrimitiveCulling is not supported.";
     }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
 
     const VkPipelineLayoutObj empty_pipeline_layout(m_device, {});
     VkShaderObj rgen_shader(this, kMinimalShaderGlsl, VK_SHADER_STAGE_RAYGEN_BIT_KHR);
@@ -1178,13 +1157,6 @@ TEST_F(NegativeRayTracing, LibraryGroupHandlesEXT) {
     auto pipeline_library_group_handles_features =
         LvlInitStruct<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT>(&ray_tracing_features);
     GetPhysicalDeviceFeatures2(pipeline_library_group_handles_features);
-
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
-    }
-    if (!pipeline_library_group_handles_features.pipelineLibraryGroupHandles) {
-        GTEST_SKIP() << "Feature pipelineLibraryGroupHandles is not supported.";
-    }
     if (!ray_tracing_features.rayTracingPipelineShaderGroupHandleCaptureReplay) {
         GTEST_SKIP() << "rayTracingShaderGroupHandleCaptureReplay not enabled";
     }

--- a/tests/unit/ray_tracing_pipeline_positive.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive.cpp
@@ -22,12 +22,8 @@ TEST_F(PositiveRayTracingPipeline, ShaderGroupsKHR) {
     }
 
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(ray_tracing_features);
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(ray_tracing_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
 
     const VkPipelineLayoutObj empty_pipeline_layout(m_device, {});
     VkShaderObj rgen_shader(this, kRayTracingMinimalGlsl, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2);
@@ -126,15 +122,8 @@ TEST_F(PositiveRayTracingPipeline, CacheControl) {
 
     auto features13 = LvlInitStruct<VkPhysicalDeviceVulkan13Features>();
     auto ray_tracing_features = LvlInitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(&features13);
-    auto features2 = GetPhysicalDeviceFeatures2(ray_tracing_features);
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
-    }
-    if (!features13.pipelineCreationCacheControl) {
-        GTEST_SKIP() << "Feature pipelineCreationCacheControl is not supported.";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(ray_tracing_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
 
     const VkPipelineLayoutObj empty_pipeline_layout(m_device, {});
     VkShaderObj rgen_shader(this, kRayTracingMinimalGlsl, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2);

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -37,13 +37,8 @@ TEST_F(PositiveRayTracing, GetAccelerationStructureBuildSizes) {
     }
 
     auto accel_struct_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(accel_struct_features);
-
-    if (accel_struct_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure feature not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(accel_struct_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &accel_struct_features));
 
     auto build_info = LvlInitStruct<VkAccelerationStructureBuildGeometryInfoKHR>();
     build_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
@@ -72,14 +67,6 @@ TEST_F(PositiveRayTracing, AccelerationStructureReference) {
     auto ray_query_features = LvlInitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
     auto acc_structure_features = LvlInitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_query_features);
     GetPhysicalDeviceFeatures2(acc_structure_features);
-
-    if (bda_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress feature is not supported";
-    }
-    if (acc_structure_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure feature not supported";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &acc_structure_features));
 
     m_commandBuffer->begin();
@@ -148,10 +135,6 @@ TEST_F(PositiveRayTracing, StridedDeviceAddressRegion) {
     // Needed for Ray Tracing
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
-    }
-
-    if (!ray_tracing_features.rayTracingPipeline) {
-        GTEST_SKIP() << "Feature rayTracing is not supported.";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
@@ -275,12 +258,6 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     auto ray_query_feature = LvlInitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>();
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&ray_query_feature);
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
-    if (!ray_query_feature.rayQuery) {
-        GTEST_SKIP() << "Ray query feature needs to be enabled";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto mem_barrier = LvlInitStruct<VkMemoryBarrier2>();
@@ -355,12 +332,6 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     auto ray_query_feature = LvlInitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>();
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&ray_query_feature);
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
-    if (!ray_query_feature.rayQuery) {
-        GTEST_SKIP() << "Ray query feature needs to be enabled";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto mem_barrier = LvlInitStruct<VkMemoryBarrier2>();
@@ -446,17 +417,6 @@ TEST_F(PositiveRayTracing, BuildAccelerationStructuresList) {
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
-
-    if (ray_query_features.rayQuery == VK_FALSE) {
-        GTEST_SKIP() << "rayQuery feature is not supported";
-    }
-    if (accel_features.accelerationStructure == VK_FALSE) {
-        GTEST_SKIP() << "accelerationStructure feature is not supported";
-    }
-    if (bda_features.bufferDeviceAddress == VK_FALSE) {
-        GTEST_SKIP() << "bufferDeviceAddress feature is not supported";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     constexpr size_t build_info_count = 10;

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -520,11 +520,6 @@ TEST_F(PositiveRenderPass, ImagelessFramebufferNonZeroBaseMip) {
 
     auto pd_imageless_fb_features = LvlInitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
     GetPhysicalDeviceFeatures2(pd_imageless_fb_features);
-
-    if (pd_imageless_fb_features.imagelessFramebuffer != VK_TRUE) {
-        GTEST_SKIP() << "VkPhysicalDeviceImagelessFramebufferFeaturesKHR::imagelessFramebuffer feature not supported";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_imageless_fb_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     constexpr uint32_t width = 512;
@@ -1647,13 +1642,8 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
     }
 
     auto separate_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
-    auto features2 = GetPhysicalDeviceFeatures2(separate_features);
-    if (!separate_features.separateDepthStencilLayouts) {
-        printf("separateDepthStencilLayouts feature not supported, skipping tests\n");
-        return;
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(separate_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &separate_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     VkFormat ds_format = VK_FORMAT_D24_UNORM_S8_UINT;
     VkFormatProperties props;

--- a/tests/unit/renderpass.cpp
+++ b/tests/unit/renderpass.cpp
@@ -800,13 +800,8 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
     }
 
     auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
-    auto features2 = GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
-
-    if (!separate_depth_stencil_layouts_features.separateDepthStencilLayouts) {
-        GTEST_SKIP() << "separateDepthStencilLayouts feature not supported, skipping test.";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &separate_depth_stencil_layouts_features));
 
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
     const VkFormat stencil_format = VK_FORMAT_S8_UINT;
@@ -1393,12 +1388,9 @@ TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
     }
 
     auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
-    auto features2 = GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
-    if (!separate_depth_stencil_layouts_features.separateDepthStencilLayouts) {
-        GTEST_SKIP() << "separateDepthStencilLayouts not supported, skipping test.";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
+    ASSERT_NO_FATAL_FAILURE(
+        InitState(nullptr, &separate_depth_stencil_layouts_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // Closure to create a render pass with just a depth/stencil image used as an input attachment (not a depth attachment!).
     // This image purposely has not VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.
@@ -1481,12 +1473,8 @@ TEST_F(NegativeRenderPass, BeginStencilFormat) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
     auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
-    auto features2 = GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
-    if (!separate_depth_stencil_layouts_features.separateDepthStencilLayouts) {
-        GTEST_SKIP() << "separateDepthStencilLayouts not supported, skipping test.";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &separate_depth_stencil_layouts_features));
 
     // Closure to create a render pass with just a depth/stencil image with specified format.
     // The layout is set to have more or less components than what this format has, triggering an error.
@@ -4445,13 +4433,9 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSynchronization2) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto synchronization2_feature = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(synchronization2_feature);
-    if (!synchronization2_feature.synchronization2) {
-        GTEST_SKIP() << "synchronization2 no supported, skipping test.";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    GetPhysicalDeviceFeatures2(sync2_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
 
     constexpr std::array<VkAttachmentDescription, 2> attachments = {{
         {0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_STORE,
@@ -4520,13 +4504,9 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSeparateDepthStencil) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto separate_depth_stencil_layout_feature = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(separate_depth_stencil_layout_feature);
-    if (!separate_depth_stencil_layout_feature.separateDepthStencilLayouts) {
-        GTEST_SKIP() << "synchronization2 no supported, skipping test.";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    auto separate_depth_stencil_layouts_features = LvlInitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR>();
+    GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &separate_depth_stencil_layouts_features));
 
     std::array<VkAttachmentDescription, 3> attachments = {{
         {0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_STORE,

--- a/tests/unit/shader_compute_positive.cpp
+++ b/tests/unit/shader_compute_positive.cpp
@@ -327,12 +327,9 @@ TEST_F(PositiveShaderCompute, ZeroInitializeWorkgroupMemoryFeature) {
     }
 
     auto zero_initialize_work_group_memory_features = LvlInitStruct<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(zero_initialize_work_group_memory_features);
-    if (!zero_initialize_work_group_memory_features.shaderZeroInitializeWorkgroupMemory) {
-        GTEST_SKIP() << "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR::shaderZeroInitializeWorkgroupMemory is required but not enabled.";
-    }
+    GetPhysicalDeviceFeatures2(zero_initialize_work_group_memory_features);
 
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &zero_initialize_work_group_memory_features));
 
     const char *spv_source = R"(
                OpCapability Shader

--- a/tests/unit/shader_cooperative_matrix.cpp
+++ b/tests/unit/shader_cooperative_matrix.cpp
@@ -33,15 +33,8 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRSpecInfo) {
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
     auto cooperative_matrix_features = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
     auto memory_model_features = LvlInitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
-    auto features2 = GetPhysicalDeviceFeatures2(memory_model_features);
-    if (memory_model_features.vulkanMemoryModel == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModel feature not supported";
-    }
-    if (!cooperative_matrix_features.cooperativeMatrix) {
-        GTEST_SKIP() << "cooperativeMatrix feature not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(memory_model_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
     std::vector<VkDescriptorSetLayoutBinding> bindings(0);
     const VkDescriptorSetLayoutObj dsl(m_device, bindings);
@@ -110,13 +103,7 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRUnsupportedStage) {
 
     auto cooperative_matrix_features = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>();
     auto memory_model_features = LvlInitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
-    auto features2 = GetPhysicalDeviceFeatures2(memory_model_features);
-    if (memory_model_features.vulkanMemoryModel == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModel feature not supported";
-    }
-    if (!cooperative_matrix_features.cooperativeMatrix) {
-        GTEST_SKIP() << "cooperativeMatrix feature not supported";
-    }
+    GetPhysicalDeviceFeatures2(memory_model_features);
 
     auto props = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixPropertiesKHR>();
     GetPhysicalDeviceProperties2(props);
@@ -125,7 +112,7 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRUnsupportedStage) {
         GTEST_SKIP() << "Cannot execute test due to vertex stage expected to be unsupported";
     }
 
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
     ASSERT_NO_FATAL_FAILURE(InitViewport());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -184,15 +171,8 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRParametersMatchProperties) {
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
     auto cooperative_matrix_features = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
     auto memory_model_features = LvlInitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
-    auto features2 = GetPhysicalDeviceFeatures2(memory_model_features);
-    if (memory_model_features.vulkanMemoryModel == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModel feature not supported";
-    }
-    if (!cooperative_matrix_features.cooperativeMatrix) {
-        GTEST_SKIP() << "cooperativeMatrix feature not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(memory_model_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
     std::vector<VkDescriptorSetLayoutBinding> bindings(0);
     const VkDescriptorSetLayoutObj dsl(m_device, bindings);
@@ -240,15 +220,8 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRDimXMultipleSubgroupSize) {
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
     auto cooperative_matrix_features = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
     auto memory_model_features = LvlInitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
-    auto features2 = GetPhysicalDeviceFeatures2(memory_model_features);
-    if (memory_model_features.vulkanMemoryModel == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModel feature not supported";
-    }
-    if (!cooperative_matrix_features.cooperativeMatrix) {
-        GTEST_SKIP() << "cooperativeMatrix feature not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(memory_model_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
     // Tests are assume that Float16 3*5 is not available
     char const *csSource = R"glsl(
@@ -320,15 +293,8 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRSameScope) {
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
     auto cooperative_matrix_features = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
     auto memory_model_features = LvlInitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
-    auto features2 = GetPhysicalDeviceFeatures2(memory_model_features);
-    if (memory_model_features.vulkanMemoryModel == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModel feature not supported";
-    }
-    if (!cooperative_matrix_features.cooperativeMatrix) {
-        GTEST_SKIP() << "cooperativeMatrix feature not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(memory_model_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
     char const *csSource = R"glsl(
         #version 450
@@ -409,14 +375,10 @@ TEST_F(NegativeShaderCooperativeMatrix, MatchSizeWithProperties) {
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
     auto cooperative_matrix_features = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
     auto memory_model_features = LvlInitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
-    auto features2 = GetPhysicalDeviceFeatures2(memory_model_features);
-    if (memory_model_features.vulkanMemoryModel == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModel feature not supported";
-    }
+    GetPhysicalDeviceFeatures2(memory_model_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
-
-        //OpExtension "SPV_KHR_storage_buffer_storage_class"
+    // OpExtension "SPV_KHR_storage_buffer_storage_class"
     const std::string csSourceTemplate = R"glsl(
         OpCapability Shader
         OpCapability VulkanMemoryModel
@@ -537,14 +499,10 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRSignedCheck) {
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
     auto cooperative_matrix_features = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
     auto memory_model_features = LvlInitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
-    auto features2 = GetPhysicalDeviceFeatures2(memory_model_features);
-    if (memory_model_features.vulkanMemoryModel == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModel feature not supported";
-    }
+    GetPhysicalDeviceFeatures2(memory_model_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
-
-        //OpExtension "SPV_KHR_storage_buffer_storage_class"
+    // OpExtension "SPV_KHR_storage_buffer_storage_class"
     const std::string csSourceTemplate = R"glsl(
         OpCapability Shader
         OpCapability VulkanMemoryModel

--- a/tests/unit/shader_cooperative_matrix_positive.cpp
+++ b/tests/unit/shader_cooperative_matrix_positive.cpp
@@ -31,12 +31,8 @@ TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixNV) {
     auto float16_features = LvlInitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
     auto cooperative_matrix_features = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesNV>(&float16_features);
     auto memory_model_features = LvlInitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
-    auto features2 = GetPhysicalDeviceFeatures2(memory_model_features);
-    if (memory_model_features.vulkanMemoryModel == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModel feature not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(memory_model_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
     std::vector<VkDescriptorSetLayoutBinding> bindings(0);
     const VkDescriptorSetLayoutObj dsl(m_device, bindings);
@@ -109,15 +105,8 @@ TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixKHR) {
     auto storage16_features = LvlInitStruct<VkPhysicalDevice16BitStorageFeatures>(&float16_features);
     auto cooperative_matrix_features = LvlInitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&storage16_features);
     auto memory_model_features = LvlInitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
-    auto features2 = GetPhysicalDeviceFeatures2(memory_model_features);
-    if (memory_model_features.vulkanMemoryModel == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModel feature not supported";
-    }
-    if (!cooperative_matrix_features.cooperativeMatrix) {
-        GTEST_SKIP() << "cooperativeMatrix feature not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(memory_model_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
     VkCooperativeMatrixPropertiesKHR props = LvlInitStruct<VkCooperativeMatrixPropertiesKHR>();
     uint32_t props_count = 1;

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -282,11 +282,6 @@ TEST_F(PositiveShaderInterface, ScalarBlockLayout) {
 
     auto scalar_block_features = LvlInitStruct<VkPhysicalDeviceScalarBlockLayoutFeaturesEXT>(NULL);
     GetPhysicalDeviceFeatures2(scalar_block_features);
-
-    if (scalar_block_features.scalarBlockLayout != VK_TRUE) {
-        GTEST_SKIP() << "scalarBlockLayout feature not supported";
-    }
-
     auto set_features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&scalar_block_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &set_features2));
@@ -371,9 +366,6 @@ TEST_F(PositiveShaderInterface, RelaxedTypeMatch) {
     }
     auto maintenance_4_features = LvlInitStruct<VkPhysicalDeviceMaintenance4FeaturesKHR>();
     GetPhysicalDeviceFeatures2(maintenance_4_features);
-    if (!maintenance_4_features.maintenance4) {
-        GTEST_SKIP() << "maintenance4 is required but not enabled.";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance_4_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -553,10 +553,8 @@ TEST_F(NegativeShaderObject, CreateShadersWithoutEnabledFeatures) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     auto shaderObjectFeatures = LvlInitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>();
     auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
-    features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&shaderObjectFeatures);
-    if (shaderObjectFeatures.shaderObject == VK_FALSE) {
-        GTEST_SKIP() << "shaderObject not supported.";
-    }
+    features2.features.tessellationShader = VK_FALSE;
+    features2.features.geometryShader = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
@@ -608,11 +606,8 @@ TEST_F(NegativeShaderObject, CreateMeshShadersWithoutEnabledFeatures) {
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     auto shaderObjectFeatures = LvlInitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
-    if (shaderObjectFeatures.shaderObject == VK_FALSE) {
-        GTEST_SKIP() << "shaderObject not supported.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(shaderObjectFeatures);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &shaderObjectFeatures));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
@@ -666,10 +661,8 @@ TEST_F(NegativeShaderObject, BindTessellationAndGeometryShadersWithoutEnabledFea
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     auto shaderObjectFeatures = LvlInitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>();
     auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
-    features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&shaderObjectFeatures);
-    if (shaderObjectFeatures.shaderObject == VK_FALSE) {
-        GTEST_SKIP() << "shaderObject not supported.";
-    }
+    features2.features.tessellationShader = VK_FALSE;
+    features2.features.geometryShader = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
@@ -831,12 +824,8 @@ TEST_F(NegativeShaderObject, BindTaskAndMeshShadersWithoutEnabledFeature) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     auto shaderObjectFeatures = LvlInitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>();
-    auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
-    features2 = LvlInitStruct<VkPhysicalDeviceFeatures2>(&shaderObjectFeatures);
-    if (shaderObjectFeatures.shaderObject == VK_FALSE) {
-        GTEST_SKIP() << "shaderObject not supported.";
-    }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(shaderObjectFeatures);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &shaderObjectFeatures));
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -372,14 +372,12 @@ TEST_F(PositiveShaderSpirv, Std430SpirvOptFlags10) {
     auto uniform_buffer_standard_layout_features = LvlInitStruct<VkPhysicalDeviceUniformBufferStandardLayoutFeatures>();
     auto scalar_block_layout_features =
         LvlInitStruct<VkPhysicalDeviceScalarBlockLayoutFeatures>(&uniform_buffer_standard_layout_features);
-    auto features2 = GetPhysicalDeviceFeatures2(scalar_block_layout_features);
-
+    GetPhysicalDeviceFeatures2(scalar_block_layout_features);
     if (scalar_block_layout_features.scalarBlockLayout == VK_FALSE ||
         uniform_buffer_standard_layout_features.uniformBufferStandardLayout == VK_FALSE) {
         GTEST_SKIP() << "scalarBlockLayout and uniformBufferStandardLayout are not supported Skipping";
     }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &scalar_block_layout_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
@@ -435,12 +433,11 @@ TEST_F(PositiveShaderSpirv, Std430SpirvOptFlags12) {
     }
 
     auto features12 = LvlInitStruct<VkPhysicalDeviceVulkan12Features>();
-    auto features2 = GetPhysicalDeviceFeatures2(features12);
+    GetPhysicalDeviceFeatures2(features12);
     if (features12.scalarBlockLayout == VK_FALSE || features12.uniformBufferStandardLayout == VK_FALSE) {
         GTEST_SKIP() << "scalarBlockLayout and uniformBufferStandardLayout are not supported";
     }
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features12));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -891,9 +891,6 @@ TEST_F(NegativeSubpass, SubpassDependencyMasksSync2) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 feature not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -26,9 +26,6 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2Features>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "Test requires (unsupported) synchronization2";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     const VkAttachmentDescription attachment = {0,
@@ -127,9 +124,6 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2Features>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "Test requires (unsupported) synchronization2";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     const VkAttachmentDescription attachment = {0,

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -797,9 +797,6 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
@@ -1594,9 +1591,6 @@ TEST_F(NegativeSyncObject, Sync2BarrierQueueFamily) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // Find queues of two families
@@ -1662,9 +1656,6 @@ TEST_F(NegativeSyncObject, BarrierAccessSync2) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     VkMemoryBarrier2 mem_barrier = LvlInitStruct<VkMemoryBarrier2>();
@@ -1866,9 +1857,6 @@ TEST_F(NegativeSyncObject, BarrierAccessVideoDecode) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     VkMemoryBarrier2 mem_barrier = LvlInitStruct<VkMemoryBarrier2>();
@@ -1981,9 +1969,8 @@ TEST_F(NegativeSyncObject, QueueSubmitWaitingSameSemaphore) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
-    auto features2 = GetPhysicalDeviceFeatures2(sync2_features);
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(sync2_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
 
     if (m_device->graphics_queues().size() < 2) {
         GTEST_SKIP() << "2 graphics queues are needed";
@@ -2034,7 +2021,9 @@ TEST_F(NegativeSyncObject, QueueSubmitWaitingSameSemaphore) {
         vk::QueueWaitIdle(m_device->m_queue);
         vk::QueueWaitIdle(other);
     }
-    if (sync2_features.synchronization2) {
+
+    // sync 2
+    if (IsExtensionsEnabled(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
         auto signal_sem_info = LvlInitStruct<VkSemaphoreSubmitInfo>();
         signal_sem_info.semaphore = semaphore.handle();
         signal_sem_info.stageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
@@ -2222,9 +2211,6 @@ TEST_F(NegativeSyncObject, MixedTimelineAndBinarySemaphores) {
 
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
@@ -2319,9 +2305,6 @@ TEST_F(NegativeSyncObject, QueueSubmitNoTimelineSemaphoreInfo) {
 
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = LvlInitStruct<VkSemaphoreTypeCreateInfoKHR>();
@@ -2374,9 +2357,6 @@ TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreValue) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
@@ -2499,9 +2479,6 @@ TEST_F(NegativeSyncObject, QueueBindSparseTimelineSemaphoreValue) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     auto index = m_device->graphics_queue_node_index_;
@@ -2640,14 +2617,8 @@ TEST_F(NegativeSyncObject, Sync2QueueSubmitTimelineSemaphoreValue) {
 
     auto vk12_features = LvlInitStruct<VkPhysicalDeviceVulkan12Features>();
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&vk12_features);
-    auto features2 = GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "VkPhysicalDeviceSynchronization2FeaturesKHR::synchronization2 required";
-    }
-    if (!vk12_features.timelineSemaphore) {
-        GTEST_SKIP() << "VkPhysicalDeviceVulkan12Features::timelineSemaphore required";
-    }
-    InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+    GetPhysicalDeviceFeatures2(sync2_features);
+    InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
 
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
     GetPhysicalDeviceProperties2(timelineproperties);
@@ -2741,9 +2712,8 @@ TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
 
     auto timeline_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>();
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&timeline_features);
-    auto features2 = GetPhysicalDeviceFeatures2(sync2_features);
-
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    GetPhysicalDeviceFeatures2(sync2_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
 
     auto semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
     // VUIDs reported change if the extension is enabled, even if the timelineSemaphore feature isn't supported.
@@ -2821,7 +2791,8 @@ TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
         ASSERT_VK_SUCCESS(vk::QueueBindSparse(m_device->m_queue, 2, bind_info, VK_NULL_HANDLE));
         ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_device->m_queue));
     }
-    if (sync2_features.synchronization2) {
+
+    if (IsExtensionsEnabled(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
         vk_testing::Semaphore semaphore[3];
         semaphore[0].init(*m_device, semaphore_create_info);
         semaphore[1].init(*m_device, semaphore_create_info);
@@ -2878,9 +2849,6 @@ TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreOutOfOrder) {
 
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     // We need two queues for this
@@ -2981,9 +2949,6 @@ TEST_F(NegativeSyncObject, WaitSemaphoresType) {
 
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = LvlInitStruct<VkSemaphoreTypeCreateInfoKHR>();
@@ -3021,13 +2986,9 @@ TEST_F(NegativeSyncObject, SignalSemaphoreType) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto timelinefeatures = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>();
-    GetPhysicalDeviceFeatures2(timelinefeatures);
-    if (!timelinefeatures.timelineSemaphore) {
-        GTEST_SKIP() << "Timeline semaphores are not supported";
-    }
-
-    ASSERT_NO_FATAL_FAILURE(InitState());
+    auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>();
+    GetPhysicalDeviceFeatures2(timeline_semaphore_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
     VkSemaphore semaphore;
@@ -3055,9 +3016,6 @@ TEST_F(NegativeSyncObject, SignalSemaphoreValue) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
@@ -3192,14 +3150,8 @@ TEST_F(NegativeSyncObject, Sync2SignalSemaphoreValue) {
 
     auto vk12_features = LvlInitStruct<VkPhysicalDeviceVulkan12Features>();
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&vk12_features);
-    auto features2 = GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "VkPhysicalDeviceSynchronization2FeaturesKHR::synchronization2 required";
-    }
-    if (!vk12_features.timelineSemaphore) {
-        GTEST_SKIP() << "VkPhysicalDeviceVulkan12Features::timelineSemaphore required";
-    }
-    InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+    GetPhysicalDeviceFeatures2(sync2_features);
+    InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
 
     auto timelineproperties = LvlInitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
     GetPhysicalDeviceProperties2(timelineproperties);
@@ -3300,10 +3252,6 @@ TEST_F(NegativeSyncObject, SemaphoreCounterType) {
 
     auto timelinefeatures = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>();
     GetPhysicalDeviceFeatures2(timelinefeatures);
-    if (!timelinefeatures.timelineSemaphore) {
-        GTEST_SKIP() << "Timeline semaphores are not supported";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -80,9 +80,6 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersImage) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     const std::optional<uint32_t> no_gfx = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
@@ -133,9 +130,6 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     const std::optional<uint32_t> no_gfx = m_device->QueueFamilyWithoutCapabilities(VK_QUEUE_GRAPHICS_BIT);
@@ -814,9 +808,6 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithTimelineSemaphoreAnd
 
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     if ((m_device->queue_props.empty()) || (m_device->queue_props[0].queueCount < 2)) {
@@ -1375,9 +1366,6 @@ TEST_F(PositiveSyncObject, ExternalTimelineSemaphore) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     // Check for external semaphore import and export capability
@@ -1798,9 +1786,6 @@ TEST_F(PositiveSyncObject, QueueSubmitTimelineSemaphore2Queue) {
 
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     vk_testing::Queue *q0 = m_device->graphics_queues()[0];
@@ -2036,9 +2021,6 @@ TEST_F(PositiveSyncObject, FenceSemThreadRace) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     auto fence_ci = LvlInitStruct<VkFenceCreateInfo>();
@@ -2292,9 +2274,6 @@ TEST_F(PositiveSyncObject, WaitTimelineSemThreadRace) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     WaitTimelineSemThreadData data(*m_device);
 
@@ -2323,10 +2302,6 @@ TEST_F(PositiveSyncObject, WaitTimelineSemaphoreWithWin32HandleRetrieved) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
     if (!SemaphoreExportImportSupported(gpu(), handle_type)) {

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -214,9 +214,6 @@ TEST_F(NegativeSyncVal, BufferCopyHazardsSync2) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     VkBufferObj buffer_a;
@@ -758,9 +755,6 @@ TEST_F(NegativeSyncVal, CopyOptimalImageHazardsSync2) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
@@ -4715,9 +4709,6 @@ TEST_F(NegativeSyncVal, QSSubmit2) {
     }
     auto sync2_features = LvlInitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
     GetPhysicalDeviceFeatures2(sync2_features);
-    if (!sync2_features.synchronization2) {
-        GTEST_SKIP() << "synchronization2 not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     QSTestContext test(m_device, m_device->m_queue_obj);

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -179,9 +179,6 @@ TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOnHost) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     constexpr uint64_t max_signal_value = 10'000;
@@ -240,9 +237,6 @@ TEST_F(PositiveSyncVal, SignalAndGetSemaphoreCounter) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     constexpr uint64_t max_signal_value = 1'000;
@@ -292,9 +286,6 @@ TEST_F(PositiveSyncVal, GetSemaphoreCounterFromMultipleThreads) {
     }
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     constexpr uint64_t max_signal_value = 15'000;

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -567,18 +567,14 @@ TEST_F(NegativeWsi, SwapchainAcquireImageNoBinarySemaphore) {
     }
 
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
-    auto features2 = GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore feature not supported.";
-    }
-
+    GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     auto timeline_semaphore_props = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreProperties>();
     GetPhysicalDeviceProperties2(timeline_semaphore_props);
     if (timeline_semaphore_props.maxTimelineSemaphoreValueDifference == 0) {
         // If using MockICD and profiles the value might be zero'ed and cause false errors
         GTEST_SKIP() << "maxTimelineSemaphoreValueDifference is 0";
     }
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
     ASSERT_TRUE(InitSwapchain());
 
     auto semaphore_type_create_info = LvlInitStruct<VkSemaphoreTypeCreateInfoKHR>();
@@ -614,11 +610,7 @@ TEST_F(NegativeWsi, SwapchainAcquireImageNoBinarySemaphore2KHR) {
     }
 
     auto timeline_semaphore_features = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
-    auto features2 = GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    if (!timeline_semaphore_features.timelineSemaphore) {
-        GTEST_SKIP() << "timelineSemaphore not supported.";
-    }
-
+    GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     auto timeline_semaphore_props = LvlInitStruct<VkPhysicalDeviceTimelineSemaphoreProperties>();
     GetPhysicalDeviceProperties2(timeline_semaphore_props);
     if (timeline_semaphore_props.maxTimelineSemaphoreValueDifference == 0) {
@@ -626,7 +618,7 @@ TEST_F(NegativeWsi, SwapchainAcquireImageNoBinarySemaphore2KHR) {
         GTEST_SKIP() << "maxTimelineSemaphoreValueDifference is 0";
     }
 
-    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     ASSERT_TRUE(InitSwapchain());
 


### PR DESCRIPTION
There is a feature requirement section in the spec with many statements such as

![image](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/115671160/eb49711d-7203-495e-ba43-0bc85e14a5e6)

I went through a large amount of these and removed the useless check for the feature bit support

1. Some tests are already forgetting to do this and work fine
2. before Profile/MockICD, the old DevSim layer couldn't enable extension feature bits so I think this is a source why they were always checked