### PR TITLE
layers: Don't print null or unknown object handles

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -95,8 +95,10 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
     std::vector<VkDebugUtilsObjectNameInfoEXT> object_name_infos;
     object_name_infos.reserve(objects.object_list.size());
     for (uint32_t i = 0; i < objects.object_list.size(); i++) {
-        // If only one VkDevice was created, it is just noise to print it out in the error message
-        if (objects.object_list[i].type == kVulkanObjectTypeDevice && debug_data->device_created <= 1) {
+        // If only one VkDevice was created, it is just noise to print it out in the error message.
+        // Also avoid printing unknown objects, likely if new function is calling error with null LogObjectList
+        if ((objects.object_list[i].type == kVulkanObjectTypeDevice && debug_data->device_created <= 1) ||
+            (objects.object_list[i].type == kVulkanObjectTypeUnknown) || (objects.object_list[i].handle == 0)) {
             continue;
         }
 


### PR DESCRIPTION
With things like `VK_EXT_shader_object` we can hit most the runtime SPIR-V validation at

1. Pipeline creation time, which will have a `VkShaderModule` handle
2. At `VkCreateShadersEXT` time which just has the `VkDevice` handle

currently we print out

> Validation Error: [ VUID-RuntimeSpirv-vulkanMemoryModel-06265 ] Object 0: VK_NULL_HANDLE, type = VK_OBJECT_TYPE_UNKNOWN;

which I find no useful and see no reason to ever print out objects that are null or unknown