### PR TITLE
layers: Label new 09198 VUID

### DIFF
--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -139,7 +139,7 @@ bool CoreChecks::ValidateInterfaceVertexInput(const PIPELINE_STATE &pipeline, co
                     const uint32_t attribute_components = FormatComponentCount(attribute_format);
                     const uint32_t input_components = module_state.GetNumComponentsInBaseType(shader_input);
                     if (attribute_components < input_components) {
-                        skip |= LogError(module_state.handle(), "UNASSIGNED-VkGraphicsPipelineCreateInfo-Component-64bit",
+                        skip |= LogError(module_state.handle(), "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-09198",
                                          "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "] Attribute at location %" PRIu32
                                          " is a %" PRIu32 "-wide 64-bit format (%s) but vertex shader input is %" PRIu32
                                          "-wide 64-bit type (%s), 64-bit vertex input don't have default values and require "

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -1098,7 +1098,7 @@ TEST_F(NegativeVertexInput, Attribute64bitUnusedComponent) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.InitState();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-VkGraphicsPipelineCreateInfo-Component-64bit");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-09198");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
adds VUID label for `VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-09198` which came out in 1.3.261

logic was fixed in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6206 (incase someone git-blame in future)