### PR TITLE
layers: Add GPU-AV support for VK_EXT_shader_object

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2493,7 +2493,7 @@ void CoreChecks::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createI
                                                void *csm_state_data) {
     ValidationStateTracker::PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders,
                                                           csm_state_data);
-    create_shader_module_api_state *csm_state = static_cast<create_shader_module_api_state *>(csm_state_data);
+    create_shader_object_api_state *csm_state = static_cast<create_shader_object_api_state *>(csm_state_data);
     // TODO - Move SPIR-V only validation from a pipeline check to here
     csm_state->valid_spirv = true;
 }

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -66,11 +66,6 @@ void DebugPrintf::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
         aborted = true;
         return;
     }
-
-    if (IsExtEnabled(device_extensions.vk_ext_shader_object)) {
-        ReportSetupProblem(
-            device, "VK_EXT_shader_object is enabled, but Debug Printf does not currently support printing from shader_objects");
-    }
 }
 
 // Free the device memory and descriptor set associated with a command buffer.
@@ -132,17 +127,28 @@ void DebugPrintf::PreCallRecordCreateShaderModule(VkDevice device, const VkShade
     ValidationStateTracker::PreCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, csm_state_data);
     create_shader_module_api_state *csm_state = static_cast<create_shader_module_api_state *>(csm_state_data);
     const bool pass = InstrumentShader(vvl::make_span(pCreateInfo->pCode, pCreateInfo->codeSize / sizeof(uint32_t)),
-                                       csm_state->instrumented_pgm, &csm_state->unique_shader_id);
+                                       csm_state->instrumented_spirv, &csm_state->unique_shader_id);
     if (pass) {
-        csm_state->instrumented_create_info.pCode = csm_state->instrumented_pgm.data();
-        csm_state->instrumented_create_info.codeSize = csm_state->instrumented_pgm.size() * sizeof(uint32_t);
+        csm_state->instrumented_create_info.pCode = csm_state->instrumented_spirv.data();
+        csm_state->instrumented_create_info.codeSize = csm_state->instrumented_spirv.size() * sizeof(uint32_t);
     }
 }
 
 void DebugPrintf::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
                                                 const VkShaderCreateInfoEXT *pCreateInfos, const VkAllocationCallbacks *pAllocator,
                                                 VkShaderEXT *pShaders, void *csm_state_data) {
-    // TODO - Add VK_EXT_shader_object support
+    ValidationStateTracker::PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders,
+                                                          csm_state_data);
+    create_shader_object_api_state *csm_state = static_cast<create_shader_object_api_state *>(csm_state_data);
+    for (uint32_t i = 0; i < createInfoCount; ++i) {
+        const bool pass = InstrumentShader(
+            vvl::make_span(static_cast<const uint32_t *>(pCreateInfos[i].pCode), pCreateInfos[i].codeSize / sizeof(uint32_t)),
+            csm_state->instrumented_spirv[i], &csm_state->unique_shader_ids[0]);
+        if (pass) {
+            csm_state->instrumented_create_info[i].pCode = csm_state->instrumented_spirv.data();
+            csm_state->instrumented_create_info[i].codeSize = csm_state->instrumented_spirv.size() * sizeof(uint32_t);
+        }
+    }
 }
 
 vartype vartype_lookup(char intype) {

--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -910,8 +910,8 @@ void GpuAssistedBase::PreCallRecordPipelineCreations(uint32_t count, const Creat
                         }
                         const VkShaderStageFlagBits stage = stage_state.create_info->stage;
                         auto &csm_state = cgpl_state.shader_states[pipeline][stage];
-                        const auto pass =
-                            InstrumentShader(module_state->spirv->words_, csm_state.instrumented_pgm, &csm_state.unique_shader_id);
+                        const auto pass = InstrumentShader(module_state->spirv->words_, csm_state.instrumented_spirv,
+                                                           &csm_state.unique_shader_id);
                         if (pass) {
                             module_state->gpu_validation_shader_id = csm_state.unique_shader_id;
 
@@ -924,7 +924,7 @@ void GpuAssistedBase::PreCallRecordPipelineCreations(uint32_t count, const Creat
                                     LvlFindInChain<VkShaderModuleCreateInfo>(stage_ci.pNext)));
                             // module_state->Handle() == VK_NULL_HANDLE should imply sm_ci != nullptr, but checking here anyway
                             if (sm_ci) {
-                                sm_ci->SetCode(csm_state.instrumented_pgm);
+                                sm_ci->SetCode(csm_state.instrumented_spirv);
                             }
                         }
                     }

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -596,6 +596,8 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
           gpu_validation_shader_id(unique_shader_id) {}
 
     // If null, means this is a empty object and no shader backing it
