### PR TITLE
layers: Avoid allocation for single semaphore wait

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -165,14 +165,16 @@ bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location &loc, VkSemaph
         case VK_SEMAPHORE_TYPE_BINARY: {
             if ((semaphore_state->Scope() == kSyncScopeInternal || internal_semaphores.count(semaphore))) {
                 VkQueue other_queue = VK_NULL_HANDLE;
-                const char *other_func = nullptr;
-                if (CannotSignal(*semaphore_state, other_queue, other_func)) {
+                vvl::Func other_command = vvl::Func::Empty;
+                if (CannotSignal(*semaphore_state, other_queue, other_command)) {
                     std::stringstream initiator;
-                    if (other_func) {
-                        initiator << other_func;
+                    if (other_command != vvl::Func::Empty) {
+                        initiator << String(other_command);
                     }
                     if (other_queue != VK_NULL_HANDLE) {
-                        if (other_func) initiator << " on ";
+                        if (other_command != vvl::Func::Empty) {
+                            initiator << " on ";
+                        }
                         initiator << core->FormatHandle(other_queue);
                         objlist.add(other_queue);
                     }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -397,17 +397,18 @@ struct SemaphoreSubmitState {
     bool ValidateWaitSemaphore(const Location& loc, VkSemaphore semaphore, uint64_t value);
     bool ValidateSignalSemaphore(const Location& loc, VkSemaphore semaphore, uint64_t value);
 
-    bool CannotSignal(const SEMAPHORE_STATE& semaphore_state, VkQueue& other_queue, const char*& other_func) const {
+    bool CannotSignal(const SEMAPHORE_STATE& semaphore_state, VkQueue& other_queue, vvl::Func& other_command) const {
         const auto semaphore = semaphore_state.semaphore();
         if (signaled_semaphores.count(semaphore)) {
             other_queue = queue;
+            other_command = vvl::Func::Empty;
             return true;
         }
         if (!unsignaled_semaphores.count(semaphore)) {
             const auto last_op = semaphore_state.LastOp();
             if (last_op && !last_op->CanBeSignaled()) {
                 other_queue = last_op->queue ? last_op->queue->Queue() : VK_NULL_HANDLE;
-                other_func = last_op->func_name;
+                other_command = last_op->command;
                 return true;
             }
         }

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -352,7 +352,7 @@ void SEMAPHORE_STATE::EnqueueWait(QUEUE_STATE *queue, uint64_t queue_seq, uint64
     }
     auto result = timeline_.emplace(payload, TimePoint(wait_op));
     if (!result.second) {
-        result.first->second.wait_ops.emplace(wait_op);
+        result.first->second.wait_ops.emplace_back(wait_op);
     }
 }
 
@@ -499,7 +499,7 @@ std::shared_future<void> SEMAPHORE_STATE::Wait(uint64_t payload) {
     auto result = timeline_.emplace(payload, TimePoint(wait_op));
     auto &timepoint = result.first->second;
     if (!result.second) {
-        timepoint.wait_ops.emplace(wait_op);
+        timepoint.wait_ops.emplace_back(wait_op);
     }
     return timepoint.waiter;
 }

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -356,11 +356,11 @@ void SEMAPHORE_STATE::EnqueueWait(QUEUE_STATE *queue, uint64_t queue_seq, uint64
     }
 }
 
-void SEMAPHORE_STATE::EnqueueAcquire(const char *func_name) {
+void SEMAPHORE_STATE::EnqueueAcquire(vvl::Func command) {
     auto guard = WriteLock();
     assert(type == VK_SEMAPHORE_TYPE_BINARY);
     auto payload = next_payload_++;
-    SemOp acquire(kBinaryAcquire, nullptr, 0, payload, func_name);
+    SemOp acquire(kBinaryAcquire, nullptr, 0, payload, command);
     timeline_.emplace(payload, acquire);
 }
 

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -21,9 +21,9 @@
 #include <condition_variable>
 #include <deque>
 #include <future>
-#include <set>
 #include <thread>
 #include <vector>
+#include "containers/custom_containers.h"
 #include "error_message/error_location.h"
 #include "utils/vk_layer_utils.h"
 
@@ -142,13 +142,13 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     struct TimePoint {
         TimePoint(SemOp &op) : signal_op(), completed(), waiter(completed.get_future()) {
             if (op.op_type == kWait) {
-                wait_ops.emplace(op);
+                wait_ops.emplace_back(op);
             } else {
                 signal_op.emplace(op);
             }
         }
         std::optional<SemOp> signal_op;
-        std::set<SemOp> wait_ops;
+        small_vector<SemOp, 1, uint32_t> wait_ops;
         std::promise<void> completed;
         std::shared_future<void> waiter;
 

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -142,10 +142,15 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     struct TimePoint {
         TimePoint(SemOp &op) : signal_op(), completed(), waiter(completed.get_future()) {
             if (op.op_type == kWait) {
-                wait_ops.emplace_back(op);
+                AddWaitOp(op);
             } else {
                 signal_op.emplace(op);
             }
+        }
+        void AddWaitOp(const SemOp &op) {
+            assert(op.op_type == kWait);
+            assert(wait_ops.empty() || wait_ops[0].payload == op.payload);
+            wait_ops.emplace_back(op);
         }
         std::optional<SemOp> signal_op;
         small_vector<SemOp, 1, uint32_t> wait_ops;

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -24,6 +24,7 @@
 #include <set>
 #include <thread>
 #include <vector>
+#include "error_message/error_location.h"
 #include "utils/vk_layer_utils.h"
 
 class CMD_BUFFER_STATE;
@@ -115,14 +116,14 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     }
 
     struct SemOp {
-        SemOp(OpType ot, QUEUE_STATE *q, uint64_t queue_seq, uint64_t timeline_payload, const char *func_name = nullptr)
-            : op_type(ot), queue(q), seq(queue_seq), payload(timeline_payload), func_name(func_name) {}
+        SemOp(OpType ot, QUEUE_STATE *q, uint64_t queue_seq, uint64_t timeline_payload, vvl::Func command = vvl::Func::Empty)
+            : op_type(ot), command(command), queue(q), seq(queue_seq), payload(timeline_payload) {}
 
         OpType op_type;
+        vvl::Func command;
         QUEUE_STATE *queue;
         uint64_t seq;
         uint64_t payload;
-        const char *func_name;  // has to be initialized with a string literal
 
         bool operator<(const SemOp &rhs) const { return payload < rhs.payload; }
 
@@ -210,7 +211,7 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     void EnqueueWait(QUEUE_STATE *queue, uint64_t queue_seq, uint64_t &payload);
 
     // Binary only special cases enqueue functions
-    void EnqueueAcquire(const char *func_name);
+    void EnqueueAcquire(vvl::Func command);
 
     // Signal queue(s) that need to retire because a wait on this payload has finished
     void Notify(uint64_t payload);

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4235,7 +4235,7 @@ void ValidationStateTracker::PostCallRecordCreateSharedSwapchainsKHR(VkDevice de
 
 void ValidationStateTracker::RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
                                                          VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex,
-                                                         const char *func_name) {
+                                                         vvl::Func command) {
     auto fence_state = Get<FENCE_STATE>(fence);
     if (fence_state) {
         // Treat as inflight since it is valid to wait on this fence, even in cases where it is technically a temporary
@@ -4247,7 +4247,7 @@ void ValidationStateTracker::RecordAcquireNextImageState(VkDevice device, VkSwap
     if (semaphore_state) {
         // Treat as signaled since it is valid to wait on this semaphore, even in cases where it is technically a
         // temporary import
-        semaphore_state->EnqueueAcquire(func_name);
+        semaphore_state->EnqueueAcquire(command);
     }
 
     // Mark the image as acquired.
@@ -4261,14 +4261,14 @@ void ValidationStateTracker::PostCallRecordAcquireNextImageKHR(VkDevice device, 
                                                                VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex,
                                                                VkResult result) {
     if ((VK_SUCCESS != result) && (VK_SUBOPTIMAL_KHR != result)) return;
-    RecordAcquireNextImageState(device, swapchain, timeout, semaphore, fence, pImageIndex, "vkAcquireNextImageKHR");
+    RecordAcquireNextImageState(device, swapchain, timeout, semaphore, fence, pImageIndex, vvl::Func::vkAcquireNextImageKHR);
 }
 
 void ValidationStateTracker::PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo,
                                                                 uint32_t *pImageIndex, VkResult result) {
     if ((VK_SUCCESS != result) && (VK_SUBOPTIMAL_KHR != result)) return;
     RecordAcquireNextImageState(device, pAcquireInfo->swapchain, pAcquireInfo->timeout, pAcquireInfo->semaphore,
-                                pAcquireInfo->fence, pImageIndex, "vkAcquireNextImage2KHR");
+                                pAcquireInfo->fence, pImageIndex, vvl::Func::vkAcquireNextImage2KHR);
 }
 
 std::shared_ptr<PHYSICAL_DEVICE_STATE> ValidationStateTracker::CreatePhysicalDeviceState(VkPhysicalDevice phys_dev) {

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1322,7 +1322,7 @@ class ValidationStateTracker : public ValidationObject {
     void PerformUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet, const UPDATE_TEMPLATE_STATE* template_state,
                                                     const void* pData);
     void RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
-                                     VkFence fence, uint32_t* pImageIndex, const char* func_name);
+                                     VkFence fence, uint32_t* pImageIndex, vvl::Func command);
     void RecordCreateSamplerYcbcrConversionState(const VkSamplerYcbcrConversionCreateInfo* create_info,
                                                  VkSamplerYcbcrConversion ycbcr_conversion);
     virtual std::shared_ptr<SWAPCHAIN_NODE> CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info,


### PR DESCRIPTION
`TimePoint` objects are regularly created and destroyed.  When such
object registers semaphore wait operation it allocates memory.
This PR avoids allocation when semaphore has a single waiter.

*First commit:*
Reduces size of `TimePoint` structure on 64 bit platforms.
The numbers is for the Release build, Debug build can add additional
debug state.

SemOp    : 40  -> 32 bytes
TimePoint: 104 -> 96 bytes

That's preparation for the second commit which increases size of
`TimePoint` in order to use build-in storage of `small_vector` to avoid
allocation for the case when semaphore has a single waiter.

We try to reduce size enough, in order not to go over 2 cache lines
(128 bytes) when `std::set` is replaced with `small_vector`. If for some
compiler settings or std library implementation we start using 3rd cache
line that should be fine too (avoid allocation is the main priority). Additional 
cache line can optionally be used to add more static slots to a small_vector.

*Second commit:*
Replaces `std::set` with a `small_vector`.

The first commit allowed to reduce sizes of `SemOp`/`TimPoint` structures
and here we borrow that size back. `TimePoint` structure in Release build
on x64 grows to 128 bytes (perfectly fits 2 cache lines).

The size of `SemOp` remains 32 bytes. In the cases with multiple waiters we'll
be able to nicely pack them in cache lines.

The original code did not use properties of set container, only iteration over
all elements, so replacing with `small_vector` is straightforward.

*Third commit:*
Added asserts to validate assumptions.