### PR TITLE
layers: Fix pnext chain handling for GetSurfaceCapabilities in swapchain creation validation

### DIFF
--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -334,16 +334,15 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
         }
     }
 
-    // Will be assigned &full_screen_info_copy if a VkSurfaceFullScreenExclusiveInfoEXT is found in pCreateInfo->pNext chain
-    void *pnext_copy_addr = nullptr;
+    void *surface_caps_query_pnext = nullptr;
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     auto full_screen_info_copy = LvlInitStruct<VkSurfaceFullScreenExclusiveInfoEXT>();
     auto win32_full_screen_info_copy = LvlInitStruct<VkSurfaceFullScreenExclusiveWin32InfoEXT>();
     const auto *full_screen_info = LvlFindInChain<VkSurfaceFullScreenExclusiveInfoEXT>(pCreateInfo->pNext);
     if (full_screen_info && full_screen_info->fullScreenExclusive == VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT) {
         full_screen_info_copy = *full_screen_info;
-        full_screen_info_copy.pNext = pnext_copy_addr;
-        pnext_copy_addr = &full_screen_info_copy;
+        full_screen_info_copy.pNext = surface_caps_query_pnext;
+        surface_caps_query_pnext = &full_screen_info_copy;
 
         if (IsExtEnabled(device_extensions.vk_khr_win32_surface)) {
             const auto *win32_full_screen_info = LvlFindInChain<VkSurfaceFullScreenExclusiveWin32InfoEXT>(pCreateInfo->pNext);
@@ -357,8 +356,8 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
                 }
             } else {
                 win32_full_screen_info_copy = *win32_full_screen_info;
-                win32_full_screen_info_copy.pNext = nullptr;
-                full_screen_info_copy.pNext = &win32_full_screen_info_copy;
+                win32_full_screen_info_copy.pNext = surface_caps_query_pnext;
+                surface_caps_query_pnext = &win32_full_screen_info_copy;
             }
         }
     }
@@ -366,12 +365,12 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
     auto present_mode_info = LvlInitStruct<VkSurfacePresentModeEXT>();
     if (IsExtEnabled(device_extensions.vk_ext_surface_maintenance1)) {
         present_mode_info.presentMode = pCreateInfo->presentMode;
-        present_mode_info.pNext = pnext_copy_addr;
-        pnext_copy_addr = &present_mode_info;
+        present_mode_info.pNext = surface_caps_query_pnext;
+        surface_caps_query_pnext = &present_mode_info;
     }
 
     const auto surface_caps2 = surface_state->GetCapabilities(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                                              physical_device_state->PhysDev(), pnext_copy_addr, this);
+                                                              physical_device_state->PhysDev(), surface_caps_query_pnext, this);
 
     bool skip = false;
     VkSurfaceTransformFlagBitsKHR current_transform = surface_caps2.surfaceCapabilities.currentTransform;
@@ -514,7 +513,7 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
         vvl::span<const safe_VkSurfaceFormat2KHR> formats{};
         if (surface_state) {
             formats = surface_state->GetFormats(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                                physical_device_state->PhysDev(), pnext_copy_addr, this);
+                                                physical_device_state->PhysDev(), surface_caps_query_pnext, this);
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             formats = physical_device_state->surfaceless_query_state.formats;
         }
@@ -556,7 +555,7 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
             if (surface_state) {
                 cached_capabilities =
                     surface_state->GetCapabilities(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                                   physical_device_state->PhysDev(), pnext_copy_addr, this);
+                                                   physical_device_state->PhysDev(), surface_caps_query_pnext, this);
             } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
                 cached_capabilities = physical_device_state->surfaceless_query_state.capabilities;
             }

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -763,7 +763,8 @@ TEST_F(PositiveWsi, CreateSurface) {
 
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
 TEST_F(PositiveWsi, CreateSwapchainFullscreenExclusive) {
-    TEST_DESCRIPTION("Test creating a swapchain with VkSurfaceFullScreenExclusiveWin32InfoEXT");
+    TEST_DESCRIPTION(
+        "Test creating a swapchain with VkSurfaceFullScreenExclusiveWin32InfoEXT and VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
@@ -787,6 +788,61 @@ TEST_F(PositiveWsi, CreateSwapchainFullscreenExclusive) {
 
     auto surface_full_screen_exlusive_info = LvlInitStruct<VkSurfaceFullScreenExclusiveInfoEXT>();
     surface_full_screen_exlusive_info.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT;
+
+    auto swapchain_create_info = LvlInitStruct<VkSwapchainCreateInfoKHR>(&surface_full_screen_exlusive_info);
+    swapchain_create_info.flags = 0;
+    swapchain_create_info.surface = m_surface;
+    swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
+    swapchain_create_info.imageFormat = m_surface_formats[0].format;
+    swapchain_create_info.imageColorSpace = m_surface_formats[0].colorSpace;
+    swapchain_create_info.imageExtent = {m_surface_capabilities.minImageExtent.width, m_surface_capabilities.minImageExtent.height};
+    swapchain_create_info.imageArrayLayers = 1;
+    swapchain_create_info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    swapchain_create_info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    swapchain_create_info.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+    swapchain_create_info.compositeAlpha = m_surface_composite_alpha;
+    swapchain_create_info.presentMode = m_surface_non_shared_present_mode;
+    swapchain_create_info.clipped = VK_FALSE;
+
+    VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+
+    vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &swapchain);
+    vk::DestroySwapchainKHR(device(), swapchain, nullptr);
+}
+#endif
+
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+TEST_F(PositiveWsi, CreateSwapchainFullscreenExclusive2) {
+    TEST_DESCRIPTION(
+        "Test creating a swapchain with VkSurfaceFullScreenExclusiveWin32InfoEXT and "
+        "VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+
+    AddSurfaceExtension();
+    AddRequiredExtensions(VK_EXT_FULL_SCREEN_EXCLUSIVE_EXTENSION_NAME);
+
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
+    }
+
+    if (!IsPlatform(kMockICD)) {
+        GTEST_SKIP() << "Only run test MockICD due to CI stability";
+    }
+
+    ASSERT_NO_FATAL_FAILURE(InitState());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    if (!InitSwapchain()) {
+        GTEST_SKIP() << "Cannot create surface or swapchain";
+    }
+
+    const POINT pt_zero = {0, 0};
+
+    auto fullscreen_exclusive_win32_info = LvlInitStruct<VkSurfaceFullScreenExclusiveWin32InfoEXT>();
+    fullscreen_exclusive_win32_info.hmonitor = MonitorFromPoint(pt_zero, MONITOR_DEFAULTTOPRIMARY);
+    auto surface_full_screen_exlusive_info = LvlInitStruct<VkSurfaceFullScreenExclusiveInfoEXT>(&fullscreen_exclusive_win32_info);
+    surface_full_screen_exlusive_info.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT;
 
     auto swapchain_create_info = LvlInitStruct<VkSwapchainCreateInfoKHR>(&surface_full_screen_exlusive_info);
     swapchain_create_info.flags = 0;


### PR DESCRIPTION
Follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6351

Fix a case where part of the pnext chain passed down to `GetSurfaceCapabilities` could be lost.
Add a new positive test that takes the problematic path.