### PR TITLE
layers: Fix VK_EXT_debug_report callback wiith no device

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -208,6 +208,11 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
             }
         } else if (!current_callback.IsUtils() && (current_callback.debug_report_msg_flags & msg_flags)) {
             // VK_EXT_debug_report callback (deprecated)
+            if (object_name_infos.empty()) {
+                // need something to provide or else if there is no object, no error message is reported
+                object_name_infos.emplace_back(VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT, nullptr, VK_OBJECT_TYPE_UNKNOWN,
+                                               VK_NULL_HANDLE, nullptr);
+            }
             if (current_callback.debug_report_callback_function_ptr(
                     msg_flags, convertCoreObjectToDebugReportObject(object_name_infos[0].objectType),
                     object_name_infos[0].objectHandle, message_id_number, 0, layer_prefix, composite.c_str(),


### PR DESCRIPTION
@Tony-LunarG pointed out some CTS was crashing on errors when using `VK_EXT_debug_report` (which is deprecated now)

This adds a fix to prevent the crash