### PR TITLE
layers: Add pnext chain extraction logic

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -150,6 +150,8 @@ core_validation_sources = [
   "layers/vulkan/generated/gpu_as_inspection_comp.h",
   "layers/vulkan/generated/gpu_pre_dispatch_comp.h",
   "layers/vulkan/generated/gpu_pre_draw_vert.h",
+  "layers/vulkan/generated/pnext_chain_extraction.cpp",
+  "layers/vulkan/generated/pnext_chain_extraction.h",
   "layers/vulkan/generated/spirv_grammar_helper.cpp",
   "layers/vulkan/generated/spirv_grammar_helper.h",
   "layers/vulkan/generated/spirv_tools_commit_id.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -255,6 +255,8 @@ target_sources(vvl PRIVATE
     layer_chassis_dispatch_manual.cpp
     ${API_TYPE}/generated/object_tracker.cpp
     ${API_TYPE}/generated/object_tracker.h
+    ${API_TYPE}/generated/pnext_chain_extraction.cpp
+    ${API_TYPE}/generated/pnext_chain_extraction.h
     ${API_TYPE}/generated/spirv_grammar_helper.cpp
     ${API_TYPE}/generated/spirv_validation_helper.cpp
     ${API_TYPE}/generated/stateless_validation_helper.cpp

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -21,9 +21,10 @@
 
 #include <string>
 
-#include "generated/vk_enum_string_helper.h"
-#include "generated/chassis.h"
 #include "core_validation.h"
+#include "generated/chassis.h"
+#include "generated/pnext_chain_extraction.h"
+#include "generated/vk_enum_string_helper.h"
 
 bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo *pCreateInfo) const {
     bool skip = false;
@@ -176,16 +177,9 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     image_format_info.usage = pCreateInfo->usage;
     image_format_info.flags = pCreateInfo->flags;
 
-    // These are pNext structs that can be in both vkGetPhysicalDeviceImageFormatProperties2 and vkCreateImage
-    // need to pass in or else driver might return NOT_SUPPORTED falsly
-    // TODO - Generate the full list
-    auto image_format_list = LvlInitStruct<VkImageFormatListCreateInfo>();
-    auto image_format_list_in = LvlFindInChain<VkImageFormatListCreateInfo>(pCreateInfo->pNext);
-    if (image_format_list_in) {
-        image_format_list.pViewFormats = image_format_list_in->pViewFormats;
-        image_format_list.viewFormatCount = image_format_list_in->viewFormatCount;
-        image_format_info.pNext = &image_format_list;
-    }
+    auto image_format_info_pnext_chain =
+        vvl::ExtractPnextChain<vvl::PnextChainVkPhysicalDeviceImageFormatInfo2>(pCreateInfo->pNext);
+    image_format_info.pNext = std::get<0>(image_format_info_pnext_chain);
 
     VkResult result = VK_SUCCESS;
     if (pCreateInfo->tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
@@ -197,14 +191,11 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                                                                     &image_format_properties.imageFormatProperties);
         }
     } else {
-        auto modifier_list = LvlFindInChain<VkImageDrmFormatModifierListCreateInfoEXT>(pCreateInfo->pNext);
-        auto explicit_modifier = LvlFindInChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pCreateInfo->pNext);
+        auto *modifier_list = LvlFindInChain<VkImageDrmFormatModifierListCreateInfoEXT>(pCreateInfo->pNext);
+        auto *explicit_modifier = LvlFindInChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pCreateInfo->pNext);
         auto drm_format_modifier = LvlInitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
-        if (image_format_list_in) {
-            image_format_list.pNext = &drm_format_modifier;
-        } else {
-            image_format_info.pNext = &drm_format_modifier;
-        }
+
+        vvl::PnextChainAdd(LvlFindLastInChain(&image_format_info), &drm_format_modifier);
         drm_format_modifier.sharingMode = pCreateInfo->sharingMode;
         drm_format_modifier.queueFamilyIndexCount = pCreateInfo->queueFamilyIndexCount;
         drm_format_modifier.pQueueFamilyIndices = pCreateInfo->pQueueFamilyIndices;
@@ -223,6 +214,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
             drm_format_modifier.drmFormatModifier = explicit_modifier->drmFormatModifier;
             result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_format_properties);
         }
