### PR TITLE
layers: Improve VK_EXT_shader_tile_image feature VU message

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2440,7 +2440,9 @@ bool CoreChecks::ValidateBarriersForShaderTileImage(const LogObjectList &objlist
 
     if (!features_enabled) {
         const auto &vuid = GetShaderTileImageVUID(outer_loc, ShaderTileImageError::kShaderTileImageFeatureError);
-        skip |= LogError(objlist, vuid, "%s can not be used if none of the features of tile image read is enabled.",
+        skip |= LogError(objlist, vuid,
+                         "%s can not be called inside a dynamic rendering instance. This can be fixed by enabling the "
+                         "VK_EXT_shader_tile_image features.",
                          outer_loc.StringFunc());
         return skip;
     }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6274

If you are looking at the current extension-less spec there is a `VUID-vkCmdPipelineBarrier2-None-06191` that says

> If vkCmdPipelineBarrier2 is called within a render pass instance, the render pass must not have been started with vkCmdBeginRendering

so not enabling the feature bits in `VK_EXT_shader_tile_image` still should produce the `VUID-vkCmdPipelineBarrier2-shaderTileImageColorReadAccess-08718` error

----

The error use to say

> vkCmdPipelineBarrier2 can not be used if none of the features of tile image read is enabled.

but now says

> vkCmdPipelineBarrier2 can not be called inside a dynamic rendering instance. This can be fixed by enabling the VK_EXT_shader_tile_image features.

to help explain what is going on better

-----
I also have [spec language](https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6065) PR collaspe `06191` and `08718` to just be `08718` to avoid future confusion