### PR TITLE
layers: Revert GetConstantValueById assert assumption

### DIFF
--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1139,7 +1139,11 @@ uint32_t SPIRV_MODULE_STATE::GetConstantValueById(uint32_t id) const {
     // If this hit, most likley a runtime array (probably from VK_EXT_descriptor_indexing)
     // or unhandled specialization constants
     // Caller needs to call GetConstantDef() and check if null
-    assert(value);
+    if (!value) {
+        // TODO - still not fixed
+        // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6293
+        return 1;
+    }
 
     return value->GetConstantValue();
 }


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6249 seems to have caused an regression as pointed out by https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6293

until I get a SPIR-V file (or a way to test), going to revert the `assert` for now