### PR TITLE
tests: Use constructor over init

### DIFF
--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -669,8 +669,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumberOfSubmissions) {
     }
 
     uint32_t current_buffer;
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore image_acquired(*m_device, semaphore_create_info);
+    vk_testing::Semaphore image_acquired(*m_device);
     ASSERT_TRUE(image_acquired.initialized());
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, image_acquired.handle(), VK_NULL_HANDLE, &current_buffer);
 

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -1553,10 +1553,7 @@ TEST_F(VkBestPracticesLayerTest, SemaphoreSetWhenCountIsZero) {
     ASSERT_NO_FATAL_FAILURE(InitBestPracticesFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-
-    auto semaphore_ci = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore;
-    semaphore.init(*m_device, semaphore_ci);
+    vk_testing::Semaphore semaphore(*m_device);
     VkSemaphore semaphore_handle = semaphore.handle();
 
     VkSubmitInfo signal_submit_info = LvlInitStruct<VkSubmitInfo>();

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -194,8 +194,7 @@ TEST_F(NegativeBuffer, BufferViewObject) {
         buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
         buffer_create_info.queueFamilyIndexCount = 1;
         buffer_create_info.pQueueFamilyIndices = &queue_family_index;
-        VkBufferObj buffer;
-        buffer.init(*m_device, buffer_create_info);
+        VkBufferObj buffer(*m_device, buffer_create_info);
 
         VkBufferViewCreateInfo bvci = LvlInitStruct<VkBufferViewCreateInfo>();
         bvci.buffer = buffer.handle();
@@ -891,8 +890,7 @@ TEST_F(NegativeBuffer, ConditionalRenderingBufferUsage) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 1024;
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     VkConditionalRenderingBeginInfoEXT conditional_rendering_begin = LvlInitStruct<VkConditionalRenderingBeginInfoEXT>();
     conditional_rendering_begin.buffer = buffer.handle();
@@ -918,8 +916,7 @@ TEST_F(NegativeBuffer, ConditionalRenderingOffset) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 128;
     buffer_create_info.usage = VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     VkConditionalRenderingBeginInfoEXT conditional_rendering_begin = LvlInitStruct<VkConditionalRenderingBeginInfoEXT>();
     conditional_rendering_begin.buffer = buffer.handle();
@@ -952,8 +949,7 @@ TEST_F(NegativeBuffer, BeginConditionalRendering) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 32;
     buffer_create_info.usage = VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     VkConditionalRenderingBeginInfoEXT conditional_rendering_begin = LvlInitStruct<VkConditionalRenderingBeginInfoEXT>();
     conditional_rendering_begin.buffer = buffer.handle();

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -5105,8 +5105,7 @@ TEST_F(NegativeCommand, IndirectDraw) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
     buffer_create_info.size = sizeof(VkDrawIndirectCommand);
-    VkBufferObj draw_buffer;
-    draw_buffer.init(*m_device, buffer_create_info);
+    VkBufferObj draw_buffer(*m_device, buffer_create_info);
 
     VkBufferObj draw_buffer_correct;
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
@@ -6079,9 +6078,7 @@ TEST_F(NegativeCommand, EndConditionalRendering) {
     rpci.dependencyCount = 1;
     rpci.pDependencies = &dep;
 
-    vk_testing::RenderPass render_pass;
-    render_pass.init(*m_device, rpci);
-    ASSERT_TRUE(render_pass.initialized());
+    vk_testing::RenderPass render_pass(*m_device, rpci);
 
     VkImageObj image(m_device);
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
@@ -6100,8 +6097,7 @@ TEST_F(NegativeCommand, EndConditionalRendering) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 32;
     buffer_create_info.usage = VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     VkConditionalRenderingBeginInfoEXT conditional_rendering_begin = LvlInitStruct<VkConditionalRenderingBeginInfoEXT>();
     conditional_rendering_begin.buffer = buffer.handle();
@@ -6696,8 +6692,7 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
     rp_ci.subpassCount = 1;
     rp_ci.pSubpasses = &subpass;
 
-    vk_testing::RenderPass render_pass;
-    render_pass.init(*m_device, rp_ci);
+    vk_testing::RenderPass render_pass(*m_device, rp_ci);
 
     auto depth_state_info = LvlInitStruct<VkPipelineDepthStencilStateCreateInfo>();
     depth_state_info.depthTestEnable = VK_TRUE;

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -644,8 +644,7 @@ TEST_F(PositiveCommand, ClearRectWith2DArray) {
         rpci.subpassCount = 1;
         rpci.pSubpasses = &subpass;
 
-        vk_testing::RenderPass render_pass;
-        render_pass.init(*m_device, rpci);
+        vk_testing::RenderPass render_pass(*m_device, rpci);
 
         VkFramebufferCreateInfo fbci = LvlInitStruct<VkFramebufferCreateInfo>();
         fbci.renderPass = render_pass.handle();
@@ -655,8 +654,7 @@ TEST_F(PositiveCommand, ClearRectWith2DArray) {
         fbci.height = image_ci.extent.height;
         fbci.layers = image_ci.extent.depth;
 
-        vk_testing::Framebuffer framebuffer;
-        framebuffer.init(*m_device, fbci);
+        vk_testing::Framebuffer framebuffer(*m_device, fbci);
 
         VkClearAttachment color_attachment;
         color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -696,8 +694,7 @@ TEST_F(PositiveCommand, EventStageMaskSecondaryCommandBuffer) {
     VkCommandBufferObj commandBuffer(m_device, m_commandPool);
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
-    vk_testing::Event event(*m_device, event_create_info);
+    vk_testing::Event event(*m_device);
 
     secondary.begin();
     vk::CmdSetEvent(secondary.handle(), event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
@@ -725,9 +722,7 @@ TEST_F(PositiveCommand, EventsInSecondaryCommandBuffers) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
     }
 
-    VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
-    vk_testing::Event ev;
-    ev.init(*m_device, event_create_info);
+    vk_testing::Event ev(*m_device);
     VkEvent ev_handle = ev.handle();
     VkCommandBufferObj secondary_cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     VkCommandBuffer scb = secondary_cb.handle();

--- a/tests/unit/descriptor_indexing.cpp
+++ b/tests/unit/descriptor_indexing.cpp
@@ -233,8 +233,7 @@ TEST_F(NegativeDescriptorIndexing, SetNonIdenticalWrite) {
     auto buff_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buff_create_info.size = 1024;
     buff_create_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buff_create_info);
+    VkBufferObj buffer(*m_device, buff_create_info);
 
     VkDescriptorBufferInfo bufferInfo[3] = {};
     bufferInfo[0].buffer = buffer.handle();

--- a/tests/unit/descriptor_indexing_positive.cpp
+++ b/tests/unit/descriptor_indexing_positive.cpp
@@ -81,8 +81,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     buffer_create_info.queueFamilyIndexCount = 1;
     buffer_create_info.pQueueFamilyIndices = &qfi;
 
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     VkDescriptorBufferInfo buffer_info[2] = {};
     buffer_info[0].buffer = buffer.handle();
@@ -92,8 +91,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     auto index_buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     index_buffer_create_info.size = sizeof(uint32_t);
     index_buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
-    VkBufferObj index_buffer;
-    index_buffer.init(*m_device, index_buffer_create_info);
+    VkBufferObj index_buffer(*m_device, index_buffer_create_info);
 
     // Only update binding 0
     VkWriteDescriptorSet descriptor_writes[2] = {};

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -263,8 +263,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetIntegrity) {
     buffCI.queueFamilyIndexCount = 1;
     buffCI.pQueueFamilyIndices = &qfi;
 
-    VkBufferObj dynamic_uniform_buffer;
-    dynamic_uniform_buffer.init(*m_device, buffCI);
+    VkBufferObj dynamic_uniform_buffer(*m_device, buffCI);
 
     VkDescriptorBufferInfo buffInfo[5] = {};
     for (int i = 0; i < 5; ++i) {
@@ -499,8 +498,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetBufferDestroyed) {
         buffCI.queueFamilyIndexCount = 1;
         buffCI.pQueueFamilyIndices = &qfi;
 
-        VkBufferObj buffer;
-        buffer.init(*m_device, buffCI);
+        VkBufferObj buffer(*m_device, buffCI);
 
         // Create PSO to be used for draw-time errors below
         char const *fsSource = R"glsl(
@@ -569,8 +567,7 @@ TEST_F(NegativeDescriptors, DrawDescriptorSetBufferDestroyed) {
         buffCI.queueFamilyIndexCount = 1;
         buffCI.pQueueFamilyIndices = &qfi;
 
-        VkBufferObj buffer;
-        buffer.init(*m_device, buffCI);
+        VkBufferObj buffer(*m_device, buffCI);
 
         // Create PSO to be used for draw-time errors below
         char const *fsSource = R"glsl(
@@ -1020,16 +1017,12 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
     image.Init(32, 32, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
-    vk_testing::ImageView view;
     auto image_view_create_info = image.BasicViewCreatInfo();
-    view.init(*m_device, image_view_create_info);
-    ASSERT_TRUE(view.initialized());
+    vk_testing::ImageView view(*m_device, image_view_create_info);
 
     // Create Sampler
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_ci);
-    ASSERT_TRUE(sampler.initialized());
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     // Setup structure for descriptor update with sampler, for update in do_test below
     VkDescriptorImageInfo img_info = {};
@@ -1140,8 +1133,6 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
     const VkFormat format_ds = m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
     bool ds_test_support = maintenance2 && (format_ds != VK_FORMAT_UNDEFINED);
     VkImageObj image_ds(m_device);
-    vk_testing::ImageView stencil_view;
-    vk_testing::ImageView depth_view;
     const VkImageLayout ds_image_layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
     const VkImageLayout depth_descriptor_layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
     const VkImageLayout stencil_descriptor_layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL;
@@ -1151,9 +1142,9 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
                       VK_IMAGE_TILING_OPTIMAL, 0);
         ASSERT_TRUE(image_ds.initialized());
         auto ds_view_ci = image_ds.BasicViewCreatInfo(VK_IMAGE_ASPECT_DEPTH_BIT);
-        depth_view.init(*m_device, ds_view_ci);
+        vk_testing::ImageView depth_view(*m_device, ds_view_ci);
         ds_view_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
-        stencil_view.init(*m_device, ds_view_ci);
+        vk_testing::ImageView stencil_view(*m_device, ds_view_ci);
         do_test(&image_ds, &depth_view, depth_stencil, ds_image_layout, depth_descriptor_layout, /* positive */ true);
         do_test(&image_ds, &depth_view, depth_stencil, ds_image_layout, VK_IMAGE_LAYOUT_GENERAL, /* positive */ false);
         do_test(&image_ds, &stencil_view, depth_stencil, ds_image_layout, stencil_descriptor_layout, /* positive */ true);
@@ -1303,8 +1294,7 @@ TEST_F(NegativeDescriptors, DynamicOffsetCases) {
     buffCI.queueFamilyIndexCount = 1;
     buffCI.pQueueFamilyIndices = &qfi;
 
-    VkBufferObj dynamic_uniform_buffer;
-    dynamic_uniform_buffer.init(*m_device, buffCI);
+    VkBufferObj dynamic_uniform_buffer(*m_device, buffCI);
 
     // Correctly update descriptor to avoid "NOT_UPDATED" error
     descriptor_set.WriteDescriptorBufferInfo(0, dynamic_uniform_buffer.handle(), 0, 1024,
@@ -1395,8 +1385,7 @@ TEST_F(NegativeDescriptors, DynamicDescriptorSet) {
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_ci.queueFamilyIndexCount = 1;
     buffer_ci.pQueueFamilyIndices = &qfi;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_ci);
+    VkBufferObj buffer(*m_device, buffer_ci);
 
     // test various uses of offsets and size
     // The non-dynamic binds are there to make sure pDynamicOffsets are matched correctly at bind time
@@ -1601,8 +1590,7 @@ TEST_F(NegativeDescriptors, UpdateDescriptorSetMismatchType) {
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_ci.queueFamilyIndexCount = 1;
     buffer_ci.pQueueFamilyIndices = &qfi;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_ci);
+    VkBufferObj buffer(*m_device, buffer_ci);
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                   {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -1726,8 +1714,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
     bci.size = 8;
     bci.queueFamilyIndexCount = 1;
     bci.pQueueFamilyIndices = &qfi;
-    VkBufferObj buffer;
-    buffer.init(*m_device, bci);
+    VkBufferObj buffer(*m_device, bci);
     VkDescriptorBufferInfo buffer_info;
     buffer_info.buffer = buffer.handle();
     buffer_info.offset = 0;
@@ -1845,8 +1832,8 @@ TEST_F(NegativeDescriptors, DSUsageBits) {
         ds_type_count[i].descriptorCount = 1;
     }
 
-    vk_testing::DescriptorPool ds_pool;
-    ds_pool.init(*m_device, vk_testing::DescriptorPool::create_info(0, kLocalDescriptorTypeRangeSize, ds_type_count));
+    vk_testing::DescriptorPool ds_pool(*m_device,
+                                       vk_testing::DescriptorPool::create_info(0, kLocalDescriptorTypeRangeSize, ds_type_count));
     ASSERT_TRUE(ds_pool.initialized());
 
     std::vector<VkDescriptorSetLayoutBinding> dsl_bindings(1);
@@ -2015,8 +2002,7 @@ TEST_F(NegativeDescriptors, DSBufferInfo) {
     buff_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buff_ci.size = m_device->props.limits.minUniformBufferOffsetAlignment;
     buff_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buff_ci);
+    VkBufferObj buffer(*m_device, buff_ci);
 
     VkDescriptorBufferInfo buff_info = {};
     buff_info.buffer = buffer.handle();
@@ -2705,8 +2691,7 @@ TEST_F(NegativeDescriptors, PushDescriptorTemplateDestroyDescriptorSetLayout) {
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_ci);
+    VkBufferObj buffer(*m_device, buffer_ci);
 
     VkDescriptorSetLayoutBinding ds_binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
     VkDescriptorSetLayout ds_layout = VK_NULL_HANDLE;
@@ -3669,12 +3654,10 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenAttachmentsAndDescript
     createView.components.a = VK_COMPONENT_SWIZZLE_A;
     createView.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 1, 1};
     createView.flags = 0;
-    vk_testing::ImageView view_sampler_overlap;
-    view_sampler_overlap.init(*m_device, createView);
+    vk_testing::ImageView view_sampler_overlap(*m_device, createView);
 
     createView.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-    vk_testing::ImageView view_sampler_not_overlap;
-    view_sampler_not_overlap.init(*m_device, createView);
+    vk_testing::ImageView view_sampler_not_overlap(*m_device, createView);
 
     const VkAttachmentDescription inputAttachment = {
         0u,
@@ -3730,12 +3713,10 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenAttachmentsAndDescript
     rp.init(*m_device, renderPassInfo);
 
     const auto fbci = LvlInitStruct<VkFramebufferCreateInfo>(0, 0u, rp.handle(), 2u, attachments, 64u, 64u, 1u);
-    vk_testing::Framebuffer fb;
-    fb.init(*m_device, fbci);
+    vk_testing::Framebuffer fb(*m_device, fbci);
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_info);
+    vk_testing::Sampler sampler(*m_device, sampler_info);
 
     char const *fsSource = R"glsl(
         #version 450
@@ -4104,8 +4085,7 @@ TEST_F(NegativeDescriptors, WriteMutableDescriptorSet) {
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
-    vk_testing::DescriptorPool pool;
-    pool.init(*m_device, ds_pool_ci);
+    vk_testing::DescriptorPool pool(*m_device, ds_pool_ci);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
     dsl_binding.binding = 0;
@@ -4131,8 +4111,7 @@ TEST_F(NegativeDescriptors, WriteMutableDescriptorSet) {
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &dsl_binding;
 
-    vk_testing::DescriptorSetLayout ds_layout;
-    ds_layout.init(*m_device, ds_layout_ci);
+    vk_testing::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
     VkDescriptorSetLayout ds_layout_handle = ds_layout.handle();
 
     auto allocate_info = LvlInitStruct<VkDescriptorSetAllocateInfo>();
@@ -4148,8 +4127,7 @@ TEST_F(NegativeDescriptors, WriteMutableDescriptorSet) {
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_ci);
+    VkBufferObj buffer(*m_device, buffer_ci);
 
     VkDescriptorBufferInfo buffer_info = {};
     buffer_info.buffer = buffer.handle();
@@ -4270,8 +4248,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateTemplate) {
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
-    vk_testing::DescriptorPool pool;
-    pool.init(*m_device, ds_pool_ci);
+    vk_testing::DescriptorPool pool(*m_device, ds_pool_ci);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
     dsl_binding.binding = 0;
@@ -4297,8 +4274,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateTemplate) {
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &dsl_binding;
 
-    vk_testing::DescriptorSetLayout ds_layout;
-    ds_layout.init(*m_device, ds_layout_ci);
+    vk_testing::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
     VkDescriptorSetLayout ds_layout_handle = ds_layout.handle();
 
     VkDescriptorUpdateTemplateEntry update_template_entry = {};
@@ -4514,13 +4490,11 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     ivci.subresourceRange.levelCount = 1;
     ivci.subresourceRange.baseArrayLayer = 0;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    vk_testing::ImageView image_view;
-    image_view.init(*m_device, ivci);
+    vk_testing::ImageView image_view(*m_device, ivci);
     VkImageView image_view_handle = image_view.handle();
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_ci);
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     auto fbci = LvlInitStruct<VkFramebufferCreateInfo>();
     fbci.width = width;
@@ -4665,13 +4639,11 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
     ivci.subresourceRange.levelCount = 1;
     ivci.subresourceRange.baseArrayLayer = 0;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    vk_testing::ImageView image_view;
-    image_view.init(*m_device, ivci);
+    vk_testing::ImageView image_view(*m_device, ivci);
     VkImageView image_view_handle = image_view.handle();
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_ci);
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     auto fbci = LvlInitStruct<VkFramebufferCreateInfo>();
     fbci.width = width;
@@ -4821,13 +4793,11 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     ivci.subresourceRange.levelCount = 1;
     ivci.subresourceRange.baseArrayLayer = 0;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    vk_testing::ImageView image_view;
-    image_view.init(*m_device, ivci);
+    vk_testing::ImageView image_view(*m_device, ivci);
     VkImageView image_view_handle = image_view.handle();
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_ci);
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     auto fbci = LvlInitStruct<VkFramebufferCreateInfo>();
     fbci.width = width;
@@ -4952,8 +4922,7 @@ TEST_F(NegativeDescriptors, AllocatingVariableDescriptorSets) {
     auto ds_layout_ci = LvlInitStruct<VkDescriptorSetLayoutCreateInfo>(&flags_create_info);
     ds_layout_ci.bindingCount = 2;
     ds_layout_ci.pBindings = bindings;
-    vk_testing::DescriptorSetLayout ds_layout;
-    ds_layout.init(*m_device, ds_layout_ci);
+    vk_testing::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
     VkDescriptorSetLayout ds_layout_handle = ds_layout.handle();
 
     auto count_alloc_info = LvlInitStruct<VkDescriptorSetVariableDescriptorCountAllocateInfoEXT>();
@@ -4967,8 +4936,7 @@ TEST_F(NegativeDescriptors, AllocatingVariableDescriptorSets) {
     dspci.poolSizeCount = 2;
     dspci.pPoolSizes = pool_sizes;
     dspci.maxSets = 1;
-    vk_testing::DescriptorPool pool;
-    pool.init(*m_device, dspci);
+    vk_testing::DescriptorPool pool(*m_device, dspci);
 
     auto ds_alloc_info = LvlInitStruct<VkDescriptorSetAllocateInfo>(&count_alloc_info);
     ds_alloc_info.descriptorPool = pool.handle();
@@ -5045,9 +5013,7 @@ TEST_F(NegativeDescriptors, BindingDescriptorSetFromHostOnlyPool) {
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
-    vk_testing::DescriptorPool pool;
-    pool.init(*m_device, ds_pool_ci);
-    ASSERT_TRUE(pool.initialized());
+    vk_testing::DescriptorPool pool(*m_device, ds_pool_ci);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
     dsl_binding.binding = 0;
@@ -5110,8 +5076,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         ds_pool_ci.poolSizeCount = 2;
         ds_pool_ci.pPoolSizes = pool_sizes;
 
-        vk_testing::DescriptorPool pool;
-        pool.init(*m_device, ds_pool_ci);
+        vk_testing::DescriptorPool pool(*m_device, ds_pool_ci);
 
         VkDescriptorSetLayoutBinding bindings[2] = {};
         bindings[0].binding = 0;
@@ -5129,8 +5094,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         create_info.bindingCount = 2;
         create_info.pBindings = bindings;
 
-        vk_testing::DescriptorSetLayout set_layout;
-        set_layout.init(*m_device, create_info);
+        vk_testing::DescriptorSetLayout set_layout(*m_device, create_info);
         VkDescriptorSetLayout set_layout_handle = set_layout.handle();
 
         VkDescriptorSetLayout layouts[2] = {set_layout_handle, set_layout_handle};
@@ -5147,8 +5111,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         buffer_ci.size = 32;
         buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
-        VkBufferObj buffer;
-        buffer.init(*m_device, buffer_ci);
+        VkBufferObj buffer(*m_device, buffer_ci);
 
         VkDescriptorBufferInfo buffer_info = {};
         buffer_info.buffer = buffer.handle();
@@ -5197,8 +5160,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         ds_pool_ci.poolSizeCount = 1;
         ds_pool_ci.pPoolSizes = &pool_size;
 
-        vk_testing::DescriptorPool pool;
-        pool.init(*m_device, ds_pool_ci);
+        vk_testing::DescriptorPool pool(*m_device, ds_pool_ci);
 
         VkDescriptorSetLayoutBinding bindings[2] = {};
         bindings[0].binding = 0;
@@ -5216,8 +5178,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         create_info.bindingCount = 2;
         create_info.pBindings = bindings;
 
-        vk_testing::DescriptorSetLayout set_layout;
-        set_layout.init(*m_device, create_info);
+        vk_testing::DescriptorSetLayout set_layout(*m_device, create_info);
         VkDescriptorSetLayout set_layout_handle = set_layout.handle();
 
         VkDescriptorSetLayout layouts[2] = {set_layout_handle, set_layout_handle};
@@ -5234,8 +5195,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         buffer_ci.size = 32;
         buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
-        VkBufferObj buffer;
-        buffer.init(*m_device, buffer_ci);
+        VkBufferObj buffer(*m_device, buffer_ci);
 
         VkDescriptorBufferInfo buffer_info = {};
         buffer_info.buffer = buffer.handle();
@@ -5288,8 +5248,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         ds_pool_ci.poolSizeCount = 2;
         ds_pool_ci.pPoolSizes = pool_sizes;
 
-        vk_testing::DescriptorPool pool;
-        pool.init(*m_device, ds_pool_ci);
+        vk_testing::DescriptorPool pool(*m_device, ds_pool_ci);
 
         VkDescriptorSetLayoutBinding bindings[2] = {};
         bindings[0].binding = 0;
@@ -5307,8 +5266,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         create_info.bindingCount = 2;
         create_info.pBindings = bindings;
 
-        vk_testing::DescriptorSetLayout set_layout;
-        set_layout.init(*m_device, create_info);
+        vk_testing::DescriptorSetLayout set_layout(*m_device, create_info);
         VkDescriptorSetLayout set_layout_handle = set_layout.handle();
 
         VkDescriptorSetLayout layouts[2] = {set_layout_handle, set_layout_handle};
@@ -5325,8 +5283,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         buffer_ci.size = 32;
         buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
-        VkBufferObj buffer;
-        buffer.init(*m_device, buffer_ci);
+        VkBufferObj buffer(*m_device, buffer_ci);
 
         VkSamplerCreateInfo sci = SafeSaneSamplerCreateInfo();
         vk_testing::Sampler sampler(*m_device, sci);
@@ -5413,8 +5370,7 @@ TEST_F(NegativeDescriptors, UpdatingMutableDescriptors) {
     ds_pool_ci.poolSizeCount = 2;
     ds_pool_ci.pPoolSizes = pool_sizes;
 
-    vk_testing::DescriptorPool pool;
-    pool.init(*m_device, ds_pool_ci);
+    vk_testing::DescriptorPool pool(*m_device, ds_pool_ci);
 
     VkDescriptorSetLayoutBinding bindings[2] = {};
     bindings[0].binding = 0;
@@ -5432,8 +5388,7 @@ TEST_F(NegativeDescriptors, UpdatingMutableDescriptors) {
     create_info.bindingCount = 2;
     create_info.pBindings = bindings;
 
-    vk_testing::DescriptorSetLayout set_layout;
-    set_layout.init(*m_device, create_info);
+    vk_testing::DescriptorSetLayout set_layout(*m_device, create_info);
     VkDescriptorSetLayout set_layout_handle = set_layout.handle();
 
     VkDescriptorSetLayout layouts[2] = {set_layout_handle, set_layout_handle};

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -145,8 +145,7 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
         buffer_create_info.queueFamilyIndexCount = 1;
         buffer_create_info.pQueueFamilyIndices = &queue_family_index;
 
-        VkBufferObj buffer;
-        buffer.init(*m_device, buffer_create_info);
+        VkBufferObj buffer(*m_device, buffer_create_info);
 
         OneOffDescriptorSet descriptor_set(m_device, {
                                                          {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -185,8 +184,7 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
         buffer_create_info.queueFamilyIndexCount = 1;
         buffer_create_info.pQueueFamilyIndices = &queue_family_index;
 
-        VkBufferObj buffer;
-        buffer.init(*m_device, buffer_create_info);
+        VkBufferObj buffer(*m_device, buffer_create_info);
 
         auto buff_view_ci = LvlInitStruct<VkBufferViewCreateInfo>();
         buff_view_ci.buffer = buffer.handle();
@@ -675,8 +673,7 @@ TEST_F(PositiveDescriptors, PushingDescriptorSetWithImmutableSampler) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    vk_testing::Sampler sampler;
-    sampler.init(*m_device, sampler_ci);
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
     VkSampler sampler_handle = sampler.handle();
 
     VkImageObj image(m_device);
@@ -746,8 +743,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
     ds_pool_ci.poolSizeCount = 2;
     ds_pool_ci.pPoolSizes = pool_sizes;
 
-    vk_testing::DescriptorPool pool;
-    pool.init(*m_device, ds_pool_ci);
+    vk_testing::DescriptorPool pool(*m_device, ds_pool_ci);
 
     VkDescriptorSetLayoutBinding bindings[2] = {};
     bindings[0].binding = 0;
@@ -765,8 +761,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
     create_info.bindingCount = 2;
     create_info.pBindings = bindings;
 
-    vk_testing::DescriptorSetLayout set_layout;
-    set_layout.init(*m_device, create_info);
+    vk_testing::DescriptorSetLayout set_layout(*m_device, create_info);
     VkDescriptorSetLayout set_layout_handle = set_layout.handle();
 
     VkDescriptorSetLayout layouts[2] = {set_layout_handle, set_layout_handle};
@@ -783,8 +778,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_ci);
+    VkBufferObj buffer(*m_device, buffer_ci);
 
     VkDescriptorBufferInfo buffer_info = {};
     buffer_info.buffer = buffer.handle();
@@ -849,8 +843,7 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
     ds_pool_ci.poolSizeCount = pool_sizes.size();
     ds_pool_ci.pPoolSizes = pool_sizes.data();
 
-    vk_testing::DescriptorPool pool;
-    pool.init(*m_device, ds_pool_ci);
+    vk_testing::DescriptorPool pool(*m_device, ds_pool_ci);
 
     std::array<VkDescriptorSetLayoutBinding, 2> bindings = {};
     bindings[0].binding = 0;
@@ -868,8 +861,7 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
     create_info.bindingCount = bindings.size();
     create_info.pBindings = bindings.data();
 
-    vk_testing::DescriptorSetLayout set_layout;
-    set_layout.init(*m_device, create_info);
+    vk_testing::DescriptorSetLayout set_layout(*m_device, create_info);
 
     std::array<VkDescriptorSetLayout, 2> layouts = {set_layout.handle(), set_layout.handle()};
 
@@ -968,13 +960,11 @@ TEST_F(PositiveDescriptors, tImageViewAsDescriptorReadAndInputAttachment) {
     ivci.subresourceRange.levelCount = 1;
     ivci.subresourceRange.baseArrayLayer = 0;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    vk_testing::ImageView image_view;
-    image_view.init(*m_device, ivci);
+    vk_testing::ImageView image_view(*m_device, ivci);
     VkImageView image_view_handle = image_view.handle();
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_ci);
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     auto fbci = LvlInitStruct<VkFramebufferCreateInfo>();
     fbci.width = width;
@@ -1092,12 +1082,10 @@ TEST_F(PositiveDescriptors, UpdateImageDescriptorSetThatHasImageViewUsage) {
     image_view_ci.components.a = VK_COMPONENT_SWIZZLE_A;
     image_view_ci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    vk_testing::ImageView image_view;
-    image_view.init(*m_device, image_view_ci);
+    vk_testing::ImageView image_view(*m_device, image_view_ci);
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    vk_testing::Sampler sampler;
-    sampler.init(*m_device, sampler_ci);
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     OneOffDescriptorSet ds(m_device, {
                                          {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
@@ -1427,8 +1415,7 @@ TEST_F(PositiveDescriptors, PushDescriptorTemplateBasic) {
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_ci);
+    VkBufferObj buffer(*m_device, buffer_ci);
 
     std::vector<VkDescriptorSetLayoutBinding> ds_bindings = {
         {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -1914,8 +1914,7 @@ TEST_F(NegativeDynamicRendering, BufferBeginInfoLegacy) {
     VkSubpassDescription subpass = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, &att_ref, nullptr, nullptr, 0, nullptr};
     VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 1, attach, 1, &subpass, 0, nullptr};
 
-    vk_testing::RenderPass rp1;
-    rp1.init(*m_device, rpci);
+    vk_testing::RenderPass rp1(*m_device, rpci);
 
     cmd_buffer_inheritance_info.renderPass = rp1.handle();
     cmd_buffer_inheritance_info.subpass = 0x5;
@@ -1956,8 +1955,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBuffer) {
     VkSubpassDescription subpass = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, &att_ref, nullptr, nullptr, 0, nullptr};
     VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 1, attach, 1, &subpass, 0, nullptr};
 
-    vk_testing::RenderPass rp1;
-    rp1.init(*m_device, rpci);
+    vk_testing::RenderPass rp1(*m_device, rpci);
 
     cmd_buf_hinfo.renderPass = rp1.handle();
     cmd_buf_hinfo.subpass = 0x5;
@@ -2041,8 +2039,7 @@ TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
                                    VK_COMPONENT_SWIZZLE_IDENTITY},
                                   {VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0, 1, 0, 1}};
 
-    vk_testing::ImageView depth_image_view;
-    depth_image_view.init(*m_device, ivci);
+    vk_testing::ImageView depth_image_view(*m_device, ivci);
 
     VkRenderingAttachmentInfoKHR color_attachment = LvlInitStruct<VkRenderingAttachmentInfoKHR>();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -2162,8 +2159,7 @@ TEST_F(NegativeDynamicRendering, InfoMismatchedSamples) {
     civ_ci.subresourceRange.levelCount = 1;
     civ_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    vk_testing::ImageView color_image_view;
-    color_image_view.init(*m_device, civ_ci);
+    vk_testing::ImageView color_image_view(*m_device, civ_ci);
 
     VkRenderingAttachmentInfoKHR color_attachment = LvlInitStruct<VkRenderingAttachmentInfoKHR>();
     color_attachment.imageView = color_image_view.handle();
@@ -2184,8 +2180,7 @@ TEST_F(NegativeDynamicRendering, InfoMismatchedSamples) {
     div_ci.subresourceRange.levelCount = 1;
     div_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
 
-    vk_testing::ImageView depth_image_view;
-    depth_image_view.init(*m_device, div_ci);
+    vk_testing::ImageView depth_image_view(*m_device, div_ci);
 
     VkRenderingAttachmentInfoKHR depth_attachment = LvlInitStruct<VkRenderingAttachmentInfoKHR>();
     depth_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -3205,8 +3200,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleRenderPass) {
     render_pass_ci.subpassCount = 1;
     render_pass_ci.pSubpasses = &subpass;
 
-    vk_testing::RenderPass render_pass;
-    render_pass.init(*m_device, render_pass_ci);
+    vk_testing::RenderPass render_pass(*m_device, render_pass_ci);
 
     VkCommandBufferObj cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     VkCommandBuffer secondary_handle = cb.handle();
@@ -3249,8 +3243,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
     render_pass_ci.subpassCount = 2;
     render_pass_ci.pSubpasses = subpasses;
 
-    vk_testing::RenderPass render_pass;
-    render_pass.init(*m_device, render_pass_ci);
+    vk_testing::RenderPass render_pass(*m_device, render_pass_ci);
 
     auto framebuffer_ci = LvlInitStruct<VkFramebufferCreateInfo>();
     framebuffer_ci.renderPass = render_pass.handle();
@@ -3258,8 +3251,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
     framebuffer_ci.height = 32;
     framebuffer_ci.layers = 1;
 
-    vk_testing::Framebuffer framebuffer;
-    framebuffer.init(*m_device, framebuffer_ci);
+    vk_testing::Framebuffer framebuffer(*m_device, framebuffer_ci);
 
     VkCommandBufferObj cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     VkCommandBuffer secondary_handle = cb.handle();

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -475,8 +475,7 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipeline) {
     render_pass_ci.attachmentCount = 1;
     render_pass_ci.pAttachments = &attach_desc;
 
-    vk_testing::RenderPass render_pass;
-    render_pass.init(*m_device, render_pass_ci);
+    vk_testing::RenderPass render_pass(*m_device, render_pass_ci);
 
     pipe.CreateVKPipeline(pl.handle(), render_pass.handle(), &create_info);
 }
@@ -526,8 +525,7 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipelineNoInfo) {
     render_pass_ci.attachmentCount = 1;
     render_pass_ci.pAttachments = &attach_desc;
 
-    vk_testing::RenderPass render_pass;
-    render_pass.init(*m_device, render_pass_ci);
+    vk_testing::RenderPass render_pass(*m_device, render_pass_ci);
 
     auto create_info = LvlInitStruct<VkGraphicsPipelineCreateInfo>();
     pipe.InitGraphicsPipelineCreateInfo(&create_info);

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -1338,8 +1338,7 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
     fb_info.height = 32;
     fb_info.layers = 1;
 
-    vk_testing::Framebuffer framebuffer_fsr;
-    framebuffer_fsr.init(*m_device, fb_info);
+    vk_testing::Framebuffer framebuffer_fsr(*m_device, fb_info);
 
     // Create a frame buffer with a render pass without FSR attachment
     VkFramebufferCreateInfo fb_info_0 = LvlInitStruct<VkFramebufferCreateInfo>();
@@ -1350,8 +1349,7 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
     fb_info_0.height = 32;
     fb_info_0.layers = 1;
 
-    vk_testing::Framebuffer framebuffer_no_fsr;
-    framebuffer_no_fsr.init(*m_device, fb_info_0);
+    vk_testing::Framebuffer framebuffer_no_fsr(*m_device, fb_info_0);
 
     VkCommandPoolObj pool(m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     VkCommandBufferObj secondary(m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
@@ -2103,7 +2101,6 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
 
     // Create view attachment
     VkImageView iv[7];
-    vk_testing::ImageView iv0;
     auto ivci = LvlInitStruct<VkImageViewCreateInfo>();
     ivci.image = fdm_image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
@@ -2114,48 +2111,42 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
     ivci.subresourceRange.levelCount = 1;
     ivci.subresourceRange.baseArrayLayer = 0;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    iv0.init(*m_device, ivci);
+    vk_testing::ImageView iv0(*m_device, ivci);
     ASSERT_TRUE(iv0.initialized());
     iv[0] = iv0.handle();
 
     ivci.format = VK_FORMAT_R8G8B8A8_UNORM;
     ivci.image = input_image.handle();
-    vk_testing::ImageView iv1;
-    iv1.init(*m_device, ivci);
+    vk_testing::ImageView iv1(*m_device, ivci);
     ASSERT_TRUE(iv1.initialized());
     iv[1] = iv1.handle();
 
     ivci.image = color_image1.handle();
-    vk_testing::ImageView iv2;
-    iv2.init(*m_device, ivci);
+    vk_testing::ImageView iv2(*m_device, ivci);
     ASSERT_TRUE(iv2.initialized());
     iv[2] = iv2.handle();
 
     ivci.image = color_image2.handle();
-    vk_testing::ImageView iv3;
-    iv3.init(*m_device, ivci);
+    vk_testing::ImageView iv3(*m_device, ivci);
     ASSERT_TRUE(iv3.initialized());
     iv[3] = iv3.handle();
 
     ivci.format = ds_format;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
     ivci.image = depth_image.handle();
-    vk_testing::ImageView iv4;
-    iv4.init(*m_device, ivci);
+    vk_testing::ImageView iv4(*m_device, ivci);
     ASSERT_TRUE(iv4.initialized());
     iv[4] = iv4.handle();
 
     ivci.format = VK_FORMAT_R8G8B8A8_UNORM;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     ivci.image = resolve_image.handle();
-    vk_testing::ImageView iv5;
-    iv5.init(*m_device, ivci);
+    vk_testing::ImageView iv5(*m_device, ivci);
     ASSERT_TRUE(iv5.initialized());
     iv[5] = iv5.handle();
 
     ivci.image = preserve_image.handle();
-    vk_testing::ImageView iv6;
-    iv6.init(*m_device, ivci);
+    vk_testing::ImageView iv6(*m_device, ivci);
     ASSERT_TRUE(iv6.initialized());
     iv[6] = iv6.handle();
 
@@ -2647,8 +2638,8 @@ TEST_F(NegativeFragmentShadingRate, StageUsage) {
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
     const vk_testing::QueryPool query_pool(*m_device, query_pool_create_info);
-    const vk_testing::Event event(*m_device, LvlInitStruct<VkEventCreateInfo>());
-    const vk_testing::Event event2(*m_device, LvlInitStruct<VkEventCreateInfo>());
+    const vk_testing::Event event(*m_device);
+    const vk_testing::Event event2(*m_device);
 
     m_commandBuffer->begin();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdResetEvent2-stageMask-07316");
@@ -2682,8 +2673,8 @@ TEST_F(NegativeFragmentShadingRate, StageUsageNV) {
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
     const vk_testing::QueryPool query_pool(*m_device, query_pool_create_info);
-    const vk_testing::Event event(*m_device, LvlInitStruct<VkEventCreateInfo>());
-    const vk_testing::Event event2(*m_device, LvlInitStruct<VkEventCreateInfo>());
+    const vk_testing::Event event(*m_device);
+    const vk_testing::Event event2(*m_device);
 
     m_commandBuffer->begin();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdResetEvent2-stageMask-07316");

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -36,8 +36,8 @@ TEST_F(PositiveFragmentShadingRate, StageInVariousAPIs) {
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
     const vk_testing::QueryPool query_pool(*m_device, query_pool_create_info);
-    const vk_testing::Event event(*m_device, LvlInitStruct<VkEventCreateInfo>());
-    const vk_testing::Event event2(*m_device, LvlInitStruct<VkEventCreateInfo>());
+    const vk_testing::Event event(*m_device);
+    const vk_testing::Event event2(*m_device);
 
     m_commandBuffer->begin();
     // Different API calls to cover three category of VUIDs: 07316, 07318, 07314

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -635,8 +635,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkBufferObj uniform_texel_buffer;
-    VkBufferObj storage_texel_buffer;
     VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     VkBufferObj offset_buffer(*m_device, 4, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, reqs);
     VkBufferObj write_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, reqs);
@@ -647,9 +645,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
     buffer_create_info.queueFamilyIndexCount = 1;
     buffer_create_info.pQueueFamilyIndices = &queue_family_index;
-    uniform_texel_buffer.init(*m_device, buffer_create_info, reqs);
+    VkBufferObj uniform_texel_buffer(*m_device, buffer_create_info, reqs);
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
-    storage_texel_buffer.init(*m_device, buffer_create_info, reqs);
+    VkBufferObj storage_texel_buffer(*m_device, buffer_create_info, reqs);
     VkBufferViewCreateInfo bvci = LvlInitStruct<VkBufferViewCreateInfo>();
     bvci.buffer = uniform_texel_buffer.handle();
     bvci.format = VK_FORMAT_R32_SFLOAT;
@@ -834,8 +832,7 @@ void VkGpuAssistedLayerTest::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDe
     bci.size = buffer_size;
     bci.queueFamilyIndexCount = 1;
     bci.pQueueFamilyIndices = &qfi;
-    VkBufferObj buffer;
-    buffer.init(*m_device, bci);
+    VkBufferObj buffer(*m_device, bci);
     VkPipelineObj pipe(m_device);
 
     VkDescriptorBufferInfo buffer_info;
@@ -1300,8 +1297,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 2 * sizeof(VkDrawIndirectCommand);
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
-    VkBufferObj draw_buffer;
-    draw_buffer.init(*m_device, buffer_create_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj draw_buffer(*m_device, buffer_create_info,
+                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.memory().map());
     memset(draw_ptr, 0, 2 * sizeof(VkDrawIndirectCommand));
     draw_buffer.memory().unmap();
@@ -1309,9 +1306,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
     VkBufferCreateInfo count_buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     count_buffer_create_info.size = sizeof(uint32_t);
     count_buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
-    VkBufferObj count_buffer;
-    count_buffer.init(*m_device, count_buffer_create_info,
-                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj count_buffer(*m_device, count_buffer_create_info,
+                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
     *count_ptr = 2;  // Fits in buffer but exceeds (fake) limit
     count_buffer.memory().unmap();
@@ -1407,8 +1403,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndexedIndirectCountDeviceLimitSubmit2) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 2 * sizeof(VkDrawIndexedIndirectCommand);
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
-    VkBufferObj draw_buffer;
-    draw_buffer.init(*m_device, buffer_create_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj draw_buffer(*m_device, buffer_create_info,
+                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     VkDrawIndexedIndirectCommand *draw_ptr = static_cast<VkDrawIndexedIndirectCommand *>(draw_buffer.memory().map());
     memset(draw_ptr, 0, 2 * sizeof(VkDrawIndexedIndirectCommand));
     draw_buffer.memory().unmap();
@@ -1416,9 +1412,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndexedIndirectCountDeviceLimitSubmit2) {
     VkBufferCreateInfo count_buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     count_buffer_create_info.size = sizeof(uint32_t);
     count_buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
-    VkBufferObj count_buffer;
-    count_buffer.init(*m_device, count_buffer_create_info,
-                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj count_buffer(*m_device, count_buffer_create_info,
+                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
     *count_ptr = 2;  // Fits in buffer but exceeds (fake) limit
     count_buffer.memory().unmap();
@@ -1479,8 +1474,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = sizeof(VkDrawIndirectCommand);
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
-    VkBufferObj draw_buffer;
-    draw_buffer.init(*m_device, buffer_create_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj draw_buffer(*m_device, buffer_create_info,
+                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.memory().map());
     draw_ptr->firstInstance = 0;
     draw_ptr->firstVertex = 0;
@@ -1491,9 +1486,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
     VkBufferCreateInfo count_buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     count_buffer_create_info.size = sizeof(uint32_t);
     count_buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
-    VkBufferObj count_buffer;
-    count_buffer.init(*m_device, count_buffer_create_info,
-                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj count_buffer(*m_device, count_buffer_create_info,
+                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
     VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = LvlInitStruct<VkPipelineLayoutCreateInfo>();
     vk_testing::PipelineLayout pipeline_layout(*m_device, pipelineLayoutCreateInfo);
@@ -1548,10 +1542,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154");
-    VkBufferObj indexed_draw_buffer;
     buffer_create_info.size = sizeof(VkDrawIndexedIndirectCommand);
-    indexed_draw_buffer.init(*m_device, buffer_create_info,
-                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj indexed_draw_buffer(*m_device, buffer_create_info,
+                                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.memory().map();
     indexed_draw_ptr->indexCount = 3;
     indexed_draw_ptr->firstIndex = 0;
@@ -1571,8 +1564,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCount) {
     VkBufferCreateInfo index_buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     index_buffer_create_info.size = 3 * sizeof(uint32_t);
     index_buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
-    VkBufferObj index_buffer;
-    index_buffer.init(*m_device, index_buffer_create_info);
+    VkBufferObj index_buffer(*m_device, index_buffer_create_info);
     vk::CmdBindIndexBuffer(m_commandBuffer->handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexedIndirectCountKHR(m_commandBuffer->handle(), indexed_draw_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                        sizeof(VkDrawIndexedIndirectCommand));
@@ -1630,8 +1622,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 4 * sizeof(VkDrawIndirectCommand);
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
-    VkBufferObj draw_buffer;
-    draw_buffer.init(*m_device, buffer_create_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj draw_buffer(*m_device, buffer_create_info,
+                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.memory().map());
     for (uint32_t i = 0; i < 4; i++) {
         draw_ptr->vertexCount = 3;
@@ -1672,10 +1664,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
 
     // Now with an offset and indexed draw
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawIndexedIndirectCommand-firstInstance-00554");
-    VkBufferObj indexed_draw_buffer;
     buffer_create_info.size = 4 * sizeof(VkDrawIndexedIndirectCommand);
-    indexed_draw_buffer.init(*m_device, buffer_create_info,
-                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj indexed_draw_buffer(*m_device, buffer_create_info,
+                                    VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.memory().map();
     for (uint32_t i = 0; i < 4; i++) {
         indexed_draw_ptr->indexCount = 3;
@@ -1695,8 +1686,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
     VkBufferCreateInfo index_buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     index_buffer_create_info.size = 3 * sizeof(uint32_t);
     index_buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
-    VkBufferObj index_buffer;
-    index_buffer.init(*m_device, index_buffer_create_info);
+    VkBufferObj index_buffer(*m_device, index_buffer_create_info);
     vk::CmdBindIndexBuffer(m_commandBuffer->handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexedIndirect(m_commandBuffer->handle(), indexed_draw_buffer.handle(), sizeof(VkDrawIndexedIndirectCommand), 3,
                                sizeof(VkDrawIndexedIndirectCommand));
@@ -2119,8 +2109,8 @@ TEST_F(VkGpuAssistedLayerTest, DispatchIndirectWorkgroupSize) {
     buffer_create_info.size = 5 * sizeof(VkDispatchIndirectCommand);
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
 
-    VkBufferObj indirect_buffer;
-    indirect_buffer.init(*m_device, buffer_create_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj indirect_buffer(*m_device, buffer_create_info,
+                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.memory().map());
     // VkDispatchIndirectCommand[0]
     ptr->x = 4;  // over
@@ -2228,8 +2218,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPL) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkBufferObj uniform_texel_buffer;
-    VkBufferObj storage_texel_buffer;
     VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     VkBufferObj offset_buffer(*m_device, 4, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, reqs);
     VkBufferObj write_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, reqs);
@@ -2240,9 +2228,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPL) {
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
     buffer_create_info.queueFamilyIndexCount = 1;
     buffer_create_info.pQueueFamilyIndices = &queue_family_index;
-    uniform_texel_buffer.init(*m_device, buffer_create_info, reqs);
+    VkBufferObj uniform_texel_buffer(*m_device, buffer_create_info, reqs);
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
-    storage_texel_buffer.init(*m_device, buffer_create_info, reqs);
+    VkBufferObj storage_texel_buffer(*m_device, buffer_create_info, reqs);
     VkBufferViewCreateInfo bvci = LvlInitStruct<VkBufferViewCreateInfo>();
     bvci.buffer = uniform_texel_buffer.handle();
     bvci.format = VK_FORMAT_R32_SFLOAT;
@@ -2409,8 +2397,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPLIndependentSets) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, pool_flags));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkBufferObj uniform_texel_buffer;
-    VkBufferObj storage_texel_buffer;
     VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     VkBufferObj offset_buffer(*m_device, 4, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, reqs);
     VkBufferObj write_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, reqs);
@@ -2421,9 +2407,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPLIndependentSets) {
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
     buffer_create_info.queueFamilyIndexCount = 1;
     buffer_create_info.pQueueFamilyIndices = &queue_family_index;
-    uniform_texel_buffer.init(*m_device, buffer_create_info, reqs);
+    VkBufferObj uniform_texel_buffer(*m_device, buffer_create_info, reqs);
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
-    storage_texel_buffer.init(*m_device, buffer_create_info, reqs);
+    VkBufferObj storage_texel_buffer(*m_device, buffer_create_info, reqs);
     VkBufferViewCreateInfo bvci = LvlInitStruct<VkBufferViewCreateInfo>();
     bvci.buffer = uniform_texel_buffer.handle();
     bvci.format = VK_FORMAT_R32_SFLOAT;

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -4907,8 +4907,7 @@ TEST_F(NegativeImage, Image2DViewOf3D) {
     view_ci.subresourceRange.levelCount = 1;
     view_ci.subresourceRange.baseArrayLayer = 0;
     view_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    vk_testing::ImageView view_2d_array;
-    view_2d_array.init(*m_device, view_ci);
+    vk_testing::ImageView view_2d_array(*m_device, view_ci);
 
     descriptor_set.WriteDescriptorImageInfo(0, view_2d_array.handle(), VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorImageInfo-imageView-06712");
@@ -4916,9 +4915,8 @@ TEST_F(NegativeImage, Image2DViewOf3D) {
     m_errorMonitor->VerifyFound();
     descriptor_set.descriptor_writes.clear();
 
-    vk_testing::ImageView view_2d;
     view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    view_2d.init(*m_device, view_ci);
+    vk_testing::ImageView view_2d(*m_device, view_ci);
     descriptor_set.WriteDescriptorImageInfo(0, view_2d.handle(), VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorImageInfo-imageView-07796");
     descriptor_set.UpdateDescriptorSets();
@@ -4985,8 +4983,7 @@ TEST_F(NegativeImage, Image2DViewOf3DFeature) {
     view_ci.subresourceRange.levelCount = 1;
     view_ci.subresourceRange.baseArrayLayer = 0;
     view_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    vk_testing::ImageView view_2d_array;
-    view_2d_array.init(*m_device, view_ci);
+    vk_testing::ImageView view_2d_array(*m_device, view_ci);
 
     descriptor_set.WriteDescriptorImageInfo(0, view_2d_array.handle(), VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorImageInfo-descriptorType-06714");
@@ -5103,9 +5100,8 @@ TEST_F(NegativeImage, ColorWthDepthAspect) {
     civ_ci.subresourceRange.levelCount = 1;
     civ_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    vk_testing::ImageView color_image_view;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
-    color_image_view.init(*m_device, civ_ci);
+    vk_testing::ImageView color_image_view(*m_device, civ_ci);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -602,8 +602,7 @@ TEST_F(PositiveImage, ImagelessLayoutTracking) {
     swapchain_images.resize(swapchain_images_count);
     vk::GetSwapchainImagesKHR(device(), m_swapchain, &swapchain_images_count, swapchain_images.data());
     uint32_t current_buffer;
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore image_acquired(*m_device, semaphore_create_info);
+    vk_testing::Semaphore image_acquired(*m_device);
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, image_acquired, VK_NULL_HANDLE, &current_buffer);
 
     VkImageView imageView = image.targetView(attachmentFormat);
@@ -1316,21 +1315,17 @@ TEST_F(PositiveImage, DescriptorSubresourceLayout) {
     VkImageSubresourceRange view_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 3, 1};
     VkImageSubresourceRange first_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     VkImageSubresourceRange full_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 5};
-    vk_testing::ImageView view;
     auto image_view_create_info = LvlInitStruct<VkImageViewCreateInfo>();
     image_view_create_info.image = image.handle();
     image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_create_info.format = format;
     image_view_create_info.subresourceRange = view_range;
 
-    view.init(*m_device, image_view_create_info);
-    ASSERT_TRUE(view.initialized());
+    vk_testing::ImageView view(*m_device, image_view_create_info);
 
     // Create Sampler
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_ci);
-    ASSERT_TRUE(sampler.initialized());
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     // Setup structure for descriptor update with sampler, for update in do_test below
     VkDescriptorImageInfo img_info = {};
@@ -1540,10 +1535,8 @@ TEST_F(VkPositiveLayerTest, ImageDescriptor3D2DSubresourceLayout) {
                                    (uint32_t)deps.size(),
                                    deps.data()};
     // Create Sampler
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_ci);
-    ASSERT_TRUE(sampler.initialized());
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     // Setup structure for descriptor update with sampler, for update in do_test below
     VkDescriptorImageInfo img_info = {};

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -1324,8 +1324,7 @@ TEST_F(NegativeImagelessFramebuffer, DescriptorUpdateTemplateEntryWithInlineUnif
     buff_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buff_ci.size = m_device->props.limits.minUniformBufferOffsetAlignment;
     buff_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buff_ci);
+    VkBufferObj buffer(*m_device, buff_ci);
 
     struct SimpleTemplateData {
         VkDescriptorBufferInfo buff_info;

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -154,8 +154,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     framebuffer_ci.height = 32;
     framebuffer_ci.layers = 1;
 
-    vk_testing::Framebuffer framebuffer;
-    framebuffer.init(*m_device, framebuffer_ci);
+    vk_testing::Framebuffer framebuffer(*m_device, framebuffer_ci);
 
     VkClearValue clear_value = {};
     clear_value.color = {{0u, 0u, 0u, 0u}};

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -930,12 +930,10 @@ TEST_F(NegativeMesh, DrawCmds) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     buffer_create_info.size = 2 * sizeof(VkDrawMeshTasksIndirectCommandEXT);
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
-    VkBufferObj count_buffer;
     buffer_create_info.size = 64;
-    count_buffer.init(*m_device, buffer_create_info);
+    VkBufferObj count_buffer(*m_device, buffer_create_info);
 
     VkPipelineLayoutObj pipeline_layout(m_device);
     VkPipelineObj pipe(m_device);
@@ -1095,8 +1093,7 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     buffer_create_info.size = 2 * sizeof(VkDrawMeshTasksIndirectCommandEXT);
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     VkPipelineLayoutObj pipeline_layout(m_device);
     VkPipelineObj pipe(m_device);
@@ -1129,8 +1126,7 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
     count_buffer_create_info.size = 64;
     count_buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
 
-    VkBufferObj count_buffer;
-    count_buffer.init(*m_device, count_buffer_create_info);
+    VkBufferObj count_buffer(*m_device, count_buffer_create_info);
     ASSERT_TRUE(count_buffer.initialized());
 
     VkBufferObj count_buffer_unbound;
@@ -1212,12 +1208,10 @@ TEST_F(NegativeMesh, DrawCmdsNV) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     buffer_create_info.size = 2 * sizeof(VkDrawMeshTasksIndirectCommandNV);
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
-    VkBufferObj count_buffer;
     buffer_create_info.size = 64;
-    count_buffer.init(*m_device, buffer_create_info);
+    VkBufferObj count_buffer(*m_device, buffer_create_info);
 
     VkPipelineLayoutObj pipeline_layout(m_device);
     VkPipelineObj pipe(m_device);

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -388,8 +388,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         pipeline_layout_info.pushConstantRangeCount = 1;
         pipeline_layout_info.pPushConstantRanges = &push_constant_range;
 
-        vk_testing::PipelineLayout layout;
-        layout.init(*m_device, pipeline_layout_info, std::vector<const vk_testing::DescriptorSetLayout *>{});
+        vk_testing::PipelineLayout layout(*m_device, pipeline_layout_info, std::vector<const vk_testing::DescriptorSetLayout *>{});
 
         CreatePipelineHelper pipe(*this);
         pipe.InitInfo();
@@ -444,8 +443,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         auto bci = LvlInitStruct<VkBufferCreateInfo>();
         bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         bci.size = 8;
-        VkBufferObj buffer;
-        buffer.init(*m_device, bci);
+        VkBufferObj buffer(*m_device, bci);
         VkDescriptorBufferInfo buffer_info;
         buffer_info.buffer = buffer.handle();
         buffer_info.offset = 0;
@@ -462,8 +460,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         pipeline_layout_info.setLayoutCount = 1;
         pipeline_layout_info.pSetLayouts = &descriptor_set.layout_.handle();
 
-        vk_testing::PipelineLayout layout;
-        layout.init(*m_device, pipeline_layout_info, std::vector<vk_testing::DescriptorSetLayout const *>{});
+        vk_testing::PipelineLayout layout(*m_device, pipeline_layout_info, std::vector<vk_testing::DescriptorSetLayout const *>{});
 
         VkShaderObj const vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
         VkShaderObj const fs(this, kFragmentUniformGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -749,8 +746,7 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
     framebufferCreateInfo.attachmentCount = 1;
     framebufferCreateInfo.pAttachments = &imageView;
 
-    vk_testing::Framebuffer framebuffer;
-    framebuffer.init(*m_device, framebufferCreateInfo);
+    vk_testing::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
 
     VkRenderPassBeginInfo render_pass_begin_info = LvlInitStruct<VkRenderPassBeginInfo>();
     render_pass_begin_info.renderPass = render_pass.handle();

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -317,8 +317,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferBufferViewDestroyed) {
         buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
         buffer_create_info.queueFamilyIndexCount = 1;
         buffer_create_info.pQueueFamilyIndices = &queue_family_index;
-        VkBufferObj buffer;
-        buffer.init(*m_device, buffer_create_info);
+        VkBufferObj buffer(*m_device, buffer_create_info);
 
         bvci.buffer = buffer.handle();
         bvci.format = VK_FORMAT_R32_SFLOAT;
@@ -372,8 +371,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferBufferViewDestroyed) {
     m_commandBuffer->Draw(1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
 
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     bvci.buffer = buffer.handle();
     VkResult err = vk::CreateBufferView(m_device->device(), &bvci, NULL, &view);
@@ -1017,8 +1015,7 @@ TEST_F(NegativeObjectLifetime, BufferViewInUseDestroyedSignaled) {
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
     buffer_create_info.queueFamilyIndexCount = 1;
     buffer_create_info.pQueueFamilyIndices = &queue_family_index;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     VkBufferView view;
     VkBufferViewCreateInfo bvci = LvlInitStruct<VkBufferViewCreateInfo>();

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -261,8 +261,7 @@ TEST_F(VkLayerTest, CustomStypeStructString) {
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
     buffer_create_info.queueFamilyIndexCount = 1;
     buffer_create_info.pQueueFamilyIndices = &queue_family_index;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
     VkBufferViewCreateInfo bvci = LvlInitStruct<VkBufferViewCreateInfo>(&custom_struct);  // Add custom struct through pNext
     bvci.buffer = buffer.handle();
     bvci.format = VK_FORMAT_R32_SFLOAT;
@@ -305,8 +304,7 @@ TEST_F(VkLayerTest, CustomStypeStructArray) {
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
     buffer_create_info.queueFamilyIndexCount = 1;
     buffer_create_info.pQueueFamilyIndices = &queue_family_index;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
     VkBufferViewCreateInfo bvci = LvlInitStruct<VkBufferViewCreateInfo>(&custom_struct_b);  // Add custom struct through pNext
     bvci.buffer = buffer.handle();
     bvci.format = VK_FORMAT_R32_SFLOAT;
@@ -1113,19 +1111,16 @@ TEST_F(VkLayerTest, UnrecognizedValueBadFlag) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "contains flag bits that are not recognized members of");
     // Specify an invalid VkFlags array entry
     // Expected to trigger an error with StatelessValidation::ValidateFlagsArray
-    VkSemaphore semaphore;
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk::CreateSemaphore(m_device->device(), &semaphore_create_info, nullptr, &semaphore);
+    vk_testing::Semaphore semaphore(*m_device);
     // `stage_flags` is set to a value which, currently, is not a defined stage flag
     // `VK_IMAGE_ASPECT_FLAG_BITS_MAX_ENUM` works well for this
     VkPipelineStageFlags stage_flags = VK_IMAGE_ASPECT_FLAG_BITS_MAX_ENUM;
     // `waitSemaphoreCount` *must* be greater than 0 to perform this check
     VkSubmitInfo submit_info = LvlInitStruct<VkSubmitInfo>();
     submit_info.waitSemaphoreCount = 1;
-    submit_info.pWaitSemaphores = &semaphore;
+    submit_info.pWaitSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &stage_flags;
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
-    vk::DestroySemaphore(m_device->device(), semaphore, nullptr);
 
     m_errorMonitor->VerifyFound();
 }
@@ -1608,10 +1603,7 @@ TEST_F(VkLayerTest, StageMaskHost) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
-    vk_testing::Event event(*m_device, event_create_info);
-    ASSERT_TRUE(event.initialized());
-
+    vk_testing::Event event(*m_device);
     m_commandBuffer->begin();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetEvent-stageMask-01149");
@@ -1624,8 +1616,7 @@ TEST_F(VkLayerTest, StageMaskHost) {
 
     m_commandBuffer->end();
 
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
+    vk_testing::Semaphore semaphore(*m_device);
     ASSERT_TRUE(semaphore.initialized());
 
     VkPipelineStageFlags stage_flags = VK_PIPELINE_STAGE_HOST_BIT;
@@ -1669,8 +1660,7 @@ TEST_F(VkLayerTest, ThreadCommandBufferCollision) {
 
     commandBuffer.begin();
 
-    VkEventCreateInfo event_info = LvlInitStruct<VkEventCreateInfo>();
-    vk_testing::Event event(*m_device, event_info);
+    vk_testing::Event event(*m_device);
     VkResult err;
 
     err = vk::ResetEvent(device(), event.handle());
@@ -2055,8 +2045,7 @@ TEST_F(VkLayerTest, ValidateStride) {
         VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     buff_create_info.queueFamilyIndexCount = 1;
     buff_create_info.pQueueFamilyIndices = &qfi;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buff_create_info);
+    VkBufferObj buffer(*m_device, buff_create_info);
 
     m_commandBuffer->reset();
     m_commandBuffer->begin();
@@ -2685,8 +2674,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     buffer_create_info.queueFamilyIndexCount = 1;
     buffer_create_info.pQueueFamilyIndices = &queue_family_index;
 
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
     VkBufferViewCreateInfo buff_view_ci = LvlInitStruct<VkBufferViewCreateInfo>();
     buff_view_ci.buffer = buffer.handle();
     buff_view_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -2776,9 +2764,8 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     m_errorMonitor->VerifyFound();
 
     metal_texture_info.image = VK_NULL_HANDLE;
-    vk_testing::ImageView image_view_no_struct;
     auto image_view_ci = image_obj.BasicViewCreatInfo();
-    image_view_no_struct.init(*m_device, image_view_ci);
+    vk_testing::ImageView image_view_no_struct(*m_device, image_view_ci);
     metal_texture_info.imageView = image_view_no_struct.handle();
     // ImageView not created with struct in pNext
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportMetalObjectsInfoEXT-pNext-06796");
@@ -2815,8 +2802,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
 
     image_view_ci.pNext = &export_metal_object_create_info;
     export_metal_object_create_info.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT;
-    vk_testing::ImageView single_plane_export_image_view;
-    single_plane_export_image_view.init(*m_device, image_view_ci);
+    vk_testing::ImageView single_plane_export_image_view(*m_device, image_view_ci);
     metal_texture_info.image = VK_NULL_HANDLE;
     metal_texture_info.imageView = single_plane_export_image_view.handle();
     // metal_texture_info.plane not plane_0 for single plane imageView
@@ -2851,8 +2837,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
 
     if (portability_features.events) {
         event_info.pNext = nullptr;
-        vk_testing::Event event_no_struct;
-        event_no_struct.init(*m_device, event_info);
+        vk_testing::Event event_no_struct(*m_device, event_info);
         metal_shared_event_info.event = event_no_struct.handle();
         metal_shared_event_info.semaphore = VK_NULL_HANDLE;
         // Event not created with struct in pNext
@@ -2903,8 +2888,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
             ivci.image = mp_image_obj.handle();
             ivci.format = mp_format;
             ivci.pNext = &ycbcr_info;
-            vk_testing::ImageView mp_image_view;
-            mp_image_view.init(*m_device, ivci);
+            vk_testing::ImageView mp_image_view(*m_device, ivci);
             metal_texture_info.image = VK_NULL_HANDLE;
             metal_texture_info.imageView = mp_image_view.handle();
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportMetalObjectsInfoEXT-pNext-06802");

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -68,11 +68,10 @@ TEST_F(NegativePipeline, BasicCompute) {
     pipe.InitState();
     pipe.CreateComputePipeline();
 
-    VkBufferObj buffer;
     auto bci = LvlInitStruct<VkBufferCreateInfo>();
     bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     bci.size = 1024;
-    buffer.init(*m_device, bci);
+    VkBufferObj buffer(*m_device, bci);
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, 1024);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
@@ -316,11 +315,10 @@ TEST_F(NegativePipeline, BadPipelineObject) {
     m_commandBuffer->DrawIndexed(1, 1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
 
-    VkBufferObj buffer;
     VkBufferCreateInfo ci = LvlInitStruct<VkBufferCreateInfo>();
     ci.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     ci.size = 1024;
-    buffer.init(*m_device, ci);
+    VkBufferObj buffer(*m_device, ci);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndirect-None-08606");
     vk::CmdDrawIndirect(m_commandBuffer->handle(), buffer.handle(), 0, 1, 0);
     m_errorMonitor->VerifyFound();
@@ -1867,14 +1865,12 @@ TEST_F(NegativePipeline, NotCompatibleForSet) {
     bci.size = 4;
     bci.queueFamilyIndexCount = 1;
     bci.pQueueFamilyIndices = &qfi;
-    VkBufferObj storage_buffer;
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    storage_buffer.init(*m_device, bci, mem_props);
+    VkBufferObj storage_buffer(*m_device, bci, mem_props);
 
-    VkBufferObj uniform_buffer;
     bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     bci.size = 20;
-    uniform_buffer.init(*m_device, bci, mem_props);
+    VkBufferObj uniform_buffer(*m_device, bci, mem_props);
 
     OneOffDescriptorSet::Bindings binding_defs = {
         {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -1056,8 +1056,7 @@ TEST_F(NegativePipelineLayout, SetLayoutFlags) {
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &layout_binding;
 
-    vk_testing::DescriptorSetLayout ds_layout;
-    ds_layout.init(*m_device, ds_layout_ci);
+    vk_testing::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
     VkDescriptorSetLayout ds_layout_handle = ds_layout.handle();
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = LvlInitStruct<VkPipelineLayoutCreateInfo>();

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -513,9 +513,8 @@ TEST_F(VkPortabilitySubsetTest, UpdateDescriptorSets) {
                                            {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                        });
     const VkPipelineLayoutObj pipeline_layout(m_device, {&descriptor_set.layout_});
-    vk_testing::ImageView view;
     auto image_view_create_info = image.BasicViewCreatInfo();
-    view.init(*m_device, image_view_create_info);
+    vk_testing::ImageView view(*m_device, image_view_create_info);
 
     VkDescriptorImageInfo img_info = {};
     img_info.sampler = sampler.handle();

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -1261,8 +1261,7 @@ TEST_F(NegativeQuery, PreciseBit) {
 
     // Test for precise bit when query type is not OCCLUSION
     if (features.occlusionQueryPrecise) {
-        VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
-        vk_testing::Event event(*m_device, event_create_info);
+        vk_testing::Event event(*m_device);
 
         m_commandBuffer->begin();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQuery-queryType-00800");
@@ -1476,11 +1475,10 @@ TEST_F(NegativeQuery, WriteTimeStamp) {
         GTEST_SKIP() << "Device graphic queue has timestampValidBits of 0, skipping.\n";
     }
 
-    vk_testing::QueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_ci = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_ci.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_ci.queryCount = 1;
-    query_pool.init(*m_device, query_pool_ci);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
 
     m_commandBuffer->begin();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdWriteTimestamp-query-04904");
@@ -1566,17 +1564,14 @@ TEST_F(NegativeQuery, CmdEndQueryIndexedEXTPrimitiveGenerated) {
     VkQueryPoolCreateInfo qpci = LvlInitStruct<VkQueryPoolCreateInfo>();
     qpci.queryCount = 1;
 
-    vk_testing::QueryPool tf_query_pool;
     qpci.queryType = VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT;
-    tf_query_pool.init(*m_device, qpci);
+    vk_testing::QueryPool tf_query_pool(*m_device, qpci);
 
-    vk_testing::QueryPool pg_query_pool;
     qpci.queryType = VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT;
-    pg_query_pool.init(*m_device, qpci);
+    vk_testing::QueryPool pg_query_pool(*m_device, qpci);
 
-    vk_testing::QueryPool query_pool;
     qpci.queryType = VK_QUERY_TYPE_OCCLUSION;
-    query_pool.init(*m_device, qpci);
+    vk_testing::QueryPool query_pool(*m_device, qpci);
 
     m_commandBuffer->begin();
 
@@ -1651,11 +1646,10 @@ TEST_F(NegativeQuery, GetResultsFlags) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    vk_testing::QueryPool query_pool;
     VkQueryPoolCreateInfo qpci = LvlInitStruct<VkQueryPoolCreateInfo>();
     qpci.queryType = VK_QUERY_TYPE_OCCLUSION;
     qpci.queryCount = 1;
-    query_pool.init(*m_device, qpci);
+    vk_testing::QueryPool query_pool(*m_device, qpci);
 
     const size_t out_data_size = 16;
     uint8_t data[out_data_size];
@@ -1789,8 +1783,7 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
     rp_ci.subpassCount = 1;
     rp_ci.pSubpasses = &subpass;
 
-    vk_testing::RenderPass render_pass;
-    render_pass.init(*m_device, rp_ci);
+    vk_testing::RenderPass render_pass(*m_device, rp_ci);
 
     VkImageObj image(m_device);
     VkImageCreateInfo image_ci = LvlInitStruct<VkImageCreateInfo>();
@@ -1807,7 +1800,6 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
     image.init(&image_ci);
     ASSERT_TRUE(image.initialized());
 
-    vk_testing::ImageView image_view;
     VkImageViewCreateInfo iv_ci = LvlInitStruct<VkImageViewCreateInfo>();
     iv_ci.image = image.handle();
     iv_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
@@ -1817,7 +1809,7 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
     iv_ci.subresourceRange.levelCount = 1;
     iv_ci.subresourceRange.baseArrayLayer = 0;
     iv_ci.subresourceRange.layerCount = 4;
-    image_view.init(*m_device, iv_ci);
+    vk_testing::ImageView image_view(*m_device, iv_ci);
 
     VkImageView image_view_handle = image_view.handle();
 
@@ -1829,15 +1821,13 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
     fb_ci.height = 64;
     fb_ci.layers = 1;
 
-    vk_testing::Framebuffer framebuffer;
-    framebuffer.init(*m_device, fb_ci);
+    vk_testing::Framebuffer framebuffer(*m_device, fb_ci);
 
     VkQueryPoolCreateInfo qpci = LvlInitStruct<VkQueryPoolCreateInfo>();
     qpci.queryType = VK_QUERY_TYPE_OCCLUSION;
     qpci.queryCount = 2;
 
-    vk_testing::QueryPool query_pool;
-    query_pool.init(*m_device, qpci);
+    vk_testing::QueryPool query_pool(*m_device, qpci);
 
     auto rp_begin = LvlInitStruct<VkRenderPassBeginInfo>();
     rp_begin.renderPass = render_pass.handle();
@@ -1877,8 +1867,7 @@ TEST_F(NegativeQuery, PipelineStatisticsQuery) {
         query_pool_ci.queryCount = 1;
         query_pool_ci.pipelineStatistics = VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT;
 
-        vk_testing::QueryPool query_pool;
-        query_pool.init(*m_device, query_pool_ci);
+        vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQuery-queryType-00805");
         vk::CmdBeginQuery(command_buffer.handle(), query_pool.handle(), 0, 0);
@@ -1898,8 +1887,7 @@ TEST_F(NegativeQuery, PipelineStatisticsQuery) {
         query_pool_ci.queryCount = 1;
         query_pool_ci.pipelineStatistics = VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT;
 
-        vk_testing::QueryPool query_pool;
-        query_pool.init(*m_device, query_pool_ci);
+        vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQuery-queryType-00804");
         vk::CmdBeginQuery(command_buffer.handle(), query_pool.handle(), 0, 0);
@@ -1919,11 +1907,10 @@ TEST_F(NegativeQuery, TestGetQueryPoolResultsDataAndStride) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    vk_testing::QueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_ci = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_ci.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_ci.queryCount = 1;
-    query_pool.init(*m_device, query_pool_ci);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetQueryPoolResults-flags-02828");
     const size_t out_data_size = 16;
@@ -1971,8 +1958,7 @@ TEST_F(NegativeQuery, PrimitivesGenerated) {
     query_pool_ci.queryType = VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT;
     query_pool_ci.queryCount = 1;
 
-    vk_testing::QueryPool query_pool;
-    query_pool.init(*m_device, query_pool_ci);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQuery-queryType-06687");
     vk::CmdBeginQuery(command_buffer.handle(), query_pool.handle(), 0, 0);
@@ -2020,8 +2006,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedFeature) {
     query_pool_ci.queryType = VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT;
     query_pool_ci.queryCount = 1;
 
-    vk_testing::QueryPool query_pool;
-    query_pool.init(*m_device, query_pool_ci);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
     m_commandBuffer->begin();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQuery-queryType-06688");
     vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 0, 0);
@@ -2069,8 +2054,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedDiscardEnabled) {
     query_pool_ci.queryCount = 1;
     query_pool_ci.queryType = VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT;
 
-    vk_testing::QueryPool query_pool;
-    query_pool.init(*m_device, query_pool_ci);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-primitivesGeneratedQueryWithRasterizerDiscard-06708");
 
@@ -2137,8 +2121,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedStreams) {
     query_pool_ci.queryCount = 1;
     query_pool_ci.queryType = VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT;
 
-    vk_testing::QueryPool query_pool;
-    query_pool.init(*m_device, query_pool_ci);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-primitivesGeneratedQueryWithNonZeroStreams-06709");
 
@@ -2294,8 +2277,7 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
     rp_ci.dependencyCount = 1;
     rp_ci.pDependencies = &dependency;
 
-    vk_testing::RenderPass render_pass;
-    render_pass.init(*m_device, rp_ci);
+    vk_testing::RenderPass render_pass(*m_device, rp_ci);
 
     VkImageObj image(m_device);
     VkImageCreateInfo image_ci = LvlInitStruct<VkImageCreateInfo>();
@@ -2312,7 +2294,6 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
     image.init(&image_ci);
     ASSERT_TRUE(image.initialized());
 
-    vk_testing::ImageView image_view;
     VkImageViewCreateInfo iv_ci = LvlInitStruct<VkImageViewCreateInfo>();
     iv_ci.image = image.handle();
     iv_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
@@ -2322,7 +2303,7 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
     iv_ci.subresourceRange.levelCount = 1;
     iv_ci.subresourceRange.baseArrayLayer = 0;
     iv_ci.subresourceRange.layerCount = 4;
-    image_view.init(*m_device, iv_ci);
+    vk_testing::ImageView image_view(*m_device, iv_ci);
 
     VkImageView image_view_handle = image_view.handle();
 
@@ -2334,15 +2315,13 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
     fb_ci.height = 64;
     fb_ci.layers = 1;
 
-    vk_testing::Framebuffer framebuffer;
-    framebuffer.init(*m_device, fb_ci);
+    vk_testing::Framebuffer framebuffer(*m_device, fb_ci);
 
     VkQueryPoolCreateInfo qpci = LvlInitStruct<VkQueryPoolCreateInfo>();
     qpci.queryType = VK_QUERY_TYPE_OCCLUSION;
     qpci.queryCount = 2;
 
-    vk_testing::QueryPool query_pool;
-    query_pool.init(*m_device, qpci);
+    vk_testing::QueryPool query_pool(*m_device, qpci);
 
     auto rp_begin = LvlInitStruct<VkRenderPassBeginInfo>();
     rp_begin.renderPass = render_pass.handle();
@@ -2514,8 +2493,7 @@ TEST_F(NegativeQuery, CmdCopyQueryPoolResultsWithoutQueryPool) {
     auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = 1024;
     buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_ci);
+    VkBufferObj buffer(*m_device, buffer_ci);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyQueryPoolResults-queryPool-parameter");
     vk::CmdCopyQueryPoolResults(m_commandBuffer->handle(), bad_query_pool, 0, 1, buffer.handle(), 0, 0, VK_QUERY_RESULT_WAIT_BIT);

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -86,9 +86,8 @@ TEST_F(PositiveQuery, BasicQuery) {
     bci.size = 4 * sizeof(uint64_t);
     bci.queueFamilyIndexCount = 1;
     bci.pQueueFamilyIndices = &qfi;
-    VkBufferObj buffer;
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    buffer.init(*m_device, bci, mem_props);
+    VkBufferObj buffer(*m_device, bci, mem_props);
 
     VkQueryPoolCreateInfo query_pool_info = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_info.queryType = VK_QUERY_TYPE_OCCLUSION;
@@ -159,9 +158,8 @@ TEST_F(PositiveQuery, DestroyQueryPoolBasedOnQueryPoolResults) {
     bci.size = sizeof_samples_passed;
     bci.queueFamilyIndexCount = 1;
     bci.pQueueFamilyIndices = &qfi;
-    VkBufferObj buffer;
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    buffer.init(*m_device, bci, mem_props);
+    VkBufferObj buffer(*m_device, bci, mem_props);
 
     constexpr uint32_t query_count = 2;
 
@@ -246,8 +244,7 @@ TEST_F(PositiveQuery, QueryAndCopySecondaryCommandBuffers) {
     buff_create_info.queueFamilyIndexCount = 1;
     buff_create_info.pQueueFamilyIndices = &qfi;
 
-    VkBufferObj buffer;
-    buffer.init(*m_device, buff_create_info);
+    VkBufferObj buffer(*m_device, buff_create_info);
 
     VkCommandBufferInheritanceInfo hinfo = LvlInitStruct<VkCommandBufferInheritanceInfo>();
     hinfo.renderPass = VK_NULL_HANDLE;
@@ -314,8 +311,7 @@ TEST_F(PositiveQuery, QueryAndCopyMultipleCommandBuffers) {
     buff_create_info.queueFamilyIndexCount = 1;
     buff_create_info.pQueueFamilyIndices = &qfi;
 
-    VkBufferObj buffer;
-    buffer.init(*m_device, buff_create_info);
+    VkBufferObj buffer(*m_device, buff_create_info);
 
     {
         VkCommandBufferBeginInfo begin_info = LvlInitStruct<VkCommandBufferBeginInfo>();
@@ -400,11 +396,10 @@ TEST_F(PositiveQuery, WriteTimestampNoneAndAll) {
         GTEST_SKIP() << "Device graphic queue has timestampValidBits of 0, skipping.\n";
     }
 
-    vk_testing::QueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_ci = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_ci.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_ci.queryCount = 2;
-    query_pool.init(*m_device, query_pool_ci);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
 
     m_commandBuffer->begin();
     vk::CmdWriteTimestamp2KHR(m_commandBuffer->handle(), VK_PIPELINE_STAGE_2_NONE_KHR, query_pool.handle(), 0);

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1843,9 +1843,8 @@ TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructureKHR) {
 
     auto alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
-    VkBufferObj src_buffer;
-    src_buffer.init(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
-                    VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
+    VkBufferObj src_buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+                           VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
 
     VkBufferCreateInfo buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
     buffer_ci.size = 1024;
@@ -1911,8 +1910,8 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructureKHR) {
     ASSERT_TRUE(device_memory.initialized());
     vk::BindBufferMemory(m_device->handle(), non_host_visible_buffer.handle(), device_memory.handle(), 0);
 
-    VkBufferObj host_buffer;
-    host_buffer.init(*m_device, 4096, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR);
+    VkBufferObj host_buffer(*m_device, 4096, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+                            VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR);
 
     auto bot_level_as = rt::as::blueprint::BuildGeometryInfoSimpleOnHostBottomLevel(DeviceValidationVersion(), *m_device);
     bot_level_as.GetDstAS()->SetDeviceBuffer(std::move(non_host_visible_buffer));
@@ -2071,9 +2070,9 @@ TEST_F(NegativeRayTracing, CreateAccelerationStructureKHR) {
     VkAccelerationStructureCreateInfoKHR as_create_info = LvlInitStruct<VkAccelerationStructureCreateInfoKHR>();
     auto alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
-    VkBufferObj buffer;
-    buffer.init(*m_device, 4096, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
-                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
+    VkBufferObj buffer(*m_device, 4096,
+                       VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+                       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
     as_create_info.buffer = buffer.handle();
     as_create_info.createFlags = 0;
     as_create_info.offset = 0;
@@ -2850,11 +2849,11 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     }
     // Buffer is missing VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR usage flag
     {
-        VkBufferObj bad_usage_buffer;
         auto alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
         alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
-        bad_usage_buffer.init(*m_device, 1024, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
-                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc_flags);
+        VkBufferObj bad_usage_buffer(*m_device, 1024,
+                                     VK_BUFFER_USAGE_RAY_TRACING_BIT_NV | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc_flags);
         auto build_info = rt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(DeviceValidationVersion(), *m_device);
         build_info.GetGeometries()[0].SetTrianglesDeviceVertexBuffer(std::move(bad_usage_buffer), 3);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673");

--- a/tests/unit/ray_tracing_gpu.cpp
+++ b/tests/unit/ray_tracing_gpu.cpp
@@ -75,9 +75,8 @@ TEST_F(NegativeGpuAssistedRayTracingNV, BuildAccelerationStructureValidationInva
     };
 
     VkDeviceSize instance_buffer_size = sizeof(VkGeometryInstanceNV);
-    VkBufferObj instance_buffer;
-    instance_buffer.init(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
-                         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj instance_buffer(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
+                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
     uint8_t *mapped_instance_buffer_data = (uint8_t *)instance_buffer.memory().map();
     std::memcpy(mapped_instance_buffer_data, (uint8_t *)&instance, static_cast<std::size_t>(instance_buffer_size));
@@ -166,9 +165,8 @@ TEST_F(NegativeGpuAssistedRayTracingNV, BuildAccelerationStructureValidationBott
     };
 
     VkDeviceSize instance_buffer_size = sizeof(VkGeometryInstanceNV);
-    VkBufferObj instance_buffer;
-    instance_buffer.init(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
-                         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj instance_buffer(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
+                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
     uint8_t *mapped_instance_buffer_data = (uint8_t *)instance_buffer.memory().map();
     std::memcpy(mapped_instance_buffer_data, (uint8_t *)&instance, static_cast<std::size_t>(instance_buffer_size));
@@ -278,9 +276,8 @@ TEST_F(NegativeGpuAssistedRayTracingNV, BuildAccelerationStructureValidationBott
     };
 
     VkDeviceSize instance_buffer_size = sizeof(VkGeometryInstanceNV);
-    VkBufferObj instance_buffer;
-    instance_buffer.init(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
-                         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj instance_buffer(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
+                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
     uint8_t *mapped_instance_buffer_data = (uint8_t *)instance_buffer.memory().map();
     std::memcpy(mapped_instance_buffer_data, (uint8_t *)&instance, static_cast<std::size_t>(instance_buffer_size));
@@ -359,9 +356,8 @@ TEST_F(NegativeGpuAssistedRayTracingNV, BuildAccelerationStructureValidationRest
     };
 
     VkDeviceSize instance_buffer_size = sizeof(VkGeometryInstanceNV);
-    VkBufferObj instance_buffer;
-    instance_buffer.init(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
-                         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkBufferObj instance_buffer(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
+                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
     uint8_t *mapped_instance_buffer_data = (uint8_t *)instance_buffer.memory().map();
     std::memcpy(mapped_instance_buffer_data, (uint8_t *)&instance, static_cast<std::size_t>(instance_buffer_size));

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -735,15 +735,13 @@ TEST_F(PositiveRenderPass, SingleMipTransition) {
     vinfo.format = VK_FORMAT_R8G8B8A8_UNORM;
     vinfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    vk_testing::ImageView fullView0;
-    fullView0.init(*m_device, vinfo);
+    vk_testing::ImageView fullView0(*m_device, vinfo);
 
     vinfo.image = depthImage.handle();
     vinfo.format = VK_FORMAT_D32_SFLOAT;
     vinfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
 
-    vk_testing::ImageView fullView1;
-    fullView1.init(*m_device, vinfo);
+    vk_testing::ImageView fullView1(*m_device, vinfo);
 
     VkImageView fullViews[] = {fullView0.handle(), fullView1.handle()};
 
@@ -1147,8 +1145,7 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
 
-    vk_testing::RenderPass rp;
-    rp.init(*m_device, rpci);
+    vk_testing::RenderPass rp(*m_device, rpci);
 
     auto image_ci = LvlInitStruct<VkImageCreateInfo>();
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -1170,8 +1167,7 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     ivci.format = VK_FORMAT_R8G8B8A8_UNORM;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 3};
-    vk_testing::ImageView view;
-    view.init(*m_device, ivci);
+    vk_testing::ImageView view(*m_device, ivci);
     VkImageView image_view_handle = view.handle();
 
     VkFramebufferCreateInfo fci = LvlInitStruct<VkFramebufferCreateInfo>();
@@ -1181,16 +1177,14 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
     fci.width = 32;
     fci.height = 32;
     fci.layers = 1;
-    vk_testing::Framebuffer fb;
-    fb.init(*m_device, fci);
+    vk_testing::Framebuffer fb(*m_device, fci);
 
     VkBufferObj buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     VkQueryPoolCreateInfo qpci = LvlInitStruct<VkQueryPoolCreateInfo>();
     qpci.queryType = VK_QUERY_TYPE_OCCLUSION;
     qpci.queryCount = 2;
-    vk_testing::QueryPool query_pool;
-    query_pool.init(*m_device, qpci);
+    vk_testing::QueryPool query_pool(*m_device, qpci);
 
     VkRenderPassBeginInfo rpbi = LvlInitStruct<VkRenderPassBeginInfo>();
     rpbi.renderPass = rp.handle();
@@ -1398,8 +1392,7 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
     rp_info.attachmentCount = depth_count;
     rp_info.pAttachments = attach_desc;
 
-    vk_testing::RenderPass renderpass;
-    renderpass.init(*m_device, rp_info);
+    vk_testing::RenderPass renderpass(*m_device, rp_info);
 
     auto fb_info = LvlInitStruct<VkFramebufferCreateInfo>();
     fb_info.renderPass = renderpass.handle();
@@ -1409,8 +1402,7 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
     fb_info.height = image_info.extent.height;
     fb_info.layers = 1;
 
-    vk_testing::Framebuffer framebuffer;
-    framebuffer.init(*m_device, fb_info);
+    vk_testing::Framebuffer framebuffer(*m_device, fb_info);
 
     auto rp_begin_info = LvlInitStruct<VkRenderPassBeginInfo>();
     rp_begin_info.renderPass = renderpass.handle();
@@ -1669,13 +1661,12 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
     const auto stencil_range = image.subresource_range(VK_IMAGE_ASPECT_STENCIL_BIT);
     const auto depth_stencil_range = image.subresource_range(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
-    vk_testing::ImageView view;
     VkImageViewCreateInfo view_info = LvlInitStruct<VkImageViewCreateInfo>();
     view_info.image = image.handle();
     view_info.subresourceRange = depth_stencil_range;
     view_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     view_info.format = ds_format;
-    view.init(*m_device, view_info);
+    vk_testing::ImageView view(*m_device, view_info);
 
     std::vector<VkImageMemoryBarrier> barriers;
 

--- a/tests/unit/renderpass.cpp
+++ b/tests/unit/renderpass.cpp
@@ -1788,11 +1788,10 @@ TEST_F(NegativeRenderPass, FramebufferDepthStencilResolveAttachment) {
     fbci.renderPass = rp.handle();
     fbci.attachmentCount = 2;
     fbci.pAttachments = image_views;
-    vk_testing::Framebuffer framebuffer;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-00880");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-02634");
-    framebuffer.init(*m_device, fbci);
+    vk_testing::Framebuffer framebuffer(*m_device, fbci);
     m_errorMonitor->VerifyFound();
 }
 
@@ -3242,13 +3241,11 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     ivci.subresourceRange.levelCount = 1;
     ivci.subresourceRange.baseArrayLayer = 0;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-    vk_testing::ImageView image_view;
-    image_view.init(*m_device, ivci);
+    vk_testing::ImageView image_view(*m_device, ivci);
     VkImageView image_view_handle = image_view.handle();
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_ci);
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     auto fbci = LvlInitStruct<VkFramebufferCreateInfo>();
     fbci.width = width;
@@ -3360,12 +3357,10 @@ TEST_F(NegativeRenderPass, ColorAttachmentImageViewUsage) {
     image_view_ci.subresourceRange.levelCount = 1;
     image_view_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    vk_testing::ImageView image_view;
-    image_view.init(*m_device, image_view_ci);
+    vk_testing::ImageView image_view(*m_device, image_view_ci);
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_ci);
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     VkDescriptorImageInfo image_info = {};
     image_info.sampler = sampler.handle();
@@ -3796,9 +3791,8 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     VkImageObj two_count_image(m_device);
     two_count_image.init(&image_create_info);
 
-    vk_testing::ImageView two_count_image_view;
     auto image_view_ci = two_count_image.BasicViewCreatInfo();
-    two_count_image_view.init(*m_device, image_view_ci);
+    vk_testing::ImageView two_count_image_view(*m_device, image_view_ci);
 
     color_attachment.imageView = two_count_image_view.handle();
     m_commandBuffer->begin();
@@ -3811,9 +3805,8 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     VkImageObj one_count_image(m_device);
     one_count_image.init(&image_create_info);
-    vk_testing::ImageView one_count_image_view;
     auto one_count_image_view_ci = one_count_image.BasicViewCreatInfo();
-    one_count_image_view.init(*m_device, one_count_image_view_ci);
+    vk_testing::ImageView one_count_image_view(*m_device, one_count_image_view_ci);
     color_attachment.imageView = one_count_image_view.handle();
     // Attachments with a sample count of VK_SAMPLE_COUNT_1_BIT must have been created with
     // VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT
@@ -3825,9 +3818,8 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     VkImageObj good_one_count_image(m_device);
     image_create_info.flags = VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT;
     good_one_count_image.init(&image_create_info);
-    vk_testing::ImageView good_one_count_image_view;
     auto good_one_count_image_view_ci = good_one_count_image.BasicViewCreatInfo();
-    good_one_count_image_view.init(*m_device, good_one_count_image_view_ci);
+    vk_testing::ImageView good_one_count_image_view(*m_device, good_one_count_image_view_ci);
     color_attachment.imageView = good_one_count_image_view.handle();
     color_attachment.resolveImageView = good_one_count_image_view.handle();
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -3918,9 +3910,8 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
             VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT | VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
         VkImageObj unsampleable_image(m_device);
         unsampleable_image.init(&image_create_info);
-        vk_testing::ImageView unsampleable_image_view;
         auto unsampleable_image_view_ci = unsampleable_image.BasicViewCreatInfo();
-        unsampleable_image_view.init(*m_device, unsampleable_image_view_ci);
+        vk_testing::ImageView unsampleable_image_view(*m_device, unsampleable_image_view_ci);
         begin_rendering_info.pNext = &ms_render_to_ss;
         ms_render_to_ss.rasterizationSamples = unsampleable_count;
         color_attachment.resolveImageView = VK_NULL_HANDLE;
@@ -4119,8 +4110,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass) {
     fb_ci.width = width;
     fb_ci.height = height;
     fb_ci.layers = 1;
-    vk_testing::Framebuffer framebuffer;
-    framebuffer.init(*m_device, fb_ci);
+    vk_testing::Framebuffer framebuffer(*m_device, fb_ci);
 
     VkClearValue clear_values[2] = {};
     clear_values[0].color = {{0, 0, 0, 0}};
@@ -4228,8 +4218,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass2) {
     fb_ci.width = width;
     fb_ci.height = height;
     fb_ci.layers = 1;
-    vk_testing::Framebuffer framebuffer;
-    framebuffer.init(*m_device, fb_ci);
+    vk_testing::Framebuffer framebuffer(*m_device, fb_ci);
 
     VkClearValue clear_values[2] = {};
     clear_values[0].color = {{0, 0, 0, 0}};

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -839,9 +839,8 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefined) {
                                            {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                        });
     const VkPipelineLayoutObj pipeline_layout(m_device, {&descriptor_set.layout_});
-    vk_testing::ImageView view;
     auto image_view_create_info = image.BasicViewCreatInfo();
-    view.init(*m_device, image_view_create_info);
+    vk_testing::ImageView view(*m_device, image_view_create_info);
 
     VkDescriptorImageInfo img_info = {};
     img_info.sampler = sampler.handle();

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -960,19 +960,17 @@ TEST_F(VkPositiveLayerTest, TestShaderInputOutputMatch) {
     pipe.pipeline_layout_ = VkPipelineLayoutObj(m_device, {&ds.layout_});
     pipe.CreateGraphicsPipeline();
 
-    VkBufferObj uniform_buffer;
     auto ub_ci = LvlInitStruct<VkBufferCreateInfo>();
     ub_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     ub_ci.size = 1024;
-    uniform_buffer.init(*m_device, ub_ci);
+    VkBufferObj uniform_buffer(*m_device, ub_ci);
     ds.WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, 1024);
     ds.UpdateDescriptorSets();
 
-    VkBufferObj buffer;
     VkBufferCreateInfo vb_ci = LvlInitStruct<VkBufferCreateInfo>();
     vb_ci.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
     vb_ci.size = 1024;
-    buffer.init(*m_device, vb_ci);
+    VkBufferObj buffer(*m_device, vb_ci);
     VkBuffer buffer_handle = buffer.handle();
     VkDeviceSize offset = 0;
 

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -6861,11 +6861,10 @@ TEST_F(NegativeShaderObject, MissingImageFilterLinearBit) {
     image.Init(32, 32, 1, format, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView image_view = image.targetView(format);
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.minFilter = VK_FILTER_LINEAR;
     sampler_info.compareEnable = VK_FALSE;
-    sampler.init(*m_device, sampler_info);
+    vk_testing::Sampler sampler(*m_device, sampler_info);
 
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler.handle());
     descriptor_set.UpdateDescriptorSets();
@@ -7082,8 +7081,7 @@ TEST_F(NegativeShaderObject, PrimitivesGeneratedQuery) {
     query_pool_ci.queryCount = 1;
     query_pool_ci.queryType = VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT;
 
-    vk_testing::QueryPool query_pool;
-    query_pool.init(*m_device, query_pool_ci);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_ci);
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderingColor(GetDynamicRenderTarget());

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -674,9 +674,7 @@ TEST_F(PositiveShaderObject, ComputeShader) {
     ds_pool_ci.flags = 0;
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
-    vk_testing::DescriptorPool ds_pool;
-    ds_pool.init(*m_device, ds_pool_ci);
-    ASSERT_TRUE(ds_pool.initialized());
+    vk_testing::DescriptorPool ds_pool(*m_device, ds_pool_ci);
 
     VkDescriptorSetLayoutBinding dsl_binding = {};
     dsl_binding.binding = 0;
@@ -1164,9 +1162,8 @@ TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
     image.Init(image_ci);
     VkImageView view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 1, 1);
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_info);
+    vk_testing::Sampler sampler(*m_device, sampler_info);
 
     frag_descriptor_set.WriteDescriptorImageInfo(0, view, sampler.handle());
     frag_descriptor_set.UpdateDescriptorSets();

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -632,12 +632,11 @@ TEST_F(PositiveShaderSpirv, SpecializationWordBoundryOffset) {
     pipe.CreateComputePipeline();
 
     // Submit shader to see SSBO output
-    VkBufferObj buffer;
     auto bci = LvlInitStruct<VkBufferCreateInfo>();
     bci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     bci.size = 1024;
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    buffer.init(*m_device, bci, mem_props);
+    VkBufferObj buffer(*m_device, bci, mem_props);
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, 1024, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -142,8 +142,7 @@ TEST_F(NegativeShaderStorageTexel, UnknownWriteLessComponent) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 1024;
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     VkBufferViewCreateInfo buff_view_ci = LvlInitStruct<VkBufferViewCreateInfo>();
     buff_view_ci.buffer = buffer.handle();
@@ -259,8 +258,7 @@ TEST_F(NegativeShaderStorageTexel, MissingFormatWriteForFormat) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 1024;
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     VkBufferViewCreateInfo buff_view_ci = LvlInitStruct<VkBufferViewCreateInfo>();
     buff_view_ci.buffer = buffer.handle();

--- a/tests/unit/shader_storage_texel_positive.cpp
+++ b/tests/unit/shader_storage_texel_positive.cpp
@@ -74,8 +74,7 @@ TEST_F(PositiveShaderStorageTexel, BufferWriteMoreComponent) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.size = 1024;
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
-    VkBufferObj buffer;
-    buffer.init(*m_device, buffer_create_info);
+    VkBufferObj buffer(*m_device, buffer_create_info);
 
     VkBufferViewCreateInfo buff_view_ci = LvlInitStruct<VkBufferViewCreateInfo>();
     buff_view_ci.buffer = buffer.handle();

--- a/tests/unit/sparse_buffer.cpp
+++ b/tests/unit/sparse_buffer.cpp
@@ -228,8 +228,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy) {
         GTEST_SKIP() << "Required queue families not present";
     }
 
-    auto s_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, s_info);
+    vk_testing::Semaphore semaphore(*m_device);
 
     VkBufferCopy copy_info;
     copy_info.srcOffset = 0;
@@ -315,8 +314,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy2) {
         GTEST_SKIP() << "Required queue families not present";
     }
 
-    auto s_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, s_info);
+    vk_testing::Semaphore semaphore(*m_device);
 
     constexpr VkDeviceSize copy_size = 16;
     std::array<VkBufferCopy, 4> copy_info_list = {};
@@ -409,8 +407,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy3) {
         GTEST_SKIP() << "Required queue families not present";
     }
 
-    auto semaphore_ci = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_ci);
+    vk_testing::Semaphore semaphore(*m_device);
 
     VkBufferCreateInfo buffer_ci =
         vk_testing::Buffer::create_info(4096 * 32, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);

--- a/tests/unit/sparse_buffer_positive.cpp
+++ b/tests/unit/sparse_buffer_positive.cpp
@@ -28,9 +28,8 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy) {
     }
 
     // 2 semaphores needed since we need to bind twice before copying
-    auto s_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, s_info);
-    vk_testing::Semaphore semaphore2(*m_device, s_info);
+    vk_testing::Semaphore semaphore(*m_device);
+    vk_testing::Semaphore semaphore2(*m_device);
 
     VkBufferCopy copy_info;
     copy_info.srcOffset = 0;
@@ -120,8 +119,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy2) {
         GTEST_SKIP() << "Required queue families not present";
     }
 
-    auto s_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, s_info);
+    vk_testing::Semaphore semaphore(*m_device);
 
     constexpr VkDeviceSize copy_size = 16;
     // Consecutive ranges
@@ -206,8 +204,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy3) {
         GTEST_SKIP() << "Required queue families not present";
     }
 
-    auto semaphore_ci = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_ci);
+    vk_testing::Semaphore semaphore(*m_device);
 
     VkBufferCreateInfo buffer_ci =
         vk_testing::Buffer::create_info(4096 * 32, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
@@ -290,8 +287,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy4) {
         GTEST_SKIP() << "Required queue families not present";
     }
 
-    auto semaphore_ci = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_ci);
+    vk_testing::Semaphore semaphore(*m_device);
 
     VkBufferCreateInfo buffer_ci =
         vk_testing::Buffer::create_info(4096 * 32, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);

--- a/tests/unit/sparse_image_positive.cpp
+++ b/tests/unit/sparse_image_positive.cpp
@@ -299,8 +299,7 @@ TEST_F(PositiveSparseImage, OpImageSparse) {
     VkImageView image_view = image.targetView(VK_FORMAT_B8G8R8A8_UNORM);
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    vk_testing::Sampler sampler;
-    sampler.init(*m_device, sampler_ci);
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     OneOffDescriptorSet ds(m_device, {
                                          {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -810,8 +810,7 @@ TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     render_pass_ci.attachmentCount = 1;
     render_pass_ci.pAttachments = &attach_desc;
 
-    vk_testing::RenderPass render_pass;
-    render_pass.init(*m_device, render_pass_ci);
+    vk_testing::RenderPass render_pass(*m_device, render_pass_ci);
 
     VkImageObj image(m_device);
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
@@ -825,8 +824,7 @@ TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     framebuffer_ci.height = 32;
     framebuffer_ci.layers = 1;
 
-    vk_testing::Framebuffer framebuffer;
-    framebuffer.init(*m_device, framebuffer_ci);
+    vk_testing::Framebuffer framebuffer(*m_device, framebuffer_ci);
 
     CreatePipelineHelper pipe1(*this);
     pipe1.InitInfo();

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -267,9 +267,8 @@ TEST_F(PositiveSyncObject, QueueSubmitSemaphoresAndLayoutTracking) {
     vk::EndCommandBuffer(cmd_bufs[3]);
 
     // Submit 4 command buffers in 3 submits, with submits 2 and 3 waiting for semaphores from submits 1 and 2
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore1(*m_device, semaphore_create_info);
-    vk_testing::Semaphore semaphore2(*m_device, semaphore_create_info);
+    vk_testing::Semaphore semaphore1(*m_device);
+    vk_testing::Semaphore semaphore2(*m_device);
     VkPipelineStageFlags flags[]{VK_PIPELINE_STAGE_ALL_COMMANDS_BIT};
     VkSubmitInfo submit_info[3];
     submit_info[0] = LvlInitStruct<VkSubmitInfo>();
@@ -403,8 +402,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
     }
 
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
+    vk_testing::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = LvlInitStruct<VkCommandPoolCreateInfo>();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
@@ -489,8 +487,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
     VkFenceCreateInfo fence_create_info = LvlInitStruct<VkFenceCreateInfo>();
     vk_testing::Fence fence(*m_device, fence_create_info);
 
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
+    vk_testing::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = LvlInitStruct<VkCommandPoolCreateInfo>();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
@@ -575,8 +572,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
     VkFenceCreateInfo fence_create_info = LvlInitStruct<VkFenceCreateInfo>();
     vk_testing::Fence fence(*m_device, fence_create_info);
 
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
+    vk_testing::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = LvlInitStruct<VkCommandPoolCreateInfo>();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
@@ -720,8 +716,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
     VkFenceCreateInfo fence_create_info = LvlInitStruct<VkFenceCreateInfo>();
     vk_testing::Fence fence(*m_device, fence_create_info);
 
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
+    vk_testing::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = LvlInitStruct<VkCommandPoolCreateInfo>();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
@@ -910,8 +905,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsOneQueueWithSemaphoreAndOneFence) {
     VkFenceCreateInfo fence_create_info = LvlInitStruct<VkFenceCreateInfo>();
     vk_testing::Fence fence(*m_device, fence_create_info);
 
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
+    vk_testing::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = LvlInitStruct<VkCommandPoolCreateInfo>();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
@@ -1143,8 +1137,7 @@ TEST_F(PositiveSyncObject, TwoSubmitInfosWithSemaphoreOneQueueSubmitsOneFence) {
     VkFenceCreateInfo fence_create_info = LvlInitStruct<VkFenceCreateInfo>();
     vk_testing::Fence fence(*m_device, fence_create_info);
 
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
+    vk_testing::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = LvlInitStruct<VkCommandPoolCreateInfo>();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
@@ -1683,8 +1676,7 @@ TEST_F(PositiveSyncObject, WaitEventThenSet) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    VkEventCreateInfo event_create_info = LvlInitStruct<VkEventCreateInfo>();
-    vk_testing::Event event(*m_device, event_create_info);
+    vk_testing::Event event(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = LvlInitStruct<VkCommandPoolCreateInfo>();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
@@ -1836,11 +1828,8 @@ TEST_F(PositiveSyncObject, QueueSubmitTimelineSemaphore2Queue) {
     auto semaphore_type_create_info = LvlInitStruct<VkSemaphoreTypeCreateInfoKHR>();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
 
-    auto semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    semaphore_create_info.pNext = &semaphore_type_create_info;
-
-    vk_testing::Semaphore semaphore;
-    semaphore.init(*m_device, semaphore_create_info);
+    auto semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>(&semaphore_type_create_info);
+    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
 
     // timeline values, Begins will be signaled by host, Ends by the queues
     constexpr uint64_t kQ0Begin = 1;
@@ -1926,8 +1915,7 @@ TEST_F(PositiveSyncObject, ResetQueryPoolFromDifferentCBWithFenceAfter) {
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
-    vk_testing::QueryPool query_pool;
-    query_pool.init(*m_device, query_pool_create_info);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_create_info);
 
     VkCommandBuffer command_buffer[2];
     VkCommandBufferAllocateInfo command_buffer_allocate_info = LvlInitStruct<VkCommandBufferAllocateInfo>();

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -2007,11 +2007,10 @@ TEST_F(NegativeSyncVal, CmdQuery) {
         GTEST_SKIP() << "Device graphic queue has timestampValidBits of 0, skipping.\n";
     }
 
-    vk_testing::QueryPool query_pool;
     VkQueryPoolCreateInfo query_pool_create_info = LvlInitStruct<VkQueryPoolCreateInfo>();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
-    query_pool.init(*m_device, query_pool_create_info);
+    vk_testing::QueryPool query_pool(*m_device, query_pool_create_info);
 
     VkMemoryPropertyFlags mem_prop = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     VkBufferUsageFlags transfer_usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
@@ -2237,12 +2236,10 @@ TEST_F(NegativeSyncVal, RenderPassLoadHazardVsInitialLayout) {
                                                    &subpassDescription,
                                                    1u,
                                                    &subpassDependency};
-    vk_testing::RenderPass rp;
-    rp.init(*m_device, renderPassInfo);
+    vk_testing::RenderPass rp(*m_device, renderPassInfo);
 
-    vk_testing::Framebuffer fb;
     VkFramebufferCreateInfo fbci = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.handle(), 2, attachments, 32, 32, 1};
-    fb.init(*m_device, fbci);
+    vk_testing::Framebuffer fb(*m_device, fbci);
 
     image_input.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
@@ -2334,19 +2331,16 @@ TEST_F(NegativeSyncVal, RenderPassWithWrongDepthStencilInitialLayout) {
                                                    &subpassDescription,
                                                    0u,
                                                    0};
-    vk_testing::RenderPass rp;
-    rp.init(*m_device, renderPassInfo);
+    vk_testing::RenderPass rp(*m_device, renderPassInfo);
 
     VkImageView fb_attachments[] = {image_color.targetView(color_format),
                                     image_ds.targetView(ds_format, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)};
     const VkFramebufferCreateInfo fbci = {
         VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, 0, 0u, rp.handle(), 2u, fb_attachments, 32, 32, 1u,
     };
-    vk_testing::Framebuffer fb;
-    fb.init(*m_device, fbci);
+    vk_testing::Framebuffer fb(*m_device, fbci);
     fb_attachments[0] = image_color2.targetView(color_format);
-    vk_testing::Framebuffer fb1;
-    fb1.init(*m_device, fbci);
+    vk_testing::Framebuffer fb1(*m_device, fbci);
 
     CreatePipelineHelper g_pipe(*this);
     g_pipe.InitInfo();
@@ -2830,10 +2824,8 @@ TEST_F(NegativeSyncVal, SubpassMultiDep) {
     rp_helper_negative.InitFramebuffer();
     rp_helper_negative.InitBeginInfo();
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_info);
-
+    vk_testing::Sampler sampler(*m_device, sampler_info);
 
     CreatePipelineHelper g_pipe(*this);
     rp_helper_positive.InitPipelineHelper(g_pipe);
@@ -3052,9 +3044,8 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
     fbci.height = kHeight;
     fbci.layers = 1;
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_info);
+    vk_testing::Sampler sampler(*m_device, sampler_info);
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, kFragmentSubpassLoadGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -3065,12 +3056,10 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
 
     // run the renderpass with no dependencies
     {
-        vk_testing::RenderPass rp;
-        vk_testing::Framebuffer fb;
-        rp.init(*m_device, renderpass_info);
+        vk_testing::RenderPass rp(*m_device, renderpass_info);
 
         fbci.renderPass = rp.handle();
-        fb.init(*m_device, fbci);
+        vk_testing::Framebuffer fb(*m_device, fbci);
 
         CreatePipelineHelper g_pipe_0(*this);
         g_pipe_0.InitInfo();
@@ -3150,12 +3139,10 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
     renderpass_info.pDependencies = subpass_dependencies.data();
 
     {
-        vk_testing::RenderPass rp;
-        vk_testing::Framebuffer fb;
-        rp.init(*m_device, renderpass_info);
+        vk_testing::RenderPass rp(*m_device, renderpass_info);
 
         fbci.renderPass = rp.handle();
-        fb.init(*m_device, fbci);
+        vk_testing::Framebuffer fb(*m_device, fbci);
 
         CreatePipelineHelper g_pipe_0(*this);
         g_pipe_0.InitInfo();
@@ -3237,12 +3224,10 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
     renderpass_info.dependencyCount = subpass_dependencies.size();
     renderpass_info.pDependencies = subpass_dependencies.data();
     {
-        vk_testing::RenderPass rp;
-        vk_testing::Framebuffer fb;
-        rp.init(*m_device, renderpass_info);
+        vk_testing::RenderPass rp(*m_device, renderpass_info);
 
         fbci.renderPass = rp.handle();
-        fb.init(*m_device, fbci);
+        vk_testing::Framebuffer fb(*m_device, fbci);
 
         CreatePipelineHelper g_pipe_0(*this);
         g_pipe_0.InitInfo();
@@ -3683,9 +3668,7 @@ TEST_F(NegativeSyncVal, Sync2FeatureDisabled) {
     vk::CmdPipelineBarrier2KHR(m_commandBuffer->handle(), &dependency_info);
     m_errorMonitor->VerifyFound();
 
-    VkEventCreateInfo eci = LvlInitStruct<VkEventCreateInfo>();
-    vk_testing::Event event;
-    event.init(*m_device, eci);
+    vk_testing::Event event(*m_device);
 
     VkPipelineStageFlagBits2KHR stage = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT_KHR;
 
@@ -3702,8 +3685,7 @@ TEST_F(NegativeSyncVal, Sync2FeatureDisabled) {
         qpci.queryType = VK_QUERY_TYPE_TIMESTAMP;
         qpci.queryCount = 1;
 
-        vk_testing::QueryPool query_pool;
-        query_pool.init(*m_device, qpci);
+        vk_testing::QueryPool query_pool(*m_device, qpci);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdWriteTimestamp2-synchronization2-03858");
         vk::CmdWriteTimestamp2KHR(m_commandBuffer->handle(), stage, query_pool.handle(), 0);
@@ -3787,8 +3769,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     buffer_create_info.queueFamilyIndexCount = 1;
     buffer_create_info.pQueueFamilyIndices = &qfi;
 
-    VkBufferObj doit_buffer;
-    doit_buffer.init(*m_device, buffer_create_info);
+    VkBufferObj doit_buffer(*m_device, buffer_create_info);
 
     auto buffer = std::make_unique<VkBufferObj>();
     buffer->init(*m_device, buffer_create_info);
@@ -3801,9 +3782,8 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     buffer_info[1].offset = 0;
     buffer_info[1].range = sizeof(uint32_t);
 
-    VkBufferObj texel_buffer;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
-    texel_buffer.init(*m_device, buffer_create_info);
+    VkBufferObj texel_buffer(*m_device, buffer_create_info);
 
     auto bvci = LvlInitStruct<VkBufferViewCreateInfo>();
     bvci.buffer = texel_buffer.handle();
@@ -3817,8 +3797,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     auto index_buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     index_buffer_create_info.size = sizeof(uint32_t);
     index_buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
-    VkBufferObj index_buffer;
-    index_buffer.init(*m_device, index_buffer_create_info);
+    VkBufferObj index_buffer(*m_device, index_buffer_create_info);
 
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     VkImageObj sampled_image(m_device);
@@ -3835,9 +3814,8 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     auto combined_view = std::make_unique<vk_testing::ImageView>();
     combined_view->init(*m_device, imageview_ci);
 
-    vk_testing::Sampler sampler;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler.init(*m_device, sampler_ci);
+    vk_testing::Sampler sampler(*m_device, sampler_ci);
 
     VkDescriptorImageInfo image_info[3] = {};
     image_info[0].sampler = sampler.handle();
@@ -4000,8 +3978,7 @@ TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {
     rp_ci.dependencyCount = 1;
     rp_ci.pDependencies = &subpass_dependency;
 
-    vk_testing::RenderPass render_pass;
-    render_pass.init(*m_device, rp_ci);
+    vk_testing::RenderPass render_pass(*m_device, rp_ci);
 
     VkClearValue clear_value = {};
     clear_value.color = {{0, 0, 0, 0}};
@@ -4022,7 +3999,6 @@ TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {
     image1.init(&image_ci);
     ASSERT_TRUE(image1.initialized());
 
-    vk_testing::ImageView image_view1;
     VkImageViewCreateInfo iv_ci = LvlInitStruct<VkImageViewCreateInfo>();
     iv_ci.image = image1.handle();
     iv_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -4032,7 +4008,7 @@ TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {
     iv_ci.subresourceRange.levelCount = 1;
     iv_ci.subresourceRange.baseArrayLayer = 0;
     iv_ci.subresourceRange.layerCount = 1;
-    image_view1.init(*m_device, iv_ci);
+    vk_testing::ImageView image_view1(*m_device, iv_ci);
 
     VkImageView framebuffer_attachments[1] = {image_view1.handle()};
 
@@ -4044,8 +4020,7 @@ TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {
     fb_ci.height = 32;
     fb_ci.layers = 1;
 
-    vk_testing::Framebuffer framebuffer;
-    framebuffer.init(*m_device, fb_ci);
+    vk_testing::Framebuffer framebuffer(*m_device, fb_ci);
 
     auto rp_bi = LvlInitStruct<VkRenderPassBeginInfo>();
     rp_bi.renderPass = render_pass.handle();

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -62,8 +62,7 @@ TEST_F(NegativeTransformFeedback, FeatureEnabled) {
         auto info = LvlInitStruct<VkBufferCreateInfo>();
         info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
         info.size = 4;
-        VkBufferObj buffer;
-        buffer.init(*m_device, info);
+        VkBufferObj buffer(*m_device, info);
         VkDeviceSize offsets[1]{};
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindTransformFeedbackBuffersEXT-transformFeedback-02355");
@@ -555,8 +554,7 @@ TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
     VkBufferCreateInfo buffer_create_info = LvlInitStruct<VkBufferCreateInfo>();
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     buffer_create_info.size = 1024;
-    VkBufferObj counter_buffer;
-    counter_buffer.init(*m_device, buffer_create_info);
+    VkBufferObj counter_buffer(*m_device, buffer_create_info);
 
     {
         CreatePipelineHelper pipeline(*this);

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -1605,9 +1605,7 @@ TEST_F(NegativeWsi, DeviceGroupSubmitInfoSemaphoreCount) {
     dev_grp_cmd_buf_info.deviceMask = 0x1;
     auto cmd_buf_info = LvlInitStruct<VkCommandBufferBeginInfo>(&dev_grp_cmd_buf_info);
 
-    auto semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
-    ASSERT_TRUE(semaphore.initialized());
+    vk_testing::Semaphore semaphore(*m_device);
 
     auto device_group_submit_info = LvlInitStruct<VkDeviceGroupSubmitInfo>();
     device_group_submit_info.commandBufferCount = 1;
@@ -2609,9 +2607,8 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionRelease) {
 
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
 
-    VkSemaphoreCreateInfo semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore acquire_semaphore(*m_device, semaphore_create_info);
-    vk_testing::Semaphore submit_semaphore(*m_device, semaphore_create_info);
+    vk_testing::Semaphore acquire_semaphore(*m_device);
+    vk_testing::Semaphore submit_semaphore(*m_device);
 
     const auto swapchain_images = GetSwapchainImages(m_swapchain);
     uint32_t image_index = 0;
@@ -3400,9 +3397,7 @@ TEST_F(NegativeWsi, SwapchainAcquireImageRetired) {
     VkSwapchainKHR swapchain;
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &swapchain);
 
-    auto semaphore_create_info = LvlInitStruct<VkSemaphoreCreateInfo>();
-    vk_testing::Semaphore semaphore(*m_device, semaphore_create_info);
-    ASSERT_TRUE(semaphore.initialized());
+    vk_testing::Semaphore semaphore(*m_device);
 
     auto acquire_info = LvlInitStruct<VkAcquireNextImageInfoKHR>();
     acquire_info.swapchain = m_swapchain;

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -1196,8 +1196,7 @@ TEST_F(NegativeYcbcr, MismatchedImageViewAndSamplerFormat) {
     sampler_conversion_ci.chromaFilter = VK_FILTER_NEAREST;
     sampler_conversion_ci.forceExplicitReconstruction = false;
 
-    vk_testing::SamplerYcbcrConversion sampler_conversion;
-    sampler_conversion.init(*m_device, sampler_conversion_ci, false);
+    vk_testing::SamplerYcbcrConversion sampler_conversion(*m_device, sampler_conversion_ci, false);
 
     auto sampler_ycbcr_conversion_info = LvlInitStruct<VkSamplerYcbcrConversionInfo>();
     sampler_ycbcr_conversion_info.conversion = sampler_conversion.handle();


### PR DESCRIPTION
Sames a good number of lines by just using the constructor inlined where possible in the tests