+        vvl::PnextChainRemoveLast(const_cast<void *>(image_format_info.pNext));
     }
 
     // 1. vkGetPhysicalDeviceImageFormatProperties[2] only success code is VK_SUCCESS
@@ -471,40 +463,38 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         const uint32_t any_type = 1u << MostSignificantBit(external_memory_create_info->handleTypes);
         auto external_image_info = LvlInitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
         external_image_info.handleType = static_cast<VkExternalMemoryHandleTypeFlagBits>(any_type);
-        auto image_info = LvlInitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_image_info);
-        image_info.format = pCreateInfo->format;
-        image_info.type = pCreateInfo->imageType;
-        image_info.tiling = pCreateInfo->tiling;
-        image_info.usage = pCreateInfo->usage;
-        image_info.flags = pCreateInfo->flags;
+        vvl::PnextChainAdd(LvlFindLastInChain(&image_format_info), &external_image_info);
 
         auto external_image_properties = LvlInitStruct<VkExternalImageFormatProperties>();
         auto image_properties = LvlInitStruct<VkImageFormatProperties2>(&external_image_properties);
         VkExternalMemoryHandleTypeFlags compatible_types = 0;
         if (pCreateInfo->tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
-            result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_info, &image_properties);
+            result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_properties);
             compatible_types = external_image_properties.externalMemoryProperties.compatibleHandleTypes;
         } else {
             auto modifier_list = LvlFindInChain<VkImageDrmFormatModifierListCreateInfoEXT>(pCreateInfo->pNext);
             auto explicit_modifier = LvlFindInChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pCreateInfo->pNext);
             auto drm_format_modifier = LvlInitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
-            external_image_info.pNext = &drm_format_modifier;
             drm_format_modifier.sharingMode = pCreateInfo->sharingMode;
             drm_format_modifier.queueFamilyIndexCount = pCreateInfo->queueFamilyIndexCount;
             drm_format_modifier.pQueueFamilyIndices = pCreateInfo->pQueueFamilyIndices;
+            vvl::PnextChainAdd(LvlFindLastInChain(&image_format_info), &drm_format_modifier);
+
             if (modifier_list) {
                 for (uint32_t i = 0; i < modifier_list->drmFormatModifierCount; i++) {
                     drm_format_modifier.drmFormatModifier = modifier_list->pDrmFormatModifiers[i];
-                    result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_info, &image_properties);
+                    result =
+                        DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_properties);
                     compatible_types |= external_image_properties.externalMemoryProperties.compatibleHandleTypes;
                     if (result != VK_SUCCESS)
                         break;
                 }
             } else if (explicit_modifier) {
                 drm_format_modifier.drmFormatModifier = explicit_modifier->drmFormatModifier;
-                result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_info, &image_properties);
+                result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_properties);
                 compatible_types = external_image_properties.externalMemoryProperties.compatibleHandleTypes;
             }
+            vvl::PnextChainRemoveLast(const_cast<void *>(image_format_info.pNext));
         }
 
         if (result != VK_SUCCESS) {
@@ -512,10 +502,10 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                 device, "VUID-VkImageCreateInfo-pNext-00990",
                 "vkCreateImage(): The handle type (%s), format (%s), type (%s), tiling (%s), usage (%s), flags (%s) "
                 "is not supported combination of parameters and vkGetPhysicalDeviceImageFormatProperties2 returned back %s.",
-                string_VkExternalMemoryHandleTypeFlagBits(external_image_info.handleType), string_VkFormat(image_info.format),
-                string_VkImageType(image_info.type), string_VkImageTiling(image_info.tiling),
-                string_VkImageUsageFlags(image_info.usage).c_str(), string_VkImageCreateFlags(image_info.flags).c_str(),
-                string_VkResult(result));
+                string_VkExternalMemoryHandleTypeFlagBits(external_image_info.handleType),
+                string_VkFormat(image_format_info.format), string_VkImageType(image_format_info.type),
+                string_VkImageTiling(image_format_info.tiling), string_VkImageUsageFlags(image_format_info.usage).c_str(),
+                string_VkImageCreateFlags(image_format_info.flags).c_str(), string_VkResult(result));
         } else if ((external_memory_create_info->handleTypes & compatible_types) != external_memory_create_info->handleTypes) {
             skip |=
                 LogError(device, "VUID-VkImageCreateInfo-pNext-00990",
@@ -523,6 +513,8 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                          "flags (%s)  that are not reported as compatible by vkGetPhysicalDeviceImageFormatProperties2.",
                          string_VkExternalMemoryHandleTypeFlags(external_memory_create_info->handleTypes).c_str());
         }
