### PR TITLE
layers: Add Location for Pipeline and Shaders

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1135,33 +1135,31 @@ bool CoreChecks::PreCallValidateCmdSetDepthBias(VkCommandBuffer commandBuffer, f
     return skip;
 }
 
-bool CoreChecks::ValidateDepthBiasRepresentationInfo(const char *caller, const LogObjectList &objlist,
-                                                     const VkDepthBiasRepresentationInfoEXT &depth_bias_representation) const {
+bool CoreChecks::ValidateDepthBiasRepresentationInfo(const Location& loc, const LogObjectList& objlist,
+                                                     const VkDepthBiasRepresentationInfoEXT& depth_bias_representation) const {
     bool skip = false;
 
     if ((depth_bias_representation.depthBiasRepresentation ==
          VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORCE_UNORM_EXT) &&
         !enabled_features.depth_bias_control_features.leastRepresentableValueForceUnormRepresentation) {
-        skip |= LogError(objlist, "VUID-VkDepthBiasRepresentationInfoEXT-leastRepresentableValueForceUnormRepresentation-08947",
-                         "%s: the "
-                         "VkPhysicalDeviceDepthBiasControlFeaturesEXT::leastRepresentableValueForceUnormRepresentation device "
-                         "feature is disabled but depthBiasRepresentation is %s.",
-                         caller, string_VkDepthBiasRepresentationEXT(depth_bias_representation.depthBiasRepresentation));
+        skip |= LogError("VUID-VkDepthBiasRepresentationInfoEXT-leastRepresentableValueForceUnormRepresentation-08947", objlist,
+                         loc.pNext(Struct::VkDepthBiasRepresentationInfoEXT, Field::depthBiasRepresentation),
+                         "is %s, but the leastRepresentableValueForceUnormRepresentation feature was not enabled.",
+                         string_VkDepthBiasRepresentationEXT(depth_bias_representation.depthBiasRepresentation));
     }
 
     if ((depth_bias_representation.depthBiasRepresentation == VK_DEPTH_BIAS_REPRESENTATION_FLOAT_EXT) &&
         !enabled_features.depth_bias_control_features.floatRepresentation) {
-        skip |= LogError(objlist, "VUID-VkDepthBiasRepresentationInfoEXT-floatRepresentation-08948",
-                         "%s: the VkPhysicalDeviceDepthBiasControlFeaturesEXT::floatReprensentation "
-                         "device feature is disabled but depthBiasRepresentation is %s.",
-                         caller, string_VkDepthBiasRepresentationEXT(depth_bias_representation.depthBiasRepresentation));
+        skip |= LogError("VUID-VkDepthBiasRepresentationInfoEXT-floatRepresentation-08948", objlist,
+                         loc.pNext(Struct::VkDepthBiasRepresentationInfoEXT, Field::depthBiasRepresentation),
+                         "is %s but the floatRepresentation feature was not enabled.",
+                         string_VkDepthBiasRepresentationEXT(depth_bias_representation.depthBiasRepresentation));
     }
 
-    if ((depth_bias_representation.depthBiasExact != VK_FALSE) && !enabled_features.depth_bias_control_features.depthBiasExact) {
-        skip |= LogError(objlist, "VUID-VkDepthBiasRepresentationInfoEXT-depthBiasExact-08949",
-                         "%s: the VkPhysicalDeviceDepthBiasControlFeaturesEXT::depthBiasExact device "
-                         "feature is disabled but depthBiasExact is %" PRIu32 ".",
-                         caller, depth_bias_representation.depthBiasExact);
+    if ((depth_bias_representation.depthBiasExact == VK_TRUE) && !enabled_features.depth_bias_control_features.depthBiasExact) {
+        skip |= LogError("VUID-VkDepthBiasRepresentationInfoEXT-depthBiasExact-08949", objlist,
+                         loc.pNext(Struct::VkDepthBiasRepresentationInfoEXT, Field::depthBiasExact),
+                         "is VK_TRUE, but the depthBiasExact feature was not enabled.");
     }
 
     return skip;
@@ -1178,8 +1176,7 @@ bool CoreChecks::PreCallValidateCmdSetDepthBias2EXT(VkCommandBuffer commandBuffe
     }
 
     if (const auto *depth_bias_representation = LvlFindInChain<VkDepthBiasRepresentationInfoEXT>(pDepthBiasInfo->pNext)) {
-        skip |= ValidateDepthBiasRepresentationInfo("vkCmdSetDepthBias2EXT()", LogObjectList(commandBuffer),
-                                                    *depth_bias_representation);
+        skip |= ValidateDepthBiasRepresentationInfo(errorObj.location, errorObj.objlist, *depth_bias_representation);
     }
 
     return skip;

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -349,7 +349,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
         std::make_pair(VK_PIPELINE_BIND_POINT_GRAPHICS, "VUID-vkCmdBindDescriptorSets-pipelineBindPoint-00361"),
         std::make_pair(VK_PIPELINE_BIND_POINT_COMPUTE, "VUID-vkCmdBindDescriptorSets-pipelineBindPoint-00361"),
         std::make_pair(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, "VUID-vkCmdBindDescriptorSets-pipelineBindPoint-00361")};
-    skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, "vkCmdBindPipeline()", bindpoint_errors);
+    skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, errorObj.location, bindpoint_errors);
 
     return skip;
 }
@@ -3361,7 +3361,7 @@ bool CoreChecks::PreCallValidateCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer
         std::make_pair(VK_PIPELINE_BIND_POINT_GRAPHICS, "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pipelineBindPoint-08067"),
         std::make_pair(VK_PIPELINE_BIND_POINT_COMPUTE, "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pipelineBindPoint-08067"),
         std::make_pair(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pipelineBindPoint-08067")};
-    skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, "vkCmdSetDescriptorBufferOffsetsEXT()", bindpoint_errors);
+    skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, errorObj.location, bindpoint_errors);
 
     if (!enabled_features.descriptor_buffer_features.descriptorBuffer) {
         skip |= LogError("VUID-vkCmdSetDescriptorBufferOffsetsEXT-None-08060", commandBuffer, errorObj.location,
@@ -3513,8 +3513,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCom
         std::make_pair(VK_PIPELINE_BIND_POINT_COMPUTE, "VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-pipelineBindPoint-08069"),
         std::make_pair(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR,
                        "VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-pipelineBindPoint-08069")};
-    skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, "vkCmdBindDescriptorBufferEmbeddedSamplersEXT()",
-                                      bindpoint_errors);
+    skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, errorObj.location, bindpoint_errors);
 
     auto pipeline_layout = Get<PIPELINE_LAYOUT_STATE>(layout);
     if (set >= pipeline_layout->set_layouts.size()) {
@@ -4452,7 +4451,7 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSetKHR(VkCommandBuffer commandB
         std::make_pair(VK_PIPELINE_BIND_POINT_COMPUTE, "VUID-vkCmdPushDescriptorSetKHR-pipelineBindPoint-00363"),
         std::make_pair(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, "VUID-vkCmdPushDescriptorSetKHR-pipelineBindPoint-00363")};
 
-    skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, "vkCmdPushDescriptorSetKHR()", bind_errors);
+    skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, errorObj.location, bind_errors);
     auto layout_data = Get<PIPELINE_LAYOUT_STATE>(layout);
 
     // Validate the set index points to a push descriptor set and is in range
@@ -4629,8 +4628,7 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSetWithTemplateKHR(VkCommandBuf
             std::make_pair(VK_PIPELINE_BIND_POINT_COMPUTE, "VUID-vkCmdPushDescriptorSetWithTemplateKHR-commandBuffer-00366"),
             std::make_pair(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR,
                            "VUID-vkCmdPushDescriptorSetWithTemplateKHR-commandBuffer-00366")};
