### PR TITLE
Syncval Performance Set 1

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -4000,11 +4000,11 @@ void ResourceAccessState::Normalize() {
 
 void ResourceAccessState::GatherReferencedTags(ResourceUsageTagSet &used) const {
     if (last_write.has_value()) {
-        used.insert(last_write->Tag());
+        used.CachedInsert(last_write->Tag());
     }
 
     for (const auto &read_access : last_reads) {
-        used.insert(read_access.tag);
+        used.CachedInsert(read_access.tag);
     }
 }
 

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -3178,7 +3178,7 @@ HazardResult ResourceAccessState::DetectHazard(const SyncStageAccessInfoType &us
     const auto &usage_index = usage_info.stage_access_index;
     if (IsRead(usage_info)) {
         if (IsRAWHazard(usage_info)) {
-            hazard.Set(this, usage_info, READ_AFTER_WRITE, last_write);
+            hazard.Set(this, usage_info, READ_AFTER_WRITE, *last_write);
         }
     } else {
         // Write operation:
@@ -3197,9 +3197,9 @@ HazardResult ResourceAccessState::DetectHazard(const SyncStageAccessInfoType &us
                     break;
                 }
             }
-        } else if (last_write.HasValue() && last_write.IsWriteHazard(usage_info)) {
+        } else if (last_write.has_value() && last_write->IsWriteHazard(usage_info)) {
             // Write-After-Write check -- if we have a previous write to test against
-            hazard.Set(this, usage_info, WRITE_AFTER_WRITE, last_write);
+            hazard.Set(this, usage_info, WRITE_AFTER_WRITE, *last_write);
         }
     }
     return hazard;
@@ -3233,12 +3233,12 @@ HazardResult ResourceAccessState::DetectHazard(const SyncStageAccessInfoType &us
             if (usage_is_ordered) {
                 // Now see of the most recent write (or a subsequent read) are ordered
                 const bool most_recent_is_ordered =
-                    last_write.IsOrdered(ordering, queue_id) || (0 != GetOrderedStages(queue_id, ordering));
+                    last_write->IsOrdered(ordering, queue_id) || (0 != GetOrderedStages(queue_id, ordering));
                 is_raw_hazard = !most_recent_is_ordered;
             }
         }
         if (is_raw_hazard) {
-            hazard.Set(this, usage_info, READ_AFTER_WRITE, last_write);
+            hazard.Set(this, usage_info, READ_AFTER_WRITE, *last_write);
         }
     } else if (usage_index == SyncStageAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION) {
         // For Image layout transitions, the barrier represents the first synchronization/access scope of the layout transition
@@ -3263,15 +3263,15 @@ HazardResult ResourceAccessState::DetectHazard(const SyncStageAccessInfoType &us
                     }
                 }
             }
