### PR TITLE
Fix debug_report with no objects

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -208,6 +208,12 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
             }
         } else if (!current_callback.IsUtils() && (current_callback.debug_report_msg_flags & msg_flags)) {
             // VK_EXT_debug_report callback (deprecated)
+            if (object_name_infos.empty()) {
+                VkDebugUtilsObjectNameInfoEXT null_object_name = {VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT, nullptr,
+                                                                  VK_OBJECT_TYPE_UNKNOWN, 0, nullptr};
+                // need to have at least one object
+                object_name_infos.emplace_back(null_object_name);
+            }
             if (current_callback.debug_report_callback_function_ptr(
                     msg_flags, convertCoreObjectToDebugReportObject(object_name_infos[0].objectType),
                     object_name_infos[0].objectHandle, message_id_number, 0, layer_prefix, composite.c_str(),


### PR DESCRIPTION
Starting with #6278, devices aren't printed if there's only one device.  The debug_report method of getting error callbacks cannot tolerate an empty object list, so use a null object to keep it working, even though it's been deprecated for years.
Fixes crashes in 
dEQP-VK.pipeline.monolithic.early_destroy.cache, 
dEQP-VK.pipeline.monolithic.extended_dynamic_state.between_pipelines.enable_raster
and other CTS tests.
Will target to add to the SDK branch once approved.

Error message with this fix:
Test case 'dEQP-VK.pipeline.monolithic.early_destroy.cache'..
Validation Error: [ VUID-VkGraphicsPipelineCreateInfo-pStages-06894 ] | MessageID = 0xdfcd6d41 | vkCreateGraphicsPipelines(): pCreateInfo[0] does not have fragment shader state, but stages (VK_SHADER_STAGE_VERTEX_BIT|VK_SHADER_STAGE_FRAGMENT_BIT) contains VK_SHADER_STAGE_FRAGMENT_BIT. The Vulkan spec states: If the pipeline requires pre-rasterization shader state but not fragment shader state, elements of pStages must not have stage set to VK_SHADER_STAGE_FRAGMENT_BIT (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkGraphicsPipelineCreateInfo-pStages-06894)
