### PR TITLE
WIP - layers: Add ErrorObject

### DIFF
--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -397,7 +397,8 @@ class BestPractices : public ValidationStateTracker {
                                                   const VkAllocationCallbacks* pAllocator,
                                                   VkSwapchainKHR* pSwapchains) const override;
     bool PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
-                                         const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const override;
+                                         const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                         ErrorObject& errorObj) const override;
     bool ValidateAttachments(const VkRenderPassCreateInfo2* rpci, uint32_t attachmentCount, const VkImageView* image_views) const;
     bool PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
                                           const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer) const override;
@@ -686,8 +687,8 @@ class BestPractices : public ValidationStateTracker {
                                                               const CALL_STATE call_state, const char* caller_name) const;
     bool PreCallValidateBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,
                                                           const VkBindAccelerationStructureMemoryInfoNV* pBindInfos) const override;
-    bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
-                                        VkFence fence) const override;
+    bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
+                                        ErrorObject& errorObj) const override;
     void ManualPostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
                                              VkFence fence, VkResult result);
     bool PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,

--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -422,7 +422,7 @@ bool BestPractices::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCo
 }
 
 bool BestPractices::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
-                                                   VkFence fence) const {
+                                                   VkFence fence, ErrorObject& errorObj) const {
     bool skip = false;
 
     for (uint32_t bind_idx = 0; bind_idx < bindInfoCount; bind_idx++) {

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -76,7 +76,8 @@ static inline bool RenderPassUsesAttachmentAsImageOnly(const safe_VkRenderPassCr
 }
 
 bool BestPractices::PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
-                                                    const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const {
+                                                    const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
+                                                    ErrorObject& errorObj) const {
     bool skip = false;
 
     for (uint32_t i = 0; i < pCreateInfo->attachmentCount; ++i) {

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -5263,8 +5263,8 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
 }
 
 bool CoreChecks::PreCallValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
-                                                 VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
-                                                 const void *pValues) const {
+                                                 VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void *pValues,
+                                                 ErrorObject &errorObj) const {
     bool skip = false;
     auto cb_state = GetRead<CMD_BUFFER_STATE>(commandBuffer);
     assert(cb_state);

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -580,7 +580,7 @@ bool CoreChecks::ValidatePrimaryCommandBufferState(
 }
 
 bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
-                                                VkFence fence) const {
+                                                VkFence fence, ErrorObject &errorObj) const {
     auto queue_data = Get<QUEUE_STATE>(queue);
     auto fence_state = Get<FENCE_STATE>(fence);
     bool skip = ValidateFenceForSubmit(fence_state.get(), "VUID-vkQueueBindSparse-fence-01114",

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1427,7 +1427,7 @@ static inline VkQueueFlags SubpassToQueueFlags(uint32_t subpass) {
     return subpass == VK_SUBPASS_EXTERNAL ? sync_utils::kAllQueueTypes : static_cast<VkQueueFlags>(VK_QUEUE_GRAPHICS_BIT);
 }
 
-bool CoreChecks::ValidateSubpassDependency(const LogObjectList &objects, const Location &in_loc,
+bool CoreChecks::ValidateSubpassDependency(ErrorObject &errorObj, const Location &in_loc,
                                            const VkSubpassDependency2 &dependency) const {
     bool skip = false;
     Location loc = in_loc;
@@ -1445,13 +1445,13 @@ bool CoreChecks::ValidateSubpassDependency(const LogObjectList &objects, const L
         converted_barrier.dstAccessMask = dependency.dstAccessMask;
     }
     auto src_queue_flags = SubpassToQueueFlags(dependency.srcSubpass);
-    skip |= ValidatePipelineStage(objects, loc.dot(Field::srcStageMask), src_queue_flags, converted_barrier.srcStageMask);
-    skip |= ValidateAccessMask(objects, loc.dot(Field::srcAccessMask), src_queue_flags, converted_barrier.srcAccessMask,
+    skip |= ValidatePipelineStage(errorObj.objlist, loc.dot(Field::srcStageMask), src_queue_flags, converted_barrier.srcStageMask);
+    skip |= ValidateAccessMask(errorObj.objlist, loc.dot(Field::srcAccessMask), src_queue_flags, converted_barrier.srcAccessMask,
                                converted_barrier.srcStageMask);
 
     auto dst_queue_flags = SubpassToQueueFlags(dependency.dstSubpass);
-    skip |= ValidatePipelineStage(objects, loc.dot(Field::dstStageMask), dst_queue_flags, converted_barrier.dstStageMask);
-    skip |= ValidateAccessMask(objects, loc.dot(Field::dstAccessMask), dst_queue_flags, converted_barrier.dstAccessMask,
+    skip |= ValidatePipelineStage(errorObj.objlist, loc.dot(Field::dstStageMask), dst_queue_flags, converted_barrier.dstStageMask);
+    skip |= ValidateAccessMask(errorObj.objlist, loc.dot(Field::dstAccessMask), dst_queue_flags, converted_barrier.dstAccessMask,
                                converted_barrier.dstStageMask);
     return skip;
 }

--- a/layers/error_message/core_error_location.h
+++ b/layers/error_message/core_error_location.h
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <limits>
 
+#include "logging.h"
 #include "containers/custom_containers.h"
 namespace core_error {
 // structure to track where a validation error occurs, and capture enough information
@@ -259,3 +260,14 @@ static const std::string& FindVUID(OuterKey key, const Location& loc, const Tabl
 }
 
 }  // namespace core_error
+
+// Contains all information needed for errors to be logged out
+// This allows only a single object to be passed around for error messages
+struct ErrorObject {
+    std::string command;
+    VulkanTypedHandle handle;  // dispatchable handle is always first parameter of the function call
+    LogObjectList objlist;
+
+    ErrorObject(std::string command_, VulkanTypedHandle handle_) : command(command_), handle(handle_), objlist(handle) {}
+    std::string Location() const { return command; }
+};

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -26,6 +26,7 @@
 #include "generated/vk_safe_struct.h"
 #include "generated/vk_validation_error_messages.h"
 #include "external/xxhash.h"
+#include "core_error_location.h"
 
 VKAPI_ATTR void SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks, debug_report_data *debug_data) {
     // For all callback in list, return their complete set of severities and modes
@@ -332,6 +333,111 @@ static bool LogMsgEnabled(const debug_report_data *debug_data, std::string_view 
         return false;
     }
     return true;
+}
+
+// TODO - Migrate LogMsg to LogMessage, but provides a migration path
+VKAPI_ATTR bool LogMessage(const debug_report_data *debug_data, VkFlags msg_flags, const ErrorObject &errorObj,
+                           std::string_view vuid_text, const char *format, va_list argptr) {
+    assert(*(vuid_text.data() + vuid_text.size()) == '\0');
+
+    VkDebugUtilsMessageSeverityFlagsEXT severity;
+    VkDebugUtilsMessageTypeFlagsEXT type;
+
+    DebugReportFlagsToAnnotFlags(msg_flags, &severity, &type);
+    std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
+    // Avoid logging cost if msg is to be ignored
+    if (!LogMsgEnabled(debug_data, vuid_text, severity, type)) {
+        return false;
+    }
+
+    // Best guess at an upper bound for message length. At least some of the extra space
+    // should get used to store the VUID URL and text in the common case, without additional allocations.
+    std::string str_plus_spec_text(1024, '\0');
+
+    // vsnprintf() returns the number of characters that *would* have been printed, if there was
+    // enough space. If we have a huge message, reallocate the string and try again.
+    int result;
+    size_t old_size = str_plus_spec_text.size();
+    // The va_list will be destroyed by the call to vsnprintf(), so use a copy in case we need
+    // to try again.
+    va_list arg_copy;
+    va_copy(arg_copy, argptr);
+    result = vsnprintf(str_plus_spec_text.data(), str_plus_spec_text.size(), format, arg_copy);
+    va_end(arg_copy);
+
+    assert(result >= 0);
+    if (result < 0) {
+        str_plus_spec_text = "Message generation failure";
+    } else if (static_cast<size_t>(result) <= old_size) {
+        // Shrink the string to exactly fit the successfully printed string
+        str_plus_spec_text.resize(result);
+    } else {
+        // Grow buffer to fit needed size. Note that the input size to vsnprintf() must
+        // include space for the trailing '\0' character, but the return value DOES NOT
+        // include the `\0' character.
+        str_plus_spec_text.resize(result + 1);
+        // consume the va_list passed to us by the caller
+        result = vsnprintf(str_plus_spec_text.data(), str_plus_spec_text.size(), format, argptr);
+        // remove the `\0' character from the string
+        str_plus_spec_text.resize(result);
+    }
+
+    str_plus_spec_text = errorObj.Location() + "(): " + str_plus_spec_text;
+
+    // Append the spec error text to the error message, unless it contains a word treated as special
+    if ((vuid_text.find("UNASSIGNED-") == std::string::npos) && (vuid_text.find(kVUIDUndefined) == std::string::npos) &&
+        (vuid_text.rfind("SYNC-", 0) == std::string::npos) && (vuid_text.find("INTERNAL-ERROR-") == std::string::npos)) {
+        // Linear search makes no assumptions about the layout of the string table. This is not fast, but it does not need to be at
+        // this point in the error reporting path
+        uint32_t num_vuids = sizeof(vuid_spec_text) / sizeof(vuid_spec_text_pair);
+        const char *spec_text = nullptr;
+        std::string spec_type;
+        for (uint32_t i = 0; i < num_vuids; i++) {
+            if (0 == strncmp(vuid_text.data(), vuid_spec_text[i].vuid, vuid_text.size())) {
+                spec_text = vuid_spec_text[i].spec_text;
+                spec_type = vuid_spec_text[i].url_id;
+                break;
+            }
+        }
+
+        // Construct and append the specification text and link to the appropriate version of the spec
+        if (nullptr != spec_text) {
+            std::string spec_link = "https://www.khronos.org/registry/vulkan/specs/_MAGIC_KHRONOS_SPEC_TYPE_/html/vkspec.html";
+#ifdef ANNOTATED_SPEC_LINK
+            spec_link = ANNOTATED_SPEC_LINK;
+#endif
+            static std::string kAtToken = "_MAGIC_ANNOTATED_SPEC_TYPE_";
+            static std::string kKtToken = "_MAGIC_KHRONOS_SPEC_TYPE_";
+            static std::string kVeToken = "_MAGIC_VERSION_ID_";
+            auto Replace = [](std::string &dest_string, const std::string &to_replace, const std::string &replace_with) {
+                if (dest_string.find(to_replace) != std::string::npos) {
+                    dest_string.replace(dest_string.find(to_replace), to_replace.size(), replace_with);
+                }
+            };
+
+            str_plus_spec_text.append(" The Vulkan spec states: ");
+            str_plus_spec_text.append(spec_text);
+            if (0 == spec_type.compare("default")) {
+                str_plus_spec_text.append(" (https://github.com/KhronosGroup/Vulkan-Docs/search?q=)");
+            } else {
+                str_plus_spec_text.append(" (");
+                str_plus_spec_text.append(spec_link);
+                std::string major_version = std::to_string(VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE));
+                std::string minor_version = std::to_string(VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE));
+                std::string patch_version = std::to_string(VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
+                std::string header_version = major_version + "." + minor_version + "." + patch_version;
+                std::string annotated_spec_type = major_version + "." + minor_version + "-extensions";
+                Replace(str_plus_spec_text, kKtToken, spec_type);
+                Replace(str_plus_spec_text, kAtToken, annotated_spec_type);
+                Replace(str_plus_spec_text, kVeToken, header_version);
+                str_plus_spec_text.append("#");  // CMake hates hashes
+            }
+            str_plus_spec_text.append(vuid_text);
+            str_plus_spec_text.append(")");
+        }
+    }
+
+    return debug_log_msg(debug_data, msg_flags, errorObj.objlist, "Validation", str_plus_spec_text.c_str(), vuid_text.data());
 }
 
 VKAPI_ATTR bool LogMsg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -303,6 +303,10 @@ static inline LogMessageTypeFlags DebugAnnotFlagsToMsgTypeFlags(VkDebugUtilsMess
 VKAPI_ATTR bool LogMsg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
                        std::string_view vuid_text, const char *format, va_list argptr);
 
+struct ErrorObject;
+VKAPI_ATTR bool LogMessage(const debug_report_data *debug_data, VkFlags msg_flags, const ErrorObject &errorObj,
+                           std::string_view vuid_text, const char *format, va_list argptr);
+
 VKAPI_ATTR VkResult LayerCreateMessengerCallback(debug_report_data *debug_data, bool default_callback,
                                                  const VkDebugUtilsMessengerCreateInfoEXT *create_info,
                                                  VkDebugUtilsMessengerEXT *messenger);

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -294,7 +294,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers2(VkCommandB
 
 bool StatelessValidation::manual_PreCallValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                                                  VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
-                                                                 const void *pValues) const {
+                                                                 const void *pValues, ErrorObject &errorObj) const {
     bool skip = false;
     const uint32_t max_push_constants_size = device_limits.maxPushConstantsSize;
     // Check that offset + size don't exceed the max.

--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -472,22 +472,22 @@ bool StatelessValidation::ValidateCreateRenderPass(VkDevice device, const VkRend
 }
 
 bool StatelessValidation::manual_PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
-                                                                 const VkAllocationCallbacks *pAllocator,
-                                                                 VkRenderPass *pRenderPass) const {
+                                                                 const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
+                                                                 ErrorObject &errorObj) const {
     safe_VkRenderPassCreateInfo2 create_info_2 = ConvertVkRenderPassCreateInfoToV2KHR(*pCreateInfo);
     return ValidateCreateRenderPass(device, create_info_2.ptr(), pAllocator, pRenderPass, RENDER_PASS_VERSION_1);
 }
 
 bool StatelessValidation::manual_PreCallValidateCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
                                                                   const VkAllocationCallbacks *pAllocator,
-                                                                  VkRenderPass *pRenderPass) const {
+                                                                  VkRenderPass *pRenderPass, ErrorObject &errorObj) const {
     safe_VkRenderPassCreateInfo2 create_info_2(pCreateInfo);
     return ValidateCreateRenderPass(device, create_info_2.ptr(), pAllocator, pRenderPass, RENDER_PASS_VERSION_2);
 }
 
 bool StatelessValidation::manual_PreCallValidateCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
                                                                      const VkAllocationCallbacks *pAllocator,
-                                                                     VkRenderPass *pRenderPass) const {
+                                                                     VkRenderPass *pRenderPass, ErrorObject &errorObj) const {
     safe_VkRenderPassCreateInfo2 create_info_2(pCreateInfo);
     return ValidateCreateRenderPass(device, create_info_2.ptr(), pAllocator, pRenderPass, RENDER_PASS_VERSION_2);
 }

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -675,13 +675,16 @@ class StatelessValidation : public ValidationObject {
                                                   const VkDescriptorSet *pDescriptorSets) const;
 
     bool manual_PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,
-                                                const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) const;
+                                                const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
+                                                ErrorObject &errorObj) const;
 
     bool manual_PreCallValidateCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
-                                                 const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) const;
+                                                 const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
+                                                 ErrorObject &errorObj) const;
 
     bool manual_PreCallValidateCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2 *pCreateInfo,
