### PR TITLE
Improve ValidateBarriersToImages messages

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -920,6 +920,7 @@ class BarrierQueueFamilyTestHelper : public BarrierQueueFamilyBase {
     VkBufferMemoryBarrier buffer_barrier_;
 };
 
+// TODO - Only works with extensions enabled, not using Vulkan1.3 (uses KHR functions)
 class Barrier2QueueFamilyTestHelper : public BarrierQueueFamilyBase {
   public:
     Barrier2QueueFamilyTestHelper(Context *context) : BarrierQueueFamilyBase(context) {}


### PR DESCRIPTION
for `VUID-VkImageMemoryBarrier2-image-03320` 

before

> vkCmdPipelineBarrier2(): .pImageMemoryBarriers[0].image references VkImage 0x967dd1000000000e[] of format VK_FORMAT_D16_UNORM_S8_UINT that must have the depth and stencil aspects set, but its aspectMask is 0x4.

now

> vkCmdPipelineBarrier2(): pDependencyInfo.pImageMemoryBarriers[0].image (VkImage 0x967dd1000000000e[]) has depth/stencil format VK_FORMAT_D16_UNORM_S8_UINT, but its aspectMask is VK_IMAGE_ASPECT_STENCIL_BIT.