-        skip |= ValidatePipelineBindPoint(cb_state.get(), template_ci.pipelineBindPoint, "vkCmdPushDescriptorSetWithTemplateKHR()",
-                                          bind_errors);
+        skip |= ValidatePipelineBindPoint(cb_state.get(), template_ci.pipelineBindPoint, errorObj.location, bind_errors);
 
         if (template_ci.templateType != VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR) {
             skip |= LogError("VUID-vkCmdPushDescriptorSetWithTemplateKHR-descriptorUpdateTemplate-07994", commandBuffer,

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -25,8 +25,8 @@
 #include "generated/chassis.h"
 #include "core_validation.h"
 
-bool CoreChecks::ValidatePipelineDerivatives(std::vector<std::shared_ptr<PIPELINE_STATE>> const &pipelines,
-                                             uint32_t pipe_index) const {
+bool CoreChecks::ValidatePipelineDerivatives(std::vector<std::shared_ptr<PIPELINE_STATE>> const &pipelines, uint32_t pipe_index,
+                                             const Location &loc) const {
     bool skip = false;
     const auto &pipeline = *pipelines[pipe_index].get();
     // If create derivative bit is set, check that we've specified a base
@@ -37,16 +37,12 @@ bool CoreChecks::ValidatePipelineDerivatives(std::vector<std::shared_ptr<PIPELIN
         const VkPipeline base_handle = pipeline.BasePipeline<VkGraphicsPipelineCreateInfo>();
         const int32_t base_index = pipeline.BasePipelineIndex<VkGraphicsPipelineCreateInfo>();
         if (!((base_handle != VK_NULL_HANDLE) ^ (base_index != -1))) {
-            skip |= LogError(device, "VUID-VkGraphicsPipelineCreateInfo-flags-07986",
-                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-                             "]: exactly one of base pipeline index and handle must be specified",
-                             pipeline.create_index);
+            skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-flags-07986", device, loc,
+                             "exactly one of base pipeline index and handle must be specified");
         } else if (base_index != -1) {
             if (static_cast<uint32_t>(base_index) >= pipeline.create_index) {
-                skip |= LogError(base_handle, "VUID-vkCreateGraphicsPipelines-flags-00720",
-                                 "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-                                 "]: base pipeline must occur earlier in array than derivative pipeline.",
-                                 pipeline.create_index);
+                skip |= LogError("VUID-vkCreateGraphicsPipelines-flags-00720", base_handle, loc,
+                                 "base pipeline must occur earlier in array than derivative pipeline.");
             } else {
                 base_pipeline = pipelines[base_index];
             }
@@ -55,54 +51,41 @@ bool CoreChecks::ValidatePipelineDerivatives(std::vector<std::shared_ptr<PIPELIN
         }
 
         if (base_pipeline && !(base_pipeline->create_flags & VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT)) {
-            skip |= LogError(base_pipeline->pipeline(), "VUID-vkCreateGraphicsPipelines-flags-00721",
-                             "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32 "]: base pipeline does not allow derivatives.",
-                             pipeline.create_index);
+            skip |= LogError("VUID-vkCreateGraphicsPipelines-flags-00721", base_pipeline->pipeline(), loc,
+                             "base pipeline does not allow derivatives.");
         }
     }
     return skip;
 }
 
-bool CoreChecks::ValidatePipelineCacheControlFlags(VkPipelineCreateFlags flags, uint32_t index, const char *caller_name,
-                                                   const char *vuid) const {
+bool CoreChecks::ValidatePipelineCacheControlFlags(VkPipelineCreateFlags flags, const Location &loc, const char *vuid) const {
     bool skip = false;
     if (enabled_features.core13.pipelineCreationCacheControl == VK_FALSE) {
         const VkPipelineCreateFlags invalid_flags =
             VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_EXT | VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT_EXT;
         if ((flags & invalid_flags) != 0) {
-            skip |= LogError(device, vuid,
-                             "%s(): pipelineCreationCacheControl is turned off but pCreateInfos[%" PRIu32
-                             "]has VkPipelineCreateFlags "
-                             "containing VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_EXT or "
-                             "VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT_EXT",
-                             caller_name, index);
+            skip |= LogError(vuid, device, loc, "is %s but pipelineCreationCacheControl feature was not enabled.",
+                             string_VkPipelineCreateFlags(flags).c_str());
         }
     }
     return skip;
 }
 
-bool CoreChecks::ValidatePipelineProtectedAccessFlags(VkPipelineCreateFlags flags, uint32_t index) const {
+bool CoreChecks::ValidatePipelineProtectedAccessFlags(VkPipelineCreateFlags flags, const Location &loc) const {
     bool skip = false;
     if (enabled_features.pipeline_protected_access_features.pipelineProtectedAccess == VK_FALSE) {
         const VkPipelineCreateFlags invalid_flags =
             VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT | VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT;
         if ((flags & invalid_flags) != 0) {
-            skip |= LogError(
-                device, "VUID-VkGraphicsPipelineCreateInfo-pipelineProtectedAccess-07368",
-                "vkCreateGraphicsPipelines(): pipelineProtectedAccess is turned off but pCreateInfos[%" PRIu32
-                "] has VkPipelineCreateFlags "
-                "(%s) "
-                "that contain VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT or VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT",
-                index, string_VkPipelineCreateFlags(flags).c_str());
+            skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pipelineProtectedAccess-07368", device, loc,
+                             "is %s, but pipelineProtectedAccess feature was not enabled.",
+                             string_VkPipelineCreateFlags(flags).c_str());
         }
     }
     if ((flags & VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT) && (flags & VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT)) {
-        skip |= LogError(
-            device, "VUID-VkGraphicsPipelineCreateInfo-flags-07369",
-            "vkCreateGraphicsPipelines(): pCreateInfos[%" PRIu32
-            "] has VkPipelineCreateFlags that "
-            "contains both VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT and VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT",
-            index);
+        skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-flags-07369", device, loc,
+                         "is %s (contains both NO_PROTECTED_ACCESS_BIT and PROTECTED_ACCESS_ONLY_BIT).",
+                         string_VkPipelineCreateFlags(flags).c_str());
     }
     return skip;
 }
@@ -113,58 +96,55 @@ bool CoreChecks::PreCallValidateCreatePipelineCache(VkDevice device, const VkPip
     bool skip = false;
     if (enabled_features.core13.pipelineCreationCacheControl == VK_FALSE) {
         if ((pCreateInfo->flags & VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT) != 0) {
-            skip |= LogError(device, "VUID-VkPipelineCacheCreateInfo-pipelineCreationCacheControl-02892",
-                             "vkCreatePipelineCache(): pipelineCreationCacheControl is turned off but pCreateInfo::flags contains "
-                             "VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT");
+            skip |= LogError("VUID-VkPipelineCacheCreateInfo-pipelineCreationCacheControl-02892", device,
+                             errorObj.location.dot(Field::pCreateInfo).dot(Field::flags),
+                             "includes "
+                             "VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT, but pipelineCreationCacheControl feature "
+                             "was not eanbled");
         }
     }
     return skip;
 }
 
 // This can be chained in the vkCreate*Pipelines() function or the VkPipelineShaderStageCreateInfo
-bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const PIPELINE_STATE &pipeline, const char *parameter_name,
-                                                      const VkPipelineRobustnessCreateInfoEXT &create_info) const {
+bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const PIPELINE_STATE &pipeline,
+                                                      const VkPipelineRobustnessCreateInfoEXT &create_info,
+                                                      const Location &loc) const {
     bool skip = false;
 
     if (!enabled_features.pipeline_robustness_features.pipelineRobustness) {
         if (create_info.storageBuffers != VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT) {
-            skip |= LogError(pipeline.pipeline(), "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06926",
-                             "%s "
-                             "has VkPipelineRobustnessCreateInfoEXT::storageBuffers == %s "
-                             "but the pipelineRobustness feature is not enabled.",
-                             parameter_name, string_VkPipelineRobustnessBufferBehaviorEXT(create_info.storageBuffers));
+            skip |= LogError("VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06926", device,
+                             loc.pNext(Struct::VkPipelineRobustnessCreateInfoEXT, Field::storageBuffers),
+                             "is %s but the pipelineRobustness feature was not enabled.",
+                             string_VkPipelineRobustnessBufferBehaviorEXT(create_info.storageBuffers));
         }
         if (create_info.uniformBuffers != VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT) {
-            skip |= LogError(pipeline.pipeline(), "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06927",
-                             "%s "
-                             "has VkPipelineRobustnessCreateInfoEXT::uniformBuffers == %s "
-                             "but the pipelineRobustness feature is not enabled.",
-                             parameter_name, string_VkPipelineRobustnessBufferBehaviorEXT(create_info.uniformBuffers));
+            skip |= LogError("VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06927", device,
+                             loc.pNext(Struct::VkPipelineRobustnessCreateInfoEXT, Field::uniformBuffers),
+                             "is %s but the pipelineRobustness feature was not enabled.",
+                             string_VkPipelineRobustnessBufferBehaviorEXT(create_info.uniformBuffers));
         }
         if (create_info.vertexInputs != VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_DEVICE_DEFAULT_EXT) {
-            skip |= LogError(pipeline.pipeline(), "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06928",
-                             "%s "
-                             "has VkPipelineRobustnessCreateInfoEXT::vertexInputs == %s "
-                             "but the pipelineRobustness feature is not enabled.",
-                             parameter_name, string_VkPipelineRobustnessBufferBehaviorEXT(create_info.vertexInputs));
+            skip |= LogError("VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06928", device,
+                             loc.pNext(Struct::VkPipelineRobustnessCreateInfoEXT, Field::vertexInputs),
+                             "is %s but the pipelineRobustness feature was not enabled.",
+                             string_VkPipelineRobustnessBufferBehaviorEXT(create_info.vertexInputs));
         }
         if (create_info.images != VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_DEVICE_DEFAULT_EXT) {
-            skip |= LogError(pipeline.pipeline(), "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06929",
-                             "%s "
-                             "has VkPipelineRobustnessCreateInfoEXT::images == %s "
-                             "but the pipelineRobustness feature is not enabled.",
-                             parameter_name, string_VkPipelineRobustnessImageBehaviorEXT(create_info.images));
+            skip |= LogError("VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06929", device,
+                             loc.pNext(Struct::VkPipelineRobustnessCreateInfoEXT, Field::images),
+                             "is %s but the pipelineRobustness feature was not enabled.",
+                             string_VkPipelineRobustnessImageBehaviorEXT(create_info.images));
         }
     }
 
     // These validation depend if the features are exposed (not just enabled)
     if (!has_robust_image_access && create_info.images == VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT) {
-        skip |= LogError(pipeline.pipeline(), "VUID-VkPipelineRobustnessCreateInfoEXT-robustImageAccess-06930",
-                         "%s "
-                         "has VkPipelineRobustnessCreateInfoEXT::images == "
-                         "VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT "
-                         "but robustImageAccess2 is not supported.",
-                         parameter_name);
+        skip |= LogError("VUID-VkPipelineRobustnessCreateInfoEXT-robustImageAccess-06930", device,
+                         loc.pNext(Struct::VkPipelineRobustnessCreateInfoEXT, Field::images),
+                         "is VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT "
+                         "but robustImageAccess2 is not supported.");
     }
     return skip;
 }