-                                                    const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass) const;
+                                                    const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
+                                                    ErrorObject &errorObj) const;
 
     bool manual_PreCallValidateFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
                                                   const VkCommandBuffer *pCommandBuffers) const;
@@ -1070,8 +1073,8 @@ class StatelessValidation : public ValidationObject {
         const VkVertexInputAttributeDescription2EXT *pVertexAttributeDescriptions) const;
 
     bool manual_PreCallValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
-                                                VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
-                                                const void *pValues) const;
+                                                VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void *pValues,
+                                                ErrorObject &errorObj) const;
 
     bool manual_PreCallValidateMergePipelineCaches(VkDevice device, VkPipelineCache dstCache, uint32_t srcCacheCount,
                                                    const VkPipelineCache *pSrcCaches) const;

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -1517,9 +1517,10 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueBindSparse(
     VkFence                                     fence) {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(queue), layer_data_map);
     bool skip = false;
+    ErrorObject errorObj("vkQueueBindSparse", VulkanTypedHandle(queue, kVulkanObjectTypeQueue));
     for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateQueueBindSparse]) {
         auto lock = intercept->ReadLock();
-        skip |= intercept->PreCallValidateQueueBindSparse(queue, bindInfoCount, pBindInfo, fence);
+        skip |= intercept->PreCallValidateQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, errorObj);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallRecordQueueBindSparse]) {
@@ -2487,9 +2488,10 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
     VkRenderPass*                               pRenderPass) {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
+    ErrorObject errorObj("vkCreateRenderPass", VulkanTypedHandle(device, kVulkanObjectTypeDevice));
     for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateCreateRenderPass]) {
         auto lock = intercept->ReadLock();
-        skip |= intercept->PreCallValidateCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass);
+        skip |= intercept->PreCallValidateCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, errorObj);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallRecordCreateRenderPass]) {
@@ -3670,9 +3672,10 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants(
     const void*                                 pValues) {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(commandBuffer), layer_data_map);
     bool skip = false;
+    ErrorObject errorObj("vkCmdPushConstants", VulkanTypedHandle(commandBuffer, kVulkanObjectTypeCommandBuffer));
     for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateCmdPushConstants]) {
         auto lock = intercept->ReadLock();
-        skip |= intercept->PreCallValidateCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
+        skip |= intercept->PreCallValidateCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, errorObj);
         if (skip) return;
     }
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallRecordCmdPushConstants]) {
@@ -4437,9 +4440,10 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2(
     VkRenderPass*                               pRenderPass) {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
+    ErrorObject errorObj("vkCreateRenderPass2", VulkanTypedHandle(device, kVulkanObjectTypeDevice));
     for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateCreateRenderPass2]) {
         auto lock = intercept->ReadLock();
-        skip |= intercept->PreCallValidateCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass);
+        skip |= intercept->PreCallValidateCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, errorObj);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallRecordCreateRenderPass2]) {
@@ -7204,9 +7208,10 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
     VkRenderPass*                               pRenderPass) {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
+    ErrorObject errorObj("vkCreateRenderPass2KHR", VulkanTypedHandle(device, kVulkanObjectTypeDevice));
     for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateCreateRenderPass2KHR]) {
         auto lock = intercept->ReadLock();
-        skip |= intercept->PreCallValidateCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
+        skip |= intercept->PreCallValidateCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, errorObj);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
     for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallRecordCreateRenderPass2KHR]) {

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -42,6 +42,7 @@
 #include "vk_layer_config.h"
 #include "containers/custom_containers.h"
 #include "error_message/logging.h"
+#include "error_message/core_error_location.h"
 #include "vk_object_types.h"
 #include "vulkan/vk_layer.h"
 #include "vk_enum_string_helper.h"
@@ -3956,6 +3957,14 @@ class ValidationObject {
             return result;
         }
 
+        bool DECORATE_PRINTF(4, 5) LogError(const ErrorObject &errorObj, std::string_view vuid_text, const char *format, ...) const {
+            va_list argptr;
+            va_start(argptr, format);
+            const bool result = LogMessage(report_data, kErrorBit, errorObj, vuid_text, format, argptr);
+            va_end(argptr);
+            return result;
+        }
+
         bool DECORATE_PRINTF(4, 5) LogWarning(const LogObjectList &objlist, std::string_view vuid_text, const char *format, ...) const {
             va_list argptr;
             va_start(argptr, format);
@@ -4158,7 +4167,7 @@ class ValidationObject {
         virtual bool PreCallValidateGetPhysicalDeviceSparseImageFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format, VkImageType type, VkSampleCountFlagBits samples, VkImageUsageFlags usage, VkImageTiling tiling, uint32_t* pPropertyCount, VkSparseImageFormatProperties* pProperties) const { return false; };
         virtual void PreCallRecordGetPhysicalDeviceSparseImageFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format, VkImageType type, VkSampleCountFlagBits samples, VkImageUsageFlags usage, VkImageTiling tiling, uint32_t* pPropertyCount, VkSparseImageFormatProperties* pProperties) {};
         virtual void PostCallRecordGetPhysicalDeviceSparseImageFormatProperties(VkPhysicalDevice physicalDevice, VkFormat format, VkImageType type, VkSampleCountFlagBits samples, VkImageUsageFlags usage, VkImageTiling tiling, uint32_t* pPropertyCount, VkSparseImageFormatProperties* pProperties) {};
-        virtual bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence) const { return false; };
+        virtual bool PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence, ErrorObject& errorObj) const { return false; };
         virtual void PreCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence) {};
         virtual void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence, VkResult result) {};
         virtual bool PreCallValidateCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkFence* pFence) const { return false; };