+
+        vvl::PnextChainRemoveLast(const_cast<void *>(image_format_info.pNext));
     } else if (external_memory_create_info_nv && external_memory_create_info_nv->handleTypes != 0) {
         if (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
             skip |= LogError(

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -510,8 +510,10 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
             skip |=
                 LogError(device, "VUID-VkImageCreateInfo-pNext-00990",
                          "vkCreateImage(): VkImageCreateInfo pNext chain contains VkExternalMemoryImageCreateInfo with handleTypes "
-                         "flags (%s)  that are not reported as compatible by vkGetPhysicalDeviceImageFormatProperties2.",
-                         string_VkExternalMemoryHandleTypeFlags(external_memory_create_info->handleTypes).c_str());
+                         "flags (%s) that are not reported as compatible by vkGetPhysicalDeviceImageFormatProperties2. Compatible "
+                         "types are %s.",
+                         string_VkExternalMemoryHandleTypeFlags(external_memory_create_info->handleTypes).c_str(),
+                         string_VkExternalMemoryHandleTypeFlags(compatible_types).c_str());
         }
 
         vvl::PnextChainRemoveLast(const_cast<void *>(image_format_info.pNext));

--- a/layers/vulkan/generated/pnext_chain_extraction.cpp
+++ b/layers/vulkan/generated/pnext_chain_extraction.cpp
@@ -1,0 +1,135 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See pnext_chain_extraction_generator.py for modifications
+
+/***************************************************************************
+*
+* Copyright (c) 2023 The Khronos Group Inc.
+* Copyright (c) 2023 Valve Corporation
+* Copyright (c) 2023 LunarG, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+****************************************************************************/
+
+// NOLINTBEGIN
+
+
+#include "pnext_chain_extraction.h"
+
+#include "vk_typemap_helper.h"
+
+#include <cassert>
+
+namespace vvl {
+       
+void* PnextChainAdd(void *chain_end, void *new_struct) {
+    assert(new_struct);
+    if (!chain_end) {
+    	return new_struct;
+    }
+    auto *vk_base_struct = reinterpret_cast<VkBaseOutStructure*>(chain_end);
+    assert(!vk_base_struct->pNext);
+    vk_base_struct->pNext = reinterpret_cast<VkBaseOutStructure*>(new_struct);
+    return new_struct;
+};
+
+void PnextChainRemoveLast(void *chain) {
+    if (!chain) {
+        return;
+    }
+    auto *current = reinterpret_cast<VkBaseOutStructure *>(chain);
+    auto *prev = current;
+    while (current) {
+        prev = current;
+        current = reinterpret_cast<VkBaseOutStructure *>(current->pNext);
+    }
+    prev->pNext = nullptr;
+}
+
+
+template <>
+PnextChainVkPhysicalDeviceImageFormatInfo2 ExtractPnextChain(const void *in_pnext_chain) {
+
+	std::tuple<void *,
+	VkImageCompressionControlEXT,
+	VkImageFormatListCreateInfo,
+	VkImageStencilUsageCreateInfo,
+	VkOpticalFlowImageFormatInfoNV,
+	VkPhysicalDeviceExternalImageFormatInfo,
+	VkPhysicalDeviceImageDrmFormatModifierInfoEXT,
+	VkPhysicalDeviceImageViewImageFormatInfoEXT,
+	VkVideoProfileListInfoKHR> out_structs;
+
+    void * &chain_end = std::get<0>(out_structs);
+
+    if (auto *chain_struct = LvlFindInChain<VkImageCompressionControlEXT>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkImageCompressionControlEXT>(out_structs);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+    	chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkImageFormatListCreateInfo>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkImageFormatListCreateInfo>(out_structs);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+    	chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkImageStencilUsageCreateInfo>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkImageStencilUsageCreateInfo>(out_structs);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+    	chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkOpticalFlowImageFormatInfoNV>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkOpticalFlowImageFormatInfoNV>(out_structs);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+    	chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkPhysicalDeviceExternalImageFormatInfo>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkPhysicalDeviceExternalImageFormatInfo>(out_structs);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+    	chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(out_structs);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+    	chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkPhysicalDeviceImageViewImageFormatInfoEXT>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkPhysicalDeviceImageViewImageFormatInfoEXT>(out_structs);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+    	chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkVideoProfileListInfoKHR>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkVideoProfileListInfoKHR>(out_structs);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+    	chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+    }
+
+	return out_structs;
+}
+
+}
+
+// NOLINTEND

--- a/layers/vulkan/generated/pnext_chain_extraction.h
+++ b/layers/vulkan/generated/pnext_chain_extraction.h
@@ -1,0 +1,63 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See pnext_chain_extraction_generator.py for modifications
+
+/***************************************************************************
+*
+* Copyright (c) 2023 The Khronos Group Inc.
+* Copyright (c) 2023 Valve Corporation
+* Copyright (c) 2023 LunarG, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+****************************************************************************/
+
+// NOLINTBEGIN
+
+#pragma once
+
+#include <tuple>
+
+#include "vulkan/vulkan.h"
+
+namespace vvl {
+
+// Add element to end of pNext chain: chain_end must be a pointer to the last struct of the chain
+void* PnextChainAdd(void *chain_end, void *new_struct);
+
+// Remove last element from pNext chain 
+void PnextChainRemoveLast(void *chain);
+
+// Utility to make a selective copy of a pNext chain.
+// Structs listed in the returned tuple are the one extending some Vulkan structs, like VkPhysicalDeviceImageFormatInfo2.
+// Copied structs are the one mentioned in the returned tuple type and found in `in_pnext_chain`.
+// If the returned tuple is stack allocated, each struct is NOT a deep copy of the corresponding struct in in_pnext_chain,
+// so be mindful of pointers copies.
+// Beginning of pNext chain is stored in `std::get<0>(returned_tuple)` as a `void *`
+template <typename T>
+T ExtractPnextChain(const void *in_pnext_chain) {}
+
+
+using PnextChainVkPhysicalDeviceImageFormatInfo2 = std::tuple<void *,
+	VkImageCompressionControlEXT,
+	VkImageFormatListCreateInfo,
+	VkImageStencilUsageCreateInfo,
+	VkOpticalFlowImageFormatInfoNV,
+	VkPhysicalDeviceExternalImageFormatInfo,
+	VkPhysicalDeviceImageDrmFormatModifierInfoEXT,
+	VkPhysicalDeviceImageViewImageFormatInfoEXT,
+	VkVideoProfileListInfoKHR>;
+template <>
+PnextChainVkPhysicalDeviceImageFormatInfo2 ExtractPnextChain(const void *in_pnext_chain);
+
+}
+
+// NOLINTEND

--- a/layers/vulkan/generated/vk_typemap_helper.h
+++ b/layers/vulkan/generated/vk_typemap_helper.h
@@ -7501,6 +7501,17 @@ template <typename T> const T *LvlFindInChain(const void *next) {
     return found;
 }
 
+// Find last element of pNext chain
+inline VkBaseOutStructure *LvlFindLastInChain(void *next) {
+    auto *current = reinterpret_cast<VkBaseOutStructure *>(next);
+    auto *prev = current;
+    while (current) {
+        prev = current;
+        current = reinterpret_cast<VkBaseOutStructure *>(current->pNext);
+    }
+    return prev;
+}
+
 // Find an entry of the given type in the pNext chain
 template <typename T> T *LvlFindModInChain(void *next) {
     VkBaseOutStructure *current = reinterpret_cast<VkBaseOutStructure *>(next);

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -64,6 +64,7 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, targetF
     from generators.valid_enum_values_generator import ValidEnumValuesOutputGenerator
     from generators.spirv_tool_commit_id_generator import SpirvToolCommitIdOutputGenerator
     from generators.error_location_helper_generator import ErrorLocationHelperOutputGenerator
+    from generators.pnext_chain_extraction_generator import PnextChainExtractionGenerator
 
     # These set fields that are needed by both OutputGenerator and BaseGenerator,
     # but are uniform and don't need to be set at a per-generated file level
@@ -270,6 +271,14 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, targetF
         },
         'vk_format_utils.cpp' : {
             'generator' : FormatUtilsOutputGenerator,
+            'genCombined': True,
+        },
+        'pnext_chain_extraction.h' : {
+            'generator' : PnextChainExtractionGenerator,
+            'genCombined': True,
+        },
+        'pnext_chain_extraction.cpp' : {
+            'generator' : PnextChainExtractionGenerator,
             'genCombined': True,
         },
     }

