### PR TITLE
tests: Remove some VkBufferObj overloads

### DIFF
--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -432,25 +432,18 @@ static constexpr NoMemT no_mem{};
 class Buffer : public internal::NonDispHandle<VkBuffer> {
   public:
     explicit Buffer() : NonDispHandle(), create_info_(LvlInitStruct<decltype(create_info_)>()) {}
-    explicit Buffer(const Device &dev, const VkBufferCreateInfo &info) { init(dev, info); }
-    explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props) {
+    explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props = 0) {
         init(dev, info, mem_props);
     }
     explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
         init(dev, info, mem_props, alloc_info_pnext);
     }
-    explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props,
-                    VkMemoryAllocateFlags alloc_flags) {
-        auto memflagsinfo = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
-        memflagsinfo.flags = alloc_flags;
-        init(dev, info, mem_props, &memflagsinfo);
-    }
     explicit Buffer(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags mem_props, VkBufferUsageFlags usage,
-                    void *alloc_info_pnext) {
+                    void *alloc_info_pnext = nullptr) {
         init(dev, size, mem_props, usage, alloc_info_pnext);
     }
     explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, NoMemT) { init_no_mem(dev, info); }
-    explicit Buffer(const Device &dev, VkDeviceSize size) { init(dev, size); }
+    explicit Buffer(const Device &dev, VkDeviceSize size) { init(dev, size, 0); }
     Buffer(Buffer &&rhs) noexcept : NonDispHandle(std::move(rhs)) {
         create_info_ = std::move(rhs.create_info_);
         internal_mem_ = std::move(rhs.internal_mem_);
@@ -480,15 +473,6 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
               void *alloc_info_pnext) {
         init(dev, create_info(size, usage), mem_props, alloc_info_pnext);
     }
-    void init(const Device &dev, VkDeviceSize size) { init(dev, size, 0); }
-    void init_as_src(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags &reqs,
-                     const std::vector<uint32_t> *queue_families = nullptr) {
-        init(dev, create_info(size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, queue_families), reqs);
-    }
-    void init_as_dst(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags &reqs,
-                     const std::vector<uint32_t> *queue_families = nullptr) {
-        init(dev, create_info(size, VK_BUFFER_USAGE_TRANSFER_DST_BIT, queue_families), reqs);
-    }
     void init_as_src_and_dst(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags &reqs,
                              const std::vector<uint32_t> *queue_families = nullptr, bool memory = true) {
         if (memory)
@@ -497,11 +481,6 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
             init_no_mem(dev,
                         create_info(size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, queue_families));
     }
