### PR TITLE
scripts: Use uppercase names for APIVersion methods

### DIFF
--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -26,12 +26,12 @@ bool StatelessValidation::ValidateApiVersion(uint32_t api_version, APIVersion ef
             skip |= LogError(instance, "VUID-VkApplicationInfo-apiVersion-04010",
                              "Invalid CreateInstance->pCreateInfo->pApplicationInfo.apiVersion number (0x%08x). "
                              "Using VK_API_VERSION_%" PRIu32 "_%" PRIu32 ".",
-                             api_version, effective_api_version.major(), effective_api_version.minor());
+                             api_version, effective_api_version.Major(), effective_api_version.Minor());
         } else {
             skip |= LogWarning(instance, kVUIDUndefined,
                                "Unrecognized CreateInstance->pCreateInfo->pApplicationInfo.apiVersion number (0x%08x). "
                                "Assuming VK_API_VERSION_%" PRIu32 "_%" PRIu32 ".",
-                               api_version, effective_api_version.major(), effective_api_version.minor());
+                               api_version, effective_api_version.Major(), effective_api_version.Minor());
         }
     }
     return skip;

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -66,11 +66,11 @@ static inline VkOffset3D CastTo3D(const VkOffset2D &d2) {
 // Convert integer API version to a string
 static inline std::string StringAPIVersion(APIVersion version) {
     std::stringstream version_name;
-    if (!version.valid()) {
+    if (!version.Valid()) {
         return "<unrecognized>";
     }
-    version_name << version.major() << "." << version.minor() << "." << version.patch() << " (0x" << std::setfill('0')
-                 << std::setw(8) << std::hex << version.value() << ")";
+    version_name << version.Major() << "." << version.Minor() << "." << version.Patch() << " (0x" << std::setfill('0')
+                 << std::setw(8) << std::hex << version.Value() << ")";
     return version_name.str();
 }
 

--- a/layers/vulkan/generated/vk_extension_helper.h
+++ b/layers/vulkan/generated/vk_extension_helper.h
@@ -85,11 +85,11 @@ class APIVersion {
         return *this;
     }
 
-    bool valid() const { return api_version_ != VVL_UNRECOGNIZED_API_VERSION; }
-    uint32_t value() const { return api_version_; }
-    uint32_t major() const { return VK_API_VERSION_MAJOR(api_version_); }
-    uint32_t minor() const { return VK_API_VERSION_MINOR(api_version_); }
-    uint32_t patch() const { return VK_API_VERSION_PATCH(api_version_); }
+    bool Valid() const { return api_version_ != VVL_UNRECOGNIZED_API_VERSION; }
+    uint32_t Value() const { return api_version_; }
+    uint32_t Major() const { return VK_API_VERSION_MAJOR(api_version_); }
+    uint32_t Minor() const { return VK_API_VERSION_MINOR(api_version_); }
+    uint32_t Patch() const { return VK_API_VERSION_PATCH(api_version_); }
 
     bool operator<(APIVersion api_version) const { return api_version_ < api_version.api_version_; }
     bool operator<=(APIVersion api_version) const { return api_version_ <= api_version.api_version_; }

--- a/scripts/generators/extension_helper_generator.py
+++ b/scripts/generators/extension_helper_generator.py
@@ -92,11 +92,11 @@ class APIVersion {
         return *this;
     }
 
-    bool valid() const { return api_version_ != VVL_UNRECOGNIZED_API_VERSION; }
-    uint32_t value() const { return api_version_; }
-    uint32_t major() const { return VK_API_VERSION_MAJOR(api_version_); }
-    uint32_t minor() const { return VK_API_VERSION_MINOR(api_version_); }
-    uint32_t patch() const { return VK_API_VERSION_PATCH(api_version_); }
+    bool Valid() const { return api_version_ != VVL_UNRECOGNIZED_API_VERSION; }
+    uint32_t Value() const { return api_version_; }
+    uint32_t Major() const { return VK_API_VERSION_MAJOR(api_version_); }
+    uint32_t Minor() const { return VK_API_VERSION_MINOR(api_version_); }
+    uint32_t Patch() const { return VK_API_VERSION_PATCH(api_version_); }
 
     bool operator<(APIVersion api_version) const { return api_version_ < api_version.api_version_; }
     bool operator<=(APIVersion api_version) const { return api_version_ <= api_version.api_version_; }

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -795,7 +795,7 @@ void VkLayerTest::SetTargetApiVersion(APIVersion target_api_version) {
     m_attempted_api_version = target_api_version;  // used to know if request failed
 
     m_target_api_version = std::min(target_api_version, m_instance_api_version);
-    app_info_.apiVersion = m_target_api_version.value();
+    app_info_.apiVersion = m_target_api_version.Value();
 }
 
 APIVersion VkLayerTest::DeviceValidationVersion() const {

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -16,7 +16,7 @@ void DescriptorBufferTest::InitBasicDescriptorBuffer(void* pNextFeatures) {
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < m_attempted_api_version) {
-        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.minor() << " is required";
+        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.Minor() << " is required";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";

--- a/tests/unit/descriptor_indexing_positive.cpp
+++ b/tests/unit/descriptor_indexing_positive.cpp
@@ -17,7 +17,7 @@ void DescriptorIndexingTest::InitBasicDescriptorIndexing(void* pNextFeatures) {
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < m_attempted_api_version) {
-        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.minor() << " is required";
+        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.Minor() << " is required";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -19,7 +19,7 @@ void DynamicRenderingTest::InitBasicDynamicRendering(void* pNextFeatures) {
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < m_attempted_api_version) {
-        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.minor() << " is required";
+        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.Minor() << " is required";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -29,7 +29,7 @@ void GraphicsLibraryTest::InitBasicGraphicsLibrary(void *pNextFeatures) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &gpl_features));
     if (DeviceValidationVersion() < m_attempted_api_version) {
-        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.minor() << " is required";
+        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.Minor() << " is required";
     }
 }
 

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -16,7 +16,7 @@ void ShaderObjectTest::InitBasicShaderObject(void* pNextFeatures, APIVersion tar
     AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < m_attempted_api_version) {
-        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.minor() << " is required";
+        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.Minor() << " is required";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -19,7 +19,7 @@ void NegativeTransformFeedback::InitBasicTransformFeedback(void *pNextFeatures) 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < m_attempted_api_version) {
-        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.minor() << " is required";
+        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.Minor() << " is required";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -26,7 +26,7 @@ void YcbcrTest::InitBasicYcbcr(void *pNextFeatures) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     if (DeviceValidationVersion() < m_attempted_api_version) {
-        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.minor() << " is required";
+        GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.Minor() << " is required";
     }
 
     auto features11 = LvlInitStruct<VkPhysicalDeviceVulkan11Features>(pNextFeatures);


### PR DESCRIPTION
On some platforms the STL libraries include some platform headers which define C macros with names "major" and "minor" and thus cause compilation issues.

This change renames the methods of the APIVersion class to avoid these conflicts.