### PR TITLE
Add check for queue that supports graphics to ray tracing GPU-AV

### DIFF
--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -209,7 +209,7 @@ class GpuAssisted : public GpuAssistedBase {
                                                          VkResult result) override;
     void PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                    VkBuffer* pBuffer, void* cb_state_data) override;
-    void CreateAccelerationStructureBuildValidationState();
+    void CreateAccelerationStructureBuildValidationState(const VkDeviceCreateInfo* pCreateInfo);
     void PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer commandBuffer, const VkAccelerationStructureInfoNV* pInfo,
                                                       VkBuffer instanceData, VkDeviceSize instanceOffset, VkBool32 update,
                                                       VkAccelerationStructureNV dst, VkAccelerationStructureNV src,


### PR DESCRIPTION
Fixes a crash in dEQP-VK.api.fill_and_update_buffer.suballocation_transfer_queue.fill_buffer_whole