@@ -174,17 +154,17 @@ bool CoreChecks::PreCallValidateGetPipelineExecutablePropertiesKHR(VkDevice devi
                                                                    VkPipelineExecutablePropertiesKHR *pProperties,
                                                                    const ErrorObject &errorObj) const {
     bool skip = false;
-    skip |= ValidatePipelineExecutableInfo(device, nullptr, "vkGetPipelineExecutablePropertiesKHR",
+    skip |= ValidatePipelineExecutableInfo(device, nullptr, errorObj.location,
                                            "VUID-vkGetPipelineExecutablePropertiesKHR-pipelineExecutableInfo-03270");
     return skip;
 }
 
 bool CoreChecks::ValidatePipelineExecutableInfo(VkDevice device, const VkPipelineExecutableInfoKHR *pExecutableInfo,
-                                                const char *caller_name, const char *feature_vuid) const {
+                                                const Location &loc, const char *feature_vuid) const {
     bool skip = false;
 
     if (!enabled_features.pipeline_exe_props_features.pipelineExecutableInfo) {
-        skip |= LogError(device, feature_vuid, "%s(): called when pipelineExecutableInfo feature is not enabled.", caller_name);
+        skip |= LogError(feature_vuid, device, loc, "called when pipelineExecutableInfo feature is not enabled.");
     }
 
     // vkGetPipelineExecutablePropertiesKHR will not have struct to validate further
@@ -197,11 +177,12 @@ bool CoreChecks::ValidatePipelineExecutableInfo(VkDevice device, const VkPipelin
         DispatchGetPipelineExecutablePropertiesKHR(device, &pi, &executable_count, NULL);
 
         if (pExecutableInfo->executableIndex >= executable_count) {
-            skip |= LogError(
-                pExecutableInfo->pipeline, "VUID-VkPipelineExecutableInfoKHR-executableIndex-03275",
-                "%s(): VkPipelineExecutableInfo::executableIndex (%1u) must be less than the number of executables associated with "
-                "the pipeline (%1u) as returned by vkGetPipelineExecutablePropertiessKHR",
-                caller_name, pExecutableInfo->executableIndex, executable_count);
+            skip |= LogError("VUID-VkPipelineExecutableInfoKHR-executableIndex-03275", pExecutableInfo->pipeline,
+                             loc.dot(Field::pExecutableInfo).dot(Field::executableIndex),
+                             "(%" PRIu32
+                             ") must be less than the number of executables associated with "
+                             "the pipeline (%" PRIu32 ") as returned by vkGetPipelineExecutablePropertiessKHR.",
+                             pExecutableInfo->executableIndex, executable_count);
         }
     }
 
@@ -214,14 +195,14 @@ bool CoreChecks::PreCallValidateGetPipelineExecutableStatisticsKHR(VkDevice devi
                                                                    VkPipelineExecutableStatisticKHR *pStatistics,
                                                                    const ErrorObject &errorObj) const {
     bool skip = false;
-    skip |= ValidatePipelineExecutableInfo(device, pExecutableInfo, "vkGetPipelineExecutableStatisticsKHR",
+    skip |= ValidatePipelineExecutableInfo(device, pExecutableInfo, errorObj.location,
                                            "VUID-vkGetPipelineExecutableStatisticsKHR-pipelineExecutableInfo-03272");
 
     auto pipeline_state = Get<PIPELINE_STATE>(pExecutableInfo->pipeline);
     if (!(pipeline_state->create_flags & VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR)) {
-        skip |= LogError(pExecutableInfo->pipeline, "VUID-vkGetPipelineExecutableStatisticsKHR-pipeline-03274",
-                         "vkGetPipelineExecutableStatisticsKHR called on a pipeline created without the "
-                         "VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR flag set");
+        skip |= LogError("VUID-vkGetPipelineExecutableStatisticsKHR-pipeline-03274", pExecutableInfo->pipeline, errorObj.location,
+                         "called on a pipeline created without the "
+                         "VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR flag set.");
     }
 
     return skip;
@@ -231,14 +212,15 @@ bool CoreChecks::PreCallValidateGetPipelineExecutableInternalRepresentationsKHR(
     VkDevice device, const VkPipelineExecutableInfoKHR *pExecutableInfo, uint32_t *pInternalRepresentationCount,
     VkPipelineExecutableInternalRepresentationKHR *pStatistics, const ErrorObject &errorObj) const {
     bool skip = false;
-    skip |= ValidatePipelineExecutableInfo(device, pExecutableInfo, "vkGetPipelineExecutableInternalRepresentationsKHR",
+    skip |= ValidatePipelineExecutableInfo(device, pExecutableInfo, errorObj.location,
                                            "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipelineExecutableInfo-03276");
 
     auto pipeline_state = Get<PIPELINE_STATE>(pExecutableInfo->pipeline);
     if (!(pipeline_state->create_flags & VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR)) {
-        skip |= LogError(pExecutableInfo->pipeline, "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipeline-03278",
-                         "vkGetPipelineExecutableInternalRepresentationsKHR called on a pipeline created without the "
-                         "VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR flag set");
+        skip |= LogError("VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipeline-03278", pExecutableInfo->pipeline,
+                         errorObj.location,
+                         "called on a pipeline created without the "
+                         "VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR flag set.");
     }
 
     return skip;
@@ -266,7 +248,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
         std::make_pair(VK_PIPELINE_BIND_POINT_COMPUTE, "VUID-vkCmdBindPipeline-pipelineBindPoint-00778"),
         std::make_pair(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, "VUID-vkCmdBindPipeline-pipelineBindPoint-02391")};
 
-    skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, "vkCmdBindPipeline()", bindpoint_errors);
+    skip |= ValidatePipelineBindPoint(cb_state.get(), pipelineBindPoint, errorObj.location, bindpoint_errors);
 
     auto pPipeline = Get<PIPELINE_STATE>(pipeline);
     assert(pPipeline);
@@ -275,17 +257,17 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
     if (pipelineBindPoint != pipeline_state.pipeline_type) {
         if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS) {
             const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
-            skip |= LogError(objlist, "VUID-vkCmdBindPipeline-pipelineBindPoint-00779",
+            skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-00779", objlist, errorObj.location,
                              "Cannot bind a pipeline of type %s to the graphics pipeline bind point",
                              string_VkPipelineBindPoint(pipeline_state.pipeline_type));
         } else if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_COMPUTE) {
             const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
-            skip |= LogError(objlist, "VUID-vkCmdBindPipeline-pipelineBindPoint-00780",
+            skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-00780", objlist, errorObj.location,
                              "Cannot bind a pipeline of type %s to the compute pipeline bind point",
                              string_VkPipelineBindPoint(pipeline_state.pipeline_type));
         } else if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
             const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
-            skip |= LogError(objlist, "VUID-vkCmdBindPipeline-pipelineBindPoint-02392",
+            skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-02392", objlist, errorObj.location,
                              "Cannot bind a pipeline of type %s to the ray-tracing pipeline bind point",
                              string_VkPipelineBindPoint(pipeline_state.pipeline_type));
         }
@@ -308,7 +290,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
 
                     if (last_bound_provoking_vertex_state_ci && !current_provoking_vertex_state_ci) {
                         const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
-                        skip |= LogError(objlist, "VUID-vkCmdBindPipeline-pipelineBindPoint-04881",
+                        skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-04881", objlist, errorObj.location,
                                          "Previous %s's provokingVertexMode is %s, but %s doesn't chain "
                                          "VkPipelineRasterizationProvokingVertexStateCreateInfoEXT.",
                                          FormatHandle(last_bound.pipeline_state->pipeline()).c_str(),
@@ -316,8 +298,8 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                                          FormatHandle(pipeline).c_str());
                     } else if (!last_bound_provoking_vertex_state_ci && current_provoking_vertex_state_ci) {
                         const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
-                        skip |= LogError(objlist, "VUID-vkCmdBindPipeline-pipelineBindPoint-04881",
-                                         " %s's provokingVertexMode is %s, but previous %s doesn't chain "
+                        skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-04881", objlist, errorObj.location,
+                                         "%s's provokingVertexMode is %s, but previous %s doesn't chain "
                                          "VkPipelineRasterizationProvokingVertexStateCreateInfoEXT.",
                                          FormatHandle(pipeline).c_str(),
                                          string_VkProvokingVertexModeEXT(current_provoking_vertex_state_ci->provokingVertexMode),
@@ -327,7 +309,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                                    current_provoking_vertex_state_ci->provokingVertexMode) {
                         const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
                         skip |=
-                            LogError(objlist, "VUID-vkCmdBindPipeline-pipelineBindPoint-04881",
+                            LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-04881", objlist, errorObj.location,
                                      "%s's provokingVertexMode is %s, but previous %s's provokingVertexMode is %s.",
                                      FormatHandle(pipeline).c_str(),
                                      string_VkProvokingVertexModeEXT(current_provoking_vertex_state_ci->provokingVertexMode),
@@ -342,7 +324,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                 const auto *sample_locations = LvlFindInChain<VkPipelineSampleLocationsStateCreateInfoEXT>(multisample_state);
                 if (sample_locations && sample_locations->sampleLocationsEnable == VK_TRUE &&
                     !pipeline_state.IsDynamic(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT)) {
-                    const VkRenderPassSampleLocationsBeginInfoEXT *sample_locations_begin_info =
+                    const auto *sample_locations_begin_info =
                         LvlFindInChain<VkRenderPassSampleLocationsBeginInfoEXT>(cb_state->active_render_pass_begin_info.pNext);
                     bool found = false;
                     if (sample_locations_begin_info) {
@@ -358,18 +340,13 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                         }
                     }
                     if (!found) {
-                        const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
-                        skip |=
-                            LogError(objlist, "VUID-vkCmdBindPipeline-variableSampleLocations-01525",
-                                     "vkCmdBindPipeline(): VkPhysicalDeviceSampleLocationsPropertiesEXT::variableSampleLocations "
-                                     "is false, pipeline is a graphics pipeline with "
-                                     "VkPipelineSampleLocationsStateCreateInfoEXT::sampleLocationsEnable equal to true and without "
-                                     "VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT, but the current render pass (%" PRIu32
-                                     ") was not begun with any element of "
-                                     "VkRenderPassSampleLocationsBeginInfoEXT::pPostSubpassSampleLocations subpassIndex "
-                                     "matching the current subpass index and sampleLocationsInfo matching sampleLocationsInfo of "
-                                     "VkPipelineSampleLocationsStateCreateInfoEXT the pipeline was created with.",
-                                     cb_state->GetActiveSubpass());
+                        const LogObjectList objlist(cb_state->commandBuffer(), pipeline, cb_state->activeRenderPass->Handle());
+                        skip |= LogError("VUID-vkCmdBindPipeline-variableSampleLocations-01525", objlist, errorObj.location,
+                                         "the current render pass was not begun with any element of "
+                                         "pPostSubpassSampleLocations subpassIndex "
+                                         "matching the current subpass index (%" PRIu32
+                                         ") and sampleLocationsInfo from VkPipelineMultisampleStateCreateInfo of the pipeline.",
+                                         cb_state->GetActiveSubpass());
                     }
                 }
             }
@@ -408,28 +385,27 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
         }
         if (pipeline_state.create_flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) {
             const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
-            skip |= LogError(
-                objlist, "VUID-vkCmdBindPipeline-pipeline-03382",
-                "vkCmdBindPipeline(): Cannot bind a pipeline that was created with the VK_PIPELINE_CREATE_LIBRARY_BIT_KHR flag.");
+            skip |= LogError("VUID-vkCmdBindPipeline-pipeline-03382", objlist, errorObj.location,
+                             "Cannot bind a pipeline that was created with the VK_PIPELINE_CREATE_LIBRARY_BIT_KHR flag.");
         }
         if (cb_state->transform_feedback_active) {
             const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
-            skip |= LogError(objlist, "VUID-vkCmdBindPipeline-None-02323", "vkCmdBindPipeline(): transform feedback is active.");
+            skip |= LogError("VUID-vkCmdBindPipeline-None-02323", objlist, errorObj.location, "transform feedback is active.");
         }
         if (enabled_features.pipeline_protected_access_features.pipelineProtectedAccess) {
             if (cb_state->unprotected) {
                 const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
                 if (pipeline_state.create_flags & VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT) {
-                    skip |= LogError(objlist, "VUID-vkCmdBindPipeline-pipelineProtectedAccess-07409",
-                                     "vkCmdBindPipeline(): Binding pipeline created with "
-                                     "VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT in an unprotected command buffer");
+                    skip |= LogError("VUID-vkCmdBindPipeline-pipelineProtectedAccess-07409", objlist, errorObj.location,
+                                     "Binding pipeline created with "
+                                     "VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT in an unprotected command buffer.");
                 }
             } else {
                 const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
                 if (pipeline_state.create_flags & VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT) {
-                    skip |= LogError(objlist, "VUID-vkCmdBindPipeline-pipelineProtectedAccess-07408",
-                                     "vkCmdBindPipeline(): Binding pipeline created with "
-                                     "VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT in a protected command buffer");
+                    skip |= LogError("VUID-vkCmdBindPipeline-pipelineProtectedAccess-07408", objlist, errorObj.location,
+                                     "Binding pipeline created with "
+                                     "VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT in a protected command buffer.");
                 }
             }
         }
@@ -441,7 +417,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
 // Validates that the supplied bind point is supported for the command buffer (vis. the command pool)
 // Takes array of error codes as some of the VUID's (e.g. vkCmdBindPipeline) are written per bindpoint
 // TODO add vkCmdBindPipeline bind_point validation using this call.
-bool CoreChecks::ValidatePipelineBindPoint(const CMD_BUFFER_STATE *cb_state, VkPipelineBindPoint bind_point, const char *func_name,
+bool CoreChecks::ValidatePipelineBindPoint(const CMD_BUFFER_STATE *cb_state, VkPipelineBindPoint bind_point, const Location &loc,
                                            const std::map<VkPipelineBindPoint, std::string> &bind_errors) const {
     bool skip = false;
     auto pool = cb_state->command_pool;
@@ -454,9 +430,9 @@ bool CoreChecks::ValidatePipelineBindPoint(const CMD_BUFFER_STATE *cb_state, VkP
         };
         const auto &qfp = physical_device_state->queue_family_properties[pool->queueFamilyIndex];
         if (0 == (qfp.queueFlags & flag_mask.at(bind_point))) {
-            const std::string &error = bind_errors.at(bind_point);
+            const std::string &vuid = bind_errors.at(bind_point);
             const LogObjectList objlist(cb_state->commandBuffer(), cb_state->createInfo.commandPool);
-            skip |= LogError(objlist, error, "%s: %s was allocated from %s that does not support bindpoint %s.", func_name,
+            skip |= LogError(vuid, objlist, loc, "%s was allocated from %s that does not support bindpoint %s.",
                              FormatHandle(cb_state->commandBuffer()).c_str(),
                              FormatHandle(cb_state->createInfo.commandPool).c_str(), string_VkPipelineBindPoint(bind_point));
         }
@@ -465,7 +441,7 @@ bool CoreChecks::ValidatePipelineBindPoint(const CMD_BUFFER_STATE *cb_state, VkP
 }
 
 bool CoreChecks::ValidateShaderSubgroupSizeControl(const StageCreateInfo &stage_create_info, VkShaderStageFlagBits stage,
-                                                   const PipelineStageState &stage_state) const {
+                                                   const PipelineStageState &stage_state, const Location &loc) const {
     bool skip = false;
 
     if (stage_create_info.pipeline) {
@@ -473,29 +449,23 @@ bool CoreChecks::ValidateShaderSubgroupSizeControl(const StageCreateInfo &stage_
 
         if ((flags & VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT) != 0 &&
             !enabled_features.core13.subgroupSizeControl) {
-            skip |= LogError(device, "VUID-VkPipelineShaderStageCreateInfo-flags-02784",
-                             "%s(): pCreateInfos[%" PRIu32
-                             "] VkPipelineShaderStageCreateInfo flags contain "
+            skip |= LogError("VUID-VkPipelineShaderStageCreateInfo-flags-02784", device, loc.dot(Field::flags),
+                             "includes "
                              "VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT, "
-                             "but the subgroupSizeControl feature is not enabled.",
-                             stage_create_info.func_name.c_str(), stage_create_info.create_index);
+                             "but the subgroupSizeControl feature was not enabled.");
         }
 
         if ((flags & VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT) != 0) {
             if (!enabled_features.core13.computeFullSubgroups) {
                 skip |=
-                    LogError(device, "VUID-VkPipelineShaderStageCreateInfo-flags-02785",
-                             "%s(): pCreateInfos[%" PRIu32
-                             "] VkPipelineShaderStageCreateInfo flags contain "
+                    LogError("VUID-VkPipelineShaderStageCreateInfo-flags-02785", device, loc.dot(Field::flags),
+                             "includes "
                              "VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT, but the computeFullSubgroups feature "
-                             "is not enabled",
-                             stage_create_info.func_name.c_str(), stage_create_info.create_index);
+                             "was not enabled");
             } else if ((stage & (VK_SHADER_STAGE_MESH_BIT_EXT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_COMPUTE_BIT)) == 0) {
-                skip |= LogError(device, "VUID-VkPipelineShaderStageCreateInfo-flags-08988",
-                                 "%s(): pCreateInfos[%" PRIu32
-                                 "] VkPipelineShaderStageCreateInfo flags contain "
+                skip |= LogError("VUID-VkPipelineShaderStageCreateInfo-flags-08988", device, loc.dot(Field::flags),
+                                 "includes "
                                  "VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT, but the stage is %s.",
-                                 stage_create_info.func_name.c_str(), stage_create_info.create_index,
                                  string_VkShaderStageFlagBits(stage));
             }
         }
@@ -503,11 +473,9 @@ bool CoreChecks::ValidateShaderSubgroupSizeControl(const StageCreateInfo &stage_
         const auto flags = stage_state.shader_object_create_info->flags;
         if ((flags & VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT) != 0) {
             if ((stage & (VK_SHADER_STAGE_MESH_BIT_EXT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_COMPUTE_BIT)) == 0) {
-                skip |= LogError(
-                    device, "VUID-VkShaderCreateInfoEXT-flags-08992",
-                    "%s(): pCreateInfos[%" PRIu32
-                    "].flags contains VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT, but the stage is %s.",
-                    stage_create_info.func_name.c_str(), stage_create_info.create_index, string_VkShaderStageFlagBits(stage));
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08992", device, loc.dot(Field::flags),
+                                 "includes VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT, but the stage is %s.",
+                                 string_VkShaderStageFlagBits(stage));
             }
         }
     }
@@ -516,36 +484,30 @@ bool CoreChecks::ValidateShaderSubgroupSizeControl(const StageCreateInfo &stage_
 }
 
 // Validate that data for each specialization entry is fully contained within the buffer.
-bool CoreChecks::ValidateSpecializations(const safe_VkSpecializationInfo *spec, const StageCreateInfo &create_info) const {
+bool CoreChecks::ValidateSpecializations(const safe_VkSpecializationInfo *spec, const StageCreateInfo &create_info,
+                                         const Location &loc) const {
     bool skip = false;
     if (spec) {
         for (auto i = 0u; i < spec->mapEntryCount; i++) {
+            const Location map_loc = loc.dot(Field::pMapEntries, i);
             if (spec->pMapEntries[i].offset >= spec->dataSize) {
-                skip |= LogError(device, "VUID-VkSpecializationInfo-offset-00773",
-                                 "%s(): pCreateInfos[%" PRIu32 "] Specialization entry %" PRIu32 " (for constant id %" PRIu32
-                                 ") references memory outside provided specialization "
-                                 "data (bytes %" PRIu32 "..%zu; %zu bytes provided).",
-                                 create_info.func_name.c_str(), create_info.create_index, i, spec->pMapEntries[i].constantID,
-                                 spec->pMapEntries[i].offset, spec->pMapEntries[i].offset + spec->dataSize - 1, spec->dataSize);
+                skip |= LogError("VUID-VkSpecializationInfo-offset-00773", device, map_loc.dot(Field::offset),
+                                 "is %" PRIu32 " but dataSize is %zu (for constantID  %" PRIu32 ").", spec->pMapEntries[i].offset,
+                                 spec->dataSize, spec->pMapEntries[i].constantID);
 
                 continue;
             }
             if (spec->pMapEntries[i].offset + spec->pMapEntries[i].size > spec->dataSize) {
-                skip |= LogError(device, "VUID-VkSpecializationInfo-pMapEntries-00774",
-                                 "%s(): pCreateInfos[%" PRIu32 "] Specialization entry %" PRIu32 " (for constant id %" PRIu32
-                                 ") references memory outside provided specialization "
-                                 "data (bytes %" PRIu32 "..%zu; %zu bytes provided).",
-                                 create_info.func_name.c_str(), create_info.create_index, i, spec->pMapEntries[i].constantID,
-                                 spec->pMapEntries[i].offset, spec->pMapEntries[i].offset + spec->pMapEntries[i].size - 1,
-                                 spec->dataSize);
+                skip |= LogError("VUID-VkSpecializationInfo-pMapEntries-00774", device, map_loc.dot(Field::size),
+                                 "(%zu) plus offset (%" PRIu32 ") is greater than dataSize (%zu) (for constantID %" PRIu32 ").",
+                                 spec->pMapEntries[i].size, spec->pMapEntries[i].offset, spec->dataSize,
+                                 spec->pMapEntries[i].constantID);
             }
             for (uint32_t j = i + 1; j < spec->mapEntryCount; ++j) {
                 if (spec->pMapEntries[i].constantID == spec->pMapEntries[j].constantID) {
-                    skip |=
-                        LogError(device, "VUID-VkSpecializationInfo-constantID-04911",
-                                 "%s(): pCreateInfos[%" PRIu32 "] Specialization entry %" PRIu32 " and %" PRIu32
-                                 " have the same constantID (%" PRIu32 ").",
-                                 create_info.func_name.c_str(), create_info.create_index, i, j, spec->pMapEntries[i].constantID);
+                    skip |= LogError("VUID-VkSpecializationInfo-constantID-04911", device, map_loc,
+                                     "and pMapEntries[%" PRIu32 "] both have constantID (%" PRIu32 ").", j,
+                                     spec->pMapEntries[i].constantID);
                 }
             }
         }
@@ -554,7 +516,8 @@ bool CoreChecks::ValidateSpecializations(const safe_VkSpecializationInfo *spec, 
     return skip;
 }
 
-bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const StageCreateInfo &create_info) const {
+bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const StageCreateInfo &create_info,
+                                                 const Location &loc) const {
     bool skip = false;
     uint32_t total_resources = 0;
 
@@ -621,18 +584,16 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
         } else {
             vuid = "VUID-VkGraphicsPipelineCreateInfo-layout-01688";
         }
-        skip |= LogError(device, vuid,
-                         "%s(): pCreateInfos[%" PRIu32
-                         "] Shader Stage %s exceeds component limit "
+        skip |= LogError(vuid, device, loc,
+                         "%s exceeds component limit "
                          "VkPhysicalDeviceLimits::maxPerStageResources (%" PRIu32 ")",
-                         pipeline.GetCreateFunctionName(), pipeline.create_index, string_VkShaderStageFlagBits(stage),
-                         phys_dev_props.limits.maxPerStageResources);
+                         string_VkShaderStageFlagBits(stage), phys_dev_props.limits.maxPerStageResources);
     }
 
     return skip;
 }
 
-bool CoreChecks::ValidateShaderModuleId(const PIPELINE_STATE &pipeline) const {
+bool CoreChecks::ValidateShaderModuleId(const PIPELINE_STATE &pipeline, const Location &loc) const {
     bool skip = false;
     for (const auto &stage_ci : pipeline.shader_stages_ci) {
         const auto module_identifier = LvlFindInChain<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>(stage_ci.pNext);
@@ -640,75 +601,55 @@ bool CoreChecks::ValidateShaderModuleId(const PIPELINE_STATE &pipeline) const {
         if (module_identifier) {
             if (module_identifier->identifierSize > 0) {
                 if (!(enabled_features.shader_module_identifier_features.shaderModuleIdentifier)) {
-                    skip |= LogError(device, "VUID-VkPipelineShaderStageModuleIdentifierCreateInfoEXT-pNext-06850",
-                                     "%s pCreateInfos[%" PRIu32
-                                     "] module (stage %s) VkPipelineShaderStageCreateInfo has a "
+                    skip |= LogError("VUID-VkPipelineShaderStageModuleIdentifierCreateInfoEXT-pNext-06850", device, loc,
+                                     "has a "
                                      "VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
-                                     "struct in the pNext chain but the shaderModuleIdentifier feature is not enabled",
-                                     pipeline.GetCreateFunctionName(), pipeline.create_index,
+                                     "struct in the pNext chain but the shaderModuleIdentifier feature was not enabled. (stage %s)",
                                      string_VkShaderStageFlagBits(stage_ci.stage));
                 }
                 if (!(pipeline.create_flags & VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT)) {
-                    skip |= LogError(
-                        device, "VUID-VkPipelineShaderStageModuleIdentifierCreateInfoEXT-pNext-06851",
-                        "%s pCreateInfos[%" PRIu32
-                        "] module (stage %s) VkPipelineShaderStageCreateInfo has a "
-                        "VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
-                        "struct in the pNext chain whose identifierSize is > 0 (%" PRIu32
-                        "), but the "
-                        "VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT bit is not set in the pipeline create flags",
-                        pipeline.GetCreateFunctionName(), pipeline.create_index, string_VkShaderStageFlagBits(stage_ci.stage),
-                        module_identifier->identifierSize);
+                    skip |= LogError("VUID-VkPipelineShaderStageModuleIdentifierCreateInfoEXT-pNext-06851", pipeline.Handle(),
+                                     loc.pNext(Struct::VkPipelineShaderStageModuleIdentifierCreateInfoEXT, Field::identifierSize),
+                                     "(%" PRIu32 "), but the pipeline was created with %s. (stage %s)",
+                                     module_identifier->identifierSize, string_VkPipelineCreateFlags(pipeline.create_flags).c_str(),
+                                     string_VkShaderStageFlagBits(stage_ci.stage));
                 }
                 if (module_identifier->identifierSize > VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT) {
-                    skip |= LogError(device, "VUID-VkPipelineShaderStageModuleIdentifierCreateInfoEXT-identifierSize-06852",
-                                     "%s pCreateInfos[%" PRIu32
-                                     "] module (stage %s) VkPipelineShaderStageCreateInfo has a "
-                                     "VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
-                                     "struct in the pNext chain whose identifierSize (%" PRIu32
-                                     ") is > VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT (%" PRIu32 ")",
-                                     pipeline.GetCreateFunctionName(), pipeline.create_index,
-                                     string_VkShaderStageFlagBits(stage_ci.stage), module_identifier->identifierSize,
-                                     VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT);
+                    skip |=
+                        LogError("VUID-VkPipelineShaderStageModuleIdentifierCreateInfoEXT-identifierSize-06852", device,
+                                 loc.pNext(Struct::VkPipelineShaderStageModuleIdentifierCreateInfoEXT, Field::identifierSize),
+                                 "(%" PRIu32 ") is larger than VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT (%" PRIu32 "). (stage %s).",
+                                 module_identifier->identifierSize, VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT,
+                                 string_VkShaderStageFlagBits(stage_ci.stage));
                 }
             }
             if (module_create_info) {
-                skip |=
-                    LogError(device, "VUID-VkPipelineShaderStageCreateInfo-stage-06844",
-                             "%s pCreateInfos[%" PRIu32
-                             "] module (stage %s) VkPipelineShaderStageCreateInfo has both a "
-                             "VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
-                             "struct and a VkShaderModuleCreateInfo struct in the pNext chain",
-                             pipeline.GetCreateFunctionName(), pipeline.create_index, string_VkShaderStageFlagBits(stage_ci.stage));
+                skip |= LogError("VUID-VkPipelineShaderStageCreateInfo-stage-06844", device, loc,
+                                 "has both a "
+                                 "VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
+                                 "struct and a VkShaderModuleCreateInfo struct in the pNext chain. (stage %s).",
+                                 string_VkShaderStageFlagBits(stage_ci.stage));
             }
             if (stage_ci.module != VK_NULL_HANDLE) {
-                skip |= LogError(
-                    device, "VUID-VkPipelineShaderStageCreateInfo-stage-06848",
-                    "%s pCreateInfos[%" PRIu32
-                    "] module (stage %s) VkPipelineShaderStageCreateInfo has a VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
-                    "struct in the pNext chain, and module is not VK_NULL_HANDLE",
-                    pipeline.GetCreateFunctionName(), pipeline.create_index, string_VkShaderStageFlagBits(stage_ci.stage));
+                skip |= LogError("VUID-VkPipelineShaderStageCreateInfo-stage-06848", device, loc,
+                                 "has a VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
+                                 "struct in the pNext chain, but module is not VK_NULL_HANDLE. (stage %s).",
+                                 string_VkShaderStageFlagBits(stage_ci.stage));
             }
         } else {
             if (enabled_features.graphics_pipeline_library_features.graphicsPipelineLibrary) {
                 if (stage_ci.module == VK_NULL_HANDLE && !module_create_info) {
-                    skip |= LogError(device, "VUID-VkPipelineShaderStageCreateInfo-stage-06845",
-                                     "%s pCreateInfos[%" PRIu32
-                                     "] module (stage %s) VkPipelineShaderStageCreateInfo has no "
-                                     "VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
-                                     "struct and no VkShaderModuleCreateInfo struct in the pNext chain, and module is not a valid "
-                                     "VkShaderModule",
-                                     pipeline.GetCreateFunctionName(), pipeline.create_index,
+                    skip |= LogError("VUID-VkPipelineShaderStageCreateInfo-stage-06845", device, loc,
+                                     "module is not a valid VkShaderModule, but no "
+                                     "VkPipelineShaderStageModuleIdentifierCreateInfoEXT or VkShaderModuleCreateInfo found in the "
+                                     "pNext chain. (stage %s).",
                                      string_VkShaderStageFlagBits(stage_ci.stage));
                 }
             } else if (stage_ci.module == VK_NULL_HANDLE && !enabled_features.maintenance5_features.maintenance5) {
-                skip |= LogError(
-                    device, "VUID-VkPipelineShaderStageCreateInfo-stage-08771",
-                    "%s pCreateInfos[%" PRIu32
-                    "] module (stage %s) VkPipelineShaderStageCreateInfo has no VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
-                    "struct in the pNext chain, the neither graphicsPipelineLibrary or maintenance5 feature are not enabled, and "
-                    "module is not a valid VkShaderModule",
-                    pipeline.GetCreateFunctionName(), pipeline.create_index, string_VkShaderStageFlagBits(stage_ci.stage));
+                skip |= LogError("VUID-VkPipelineShaderStageCreateInfo-stage-08771", device, loc,
+                                 "module is not a valid VkShaderModule and both teh graphicsPipelineLibrary and maintenance5 "
+                                 "features were not enabled. (stage %s).",
+                                 string_VkShaderStageFlagBits(stage_ci.stage));
             }
         }
     }

--- a/layers/core_checks/cc_pipeline_compute.cpp
+++ b/layers/core_checks/cc_pipeline_compute.cpp
@@ -22,9 +22,9 @@
 #include "generated/chassis.h"
 #include "core_validation.h"
 
-bool CoreChecks::ValidateComputePipelineShaderState(const PIPELINE_STATE &pipeline) const {
+bool CoreChecks::ValidateComputePipelineShaderState(const PIPELINE_STATE &pipeline, const Location &loc) const {
     StageCreateInfo stage_create_info("vkCreateComputePipelines", &pipeline);
-    return ValidatePipelineShaderStage(stage_create_info, pipeline.stage_states[0]);
+    return ValidatePipelineShaderStage(stage_create_info, pipeline.stage_states[0], loc.dot(Field::stage));
 }
 
 bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
@@ -40,16 +40,15 @@ bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipeli
         if (!pipeline) {
             continue;
         }
-        skip |= ValidateComputePipelineShaderState(*pipeline);
-        skip |= ValidateShaderModuleId(*pipeline);
-        skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, i, "vkCreateComputePipelines",
+        const Location loc = errorObj.location.dot(Field::pCreateInfos, i);
+        skip |= ValidateComputePipelineShaderState(*pipeline, loc);
+        skip |= ValidateShaderModuleId(*pipeline, loc);
+        skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, loc.dot(Field::flags),
                                                   "VUID-VkComputePipelineCreateInfo-pipelineCreationCacheControl-02875");
 
         if (const auto *pipeline_robustness_info = LvlFindInChain<VkPipelineRobustnessCreateInfoEXT>(pCreateInfos[i].pNext);
             pipeline_robustness_info) {
-            std::stringstream parameter_name;
-            parameter_name << "vkCreateComputePipelines(): pCreateInfos[" << i << "]";
-            skip |= ValidatePipelineRobustnessCreateInfo(*pipeline, parameter_name.str().c_str(), *pipeline_robustness_info);
+            skip |= ValidatePipelineRobustnessCreateInfo(*pipeline, *pipeline_robustness_info, loc);
         }
     }
     return skip;

--- a/layers/core_checks/cc_pipeline_ray_tracing.cpp
+++ b/layers/core_checks/cc_pipeline_ray_tracing.cpp
@@ -24,152 +24,140 @@
 
 bool CoreChecks::ValidateRayTracingPipeline(const PIPELINE_STATE &pipeline,
                                             const safe_VkRayTracingPipelineCreateInfoCommon &create_info,
-                                            VkPipelineCreateFlags flags, bool isKHR) const {
+                                            VkPipelineCreateFlags flags, const Location &loc) const {
     bool skip = false;
+    bool isKHR = loc.function == Func::vkCreateRayTracingPipelinesKHR;
 
     if (isKHR) {
         if (create_info.maxPipelineRayRecursionDepth > phys_dev_ext_props.ray_tracing_props_khr.maxRayRecursionDepth) {
-            skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-maxPipelineRayRecursionDepth-03589",
-                             "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32
-                             "] maxPipelineRayRecursionDepth (%d ) must be less than or equal to "
-                             "VkPhysicalDeviceRayTracingPipelinePropertiesKHR::maxRayRecursionDepth %d",
-                             pipeline.create_index, create_info.maxPipelineRayRecursionDepth,
-                             phys_dev_ext_props.ray_tracing_props_khr.maxRayRecursionDepth);
+            skip |=
+                LogError("VUID-VkRayTracingPipelineCreateInfoKHR-maxPipelineRayRecursionDepth-03589", device,
+                         loc.dot(Field::maxPipelineRayRecursionDepth),
+                         "(%" PRIu32
+                         ") must be less than or equal to "
+                         "maxRayRecursionDepth (%" PRIu32 ").",
+                         create_info.maxPipelineRayRecursionDepth, phys_dev_ext_props.ray_tracing_props_khr.maxRayRecursionDepth);
         }
         if (create_info.pLibraryInfo) {
             for (uint32_t i = 0; i < create_info.pLibraryInfo->libraryCount; ++i) {
+                const Location library_info_loc = loc.dot(Field::pLibraryInfo);
+                const Location library_loc = library_info_loc.dot(Field::pLibraries, i);
                 const auto library_pipelinestate = Get<PIPELINE_STATE>(create_info.pLibraryInfo->pLibraries[i]);
                 const auto &library_create_info = library_pipelinestate->GetCreateInfo<VkRayTracingPipelineCreateInfoKHR>();
                 if (library_create_info.maxPipelineRayRecursionDepth != create_info.maxPipelineRayRecursionDepth) {
                     skip |= LogError(
-                        device, "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraries-03591",
-                        "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32 "] pLibraries[%" PRIu32
-                        "] member of libraries must have been"
-                        "created with the value of maxPipelineRayRecursionDepth (%d) equal to that in this pipeline (%d) .",
-                        pipeline.create_index, i, library_create_info.maxPipelineRayRecursionDepth,
-                        create_info.maxPipelineRayRecursionDepth);
+                        "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraries-03591", device, library_loc,
+                        "was created with maxPipelineRayRecursionDepth (%" PRIu32 ") which is not equal %s (%" PRIu32 ") .",
+                        library_create_info.maxPipelineRayRecursionDepth,
+                        loc.dot(Field::maxPipelineRayRecursionDepth).Fields().c_str(), create_info.maxPipelineRayRecursionDepth);
                 }
                 if (library_create_info.pLibraryInfo && (library_create_info.pLibraryInterface->maxPipelineRayHitAttributeSize !=
                                                              create_info.pLibraryInterface->maxPipelineRayHitAttributeSize ||
                                                          library_create_info.pLibraryInterface->maxPipelineRayPayloadSize !=
                                                              create_info.pLibraryInterface->maxPipelineRayPayloadSize)) {
-                    skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03593",
-                                     "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32 "] pLibraries[%" PRIu32
-                                     "] must have been created with values of the maxPipelineRayPayloadSize and "
-                                     "maxPipelineRayHitAttributeSize members of pLibraryInterface equal to those in this pipeline",
-                                     pipeline.create_index, i);
+                    skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03593", device, library_loc,
+                                     "was created with maxPipelineRayPayloadSize (%" PRIu32
+                                     ") and "
+                                     "maxPipelineRayHitAttributeSize (%" PRIu32 ") which is not equal to %s values of (%" PRIu32
+                                     ") and (%" PRIu32 ").",
+                                     library_create_info.pLibraryInterface->maxPipelineRayPayloadSize,
+                                     library_create_info.pLibraryInterface->maxPipelineRayHitAttributeSize,
+                                     loc.dot(Field::pLibraryInterface).Fields().c_str(),
+                                     create_info.pLibraryInterface->maxPipelineRayPayloadSize,
+                                     create_info.pLibraryInterface->maxPipelineRayHitAttributeSize);
                 }
                 if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR) &&
                     !(library_create_info.flags & VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR)) {
                     skip |=
-                        LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-flags-03594",
-                                 "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32
-                                 "] If flags includes "
-                                 "VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR, pLibraries[%" PRIu32
-                                 "] must have been created with the "
-                                 "VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR bit set",
-                                 pipeline.create_index, i);
+                        LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-03594", device, library_loc,
+                                 "was created with %s, which is missing "
+                                 "VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR included in %s (%s).",
+                                 string_VkPipelineCreateFlags(flags).c_str(), loc.dot(Field::flags).Fields().c_str(),
+                                 string_VkPipelineCreateFlags(library_create_info.flags).c_str());
                 }
             }
         }
     } else {
         if (create_info.maxRecursionDepth > phys_dev_ext_props.ray_tracing_props_nv.maxRecursionDepth) {
-            skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoNV-maxRecursionDepth-03457",
-                             "vkCreateRayTracingPipelinesNV: pCreateInfos[%" PRIu32
-                             "] maxRecursionDepth (%d) must be less than or equal to "
-                             "VkPhysicalDeviceRayTracingPropertiesNV::maxRecursionDepth (%d)",
-                             pipeline.create_index, create_info.maxRecursionDepth,
-                             phys_dev_ext_props.ray_tracing_props_nv.maxRecursionDepth);
+            skip |=
+                LogError("VUID-VkRayTracingPipelineCreateInfoNV-maxRecursionDepth-03457", device, loc.dot(Field::maxRecursionDepth),
+                         "(%" PRIu32
+                         ") must be less than or equal to "
+                         "maxRecursionDepth (%" PRIu32 ")",
+                         create_info.maxRecursionDepth, phys_dev_ext_props.ray_tracing_props_nv.maxRecursionDepth);
         }
     }
     const auto *groups = create_info.ptr()->pGroups;
 
-    for (auto &stage_state : pipeline.stage_states) {
+    for (uint32_t i = 0; i < pipeline.stage_states.size(); i++) {
         StageCreateInfo stage_create_info("vkCreateRayTracingPipelinesKHR", &pipeline);
-        skip |= ValidatePipelineShaderStage(stage_create_info, stage_state);
+        skip |= ValidatePipelineShaderStage(stage_create_info, pipeline.stage_states[i], loc.dot(Field::pStages, i));
     }
 
     if (const auto *pipeline_robustness_info = LvlFindInChain<VkPipelineRobustnessCreateInfoEXT>(create_info.pNext);
         pipeline_robustness_info) {
-        std::stringstream parameter_name;
-        parameter_name << "vkCreateRayTracingPipelinesKHR(): pCreateInfos[" << pipeline.create_index << "]";
-        skip |= ValidatePipelineRobustnessCreateInfo(pipeline, parameter_name.str().c_str(), *pipeline_robustness_info);
+        skip |= ValidatePipelineRobustnessCreateInfo(pipeline, *pipeline_robustness_info, loc);
     }
 
     if ((create_info.flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) {
         const uint32_t raygen_stages_count = CalcShaderStageCount(pipeline, VK_SHADER_STAGE_RAYGEN_BIT_KHR);
         if (raygen_stages_count == 0) {
             skip |= LogError(
-                device,
                 isKHR ? "VUID-VkRayTracingPipelineCreateInfoKHR-stage-03425" : "VUID-VkRayTracingPipelineCreateInfoNV-stage-06232",
-                "vkCreateRayTracingPipelinesKHR : pCreateInfos[%" PRIu32
-                "] The stage member of at least one element of pStages must be VK_SHADER_STAGE_RAYGEN_BIT_KHR.",
-                pipeline.create_index);
+                device, loc, "The stage member of at least one element of pStages must be VK_SHADER_STAGE_RAYGEN_BIT_KHR.");
         }
     }
     if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR) != 0 &&
         (flags & VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR) != 0) {
-        skip |= LogError(device, "VUID-VkRayTracingPipelineCreateInfoKHR-flags-06546",
-                         "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32
-                         "] flags (%s) contains both VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR and "
-                         "VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR bits.",
-                         pipeline.create_index, string_VkPipelineCreateFlags(flags).c_str());
+        skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-06546", device, loc.dot(Field::flags),
+                         "is %s (contains both SKIP_TRIANGLES and SKIP_AABBS).", string_VkPipelineCreateFlags(flags).c_str());
     }
 
     for (uint32_t group_index = 0; group_index < create_info.groupCount; group_index++) {
         const auto &group = groups[group_index];
+        const Location &group_loc = loc.dot(Field::pGroups, group_index);
 
         if (group.type == VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_NV) {
             if (!GroupHasValidIndex(
                     pipeline, group.generalShader,
                     VK_SHADER_STAGE_RAYGEN_BIT_NV | VK_SHADER_STAGE_MISS_BIT_NV | VK_SHADER_STAGE_CALLABLE_BIT_NV)) {
-                skip |= LogError(device,
-                                 isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03474"
+                skip |= LogError(isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03474"
                                        : "VUID-VkRayTracingShaderGroupCreateInfoNV-type-02413",
-                                 "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32 "] pGroups[%d]", pipeline.create_index,
-                                 group_index);
+                                 device, group_loc.dot(Field::generalShader), "is %" PRIu32 ".", group.generalShader);
             }
             if (group.anyHitShader != VK_SHADER_UNUSED_NV || group.closestHitShader != VK_SHADER_UNUSED_NV ||
                 group.intersectionShader != VK_SHADER_UNUSED_NV) {
-                skip |= LogError(device,
-                                 isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03475"
+                skip |= LogError(isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03475"
                                        : "VUID-VkRayTracingShaderGroupCreateInfoNV-type-02414",
-                                 "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32 "] pGroups[%d]", pipeline.create_index,
-                                 group_index);
+                                 device, group_loc,
+                                 "anyHitShader is %" PRIu32 ", closestHitShader is %" PRIu32 ", intersectionShader is %" PRIu32 ".",
+                                 group.anyHitShader, group.closestHitShader, group.intersectionShader);
             }
         } else if (group.type == VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_NV) {
             if (!GroupHasValidIndex(pipeline, group.intersectionShader, VK_SHADER_STAGE_INTERSECTION_BIT_NV)) {
-                skip |= LogError(device,
-                                 isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03476"
+                skip |= LogError(isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03476"
                                        : "VUID-VkRayTracingShaderGroupCreateInfoNV-type-02415",
-                                 "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32 "] pGroups[%d]", pipeline.create_index,
-                                 group_index);
+                                 device, group_loc.dot(Field::intersectionShader), "is %" PRIu32 ".", group.intersectionShader);
             }
         } else if (group.type == VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_NV) {
             if (group.intersectionShader != VK_SHADER_UNUSED_NV) {
-                skip |= LogError(device,
-                                 isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03477"
+                skip |= LogError(isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-type-03477"
                                        : "VUID-VkRayTracingShaderGroupCreateInfoNV-type-02416",
-                                 "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32 "] pGroups[%d]", pipeline.create_index,
-                                 group_index);
+                                 device, group_loc.dot(Field::intersectionShader), "is %" PRIu32 ".", group.intersectionShader);
             }
         }
 
         if (group.type == VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_NV ||
             group.type == VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_NV) {
             if (!GroupHasValidIndex(pipeline, group.anyHitShader, VK_SHADER_STAGE_ANY_HIT_BIT_KHR)) {
-                skip |= LogError(device,
-                                 isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-anyHitShader-03479"
+                skip |= LogError(isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-anyHitShader-03479"
                                        : "VUID-VkRayTracingShaderGroupCreateInfoNV-anyHitShader-02418",
-                                 "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32 "] pGroups[%d]", pipeline.create_index,
-                                 group_index);
+                                 device, group_loc.dot(Field::anyHitShader), "is %" PRIu32 ".", group.anyHitShader);
             }
             if (!GroupHasValidIndex(pipeline, group.closestHitShader, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR)) {
-                skip |= LogError(device,
-                                 isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-closestHitShader-03478"
+                skip |= LogError(isKHR ? "VUID-VkRayTracingShaderGroupCreateInfoKHR-closestHitShader-03478"
                                        : "VUID-VkRayTracingShaderGroupCreateInfoNV-closestHitShader-02417",
-                                 "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32 "] pGroups[%d]", pipeline.create_index,
-                                 group_index);
+                                 device, group_loc.dot(Field::closestHitShader), "is %" PRIu32 ".", group.closestHitShader);
             }
         }
     }