+    // TODO - This (and SHADER_OBJECT_STATE) could be unique, but need handle multiple ValidationObjects
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6265/files
     std::shared_ptr<SPIRV_MODULE_STATE> spirv;
 
     // Used as way to match instrumented GPU-AV shader to a VkShaderModule handle
@@ -604,12 +606,12 @@ struct SHADER_MODULE_STATE : public BASE_NODE {
 
 // Represents a VkShaderEXT (VK_EXT_shader_object) handle
 struct SHADER_OBJECT_STATE : public BASE_NODE {
-    SHADER_OBJECT_STATE(const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object, uint32_t unique_shader_id = 0)
-        : BASE_NODE(shader_object, kVulkanObjectTypeShaderEXT),
-          spirv(std::make_unique<SPIRV_MODULE_STATE>(create_info.codeSize, static_cast<const uint32_t *>(create_info.pCode))),
-          gpu_validation_shader_id(unique_shader_id) {}
+    SHADER_OBJECT_STATE(VkShaderEXT shader_object, std::shared_ptr<SPIRV_MODULE_STATE> &spirv_module, uint32_t unique_shader_id)
+        : BASE_NODE(shader_object, kVulkanObjectTypeShaderEXT), spirv(spirv_module), gpu_validation_shader_id(unique_shader_id) {
+        spirv->handle_ = handle_;
+    }
 
-    std::unique_ptr<SPIRV_MODULE_STATE> spirv;
+    std::shared_ptr<SPIRV_MODULE_STATE> spirv;
 
     // Used as way to match instrumented GPU-AV shader to a VkShaderEXT handle
     uint32_t gpu_validation_shader_id = 0;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -89,7 +89,25 @@ struct create_shader_module_api_state {
 
     // Pass the instrumented SPIR-V info from PreCallRecord to Dispatch (so GPU-AV logic can run with it)
     VkShaderModuleCreateInfo instrumented_create_info;
-    std::vector<uint32_t> instrumented_pgm;
+    std::vector<uint32_t> instrumented_spirv;
+};
+
+// same idea as create_shader_module_api_state but for VkShaderEXT (VK_EXT_shader_object)
+struct create_shader_object_api_state {
+    std::vector<std::shared_ptr<SPIRV_MODULE_STATE>> module_states;  // contains SPIR-V to validate
+    std::vector<uint32_t> unique_shader_ids;
+    bool valid_spirv = true;
+
+    // Pass the instrumented SPIR-V info from PreCallRecord to Dispatch (so GPU-AV logic can run with it)
+    VkShaderCreateInfoEXT* instrumented_create_info;
+    std::vector<std::vector<uint32_t>> instrumented_spirv;
+
+    create_shader_object_api_state(uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos) {
+        instrumented_create_info = const_cast<VkShaderCreateInfoEXT*>(pCreateInfos);
+        module_states.resize(createInfoCount);
+        unique_shader_ids.resize(createInfoCount);
+        instrumented_spirv.resize(createInfoCount);
+    }
 };
 
 // This structure is used to save data across the CreateGraphicsPipelines down-chain API call
@@ -864,11 +882,12 @@ class ValidationStateTracker : public ValidationObject {
 
     void PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                           const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule, VkResult result,
-                                          void* csm_state) override;
+                                          void* csm_state_data) override;
     void PreCallRecordDestroyShaderModule(VkDevice device, VkShaderModule shaderModule,
                                           const VkAllocationCallbacks* pAllocator) override;
     void PostCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
-                                        const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders, VkResult result) override;
+                                        const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders, VkResult result,
+                                        void* csm_state_data) override;
     void PreCallRecordDestroyShaderEXT(VkDevice device, VkShaderEXT shader, const VkAllocationCallbacks* pAllocator) override;
     void PreCallRecordDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
                                         const VkAllocationCallbacks* pAllocator) override;

