### PR TITLE
ci: Cleanup Android CI name

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Test Max Profile
         run: python scripts/tests.py --test
 
-  android_cmake:
+  android:
       runs-on: ubuntu-22.04
       strategy:
         matrix:
@@ -180,7 +180,6 @@ jobs:
         - name: Build
           run: cmake --build build/
         - name: Test
-          if: matrix.build_tests == 'ON'
           working-directory: ./build
           run: ctest --output-on-failure -C Debug
 


### PR DESCRIPTION
cmake is now redundant now that ndk-build is gone.

ctest will return exit code 0 even if there are 0 tests.