@@ -189,6 +177,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkP
         if (!pipeline) {
             continue;
         }
+        const Location loc = errorObj.location.dot(Field::pCreateInfos, i);
         using CIType = vvl::base_type<decltype(pCreateInfos)>;
         if (pipeline->create_flags & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
             std::shared_ptr<const PIPELINE_STATE> base_pipeline;
@@ -200,18 +189,16 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkP
                 base_pipeline = Get<PIPELINE_STATE>(bph);
             }
             if (!base_pipeline || !(base_pipeline->create_flags & VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT)) {
-                skip |=
-                    LogError(device, "VUID-vkCreateRayTracingPipelinesNV-flags-03416",
-                             "vkCreateRayTracingPipelinesNV: pCreateInfos[%" PRIu32
-                             "]  If the flags member of any element of pCreateInfos contains the "
-                             "VK_PIPELINE_CREATE_DERIVATIVE_BIT flag,"
-                             "the base pipeline must have been created with the VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT flag set.",
-                             i);
+                skip |= LogError(
+                    "VUID-vkCreateRayTracingPipelinesNV-flags-03416", device, loc,
+                    "If the flags member of any element of pCreateInfos contains the "
+                    "VK_PIPELINE_CREATE_DERIVATIVE_BIT flag,"
+                    "the base pipeline must have been created with the VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT flag set.");
             }
         }