--- a/layers/vulkan/generated/best_practices.cpp
+++ b/layers/vulkan/generated/best_practices.cpp
@@ -3142,8 +3142,9 @@ void BestPractices::PostCallRecordCreateShadersEXT(
     const VkShaderCreateInfoEXT*                pCreateInfos,
     const VkAllocationCallbacks*                pAllocator,
     VkShaderEXT*                                pShaders,
-    VkResult                                    result) {
-    ValidationStateTracker::PostCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, result);
+    VkResult                                    result,
+    void*                                       state_data) {
+    ValidationStateTracker::PostCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, result, state_data);
     if (result < VK_SUCCESS) {
         LogErrorCode("vkCreateShadersEXT", result); // VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY, VK_ERROR_INITIALIZATION_FAILED, VK_ERROR_INCOMPATIBLE_SHADER_BINARY_EXT
     }

--- a/layers/vulkan/generated/best_practices.h
+++ b/layers/vulkan/generated/best_practices.h
@@ -1685,7 +1685,8 @@ void PostCallRecordCreateShadersEXT(
     const VkShaderCreateInfoEXT*                pCreateInfos,
     const VkAllocationCallbacks*                pAllocator,
     VkShaderEXT*                                pShaders,
-    VkResult                                    result) override;
+    VkResult                                    result,
+    void*                                       state_data) override;
 
 void PostCallRecordGetShaderBinaryDataEXT(
     VkDevice                                    device,

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -799,7 +799,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
 
-    create_shader_module_api_state csm_state{};
+    create_shader_object_api_state csm_state(createInfoCount, pCreateInfos);
 
     for (const ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->ReadLock();
@@ -814,7 +814,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(
     // Special extra check if SPIR-V itself fails runtime validation in PreCallRecord
     if (!csm_state.valid_spirv) return VK_ERROR_VALIDATION_FAILED_EXT;
 
-    VkResult result = DispatchCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders);
+    VkResult result = DispatchCreateShadersEXT(device, createInfoCount, csm_state.instrumented_create_info, pAllocator, pShaders);
     for (ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, result, &csm_state);

--- a/scripts/generators/best_practices_generator.py
+++ b/scripts/generators/best_practices_generator.py
@@ -42,6 +42,7 @@ class BestPracticesOutputGenerator(BaseGenerator):
         # Commands that require an extra parameter for state sharing between validate/record steps
         self.extra_parameter_list = [
             "vkCreateShaderModule",
+            "vkCreateShadersEXT",
             "vkCreateGraphicsPipelines",
             "vkCreateComputePipelines",
             "vkAllocateDescriptorSets",

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1499,7 +1499,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
     bool skip = false;
 
-    create_shader_module_api_state csm_state{};
+    create_shader_object_api_state csm_state(createInfoCount, pCreateInfos);
 
     for (const ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->ReadLock();
@@ -1514,7 +1514,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(
     // Special extra check if SPIR-V itself fails runtime validation in PreCallRecord
     if (!csm_state.valid_spirv) return VK_ERROR_VALIDATION_FAILED_EXT;
 
-    VkResult result = DispatchCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders);
+    VkResult result = DispatchCreateShadersEXT(device, createInfoCount, csm_state.instrumented_create_info, pAllocator, pShaders);
     for (ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, result, &csm_state);


### PR DESCRIPTION
This adds all the plumbing support so that `VK_EXT_shader_object` can be used in GPU-AV

It uses the new flow from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6230

The core idea is the idea of `SPIRV` and `ShaderModule`/`ShaderEXT` are completely separated 

( related https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6265 )