--- a/scripts/generators/pnext_chain_extraction_generator.py
+++ b/scripts/generators/pnext_chain_extraction_generator.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2015-2023 The Khronos Group Inc.
+# Copyright (c) 2015-2023 Valve Corporation
+# Copyright (c) 2015-2023 LunarG, Inc.
+# Copyright (c) 2015-2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import os
+from generators.generator_utils import (incIndent, decIndent, addIndent)
+from generators.vulkan_object import (Member)
+from generators.base_generator import BaseGenerator
+
+class PnextChainExtractionGenerator(BaseGenerator):
+    def __init__(self):
+        BaseGenerator.__init__(self)
+
+        # List of Vulkan structures that a pnext chain extraction function will be generated for
+        self.target_structs = [
+            'VkPhysicalDeviceImageFormatInfo2'
+            ]
+    
+    def generate(self):
+        out = []
+        out.append(f'''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See {os.path.basename(__file__)} for modifications
+
+/***************************************************************************
+*
+* Copyright (c) 2023 The Khronos Group Inc.
+* Copyright (c) 2023 Valve Corporation
+* Copyright (c) 2023 LunarG, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+****************************************************************************/\n\n''')
+        out.append('// NOLINTBEGIN\n\n') # Wrap for clang-tidy to ignore
+
+        if self.filename == 'pnext_chain_extraction.h':
+            out.append(self.generateHeader())
+        elif self.filename == 'pnext_chain_extraction.cpp':
+            out.append(self.generateSource())
+        else:
+            out.append(f'\nFile name {self.filename} has no code to generate\n')
+
+        out.append('\n// NOLINTEND') # Wrap for clang-tidy to ignore
+        self.write("".join(out))
+
+    def generateHeader(self):
+        out = []
+        out.append(f'''#pragma once
+
+#include <tuple>
+
+#include "vulkan/vulkan.h"
+
+namespace vvl {{
+
+// Add element to end of pNext chain: chain_end must be a pointer to the last struct of the chain
+void* PnextChainAdd(void *chain_end, void *new_struct);
+
+// Remove last element from pNext chain 
+void PnextChainRemoveLast(void *chain);
+
+// Utility to make a selective copy of a pNext chain.
+// Structs listed in the returned tuple are the one extending some Vulkan structs, like VkPhysicalDeviceImageFormatInfo2.
+// Copied structs are the one mentioned in the returned tuple type and found in `in_pnext_chain`.
+// If the returned tuple is stack allocated, each struct is NOT a deep copy of the corresponding struct in in_pnext_chain,
+// so be mindful of pointers copies.
+// Beginning of pNext chain is stored in `std::get<0>(returned_tuple)` as a `void *`
+template <typename T>
+T ExtractPnextChain(const void *in_pnext_chain) {{}}
+
+''')
+        # Declare functions
+        for struct_name in self.target_structs:
+            struct = self.vk.structs[struct_name]
+            out.append(f'\nusing PnextChain{struct_name} = std::tuple<void *,\n\t')
+            out.append(',\n\t'.join(struct.extendedBy))
+            out.append('>;\n')
+            out.append('template <>\n')
+            out.append(f'PnextChain{struct_name} ExtractPnextChain(const void *in_pnext_chain);\n\n')
+
+        out.append('}\n')
+        return "".join(out)
+
+    def generateSource(self):
+        out = []
+        out.append(f'''
+#include "pnext_chain_extraction.h"
+
+#include "vk_typemap_helper.h"
+
+#include <cassert>
+
+namespace vvl {{
+       
+void* PnextChainAdd(void *chain_end, void *new_struct) {{
+    assert(new_struct);
+    if (!chain_end) {{
+    	return new_struct;
+    }}
+    auto *vk_base_struct = reinterpret_cast<VkBaseOutStructure*>(chain_end);
+    assert(!vk_base_struct->pNext);
+    vk_base_struct->pNext = reinterpret_cast<VkBaseOutStructure*>(new_struct);
+    return new_struct;
+}};
+
+void PnextChainRemoveLast(void *chain) {{
+    if (!chain) {{
+        return;
+    }}
+    auto *current = reinterpret_cast<VkBaseOutStructure *>(chain);
+    auto *prev = current;
+    while (current) {{
+        prev = current;
+        current = reinterpret_cast<VkBaseOutStructure *>(current->pNext);
+    }}
+    prev->pNext = nullptr;
+}}
+
+''')
+
+        # Define functions
+        for struct_name in self.target_structs:
+            struct = self.vk.structs[struct_name]
+            out.append('\ntemplate <>\n')
+            out.append(f'PnextChain{struct_name} ExtractPnextChain(const void *in_pnext_chain) {{\n\n')
+            
+            # Declare object to be returned
+            out.append('\tstd::tuple<void *,\n\t')
+            out.append(',\n\t'.join(struct.extendedBy))
+            out.append('> out_structs;\n')
+
+            out.append(f'''
+    void * &chain_end = std::get<0>(out_structs);\n''')
+
+            # Add extraction logic for each struct extending target struct
+            for extending_struct in struct.extendedBy:
+                out.append(f'''
+    if (auto *chain_struct = LvlFindInChain<{extending_struct}>(in_pnext_chain)) {{
+    	auto &out_chain_struct = std::get<{extending_struct}>(out_structs);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+    	chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+    }}\n''')
+            out.append('\n\treturn out_structs;\n}\n')
+
+        out.append('\n}\n')
+        return "".join(out)

