### PR TITLE
layers: Minimal fix for doubly moved unique_ptr

### DIFF
--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -52,9 +52,8 @@ PIPELINE_STATE::StageStateVec PIPELINE_STATE::GetStageStates(const ValidationSta
                     const uint32_t unique_shader_id = (csm_states) ? (*csm_states)[stage].unique_shader_id : 0;
                     if (shader_ci) {
                         // don't need to worry about GroupDecoration in GPL
-                        auto spirv_module = std::make_unique<SPIRV_MODULE_STATE>(shader_ci->codeSize, shader_ci->pCode);
-                        module_state =
-                            std::make_shared<SHADER_MODULE_STATE>(VK_NULL_HANDLE, std::move(spirv_module), unique_shader_id);
+                        auto spirv_module = std::make_shared<SPIRV_MODULE_STATE>(shader_ci->codeSize, shader_ci->pCode);
+                        module_state = std::make_shared<SHADER_MODULE_STATE>(VK_NULL_HANDLE, spirv_module, unique_shader_id);
                     } else {
                         // VK_EXT_shader_module_identifier could legally provide a null module handle
                         module_state = std::make_shared<SHADER_MODULE_STATE>(unique_shader_id);

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -79,8 +79,8 @@ PreRasterState::PreRasterState(const PIPELINE_STATE &p, const ValidationStateTra
                 const auto shader_ci = LvlFindInChain<VkShaderModuleCreateInfo>(create_info.pStages[i].pNext);
                 if (shader_ci) {
                     // don't need to worry about GroupDecoration in GPL
-                    auto spirv_module = std::make_unique<SPIRV_MODULE_STATE>(shader_ci->codeSize, shader_ci->pCode);
-                    module_state = std::make_shared<SHADER_MODULE_STATE>(VK_NULL_HANDLE, std::move(spirv_module), 0);
+                    auto spirv_module = std::make_shared<SPIRV_MODULE_STATE>(shader_ci->codeSize, shader_ci->pCode);
+                    module_state = std::make_shared<SHADER_MODULE_STATE>(VK_NULL_HANDLE, spirv_module, 0);
                 }
             }
 
@@ -176,8 +176,8 @@ void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const Validatio
                 const auto shader_ci = LvlFindInChain<VkShaderModuleCreateInfo>(create_info.pStages[i].pNext);
                 if (shader_ci) {
                     // don't need to worry about GroupDecoration in GPL
-                    auto spirv_module = std::make_unique<SPIRV_MODULE_STATE>(shader_ci->codeSize, shader_ci->pCode);
-                    module_state = std::make_shared<SHADER_MODULE_STATE>(VK_NULL_HANDLE, std::move(spirv_module), 0);
+                    auto spirv_module = std::make_shared<SPIRV_MODULE_STATE>(shader_ci->codeSize, shader_ci->pCode);
+                    module_state = std::make_shared<SHADER_MODULE_STATE>(VK_NULL_HANDLE, spirv_module, 0);
                 }
             }
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -585,10 +585,8 @@ struct SPIRV_MODULE_STATE {
 
 // Represents a VkShaderModule handle
 struct SHADER_MODULE_STATE : public BASE_NODE {
-    SHADER_MODULE_STATE(VkShaderModule shader_module, std::unique_ptr<SPIRV_MODULE_STATE> spirv_module, uint32_t unique_shader_id)
-        : BASE_NODE(shader_module, kVulkanObjectTypeShaderModule),
-          spirv(std::move(spirv_module)),
-          gpu_validation_shader_id(unique_shader_id) {
+    SHADER_MODULE_STATE(VkShaderModule shader_module, std::shared_ptr<SPIRV_MODULE_STATE> &spirv_module, uint32_t unique_shader_id)
+        : BASE_NODE(shader_module, kVulkanObjectTypeShaderModule), spirv(spirv_module), gpu_validation_shader_id(unique_shader_id) {
         spirv->handle_ = handle_;
     }
 
@@ -598,7 +596,7 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
           gpu_validation_shader_id(unique_shader_id) {}
 
     // If null, means this is a empty object and no shader backing it
-    std::unique_ptr<SPIRV_MODULE_STATE> spirv;
+    std::shared_ptr<SPIRV_MODULE_STATE> spirv;
 
     // Used as way to match instrumented GPU-AV shader to a VkShaderModule handle
     uint32_t gpu_validation_shader_id = 0;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5069,7 +5069,7 @@ void ValidationStateTracker::PostCallRecordCreateShaderModule(VkDevice device, c
                                                               void *csm_state_data) {
     if (VK_SUCCESS != result) return;
     create_shader_module_api_state *csm_state = static_cast<create_shader_module_api_state *>(csm_state_data);
-    Add(std::make_shared<SHADER_MODULE_STATE>(*pShaderModule, std::move(csm_state->module_state), csm_state->unique_shader_id));
+    Add(std::make_shared<SHADER_MODULE_STATE>(*pShaderModule, csm_state->module_state, csm_state->unique_shader_id));
 }
 
 void ValidationStateTracker::PostCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -83,7 +83,7 @@ struct create_shader_module_api_state {
     // We build a SPIRV_MODULE_STATE at PreCallRecord time were we can do basic validation of the SPIR-V (which can crash drivers
     // if passed in the Dispatch). It is then passed to PostCallRecord to save in state tracking so it can be used at Pipeline
     // creation time where the rest of the information is needed to do the remaining SPIR-V validation.
-    std::unique_ptr<SPIRV_MODULE_STATE> module_state;  // contains SPIR-V to validate
+    std::shared_ptr<SPIRV_MODULE_STATE> module_state;  // contains SPIR-V to validate
     uint32_t unique_shader_id = 0;
     bool valid_spirv = true;
 


### PR DESCRIPTION
Replace the unique_ptr  with shared_ptr as the api state data is being shared across VO.

Need to revisit what we're doing re: shared and modified api_state...

@spencer-lunarg -- MNC to unbreak the multi-state-tracker config... needs more testing.