-        skip |= ValidateRayTracingPipeline(*pipeline, pipeline->GetCreateInfo<CIType>(), pCreateInfos[i].flags, /*isKHR*/ false);
-        skip |= ValidateShaderModuleId(*pipeline);
-        skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, i, "vkCreateRayTracingPipelinesNV",
+        skip |= ValidateRayTracingPipeline(*pipeline, pipeline->GetCreateInfo<CIType>(), pCreateInfos[i].flags, loc);
+        skip |= ValidateShaderModuleId(*pipeline, loc);
+        skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, loc.dot(Field::flags),
                                                   "VUID-VkRayTracingPipelineCreateInfoNV-pipelineCreationCacheControl-02905");
     }
     return skip;
@@ -231,6 +218,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
         if (!pipeline) {
             continue;
         }
+        const Location loc = errorObj.location.dot(Field::pCreateInfos, i);
         using CIType = vvl::base_type<decltype(pCreateInfos)>;
         if (pipeline->create_flags & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
             std::shared_ptr<const PIPELINE_STATE> base_pipeline;
@@ -242,18 +230,16 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
                 base_pipeline = Get<PIPELINE_STATE>(bph);
             }
             if (!base_pipeline || !(base_pipeline->create_flags & VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT)) {
-                skip |=
-                    LogError(device, "VUID-vkCreateRayTracingPipelinesKHR-flags-03416",
-                             "vkCreateRayTracingPipelinesKHR: pCreateInfos[%" PRIu32
-                             "]  If the flags member of any element of pCreateInfos contains the "
-                             "VK_PIPELINE_CREATE_DERIVATIVE_BIT flag,"
-                             "the base pipeline must have been created with the VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT flag set.",
-                             i);
+                skip |= LogError(
+                    "VUID-vkCreateRayTracingPipelinesKHR-flags-03416", device, loc,
+                    "If the flags member of any element of pCreateInfos contains the "
+                    "VK_PIPELINE_CREATE_DERIVATIVE_BIT flag,"
+                    "the base pipeline must have been created with the VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT flag set.");
             }
         }
