### PR TITLE
layers: Only print VK_OBJECT_TYPE_DEVICE if multi-device

### DIFF
--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -189,6 +189,7 @@ typedef struct _debug_report_data {
     mutable vvl::unordered_map<uint32_t, int32_t> duplicate_message_count_map{};
     const void *instance_pnext_chain{};
     bool forceDefaultLogCallback{false};
+    uint32_t device_created = 0;
 
     void DebugReportSetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
         std::unique_lock<std::mutex> lock(debug_output_mutex);

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -525,6 +525,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     device_interceptor->instance = instance_interceptor->instance;
     device_interceptor->report_data = instance_interceptor->report_data;
 
+    instance_interceptor->report_data->device_created++;
+
     InitDeviceObjectDispatch(instance_interceptor, device_interceptor);
 
     // Initialize all of the objects with the appropriate data
@@ -577,6 +579,9 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(VkDevice device, const VkAllocationCall
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordDestroyDevice(device, pAllocator);
     }
+
+    auto instance_interceptor = GetLayerDataPtr(get_dispatch_key(layer_data->physical_device), layer_data_map);
+    instance_interceptor->report_data->device_created--;
 
     for (auto item = layer_data->object_dispatch.begin(); item != layer_data->object_dispatch.end(); item++) {
         delete *item;

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1225,6 +1225,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     device_interceptor->instance = instance_interceptor->instance;
     device_interceptor->report_data = instance_interceptor->report_data;
 
+    instance_interceptor->report_data->device_created++;
+
     InitDeviceObjectDispatch(instance_interceptor, device_interceptor);
 
     // Initialize all of the objects with the appropriate data
@@ -1277,6 +1279,9 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(VkDevice device, const VkAllocationCall
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordDestroyDevice(device, pAllocator);
     }
+
+    auto instance_interceptor = GetLayerDataPtr(get_dispatch_key(layer_data->physical_device), layer_data_map);
+    instance_interceptor->report_data->device_created--;
 
     for (auto item = layer_data->object_dispatch.begin(); item != layer_data->object_dispatch.end(); item++) {
         delete *item;


### PR DESCRIPTION
Currently our error messages look like

> Validation Error: [ VUID-VkImageCreateInfo-mipLevels-00947 ] Object 0: handle = 0x561abf1affe0, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x4ca5e939 | vkCreateImage: parameter pCreateInfo->mipLevels is zero

but when using 1 `VkDevice` its quite obvious which device it is and this `VK_OBJECT_TYPE_DEVICE` serves no purpose and just adds noise

with this change it now just looks like

> Validation Error: [ VUID-VkImageCreateInfo-mipLevels-00947 ] | MessageID = 0x4ca5e939 | vkCreateImage: parameter pCreateInfo->mipLevels is zero

and when dealing with multi-device VUs it still works as normal

> Validation Error: [ VUID-vkCmdBindPipeline-commonparent ] Object 0: handle = 0x5567d5eae030, type = VK_OBJECT_TYPE_INSTANCE; Object 1: handle = 0x5567d6c32c70, type = VK_OBJECT_TYPE_DEVICE; Object 2: handle = 0x5567d6cc5c80, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xa6c0eb9e | vkCmdBindPipeline(): Expected all Dispatchable Handles to use VkDevice 0x5567d6c32c70[], but the VkPipeline (0xf443490000000006) was created, allocated or retrieved from VkDevice 0x5567d6cc5c80[].
