### PR TITLE
layers: Fix buffer size not using createInfo size

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -409,11 +409,11 @@ bool CoreChecks::ValidateCmdBindIndexBuffer(const CMD_BUFFER_STATE &cb_state, co
         skip |= LogError(vuid, objlist, loc.dot(Field::offset), "(%" PRIu64 ") does not fall on alignment (%s) boundary.", offset,
                          string_VkIndexType(indexType));
     }
-    if (offset >= buffer_state.requirements.size) {
+    if (offset >= buffer_state.createInfo.size) {
         const LogObjectList objlist(cb_state.commandBuffer(), buffer_state.buffer());
         vuid = is_2 ? "VUID-vkCmdBindIndexBuffer2KHR-offset-08782" : "VUID-vkCmdBindIndexBuffer-offset-08782";
         skip |= LogError(vuid, objlist, loc.dot(Field::offset), "(%" PRIu64 ") is not less than the size (%" PRIu64 ").", offset,
-                         buffer_state.requirements.size);
+                         buffer_state.createInfo.size);
     }
 
     return skip;
@@ -440,12 +440,12 @@ bool CoreChecks::PreCallValidateCmdBindIndexBuffer2KHR(VkCommandBuffer commandBu
                              "vkCmdBindIndexBuffer2KHR() size (%" PRIu64 ") does not fall on alignment (%s) boundary.", size,
                              string_VkIndexType(indexType));
         }
-        if ((offset + size) > buffer_state->requirements.size) {
+        if ((offset + size) > buffer_state->createInfo.size) {
             const LogObjectList objlist(commandBuffer, buffer);
             skip |= LogError(commandBuffer, "VUID-vkCmdBindIndexBuffer2KHR-size-08768",
                              "vkCmdBindIndexBuffer2KHR() size (%" PRIu64 ") + offset (%" PRIu64
                              ") is larger then the buffer size (%" PRIu64 ").",
-                             size, offset, buffer_state->requirements.size);
+                             size, offset, buffer_state->createInfo.size);
         }
     }
     return skip;

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -656,15 +656,14 @@ TEST_F(NegativeBuffer, IndexBufferOffset) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-    VkBufferObj buffer(*m_device, 32, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    VkMemoryRequirements mem_reqs;
-    vk::GetBufferMemoryRequirements(m_device->device(), buffer.handle(), &mem_reqs);
+    const uint32_t buffer_size = 32;
+    VkBufferObj buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
     // Set offset over buffer size
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindIndexBuffer-offset-08782");
-    m_commandBuffer->BindIndexBuffer(&buffer, mem_reqs.size + sizeof(uint32_t), VK_INDEX_TYPE_UINT32);
+    m_commandBuffer->BindIndexBuffer(&buffer, buffer_size + 4, VK_INDEX_TYPE_UINT32);
     m_errorMonitor->VerifyFound();
 
     // Set offset to be misaligned with index buffer UINT32 type
@@ -698,16 +697,14 @@ TEST_F(NegativeBuffer, IndexBuffer2Offset) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-    VkBufferObj buffer(*m_device, 32, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    VkMemoryRequirements mem_reqs;
-    vk::GetBufferMemoryRequirements(m_device->device(), buffer.handle(), &mem_reqs);
+    const uint32_t buffer_size = 32;
+    VkBufferObj buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
     // Set offset over buffer size
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindIndexBuffer2KHR-offset-08782");
-    vk::CmdBindIndexBuffer2KHR(m_commandBuffer->handle(), buffer.handle(), mem_reqs.size + sizeof(uint32_t), VK_WHOLE_SIZE,
-                               VK_INDEX_TYPE_UINT32);
+    vk::CmdBindIndexBuffer2KHR(m_commandBuffer->handle(), buffer.handle(), buffer_size + 4, VK_WHOLE_SIZE, VK_INDEX_TYPE_UINT32);
     m_errorMonitor->VerifyFound();
 
     // Set offset to be misaligned with index buffer UINT32 type
@@ -740,7 +737,8 @@ TEST_F(NegativeBuffer, IndexBuffer2Size) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkBufferObj buffer(*m_device, 32, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    const uint32_t buffer_size = 32;
+    VkBufferObj buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(m_device->device(), buffer.handle(), &mem_reqs);
     m_commandBuffer->begin();
@@ -751,7 +749,7 @@ TEST_F(NegativeBuffer, IndexBuffer2Size) {
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindIndexBuffer2KHR-size-08768");
-    vk::CmdBindIndexBuffer2KHR(m_commandBuffer->handle(), buffer.handle(), 4, mem_reqs.size, VK_INDEX_TYPE_UINT32);
+    vk::CmdBindIndexBuffer2KHR(m_commandBuffer->handle(), buffer.handle(), 4, buffer_size, VK_INDEX_TYPE_UINT32);
     m_errorMonitor->VerifyFound();
 
     m_commandBuffer->EndRenderPass();

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -203,15 +203,14 @@ TEST_F(PositiveBuffer, IndexBuffer2Size) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkBufferObj buffer(*m_device, 32, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    VkMemoryRequirements mem_reqs;
-    vk::GetBufferMemoryRequirements(m_device->device(), buffer.handle(), &mem_reqs);
+    const uint32_t buffer_size = 32;
+    VkBufferObj buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindIndexBuffer2KHR(m_commandBuffer->handle(), buffer.handle(), 4, 8, VK_INDEX_TYPE_UINT32);
 
-    vk::CmdBindIndexBuffer2KHR(m_commandBuffer->handle(), buffer.handle(), 0, mem_reqs.size, VK_INDEX_TYPE_UINT32);
+    vk::CmdBindIndexBuffer2KHR(m_commandBuffer->handle(), buffer.handle(), 0, buffer_size, VK_INDEX_TYPE_UINT32);
 
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();


### PR DESCRIPTION
as clarified here https://gitlab.khronos.org/vulkan/vulkan/-/issues/3588

> VUID-vkCmdBindIndexBuffer-offset-08782
>
> offset must be less than the size of buffer

the `size` here is the `VkBufferCreateInfo` size, not the requirements, this is the only case we were doing it wrong