-        skip |= ValidateRayTracingPipeline(*pipeline, pipeline->GetCreateInfo<CIType>(), pCreateInfos[i].flags, /*isKHR*/ true);
-        skip |= ValidateShaderModuleId(*pipeline);
-        skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, i, "vkCreateRayTracingPipelinesKHR",
+        skip |= ValidateRayTracingPipeline(*pipeline, pipeline->GetCreateInfo<CIType>(), pCreateInfos[i].flags, loc);
+        skip |= ValidateShaderModuleId(*pipeline, loc);
+        skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, loc.dot(Field::flags),
                                                   "VUID-VkRayTracingPipelineCreateInfoKHR-pipelineCreationCacheControl-02905");
         const auto create_info = pipeline->GetCreateInfo<VkRayTracingPipelineCreateInfoKHR>();
         if (create_info.pLibraryInfo) {
@@ -269,37 +255,36 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
                 {"VUID-VkRayTracingPipelineCreateInfoKHR-flags-04723", VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR},
                 {"VUID-VkRayTracingPipelineCreateInfoKHR-flags-07403", VK_PIPELINE_CREATE_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT},
             }};
-            unsigned int descriptor_buffer_library_count = 0;
+            bool uses_descriptor_buffer = false;
             for (uint32_t j = 0; j < create_info.pLibraryInfo->libraryCount; ++j) {
+                const Location library_info_loc = loc.dot(Field::pLibraryInfo);
+                const Location library_loc = library_info_loc.dot(Field::pLibraries, j);
                 const auto lib = Get<PIPELINE_STATE>(create_info.pLibraryInfo->pLibraries[j]);
                 if ((lib->create_flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) {
-                    skip |= LogError(device, "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-03381",
-                                     "vkCreateRayTracingPipelinesKHR(): pCreateInfo[%" PRIu32 "].pLibraryInfo->pLibraries[%" PRIu32
-                                     "] was not created with VK_PIPELINE_CREATE_LIBRARY_BIT_KHR.",
-                                     i, j);
-                }
-                if (lib->descriptor_buffer_mode) {
-                    ++descriptor_buffer_library_count;
+                    skip |= LogError("VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-03381", device, library_loc,
+                                     "was created with %s.", string_VkPipelineCreateFlags(lib->create_flags).c_str());
                 }
                 for (const auto &pair : vuid_map) {
                     if (pipeline->create_flags & pair.second) {
                         if ((lib->create_flags & pair.second) == 0) {
-                            skip |= LogError(device, pair.first,
-                                             "vkCreateRayTracingPipelinesKHR(): pCreateInfo[%" PRIu32
-                                             "].flags contains %s bit, but pCreateInfo[%" PRIu32
-                                             "].pLibraryInfo->pLibraries[%" PRIu32 "] was created without it.",
-                                             i, string_VkPipelineCreateFlags(pair.second).c_str(), i, j);
+                            skip |= LogError(
+                                pair.first, device, library_loc, "was created with %s, which is missing %s included in %s (%s).",
+                                string_VkPipelineCreateFlags(lib->create_flags).c_str(),
+                                string_VkPipelineCreateFlags(pair.second).c_str(), loc.dot(Field::flags).Fields().c_str(),
+                                string_VkPipelineCreateFlags(pipeline->create_flags).c_str());
                         }
                     }
                 }
-            }
-            if ((descriptor_buffer_library_count != 0) &&
-                (create_info.pLibraryInfo->libraryCount != descriptor_buffer_library_count)) {
-                skip |= LogError(device, "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-08096",
-                                 "vkCreateRayTracingPipelinesKHR(): All or none of the elements of pCreateInfo[%" PRIu32
-                                 "].pLibraryInfo->pLibraries must be created "
-                                 "with VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT.",
-                                 i);
+
+                if (j == 0) {
+                    uses_descriptor_buffer = lib->descriptor_buffer_mode;
+                } else if (uses_descriptor_buffer != lib->descriptor_buffer_mode) {
+                    skip |= LogError(
+                        "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-08096", device, library_loc,
+                        "%s created with VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT which is opopposite of pLibraries[0].",
+                        lib->descriptor_buffer_mode ? "was" : "was not");
+                    break;  // no point keep checking as might have many of same error
+                }
             }
         }
     }

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -272,12 +272,13 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
 
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         if (pCreateInfos[i].codeType == VK_SHADER_CODE_TYPE_SPIRV_EXT) {
+            const Location loc = errorObj.location.dot(Field::pCreateInfos, i);
             const StageCreateInfo stage_create_info("vkCreateShadersEXT", i, pCreateInfos[i]);
             const auto spirv =
                 std::make_shared<SPIRV_MODULE_STATE>(pCreateInfos[i].codeSize, static_cast<const uint32_t*>(pCreateInfos[i].pCode));
             safe_VkShaderCreateInfoEXT safe_create_info = safe_VkShaderCreateInfoEXT(&pCreateInfos[i]);
             const PipelineStageState stage_state(nullptr, &safe_create_info, nullptr, spirv);
-            skip |= ValidatePipelineShaderStage(stage_create_info, stage_state);
+            skip |= ValidatePipelineShaderStage(stage_create_info, stage_state, loc);
         }
     }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -483,10 +483,11 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateIdleDescriptorSet(VkDescriptorSet set, const Location& loc) const;
     bool ValidatePipelineLibraryFlags(const VkGraphicsPipelineLibraryFlagsEXT lib_flags,
                                       const VkPipelineLibraryCreateInfoKHR& link_info,
-                                      const VkPipelineRenderingCreateInfo* rendering_struct, uint32_t pipe_index, int lib_index,
+                                      const VkPipelineRenderingCreateInfo* rendering_struct, const Location& loc, int lib_index,
                                       const char* vuid) const;