-        } else if (last_write.HasValue() && !(last_write.IsOrdered(ordering, queue_id) && usage_write_is_ordered)) {
+        } else if (last_write.has_value() && !(last_write->IsOrdered(ordering, queue_id) && usage_write_is_ordered)) {
             bool ilt_ilt_hazard = false;
-            if ((usage_index == SYNC_IMAGE_LAYOUT_TRANSITION) && (last_write.IsIndex(SYNC_IMAGE_LAYOUT_TRANSITION))) {
+            if ((usage_index == SYNC_IMAGE_LAYOUT_TRANSITION) && (last_write->IsIndex(SYNC_IMAGE_LAYOUT_TRANSITION))) {
                 // ILT after ILT is a special case where we check the 2nd access scope of the first ILT against the first access
                 // scope of the second ILT, which has been passed (smuggled?) in the ordering barrier
-                ilt_ilt_hazard = !(last_write.Barriers() & ordering.access_scope).any();
+                ilt_ilt_hazard = !(last_write->Barriers() & ordering.access_scope).any();
             }
-            if (ilt_ilt_hazard || last_write.IsWriteHazard(usage_info)) {
-                hazard.Set(this, usage_info, WRITE_AFTER_WRITE, last_write);
+            if (ilt_ilt_hazard || last_write->IsWriteHazard(usage_info)) {
+                hazard.Set(this, usage_info, WRITE_AFTER_WRITE, *last_write);
             }
         }
     }
@@ -3343,12 +3343,12 @@ HazardResult ResourceAccessState::DetectAsyncHazard(const SyncStageAccessInfoTyp
     // subpasses.  Anything older than that should have been checked at the start of each subpass, taking into account all of
     // the raster ordering rules.
     if (IsRead(usage_info)) {
-        if (last_write.HasValue() && (last_write.write_tag >= start_tag)) {
-            hazard.Set(this, usage_info, READ_RACING_WRITE, last_write);
+        if (last_write.has_value() && (last_write->write_tag >= start_tag)) {
+            hazard.Set(this, usage_info, READ_RACING_WRITE, *last_write);
         }
     } else {
-        if (last_write.HasValue() && (last_write.write_tag >= start_tag)) {
-            hazard.Set(this, usage_info, WRITE_RACING_WRITE, last_write);
+        if (last_write.has_value() && (last_write->write_tag >= start_tag)) {
+            hazard.Set(this, usage_info, WRITE_RACING_WRITE, *last_write);
         } else if (last_reads.size() > 0) {
             // Any reads during the other subpass will conflict with this write, so we need to check them all.
             for (const auto &read_access : last_reads) {
@@ -3396,8 +3396,8 @@ HazardResult ResourceAccessState::DetectBarrierHazard(const SyncStageAccessInfoT
                 break;
             }
         }
-    } else if (last_write.HasValue() && IsWriteBarrierHazard(queue_id, src_exec_scope, src_access_scope)) {
-        hazard.Set(this, usage_info, WRITE_AFTER_WRITE, last_write);
+    } else if (last_write.has_value() && IsWriteBarrierHazard(queue_id, src_exec_scope, src_access_scope)) {
+        hazard.Set(this, usage_info, WRITE_AFTER_WRITE, *last_write);
     }
 
     return hazard;
@@ -3413,9 +3413,9 @@ HazardResult ResourceAccessState::DetectBarrierHazard(const SyncStageAccessInfoT
     assert(usage_index == SyncStageAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION);
     HazardResult hazard;
 
-    if (last_write.HasValue() && (last_write.write_tag >= event_tag)) {
+    if (last_write.has_value() && (last_write->write_tag >= event_tag)) {
         // Any write after the event precludes the possibility of being in the first access scope for the layout transition
-        hazard.Set(this, usage_info, WRITE_AFTER_WRITE, last_write);
+        hazard.Set(this, usage_info, WRITE_AFTER_WRITE, *last_write);
     } else {
         // only test for WAW if there no intervening read operations.
         // See DetectHazard(SyncStagetAccessIndex) above for more details.
@@ -3450,12 +3450,12 @@ HazardResult ResourceAccessState::DetectBarrierHazard(const SyncStageAccessInfoT
                 const ReadState &current_read = last_reads[scope_read_count];
                 hazard.Set(this, usage_index, WRITE_AFTER_READ, current_read.access, current_read.tag);
             }
-        } else if (last_write.HasValue()) {
+        } else if (last_write.has_value()) {
             // if there are no reads, the write is either the reason the access is in the event scope... they are a hazard
             // The write is in the first sync scope of the event (sync their aren't any reads to be the reason)
             // So do a normal barrier hazard check
             if (scope_state.IsWriteBarrierHazard(event_queue, src_exec_scope, src_access_scope)) {
-                hazard.Set(&scope_state, usage_info, WRITE_AFTER_WRITE, scope_state.last_write);
+                hazard.Set(&scope_state, usage_info, WRITE_AFTER_WRITE, *scope_state.last_write);
             }
         }
     }
@@ -3524,9 +3524,9 @@ void ResourceAccessState::MergeReads(const ResourceAccessState &other) {
 // exists, but if you fix *that* hazard it either fixes or unmasks the subsequent ones.
 void ResourceAccessState::Resolve(const ResourceAccessState &other) {
     bool skip_first = false;
-    if (last_write.HasValue()) {
-        if (other.last_write.HasValue()) {
-            if (last_write.Tag() < other.last_write.Tag()) {
+    if (last_write.has_value()) {
+        if (other.last_write.has_value()) {
+            if (last_write->Tag() < other.last_write->Tag()) {
                 // NOTE: Both last and other have writes, and thus first access is "closed". We are selecting other's
                 //       first_access state, but it and this can only differ if there are async hazards
                 //       error state.
@@ -3535,10 +3535,10 @@ void ResourceAccessState::Resolve(const ResourceAccessState &other) {
                 // operation
                 *this = other;
                 skip_first = true;
-            } else if (last_write.Tag() == other.last_write.Tag()) {
+            } else if (last_write->Tag() == other.last_write->Tag()) {
                 // In the *equals* case for write operations, we merged the write barriers and the read state (but without the
                 // dependency chaining logic or any stage expansion)
-                last_write.MergeBarriers(other.last_write);
+                last_write->MergeBarriers(*other.last_write);
                 MergePending(other);
                 MergeReads(other);
             } else {
@@ -3551,7 +3551,7 @@ void ResourceAccessState::Resolve(const ResourceAccessState &other) {
             // Since this has a write first access is closed and shouldn't be updated by other
             skip_first = true;
         }
-    } else if (other.last_write.HasValue()) {  // && not this->last_write
+    } else if (other.last_write.has_value()) {  // && not this->last_write
         // Other has write and this doesn't, thus keep it, See first access NOTE above
         *this = other;
         skip_first = true;
@@ -3639,10 +3639,14 @@ void ResourceAccessState::Update(const SyncStageAccessInfoType &usage_info, Sync
 // Note: intentionally ignore pending barriers and chains (i.e. don't apply or clear them), let ApplyPendingBarriers handle them.
 void ResourceAccessState::SetWrite(const SyncStageAccessInfoType &usage_info, const ResourceUsageTag tag) {
     ClearRead();
-    last_write.Set(usage_info, tag);
+    if (last_write.has_value()) {
+        last_write->Set(usage_info, tag);
+    } else {
+        last_write.emplace(usage_info, tag);
+    }
 }
 
-void ResourceAccessState::ClearWrite() { last_write.Reset(); }
+void ResourceAccessState::ClearWrite() { last_write.reset(); }
 
 void ResourceAccessState::ClearRead() {
     last_reads.clear();
@@ -3689,7 +3693,7 @@ void ResourceAccessState::ApplyBarrier(ScopeOps &&scope, const SyncBarrier &barr
             pending_layout_ordering_ |= OrderingBarrier(barrier.src_exec_scope.exec_scope, barrier.src_access_scope);
         }
     }
-    // Track layout transistion as pending as we can't modify last_write.HasValue() until all barriers processed
+    // Track layout transistion as pending as we can't modify last_write.has_value() until all barriers processed
     pending_layout_transition |= layout_transition;
 
     if (!pending_layout_transition) {
@@ -3733,9 +3737,9 @@ void ResourceAccessState::ApplyPendingBarriers(const ResourceUsageTag tag) {
     }
 
     // We OR in the accumulated write chain and barriers even in the case of a layout transition as SetWrite zeros them.
-    if (last_write.HasValue()) {
-        last_write.write_dependency_chain |= pending_write_dep_chain;
-        last_write.write_barriers |= pending_write_barriers;
+    if (last_write.has_value()) {
+        last_write->write_dependency_chain |= pending_write_dep_chain;
+        last_write->write_barriers |= pending_write_barriers;
         pending_write_dep_chain = VK_PIPELINE_STAGE_2_NONE;
         pending_write_barriers.reset();
     }
@@ -3756,15 +3760,15 @@ void ResourceAccessState::ApplySemaphore(const SemaphoreScope &signal, const Sem
         }
     }
     if (WriteInQueueSourceScopeOrChain(signal.queue, signal.exec_scope, signal.valid_accesses)) {
-        assert(last_write.HasValue());
+        assert(last_write.has_value());
         // Will deflect RAW wait queue, WAW needs a chained barrier on wait queue
         read_execution_barriers = wait.exec_scope;
-        last_write.write_barriers = wait.valid_accesses;
+        last_write->write_barriers = wait.valid_accesses;
     } else {
         read_execution_barriers = VK_PIPELINE_STAGE_2_NONE;
-        if (last_write.HasValue()) last_write.write_barriers.reset();
+        if (last_write.has_value()) last_write->write_barriers.reset();
     }
-    if (last_write.HasValue()) last_write.write_dependency_chain = read_execution_barriers;
+    if (last_write.has_value()) last_write->write_dependency_chain = read_execution_barriers;
 }
 
 // Read access predicate for queue wait
@@ -3773,8 +3777,8 @@ bool ResourceAccessState::WaitQueueTagPredicate::operator()(const ResourceAccess
            (read_access.stage != VK_PIPELINE_STAGE_2_PRESENT_ENGINE_BIT_SYNCVAL);
 }
 bool ResourceAccessState::WaitQueueTagPredicate::operator()(const ResourceAccessState &access) const {
-    if (!access.last_write.HasValue()) return false;
-    const auto &write_state = access.last_write;
+    if (!access.last_write.has_value()) return false;
+    const auto &write_state = *access.last_write;
     return write_state.IsQueue(queue) && (write_state.Tag() <= tag) &&
            !write_state.IsIndex(SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_PRESENTED_SYNCVAL);
 }
@@ -3784,8 +3788,8 @@ bool ResourceAccessState::WaitTagPredicate::operator()(const ResourceAccessState
     return (read_access.tag <= tag) && (read_access.stage != VK_PIPELINE_STAGE_2_PRESENT_ENGINE_BIT_SYNCVAL);
 }
 bool ResourceAccessState::WaitTagPredicate::operator()(const ResourceAccessState &access) const {
-    if (!access.last_write.HasValue()) return false;
-    const auto &write_state = access.last_write;
+    if (!access.last_write.has_value()) return false;
+    const auto &write_state = *access.last_write;
     return (write_state.Tag() <= tag) && !write_state.IsIndex(SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_PRESENTED_SYNCVAL);
 }
 
@@ -3794,8 +3798,8 @@ bool ResourceAccessState::WaitAcquirePredicate::operator()(const ResourceAccessS
     return (read_access.tag == acquire_tag) && (read_access.stage == VK_PIPELINE_STAGE_2_PRESENT_ENGINE_BIT_SYNCVAL);
 }
 bool ResourceAccessState::WaitAcquirePredicate::operator()(const ResourceAccessState &access) const {
-    if (!access.last_write.HasValue()) return false;
-    const auto &write_state = access.last_write;
+    if (!access.last_write.has_value()) return false;
+    const auto &write_state = *access.last_write;
     return (write_state.Tag() == present_tag) && write_state.IsIndex(SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_PRESENTED_SYNCVAL);
 }
 
@@ -3846,7 +3850,7 @@ bool ResourceAccessState::ApplyPredicatedWait(Predicate &predicate) {
     }
 
     bool all_clear = last_reads.size() == 0;
-    if (last_write.HasValue()) {
+    if (last_write.has_value()) {
         if (predicate(*this) || sync_reads) {
             // Clear any predicated write, or any the write from any any access with synchronized reads.
             // This could drop RAW detection, but only if the synchronized reads were RAW hazards, and given
@@ -3867,7 +3871,7 @@ bool ResourceAccessState::FirstAccessInTagRange(const ResourceUsageRange &tag_ra
 }
 
 void ResourceAccessState::OffsetTag(ResourceUsageTag offset) {
-    if (last_write.HasValue()) last_write.OffsetTag(offset);
+    if (last_write.has_value()) last_write->OffsetTag(offset);
     for (auto &read_access : last_reads) {
         read_access.tag += offset;
     }
@@ -3911,27 +3915,27 @@ void ResourceAccessState::SetQueueId(QueueId id) {
             read_access.queue = id;
         }
     }
-    if (last_write.HasValue()) last_write.SetQueueId(id);
+    if (last_write.has_value()) last_write->SetQueueId(id);
 }
 
 bool ResourceAccessState::IsWriteBarrierHazard(QueueId queue_id, VkPipelineStageFlags2KHR src_exec_scope,
                                                const SyncStageAccessFlags &src_access_scope) const {
-    return last_write.HasValue() && last_write.IsWriteBarrierHazard(queue_id, src_exec_scope, src_access_scope);
+    return last_write.has_value() && last_write->IsWriteBarrierHazard(queue_id, src_exec_scope, src_access_scope);
 }
 
 bool ResourceAccessState::WriteInSourceScopeOrChain(VkPipelineStageFlags2KHR src_exec_scope,
                                                     SyncStageAccessFlags src_access_scope) const {
-    return last_write.HasValue() && last_write.WriteInSourceScopeOrChain(src_exec_scope, src_access_scope);
+    return last_write.has_value() && last_write->WriteInSourceScopeOrChain(src_exec_scope, src_access_scope);
 }
 
 bool ResourceAccessState::WriteInQueueSourceScopeOrChain(QueueId queue, VkPipelineStageFlags2KHR src_exec_scope,
                                                          const SyncStageAccessFlags &src_access_scope) const {
-    return last_write.HasValue() && last_write.WriteInQueueSourceScopeOrChain(queue, src_exec_scope, src_access_scope);
+    return last_write.has_value() && last_write->WriteInQueueSourceScopeOrChain(queue, src_exec_scope, src_access_scope);
 }
 
 bool ResourceAccessState::WriteInEventScope(VkPipelineStageFlags2KHR src_exec_scope, const SyncStageAccessFlags &src_access_scope,
                                             QueueId scope_queue, ResourceUsageTag scope_tag) const {
-    return last_write.HasValue() && last_write.WriteInEventScope(src_exec_scope, src_access_scope, scope_queue, scope_tag);
+    return last_write.has_value() && last_write->WriteInEventScope(src_exec_scope, src_access_scope, scope_queue, scope_tag);
 }
 
 bool ResourceAccessWriteState::WriteInChain(VkPipelineStageFlags2KHR src_exec_scope) const {
@@ -3981,9 +3985,6 @@ bool operator<(const ResourceAccessState::ReadState &lhs, const ResourceAccessSt
 }
 
 void ResourceAccessState::Normalize() {
-    if (!last_write.HasValue()) {
-        ClearWrite();
-    }
     if (!last_reads.size()) {
         ClearRead();
     } else {
@@ -3999,8 +4000,8 @@ void ResourceAccessState::Normalize() {
 }
 
 void ResourceAccessState::GatherReferencedTags(ResourceUsageTagSet &used) const {
-    if (last_write.HasValue()) {
-        used.insert(last_write.Tag());
+    if (last_write.has_value()) {
+        used.insert(last_write->Tag());
     }
 
     for (const auto &read_access : last_reads) {
@@ -4015,8 +4016,8 @@ bool ResourceAccessState::IsRAWHazard(const SyncStageAccessInfoType &usage_info)
     //      any reads that happen after.
     //    * the previous reads *are* hazards to last_write, have been reported, and if that hazard is fixed
     //      the current read will be also not be a hazard, thus reporting a hazard here adds no needed information.
-    return last_write.HasValue() && (0 == (read_execution_barriers & usage_info.stage_mask)) &&
-           last_write.IsWriteHazard(usage_info);
+    return last_write.has_value() && (0 == (read_execution_barriers & usage_info.stage_mask)) &&
+           last_write->IsWriteHazard(usage_info);
 }
 
 VkPipelineStageFlags2 ResourceAccessState::GetOrderedStages(QueueId queue_id, const OrderingBarrier &ordering) const {
@@ -9025,8 +9026,6 @@ bool ResourceAccessWriteState::IsWriteBarrierHazard(QueueId queue_id, VkPipeline
     // Otherwise treat as an ordinary write hazard check with ordering rules.
     return IsOrderedWriteHazard(src_exec_scope, src_access_scope);
 }
-
-void ResourceAccessWriteState::Reset() { *this = ResourceAccessWriteState(); }
 
 void ResourceAccessWriteState::Set(const SyncStageAccessInfoType &usage_info_, ResourceUsageTag tag_) {
     last_write = &usage_info_;

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -413,16 +413,16 @@ class SignaledSemaphores {
 
 struct ResourceFirstAccess {
     ResourceUsageTag tag;
-    SyncStageAccessIndex usage_index;
+    const SyncStageAccessInfoType *usage_info;
     SyncOrdering ordering_rule;
-    ResourceFirstAccess(ResourceUsageTag tag_, SyncStageAccessIndex usage_index_, SyncOrdering ordering_rule_)
-        : tag(tag_), usage_index(usage_index_), ordering_rule(ordering_rule_){};
+    ResourceFirstAccess(ResourceUsageTag tag_, const SyncStageAccessInfoType &usage_info_, SyncOrdering ordering_rule_)
+        : tag(tag_), usage_info(&usage_info_), ordering_rule(ordering_rule_){};
     ResourceFirstAccess(const ResourceFirstAccess &other) = default;
     ResourceFirstAccess(ResourceFirstAccess &&other) = default;
     ResourceFirstAccess &operator=(const ResourceFirstAccess &rhs) = default;
     ResourceFirstAccess &operator=(ResourceFirstAccess &&rhs) = default;
     bool operator==(const ResourceFirstAccess &rhs) const {
-        return (tag == rhs.tag) && (usage_index == rhs.usage_index) && (ordering_rule == rhs.ordering_rule);
+        return (tag == rhs.tag) && (usage_info == rhs.usage_info) && (ordering_rule == rhs.ordering_rule);
     }
 };
 
@@ -706,7 +706,7 @@ class ResourceAccessState : public SyncStageAccess {
     }
     VkPipelineStageFlags2 GetOrderedStages(QueueId queue_id, const OrderingBarrier &ordering) const;
 
-    void UpdateFirst(ResourceUsageTag tag, SyncStageAccessIndex usage_index, SyncOrdering ordering_rule);
+    void UpdateFirst(ResourceUsageTag tag, const SyncStageAccessInfoType &usage_info, SyncOrdering ordering_rule);
     void TouchupFirstForLayoutTransition(ResourceUsageTag tag, const OrderingBarrier &layout_ordering);
     void MergePending(const ResourceAccessState &other);
     void MergeReads(const ResourceAccessState &other);

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -103,13 +103,11 @@ struct SyncStageAccess {
         return syncStageAccessInfoByStageAccessIndex()[stage_access].stage_access_bit;
     }
 
-    static bool IsRead(const SyncStageAccessFlags &stage_access_bit) { return (stage_access_bit & syncStageAccessReadMask).any(); }
-    static bool IsRead(SyncStageAccessIndex stage_access_index) { return IsRead(FlagBit(stage_access_index)); }
+    static bool IsRead(SyncStageAccessIndex stage_access_index) { return syncStageAccessReadMask[stage_access_index]; }
+    static bool IsRead(const SyncStageAccessInfoType &info) { return IsRead(info.stage_access_index); }
+    static bool IsWrite(SyncStageAccessIndex stage_access_index) { return syncStageAccessWriteMask[stage_access_index]; }
+    static bool IsWrite(const SyncStageAccessInfoType &info) { return IsWrite(info.stage_access_index); }
 
-    static bool IsWrite(const SyncStageAccessFlags &stage_access_bit) {
-        return (stage_access_bit & syncStageAccessWriteMask).any();
-    }
-    static bool IsWrite(SyncStageAccessIndex stage_access_index) { return IsWrite(FlagBit(stage_access_index)); }
     static VkPipelineStageFlags2KHR PipelineStageBit(SyncStageAccessIndex stage_access_index) {
         return syncStageAccessInfoByStageAccessIndex()[stage_access_index].stage_mask;
     }

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -96,11 +96,11 @@ enum class SyncOrdering : uint8_t {
 
 // Useful Utilites for manipulating StageAccess parameters, suitable as base class to save typing
 struct SyncStageAccess {
+    static inline const SyncStageAccessInfoType &UsageInfo(SyncStageAccessIndex stage_access_index) {
+        return syncStageAccessInfoByStageAccessIndex()[stage_access_index];
+    }
     static inline SyncStageAccessFlags FlagBit(SyncStageAccessIndex stage_access) {
         return syncStageAccessInfoByStageAccessIndex()[stage_access].stage_access_bit;
-    }
-    static inline SyncStageAccessFlags Flags(SyncStageAccessIndex stage_access) {
-        return static_cast<SyncStageAccessFlags>(FlagBit(stage_access));
     }
 
     static bool IsRead(const SyncStageAccessFlags &stage_access_bit) { return (stage_access_bit & syncStageAccessReadMask).any(); }
@@ -499,22 +499,23 @@ class ResourceAccessState : public SyncStageAccess {
         VkPipelineStageFlags2 ApplyPendingBarriers();
     };
 
-    HazardResult DetectHazard(SyncStageAccessIndex usage_index) const;
-    HazardResult DetectHazard(SyncStageAccessIndex usage_index, SyncOrdering ordering_rule, QueueId queue_id) const;
-    HazardResult DetectHazard(SyncStageAccessIndex usage_index, const OrderingBarrier &ordering, QueueId queue_id) const;
+    HazardResult DetectHazard(const SyncStageAccessInfoType &usage_info) const;
+    HazardResult DetectHazard(const SyncStageAccessInfoType &usage_info, SyncOrdering ordering_rule, QueueId queue_id) const;
+    HazardResult DetectHazard(const SyncStageAccessInfoType &usage_info, const OrderingBarrier &ordering, QueueId queue_id) const;
     HazardResult DetectHazard(const ResourceAccessState &recorded_use, QueueId queue_id, const ResourceUsageRange &tag_range) const;
 
-    HazardResult DetectAsyncHazard(SyncStageAccessIndex usage_index, ResourceUsageTag start_tag) const;
+    HazardResult DetectAsyncHazard(const SyncStageAccessInfoType &usage_info, ResourceUsageTag start_tag) const;
     HazardResult DetectAsyncHazard(const ResourceAccessState &recorded_use, const ResourceUsageRange &tag_range,
                                    ResourceUsageTag start_tag) const;
 
-    HazardResult DetectBarrierHazard(SyncStageAccessIndex usage_index, QueueId queue_id, VkPipelineStageFlags2KHR source_exec_scope,
+    HazardResult DetectBarrierHazard(const SyncStageAccessInfoType &usage_info, QueueId queue_id,
+                                     VkPipelineStageFlags2KHR source_exec_scope,
                                      const SyncStageAccessFlags &source_access_scope) const;
-    HazardResult DetectBarrierHazard(SyncStageAccessIndex usage_index, const ResourceAccessState &scope_state,
+    HazardResult DetectBarrierHazard(const SyncStageAccessInfoType &usage_info, const ResourceAccessState &scope_state,
                                      VkPipelineStageFlags2KHR source_exec_scope, const SyncStageAccessFlags &source_access_scope,
                                      QueueId event_queue, ResourceUsageTag event_tag) const;
 
-    void Update(SyncStageAccessIndex usage_index, SyncOrdering ordering_rule, ResourceUsageTag tag);
+    void Update(const SyncStageAccessInfoType &usage_info, SyncOrdering ordering_rule, ResourceUsageTag tag);
     void SetWrite(const SyncStageAccessFlags &usage_bit, ResourceUsageTag tag);
     void ClearWrite();
     void ClearRead();


### PR DESCRIPTION
A series of changes that improved various traces between 1% and 10% reduction in frametime (cumulatively) in local testing.  Each change is in a separate commit.  Relative performance is batched, and relative to the previous batch reported (SB == Strange Brigade  TS == TheSurge)  

This branch is built on the QueueSubmit rework branch (which had a 5%-67% reduction in frametime on one trace all by itself).  

Some expansion on each 

syncval: Cleanup of ResourceAccessState for perf 

Mostly housekeeping change 0's to applicable constants, except for using `reset` for the bitsets vs. `= 0` which was more efficient in the profiling

syncval: Convert usage index to info part 1

Changed from passing around usage information as an index to passing around a pointer to an entry to a const (static) array of usage information structs.  Prevented each ResourceAccessState operation from having to do the array lookup multiple times. During range_map traversal, the info struct is likely staying in memory, as part of the perf improvement.

syncval: Convert read/write to bit lookups 

When we converted from integers to bits sets we kept the bitwise operations paradigm for working with the Stage/Access masks.  When looking for whether a single bit is set, `bitset::hoperator[]` is faster that (bitset_a & bitset_b).any().  So do it everywhere wi

syncval: Convert last InfoType  (7% SB 10% TS)
Storage of the infotype pointer is larger than the enum index, but avoids look ups. 

syncval: Isolate last_write info to class

Something a of a straight clean-up/reorg, but keeps the next step isolated for performance testing

syncval: Convert last_write to optional (1.4% SB 2.8% TS)

It turns out that a lot of ResourceAccessState entries contain read entries (about 98%).  Avoiding the construction/destruction of the (now encapsulated) write state proved a win.

syncval: Convert First Access to InfoType (1% SB 1.5 TS)

Small perf win, maintenance cleanup of the resolve operation

syncval: Small refinements in ApplyBarrier 6.6% SB 6.6 TS)

The code was checking conditions it could know the answers to, and the optimizer wasn't finding it.  Small improvement.

syncval: Cached Insert for tag usage (1% SB 1.2% TS)

Set insertion showed up as a hot spot.  This simple 1-way direct-mapped cache gave a 40% hit rate, saving nearly half of the insertions.  Larger, multi-way, LRU caches had better hit rates, but no better performance.  Probably due to a balance of the (physical) cache residency of the insert cache array.

syncval: Encapsulate pending_write in write state (1% SB)

there are a set of pending_ fields only used when a write is present, this eliminates creation/destruction when no write is present
