@@ -4302,7 +4311,7 @@ class ValidationObject {
         virtual bool PreCallValidateDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator) const { return false; };
         virtual void PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator) {};
         virtual void PostCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator) {};
-        virtual bool PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const { return false; };
+        virtual bool PreCallValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass, ErrorObject& errorObj) const { return false; };
         virtual void PreCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) {};
         virtual void PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass, VkResult result) {};
         virtual bool PreCallValidateDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator) const { return false; };
@@ -4452,7 +4461,7 @@ class ValidationObject {
         virtual bool PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize stride, VkQueryResultFlags flags) const { return false; };
         virtual void PreCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize stride, VkQueryResultFlags flags) {};
         virtual void PostCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize stride, VkQueryResultFlags flags) {};
-        virtual bool PreCallValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout, VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void* pValues) const { return false; };
+        virtual bool PreCallValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout, VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void* pValues, ErrorObject& errorObj) const { return false; };
         virtual void PreCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout, VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void* pValues) {};
         virtual void PostCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout, VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void* pValues) {};
         virtual bool PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin, VkSubpassContents contents) const { return false; };
@@ -4554,7 +4563,7 @@ class ValidationObject {
         virtual bool PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) const { return false; };
         virtual void PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {};
         virtual void PostCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {};