-    bool ValidatePipelineDerivatives(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipelines, uint32_t pipe_index) const;
-    bool ValidateGraphicsPipeline(const PIPELINE_STATE& pipeline) const;
+    bool ValidatePipelineDerivatives(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipelines, uint32_t pipe_index,
+                                     const Location& loc) const;
+    bool ValidateGraphicsPipeline(const PIPELINE_STATE& pipeline, const Location& loc) const;
     bool ValidImageBufferQueue(const CMD_BUFFER_STATE& cb_state, const VulkanTypedHandle& object, uint32_t queueFamilyIndex,
                                uint32_t count, const uint32_t* indices, const Location& loc) const;
     bool ValidateFenceForSubmit(const FENCE_STATE* pFence, const char* inflight_vuid, const char* retired_vuid,
@@ -545,10 +546,9 @@ class CoreChecks : public ValidationStateTracker {
 
     bool ValidatePipelineVertexDivisors(const safe_VkPipelineVertexInputStateCreateInfo& input_state,
                                         const std::vector<VkVertexInputBindingDescription>& binding_descriptions,
-                                        const uint32_t pipe_index) const;
-    bool ValidatePipelineCacheControlFlags(VkPipelineCreateFlags flags, uint32_t index, const char* caller_name,
-                                           const char* vuid) const;
-    bool ValidatePipelineProtectedAccessFlags(VkPipelineCreateFlags flags, uint32_t index) const;
+                                        const Location& loc) const;
+    bool ValidatePipelineCacheControlFlags(VkPipelineCreateFlags flags, const Location& loc, const char* vuid) const;
+    bool ValidatePipelineProtectedAccessFlags(VkPipelineCreateFlags flags, const Location& loc) const;
     template <typename ImgBarrier>
     void EnqueueSubmitTimeValidateImageBarrierAttachment(const Location& loc, CMD_BUFFER_STATE* cb_state,
                                                          const ImgBarrier& barrier);
@@ -623,7 +623,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const* pCreateInfo, const SURFACE_STATE* surface_state,
                                  const SWAPCHAIN_NODE* old_swapchain_state, const Location& loc) const;
     bool ValidateGraphicsPipelineBindPoint(const CMD_BUFFER_STATE* cb_state, const PIPELINE_STATE& pipeline) const;
-    bool ValidatePipelineBindPoint(const CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point, const char* func_name,
+    bool ValidatePipelineBindPoint(const CMD_BUFFER_STATE* cb_state, VkPipelineBindPoint bind_point, const Location& loc,
                                    const std::map<VkPipelineBindPoint, std::string>& bind_errors) const;
     bool ValidateMemoryIsMapped(uint32_t memoryRangeCount, const VkMappedMemoryRange* pMemoryRanges,
                                 const ErrorObject& errorObj) const;
@@ -943,31 +943,31 @@ class CoreChecks : public ValidationStateTracker {
                                       const VkCopyDescriptorSet* p_cds, const char* func_name) const;
 
     // Stuff from shader_validation
-    bool ValidateGraphicsPipelineShaderState(const PIPELINE_STATE& pipeline) const;
+    bool ValidateGraphicsPipelineShaderState(const PIPELINE_STATE& pipeline, const Location& loc) const;
     bool ValidateGraphicsPipelinePortability(const PIPELINE_STATE& pipeline) const;
-    bool ValidateGraphicsPipelineLibrary(const PIPELINE_STATE& pipeline) const;
+    bool ValidateGraphicsPipelineLibrary(const PIPELINE_STATE& pipeline, const Location& loc) const;
     bool ValidateGraphicsPipelineShaderDynamicState(const PIPELINE_STATE& pipeline, const CMD_BUFFER_STATE& cb_state,
                                                     const char* caller, const DrawDispatchVuid& vuid) const;
-    bool ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE& pipeline) const;
-    bool ValidateGraphicsPipelinePreRasterState(const PIPELINE_STATE& pipeline) const;
-    bool ValidateGraphicsPipelineInputAssemblyState(const PIPELINE_STATE& pipeline) const;
-    bool ValidateGraphicsPipelineColorBlendState(const PIPELINE_STATE& pipeline,
-                                                 const safe_VkSubpassDescription2* subpass_desc) const;
-    bool ValidateGraphicsPipelineRasterizationState(const PIPELINE_STATE& pipeline,
-                                                    const safe_VkSubpassDescription2* subpass_desc) const;
-    bool ValidateGraphicsPipelineMultisampleState(const PIPELINE_STATE& pipeline,
-                                                  const safe_VkSubpassDescription2* subpass_desc) const;
-    bool ValidateGraphicsPipelineDepthStencilState(const PIPELINE_STATE& pipeline) const;
+    bool ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE& pipeline, const Location& loc) const;
+    bool ValidateGraphicsPipelinePreRasterState(const PIPELINE_STATE& pipeline, const Location& loc) const;
+    bool ValidateGraphicsPipelineInputAssemblyState(const PIPELINE_STATE& pipeline, const Location& loc) const;
+    bool ValidateGraphicsPipelineColorBlendState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
+                                                 const Location& loc) const;
+    bool ValidateGraphicsPipelineRasterizationState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
+                                                    const Location& loc) const;
+    bool ValidateGraphicsPipelineMultisampleState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
+                                                  const Location& loc) const;
+    bool ValidateGraphicsPipelineDepthStencilState(const PIPELINE_STATE& pipeline, const Location& loc) const;
     bool ValidateGraphicsPipelineDynamicState(const PIPELINE_STATE& pipeline) const;
-    bool ValidateGraphicsPipelineFragmentShadingRateState(const PIPELINE_STATE& pipeline) const;
-    bool ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE& pipeline) const;
-    bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline) const;
-    bool ValidatePipelineRobustnessCreateInfo(const PIPELINE_STATE& pipeline, const char* parameter_name,
-                                              const VkPipelineRobustnessCreateInfoEXT& create_info) const;
+    bool ValidateGraphicsPipelineFragmentShadingRateState(const PIPELINE_STATE& pipeline, const Location& loc) const;
+    bool ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE& pipeline, const Location& loc) const;
+    bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline, const Location& loc) const;
+    bool ValidatePipelineRobustnessCreateInfo(const PIPELINE_STATE& pipeline, const VkPipelineRobustnessCreateInfoEXT& create_info,
+                                              const Location& loc) const;
     uint32_t CalcShaderStageCount(const PIPELINE_STATE& pipeline, VkShaderStageFlagBits stageBit) const;
     bool GroupHasValidIndex(const PIPELINE_STATE& pipeline, uint32_t group, uint32_t stage) const;
     bool ValidateRayTracingPipeline(const PIPELINE_STATE& pipeline, const safe_VkRayTracingPipelineCreateInfoCommon& create_info,
-                                    VkPipelineCreateFlags flags, bool isKHR) const;
+                                    VkPipelineCreateFlags flags, const Location& loc) const;
     bool PreCallValidateGetShaderModuleIdentifierEXT(VkDevice device, VkShaderModule shaderModule,
                                                      VkShaderModuleIdentifierEXT* pIdentifier,
                                                      const ErrorObject& errorObj) const override;
@@ -983,65 +983,72 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                            const ErrorObject& errorObj) const override;
-    bool ValidatePipelineShaderStage(const StageCreateInfo& stage_create_info, const PipelineStageState& stage_state) const;
+    bool ValidatePipelineShaderStage(const StageCreateInfo& stage_create_info, const PipelineStageState& stage_state,
+                                     const Location& loc) const;
     bool ValidatePointSizeShaderState(const StageCreateInfo& create_info, const SPIRV_MODULE_STATE& module_state,
-                                      const EntryPoint& entrypoint, VkShaderStageFlagBits stage) const;
+                                      const EntryPoint& entrypoint, VkShaderStageFlagBits stage, const Location& loc) const;
     bool ValidatePrimitiveRateShaderState(const StageCreateInfo& create_info, const SPIRV_MODULE_STATE& module_state,
-                                          const EntryPoint& entrypoint, VkShaderStageFlagBits stage) const;
-    bool ValidateTexelOffsetLimits(const SPIRV_MODULE_STATE& module_state, const Instruction& insn) const;
+                                          const EntryPoint& entrypoint, VkShaderStageFlagBits stage, const Location& loc) const;
+    bool ValidateTexelOffsetLimits(const SPIRV_MODULE_STATE& module_state, const Instruction& insn, const Location& loc) const;
 
     // Auto-generated helper functions
-    bool ValidateShaderCapabilitiesAndExtensions(const Instruction& insn, const bool pipeline) const;
+    bool ValidateShaderCapabilitiesAndExtensions(const Instruction& insn, const bool pipeline, const Location& loc) const;
     VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) const;
 
     bool ValidateShaderStageInputOutputLimits(const SPIRV_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
-                                              const StageCreateInfo& create_info, const EntryPoint& entrypoint) const;
-    bool ValidateShaderStorageImageFormatsVariables(const SPIRV_MODULE_STATE& module_state, const Instruction* insn) const;
-    bool ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const StageCreateInfo& create_info) const;
-    bool ValidateShaderStageGroupNonUniform(const SPIRV_MODULE_STATE& module_state, VkShaderStageFlagBits stage) const;
-    bool ValidateMemoryScope(const SPIRV_MODULE_STATE& module_state, const Instruction& insn) const;
+                                              const StageCreateInfo& create_info, const EntryPoint& entrypoint,
+                                              const Location& loc) const;
+    bool ValidateShaderStorageImageFormatsVariables(const SPIRV_MODULE_STATE& module_state, const Instruction* insn,
+                                                    const Location& loc) const;
+    bool ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const StageCreateInfo& create_info,
+                                         const Location& loc) const;
+    bool ValidateShaderStageGroupNonUniform(const SPIRV_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
+                                            const Location& loc) const;
+    bool ValidateMemoryScope(const SPIRV_MODULE_STATE& module_state, const Instruction& insn, const Location& loc) const;
     bool ValidateCooperativeMatrix(const SPIRV_MODULE_STATE& module_state, const PipelineStageState& stage_state) const;
     bool ValidateCooperativeMatrixKHR(const SPIRV_MODULE_STATE& module_state, const PipelineStageState& stage_state,
                                       const uint32_t local_size_x) const;
     bool ValidateShaderResolveQCOM(const SPIRV_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
-                                   const StageCreateInfo& create_info) const;
+                                   const StageCreateInfo& create_info, const Location& loc) const;
     bool ValidateShaderSubgroupSizeControl(const StageCreateInfo& stage_create_info, VkShaderStageFlagBits stage,
-                                           const PipelineStageState& stage_state) const;
+                                           const PipelineStageState& stage_state, const Location& loc) const;
     bool ValidateWorkgroupSharedMemory(const SPIRV_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
-                                       uint32_t total_workgroup_shared_memory) const;
+                                       uint32_t total_workgroup_shared_memory, const Location& loc) const;
     bool ValidateShaderTileImage(const SPIRV_MODULE_STATE& module_state, const EntryPoint& entrypoint,
-                                 const StageCreateInfo& create_info, const VkShaderStageFlagBits stage) const;
-    bool ValidateAtomicsTypes(const SPIRV_MODULE_STATE& module_state) const;
+                                 const StageCreateInfo& create_info, const VkShaderStageFlagBits stage, const Location& loc) const;
+    bool ValidateAtomicsTypes(const SPIRV_MODULE_STATE& module_state, const Location& loc) const;
     bool ValidateExecutionModes(const SPIRV_MODULE_STATE& module_state, const EntryPoint& entrypoint, VkShaderStageFlagBits stage,
-                                const StageCreateInfo& create_info) const;
+                                const StageCreateInfo& create_info, const Location& loc) const;
     bool ValidateInterfaceVertexInput(const PIPELINE_STATE& pipeline, const SPIRV_MODULE_STATE& module_state,
                                       const EntryPoint& entrypoint) const;
     bool ValidateInterfaceFragmentOutput(const PIPELINE_STATE& pipeline, const SPIRV_MODULE_STATE& module_state,
                                          const EntryPoint& entrypoint) const;
     bool ValidateShaderInputAttachment(const SPIRV_MODULE_STATE& module_state, const PIPELINE_STATE& pipeline,
-                                       const ResourceInterfaceVariable& variable) const;
+                                       const ResourceInterfaceVariable& variable, const Location& loc) const;
     bool ValidateConservativeRasterization(const SPIRV_MODULE_STATE& module_state, const EntryPoint& entrypoint,
-                                           const StageCreateInfo& stage_create_info) const;
+                                           const StageCreateInfo& stage_create_info, const Location& loc) const;
     bool ValidatePushConstantUsage(const StageCreateInfo& create_info, const SPIRV_MODULE_STATE& module_state,
-                                   const EntryPoint& entrypoint) const;
+                                   const EntryPoint& entrypoint, const Location& loc) const;
     bool ValidateBuiltinLimits(const SPIRV_MODULE_STATE& module_state, const EntryPoint& entrypoint,
-                               const StageCreateInfo& create_info) const;
-    bool ValidateSpecializations(const safe_VkSpecializationInfo* spec, const StageCreateInfo& create_info) const;
+                               const StageCreateInfo& create_info, const Location& loc) const;
+    bool ValidateSpecializations(const safe_VkSpecializationInfo* spec, const StageCreateInfo& create_info,
+                                 const Location& loc) const;
     bool RequirePropertyFlag(const SPIRV_MODULE_STATE& module_state, VkBool32 check, char const* flag, char const* structure,
                              const char* vuid) const;
     bool RequireFeature(const SPIRV_MODULE_STATE& module_state, VkBool32 feature, char const* feature_name, const char* vuid) const;
     bool ValidateInterfaceBetweenStages(const SPIRV_MODULE_STATE& producer, const EntryPoint& producer_entrypoint,
                                         const SPIRV_MODULE_STATE& consumer, const EntryPoint& consumer_entrypoint,
                                         uint32_t pipe_index) const;
