### PR TITLE
layers: Fix 00117 (buffer copy) for sparse resources

### DIFF
--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -38,14 +38,15 @@ namespace {
         }                                                                                                   \
     } while (0)
 
-#define NON_DISPATCHABLE_HANDLE_DTOR(cls, destroy_func) \
-    void cls::destroy() noexcept {                      \
-        if (!initialized()) {                           \
-            return;                                     \
-        }                                               \
-        destroy_func(device(), handle(), NULL);         \
-        handle_ = VK_NULL_HANDLE;                       \
-    }                                                   \
+#define NON_DISPATCHABLE_HANDLE_DTOR(cls, destroy_func)        \
+    void cls::destroy() noexcept {                             \
+        if (!initialized()) {                                  \
+            return;                                            \
+        }                                                      \
+        destroy_func(device(), handle(), NULL);                \
+        handle_ = VK_NULL_HANDLE;                              \
+        internal::NonDispHandle<decltype(handle_)>::destroy(); \
+    }                                                          \
     cls::~cls() noexcept { destroy(); }
 
 #define STRINGIFY(x) #x

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -140,6 +140,8 @@ class NonDispHandle : public Handle<T> {
         dev_handle_ = dev;
     }
 
+    void destroy() noexcept { dev_handle_ = VK_NULL_HANDLE; }
+
   private:
     VkDevice dev_handle_;
 };

--- a/tests/unit/sparse.cpp
+++ b/tests/unit/sparse.cpp
@@ -791,6 +791,11 @@ TEST_F(NegativeSparse, OverlappingBufferCopy) {
         GTEST_SKIP() << "Requires unsupported sparseBinding feature.";
     }
 
+    const std::optional<uint32_t> sparse_index = m_device->QueueFamilyMatching(VK_QUEUE_SPARSE_BINDING_BIT, 0u);
+    if (!sparse_index) {
+        GTEST_SKIP() << "Required queue families not present";
+    }
+
     auto s_info = LvlInitStruct<VkSemaphoreCreateInfo>();
     vk_testing::Semaphore semaphore(*m_device, s_info);
 