-        virtual bool PreCallValidateCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const { return false; };
+        virtual bool PreCallValidateCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass, ErrorObject& errorObj) const { return false; };
         virtual void PreCallRecordCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) {};
         virtual void PostCallRecordCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass, VkResult result) {};
         virtual bool PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin, const VkSubpassBeginInfo* pSubpassBeginInfo) const { return false; };
@@ -4943,7 +4952,7 @@ class ValidationObject {
         virtual bool PreCallValidateUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) const { return false; };
         virtual void PreCallRecordUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {};
         virtual void PostCallRecordUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet, VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData) {};
-        virtual bool PreCallValidateCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) const { return false; };
+        virtual bool PreCallValidateCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass, ErrorObject& errorObj) const { return false; };
         virtual void PreCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass) {};
         virtual void PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass, VkResult result) {};
         virtual bool PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin, const VkSubpassBeginInfo* pSubpassBeginInfo) const { return false; };

--- a/layers/vulkan/generated/object_tracker.cpp
+++ b/layers/vulkan/generated/object_tracker.cpp
@@ -459,7 +459,8 @@ bool ObjectLifetimes::PreCallValidateQueueBindSparse(
     VkQueue                                     queue,
     uint32_t                                    bindInfoCount,
     const VkBindSparseInfo*                     pBindInfo,
-    VkFence                                     fence) const {
+    VkFence                                     fence,
+    ErrorObject&                                errorObj) const {
     bool skip = false;
     skip |= ValidateObject(queue, kVulkanObjectTypeQueue, false, "VUID-vkQueueBindSparse-queue-parameter", "VUID-vkQueueBindSparse-commonparent", "vkQueueBindSparse");
     if (pBindInfo) {
@@ -1328,7 +1329,8 @@ bool ObjectLifetimes::PreCallValidateCreateRenderPass(
     VkDevice                                    device,
     const VkRenderPassCreateInfo*               pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const {
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const {
     bool skip = false;
     skip |= ValidateObject(device, kVulkanObjectTypeDevice, false, "VUID-vkCreateRenderPass-device-parameter", kVUIDUndefined, "vkCreateRenderPass");
 
@@ -1963,7 +1965,8 @@ bool ObjectLifetimes::PreCallValidateCmdPushConstants(
     VkShaderStageFlags                          stageFlags,
     uint32_t                                    offset,
     uint32_t                                    size,
-    const void*                                 pValues) const {
+    const void*                                 pValues,
+    ErrorObject&                                errorObj) const {
     bool skip = false;
     skip |= ValidateObject(commandBuffer, kVulkanObjectTypeCommandBuffer, false, "VUID-vkCmdPushConstants-commandBuffer-parameter", "VUID-vkCmdPushConstants-commonparent", "vkCmdPushConstants");
     skip |= ValidateObject(layout, kVulkanObjectTypePipelineLayout, false, "VUID-vkCmdPushConstants-layout-parameter", "VUID-vkCmdPushConstants-commonparent", "vkCmdPushConstants");
@@ -2358,7 +2361,8 @@ bool ObjectLifetimes::PreCallValidateCreateRenderPass2(
     VkDevice                                    device,
     const VkRenderPassCreateInfo2*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const {
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const {
     bool skip = false;
     skip |= ValidateObject(device, kVulkanObjectTypeDevice, false, "VUID-vkCreateRenderPass2-device-parameter", kVUIDUndefined, "vkCreateRenderPass2");
 
@@ -4015,7 +4019,8 @@ bool ObjectLifetimes::PreCallValidateCreateRenderPass2KHR(
     VkDevice                                    device,
     const VkRenderPassCreateInfo2*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const {
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const {
     bool skip = false;
     skip |= ValidateObject(device, kVulkanObjectTypeDevice, false, "VUID-vkCreateRenderPass2-device-parameter", kVUIDUndefined, "vkCreateRenderPass2KHR");
 

--- a/layers/vulkan/generated/object_tracker.h
+++ b/layers/vulkan/generated/object_tracker.h
@@ -196,7 +196,8 @@ bool PreCallValidateQueueBindSparse(
     VkQueue                                     queue,
     uint32_t                                    bindInfoCount,
     const VkBindSparseInfo*                     pBindInfo,
-    VkFence                                     fence) const override;
+    VkFence                                     fence,
+    ErrorObject&                                errorObj) const override;
 bool PreCallValidateCreateFence(
     VkDevice                                    device,
     const VkFenceCreateInfo*                    pCreateInfo,
@@ -594,7 +595,8 @@ bool PreCallValidateCreateRenderPass(
     VkDevice                                    device,
     const VkRenderPassCreateInfo*               pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const override;
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const override;
 void PostCallRecordCreateRenderPass(
     VkDevice                                    device,
     const VkRenderPassCreateInfo*               pCreateInfo,
@@ -895,7 +897,8 @@ bool PreCallValidateCmdPushConstants(
     VkShaderStageFlags                          stageFlags,
     uint32_t                                    offset,
     uint32_t                                    size,
-    const void*                                 pValues) const override;
+    const void*                                 pValues,
+    ErrorObject&                                errorObj) const override;
 bool PreCallValidateCmdBeginRenderPass(
     VkCommandBuffer                             commandBuffer,
     const VkRenderPassBeginInfo*                pRenderPassBegin,
@@ -1073,7 +1076,8 @@ bool PreCallValidateCreateRenderPass2(
     VkDevice                                    device,
     const VkRenderPassCreateInfo2*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const override;
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const override;
 void PostCallRecordCreateRenderPass2(
     VkDevice                                    device,
     const VkRenderPassCreateInfo2*              pCreateInfo,
@@ -1731,7 +1735,8 @@ bool PreCallValidateCreateRenderPass2KHR(
     VkDevice                                    device,
     const VkRenderPassCreateInfo2*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const override;
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const override;
 void PostCallRecordCreateRenderPass2KHR(
     VkDevice                                    device,
     const VkRenderPassCreateInfo2*              pCreateInfo,

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -6122,7 +6122,8 @@ bool StatelessValidation::PreCallValidateQueueBindSparse(
     VkQueue                                     queue,
     uint32_t                                    bindInfoCount,
     const VkBindSparseInfo*                     pBindInfo,
-    VkFence                                     fence) const {
+    VkFence                                     fence,
+    ErrorObject&                                errorObj) const {
     bool skip = false;
     skip |= ValidateStructTypeArray("vkQueueBindSparse", "bindInfoCount", "pBindInfo", "VK_STRUCTURE_TYPE_BIND_SPARSE_INFO", bindInfoCount, pBindInfo, VK_STRUCTURE_TYPE_BIND_SPARSE_INFO, false, true, "VUID-VkBindSparseInfo-sType-sType", "VUID-vkQueueBindSparse-pBindInfo-parameter", kVUIDUndefined);
     if (pBindInfo != nullptr)
@@ -7664,7 +7665,8 @@ bool StatelessValidation::PreCallValidateCreateRenderPass(
     VkDevice                                    device,
     const VkRenderPassCreateInfo*               pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const {
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const {
     bool skip = false;
     skip |= ValidateStructType("vkCreateRenderPass", "pCreateInfo", "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO", pCreateInfo, VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, true, "VUID-vkCreateRenderPass-pCreateInfo-parameter", "VUID-VkRenderPassCreateInfo-sType-sType");
     if (pCreateInfo != nullptr)
@@ -7787,7 +7789,7 @@ bool StatelessValidation::PreCallValidateCreateRenderPass(
         }
     }
     skip |= ValidateRequiredPointer("vkCreateRenderPass", "pRenderPass", pRenderPass, "VUID-vkCreateRenderPass-pRenderPass-parameter");
-    if (!skip) skip |= manual_PreCallValidateCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass);
+    if (!skip) skip |= manual_PreCallValidateCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, errorObj);
     return skip;
 }
 
@@ -8660,12 +8662,13 @@ bool StatelessValidation::PreCallValidateCmdPushConstants(
     VkShaderStageFlags                          stageFlags,
     uint32_t                                    offset,
     uint32_t                                    size,
-    const void*                                 pValues) const {
+    const void*                                 pValues,
+    ErrorObject&                                errorObj) const {
     bool skip = false;
     skip |= ValidateRequiredHandle("vkCmdPushConstants", "layout", layout);
     skip |= ValidateFlags("vkCmdPushConstants", "stageFlags", "VkShaderStageFlagBits", AllVkShaderStageFlagBits, stageFlags, kRequiredFlags, "VUID-vkCmdPushConstants-stageFlags-parameter", "VUID-vkCmdPushConstants-stageFlags-requiredbitmask");
     skip |= ValidateArray("vkCmdPushConstants", "size", "pValues", size, &pValues, true, true, "VUID-vkCmdPushConstants-size-arraylength", "VUID-vkCmdPushConstants-pValues-parameter");
-    if (!skip) skip |= manual_PreCallValidateCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
+    if (!skip) skip |= manual_PreCallValidateCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, errorObj);
     return skip;
 }
 
@@ -9362,7 +9365,8 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(
     VkDevice                                    device,
     const VkRenderPassCreateInfo2*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const {
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const {
     bool skip = false;
     skip |= ValidateStructType("vkCreateRenderPass2", "pCreateInfo", "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2", pCreateInfo, VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2, true, "VUID-vkCreateRenderPass2-pCreateInfo-parameter", "VUID-VkRenderPassCreateInfo2-sType-sType");
     if (pCreateInfo != nullptr)
@@ -9531,7 +9535,7 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(
         }
     }
     skip |= ValidateRequiredPointer("vkCreateRenderPass2", "pRenderPass", pRenderPass, "VUID-vkCreateRenderPass2-pRenderPass-parameter");
-    if (!skip) skip |= manual_PreCallValidateCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass);
+    if (!skip) skip |= manual_PreCallValidateCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, errorObj);
     return skip;
 }
 
@@ -12578,7 +12582,8 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2KHR(
     VkDevice                                    device,
     const VkRenderPassCreateInfo2*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const {
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const {
     bool skip = false;
     if (!IsExtEnabled(device_extensions.vk_khr_create_renderpass2)) skip |= OutputExtensionError("vkCreateRenderPass2KHR", "VK_KHR_create_renderpass2");
     skip |= ValidateStructType("vkCreateRenderPass2KHR", "pCreateInfo", "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2", pCreateInfo, VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2, true, "VUID-vkCreateRenderPass2-pCreateInfo-parameter", "VUID-VkRenderPassCreateInfo2-sType-sType");
@@ -12748,7 +12753,7 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2KHR(
         }
     }
     skip |= ValidateRequiredPointer("vkCreateRenderPass2KHR", "pRenderPass", pRenderPass, "VUID-vkCreateRenderPass2-pRenderPass-parameter");
-    if (!skip) skip |= manual_PreCallValidateCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
+    if (!skip) skip |= manual_PreCallValidateCreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass, errorObj);
     return skip;
 }
 

--- a/layers/vulkan/generated/stateless_validation_helper.h
+++ b/layers/vulkan/generated/stateless_validation_helper.h
@@ -147,7 +147,8 @@ bool PreCallValidateQueueBindSparse(
     VkQueue                                     queue,
     uint32_t                                    bindInfoCount,
     const VkBindSparseInfo*                     pBindInfo,
-    VkFence                                     fence) const override;
+    VkFence                                     fence,
+    ErrorObject&                                errorObj) const override;
 bool PreCallValidateCreateFence(
     VkDevice                                    device,
     const VkFenceCreateInfo*                    pCreateInfo,
@@ -370,7 +371,8 @@ bool PreCallValidateCreateRenderPass(
     VkDevice                                    device,
     const VkRenderPassCreateInfo*               pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const override;
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const override;
 bool PreCallValidateDestroyRenderPass(
     VkDevice                                    device,
     VkRenderPass                                renderPass,
@@ -646,7 +648,8 @@ bool PreCallValidateCmdPushConstants(
     VkShaderStageFlags                          stageFlags,
     uint32_t                                    offset,
     uint32_t                                    size,
-    const void*                                 pValues) const override;
+    const void*                                 pValues,
+    ErrorObject&                                errorObj) const override;
 bool PreCallValidateCmdBeginRenderPass(
     VkCommandBuffer                             commandBuffer,
     const VkRenderPassBeginInfo*                pRenderPassBegin,
@@ -795,7 +798,8 @@ bool PreCallValidateCreateRenderPass2(
     VkDevice                                    device,
     const VkRenderPassCreateInfo2*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const override;
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const override;
 bool PreCallValidateCmdBeginRenderPass2(
     VkCommandBuffer                             commandBuffer,
     const VkRenderPassBeginInfo*                pRenderPassBegin,
@@ -1326,7 +1330,8 @@ bool PreCallValidateCreateRenderPass2KHR(
     VkDevice                                    device,
     const VkRenderPassCreateInfo2*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
-    VkRenderPass*                               pRenderPass) const override;
+    VkRenderPass*                               pRenderPass,
+    ErrorObject&                                errorObj) const override;
 bool PreCallValidateCmdBeginRenderPass2KHR(
     VkCommandBuffer                             commandBuffer,
     const VkRenderPassBeginInfo*                pRenderPassBegin,

--- a/scripts/generators/generator_utils.py
+++ b/scripts/generators/generator_utils.py
@@ -18,6 +18,17 @@ import os
 import sys
 import json
 
+# TODO - This is a temporary design to allow us to slowly increase functions to use
+#  ErrorObject until we feel confident with the design to roll it out everywhere
+# (this allows use to see what works well before spending time refactoring each call)
+error_object_functions = [
+    'vkCreateRenderPass',
+    'vkCreateRenderPass2',
+    'vkCreateRenderPass2KHR',
+    'vkCmdPushConstants',
+    'vkQueueBindSparse',
+]
+
 # Build a set of all vuid text strings found in validusage.json
 def buildListVUID(valid_usage_file: str) -> set:
 

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -20,7 +20,7 @@
 
 import os
 import re
-from generators.generator_utils import (buildListVUID, incIndent, decIndent)
+from generators.generator_utils import (buildListVUID, incIndent, decIndent, error_object_functions)
 from generators.vulkan_object import (Member)
 from generators.base_generator import BaseGenerator
 
@@ -277,6 +277,8 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             prototype = prototype.replace(');', ') const override;\n')
             if 'ValidationCache' in command.name:
                 prototype = prototype.replace('const override', 'const')
+            if command.name in error_object_functions:
+                prototype = prototype.replace(')', ',\n    ErrorObject&                                errorObj)')
             out.append(prototype)
             out.extend([f'#endif // {command.protect}\n'] if command.protect else [])
         self.write("".join(out))
@@ -443,6 +445,8 @@ bool StatelessValidation::ValidatePnextStructContents(const char *api_name, cons
                 prototype = '\n'.join(prototype)
                 prototype += ' const {\n'
                 prototype = prototype.split('VKAPI_CALL vk')[1]
+                if command.name in error_object_functions:
+                    prototype = prototype.replace(')', ',\n    ErrorObject&                                errorObj)')
                 out.append('bool StatelessValidation::PreCallValidate' + prototype)
                 out.append(f'{indent}bool skip = false;\n')
                 if command.instance and command.version:
@@ -459,6 +463,7 @@ bool StatelessValidation::ValidatePnextStructContents(const char *api_name, cons
                     params_text = ''
                     for param in command.params:
                         params_text += f'{param.name}, '
+                    params_text += 'errorObj, ' if command.name in error_object_functions else ''
                     params_text = params_text[:-2] + ');\n'
                     out.append(f'    if (!skip) skip |= manual_PreCallValidate{command.name[2:]}({params_text}')
                 out.append(f'{indent}return skip;\n')


### PR DESCRIPTION
This adds a `ErrorObject` that is designed to be a replacement for passing various parameters through functions for the sake of logging them.

The main idea is that in the same way we have a `VkResult` in all `PostCallRecord`, we would add a `ErrorObject` on the stack when the chassis calls all `PreCallValidate` functions

Currently this is WIP as want feedback on the design, things I want to still add is

- Integrate the `Location`/`Loc` system used in the Synchronization validation 
- Have a way so you can add to things like `LogObjectList` and it resets when you leave scope