-    bool ValidateVariables(const SPIRV_MODULE_STATE& module_state) const;
-    bool ValidateShaderDescriptorVariable(const SPIRV_MODULE_STATE& module_state, VkShaderStageFlagBits stage,
-                                          const StageCreateInfo& stage_create_info, const EntryPoint& entrypoint) const;
+    bool ValidateVariables(const SPIRV_MODULE_STATE& module_state, const Location& loc) const;
+    bool ValidateShaderDescriptorVariable(const SPIRV_MODULE_STATE& module_state, const StageCreateInfo& stage_create_info,
+                                          const EntryPoint& entrypoint, const Location& loc) const;
     bool ValidateTransformFeedback(const SPIRV_MODULE_STATE& module_state, const EntryPoint& entrypoint,
-                                   const StageCreateInfo& create_info) const;
-    bool ValidateTransformFeedbackDecorations(const SPIRV_MODULE_STATE& module_state, const StageCreateInfo& create_info) const;
-    virtual bool ValidateShaderModuleId(const PIPELINE_STATE& pipeline) const;
-    bool ValidateShaderClock(const SPIRV_MODULE_STATE& module_state) const;
-    bool ValidateImageWrite(const SPIRV_MODULE_STATE& module_state) const;
+                                   const StageCreateInfo& create_info, const Location& loc) const;
+    bool ValidateTransformFeedbackDecorations(const SPIRV_MODULE_STATE& module_state, const StageCreateInfo& create_info,
+                                              const Location& loc) const;
+    virtual bool ValidateShaderModuleId(const PIPELINE_STATE& pipeline, const Location& loc) const;
+    bool ValidateShaderClock(const SPIRV_MODULE_STATE& module_state, const Location& loc) const;
+    bool ValidateImageWrite(const SPIRV_MODULE_STATE& module_state, const Location& loc) const;
 
     template <typename RegionType>
     bool ValidateCopyImageTransferGranularityRequirements(const CMD_BUFFER_STATE& cb_state, const IMAGE_STATE& src_image_state,
@@ -1507,8 +1514,8 @@ class CoreChecks : public ValidationStateTracker {
                                                            uint32_t* pExecutableCount,
                                                            VkPipelineExecutablePropertiesKHR* pProperties,
                                                            const ErrorObject& errorObj) const override;
-    bool ValidatePipelineExecutableInfo(VkDevice device, const VkPipelineExecutableInfoKHR* pExecutableInfo,
-                                        const char* caller_name, const char* feature_vuid) const;
+    bool ValidatePipelineExecutableInfo(VkDevice device, const VkPipelineExecutableInfoKHR* pExecutableInfo, const Location& loc,
+                                        const char* feature_vuid) const;
     bool PreCallValidateGetPipelineExecutableStatisticsKHR(VkDevice device, const VkPipelineExecutableInfoKHR* pExecutableInfo,
                                                            uint32_t* pStatisticCount, VkPipelineExecutableStatisticKHR* pStatistic,
                                                            const ErrorObject& errorObjs) const override;
@@ -1791,7 +1798,7 @@ class CoreChecks : public ValidationStateTracker {
                                              const ErrorObject& errorObj) const override;
     bool PreCallValidateCmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor, float depthBiasClamp,
                                         float depthBiasSlopeFactor, const ErrorObject& errorObj) const override;
-    bool ValidateDepthBiasRepresentationInfo(const char* caller, const LogObjectList& objlist,
+    bool ValidateDepthBiasRepresentationInfo(const Location& loc, const LogObjectList& objlist,
                                              const VkDepthBiasRepresentationInfoEXT& depth_bias_representation) const;
     bool PreCallValidateCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const VkDepthBiasInfoEXT* pDepthBiasInfo,
                                             const ErrorObject& errorObj) const override;
@@ -2283,10 +2290,10 @@ class CoreChecks : public ValidationStateTracker {
                                                  const ErrorObject& errorObj) const override;
     bool ValidateComputeWorkGroupSizes(const SPIRV_MODULE_STATE& module_state, const EntryPoint& entrypoint,
                                        const PipelineStageState& stage_state, uint32_t local_size_x, uint32_t local_size_y,
-                                       uint32_t local_size_z) const;
+                                       uint32_t local_size_z, const Location& loc) const;
     bool ValidateTaskMeshWorkGroupSizes(const SPIRV_MODULE_STATE& module_state, const EntryPoint& entrypoint,
                                         const PipelineStageState& stage_state, uint32_t local_size_x, uint32_t local_size_y,
-                                        uint32_t local_size_z) const;
+                                        uint32_t local_size_z, const Location& loc) const;
 
     bool ValidateResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
                                 const ErrorObject& errorObj) const;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -203,22 +203,6 @@ class PIPELINE_STATE : public BASE_NODE {
 
     void SetHandle(VkPipeline p) { handle_.handle = CastToUint64(p); }
 
-    inline const char *GetCreateFunctionName() const {
-        switch (create_info.graphics.sType) {
-            case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO:
-                return "vkCreateGraphicsPipelines";
-            case VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO:
-                return "vkCreateComputePipelines";
-            case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV:
-                return "vkCreateRayTracingPipelinesNV";
-            case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR:
-                return "vkCreateRayTracingPipelinesKHR";
-            default:
-                assert(false);
-                return "";
-        }
-    }
-
     bool IsGraphicsLibrary() const { return !HasFullState(); }
     bool HasFullState() const {
         // First make sure that this pipeline is a "classic" pipeline, or is linked together with the appropriate sub-state

--- a/scripts/generators/spirv_validation_generator.py
+++ b/scripts/generators/spirv_validation_generator.py
@@ -339,17 +339,15 @@ static inline const char* SpvExtensionRequirments(std::string_view extension) {
         #
         # The main function to validate all the extensions and capabilities
         out.append('''
-bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn, const bool pipeline) const {
+bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn, const bool pipeline, const Location& loc) const {
     bool skip = false;
-
-    const char *func_name = pipeline ? "vkCreateShaderModule" : "vkCreateShadersEXT";
 
     if (insn.Opcode() == spv::OpCapability) {
         // All capabilities are generated so if it is not in the list it is not supported by Vulkan
         if (spirvCapabilities.count(insn.Word(1)) == 0) {
             const char *vuid = pipeline ? "VUID-VkShaderModuleCreateInfo-pCode-08739" : "VUID-VkShaderCreateInfoEXT-pCode-08739";
-            skip |= LogError(device, vuid,
-                "%s(): A SPIR-V Capability (%s) was declared that is not supported by Vulkan.", func_name, string_SpvCapability(insn.Word(1)));
+            skip |= LogError(vuid, device, loc,
+                "SPIR-V has Capability (%s) declared, but this is not supported by Vulkan.", string_SpvCapability(insn.Word(1)));
             return skip; // no known capability to validate
         }
 
@@ -403,16 +401,16 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn
 
         if (has_support == false) {
             const char *vuid = pipeline ? "VUID-VkShaderModuleCreateInfo-pCode-08740" : "VUID-VkShaderCreateInfoEXT-pCode-08740";
-            skip |= LogError(device, vuid,
-                "%s(): The SPIR-V Capability (%s) was declared, but one of the following requirements is required (%s).", func_name, string_SpvCapability(insn.Word(1)), SpvCapabilityRequirments(insn.Word(1)));
+            skip |= LogError(vuid, device, loc,
+                "SPIR-V Capability %s was declared, but one of the following requirements is required (%s).", string_SpvCapability(insn.Word(1)), SpvCapabilityRequirments(insn.Word(1)));
         }
 
         // Portability checks
         if (IsExtEnabled(device_extensions.vk_khr_portability_subset)) {
             if ((VK_FALSE == enabled_features.portability_subset_features.shaderSampleRateInterpolationFunctions) &&
                 (spv::CapabilityInterpolationFunction == insn.Word(1))) {
-                skip |= LogError(device, "VUID-RuntimeSpirv-shaderSampleRateInterpolationFunctions-06325",
-                                    "Invalid shader capability (portability error): interpolation functions are not supported "
+                skip |= LogError("VUID-RuntimeSpirv-shaderSampleRateInterpolationFunctions-06325", device, loc,
+                                    "SPIR-V (portability error) InterpolationFunction Capability are not supported "
                                     "by this platform");
             }
         }
@@ -423,16 +421,16 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn
         if (0 == extension_name.compare(0, spv_prefix.size(), spv_prefix)) {
             if (spirvExtensions.count(extension_name) == 0) {
                 const char *vuid = pipeline ? "VUID-VkShaderModuleCreateInfo-pCode-08741" : "VUID-VkShaderCreateInfoEXT-pCode-08741";
-                skip |= LogError(device, vuid,
-                    "%s(): A SPIR-V Extension (%s) was declared that is not supported by Vulkan.", func_name, extension_name.c_str());
+                skip |= LogError(vuid, device,loc,
+                    "SPIR-V Extension %s was declared, but that is not supported by Vulkan.", extension_name.c_str());
                 return skip; // no known extension to validate
             }
         } else {
             const char *vuid = pipeline ? "VUID-VkShaderModuleCreateInfo-pCode-08741" : "VUID-VkShaderCreateInfoEXT-pCode-08741";
-            skip |= LogError(device, vuid,
-                "%s(): The SPIR-V code uses the '%s' extension which is not a SPIR-V extension. Please use a SPIR-V"
+            skip |= LogError( vuid, device,loc,
+                "SPIR-V Extension %s was declared, but this is not a SPIR-V extension. Please use a SPIR-V"
                 " extension (https://github.com/KhronosGroup/SPIRV-Registry) for OpExtension instructions. Non-SPIR-V extensions can be"
-                " recorded in SPIR-V using the OpSourceExtension instruction.", func_name, extension_name.c_str());
+                " recorded in SPIR-V using the OpSourceExtension instruction.", extension_name.c_str());
             return skip; // no known extension to validate
         }
 
@@ -459,8 +457,8 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const Instruction &insn
 
         if (has_support == false) {
             const char *vuid = pipeline ? "VUID-VkShaderModuleCreateInfo-pCode-08742" : "VUID-VkShaderCreateInfoEXT-pCode-08742";
-            skip |= LogError(device, vuid,
-                "%s(): The SPIR-V Extension (%s) was declared, but one of the following requirements is required (%s).", func_name, extension_name.c_str(), SpvExtensionRequirments(extension_name));
+            skip |= LogError(vuid, device, loc,
+                "SPIR-V Extension %s was declared, but one of the following requirements is required (%s).", extension_name.c_str(), SpvExtensionRequirments(extension_name));
         }
     } //spv::OpExtension
     return skip;

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -943,7 +943,7 @@ TEST_F(NegativePipelineLayout, UniformBlockNotProvided) {
     TEST_DESCRIPTION(
         "Test that an error is produced for a shader consuming a uniform block which has no corresponding binding in the pipeline "
         "layout");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "not declared in pipeline layout");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07988");
 
     ASSERT_NO_FATAL_FAILURE(Init());
 

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -4945,7 +4945,7 @@ TEST_F(NegativeShaderObject, SpecializationSameConstantId) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeShaderObject, MissingEntryPoint) {
+TEST_F(NegativeShaderObject, MissingEntrypoint) {
     TEST_DESCRIPTION("Create shader with invalid spirv code size.");
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderCreateInfoEXT-pName-08440");


### PR DESCRIPTION
This is just updating a LOT of `LogError` to use the new `Location` flow (not 100% coverage, some errors need more attention)

for Pipeline - we use to have the `create_index` and various other things carried around the pipeline state, this provides much better error messages, mainly focused knowing where in the massive `VkGraphicsPipelineCreateInfo` an error is

For shaders - before were almost never saying much about when the called occured, with the new `VK_EXT_shader_object` this is more important. This tries to replace the word `shader` for `SPIR-V` where it makes the most sense to prevent confusion about the new `VkShadersEXT` object