--- a/scripts/generators/typemap_helper_generator.py
+++ b/scripts/generators/typemap_helper_generator.py
@@ -90,6 +90,17 @@ template <typename T> const T *LvlFindInChain(const void *next) {
     return found;
 }
 
+// Find last element of pNext chain
+inline VkBaseOutStructure *LvlFindLastInChain(void *next) {
+    auto *current = reinterpret_cast<VkBaseOutStructure *>(next);
+    auto *prev = current;
+    while (current) {
+        prev = current;
+        current = reinterpret_cast<VkBaseOutStructure *>(current->pNext);
+    }
+    return prev;
+}
+
 // Find an entry of the given type in the pNext chain
 template <typename T> T *LvlFindModInChain(void *next) {
     VkBaseOutStructure *current = reinterpret_cast<VkBaseOutStructure *>(next);

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -1200,6 +1200,10 @@ TEST_F(PositiveImage, CreateDrmImageWithExternalMemory) {
             result != VK_SUCCESS) {
             GTEST_SKIP() << "Unable to create image. VkResult = " << vk_result_string(result);
         }
+        if (!((external_image_properties.externalMemoryProperties.compatibleHandleTypes & external_info.handleTypes) ==
+              external_info.handleTypes)) {
+            GTEST_SKIP() << "Unable to create image, VkExternalMemoryImageCreateInfo::handleTypes not supported";
+        }
     }
 
     CreateImageTest(*this, &ci);

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -13,8 +13,11 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_extension_helper.h"
+#include "generated/vk_enum_string_helper.h"
 
 #include "utils/vk_layer_utils.h"
