### PR TITLE
layers: Use Location for stateless external objects

### DIFF
--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -89,9 +89,9 @@ bool StatelessValidation::manual_PreCallValidateCreateBufferView(VkDevice device
                                                                  const ErrorObject &error_obj) const {
     bool skip = false;
 #ifdef VK_USE_PLATFORM_METAL_EXT
-    skip |= ExportMetalObjectsPNextUtil(
-        VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT, "VUID-VkBufferViewCreateInfo-pNext-06782",
-        "vkCreateBufferView():", "VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT", pCreateInfo->pNext);
+    skip |=
+        ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT, "VUID-VkBufferViewCreateInfo-pNext-06782",
+                                    error_obj.location, "VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT", pCreateInfo->pNext);
 #endif  // VK_USE_PLATFORM_METAL_EXT
     return skip;
 }

--- a/layers/stateless/sl_device_memory.cpp
+++ b/layers/stateless/sl_device_memory.cpp
@@ -173,9 +173,9 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
             }
         }
 #ifdef VK_USE_PLATFORM_METAL_EXT
-        skip |= ExportMetalObjectsPNextUtil(
-            VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT, "VUID-VkMemoryAllocateInfo-pNext-06780",
-            "vkAllocateMemory():", "VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT", pAllocateInfo->pNext);
+        skip |= ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT,
+                                            "VUID-VkMemoryAllocateInfo-pNext-06780", error_obj.location,
+                                            "VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT", pAllocateInfo->pNext);
 #endif  // VK_USE_PLATFORM_METAL_EXT
     }
     return skip;

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -715,9 +715,9 @@ bool StatelessValidation::manual_PreCallValidateCreateImageView(VkDevice device,
             }
         }
 #ifdef VK_USE_PLATFORM_METAL_EXT
-        skip |= ExportMetalObjectsPNextUtil(
-            VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT, "VUID-VkImageViewCreateInfo-pNext-06787",
-            "vkCreateImageView():", "VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT", pCreateInfo->pNext);
+        skip |= ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT,
+                                            "VUID-VkImageViewCreateInfo-pNext-06787", error_obj.location,
+                                            "VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT", pCreateInfo->pNext);
 #endif  // VK_USE_PLATFORM_METAL_EXT
     }
     return skip;

--- a/layers/stateless/sl_synchronization.cpp
+++ b/layers/stateless/sl_synchronization.cpp
@@ -23,9 +23,9 @@ bool StatelessValidation::manual_PreCallValidateCreateSemaphore(VkDevice device,
                                                                 const ErrorObject &error_obj) const {
     bool skip = false;
 #ifdef VK_USE_PLATFORM_METAL_EXT
-    skip |= ExportMetalObjectsPNextUtil(
-        VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT, "VUID-VkSemaphoreCreateInfo-pNext-06789",
-        "vkCreateSemaphore():", "VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT", pCreateInfo->pNext);
+    skip |= ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT,
+                                        "VUID-VkSemaphoreCreateInfo-pNext-06789", error_obj.location,
+                                        "VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT", pCreateInfo->pNext);
 #endif  // VK_USE_PLATFORM_METAL_EXT
     return skip;
 }
@@ -34,9 +34,9 @@ bool StatelessValidation::manual_PreCallValidateCreateEvent(VkDevice device, con
                                                             const ErrorObject &error_obj) const {
     bool skip = false;
 #ifdef VK_USE_PLATFORM_METAL_EXT
-    skip |= ExportMetalObjectsPNextUtil(
-        VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT, "VUID-VkEventCreateInfo-pNext-06790",
-        "vkCreateEvent():", "VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT", pCreateInfo->pNext);
+    skip |= ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT,
+                                        "VUID-VkEventCreateInfo-pNext-06790", error_obj.location,
+                                        "VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT", pCreateInfo->pNext);
 #endif  // VK_USE_PLATFORM_METAL_EXT
     return skip;
 }

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -664,7 +664,7 @@ class StatelessValidation : public ValidationObject {
                                                 const ErrorObject &error_obj) const;
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
-    bool ExportMetalObjectsPNextUtil(VkExportMetalObjectTypeFlagBitsEXT bit, const char *vuid, const char *api_call,
+    bool ExportMetalObjectsPNextUtil(VkExportMetalObjectTypeFlagBitsEXT bit, const char *vuid, const Location &loc,
                                      const char *sType, const void *pNext) const;
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
@@ -914,10 +914,10 @@ class StatelessValidation : public ValidationObject {
     bool manual_PreCallValidateGetMemoryFdPropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, int fd,
                                                         VkMemoryFdPropertiesKHR *pMemoryFdProperties,
                                                         const ErrorObject &error_obj) const;
-    bool ValidateExternalSemaphoreHandleType(VkSemaphore semaphore, const char *vuid, const char *caller,
+    bool ValidateExternalSemaphoreHandleType(VkSemaphore semaphore, const char *vuid, const Location &handle_type_loc,
                                              VkExternalSemaphoreHandleTypeFlagBits handle_type,
                                              VkExternalSemaphoreHandleTypeFlags allowed_types) const;
-    bool ValidateExternalFenceHandleType(VkFence fence, const char *vuid, const char *caller,
+    bool ValidateExternalFenceHandleType(VkFence fence, const char *vuid, const Location &handle_type_loc,
                                          VkExternalFenceHandleTypeFlagBits handle_type,
                                          VkExternalFenceHandleTypeFlags allowed_types) const;
     bool manual_PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR *pImportSemaphoreFdInfo,


### PR DESCRIPTION
using `Location` for all the error messages in `sl_external_object.cpp`