### PR TITLE
layers: Fix and test VUID 03230 and 03233

### DIFF
--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -50,9 +50,11 @@ bool CoreChecks::ValidatePerformanceQueryResults(const char *cmd_name, const QUE
                                                  uint32_t firstQuery, uint32_t queryCount, VkQueryResultFlags flags) const {
     bool skip = false;
 
-    if (flags & (VK_QUERY_RESULT_WITH_AVAILABILITY_BIT | VK_QUERY_RESULT_PARTIAL_BIT | VK_QUERY_RESULT_64_BIT)) {
+    if (flags & (VK_QUERY_RESULT_WITH_AVAILABILITY_BIT | VK_QUERY_RESULT_WITH_STATUS_BIT_KHR | VK_QUERY_RESULT_PARTIAL_BIT |
+                 VK_QUERY_RESULT_64_BIT)) {
         std::string invalid_flags_string;
-        for (auto flag : {VK_QUERY_RESULT_WITH_AVAILABILITY_BIT, VK_QUERY_RESULT_PARTIAL_BIT, VK_QUERY_RESULT_64_BIT}) {
+        for (auto flag : {VK_QUERY_RESULT_WITH_AVAILABILITY_BIT, VK_QUERY_RESULT_WITH_STATUS_BIT_KHR, VK_QUERY_RESULT_PARTIAL_BIT,
+                          VK_QUERY_RESULT_64_BIT}) {
             if (flag & flags) {
                 if (invalid_flags_string.size()) {
                     invalid_flags_string += " and ";


### PR DESCRIPTION
This PR is the validation and test fixes for https://github.com/KhronosGroup/Vulkan-Docs/issues/2185.

I've also added some tests for VUID 03233 which didn't have any tests before.

@spencer-lunarg, I guess you'd like to take a look at it.

@llandwerlin-intel, I think you might want to look at this, considering you have an implementation of `VK_KHR_performance_query`.