+
+#include <iostream>
 
 // A reasonable well supported default VkImageCreateInfo for image creation
 VkImageCreateInfo ImageTest::DefaultImageInfo() {
@@ -1200,8 +1203,16 @@ TEST_F(PositiveImage, CreateDrmImageWithExternalMemory) {
             result != VK_SUCCESS) {
             GTEST_SKIP() << "Unable to create image. VkResult = " << vk_result_string(result);
         }
-        if (!((external_image_properties.externalMemoryProperties.compatibleHandleTypes & external_info.handleTypes) ==
-              external_info.handleTypes)) {
+
+        std::cout << "external_image_properties.externalMemoryProperties.compatibleHandleTypes: "
+                  << string_VkExternalMemoryHandleTypeFlags(
+                         external_image_properties.externalMemoryProperties.compatibleHandleTypes)
+                  << '\n';
+
+        std::cout << "external_info.handleTypes: " << string_VkExternalMemoryHandleTypeFlags(external_info.handleTypes) << '\n';
+
+        if ((external_image_properties.externalMemoryProperties.compatibleHandleTypes & external_info.handleTypes) !=
+            external_info.handleTypes) {
             GTEST_SKIP() << "Unable to create image, VkExternalMemoryImageCreateInfo::handleTypes not supported";
         }
     }


### PR DESCRIPTION
- Should close https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6256

Add utilities to make a selective copy of a pNext chain. Selected elements are the structs extending some reference struct.

