### PR TITLE
tests: Confirm ShaderVal handles descriptorIndexing

### DIFF
--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -170,8 +170,8 @@ struct ImageAccess {
     bool is_read_from = false;
 
     static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
-    uint32_t image_access_chain_index = kInvalidValue;    // Index 0
-    uint32_t sampler_access_chain_index = kInvalidValue;  // Index 0
+    uint32_t image_access_chain_index = kInvalidValue;    // OpAccessChain's Index 0
+    uint32_t sampler_access_chain_index = kInvalidValue;  // OpAccessChain's Index 0
     uint32_t texel_component_count = kInvalidValue;
 
     ImageAccess(const SPIRV_MODULE_STATE &module_state, const Instruction &image_insn);

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -336,6 +336,7 @@ class DescriptorIndexingTest : public VkLayerTest {
   public:
     void InitBasicDescriptorIndexing(void *pNextFeatures = nullptr);
     VkPhysicalDeviceDescriptorIndexingFeatures descriptor_indexing_features;
+    void ComputePipelineShaderTest(const char *shader, std::vector<VkDescriptorSetLayoutBinding> &bindings);
 };
 class NegativeDescriptorIndexing : public DescriptorIndexingTest {};
 class PositiveDescriptorIndexing : public DescriptorIndexingTest {};

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -1910,7 +1910,6 @@ TEST_F(NegativePipeline, NotCompatibleForSet) {
 
     char const *csSource = R"glsl(
         #version 450
-        #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) buffer StorageBuffer { uint index; } u_index;
         layout(set = 0, binding = 1) uniform UniformStruct { ivec4 dummy; int val; } ubo;
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5465

Finally looking into this, I feel confident that we handle all cases of descriptor indexing correctly now in Shader Validation. I added some tests to confirm this