### PR TITLE
scripts: Add upcoming unicode to ascii in VUID

### DIFF
--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -81,6 +81,12 @@ class ValidationJSON:
             '\u2026' : '...',# HORIZONTAL ELLIPSIS
             '\u2032' : "'",  # PRIME
             '\u2192' : '->', # RIGHTWARDS ARROW
+            '\u2308' : '⌈', # LEFT CEILING
+            '\u2309' : '⌉', # RIGHT CEILING
+            '\u230a' : '⌊', # LEFT FLOOR
+            '\u230b' : '⌋', # RIGHT FLOOR
+            '\u00d7' : '×', # MULTIPLICATION SIGN
+            '\u2264' : '≤', # LESS-THAN OR EQUAL TO
         }
 
     def sanitize(self, text, location):


### PR DESCRIPTION
The change in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6084 will improve the strings such as

```patch
-    {"VUID-BaryCoordKHR-BaryCoordKHR-04154", "The BaryCoordKHR decoration must be used only within the Fragment {ExecutionModel}", "1.3-extensions"},
+    {"VUID-BaryCoordKHR-BaryCoordKHR-04154", "The BaryCoordKHR decoration must be used only within the Fragment Execution Model", "1.3-extensions"},

-    {"VUID-VkImageSubresourceRange-aspectMask-02278", "aspectMask must not include VK_IMAGE_ASPECT_MEMORY_PLANE{ibit}BIT_EXT for any index i", "1.3-extensions"},
+    {"VUID-VkImageSubresourceRange-aspectMask-02278", "aspectMask must not include VK_IMAGE_ASPECT_MEMORY_PLANE_i_BIT_EXT for any index i", "1.3-extensions"},
```

there are some new Unicode that we need to catch