-    void init_as_storage(const Device &dev, VkDeviceSize size, VkMemoryPropertyFlags &reqs,
-        const std::vector<uint32_t> *queue_families = nullptr) {
-        init(dev, create_info(size, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, queue_families), reqs);
-    }
-
     void init_no_mem(const Device &dev, const VkBufferCreateInfo &info);
 
     // get the internal memory

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -1298,12 +1298,11 @@ TEST_F(NegativeCommand, CompressedImageMipCopy) {
     ASSERT_TRUE(odd_image.initialized());
 
     // Allocate buffers
-    VkMemoryPropertyFlags reqs = 0;
-    VkBufferObj buffer_1024, buffer_64, buffer_16, buffer_8;
-    buffer_1024.init_as_src_and_dst(*m_device, 1024, reqs);
-    buffer_64.init_as_src_and_dst(*m_device, 64, reqs);
-    buffer_16.init_as_src_and_dst(*m_device, 16, reqs);
-    buffer_8.init_as_src_and_dst(*m_device, 8, reqs);
+    VkBufferUsageFlags transfer_usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    VkBufferObj buffer_1024(*m_device, 1024, 0, transfer_usage);
+    VkBufferObj buffer_64(*m_device, 64, 0, transfer_usage);
+    VkBufferObj buffer_16(*m_device, 16, 0, transfer_usage);
+    VkBufferObj buffer_8(*m_device, 8, 0, transfer_usage);
 
     VkBufferImageCopy region = {};
     region.bufferRowLength = 0;
@@ -1606,12 +1605,11 @@ TEST_F(NegativeCommand, ImageBufferCopy) {
     }
 
     // Allocate buffers
-    VkBufferObj buffer_256k, buffer_128k, buffer_64k, buffer_16k;
-    VkMemoryPropertyFlags reqs = 0;
-    buffer_256k.init_as_src_and_dst(*m_device, 262144, reqs);  // 256k
-    buffer_128k.init_as_src_and_dst(*m_device, 131072, reqs);  // 128k
-    buffer_64k.init_as_src_and_dst(*m_device, 65536, reqs);    // 64k
-    buffer_16k.init_as_src_and_dst(*m_device, 16384, reqs);    // 16k
+    VkBufferUsageFlags transfer_usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    VkBufferObj buffer_256k(*m_device, 262144, 0, transfer_usage);  // 256k
+    VkBufferObj buffer_128k(*m_device, 131072, 0, transfer_usage);  // 128k
+    VkBufferObj buffer_64k(*m_device, 65536, 0, transfer_usage);    // 64k
+    VkBufferObj buffer_16k(*m_device, 16384, 0, transfer_usage);    // 16k
 
     VkBufferImageCopy region = {};
     region.bufferRowLength = 0;
@@ -2140,10 +2138,8 @@ TEST_F(NegativeCommand, MiscImageLayer) {
 
     VkImageObj image(m_device);
     image.Init(128, 128, 1, VK_FORMAT_R16G16B16A16_UINT, VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_OPTIMAL, 0);  // 64bpp
+    VkBufferObj buffer(*m_device, 128 * 128 * 8, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, nullptr);
     ASSERT_TRUE(image.initialized());
-    VkBufferObj buffer;
-    VkMemoryPropertyFlags reqs = 0;
-    buffer.init_as_src(*m_device, 128 * 128 * 8, reqs);
     VkBufferImageCopy region = {};
     region.bufferRowLength = 128;
     region.bufferImageHeight = 128;
@@ -2157,9 +2153,7 @@ TEST_F(NegativeCommand, MiscImageLayer) {
     VkImageObj image2(m_device);
     image2.Init(128, 128, 1, VK_FORMAT_R8G8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_OPTIMAL, 0);  // 16bpp
     ASSERT_TRUE(image2.initialized());
-    VkBufferObj buffer2;
-    VkMemoryPropertyFlags reqs2 = 0;
-    buffer2.init_as_src(*m_device, 128 * 128 * 2, reqs2);
+    VkBufferObj buffer2(*m_device, 128 * 128 * 2, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, nullptr);
     m_commandBuffer->begin();
 
     // Image must have offset.z of 0 and extent.depth of 1
@@ -2965,9 +2959,8 @@ TEST_F(NegativeCommand, CopyImageZeroSize) {
     dst_image.init(&ci);
     ASSERT_TRUE(dst_image.initialized());
 
-    VkBufferObj buffer;
-    VkMemoryPropertyFlags reqs = 0;
-    buffer.init_as_src_and_dst(*m_device, 16384, reqs);  // large enough for image
+    // large enough for image
+    VkBufferObj buffer(*m_device, 16384, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
 
     m_commandBuffer->begin();
 
@@ -4378,10 +4371,8 @@ TEST_F(NegativeCommand, DepthStencilImageCopyNoGraphicsQueueFlags) {
                   VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(ds_image.initialized());
 
-    // Allocate buffers
-    VkBufferObj buffer;
-    VkMemoryPropertyFlags reqs = 0;
-    buffer.init_as_src_and_dst(*m_device, 262144, reqs);  // 256k to have more then enough to copy
+    // 256k to have more then enough to copy
+    VkBufferObj buffer(*m_device, 262144, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
 
     VkBufferImageCopy region = {};
     region.bufferRowLength = 0;
@@ -4424,10 +4415,8 @@ TEST_F(NegativeCommand, ImageCopyTransferQueueFlags) {
                VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
-    // Allocate buffers
-    VkBufferObj buffer;
-    VkMemoryPropertyFlags reqs = 0;
-    buffer.init_as_src_and_dst(*m_device, 262144, reqs);  // 256k to have more then enough to copy
+    // 256k to have more then enough to copy
+    VkBufferObj buffer(*m_device, 262144, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
 
     VkBufferImageCopy region = {};
     region.bufferRowLength = 0;
@@ -5769,9 +5758,7 @@ TEST_F(NegativeCommand, CmdUpdateBufferSize) {
 
     uint32_t update_data[4] = {0, 0, 0, 0};
     VkDeviceSize dataSize = sizeof(uint32_t) * 4;
-    VkMemoryPropertyFlags reqs = 0;
-    VkBufferObj buffer;
-    buffer.init_as_src_and_dst(*m_device, dataSize, reqs);
+    VkBufferObj buffer(*m_device, dataSize, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdUpdateBuffer-dataSize-00033");
     m_commandBuffer->begin();
@@ -5787,9 +5774,7 @@ TEST_F(NegativeCommand, CmdUpdateBufferDstOffset) {
 
     uint32_t update_data[4] = {0, 0, 0, 0};
     VkDeviceSize dataSize = sizeof(uint32_t) * 4;
-    VkMemoryPropertyFlags reqs = 0;
-    VkBufferObj buffer;
-    buffer.init_as_src_and_dst(*m_device, dataSize, reqs);
+    VkBufferObj buffer(*m_device, dataSize, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdUpdateBuffer-dstOffset-00032");
     m_commandBuffer->begin();
@@ -6236,11 +6221,8 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     image2.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
                 VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
-    VkBufferObj dst_buffer;
-    VkMemoryPropertyFlags reqs = 0;
-    dst_buffer.init_as_dst(*m_device, 128 * 128, reqs);
-    VkBufferObj src_buffer;
-    src_buffer.init_as_src(*m_device, 128 * 128, reqs);
+    VkBufferObj dst_buffer(*m_device, 128 * 128, 0, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    VkBufferObj src_buffer(*m_device, 128 * 128, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     auto copy_region = LvlInitStruct<VkImageCopy2>();
     copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     copy_region.srcSubresource.layerCount = 1;

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -925,10 +925,7 @@ TEST_F(PositiveCommand, FillBufferCmdPoolTransferQueue) {
 
     VkCommandPoolObj pool(m_device, transfer.value(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     VkCommandBufferObj cb(m_device, &pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
-
-    VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-    VkBufferObj buffer;
-    buffer.init_as_dst(*m_device, (VkDeviceSize)20, reqs);
+    VkBufferObj buffer(*m_device, 20, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
     cb.begin();
     cb.FillBuffer(buffer.handle(), 0, 12, 0x11111111);

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -493,7 +493,9 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         buffCI.queueFamilyIndexCount = 1;
         buffCI.pQueueFamilyIndices = &qfi;
 
-        vk_testing::Buffer d_buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
+        auto allocate_flag_info = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+        allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+        vk_testing::Buffer d_buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
         auto dbbi = LvlInitStruct<VkDescriptorBufferBindingInfoEXT>();
         dbbi.address = d_buffer.address();
@@ -554,7 +556,9 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         buffCI.usage |= VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT;
     }
 
-    vk_testing::Buffer d_buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
+    auto allocate_flag_info = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    vk_testing::Buffer d_buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
     {
         auto dbbi = LvlInitStruct<VkDescriptorBufferBindingInfoEXT>();
@@ -601,7 +605,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         }
     }
 
-    vk_testing::Buffer d_buffer2(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
+    vk_testing::Buffer d_buffer2(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
     if (descriptor_buffer_properties.descriptorBufferOffsetAlignment != 1) {
         auto dbbi2 = LvlInitStruct<VkDescriptorBufferBindingInfoEXT>();
@@ -616,8 +620,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
 
     {
         buffCI.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-
-        vk_testing::Buffer bufferA(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
+        vk_testing::Buffer bufferA(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
         auto dbbi2 = LvlInitStruct<VkDescriptorBufferBindingInfoEXT>();
         dbbi2.address = bufferA.address();
@@ -688,7 +691,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         buffCI.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
         buffCI.queueFamilyIndexCount = 1;
         buffCI.pQueueFamilyIndices = &qfi;
-        vk_testing::Buffer bufferA(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
+        vk_testing::Buffer bufferA(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
         auto dbbi2 = LvlInitStruct<VkDescriptorBufferBindingInfoEXT>();
         dbbi2.address = bufferA.address();
@@ -861,7 +864,9 @@ TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
     buffCI.queueFamilyIndexCount = 1;
     buffCI.pQueueFamilyIndices = &qfi;
 
-    vk_testing::Buffer buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
+    auto allocate_flag_info = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    vk_testing::Buffer buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
     auto dbbi = LvlInitStruct<VkDescriptorBufferBindingInfoEXT>();
     dbbi.address = buffer.address();

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -67,7 +67,9 @@ TEST_F(PositiveDescriptorBuffer, BindBufferAndSetOffset) {
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-    vk_testing::Buffer buffer(*m_device, buffer_ci, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
+    auto allocate_flag_info = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    vk_testing::Buffer buffer(*m_device, buffer_ci, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
     auto buffer_binding_info = LvlInitStruct<VkDescriptorBufferBindingInfoEXT>();
     buffer_binding_info.address = buffer.address();

--- a/tests/unit/descriptor_indexing.cpp
+++ b/tests/unit/descriptor_indexing.cpp
@@ -402,9 +402,7 @@ TEST_F(NegativeDescriptorIndexing, SetLayout) {
             VkDescriptorSet ds;
             VkResult err = vk::AllocateDescriptorSets(m_device->handle(), &ds_alloc_info, &ds);
             ASSERT_VK_SUCCESS(err);
-            VkBufferObj buffer;
-            VkMemoryPropertyFlags reqs = 0;
-            buffer.init_as_dst(*m_device, 128 * 128, reqs);
+            VkBufferObj buffer(*m_device, 128 * 128, 0, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
             VkDescriptorBufferInfo buffer_info[3] = {};
             for (int i = 0; i < 3; i++) {
                 buffer_info[i].buffer = buffer.handle();

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -2614,9 +2614,8 @@ TEST_F(NegativeDynamicRendering, WithBarrier) {
 
     m_commandBuffer->BeginRendering(begin_rendering_info);
 
-    VkBufferObj buffer;
-    VkMemoryPropertyFlags mem_reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-    buffer.init_as_src_and_dst(*m_device, 256, mem_reqs);
+    VkBufferObj buffer(*m_device, 256, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+                       VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
     auto buf_barrier = LvlInitStruct<VkBufferMemoryBarrier2KHR>();
     buf_barrier.buffer = buffer.handle();
@@ -2774,9 +2773,8 @@ TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
     vk::CmdPipelineBarrier2(m_commandBuffer->handle(), &dependency_info);
     m_errorMonitor->VerifyFound();
 
-    VkBufferObj buffer;
-    VkMemoryPropertyFlags mem_reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
-    buffer.init_as_src_and_dst(*m_device, 256, mem_reqs);
+    VkBufferObj buffer(*m_device, 256, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+                       VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
     auto buf_barrier_2 = LvlInitStruct<VkBufferMemoryBarrier2KHR>();
     buf_barrier_2.buffer = buffer.handle();

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -547,11 +547,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuRobustBufferOOB) {
     pipeline_robustness_features.pipelineRobustness = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-    VkBufferObj uniform_buffer;
-    VkBufferObj storage_buffer;
     VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    uniform_buffer.init(*m_device, 4, reqs);
-    storage_buffer.init_as_storage(*m_device, 16, reqs);
+    VkBufferObj uniform_buffer(*m_device, 4, reqs, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    VkBufferObj storage_buffer(*m_device, 16, reqs, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
     OneOffDescriptorSet descriptor_set(m_device, {
         {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
         {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -642,13 +640,11 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkBufferObj offset_buffer;
-    VkBufferObj write_buffer;
     VkBufferObj uniform_texel_buffer;
     VkBufferObj storage_texel_buffer;
     VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    offset_buffer.init(*m_device, 4, reqs);
-    write_buffer.init_as_storage(*m_device, 16, reqs);
+    VkBufferObj offset_buffer(*m_device, 4, reqs, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    VkBufferObj write_buffer(*m_device, 16, reqs, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     uint32_t queue_family_index = 0;
@@ -1036,7 +1032,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     // Make another buffer to write to
     bci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
     bci.size = 64;  // Buffer should be 16*4 = 64 bytes
-    vk_testing::Buffer buffer1(*m_device, bci, mem_props, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
+    auto allocate_flag_info = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    vk_testing::Buffer buffer1(*m_device, bci, mem_props, &allocate_flag_info);
 
     // Get device address of buffer to write to
     auto pBuffer = buffer1.address();
@@ -2241,13 +2239,11 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPL) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkBufferObj offset_buffer;
-    VkBufferObj write_buffer;
     VkBufferObj uniform_texel_buffer;
     VkBufferObj storage_texel_buffer;
     VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    offset_buffer.init(*m_device, 4, reqs);
-    write_buffer.init_as_storage(*m_device, 16, reqs);
+    VkBufferObj offset_buffer(*m_device, 4, reqs, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    VkBufferObj write_buffer(*m_device, 16, reqs, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     uint32_t queue_family_index = 0;
@@ -2424,13 +2420,11 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPLIndependentSets) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkBufferObj offset_buffer;
-    VkBufferObj write_buffer;
     VkBufferObj uniform_texel_buffer;
     VkBufferObj storage_texel_buffer;
     VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    offset_buffer.init(*m_device, 4, reqs);
-    write_buffer.init_as_storage(*m_device, 16, reqs);
+    VkBufferObj offset_buffer(*m_device, 4, reqs, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    VkBufferObj write_buffer(*m_device, 16, reqs, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     uint32_t queue_family_index = 0;

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -335,7 +335,9 @@ TEST_F(PositiveGpuAssistedLayer, GpuBufferDeviceAddress) {
     // Make another buffer to write to
     bci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
     bci.size = 64;  // Buffer should be 16*4 = 64 bytes
-    vk_testing::Buffer buffer1(*m_device, bci, mem_props, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT);
+    auto allocate_flag_info = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    vk_testing::Buffer buffer1(*m_device, bci, mem_props, &allocate_flag_info);
 
     // Get device address of buffer to write to
     auto pBuffer = buffer1.address();

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -46,9 +46,7 @@ TEST_F(NegativeImage, UsageBits) {
     CreateImageViewTest(*this, &dsvci, "VUID-VkImageViewCreateInfo-image-04441");
 
     // Initialize buffer with TRANSFER_DST usage
-    VkBufferObj buffer;
-    VkMemoryPropertyFlags reqs = 0;
-    buffer.init_as_dst(*m_device, 128 * 128, reqs);
+    VkBufferObj buffer(*m_device, 128 * 128, 0, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     VkBufferImageCopy region = {};
     region.bufferRowLength = 128;
     region.bufferImageHeight = 128;
@@ -106,9 +104,7 @@ TEST_F(NegativeImage, CopyBufferToCompressedImage) {
 
     VkImageObj width_image(m_device);
     VkImageObj height_image(m_device);
-    VkBufferObj buffer;
-    VkMemoryPropertyFlags reqs = 0;
-    buffer.init_as_src(*m_device, 8 * 4 * 2, reqs);
+    VkBufferObj buffer(*m_device, 8 * 4 * 2, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     VkBufferImageCopy region = {};
     region.bufferRowLength = 0;
     region.bufferImageHeight = 0;
@@ -197,7 +193,6 @@ TEST_F(NegativeImage, SampleCounts) {
     TEST_DESCRIPTION("Use bad sample counts in image transfer calls to trigger validation errors.");
     ASSERT_NO_FATAL_FAILURE(Init(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    VkMemoryPropertyFlags reqs = 0;
     VkImageCreateInfo image_create_info = LvlInitStruct<VkImageCreateInfo>();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -277,8 +272,7 @@ TEST_F(NegativeImage, SampleCounts) {
     // Create src buffer and dst image with sampleCount = 4 and attempt to copy
     // buffer to image
     {
-        VkBufferObj src_buffer;
-        src_buffer.init_as_src(*m_device, 128 * 128 * 4, reqs);
+        VkBufferObj src_buffer(*m_device, 128 * 128 * 4, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
         image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
         VkImageObj dst_image(m_device);
@@ -296,12 +290,11 @@ TEST_F(NegativeImage, SampleCounts) {
     // Create dst buffer and src image with sampleCount = 4 and attempt to copy
     // image to buffer
     {
-        VkBufferObj dst_buffer;
-        dst_buffer.init_as_dst(*m_device, 128 * 128 * 4, reqs);
+        VkBufferObj dst_buffer(*m_device, 128 * 128 * 4, 0, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
         image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
         vk_testing::Image src_image;
-        src_image.init(*m_device, (const VkImageCreateInfo &)image_create_info, reqs);
+        src_image.init(*m_device, (const VkImageCreateInfo &)image_create_info, 0);
         m_commandBuffer->begin();
         m_errorMonitor->SetDesiredFailureMsg(
             kErrorBit, "was created with a sample count of VK_SAMPLE_COUNT_4_BIT but must be VK_SAMPLE_COUNT_1_BIT");

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1407,7 +1407,9 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirectKHR) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     buf_info.size = 4096;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkBufferObj buffer(*m_device, buf_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR);
+    auto allocate_flag_info = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    VkBufferObj buffer(*m_device, buf_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
 
     auto ray_tracing_properties = LvlInitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
     GetPhysicalDeviceProperties2(ray_tracing_properties);
@@ -1496,7 +1498,9 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRFeatureDisabled) {
     buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     buffer_info.size = 4096;
     buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkBufferObj buffer(*m_device, buffer_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR);
+    auto allocate_flag_info = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    VkBufferObj buffer(*m_device, buffer_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
 
     const VkDeviceAddress device_address = buffer.address(DeviceValidationVersion());
 
@@ -1538,7 +1542,9 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRAddress) {
     buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     buffer_info.size = 4096;
     buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkBufferObj buffer(*m_device, buffer_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR);
+    auto allocate_flag_info = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    VkBufferObj buffer(*m_device, buffer_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
 
     const VkDeviceAddress device_address = buffer.address(DeviceValidationVersion());
 

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -2212,7 +2212,7 @@ struct SemBufferRaceData {
 
             VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
             auto buffer = std::make_unique<vk_testing::Buffer>();
-            buffer->init_as_dst(dev, (VkDeviceSize)20, reqs);
+            buffer->init(dev, 20, reqs, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
             // main thread sets up buffer
             // main thread signals 1

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -24,13 +24,11 @@ TEST_F(NegativeSyncVal, BufferCopyHazards) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     bool has_amd_buffer_maker = IsExtensionsEnabled(VK_AMD_BUFFER_MARKER_EXTENSION_NAME);
 
-    VkBufferObj buffer_a;
-    VkBufferObj buffer_b;
-    VkBufferObj buffer_c;
     VkMemoryPropertyFlags mem_prop = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-    buffer_a.init_as_src_and_dst(*m_device, 256, mem_prop);
-    buffer_b.init_as_src_and_dst(*m_device, 256, mem_prop);
-    buffer_c.init_as_src_and_dst(*m_device, 256, mem_prop);
+    VkBufferUsageFlags transfer_usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    VkBufferObj buffer_a(*m_device, 256, mem_prop, transfer_usage);
+    VkBufferObj buffer_b(*m_device, 256, mem_prop, transfer_usage);
+    VkBufferObj buffer_c(*m_device, 256, mem_prop, transfer_usage);
 
     VkBufferCopy region = {0, 0, 256};
     VkBufferCopy front2front = {0, 0, 128};

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -150,7 +150,6 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopyBufferToImage) {
     std::array<VkImageAspectFlagBits, 3> aspects = {
         {VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT, VK_IMAGE_ASPECT_PLANE_2_BIT}};
     std::array<VkBufferObj, 3> buffers;
-    VkMemoryPropertyFlags reqs = 0;
 
     VkBufferImageCopy copy = {};
     copy.imageSubresource.layerCount = 1;
@@ -159,7 +158,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopyBufferToImage) {
     copy.imageExtent.width = 16;
 
     for (size_t i = 0; i < aspects.size(); ++i) {
-        buffers[i].init_as_src(*m_device, (VkDeviceSize)16 * 16 * 1, reqs);
+        buffers[i].init(*m_device, 16 * 16 * 1, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
         copy.imageSubresource.aspectMask = aspects[i];
         vk::CmdCopyBufferToImage(m_commandBuffer->handle(), buffers[i].handle(), image.handle(),
                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
@@ -321,9 +320,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageTests) {
     }
 
     // Test that changing the layout of ASPECT_COLOR also changes the layout of the individual planes
-    VkBufferObj buffer;
-    VkMemoryPropertyFlags reqs = 0;
-    buffer.init_as_src(*m_device, (VkDeviceSize)128 * 128 * 3, reqs);
+    VkBufferObj buffer(*m_device, 128 * 128 * 3, 0, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     VkImageObj mpimage(m_device);
     mpimage.Init(256, 256, 1, VK_FORMAT_G8_B8_R8_3PLANE_422_UNORM_KHR, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
                  VK_IMAGE_TILING_OPTIMAL, 0);


### PR DESCRIPTION
Currently we have so many random ways to create a `VkBufferObj` that it becomes hard to follow which path does what

This also leads to a lot of times we need to do things like

```
VkMemoryPropertyFlags reqs = 0
VkBufferObj buffer_one(*m_device, 2048, reqs);
```

Because `VkBufferObj buffer_one(*m_device, 2048, 0);` is ambiguous with the various overloads

This just a small change to get things in cleaner direction
