### PR TITLE
layers: Disable part of accel struct validation (Fix CTS)

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -300,7 +300,8 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
             // acceleration structure's memory if build mode is update, or other scratch buffers' memory.
             // Here validation is pessimistic: if one buffer associated to pInfos[other_info_j].scratchData.deviceAddress has an
             // overlap, an error will be logged.
-
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6040
+#if 0
             if (auto other_scratches = GetBuffersByAddress(pInfos[other_info_j].scratchData.deviceAddress);
                 !other_scratches.empty()) {
                 using BUFFER_STATE_PTR = ValidationStateTracker::BUFFER_STATE_PTR;
@@ -529,7 +530,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
                     *this, other_scratches, "vkCmdBuildAccelerationStructuresKHR()", address_name_ss.str(),
                     pInfos[other_info_j].scratchData.deviceAddress);
             }
-
+#endif
             // skip comparing to self pInfos[info_i]
             if (other_info_j != info_i) {
                 const auto other_dst_as_state =

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -2891,7 +2891,8 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6040
+TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
     TEST_DESCRIPTION(
         "Validate acceleration structure building when source/destination acceleration structures and scratch buffers overlap.");
 


### PR DESCRIPTION
- Reopen https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6040

It seems that the disabled part is responsible for a hang when running specific CTS tests.
In this disabled code part, the only calls that go down to the driver are the ones to DispatchGetAccelerationStructureBuildSizesKHR, so something must be wrong around here.