### PR TITLE
scripts: Move IsDuplicatePnext to proper file

### DIFF
--- a/layers/vulkan/generated/stateless_validation_helper.h
+++ b/layers/vulkan/generated/stateless_validation_helper.h
@@ -22,6 +22,25 @@
 
 // NOLINTBEGIN
 #pragma once
+
+static inline bool IsDuplicatePnext(VkStructureType input_value) {
+    switch (input_value) {
+        case VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO:
+        case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
+        case VK_STRUCTURE_TYPE_DEVICE_DEVICE_MEMORY_REPORT_CREATE_INFO_EXT:
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT:
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT:
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT:
+        case VK_STRUCTURE_TYPE_IMPORT_METAL_TEXTURE_INFO_EXT:
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT:
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT:
+            return true;
+        default:
+            return false;
+    }
+}
+
 bool PreCallValidateCreateInstance(
     const VkInstanceCreateInfo*                 pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,

--- a/layers/vulkan/generated/vk_enum_string_helper.h
+++ b/layers/vulkan/generated/vk_enum_string_helper.h
@@ -24,25 +24,6 @@
 #pragma once
 #include <string>
 #include <vulkan/vulkan.h>
-
-static inline bool IsDuplicatePnext(VkStructureType input_value) {
-    switch (input_value) {
-        case VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO:
-        case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_DEVICE_DEVICE_MEMORY_REPORT_CREATE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_IMPORT_METAL_TEXTURE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT:
-            return true;
-        default:
-            return false;
-    }
-}
-
 static inline const char* string_VkResult(VkResult input_value) {
     switch (input_value) {
         case VK_SUCCESS:

--- a/scripts/generators/enum_string_helper_generator.py
+++ b/scripts/generators/enum_string_helper_generator.py
@@ -58,20 +58,6 @@ class EnumStringHelperOutputGenerator(BaseGenerator):
 #include <vulkan/vulkan.h>
 ''')
 
-        # TODO - this should be moved into different generated util file
-        out.append('\nstatic inline bool IsDuplicatePnext(VkStructureType input_value) {\n')
-        out.append('    switch (input_value) {\n')
-
-        for struct in [x for x in self.vk.structs.values() if x.allowDuplicate and x.sType is not None]:
-            # The sType will always be first member of struct
-            out.append(f'        case {struct.sType}:\n')
-        out.append('            return true;\n')
-        out.append('        default:\n')
-        out.append('            return false;\n')
-        out.append('    }\n')
-        out.append('}\n')
-        out.append('\n')
-
         # If there are no fields (empty enum) ignore
         for enum in [x for x in self.vk.enums.values() if len(x.fields) > 0]:
             groupType = enum.name if enum.bitWidth == 32 else 'uint64_t'

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -271,6 +271,19 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
     def generateHeader(self):
         out = []
         out.append('#pragma once\n')
+
+        out.append('\nstatic inline bool IsDuplicatePnext(VkStructureType input_value) {\n')
+        out.append('    switch (input_value) {\n')
+        for struct in [x for x in self.vk.structs.values() if x.allowDuplicate and x.sType is not None]:
+            # The sType will always be first member of struct
+            out.append(f'        case {struct.sType}:\n')
+        out.append('            return true;\n')
+        out.append('        default:\n')
+        out.append('            return false;\n')
+        out.append('    }\n')
+        out.append('}\n')
+        out.append('\n')
+
         for command in [x for x in self.vk.commands.values() if x.name not in self.blacklist]:
             out.extend([f'#ifdef {command.protect}\n'] if command.protect else [])
             prototype = command.cPrototype.split('VKAPI_CALL ')[1]


### PR DESCRIPTION
the `vk_enum_string_helper.h` will soon [be moved to VUL](https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/63/files#r1295272207) so moved this helper function out the the stateless validation helper generated file as this is only used by `sl_utils.cpp`