### PR TITLE
Add VkCommandBufferInheritanceInfo::queryFlags check

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1314,9 +1314,10 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                 const LogObjectList objlist(commandBuffer, pCommandBuffers[i]);
                 skip |= LogError(objlist, "VUID-vkCmdExecuteCommands-commandBuffer-00103",
                                  "vkCmdExecuteCommands(): command buffer %s has an active occlusion query with VkQueryControlFlags "
-                                 "0X%x, but secondary command "
+                                 "0X%" PRIx32
+                                 ", but secondary command "
                                  "buffer %s (pCommandBuffers[%" PRIu32
-                                 "]) was recorded with VkCommandBufferInheritanceInfo::queryFlags 0X%x",
+                                 "]) was recorded with VkCommandBufferInheritanceInfo::queryFlags 0X%" PRIx32 "",
                                  FormatHandle(commandBuffer).c_str(), active_occlusion_query->control_flags,
                                  FormatHandle(pCommandBuffers[i]).c_str(), i, sub_cb_state.inheritanceInfo.queryFlags);
             }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -562,8 +562,8 @@ class CoreChecks : public ValidationStateTracker {
                                    VkQueryPool& firstPerfQueryPool, uint32_t perfPass, QueryMap* localQueryToStateMap);
     static bool ValidatePerformanceQuery(const CMD_BUFFER_STATE& cb_state, const QueryObject& query_obj, const CMD_TYPE cmd_type,
                                          VkQueryPool& firstPerfQueryPool, uint32_t perfPass, QueryMap* localQueryToStateMap);
-    bool ValidateBeginQuery(const CMD_BUFFER_STATE& cb_state, const QueryObject& query_obj, VkFlags flags, uint32_t index,
-                            CMD_TYPE cmd, const ValidateBeginQueryVuids* vuids) const;
+    bool ValidateBeginQuery(const CMD_BUFFER_STATE& cb_state, const QueryObject& query_obj, VkQueryControlFlags flags,
+                            uint32_t index, CMD_TYPE cmd, const ValidateBeginQueryVuids* vuids) const;
     bool ValidateCmdEndQuery(const CMD_BUFFER_STATE& cb_state, const QueryObject& query_obj, uint32_t index, CMD_TYPE cmd,
                              const ValidateEndQueryVuids* vuids) const;
 
@@ -1699,8 +1699,9 @@ class CoreChecks : public ValidationStateTracker {
 
     void EnqueueVerifyBeginQuery(VkCommandBuffer, const QueryObject& query_obj, const CMD_TYPE cmd_type);
     bool PreCallValidateCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
-                                      VkFlags flags) const override;
-    void PreCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot, VkFlags flags) override;
+                                      VkQueryControlFlags flags) const override;
+    void PreCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
+                                    VkQueryControlFlags flags) override;
     void EnqueueVerifyEndQuery(CMD_BUFFER_STATE& cb_state, const QueryObject& query_obj);
     bool PreCallValidateCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot) const override;
     void PreCallRecordCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot) override;

--- a/layers/state_tracker/query_state.h
+++ b/layers/state_tracker/query_state.h
@@ -91,6 +91,7 @@ struct QueryObject {
     VkQueryPool pool;
     uint32_t slot;  // use 'slot' as alias to 'query' parameter to help reduce confusing namespace
     uint32_t perf_pass;
+    VkQueryControlFlags control_flags;
 
     // These next five fields are *not* used in hash or comparison, they are effectively a data payload
     mutable uint32_t active_query_index;
@@ -102,10 +103,12 @@ struct QueryObject {
     // the end of the query).
     uint64_t end_command_index;
 
-    QueryObject(VkQueryPool pool_, uint32_t slot_, uint32_t perf_pass_ = 0, bool indexed_ = false, uint32_t index_ = 0)
+    QueryObject(VkQueryPool pool_, uint32_t slot_, VkQueryControlFlags control_flags_ = 0, uint32_t perf_pass_ = 0,
+                bool indexed_ = false, uint32_t index_ = 0)
         : pool(pool_),
           slot(slot_),
           perf_pass(perf_pass_),
+          control_flags(control_flags_),
           active_query_index(slot_),
           last_activatable_query_index(slot_),
           index(index_),
@@ -117,6 +120,7 @@ struct QueryObject {
         : pool(obj.pool),
           slot(obj.slot),
           perf_pass(perf_pass_),
+          control_flags(obj.control_flags),
           active_query_index(obj.active_query_index),
           last_activatable_query_index(obj.last_activatable_query_index),
           index(obj.index),

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3442,7 +3442,7 @@ void ValidationStateTracker::PreCallRecordCmdPipelineBarrier2(VkCommandBuffer co
 }
 
 void ValidationStateTracker::PostCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
-                                                         VkFlags flags) {
+                                                         VkQueryControlFlags flags) {
     if (disabled[query_validation]) return;
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
 
@@ -3453,7 +3453,7 @@ void ValidationStateTracker::PostCallRecordCmdBeginQuery(VkCommandBuffer command
         num_queries = std::max(num_queries, bits);
     }
     for (uint32_t i = 0; i < num_queries; ++i) {
-        QueryObject query_obj = {queryPool, slot};
+        QueryObject query_obj = {queryPool, slot, flags};
         cb_state->RecordCmd(CMD_BEGINQUERY);
         if (!disabled[query_validation]) {
             cb_state->BeginQuery(query_obj);
@@ -4673,7 +4673,7 @@ void ValidationStateTracker::PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuff
     }
 
     for (uint32_t i = 0; i < num_queries; ++i) {
-        QueryObject query_obj = {queryPool, slot, 0, true, index + i};
+        QueryObject query_obj = {queryPool, slot, flags, 0, true, index + i};
         cb_state->RecordCmd(CMD_BEGINQUERYINDEXEDEXT);
         cb_state->BeginQuery(query_obj);
     }
@@ -4690,7 +4690,7 @@ void ValidationStateTracker::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer
     }
 
     for (uint32_t i = 0; i < num_queries; ++i) {
-        QueryObject query_obj = {queryPool, slot, 0, true, index + i};
+        QueryObject query_obj = {queryPool, slot, 0, 0, true, index + i};
         cb_state->RecordCmd(CMD_ENDQUERYINDEXEDEXT);
         cb_state->EndQuery(query_obj);
     }

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -938,7 +938,8 @@ class ValidationStateTracker : public ValidationObject {
 
     // Recorded Commands
     void PreCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo) override;
-    void PostCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot, VkFlags flags) override;
+    void PostCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
+                                     VkQueryControlFlags flags) override;
     void PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                                VkQueryControlFlags flags, uint32_t index) override;
     void PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5430

This adds ` VUID-vkCmdExecuteCommands-commandBuffer-00103`

While here, I cleaned up things to use const ref for the command buffers