@@ -835,13 +840,10 @@ TEST_F(NegativeSparse, OverlappingBufferCopy) {
     bind_info.signalSemaphoreCount = 1;
     bind_info.pSignalSemaphores = &semaphore.handle();
 
-    const std::optional<uint32_t> sparse_index = m_device->QueueFamilyMatching(VK_QUEUE_SPARSE_BINDING_BIT, 0u);
-    if (!sparse_index) {
-        GTEST_SKIP() << "Required queue families not present";
-    }
     VkQueue sparse_queue = m_device->graphics_queues()[sparse_index.value()]->handle();
-
-    vk::QueueBindSparse(sparse_queue, 1, &bind_info, VK_NULL_HANDLE);
+    VkFenceObj sparse_queue_fence(*m_device);
+    vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
+    ASSERT_VK_SUCCESS(sparse_queue_fence.wait(kWaitTimeout));
     // Set up complete
 
     m_commandBuffer->begin();
@@ -865,6 +867,190 @@ TEST_F(NegativeSparse, OverlappingBufferCopy) {
 
     // Wait for operations to finish before destroying anything
     vk::QueueWaitIdle(m_device->m_queue);
+}
+
+TEST_F(NegativeSparse, OverlappingBufferCopy2) {
+    TEST_DESCRIPTION("Test overlapping sparse buffers' copy with overlapping device memory");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    if (!m_device->phy().features().sparseBinding) {
+        GTEST_SKIP() << "Requires unsupported sparseBinding feature.";
+    }
+
+    const std::optional<uint32_t> sparse_index = m_device->QueueFamilyMatching(VK_QUEUE_SPARSE_BINDING_BIT, 0u);
+    if (!sparse_index) {
+        GTEST_SKIP() << "Required queue families not present";
+    }
+
+    auto s_info = LvlInitStruct<VkSemaphoreCreateInfo>();
+    vk_testing::Semaphore semaphore(*m_device, s_info);
+
+    constexpr VkDeviceSize copy_size = 16;
+    std::array<VkBufferCopy, 4> copy_info_list = {};
+    copy_info_list[0].srcOffset = 0;
+    copy_info_list[0].dstOffset = 16;
+    copy_info_list[0].size = copy_size;
+
+    copy_info_list[1].srcOffset = 16;  // source overlaps copy_info_list[0].dst
+    copy_info_list[1].dstOffset = 32;
+    copy_info_list[1].size = copy_size;
+
+    copy_info_list[2].srcOffset = 32;  // source overlaps copy_info_list[1].dst
+    copy_info_list[2].dstOffset = 48;
+    copy_info_list[2].size = copy_size;
+
+    copy_info_list[3].srcOffset = 48;  // source overlaps copy_info_list[2].dst
+    copy_info_list[3].dstOffset = 64;
+    copy_info_list[3].size = copy_size;
+
+    VkBufferCreateInfo b_info =
+        vk_testing::Buffer::create_info(256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
+    b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
+    VkBufferObj buffer_sparse;
+    buffer_sparse.init_no_mem(*m_device, b_info);
+
+    VkMemoryRequirements buffer_mem_reqs;
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    VkMemoryAllocateInfo buffer_mem_alloc =
+        vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    vk_testing::DeviceMemory buffer_mem;
+    buffer_mem.init(*m_device, buffer_mem_alloc);
+
+    VkSparseMemoryBind buffer_memory_bind_1 = {};
+    buffer_memory_bind_1.size = buffer_mem_reqs.size;
+    buffer_memory_bind_1.memory = buffer_mem.handle();
+
+    std::array<VkSparseBufferMemoryBindInfo, 1> buffer_memory_bind_infos = {};
+    buffer_memory_bind_infos[0].buffer = buffer_sparse.handle();
+    buffer_memory_bind_infos[0].bindCount = 1;
+    buffer_memory_bind_infos[0].pBinds = &buffer_memory_bind_1;
+
+    auto bind_info = LvlInitStruct<VkBindSparseInfo>();
+    bind_info.bufferBindCount = size32(buffer_memory_bind_infos);
+    bind_info.pBufferBinds = buffer_memory_bind_infos.data();
+    bind_info.signalSemaphoreCount = 1;
+    bind_info.pSignalSemaphores = &semaphore.handle();
+
+    VkQueue sparse_queue = m_device->graphics_queues()[sparse_index.value()]->handle();
+    VkFenceObj sparse_queue_fence(*m_device);
+    vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
+    ASSERT_VK_SUCCESS(sparse_queue_fence.wait(kWaitTimeout));
+    // Set up complete
+
+    m_commandBuffer->begin();
+    vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
+                      copy_info_list.data());
+    m_commandBuffer->end();
+
+    // Submitting copy command with overlapping device memory regions
+    VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    auto submit_info = LvlInitStruct<VkSubmitInfo>();
+    submit_info.waitSemaphoreCount = 1;
+    submit_info.pWaitSemaphores = &semaphore.handle();
+    submit_info.pWaitDstStageMask = &mask;
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &m_commandBuffer->handle();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBuffer-pRegions-00117");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBuffer-pRegions-00117");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBuffer-pRegions-00117");
+    vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyFound();
+
+    // Wait for operations to finish before destroying anything
+    vk::QueueWaitIdle(m_device->m_queue);
+}
+
+TEST_F(NegativeSparse, OverlappingBufferCopy3) {
+    TEST_DESCRIPTION("Test coyping from a range that spans two different memory chunks");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    if (!m_device->phy().features().sparseBinding) {
+        GTEST_SKIP() << "Requires unsupported sparseBinding feature.";
+    }
+
+    const std::optional<uint32_t> sparse_index = m_device->QueueFamilyMatching(VK_QUEUE_SPARSE_BINDING_BIT, 0u);
+    if (!sparse_index) {
+        GTEST_SKIP() << "Required queue families not present";
+    }
+
+    auto semaphore_ci = LvlInitStruct<VkSemaphoreCreateInfo>();
+    vk_testing::Semaphore semaphore(*m_device, semaphore_ci);
+
+    VkBufferCreateInfo buffer_ci =
+        vk_testing::Buffer::create_info(4096 * 32, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
+    buffer_ci.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
+    VkBufferObj buffer_sparse;
+    buffer_sparse.init_no_mem(*m_device, buffer_ci);
+
+    VkMemoryRequirements buffer_mem_reqs;
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    if (buffer_mem_reqs.alignment <= 1) {
+        GTEST_SKIP() << "Buffer copy will not work as intended if VkMemoryRequirements::alignment is not superior to 1";
+    }
+    buffer_sparse.destroy();
+    buffer_ci.size = 2 * buffer_mem_reqs.alignment;
+    buffer_sparse.init_no_mem(*m_device, buffer_ci);
+    VkMemoryAllocateInfo buffer_mem_alloc =
+        vk_testing::DeviceMemory::get_resource_alloc_info(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    vk_testing::DeviceMemory buffer_mem_1;
+    buffer_mem_1.init(*m_device, buffer_mem_alloc);
+    vk_testing::DeviceMemory buffer_mem_2;
+    buffer_mem_2.init(*m_device, buffer_mem_alloc);
+
+    std::array<VkSparseMemoryBind, 2> buffer_memory_binds = {};
+    buffer_memory_binds[0].size = buffer_mem_reqs.alignment;
+    buffer_memory_binds[0].memory = buffer_mem_1.handle();
+    buffer_memory_binds[1].resourceOffset = buffer_mem_reqs.alignment;
+    buffer_memory_binds[1].size = buffer_mem_reqs.alignment;
+    buffer_memory_binds[1].memory = buffer_mem_2.handle();
+
+    VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
+    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.bindCount = size32(buffer_memory_binds);
+    buffer_memory_bind_info.pBinds = buffer_memory_binds.data();
+
+    auto bind_info = LvlInitStruct<VkBindSparseInfo>();
+    bind_info.bufferBindCount = 1;
+    bind_info.pBufferBinds = &buffer_memory_bind_info;
+    bind_info.signalSemaphoreCount = 1;
+    bind_info.pSignalSemaphores = &semaphore.handle();
+
+    VkQueue sparse_queue = m_device->graphics_queues()[sparse_index.value()]->handle();
+    VkFenceObj sparse_queue_fence(*m_device);
+    vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
+    ASSERT_VK_SUCCESS(sparse_queue_fence.wait(kWaitTimeout));
+    // Set up complete
+
+    VkBufferCopy copy_info;
+    copy_info.srcOffset = 0;                              // srcOffset is the start of buffer_mem_1, or 0 in this space.
+    copy_info.dstOffset = buffer_mem_reqs.alignment / 2;  // dstOffset is the start of buffer_mem_2, or 0 in this space
+                                                          // => since overlaps are computed in buffer space, none should be detected
+    copy_info.size = buffer_mem_reqs.alignment;
+    m_commandBuffer->begin();
+    vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
+    m_commandBuffer->end();
+
+    // Submitting copy command with overlapping device memory regions
+    VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    auto submit_info = LvlInitStruct<VkSubmitInfo>();
+    submit_info.waitSemaphoreCount = 1;
+    submit_info.pWaitSemaphores = &semaphore.handle();
+    submit_info.pWaitDstStageMask = &mask;
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &m_commandBuffer->handle();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBuffer-pRegions-00117");
+    vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
+    m_errorMonitor->VerifyFound();
+
+    // Wait for operations to finish before destroying anything
+    vk::QueueWaitIdle(m_device->m_queue);
+    vk::QueueWaitIdle(sparse_queue);
 }
 
 TEST_F(NegativeSparse, BufferFlagsFeature) {


### PR DESCRIPTION
- Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6144

Fixed validation. Validation message has been improved with the overlapping buffer ranges. Given validation is done at `vkQueueSubmit` time, finding which `vkCmdCopyBuffer` triggered validation errors is still a problem, but it goes beyond the scope of this PR. 