### PR TITLE
layers: Give better Location names

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -3018,30 +3018,30 @@ bool CoreChecks::ValidateHostCopyImageLayout(const VkDevice device, const VkImag
 bool CoreChecks::PreCallValidateCopyMemoryToImageEXT(VkDevice device, const VkCopyMemoryToImageInfoEXT *pCopyMemoryToImageInfo,
                                                      const ErrorObject &error_obj) const {
     bool skip = false;
-    const Location loc = error_obj.location.dot(Field::pCopyMemoryToImageInfo);
+    const Location copy_loc = error_obj.location.dot(Field::pCopyMemoryToImageInfo);
     auto dst_image = pCopyMemoryToImageInfo->dstImage;
     auto image_state = Get<IMAGE_STATE>(dst_image);
 
-    skip |= ValidateMemoryImageCopyCommon(device, pCopyMemoryToImageInfo, loc);
+    skip |= ValidateMemoryImageCopyCommon(device, pCopyMemoryToImageInfo, copy_loc);
     auto *props = &phys_dev_ext_props.host_image_copy_properties;
     skip |= ValidateHostCopyImageLayout(device, dst_image, props->copyDstLayoutCount, props->pCopyDstLayouts,
-                                        pCopyMemoryToImageInfo->dstImageLayout, loc.dot(Field::dstImageLayout), "pCopyDstLayouts",
-                                        "VUID-VkCopyMemoryToImageInfoEXT-dstImageLayout-09060");
+                                        pCopyMemoryToImageInfo->dstImageLayout, copy_loc.dot(Field::dstImageLayout),
+                                        "pCopyDstLayouts", "VUID-VkCopyMemoryToImageInfoEXT-dstImageLayout-09060");
     return skip;
 };
 
 bool CoreChecks::PreCallValidateCopyImageToMemoryEXT(VkDevice device, const VkCopyImageToMemoryInfoEXT *pCopyImageToMemoryInfo,
                                                      const ErrorObject &error_obj) const {
     bool skip = false;
-    const Location loc = error_obj.location.dot(Field::pCopyImageToMemoryInfo);
+    const Location copy_loc = error_obj.location.dot(Field::pCopyImageToMemoryInfo);
     auto src_image = pCopyImageToMemoryInfo->srcImage;
     auto image_state = Get<IMAGE_STATE>(src_image);
 
-    skip |= ValidateMemoryImageCopyCommon(device, pCopyImageToMemoryInfo, loc);
+    skip |= ValidateMemoryImageCopyCommon(device, pCopyImageToMemoryInfo, copy_loc);
     auto *props = &phys_dev_ext_props.host_image_copy_properties;
     skip |= ValidateHostCopyImageLayout(device, src_image, props->copySrcLayoutCount, props->pCopySrcLayouts,
-                                        pCopyImageToMemoryInfo->srcImageLayout, loc.dot(Field::srcImageLayout), "pCopySrcLayouts",
-                                        "VUID-VkCopyImageToMemoryInfoEXT-srcImageLayout-09065");
+                                        pCopyImageToMemoryInfo->srcImageLayout, copy_loc.dot(Field::srcImageLayout),
+                                        "pCopySrcLayouts", "VUID-VkCopyImageToMemoryInfoEXT-srcImageLayout-09065");
     return skip;
 };
 

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -549,12 +549,12 @@ bool CoreChecks::PreCallValidateGetDeviceQueue2(VkDevice device, const VkDeviceQ
     bool skip = false;
 
     if (pQueueInfo) {
-        const Location loc = error_obj.location.dot(Field::pQueueInfo);
+        const Location queue_info_loc = error_obj.location.dot(Field::pQueueInfo);
         const uint32_t queueFamilyIndex = pQueueInfo->queueFamilyIndex;
         const uint32_t queueIndex = pQueueInfo->queueIndex;
         const VkDeviceQueueCreateFlags flags = pQueueInfo->flags;
 
-        skip |= ValidateDeviceQueueFamily(queueFamilyIndex, loc.dot(Field::queueFamilyIndex),
+        skip |= ValidateDeviceQueueFamily(queueFamilyIndex, queue_info_loc.dot(Field::queueFamilyIndex),
                                           "VUID-VkDeviceQueueInfo2-queueFamilyIndex-01842");
 
         // ValidateDeviceQueueFamily() already checks if queueFamilyIndex but need to make sure flags match with it
@@ -734,12 +734,12 @@ bool CoreChecks::PreCallValidateCreateCommandPool(VkDevice device, const VkComma
                                                   const VkAllocationCallbacks *pAllocator, VkCommandPool *pCommandPool,
                                                   const ErrorObject &error_obj) const {
     bool skip = false;
-    const Location loc = error_obj.location.dot(Field::pCreateInfo);
-    skip |= ValidateDeviceQueueFamily(pCreateInfo->queueFamilyIndex, loc.dot(Field::queueFamilyIndex),
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
+    skip |= ValidateDeviceQueueFamily(pCreateInfo->queueFamilyIndex, create_info_loc.dot(Field::queueFamilyIndex),
                                       "VUID-vkCreateCommandPool-queueFamilyIndex-01937");
     if ((enabled_features.core11.protectedMemory == VK_FALSE) &&
         ((pCreateInfo->flags & VK_COMMAND_POOL_CREATE_PROTECTED_BIT) != 0)) {
-        skip |= LogError("VUID-VkCommandPoolCreateInfo-flags-02860", device, loc.dot(Field::flags),
+        skip |= LogError("VUID-VkCommandPoolCreateInfo-flags-02860", device, create_info_loc.dot(Field::flags),
                          "includes VK_COMMAND_POOL_CREATE_PROTECTED_BIT, but the protectedMemory feature was not enabled.");
     }
 

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -105,12 +105,12 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                                             const VkAllocationCallbacks *pAllocator, VkImage *pImage,
                                             const ErrorObject &error_obj) const {
     bool skip = false;
-    const Location loc = error_obj.location.dot(Field::pCreateInfo);
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     if (IsExtEnabled(device_extensions.vk_android_external_memory_android_hardware_buffer)) {
         skip |= ValidateCreateImageANDROID(pCreateInfo);
     } else {  // These checks are omitted or replaced when Android HW Buffer extension is active
         if (pCreateInfo->format == VK_FORMAT_UNDEFINED) {
-            return LogError("VUID-VkImageCreateInfo-pNext-01975", device, loc.dot(Field::format),
+            return LogError("VUID-VkImageCreateInfo-pNext-01975", device, create_info_loc.dot(Field::format),
                             "must not be VK_FORMAT_UNDEFINED.");
         }
     }
@@ -120,7 +120,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                                            VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     if (pCreateInfo->usage & attach_flags) {
         if (pCreateInfo->extent.width > device_limits->maxFramebufferWidth) {
-            skip |= LogError("VUID-VkImageCreateInfo-usage-00964", device, loc.dot(Field::usage),
+            skip |= LogError("VUID-VkImageCreateInfo-usage-00964", device, create_info_loc.dot(Field::usage),
                              "(%s) include a frame buffer attachment bit and image width (%" PRIu32
                              ") exceeds "
                              "device maxFramebufferWidth (%" PRIu32 ").",
@@ -128,7 +128,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                              device_limits->maxFramebufferWidth);
         }
         if (pCreateInfo->extent.height > device_limits->maxFramebufferHeight) {
-            skip |= LogError("VUID-VkImageCreateInfo-usage-00965", device, loc.dot(Field::usage),
+            skip |= LogError("VUID-VkImageCreateInfo-usage-00965", device, create_info_loc.dot(Field::usage),
                              "(%s) include a frame buffer attachment bit and image height (%" PRIu32
                              ") exceeds "
                              "device maxFramebufferHeight (%" PRIu32 ").",
@@ -140,7 +140,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     VkImageCreateFlags sparseFlags =
         VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_ALIASED_BIT;
     if ((pCreateInfo->flags & sparseFlags) && (pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT)) {
-        skip |= LogError("VUID-VkImageCreateInfo-None-01925", device, loc,
+        skip |= LogError("VUID-VkImageCreateInfo-None-01925", device, create_info_loc,
                          "images using sparse memory cannot have VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT set.");
     }
 
@@ -150,7 +150,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
             static_cast<float>(device_limits->maxFramebufferWidth) /
             std::max(static_cast<float>(phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.width), 1.0f)));
         if (pCreateInfo->extent.width > ceiling_width) {
-            skip |= LogError("VUID-VkImageCreateInfo-fragmentDensityMapOffset-06514", device, loc.dot(Field::usage),
+            skip |= LogError("VUID-VkImageCreateInfo-fragmentDensityMapOffset-06514", device, create_info_loc.dot(Field::usage),
                              "includes VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT and image width (%" PRIu32
                              ") exceeds the "
                              "ceiling of device "
@@ -164,7 +164,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
             static_cast<float>(device_limits->maxFramebufferHeight) /
             std::max(static_cast<float>(phys_dev_ext_props.fragment_density_map_props.minFragmentDensityTexelSize.height), 1.0f)));
         if (pCreateInfo->extent.height > ceiling_height) {
-            skip |= LogError("VUID-VkImageCreateInfo-fragmentDensityMapOffset-06515", device, loc.dot(Field::usage),
+            skip |= LogError("VUID-VkImageCreateInfo-fragmentDensityMapOffset-06515", device, create_info_loc.dot(Field::usage),
                              "includes VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT and image height (%" PRIu32
                              ") exceeds the "
                              "ceiling of device "
@@ -243,7 +243,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
             const char *dispatchFunction = IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)
                                                ? "VkGetPhysicalDeviceImageFormatProperties2"
                                                : "VkGetPhysicalDeviceImageFormatProperties";
-            skip |= LogError("VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251", device, loc,
+            skip |= LogError("VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251", device, create_info_loc,
                              "The following parameters -\n"
                              "format (%s)\n"
                              "type (%s)\n"
@@ -260,7 +260,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     } else {
         const auto format_limits = image_format_properties.imageFormatProperties;
         if (pCreateInfo->mipLevels > format_limits.maxMipLevels) {
-            skip |= LogError("VUID-VkImageCreateInfo-mipLevels-02255", device, loc.dot(Field::mipLevels),
+            skip |= LogError("VUID-VkImageCreateInfo-mipLevels-02255", device, create_info_loc.dot(Field::mipLevels),
                              "(%d) exceed image format maxMipLevels (%d) for format %s.", pCreateInfo->mipLevels,
                              format_limits.maxMipLevels, string_VkFormat(pCreateInfo->format));
         }
@@ -289,32 +289,32 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         }
 
         if (pCreateInfo->arrayLayers > format_limits.maxArrayLayers) {
-            skip |= LogError("VUID-VkImageCreateInfo-arrayLayers-02256", device, loc.dot(Field::arrayLayers),
+            skip |= LogError("VUID-VkImageCreateInfo-arrayLayers-02256", device, create_info_loc.dot(Field::arrayLayers),
                              "(%d) exceeds allowable maximum supported by format %s (format maxArrayLayers: %" PRIu32 ").",
                              pCreateInfo->arrayLayers, string_VkFormat(pCreateInfo->format), format_limits.maxArrayLayers);
         }
 
         if ((pCreateInfo->samples & format_limits.sampleCounts) == 0) {
-            skip |= LogError("VUID-VkImageCreateInfo-samples-02258", device, loc.dot(Field::samples),
+            skip |= LogError("VUID-VkImageCreateInfo-samples-02258", device, create_info_loc.dot(Field::samples),
                              "(%s) is not supported by format %s (format sampleCounts: 0x%.8X).",
                              string_VkSampleCountFlagBits(pCreateInfo->samples), string_VkFormat(pCreateInfo->format),
                              format_limits.sampleCounts);
         }
 
         if (pCreateInfo->extent.width > format_limits.maxExtent.width) {
-            skip |= LogError("VUID-VkImageCreateInfo-extent-02252", device, loc.dot(Field::extent).dot(Field::width),
+            skip |= LogError("VUID-VkImageCreateInfo-extent-02252", device, create_info_loc.dot(Field::extent).dot(Field::width),
                              "(%" PRIu32 ") exceeds allowable maximum image extent width %" PRIu32 " for format %s.",
                              pCreateInfo->extent.width, format_limits.maxExtent.width, string_VkFormat(pCreateInfo->format));
         }
 
         if (pCreateInfo->extent.height > format_limits.maxExtent.height) {
-            skip |= LogError("VUID-VkImageCreateInfo-extent-02253", device, loc.dot(Field::extent).dot(Field::height),
+            skip |= LogError("VUID-VkImageCreateInfo-extent-02253", device, create_info_loc.dot(Field::extent).dot(Field::height),
                              "(%" PRIu32 ") exceeds allowable maximum image extent height %" PRIu32 " for format %s.",
                              pCreateInfo->extent.height, format_limits.maxExtent.height, string_VkFormat(pCreateInfo->format));
         }
 
         if (pCreateInfo->extent.depth > format_limits.maxExtent.depth) {
-            skip |= LogError("VUID-VkImageCreateInfo-extent-02254", device, loc.dot(Field::extent).dot(Field::depth),
+            skip |= LogError("VUID-VkImageCreateInfo-extent-02254", device, create_info_loc.dot(Field::extent).dot(Field::depth),
                              "(%" PRIu32 ") exceeds allowable maximum image extent depth %" PRIu32 " for format %s.",
                              pCreateInfo->extent.depth, format_limits.maxExtent.depth, string_VkFormat(pCreateInfo->format));
         }
@@ -323,20 +323,20 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     // Tests for "Formats requiring sampler YCBCR conversion for VK_IMAGE_ASPECT_COLOR_BIT image views"
     if (FormatRequiresYcbcrConversionExplicitly(pCreateInfo->format)) {
         if (pCreateInfo->mipLevels != 1) {
-            skip |= LogError("VUID-VkImageCreateInfo-format-06410", device, loc.dot(Field::mipLevels),
+            skip |= LogError("VUID-VkImageCreateInfo-format-06410", device, create_info_loc.dot(Field::mipLevels),
                              "(%d), but when using a YCbCr Conversion format (%s), mipLevels must be 1.", pCreateInfo->mipLevels,
                              string_VkFormat(pCreateInfo->format));
         }
 
         if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
-            skip |= LogError("VUID-VkImageCreateInfo-format-06411", device, loc.dot(Field::samples),
+            skip |= LogError("VUID-VkImageCreateInfo-format-06411", device, create_info_loc.dot(Field::samples),
                              "(%s), but when using a YCbCr Conversion format (%s), samples must be "
                              "VK_SAMPLE_COUNT_1_BIT.",
                              string_VkSampleCountFlagBits(pCreateInfo->samples), string_VkFormat(pCreateInfo->format));
         }
 
         if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
-            skip |= LogError("VUID-VkImageCreateInfo-format-06412", device, loc.dot(Field::imageType),
+            skip |= LogError("VUID-VkImageCreateInfo-format-06412", device, create_info_loc.dot(Field::imageType),
                              "(%s), but when using a YCbCr Conversion format (%s), imageType must be "
                              "VK_IMAGE_TYPE_2D.",
                              string_VkImageType(pCreateInfo->imageType), string_VkFormat(pCreateInfo->format));
@@ -347,12 +347,12 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         if (pCreateInfo->flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT) {
             if (!FormatIsCompressed(pCreateInfo->format)) {
                 skip |= LogError(
-                    "VUID-VkImageCreateInfo-flags-01572", device, loc.dot(Field::flags),
+                    "VUID-VkImageCreateInfo-flags-01572", device, create_info_loc.dot(Field::flags),
                     "contains VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT, but format (%s) must be a compressed image format.",
                     string_VkFormat(pCreateInfo->format));
             }
             if (!(pCreateInfo->flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT)) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-01573", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-flags-01573", device, create_info_loc.dot(Field::flags),
                                  "contains VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT, "
                                  "flags must also contain VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.");
             }
@@ -360,13 +360,13 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     }
 
     if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT && pCreateInfo->pQueueFamilyIndices) {
-        skip |= ValidatePhysicalDeviceQueueFamilies(pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices, loc,
-                                                    "VUID-VkImageCreateInfo-sharingMode-01420");
+        skip |= ValidatePhysicalDeviceQueueFamilies(pCreateInfo->queueFamilyIndexCount, pCreateInfo->pQueueFamilyIndices,
+                                                    create_info_loc, "VUID-VkImageCreateInfo-sharingMode-01420");
     }
 
     if (!FormatIsMultiplane(pCreateInfo->format) && !(pCreateInfo->flags & VK_IMAGE_CREATE_ALIAS_BIT) &&
         (pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT)) {
-        skip |= LogError("VUID-VkImageCreateInfo-format-01577", device, loc,
+        skip |= LogError("VUID-VkImageCreateInfo-format-01577", device, create_info_loc,
                          "format is %s and flags are %s. The flags should not include VK_IMAGE_CREATE_DISJOINT_BIT.",
                          string_VkFormat(pCreateInfo->format), string_VkImageCreateFlags(pCreateInfo->flags).c_str());
     }
@@ -381,20 +381,20 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
             const char *vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
             if (((swapchain_flags & VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR) != 0) &&
                 ((pCreateInfo->flags & VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT) == 0)) {
-                skip |= LogError(vuid, device, loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
+                skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
                                  "was created with VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR flag so "
                                  "all swapchain images must have the VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT flag set.");
             }
             if (((swapchain_flags & VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR) != 0) &&
                 ((pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0)) {
-                skip |= LogError(vuid, device, loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
+                skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
                                  "was created with VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR flag so all "
                                  "swapchain images must have the VK_IMAGE_CREATE_PROTECTED_BIT flag set.");
             }
             const VkImageCreateFlags mutable_flags = (VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
             if (((swapchain_flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR) != 0) &&
                 ((pCreateInfo->flags & mutable_flags) != mutable_flags)) {
-                skip |= LogError(vuid, device, loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
+                skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
                                  "was created with VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR flag so "
                                  "all swapchain images must have the VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT and "
                                  "VK_IMAGE_CREATE_EXTENDED_USAGE_BIT flags both set.");
@@ -404,43 +404,44 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 
     if ((pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) != 0) {
         if (enabled_features.core11.protectedMemory == VK_FALSE) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-01890", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageCreateInfo-flags-01890", device, create_info_loc.dot(Field::flags),
                              "has VK_IMAGE_CREATE_PROTECTED_BIT set, but the protectedMemory device feature is not enabled.");
         }
         const VkImageCreateFlags invalid_flags =
             VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_ALIASED_BIT;
         if ((pCreateInfo->flags & invalid_flags) != 0) {
-            skip |= LogError("VUID-VkImageCreateInfo-None-01891", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageCreateInfo-None-01891", device, create_info_loc.dot(Field::flags),
                              "can't have both protected and sparse flags set.");
         }
     }
 
     if ((pCreateInfo->flags & VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT) != 0) {
         if (!(enabled_features.multisampled_render_to_single_sampled_features.multisampledRenderToSingleSampled)) {
-            skip |= LogError("VUID-VkImageCreateInfo-multisampledRenderToSingleSampled-06882", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageCreateInfo-multisampledRenderToSingleSampled-06882", device,
+                             create_info_loc.dot(Field::flags),
                              "contains VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT but the "
                              "multisampledRenderToSingleSampled feature is not enabled.");
         }
         if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-06883", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageCreateInfo-flags-06883", device, create_info_loc.dot(Field::flags),
                              "contains VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT but samples (%s) is not equal "
                              "to VK_SAMPLE_COUNT_1_BIT.",
                              string_VkSampleCountFlagBits(pCreateInfo->samples));
         }
     }
 
-    skip |= ValidateImageFormatFeatures(pCreateInfo, loc);
+    skip |= ValidateImageFormatFeatures(pCreateInfo, create_info_loc);
 
     // Check compatibility with VK_KHR_portability_subset
     if (IsExtEnabled(device_extensions.vk_khr_portability_subset)) {
         if (VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT & pCreateInfo->flags &&
             VK_FALSE == enabled_features.portability_subset_features.imageView2DOn3DImage) {
-            skip |= LogError("VUID-VkImageCreateInfo-imageView2DOn3DImage-04459", device, loc,
+            skip |= LogError("VUID-VkImageCreateInfo-imageView2DOn3DImage-04459", device, create_info_loc,
                              "(portability error) VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT is not supported.");
         }
         if ((VK_SAMPLE_COUNT_1_BIT != pCreateInfo->samples) && (1 != pCreateInfo->arrayLayers) &&
             (VK_FALSE == enabled_features.portability_subset_features.multisampleArrayImage)) {
-            skip |= LogError("VUID-VkImageCreateInfo-multisampleArrayImage-04460", device, loc,
+            skip |= LogError("VUID-VkImageCreateInfo-multisampleArrayImage-04460", device, create_info_loc,
                              "(portability error) Cannot create an image with samples/texel > 1 && arrayLayers != 1");
         }
     }
@@ -448,14 +449,14 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     const auto external_memory_create_info_nv = LvlFindInChain<VkExternalMemoryImageCreateInfoNV>(pCreateInfo->pNext);
     const auto external_memory_create_info = LvlFindInChain<VkExternalMemoryImageCreateInfo>(pCreateInfo->pNext);
     if (external_memory_create_info_nv != nullptr && external_memory_create_info != nullptr) {
-        skip |= LogError("VUID-VkImageCreateInfo-pNext-00988", device, loc,
+        skip |= LogError("VUID-VkImageCreateInfo-pNext-00988", device, create_info_loc,
                          "has both VkExternalMemoryImageCreateInfoNV and "
                          "VkExternalMemoryImageCreateInfo chained structs.");
     }
     if (external_memory_create_info && external_memory_create_info->handleTypes != 0) {
         if (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
             skip |= LogError("VUID-VkImageCreateInfo-pNext-01443", device,
-                             loc.pNext(Struct::VkExternalMemoryImageCreateInfo, Field::handleTypes),
+                             create_info_loc.pNext(Struct::VkExternalMemoryImageCreateInfo, Field::handleTypes),
                              "is %" PRIu32 " but pCreateInfo->initialLayout is %s.", external_memory_create_info->handleTypes,
                              string_VkImageLayout(pCreateInfo->initialLayout));
         }
@@ -501,7 +502,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 
         if (result != VK_SUCCESS) {
             skip |= LogError(
-                "VUID-VkImageCreateInfo-pNext-00990", device, loc,
+                "VUID-VkImageCreateInfo-pNext-00990", device, create_info_loc,
                 "The handle type (%s), format (%s), type (%s), tiling (%s), usage (%s), flags (%s) "
                 "is not supported combination of parameters and vkGetPhysicalDeviceImageFormatProperties2 returned back %s.",
                 string_VkExternalMemoryHandleTypeFlagBits(external_image_info.handleType), string_VkFormat(image_info.format),
@@ -510,14 +511,14 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                 string_VkResult(result));
         } else if ((external_memory_create_info->handleTypes & compatible_types) != external_memory_create_info->handleTypes) {
             skip |= LogError("VUID-VkImageCreateInfo-pNext-00990", device,
-                             loc.pNext(Struct::VkExternalMemoryImageCreateInfo, Field::handleTypes),
+                             create_info_loc.pNext(Struct::VkExternalMemoryImageCreateInfo, Field::handleTypes),
                              "(%s) is not reported as compatible by vkGetPhysicalDeviceImageFormatProperties2.",
                              string_VkExternalMemoryHandleTypeFlags(external_memory_create_info->handleTypes).c_str());
         }
     } else if (external_memory_create_info_nv && external_memory_create_info_nv->handleTypes != 0) {
         if (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
             skip |= LogError("VUID-VkImageCreateInfo-pNext-01443", device,
-                             loc.pNext(Struct::VkExternalMemoryImageCreateInfoNV, Field::handleTypes),
+                             create_info_loc.pNext(Struct::VkExternalMemoryImageCreateInfoNV, Field::handleTypes),
                              "is %" PRIu32 " but pCreateInfo->initialLayout is %s.", external_memory_create_info_nv->handleTypes,
                              string_VkImageLayout(pCreateInfo->initialLayout));
         }
@@ -531,7 +532,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         const auto compatible_types = external_image_properties.compatibleHandleTypes;
 
         if (result != VK_SUCCESS) {
-            skip |= LogError("VUID-VkImageCreateInfo-pNext-00991", device, loc,
+            skip |= LogError("VUID-VkImageCreateInfo-pNext-00991", device, create_info_loc,
                              "The handle type (%s), format (%s), type (%s), tiling (%s), usage (%s), flags (%s) "
                              "is not supported combination of parameters and vkGetPhysicalDeviceExternalImageFormatPropertiesNV "
                              "returned back %s.",
@@ -542,7 +543,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         } else if ((external_memory_create_info_nv->handleTypes & compatible_types) !=
                    external_memory_create_info_nv->handleTypes) {
             skip |= LogError("VUID-VkImageCreateInfo-pNext-00991", device,
-                             loc.pNext(Struct::VkExternalMemoryImageCreateInfoNV, Field::handleTypes),
+                             create_info_loc.pNext(Struct::VkExternalMemoryImageCreateInfoNV, Field::handleTypes),
                              "(%s) is not reported as compatible by vkGetPhysicalDeviceExternalImageFormatPropertiesNV.",
                              string_VkExternalMemoryHandleTypeFlagsNV(external_memory_create_info_nv->handleTypes).c_str());
         }
@@ -550,7 +551,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 
     if (device_group_create_info.physicalDeviceCount == 1) {
         if (pCreateInfo->flags & VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT) {
-            skip |= LogError("VUID-VkImageCreateInfo-physicalDeviceCount-01421", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageCreateInfo-physicalDeviceCount-01421", device, create_info_loc.dot(Field::flags),
                              "contains VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT, but the device was created with "
                              "VkDeviceGroupDeviceCreateInfo::physicalDeviceCount equal to 1. Device creation with "
                              "VkDeviceGroupDeviceCreateInfo::physicalDeviceCount equal to 1 may have been implicit.");
@@ -559,14 +560,14 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 
     if ((pCreateInfo->flags & VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) &&
         !enabled_features.descriptor_buffer_features.descriptorBufferCaptureReplay) {
-        skip |= LogError("VUID-VkImageCreateInfo-flags-08104", device, loc.dot(Field::flags),
+        skip |= LogError("VUID-VkImageCreateInfo-flags-08104", device, create_info_loc.dot(Field::flags),
                          "contains VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT but the descriptorBufferCaptureReplay "
                          "feature is not enabled.");
     }
 
     auto opaque_capture_descriptor_buffer = LvlFindInChain<VkOpaqueCaptureDescriptorDataCreateInfoEXT>(pCreateInfo->pNext);
     if (opaque_capture_descriptor_buffer && !(pCreateInfo->flags & VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
-        skip |= LogError("VUID-VkImageCreateInfo-pNext-08105", device, loc.dot(Field::flags),
+        skip |= LogError("VUID-VkImageCreateInfo-pNext-08105", device, create_info_loc.dot(Field::flags),
                          "(%s) does not have VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT, but "
                          "VkOpaqueCaptureDescriptorDataCreateInfoEXT is in pNext chain.",
                          string_VkImageCreateFlags(pCreateInfo->flags).c_str());
@@ -599,7 +600,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 
             if (!supported_video_format) {
                 skip |=
-                    LogError("VUID-VkImageCreateInfo-pNext-06811", device, loc,
+                    LogError("VUID-VkImageCreateInfo-pNext-06811", device, create_info_loc,
                              "image creation parameters (flags: 0x%08x, format: %s, imageType: %s, "
                              "tiling: %s) are not supported by any of the supported video format properties for "
                              "the video profiles specified in the VkVideoProfileListInfoKHR structure included in "
@@ -1497,7 +1498,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     if (!image_state_ptr) {
         return skip;
     }
-    const Location loc = error_obj.location.dot(Field::pCreateInfo);
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     const auto &image_state = *image_state_ptr;
 
     const VkImageUsageFlags valid_usage_flags = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT |
@@ -1509,13 +1510,13 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                                                 VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR |
                                                 VK_IMAGE_USAGE_SAMPLE_WEIGHT_BIT_QCOM | VK_IMAGE_USAGE_SAMPLE_BLOCK_MATCH_BIT_QCOM;
     skip |= ValidateImageUsageFlags(VK_NULL_HANDLE, image_state, valid_usage_flags, false, "VUID-VkImageViewCreateInfo-image-04441",
-                                    loc.dot(Field::image));
+                                    create_info_loc.dot(Field::image));
     // If this isn't a sparse image, it needs to have memory backing it at CreateImageView time
     skip |= ValidateMemoryIsBoundToImage(device, image_state, "vkCreateImageView()", "VUID-VkImageViewCreateInfo-image-01020");
     // Checks imported from image layer
     skip |= ValidateCreateImageViewSubresourceRange(
         image_state, pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_2D || pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY,
-        pCreateInfo->subresourceRange, loc);
+        pCreateInfo->subresourceRange, create_info_loc);
 
     const auto normalized_subresource_range = image_state.NormalizeSubresourceRange(pCreateInfo->subresourceRange);
     const VkImageCreateFlags image_flags = image_state.createInfo.flags;
@@ -1535,7 +1536,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                 if ((image_usage | chained_ivuci_struct->usage) != image_usage) {
                     skip |=
                         LogError("VUID-VkImageViewCreateInfo-pNext-02662", pCreateInfo->image,
-                                 loc.pNext(Struct::VkImageViewUsageCreateInfo, Field::usage),
+                                 create_info_loc.pNext(Struct::VkImageViewUsageCreateInfo, Field::usage),
                                  "(%s) must not include any bits that were not set in VkImageCreateInfo::usage (%s) of the image.",
                                  string_VkImageUsageFlags(chained_ivuci_struct->usage).c_str(),
                                  string_VkImageUsageFlags(image_usage).c_str());
@@ -1545,7 +1546,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                     (image_stencil_struct->stencilUsage | chained_ivuci_struct->usage) != image_stencil_struct->stencilUsage) {
                     skip |=
                         LogError("VUID-VkImageViewCreateInfo-pNext-02663", pCreateInfo->image,
-                                 loc.pNext(Struct::VkImageViewUsageCreateInfo, Field::usage),
+                                 create_info_loc.pNext(Struct::VkImageViewUsageCreateInfo, Field::usage),
                                  "(%s) must not include any bits that were not set in VkImageStencilUsageCreateInfo::stencilUsage "
                                  "(%s) if subResourceRange.aspectMask includes VK_IMAGE_ASPECT_STENCIL_BIT.",
                                  string_VkImageUsageFlags(chained_ivuci_struct->usage).c_str(),
@@ -1555,7 +1556,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                     (image_usage | chained_ivuci_struct->usage) != image_usage) {
                     skip |=
                         LogError("VUID-VkImageViewCreateInfo-pNext-02664", pCreateInfo->image,
-                                 loc.pNext(Struct::VkImageViewUsageCreateInfo, Field::usage),
+                                 create_info_loc.pNext(Struct::VkImageViewUsageCreateInfo, Field::usage),
                                  "(%s) must not include any bits that were not set in VkImageCreateInfo::usage (%s) of the image "
                                  "if subResourceRange.aspectMask (%s) includes bits other than VK_IMAGE_ASPECT_STENCIL_BIT.",
                                  string_VkImageUsageFlags(chained_ivuci_struct->usage).c_str(),
@@ -1571,23 +1572,23 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         sliced_create_info_ext) {
         const bool feature_disabled = (enabled_features.sliced_3d_features.imageSlicedViewOf3D == VK_FALSE);
         if (feature_disabled) {
-            skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-None-07871", pCreateInfo->image, loc,
+            skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-None-07871", pCreateInfo->image, create_info_loc,
                              "imageSlicedViewOf3D is not enabled.");
         }
 
         if (image_type != VK_IMAGE_TYPE_3D) {
-            skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-image-07869", pCreateInfo->image, loc.dot(Field::image),
-                             "was created with imageType (%s).", string_VkImageType(image_type));
+            skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-image-07869", pCreateInfo->image,
+                             create_info_loc.dot(Field::image), "was created with imageType (%s).", string_VkImageType(image_type));
         }
 
         if (view_type != VK_IMAGE_VIEW_TYPE_3D) {
-            skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-viewType-07909", pCreateInfo->image, loc.dot(Field::viewType),
-                             "is (%s).", string_VkImageViewType(view_type));
+            skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-viewType-07909", pCreateInfo->image,
+                             create_info_loc.dot(Field::viewType), "is (%s).", string_VkImageViewType(view_type));
         }
 
         const uint32_t effective_mip_levels = ResolveRemainingLevels(image_state.createInfo, pCreateInfo->subresourceRange);
         if (effective_mip_levels != 1) {
-            skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-None-07870", pCreateInfo->image, loc,
+            skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-None-07870", pCreateInfo->image, create_info_loc,
                              "Image view references %" PRIu32 " mip levels.", effective_mip_levels);
         }
 
@@ -1598,7 +1599,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
 
         if (slice_offset >= effective_view_depth) {
             skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-sliceOffset-07867", pCreateInfo->image,
-                             loc.pNext(Struct::VkImageViewSlicedCreateInfoEXT, Field::sliceOffset),
+                             create_info_loc.pNext(Struct::VkImageViewSlicedCreateInfoEXT, Field::sliceOffset),
                              "(%" PRIu32 ") must be less than the effective view depth (%" PRIu32 ").", slice_offset,
                              effective_view_depth);
         }
@@ -1606,12 +1607,12 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         if (slice_count != VK_REMAINING_3D_SLICES_EXT) {
             if (slice_count == 0) {
                 skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-sliceCount-07868", pCreateInfo->image,
-                                 loc.pNext(Struct::VkImageViewSlicedCreateInfoEXT, Field::sliceCount), "is 0.");
+                                 create_info_loc.pNext(Struct::VkImageViewSlicedCreateInfoEXT, Field::sliceCount), "is 0.");
             }
 
             if ((slice_offset + slice_count) > effective_view_depth) {
                 skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-sliceCount-07868", pCreateInfo->image,
-                                 loc.pNext(Struct::VkImageViewSlicedCreateInfoEXT, Field::sliceOffset),
+                                 create_info_loc.pNext(Struct::VkImageViewSlicedCreateInfoEXT, Field::sliceOffset),
                                  "(%" PRIu32 ") + sliceCount (%" PRIu32 ") greater than effective view depth (%" PRIu32 ").",
                                  slice_offset, slice_count, effective_view_depth);
             }
@@ -1630,7 +1631,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         }
         if (found_format == false) {
             skip |= LogError("VUID-VkImageViewCreateInfo-pNext-01585", pCreateInfo->image,
-                             loc.pNext(Struct::VkImageFormatListCreateInfo, Field::pViewFormats),
+                             create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::pViewFormats),
                              "has no formats that match the VkImageViewCreateInfo::format (%s).", string_VkFormat(view_format));
         }
     }
@@ -1638,7 +1639,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     const bool multiplane_image = FormatIsMultiplane(image_format);
     if (multiplane_image && IsMultiplePlaneAspect(aspect_mask)) {
         skip |= LogError("VUID-VkImageViewCreateInfo-subresourceRange-07818", pCreateInfo->image,
-                         loc.dot(Field::subresourceRange).dot(Field::aspectMask), "(%s) is invalid for %s.",
+                         create_info_loc.dot(Field::subresourceRange).dot(Field::aspectMask), "(%s) is invalid for %s.",
                          string_VkImageAspectFlags(aspect_mask).c_str(), string_VkFormat(image_format));
     }
 
@@ -1654,7 +1655,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
             if (has_valid_aspect && ((image_class != view_class) || (image_class == FORMAT_COMPATIBILITY_CLASS::NONE))) {
                 // Need to only check if one is NONE to handle edge case both are NONE
                 // View format must match the multiplane compatible format
-                skip |= LogError("VUID-VkImageViewCreateInfo-image-01586", pCreateInfo->image, loc.dot(Field::format),
+                skip |= LogError("VUID-VkImageViewCreateInfo-image-01586", pCreateInfo->image, create_info_loc.dot(Field::format),
                                  "(%s) is not compatible with plane %" PRIu32 " of the %s format %s, must be compatible with %s.",
                                  string_VkFormat(view_format), GetPlaneIndex(aspect_mask), FormatHandle(pCreateInfo->image).c_str(),
                                  string_VkFormat(image_format), string_VkFormat(compat_format));
@@ -1665,7 +1666,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
             // Need to only check if one is NONE to handle edge case both are NONE
             if ((image_class != view_class) || (image_class == FORMAT_COMPATIBILITY_CLASS::NONE)) {
                 skip |=
-                    LogError("VUID-VkImageViewCreateInfo-image-01761", pCreateInfo->image, loc.dot(Field::format),
+                    LogError("VUID-VkImageViewCreateInfo-image-01761", pCreateInfo->image, create_info_loc.dot(Field::format),
                              "%s is not in the same format compatibility class as %s format %s. Images created with the "
                              "VK_IMAGE_CREATE_MUTABLE_FORMAT BIT can support ImageViews with differing formats but they must be in "
                              "the same compatibility class.",
@@ -1676,7 +1677,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         // Format MUST be IDENTICAL to the format the image was created with
         // Unless it is a multi-planar color bit aspect
         if ((image_format != view_format) && (!multiplane_image || (aspect_mask != VK_IMAGE_ASPECT_COLOR_BIT))) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-image-01762", pCreateInfo->image, loc.dot(Field::format),
+            skip |= LogError("VUID-VkImageViewCreateInfo-image-01762", pCreateInfo->image, create_info_loc.dot(Field::format),
                              "%s id different from %s format (%s). Formats MUST be IDENTICAL unless VK_IMAGE_CREATE_MUTABLE_FORMAT "
                              "BIT was set on image creation.",
                              string_VkFormat(view_format), FormatHandle(pCreateInfo->image).c_str(), string_VkFormat(image_format));
@@ -1685,7 +1686,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
 
     if (image_state.createInfo.samples != VK_SAMPLE_COUNT_1_BIT && view_type != VK_IMAGE_VIEW_TYPE_2D &&
         view_type != VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
-        skip |= LogError("VUID-VkImageViewCreateInfo-image-04972", pCreateInfo->image, loc.dot(Field::image),
+        skip |= LogError("VUID-VkImageViewCreateInfo-image-04972", pCreateInfo->image, create_info_loc.dot(Field::image),
                          "was created with sample count %s, but pCreateInfo->viewType is %s.",
                          string_VkSampleCountFlagBits(image_state.createInfo.samples), string_VkImageViewType(view_type));
     }
@@ -1693,14 +1694,14 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     if (image_usage & (VK_IMAGE_USAGE_VIDEO_ENCODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR |
                        VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR)) {
         if (view_type != VK_IMAGE_VIEW_TYPE_2D && view_type != VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-image-04818", pCreateInfo->image, loc.dot(Field::image),
+            skip |= LogError("VUID-VkImageViewCreateInfo-image-04818", pCreateInfo->image, create_info_loc.dot(Field::image),
                              "was created with video encode usage flags, but pCreateInfo->viewType (%s) "
                              "is not VK_IMAGE_VIEW_TYPE_2D or VK_IMAGE_VIEW_TYPE_2D_ARRAY.",
                              string_VkImageViewType(view_type));
         }
         if (!IsIdentitySwizzle(pCreateInfo->components)) {
             skip |= LogError(
-                "VUID-VkImageViewCreateInfo-image-04818", pCreateInfo->image, loc.dot(Field::image),
+                "VUID-VkImageViewCreateInfo-image-04818", pCreateInfo->image, create_info_loc.dot(Field::image),
                 "was created with video encode usage flags, but not all members of "
                 "pCreateInfo->components have identity swizzle. Here are the actual swizzle values:\n"
                 "r swizzle = %s\n"
@@ -1719,21 +1720,21 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     switch (image_type) {
         case VK_IMAGE_TYPE_1D:
             if (view_type != VK_IMAGE_VIEW_TYPE_1D && view_type != VK_IMAGE_VIEW_TYPE_1D_ARRAY) {
-                skip |= LogError("VUID-VkImageViewCreateInfo-subResourceRange-01021", pCreateInfo->image, loc.dot(Field::viewType),
-                                 "(%s) is not compatible with image type %s.", string_VkImageViewType(view_type),
-                                 string_VkImageType(image_type));
+                skip |= LogError("VUID-VkImageViewCreateInfo-subResourceRange-01021", pCreateInfo->image,
+                                 create_info_loc.dot(Field::viewType), "(%s) is not compatible with image type %s.",
+                                 string_VkImageViewType(view_type), string_VkImageType(image_type));
             }
             break;
         case VK_IMAGE_TYPE_2D:
             if (view_type != VK_IMAGE_VIEW_TYPE_2D && view_type != VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
                 if ((view_type == VK_IMAGE_VIEW_TYPE_CUBE || view_type == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) &&
                     !(image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)) {
-                    skip |= LogError("VUID-VkImageViewCreateInfo-image-01003", pCreateInfo->image, loc.dot(Field::viewType),
-                                     "(%s) is not compatible with image type %s.", string_VkImageViewType(view_type),
-                                     string_VkImageType(image_type));
+                    skip |= LogError("VUID-VkImageViewCreateInfo-image-01003", pCreateInfo->image,
+                                     create_info_loc.dot(Field::viewType), "(%s) is not compatible with image type %s.",
+                                     string_VkImageViewType(view_type), string_VkImageType(image_type));
                 } else if (view_type != VK_IMAGE_VIEW_TYPE_CUBE && view_type != VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
                     skip |= LogError("VUID-VkImageViewCreateInfo-subResourceRange-01021", pCreateInfo->image,
-                                     loc.dot(Field::viewType), "(%s) is not compatible with image type %s.",
+                                     create_info_loc.dot(Field::viewType), "(%s) is not compatible with image type %s.",
                                      string_VkImageViewType(view_type), string_VkImageType(image_type));
                 }
             }
@@ -1746,14 +1747,15 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                             if (!(image_flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT)) {
                                 if (view_type == VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
                                     skip |= LogError(
-                                        "VUID-VkImageViewCreateInfo-image-06723", pCreateInfo->image, loc.dot(Field::viewType),
+                                        "VUID-VkImageViewCreateInfo-image-06723", pCreateInfo->image,
+                                        create_info_loc.dot(Field::viewType),
                                         "(%s) is not compatible with image type "
                                         "%s since the image doesn't have VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT flag set.",
                                         string_VkImageViewType(view_type), string_VkImageType(image_type));
                                 } else if (view_type == VK_IMAGE_VIEW_TYPE_2D &&
                                            !(image_flags & VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT)) {
                                     skip |= LogError("VUID-VkImageViewCreateInfo-image-06728", pCreateInfo->image,
-                                                     loc.dot(Field::viewType),
+                                                     create_info_loc.dot(Field::viewType),
                                                      "(%s) is not compatible with image type "
                                                      "%s since the image doesn't have VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT or "
                                                      "VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT flag set.",
@@ -1763,7 +1765,8 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                         } else if (!(image_flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT) &&
                                    (view_type == VK_IMAGE_VIEW_TYPE_2D)) {
                             // TODO - combine this logic
-                            skip |= LogError("VUID-VkImageViewCreateInfo-image-06728", pCreateInfo->image, loc.dot(Field::viewType),
+                            skip |= LogError("VUID-VkImageViewCreateInfo-image-06728", pCreateInfo->image,
+                                             create_info_loc.dot(Field::viewType),
                                              "(VK)_IMAGE_VIEW_TYPE_2D is not compatible "
                                              "with image type "
                                              "%s since the image doesn't have VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT flag set.",
@@ -1771,14 +1774,15 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                         }
                         if ((image_flags & (VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT |
                                             VK_IMAGE_CREATE_SPARSE_ALIASED_BIT))) {
-                            skip |=
-                                LogError("VUID-VkImageViewCreateInfo-image-04971", pCreateInfo->image, loc.dot(Field::viewType),
-                                         "(%s) is not compatible with image type %s "
-                                         "when the VK_IMAGE_CREATE_SPARSE_BINDING_BIT, VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT, or "
-                                         "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT flags are enabled.",
-                                         string_VkImageViewType(view_type), string_VkImageType(image_type));
+                            skip |= LogError(
+                                "VUID-VkImageViewCreateInfo-image-04971", pCreateInfo->image, create_info_loc.dot(Field::viewType),
+                                "(%s) is not compatible with image type %s "
+                                "when the VK_IMAGE_CREATE_SPARSE_BINDING_BIT, VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT, or "
+                                "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT flags are enabled.",
+                                string_VkImageViewType(view_type), string_VkImageType(image_type));
                         } else if (pCreateInfo->subresourceRange.levelCount != 1) {
-                            skip |= LogError("VUID-VkImageViewCreateInfo-image-04970", pCreateInfo->image, loc.dot(Field::viewType),
+                            skip |= LogError("VUID-VkImageViewCreateInfo-image-04970", pCreateInfo->image,
+                                             create_info_loc.dot(Field::viewType),
                                              "(%s) is with image type %s must have a "
                                              "levelCount of 1 but it is %" PRIu32 ".",
                                              string_VkImageViewType(view_type), string_VkImageType(image_type),
@@ -1786,7 +1790,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                         }
                     } else {
                         skip |= LogError("VUID-VkImageViewCreateInfo-subResourceRange-01021", pCreateInfo->image,
-                                         loc.dot(Field::viewType), "(%s) is not compatible with image type %s.",
+                                         create_info_loc.dot(Field::viewType), "(%s) is not compatible with image type %s.",
                                          string_VkImageViewType(view_type), string_VkImageType(image_type));
                     }
                 }
@@ -1795,13 +1799,13 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                     // Help point to VK_KHR_maintenance1
                     if ((view_type == VK_IMAGE_VIEW_TYPE_2D || view_type == VK_IMAGE_VIEW_TYPE_2D_ARRAY)) {
                         skip |= LogError("VUID-VkImageViewCreateInfo-subResourceRange-01021", pCreateInfo->image,
-                                         loc.dot(Field::viewType),
+                                         create_info_loc.dot(Field::viewType),
                                          "(%s) is not compatible with image type %s "
                                          "without VK_KHR_maintenance1 enabled which was promoted in Vulkan 1.0.",
                                          string_VkImageViewType(view_type), string_VkImageType(image_type));
                     } else {
                         skip |= LogError("VUID-VkImageViewCreateInfo-subResourceRange-01021", pCreateInfo->image,
-                                         loc.dot(Field::viewType), "(%s) is not compatible with image type %s.",
+                                         create_info_loc.dot(Field::viewType), "(%s) is not compatible with image type %s.",
                                          string_VkImageViewType(view_type), string_VkImageType(image_type));
                     }
                 }
@@ -1817,7 +1821,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     if (enabled_features.shading_rate_image_features.shadingRateImage) {
         if (image_usage & VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV) {
             if (view_format != VK_FORMAT_R8_UINT) {
-                skip |= LogError("VUID-VkImageViewCreateInfo-image-02087", pCreateInfo->image, loc.dot(Field::image),
+                skip |= LogError("VUID-VkImageViewCreateInfo-image-02087", pCreateInfo->image, create_info_loc.dot(Field::image),
                                  "was created with usage containing "
                                  "VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, format must be VK_FORMAT_R8_UINT.");
             }
@@ -1828,7 +1832,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         enabled_features.fragment_shading_rate_features.attachmentFragmentShadingRate) {
         if (image_usage & VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) {
             if (view_type != VK_IMAGE_VIEW_TYPE_2D && view_type != VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
-                skip |= LogError("VUID-VkImageViewCreateInfo-image-02086", pCreateInfo->image, loc.dot(Field::image),
+                skip |= LogError("VUID-VkImageViewCreateInfo-image-02086", pCreateInfo->image, create_info_loc.dot(Field::image),
                                  "was created with usage containing "
                                  "VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, viewType must be "
                                  "VK_IMAGE_VIEW_TYPE_2D or VK_IMAGE_VIEW_TYPE_2D_ARRAY.");
@@ -1840,7 +1844,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         !phys_dev_ext_props.fragment_shading_rate_props.layeredShadingRateAttachments &&
         image_usage & VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR && normalized_subresource_range.layerCount != 1) {
         skip |= LogError("VUID-VkImageViewCreateInfo-usage-04551", pCreateInfo->image,
-                         loc.dot(Field::subresourceRange).dot(Field::layerCount),
+                         create_info_loc.dot(Field::subresourceRange).dot(Field::layerCount),
                          "is %" PRIu32 " for a shading rate attachment image view.", normalized_subresource_range.layerCount);
     }
 
@@ -1848,26 +1852,27 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         const uint32_t remaining_layers = image_state.createInfo.arrayLayers - pCreateInfo->subresourceRange.baseArrayLayer;
         if (view_type == VK_IMAGE_VIEW_TYPE_CUBE && remaining_layers != 6) {
             skip |= LogError("VUID-VkImageViewCreateInfo-viewType-02962", pCreateInfo->image,
-                             loc.dot(Field::subresourceRange).dot(Field::layerCount), "VK_REMAINING_ARRAY_LAYERS=(%d) must be 6.",
-                             remaining_layers);
+                             create_info_loc.dot(Field::subresourceRange).dot(Field::layerCount),
+                             "VK_REMAINING_ARRAY_LAYERS=(%d) must be 6.", remaining_layers);
         }
         if (view_type == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY && ((remaining_layers) % 6) != 0) {
             skip |= LogError("VUID-VkImageViewCreateInfo-viewType-02963", pCreateInfo->image,
-                             loc.dot(Field::subresourceRange).dot(Field::layerCount),
+                             create_info_loc.dot(Field::subresourceRange).dot(Field::layerCount),
                              "VK_REMAINING_ARRAY_LAYERS=(%d) must be a multiple of 6.", remaining_layers);
         }
         if ((remaining_layers != 1) && ((view_type == VK_IMAGE_VIEW_TYPE_1D) || (view_type == VK_IMAGE_VIEW_TYPE_2D) ||
                                         (view_type == VK_IMAGE_VIEW_TYPE_3D))) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-imageViewType-04974", pCreateInfo->image, loc.dot(Field::viewType),
-                             "%s and the subresourceRange.layerCount "
-                             "VK_REMAINING_ARRAY_LAYERS=(%d) and must 1 (try looking into VK_IMAGE_VIEW_TYPE_*_ARRAY).",
-                             string_VkImageViewType(view_type), remaining_layers);
+            skip |=
+                LogError("VUID-VkImageViewCreateInfo-imageViewType-04974", pCreateInfo->image, create_info_loc.dot(Field::viewType),
+                         "%s and the subresourceRange.layerCount "
+                         "VK_REMAINING_ARRAY_LAYERS=(%d) and must 1 (try looking into VK_IMAGE_VIEW_TYPE_*_ARRAY).",
+                         string_VkImageViewType(view_type), remaining_layers);
         }
     } else {
         if ((layer_count != 1) && ((view_type == VK_IMAGE_VIEW_TYPE_1D) || (view_type == VK_IMAGE_VIEW_TYPE_2D) ||
                                    (view_type == VK_IMAGE_VIEW_TYPE_3D))) {
             skip |= LogError("VUID-VkImageViewCreateInfo-imageViewType-04973", pCreateInfo->image,
-                             loc.dot(Field::subresourceRange).dot(Field::layerCount),
+                             create_info_loc.dot(Field::subresourceRange).dot(Field::layerCount),
                              "(%" PRIu32 ") must be 1 when using viewType %s (try looking into VK_IMAGE_VIEW_TYPE_*_ARRAY).",
                              layer_count, string_VkImageViewType(view_type));
         }
@@ -1875,7 +1880,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
 
     if (image_usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) {
         if (normalized_subresource_range.levelCount != 1) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-image-02571", pCreateInfo->image, loc.dot(Field::image),
+            skip |= LogError("VUID-VkImageViewCreateInfo-image-02571", pCreateInfo->image, create_info_loc.dot(Field::image),
                              "was created with usage containing "
                              "VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT, subresourceRange.levelCount (%d) must be 1",
                              pCreateInfo->subresourceRange.levelCount);
@@ -1883,7 +1888,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     }
     if (pCreateInfo->flags & VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DYNAMIC_BIT_EXT) {
         if (!enabled_features.fragment_density_map_features.fragmentDensityMapDynamic) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-flags-02572", pCreateInfo->image, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageViewCreateInfo-flags-02572", pCreateInfo->image, create_info_loc.dot(Field::flags),
                              "contains VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DYNAMIC_BIT_EXT but the fragmentDensityMapDynamic "
                              "feature is not enabled.");
         }
@@ -1891,7 +1896,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         if (image_usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) {
             if (image_flags & (VK_IMAGE_CREATE_PROTECTED_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT |
                                VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_ALIASED_BIT)) {
-                skip |= LogError("VUID-VkImageViewCreateInfo-flags-04116", pCreateInfo->image, loc.dot(Field::image),
+                skip |= LogError("VUID-VkImageViewCreateInfo-flags-04116", pCreateInfo->image, create_info_loc.dot(Field::image),
                                  "was created with usage containing "
                                  "VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT flags must not contain any of "
                                  "VK_IMAGE_CREATE_PROTECTED_BIT, VK_IMAGE_CREATE_SPARSE_BINDING_BIT, "
@@ -1903,13 +1908,13 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     if (image_flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT) {
         if (!FormatIsCompressed(view_format)) {
             if (pCreateInfo->subresourceRange.levelCount != 1) {
-                skip |= LogError("VUID-VkImageViewCreateInfo-image-07072", pCreateInfo->image, loc.dot(Field::image),
+                skip |= LogError("VUID-VkImageViewCreateInfo-image-07072", pCreateInfo->image, create_info_loc.dot(Field::image),
                                  "was created with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT bit, "
                                  "and format (%s) is not compressed, but subresourcesRange.levelCount (%" PRIu32 ") is not 1.",
                                  string_VkFormat(view_format), pCreateInfo->subresourceRange.levelCount);
             }
             if (pCreateInfo->subresourceRange.layerCount != 1) {
-                skip |= LogError("VUID-VkImageViewCreateInfo-image-07072", pCreateInfo->image, loc.dot(Field::image),
+                skip |= LogError("VUID-VkImageViewCreateInfo-image-07072", pCreateInfo->image, create_info_loc.dot(Field::image),
                                  "was created with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT bit, "
                                  "and format (%s) is not compressed, but subresourcesRange.layerCount (%" PRIu32 ") is not 1.",
                                  string_VkFormat(view_format), pCreateInfo->subresourceRange.layerCount);
@@ -1921,7 +1926,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         const bool size_compatible =
             FormatIsCompressed(view_format) ? false : FormatElementSize(view_format) == FormatElementSize(image_format);
         if (!class_compatible && !size_compatible) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-image-01583", pCreateInfo->image, loc.dot(Field::image),
+            skip |= LogError("VUID-VkImageViewCreateInfo-image-01583", pCreateInfo->image, create_info_loc.dot(Field::image),
                              "was created with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT bit and "
                              "format (%s), but pCreateInfo->format (%s) are not compatible.",
                              string_VkFormat(image_format), string_VkFormat(view_format));
@@ -1930,12 +1935,12 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
 
     if (pCreateInfo->flags & VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DEFERRED_BIT_EXT) {
         if (!enabled_features.fragment_density_map2_features.fragmentDensityMapDeferred) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-flags-03567", pCreateInfo->image, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageViewCreateInfo-flags-03567", pCreateInfo->image, create_info_loc.dot(Field::flags),
                              "includes VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DEFERRED_BIT_EXT but the "
                              "fragmentDensityMapDeferred feature is not enabled.");
         }
         if (pCreateInfo->flags & VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DYNAMIC_BIT_EXT) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-flags-03568", pCreateInfo->image, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageViewCreateInfo-flags-03568", pCreateInfo->image, create_info_loc.dot(Field::flags),
                              "(%s) includes both DEFERRED_BIT and DYNAMIC_BIT.",
                              string_VkImageViewCreateFlags(pCreateInfo->flags).c_str());
         }
@@ -1943,7 +1948,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     if (IsExtEnabled(device_extensions.vk_ext_fragment_density_map2)) {
         if ((image_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) && (image_usage & VK_IMAGE_USAGE_SAMPLED_BIT) &&
             (layer_count > phys_dev_ext_props.fragment_density_map2_props.maxSubsampledArrayLayers)) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-image-03569", pCreateInfo->image, loc.dot(Field::image),
+            skip |= LogError("VUID-VkImageViewCreateInfo-image-03569", pCreateInfo->image, create_info_loc.dot(Field::image),
                              "was created with flags containing "
                              "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT and usage containing VK_IMAGE_USAGE_SAMPLED_BIT "
                              "subresourceRange.layerCount (%d) must: be less than or equal to maxSubsampledArrayLayers (%d)",
@@ -1956,7 +1961,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         if ((enabled_features.astc_decode_features.decodeModeSharedExponent == VK_FALSE) &&
             (astc_decode_mode->decodeMode == VK_FORMAT_E5B9G9R9_UFLOAT_PACK32)) {
             skip |= LogError("VUID-VkImageViewASTCDecodeModeEXT-decodeMode-02231", pCreateInfo->image,
-                             loc.pNext(Struct::VkImageViewASTCDecodeModeEXT, Field::decodeMode),
+                             create_info_loc.pNext(Struct::VkImageViewASTCDecodeModeEXT, Field::decodeMode),
                              "is VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 but decodeModeSharedExponent feature is not enabled.");
         }
     }
@@ -1970,7 +1975,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         //       Spec change is at https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/4600
         if ((VK_FALSE == enabled_features.portability_subset_features.imageViewFormatSwizzle) &&
             !IsIdentitySwizzle(pCreateInfo->components)) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-imageViewFormatSwizzle-04465", pCreateInfo->image, loc,
+            skip |= LogError("VUID-VkImageViewCreateInfo-imageViewFormatSwizzle-04465", pCreateInfo->image, create_info_loc,
                              "(portability error): swizzle is disabled for this device.");
         }
 
@@ -1978,23 +1983,24 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         // disabled
         if (!enabled_features.portability_subset_features.imageViewFormatReinterpretation &&
             !FormatsSameComponentBits(pCreateInfo->format, image_state.createInfo.format)) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466", pCreateInfo->image, loc,
-                             "(portability error): ImageView format must have"
-                             " the same number of components and bits per component as the Image's format");
+            skip |=
+                LogError("VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466", pCreateInfo->image, create_info_loc,
+                         "(portability error): ImageView format must have"
+                         " the same number of components and bits per component as the Image's format");
         }
     }
 
     if (const auto image_view_min_lod = LvlFindInChain<VkImageViewMinLodCreateInfoEXT>(pCreateInfo->pNext); image_view_min_lod) {
         if ((!enabled_features.image_view_min_lod_features.minLod) && (image_view_min_lod->minLod != 0)) {
             skip |= LogError("VUID-VkImageViewMinLodCreateInfoEXT-minLod-06455", pCreateInfo->image,
-                             loc.pNext(Struct::VkImageViewMinLodCreateInfoEXT, Field::minLod),
+                             create_info_loc.pNext(Struct::VkImageViewMinLodCreateInfoEXT, Field::minLod),
                              "%f, but the minLod feature is not enabled.", image_view_min_lod->minLod);
         }
         const auto max_level =
             static_cast<float>(pCreateInfo->subresourceRange.baseMipLevel + (pCreateInfo->subresourceRange.levelCount - 1));
         if (image_view_min_lod->minLod > max_level) {
             skip |= LogError("VUID-VkImageViewMinLodCreateInfoEXT-minLod-06456", pCreateInfo->image,
-                             loc.pNext(Struct::VkImageViewMinLodCreateInfoEXT, Field::minLod),
+                             create_info_loc.pNext(Struct::VkImageViewMinLodCreateInfoEXT, Field::minLod),
                              "(%f) must be less or equal to the index of the last mipmap level "
                              "accessible to the view (%f).",
                              image_view_min_lod->minLod, max_level);
@@ -2006,12 +2012,12 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         auto ycbcr_state = Get<SAMPLER_YCBCR_CONVERSION_STATE>(ycbcr_conversion->conversion);
         if (pCreateInfo->format != ycbcr_state->format) {
             skip |= LogError("VUID-VkImageViewCreateInfo-pNext-06658", pCreateInfo->image,
-                             loc.pNext(Struct::VkSamplerYcbcrConversionInfo, Field::conversion),
+                             create_info_loc.pNext(Struct::VkSamplerYcbcrConversionInfo, Field::conversion),
                              "was created with format %s which is different than pCreateInfo->format %s.",
                              string_VkFormat(ycbcr_state->format), string_VkFormat(view_format));
         }
     } else if ((image_usage & VK_IMAGE_USAGE_SAMPLED_BIT) && FormatRequiresYcbcrConversionExplicitly(view_format)) {
-        skip |= LogError("VUID-VkImageViewCreateInfo-format-06415", pCreateInfo->image, loc.dot(Field::image),
+        skip |= LogError("VUID-VkImageViewCreateInfo-format-06415", pCreateInfo->image, create_info_loc.dot(Field::image),
                          "was created with VK_IMAGE_USAGE_SAMPLED_BIT, but pCreateInfo->format %s requires a "
                          "VkSamplerYcbcrConversion but one was not passed in the pNext chain.",
                          string_VkFormat(view_format));
@@ -2021,14 +2027,14 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         VkImageUsageFlags decode_usage = VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR | VK_IMAGE_USAGE_VIDEO_DECODE_SRC_BIT_KHR |
                                          VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR;
         if (image_usage & decode_usage) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-image-04817", pCreateInfo->image, loc.dot(Field::viewType),
+            skip |= LogError("VUID-VkImageViewCreateInfo-image-04817", pCreateInfo->image, create_info_loc.dot(Field::viewType),
                              "%s is incompatible with decode usage.", string_VkImageViewType(pCreateInfo->viewType));
         }
     }
 
     if ((pCreateInfo->flags & VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) &&
         !enabled_features.descriptor_buffer_features.descriptorBufferCaptureReplay) {
-        skip |= LogError("VUID-VkImageViewCreateInfo-flags-08106", pCreateInfo->image, loc.dot(Field::flags),
+        skip |= LogError("VUID-VkImageViewCreateInfo-flags-08106", pCreateInfo->image, create_info_loc.dot(Field::flags),
                          "includes VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT but the "
                          "descriptorBufferCaptureReplay feature is not enabled.");
     }
@@ -2036,13 +2042,13 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     if (const auto opaque_capture_descriptor_buffer =
             LvlFindInChain<VkOpaqueCaptureDescriptorDataCreateInfoEXT>(pCreateInfo->pNext);
         opaque_capture_descriptor_buffer && !(pCreateInfo->flags & VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
-        skip |= LogError("VUID-VkImageViewCreateInfo-pNext-08107", pCreateInfo->image, loc.dot(Field::flags),
+        skip |= LogError("VUID-VkImageViewCreateInfo-pNext-08107", pCreateInfo->image, create_info_loc.dot(Field::flags),
                          "(%s) is missing VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT but "
                          "VkOpaqueCaptureDescriptorDataCreateInfoEXT is in pNext chain.",
                          string_VkImageViewCreateFlags(pCreateInfo->flags).c_str());
     }
 
-    skip |= ValidateImageViewSampleWeightQCOM(pCreateInfo, image_state, loc);
+    skip |= ValidateImageViewSampleWeightQCOM(pCreateInfo, image_state, create_info_loc);
 
     return skip;
 }
@@ -2255,7 +2261,7 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
     const char *func_name = "vkTransitionImageLayoutEXT()";
 
     for (uint32_t i = 0; i < transitionCount; ++i) {
-        const Location loc = error_obj.location.dot(Field::pTransitions, i);
+        const Location transition_loc = error_obj.location.dot(Field::pTransitions, i);
         const auto &transition = pTransitions[i];
         const auto image_state = Get<IMAGE_STATE>(transition.image);
         const auto image_format = image_state->createInfo.format;
@@ -2265,7 +2271,7 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
 
         if ((image_state->createInfo.usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
             const LogObjectList objlist(device, image_state->Handle());
-            skip |= LogError("VUID-VkHostImageLayoutTransitionInfoEXT-image-09055", objlist, loc.dot(Field::image),
+            skip |= LogError("VUID-VkHostImageLayoutTransitionInfoEXT-image-09055", objlist, transition_loc.dot(Field::image),
                              "was created with usage (%s) which does not contain "
                              "VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT.",
                              string_VkImageUsageFlags(image_state->createInfo.usage).c_str());
@@ -2273,7 +2279,7 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
 
         skip |= ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_state->createInfo.arrayLayers,
                                               transition.subresourceRange, "arrayLayers", image_state->image(),
-                                              TransitionImageLayoutVUIDs, loc.dot(Field::subresourceRange));
+                                              TransitionImageLayoutVUIDs, transition_loc.dot(Field::subresourceRange));
         skip |=
             ValidateMemoryIsBoundToImage(device, *image_state, func_name, "VUID-VkHostImageLayoutTransitionInfoEXT-image-01932");
 
@@ -2282,7 +2288,7 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
             if (aspect_mask != VK_IMAGE_ASPECT_COLOR_BIT) {
                 const LogObjectList objlist(device, image_state->Handle());
                 skip |= LogError("VUID-VkHostImageLayoutTransitionInfoEXT-image-01671", objlist,
-                                 loc.dot(Field::subresourceRange).dot(Field::aspectMask),
+                                 transition_loc.dot(Field::subresourceRange).dot(Field::aspectMask),
                                  "is %s (not VK_IMAGE_ASPECT_COLOR_BIT) and image was created with format %s.",
                                  string_VkImageAspectFlags(aspect_mask).c_str(), string_VkFormat(image_format));
             }
@@ -2290,10 +2296,10 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
         if ((FormatIsMultiplane(image_format)) && (image_state->disjoint == true)) {
             if (!IsValidPlaneAspect(image_format, aspect_mask) && ((aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) == 0)) {
                 const LogObjectList objlist(device, image_state->Handle());
-                skip |=
-                    LogError("VUID-VkHostImageLayoutTransitionInfoEXT-image-01672", objlist,
-                             loc.dot(Field::subresourceRange).dot(Field::aspectMask), "is %s and image was created with format %s.",
-                             string_VkImageAspectFlags(aspect_mask).c_str(), string_VkFormat(image_format));
+                skip |= LogError("VUID-VkHostImageLayoutTransitionInfoEXT-image-01672", objlist,
+                                 transition_loc.dot(Field::subresourceRange).dot(Field::aspectMask),
+                                 "is %s and image was created with format %s.", string_VkImageAspectFlags(aspect_mask).c_str(),
+                                 string_VkFormat(image_format));
             }
         }
         if (FormatIsDepthAndStencil(image_format)) {
@@ -2301,7 +2307,7 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
                 if (!has_depth_mask && !has_stencil_mask) {
                     const LogObjectList objlist(device, image_state->Handle());
                     skip |= LogError("VUID-VkHostImageLayoutTransitionInfoEXT-image-03319", objlist,
-                                     loc.dot(Field::subresourceRange).dot(Field::aspectMask),
+                                     transition_loc.dot(Field::subresourceRange).dot(Field::aspectMask),
                                      "is %s and image was created with format %s.", string_VkImageAspectFlags(aspect_mask).c_str(),
                                      string_VkFormat(image_format));
                 }
@@ -2309,7 +2315,7 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
                 if (!has_depth_mask || !has_stencil_mask) {
                     const LogObjectList objlist(device, image_state->Handle());
                     skip |= LogError("VUID-VkHostImageLayoutTransitionInfoEXT-image-03320", objlist,
-                                     loc.dot(Field::subresourceRange).dot(Field::aspectMask),
+                                     transition_loc.dot(Field::subresourceRange).dot(Field::aspectMask),
                                      "is %s and image was created with format %s.", string_VkImageAspectFlags(aspect_mask).c_str(),
                                      string_VkFormat(image_format));
                 }
@@ -2322,7 +2328,7 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
                 (transition.newLayout == VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL)) {
                 const LogObjectList objlist(device, image_state->Handle());
                 skip |= LogError("VUID-VkHostImageLayoutTransitionInfoEXT-aspectMask-08702", objlist,
-                                 loc.dot(Field::subresourceRange).dot(Field::aspectMask),
+                                 transition_loc.dot(Field::subresourceRange).dot(Field::aspectMask),
                                  "is %s meaning that neither oldLayout nor newLayout can be "
                                  "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL or VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL"
                                  " (oldLayout = %s and newLayout = %s).",
@@ -2337,7 +2343,7 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
                 (transition.newLayout == VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL)) {
                 const LogObjectList objlist(device, image_state->Handle());
                 skip |= LogError("VUID-VkHostImageLayoutTransitionInfoEXT-aspectMask-08703", objlist,
-                                 loc.dot(Field::subresourceRange).dot(Field::aspectMask),
+                                 transition_loc.dot(Field::subresourceRange).dot(Field::aspectMask),
                                  "is %s meaning that neither oldLayout nor newLayout can be "
                                  "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL or VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL"
                                  " (oldLayout = %s and newLayout = %s).",
@@ -2348,17 +2354,18 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
         if ((transition.oldLayout != VK_IMAGE_LAYOUT_UNDEFINED) && (transition.oldLayout != VK_IMAGE_LAYOUT_PREINITIALIZED)) {
             auto *props = &phys_dev_ext_props.host_image_copy_properties;
             skip |= ValidateHostCopyImageLayout(device, transition.image, props->copySrcLayoutCount, props->pCopySrcLayouts,
-                                                transition.oldLayout, loc.dot(Field::oldLayout), "pCopySrcLayouts",
+                                                transition.oldLayout, transition_loc.dot(Field::oldLayout), "pCopySrcLayouts",
                                                 "VUID-VkHostImageLayoutTransitionInfoEXT-oldLayout-09056");
         }
 
         const auto *props = &phys_dev_ext_props.host_image_copy_properties;
         skip |= ValidateHostCopyImageLayout(device, transition.image, props->copyDstLayoutCount, props->pCopyDstLayouts,
-                                            transition.newLayout, loc.dot(Field::newLayout), "pCopyDstLayouts",
+                                            transition.newLayout, transition_loc.dot(Field::newLayout), "pCopyDstLayouts",
                                             "VUID-VkHostImageLayoutTransitionInfoEXT-newLayout-09057");
         if (transition.oldLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
             skip |= ValidateHostCopyCurrentLayout(device, transition.oldLayout, transition.subresourceRange, i, *image_state,
-                                                  loc.dot(Field::oldLayout), "transition", "WIP: Should there be a VUID for this?");
+                                                  transition_loc.dot(Field::oldLayout), "transition",
+                                                  "WIP: Should there be a VUID for this?");
         }
     }
     return skip;

--- a/layers/core_checks/cc_pipeline_compute.cpp
+++ b/layers/core_checks/cc_pipeline_compute.cpp
@@ -22,9 +22,9 @@
 #include "generated/chassis.h"
 #include "core_validation.h"
 
-bool CoreChecks::ValidateComputePipelineShaderState(const PIPELINE_STATE &pipeline, const Location &loc) const {
-    StageCreateInfo stage_create_info(loc.function, &pipeline);
-    return ValidatePipelineShaderStage(stage_create_info, pipeline.stage_states[0], loc.dot(Field::stage));
+bool CoreChecks::ValidateComputePipelineShaderState(const PIPELINE_STATE &pipeline, const Location &create_info_loc) const {
+    StageCreateInfo stage_create_info(create_info_loc.function, &pipeline);
+    return ValidatePipelineShaderStage(stage_create_info, pipeline.stage_states[0], create_info_loc.dot(Field::stage));
 }
 
 bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
@@ -40,15 +40,15 @@ bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipeli
         if (!pipeline) {
             continue;
         }
-        const Location loc = error_obj.location.dot(Field::pCreateInfos, i);
-        skip |= ValidateComputePipelineShaderState(*pipeline, loc);
-        skip |= ValidateShaderModuleId(*pipeline, loc);
-        skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, loc.dot(Field::flags),
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
+        skip |= ValidateComputePipelineShaderState(*pipeline, create_info_loc);
+        skip |= ValidateShaderModuleId(*pipeline, create_info_loc);
+        skip |= ValidatePipelineCacheControlFlags(pCreateInfos[i].flags, create_info_loc.dot(Field::flags),
                                                   "VUID-VkComputePipelineCreateInfo-pipelineCreationCacheControl-02875");
 
         if (const auto *pipeline_robustness_info = LvlFindInChain<VkPipelineRobustnessCreateInfoEXT>(pCreateInfos[i].pNext);
             pipeline_robustness_info) {
-            skip |= ValidatePipelineRobustnessCreateInfo(*pipeline, *pipeline_robustness_info, loc);
+            skip |= ValidatePipelineRobustnessCreateInfo(*pipeline, *pipeline_robustness_info, create_info_loc);
         }
     }
     return skip;

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -163,7 +163,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
     }
 
     for (uint32_t info_i = 0; info_i < infoCount; ++info_i) {
-        const Location loc = error_obj.location.dot(Field::pInfos, info_i);
+        const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
         const auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfos[info_i].srcAccelerationStructure);
         const auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfos[info_i].dstAccelerationStructure);
 
@@ -176,12 +176,12 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
             if (pInfos[info_i].srcAccelerationStructure == VK_NULL_HANDLE) {
                 const LogObjectList objlist(device, commandBuffer);
                 skip |=
-                    LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-04630", objlist, loc.dot(Field::mode),
+                    LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-04630", objlist, info_loc.dot(Field::mode),
                              "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR but srcAccelerationStructure is VK_NULL_HANDLE.");
             } else if (src_as_state == nullptr || !src_as_state->built ||
                        !(src_as_state->build_info_khr.flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR)) {
                 const LogObjectList objlist(device, commandBuffer);
-                skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03667", objlist, loc.dot(Field::mode),
+                skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03667", objlist, info_loc.dot(Field::mode),
                                  "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, srcAccelerationStructure has been previously "
                                  "constructed with flags %s.",
                                  string_VkBuildAccelerationStructureFlagsKHR(src_as_state->build_info_khr.flags).c_str());
@@ -189,7 +189,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
             if (src_as_state != nullptr) {
                 if (!src_as_state->buffer_state) {
                     const LogObjectList objlist(device, commandBuffer, src_as_state->Handle());
-                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03708", objlist, loc.dot(Field::mode),
+                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03708", objlist, info_loc.dot(Field::mode),
                                      "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR but the buffer associated with "
                                      "srcAccelerationStructure is not valid.");
                 } else {
@@ -199,7 +199,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
                 }
                 if (pInfos[info_i].geometryCount != src_as_state->build_info_khr.geometryCount) {
                     const LogObjectList objlist(device, commandBuffer);
-                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03758", objlist, loc.dot(Field::mode),
+                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03758", objlist, info_loc.dot(Field::mode),
                                      "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR,"
                                      " but geometryCount (%" PRIu32
                                      ")  must have the same value which was specified when "
@@ -209,7 +209,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
                 if (pInfos[info_i].flags != src_as_state->build_info_khr.flags) {
                     const LogObjectList objlist(device, commandBuffer);
                     skip |=
-                        LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03759", objlist, loc.dot(Field::mode),
+                        LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03759", objlist, info_loc.dot(Field::mode),
                                  "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but flags (%s) must have the same value which"
                                  " was specified when srcAccelerationStructure was last built (%s).",
                                  string_VkBuildAccelerationStructureFlagsKHR(pInfos[info_i].flags).c_str(),
@@ -218,7 +218,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
                 if (pInfos[info_i].type != src_as_state->build_info_khr.type) {
                     const LogObjectList objlist(device, commandBuffer);
                     skip |=
-                        LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03760", objlist, loc.dot(Field::mode),
+                        LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03760", objlist, info_loc.dot(Field::mode),
                                  "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but type (%s) must have the same value which"
                                  " was specified when srcAccelerationStructure was last built (%s).",
                                  string_VkAccelerationStructureTypeKHR(pInfos[info_i].type),
@@ -232,7 +232,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
                  dst_as_state->create_infoKHR.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR)) {
                 const LogObjectList objlist(device, commandBuffer);
                 skip |= LogError(
-                    "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03700", objlist, loc.dot(Field::type),
+                    "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03700", objlist, info_loc.dot(Field::type),
                     "is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR, but its dstAccelerationStructure was created with %s.",
                     string_VkAccelerationStructureTypeKHR(dst_as_state->create_infoKHR.type));
             }
@@ -243,13 +243,13 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
                  dst_as_state->create_infoKHR.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR)) {
                 const LogObjectList objlist(device, commandBuffer);
                 skip |= LogError(
-                    "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03699", objlist, loc.dot(Field::type),
+                    "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03699", objlist, info_loc.dot(Field::type),
                     "is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR, but its dstAccelerationStructure was created with %s.",
                     string_VkAccelerationStructureTypeKHR(dst_as_state->create_infoKHR.type));
             }
         }
 
-        skip |= ValidateAccelerationBuffers(info_i, pInfos[info_i], loc);
+        skip |= ValidateAccelerationBuffers(info_i, pInfos[info_i], info_loc);
     }
 
     auto no_as_buffer_memory_overlap_msg =

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -81,54 +81,54 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
     uint32_t linked_spirv_index = invalid;
     uint32_t linked_binary_index = invalid;
     for (uint32_t i = 0; i < createInfoCount; ++i) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfos, i);
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
         const VkShaderCreateInfoEXT& createInfo = pCreateInfos[i];
         if (createInfo.stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
             createInfo.stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) {
             if (enabled_features.core.tessellationShader == VK_FALSE) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08419", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08419", device, create_info_loc.dot(Field::stage),
                                  "is %s, but the tessellationShader feature was not enabled.",
                                  string_VkShaderStageFlagBits(createInfo.stage));
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_GEOMETRY_BIT) {
             if (enabled_features.core.geometryShader == VK_FALSE) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08420", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08420", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_GEOMETRY_BIT, but the geometryShader feature was not enabled.");
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_TASK_BIT_EXT) {
             if (enabled_features.mesh_shader_features.taskShader == VK_FALSE) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08421", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08421", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_TASK_BIT_EXT, but the taskShader feature was not enabled.");
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_MESH_BIT_EXT) {
             if (enabled_features.mesh_shader_features.meshShader == VK_FALSE) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08422", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08422", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_MESH_BIT_EXT, but the meshShader feature was not enabled.");
             }
         }
 
         if ((createInfo.flags & VK_SHADER_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_EXT) != 0 &&
             enabled_features.fragment_shading_rate_features.attachmentFragmentShadingRate == VK_FALSE) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08487", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08487", device, create_info_loc.dot(Field::flags),
                              "is %s, but the attachmentFragmentShadingRate feature was not enabled.",
                              string_VkShaderCreateFlagsEXT(createInfo.flags).c_str());
         }
         if ((createInfo.flags & VK_SHADER_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT) != 0 &&
             enabled_features.fragment_density_map_features.fragmentDensityMap == VK_FALSE) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08489", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08489", device, create_info_loc.dot(Field::flags),
                              "is %s, but the fragmentDensityMap feature was not enabled.",
                              string_VkShaderCreateFlagsEXT(createInfo.flags).c_str());
         }
 
         if ((createInfo.flags & VK_SHADER_CREATE_LINK_STAGE_BIT_EXT) != 0 && createInfoCount == 1) {
-            skip |= LogError("VUID-vkCreateShadersEXT-pCreateInfos-08401", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-vkCreateShadersEXT-pCreateInfos-08401", device, create_info_loc.dot(Field::flags),
                              "is %s, but createInfoCount is 1.", string_VkShaderCreateFlagsEXT(createInfo.flags).c_str());
         }
         if ((createInfo.flags & VK_SHADER_CREATE_LINK_STAGE_BIT_EXT) != 0) {
             const auto nextStage = FindNextStage(createInfoCount, pCreateInfos, createInfo.stage);
             if (nextStage != 0 && createInfo.nextStage != nextStage) {
                 skip |=
-                    LogError("VUID-vkCreateShadersEXT-pCreateInfos-08409", device, loc.dot(Field::flags),
+                    LogError("VUID-vkCreateShadersEXT-pCreateInfos-08409", device, create_info_loc.dot(Field::flags),
                              "is %s, but nextStage (%s) does not equal the "
                              "logically next stage (%s) which also has the VK_SHADER_CREATE_LINK_STAGE_BIT_EXT bit.",
                              string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
@@ -136,7 +136,7 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
             }
             for (uint32_t j = i; j < createInfoCount; ++j) {
                 if (i != j && createInfo.stage == pCreateInfos[j].stage) {
-                    skip |= LogError("VUID-vkCreateShadersEXT-pCreateInfos-08410", device, loc,
+                    skip |= LogError("VUID-vkCreateShadersEXT-pCreateInfos-08410", device, create_info_loc,
                                      "and pCreateInfos[%" PRIu32
                                      "] both contain VK_SHADER_CREATE_LINK_STAGE_BIT_EXT and have the stage %s.",
                                      j, string_VkShaderStageFlagBits(createInfo.stage));
@@ -171,44 +171,44 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
         if (enabled_features.core.tessellationShader == VK_FALSE &&
             (createInfo.nextStage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
              createInfo.nextStage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08428", device, loc.dot(Field::nextStage),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08428", device, create_info_loc.dot(Field::nextStage),
                              "is %s, but tessellationShader feature was not enabled.",
                              string_VkShaderStageFlags(createInfo.nextStage).c_str());
         }
         if (enabled_features.core.geometryShader == VK_FALSE && createInfo.nextStage == VK_SHADER_STAGE_GEOMETRY_BIT) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08429", device, loc.dot(Field::nextStage),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08429", device, create_info_loc.dot(Field::nextStage),
                              "is VK_SHADER_STAGE_GEOMETRY_BIT, but tessellationShader feature was not enabled.");
         }
         if (createInfo.stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT &&
             (createInfo.nextStage & ~VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) > 0) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08430", device, loc.dot(Field::stage),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08430", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, but nextStage is %s.",
                              string_VkShaderStageFlags(createInfo.nextStage).c_str());
         }
         if (createInfo.stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT &&
             (createInfo.nextStage & ~(VK_SHADER_STAGE_GEOMETRY_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)) > 0) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08431", device, loc.dot(Field::stage),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08431", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, but nextStage is %s.",
                              string_VkShaderStageFlags(createInfo.nextStage).c_str());
         }
         if (createInfo.stage == VK_SHADER_STAGE_GEOMETRY_BIT && (createInfo.nextStage & ~VK_SHADER_STAGE_FRAGMENT_BIT) > 0) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08433", device, loc.dot(Field::stage),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08433", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_GEOMETRY_BIT, but nextStage is %s.",
                              string_VkShaderStageFlags(createInfo.nextStage).c_str());
         }
         if ((createInfo.stage == VK_SHADER_STAGE_FRAGMENT_BIT || createInfo.stage == VK_SHADER_STAGE_COMPUTE_BIT) &&
             createInfo.nextStage > 0) {
-            skip |=
-                LogError("VUID-VkShaderCreateInfoEXT-nextStage-08434", device, loc.dot(Field::stage), "is %s, but nextStage is %s.",
-                         string_VkShaderStageFlagBits(createInfo.stage), string_VkShaderStageFlags(createInfo.nextStage).c_str());
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08434", device, create_info_loc.dot(Field::stage),
+                             "is %s, but nextStage is %s.", string_VkShaderStageFlagBits(createInfo.stage),
+                             string_VkShaderStageFlags(createInfo.nextStage).c_str());
         }
         if (createInfo.stage == VK_SHADER_STAGE_TASK_BIT_EXT && (createInfo.nextStage & ~VK_SHADER_STAGE_MESH_BIT_EXT) > 0) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08435", device, loc.dot(Field::stage),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08435", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_TASK_BIT_EXT, but nextStage is %s.",
                              string_VkShaderStageFlags(createInfo.nextStage).c_str());
         }
         if (createInfo.stage == VK_SHADER_STAGE_MESH_BIT_EXT && (createInfo.nextStage & ~VK_SHADER_STAGE_FRAGMENT_BIT) > 0) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08436", device, loc.dot(Field::stage),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08436", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_MESH_BIT_EXT, but nextStage is %s.",
                              string_VkShaderStageFlags(createInfo.nextStage).c_str());
         }
@@ -253,13 +253,13 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
 
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         if (pCreateInfos[i].codeType == VK_SHADER_CODE_TYPE_SPIRV_EXT) {
-            const Location loc = error_obj.location.dot(Field::pCreateInfos, i);
-            const StageCreateInfo stage_create_info(loc.function, i, pCreateInfos[i]);
+            const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
+            const StageCreateInfo stage_create_info(create_info_loc.function, i, pCreateInfos[i]);
             const auto spirv =
                 std::make_shared<SPIRV_MODULE_STATE>(pCreateInfos[i].codeSize, static_cast<const uint32_t*>(pCreateInfos[i].pCode));
             safe_VkShaderCreateInfoEXT safe_create_info = safe_VkShaderCreateInfoEXT(&pCreateInfos[i]);
             const PipelineStageState stage_state(nullptr, &safe_create_info, nullptr, spirv);
-            skip |= ValidatePipelineShaderStage(stage_create_info, stage_state, loc);
+            skip |= ValidatePipelineShaderStage(stage_create_info, stage_state, create_info_loc);
         }
     }
 

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2510,11 +2510,11 @@ bool CoreChecks::PreCallValidateCreateShaderModule(VkDevice device, const VkShad
         return false;
     }
 
-    const Location loc = error_obj.location.dot(Field::pCreateInfo);
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     auto have_glsl_shader = IsExtEnabled(device_extensions.vk_nv_glsl_shader);
 
     if (!have_glsl_shader && (pCreateInfo->codeSize % 4)) {
-        skip |= LogError("VUID-VkShaderModuleCreateInfo-codeSize-08735", device, loc.dot(Field::codeSize),
+        skip |= LogError("VUID-VkShaderModuleCreateInfo-codeSize-08735", device, create_info_loc.dot(Field::codeSize),
                          "(%zu) must be a multiple of 4.", pCreateInfo->codeSize);
     } else {
         auto cache = GetValidationCacheInfo(pCreateInfo);
@@ -2541,7 +2541,7 @@ bool CoreChecks::PreCallValidateCreateShaderModule(VkDevice device, const VkShad
                     skip |= LogWarning(device, "VUID-VkShaderModuleCreateInfo-pCode-01379", "SPIR-V module not valid: %s",
                                        diag && diag->error ? diag->error : "(no error text)");
                 } else {
-                    skip |= LogError("VUID-VkShaderModuleCreateInfo-pCode-01379", device, loc.dot(Field::pCode),
+                    skip |= LogError("VUID-VkShaderModuleCreateInfo-pCode-01379", device, create_info_loc.dot(Field::pCode),
                                      "is not valid SPIR-V: %s", diag && diag->error ? diag->error : "(no error text)");
                 }
             }

--- a/layers/core_checks/cc_ycbcr.cpp
+++ b/layers/core_checks/cc_ycbcr.cpp
@@ -40,7 +40,7 @@ bool CoreChecks::PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, co
                                                              const ErrorObject &error_obj) const {
     bool skip = false;
     const VkFormat conversion_format = pCreateInfo->format;
-    const Location loc = error_obj.location.dot(Field::pCreateInfo);
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
 
     // Need to check for external format conversion first as it allows for non-UNORM format
     bool external_format = false;
@@ -49,7 +49,7 @@ bool CoreChecks::PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, co
     if ((nullptr != ext_format_android) && (0 != ext_format_android->externalFormat)) {
         external_format = true;
         if (VK_FORMAT_UNDEFINED != conversion_format) {
-            return LogError("VUID-VkSamplerYcbcrConversionCreateInfo-format-01904", device, loc.dot(Field::format),
+            return LogError("VUID-VkSamplerYcbcrConversionCreateInfo-format-01904", device, create_info_loc.dot(Field::format),
                             "(%s) is not VK_FORMAT_UNDEFINED while "
                             "there is a chained VkExternalFormatANDROID struct with a non-zero externalFormat.",
                             string_VkFormat(conversion_format));
@@ -58,7 +58,7 @@ bool CoreChecks::PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, co
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
     if ((external_format == false) && (FormatIsUNORM(conversion_format) == false)) {
-        skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-format-04061", device, loc.dot(Field::format),
+        skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-format-04061", device, create_info_loc.dot(Field::format),
                          "(%s) is not an UNORM format and there is no external format conversion being created.",
                          string_VkFormat(conversion_format));
     }
@@ -85,52 +85,56 @@ bool CoreChecks::PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, co
     // These can't be in StatelessValidation due to needing possible External AHB state for feature support
     if (((format_features & VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR) == 0) &&
         ((format_features & VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR) == 0)) {
-        skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-format-01650", device, loc.dot(Field::format),
+        skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-format-01650", device, create_info_loc.dot(Field::format),
                          "(%s) does not support either VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT or "
                          "VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT",
                          string_VkFormat(conversion_format));
     }
     if ((format_features & VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT_KHR) == 0) {
         if (FormatIsXChromaSubsampled(conversion_format) && pCreateInfo->xChromaOffset == VK_CHROMA_LOCATION_COSITED_EVEN) {
-            skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651", device, loc.dot(Field::format),
-                             "(%s) does not support VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT so xChromaOffset can't "
-                             "be VK_CHROMA_LOCATION_COSITED_EVEN",
-                             string_VkFormat(conversion_format));
+            skip |=
+                LogError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651", device, create_info_loc.dot(Field::format),
+                         "(%s) does not support VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT so xChromaOffset can't "
+                         "be VK_CHROMA_LOCATION_COSITED_EVEN",
+                         string_VkFormat(conversion_format));
         }
         if (FormatIsYChromaSubsampled(conversion_format) && pCreateInfo->yChromaOffset == VK_CHROMA_LOCATION_COSITED_EVEN) {
-            skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651", device, loc.dot(Field::format),
-                             "(%s) does not support VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT so yChromaOffset can't "
-                             "be VK_CHROMA_LOCATION_COSITED_EVEN",
-                             string_VkFormat(conversion_format));
+            skip |=
+                LogError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01651", device, create_info_loc.dot(Field::format),
+                         "(%s) does not support VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT so yChromaOffset can't "
+                         "be VK_CHROMA_LOCATION_COSITED_EVEN",
+                         string_VkFormat(conversion_format));
         }
     }
     if ((format_features & VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT_KHR) == 0) {
         if (FormatIsXChromaSubsampled(conversion_format) && pCreateInfo->xChromaOffset == VK_CHROMA_LOCATION_MIDPOINT) {
-            skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652", device, loc.dot(Field::format),
-                             "(%s) does not support VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT so xChromaOffset can't "
-                             "be VK_CHROMA_LOCATION_MIDPOINT",
-                             string_VkFormat(conversion_format));
+            skip |=
+                LogError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652", device, create_info_loc.dot(Field::format),
+                         "(%s) does not support VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT so xChromaOffset can't "
+                         "be VK_CHROMA_LOCATION_MIDPOINT",
+                         string_VkFormat(conversion_format));
         }
         if (FormatIsYChromaSubsampled(conversion_format) && pCreateInfo->yChromaOffset == VK_CHROMA_LOCATION_MIDPOINT) {
-            skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652", device, loc.dot(Field::format),
-                             "(%s) does not support VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT so yChromaOffset can't "
-                             "be VK_CHROMA_LOCATION_MIDPOINT",
-                             string_VkFormat(conversion_format));
+            skip |=
+                LogError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652", device, create_info_loc.dot(Field::format),
+                         "(%s) does not support VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT so yChromaOffset can't "
+                         "be VK_CHROMA_LOCATION_MIDPOINT",
+                         string_VkFormat(conversion_format));
         }
     }
     if (((format_features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT_KHR) ==
          0) &&
         (pCreateInfo->forceExplicitReconstruction == VK_TRUE)) {
-        skip |=
-            LogError("VUID-VkSamplerYcbcrConversionCreateInfo-forceExplicitReconstruction-01656", device, loc.dot(Field::format),
-                     "(%s) does not support "
-                     "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT so "
-                     "forceExplicitReconstruction must be VK_FALSE",
-                     string_VkFormat(conversion_format));
+        skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-forceExplicitReconstruction-01656", device,
+                         create_info_loc.dot(Field::format),
+                         "(%s) does not support "
+                         "VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT so "
+                         "forceExplicitReconstruction must be VK_FALSE",
+                         string_VkFormat(conversion_format));
     }
     if (((format_features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT_KHR) == 0) &&
         (pCreateInfo->chromaFilter == VK_FILTER_LINEAR)) {
-        skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-chromaFilter-01657", device, loc.dot(Field::format),
+        skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-chromaFilter-01657", device, create_info_loc.dot(Field::format),
                          "(%s) does not support VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT so "
                          "chromaFilter must not be VK_FILTER_LINEAR",
                          string_VkFormat(conversion_format));

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -487,7 +487,7 @@ class CoreChecks : public ValidationStateTracker {
                                       const char* vuid) const;
     bool ValidatePipelineDerivatives(std::vector<std::shared_ptr<PIPELINE_STATE>> const& pipelines, uint32_t pipe_index,
                                      const Location& loc) const;
-    bool ValidateGraphicsPipeline(const PIPELINE_STATE& pipeline, const Location& loc) const;
+    bool ValidateGraphicsPipeline(const PIPELINE_STATE& pipeline, const Location& create_info_loc) const;
     bool ValidImageBufferQueue(const CMD_BUFFER_STATE& cb_state, const VulkanTypedHandle& object, uint32_t queueFamilyIndex,
                                uint32_t count, const uint32_t* indices, const Location& loc) const;
     bool ValidateFenceForSubmit(const FENCE_STATE* pFence, const char* inflight_vuid, const char* retired_vuid,
@@ -953,13 +953,13 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineDynamicState(const PIPELINE_STATE& pipeline) const;
     bool ValidateGraphicsPipelineFragmentShadingRateState(const PIPELINE_STATE& pipeline, const Location& loc) const;
     bool ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE& pipeline, const Location& loc) const;
-    bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline, const Location& loc) const;
+    bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline, const Location& create_info_loc) const;
     bool ValidatePipelineRobustnessCreateInfo(const PIPELINE_STATE& pipeline, const VkPipelineRobustnessCreateInfoEXT& create_info,
                                               const Location& loc) const;
     uint32_t CalcShaderStageCount(const PIPELINE_STATE& pipeline, VkShaderStageFlagBits stageBit) const;
     bool GroupHasValidIndex(const PIPELINE_STATE& pipeline, uint32_t group, uint32_t stage) const;
     bool ValidateRayTracingPipeline(const PIPELINE_STATE& pipeline, const safe_VkRayTracingPipelineCreateInfoCommon& create_info,
-                                    VkPipelineCreateFlags flags, const Location& loc) const;
+                                    VkPipelineCreateFlags flags, const Location& create_info_loc) const;
     bool PreCallValidateGetShaderModuleIdentifierEXT(VkDevice device, VkShaderModule shaderModule,
                                                      VkShaderModuleIdentifierEXT* pIdentifier,
                                                      const ErrorObject& error_obj) const override;

--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -24,14 +24,14 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
     bool skip = false;
 
     if (pCreateInfo != nullptr) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfo);
-        skip |= ValidateNotZero(pCreateInfo->size == 0, "VUID-VkBufferCreateInfo-size-00912", loc.dot(Field::size));
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
+        skip |= ValidateNotZero(pCreateInfo->size == 0, "VUID-VkBufferCreateInfo-size-00912", create_info_loc.dot(Field::size));
 
         // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
         if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT) {
             // If sharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1
             if (pCreateInfo->queueFamilyIndexCount <= 1) {
-                skip |= LogError("VUID-VkBufferCreateInfo-sharingMode-00914", device, loc.dot(Field::sharingMode),
+                skip |= LogError("VUID-VkBufferCreateInfo-sharingMode-00914", device, create_info_loc.dot(Field::sharingMode),
                                  "VK_SHARING_MODE_CONCURRENT, but queueFamilyIndexCount is %" PRIu32 ".",
                                  pCreateInfo->queueFamilyIndexCount);
             }
@@ -39,25 +39,25 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
             // If sharingMode is VK_SHARING_MODE_CONCURRENT, pQueueFamilyIndices must be a pointer to an array of
             // queueFamilyIndexCount uint32_t values
             if (pCreateInfo->pQueueFamilyIndices == nullptr) {
-                skip |= LogError("VUID-VkBufferCreateInfo-sharingMode-00913", device, loc.dot(Field::sharingMode),
+                skip |= LogError("VUID-VkBufferCreateInfo-sharingMode-00913", device, create_info_loc.dot(Field::sharingMode),
                                  "is VK_SHARING_MODE_CONCURRENT, but pQueueFamilyIndices is NULL.");
             }
         }
 
         if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) && (!physical_device_features.sparseBinding)) {
-            skip |= LogError("VUID-VkBufferCreateInfo-flags-00915", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkBufferCreateInfo-flags-00915", device, create_info_loc.dot(Field::flags),
                              "includes VK_BUFFER_CREATE_SPARSE_BINDING_BIT, but the sparseBinding feature is not enabled.");
         }
 
         if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) && (!physical_device_features.sparseResidencyBuffer)) {
             skip |=
-                LogError("VUID-VkBufferCreateInfo-flags-00916", device, loc.dot(Field::flags),
+                LogError("VUID-VkBufferCreateInfo-flags-00916", device, create_info_loc.dot(Field::flags),
                          "includes VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT, but the sparseResidencyBuffer feature is not enabled.");
         }
 
         if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_ALIASED_BIT) && (!physical_device_features.sparseResidencyAliased)) {
             skip |=
-                LogError("VUID-VkBufferCreateInfo-flags-00917", device, loc.dot(Field::flags),
+                LogError("VUID-VkBufferCreateInfo-flags-00917", device, create_info_loc.dot(Field::flags),
                          "includes VK_BUFFER_CREATE_SPARSE_ALIASED_BIT, but the sparseResidencyAliased feature is not enabled.");
         };
 
@@ -65,14 +65,14 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
         // VK_BUFFER_CREATE_SPARSE_BINDING_BIT
         if (((pCreateInfo->flags & (VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_ALIASED_BIT)) != 0) &&
             ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != VK_BUFFER_CREATE_SPARSE_BINDING_BIT)) {
-            skip |= LogError("VUID-VkBufferCreateInfo-flags-00918", device, loc.dot(Field::flags), "is %s.",
+            skip |= LogError("VUID-VkBufferCreateInfo-flags-00918", device, create_info_loc.dot(Field::flags), "is %s.",
                              string_VkBufferCreateFlags(pCreateInfo->flags).c_str());
         }
 
         const auto *maintenance4_features = LvlFindInChain<VkPhysicalDeviceMaintenance4FeaturesKHR>(device_createinfo_pnext);
         if (maintenance4_features && maintenance4_features->maintenance4) {
             if (pCreateInfo->size > phys_dev_ext_props.maintenance4_props.maxBufferSize) {
-                skip |= LogError("VUID-VkBufferCreateInfo-size-06409", device, loc.dot(Field::size),
+                skip |= LogError("VUID-VkBufferCreateInfo-size-06409", device, create_info_loc.dot(Field::size),
                                  "(%" PRIu64
                                  ") is larger than the maximum allowed buffer size "
                                  "VkPhysicalDeviceMaintenance4Properties.maxBufferSize (%" PRIu64 ").",

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -85,13 +85,13 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers(VkCommandBu
 
     for (uint32_t i = 0; i < bindingCount; ++i) {
         if (pBuffers[i] == VK_NULL_HANDLE) {
-            const Location loc = error_obj.location.dot(Field::pBuffers, i);
+            const Location buffer_loc = error_obj.location.dot(Field::pBuffers, i);
             const auto *robustness2_features = LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
             if (!(robustness2_features && robustness2_features->nullDescriptor)) {
-                skip |= LogError("VUID-vkCmdBindVertexBuffers-pBuffers-04001", commandBuffer, loc, "is VK_NULL_HANDLE.");
+                skip |= LogError("VUID-vkCmdBindVertexBuffers-pBuffers-04001", commandBuffer, buffer_loc, "is VK_NULL_HANDLE.");
             } else {
                 if (pOffsets[i] != 0) {
-                    skip |= LogError("VUID-vkCmdBindVertexBuffers-pBuffers-04002", commandBuffer, loc,
+                    skip |= LogError("VUID-vkCmdBindVertexBuffers-pBuffers-04002", commandBuffer, buffer_loc,
                                      "is VK_NULL_HANDLE, but pOffsets[%" PRIu32 "] is not 0.", i);
                 }
             }
@@ -237,13 +237,13 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers2(VkCommandB
 
     for (uint32_t i = 0; i < bindingCount; ++i) {
         if (pBuffers[i] == VK_NULL_HANDLE) {
-            const Location loc = error_obj.location.dot(Field::pBuffers, i);
+            const Location buffer_loc = error_obj.location.dot(Field::pBuffers, i);
             const auto *robustness2_features = LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
             if (!(robustness2_features && robustness2_features->nullDescriptor)) {
-                skip |= LogError("VUID-vkCmdBindVertexBuffers2-pBuffers-04111", commandBuffer, loc, "is VK_NULL_HANDLE.");
+                skip |= LogError("VUID-vkCmdBindVertexBuffers2-pBuffers-04111", commandBuffer, buffer_loc, "is VK_NULL_HANDLE.");
             } else {
                 if (pOffsets[i] != 0) {
-                    skip |= LogError("VUID-vkCmdBindVertexBuffers2-pBuffers-04112", commandBuffer, loc,
+                    skip |= LogError("VUID-vkCmdBindVertexBuffers2-pBuffers-04112", commandBuffer, buffer_loc,
                                      "is VK_NULL_HANDLE, but pOffsets[%" PRIu32 "] is not 0.", i);
                 }
             }
@@ -382,14 +382,16 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
                                                                   const VkRenderingInfo *pRenderingInfo,
                                                                   const ErrorObject &error_obj) const {
     bool skip = false;
-    const Location loc = error_obj.location.dot(Field::pRenderingInfo);
+    const Location rendering_info_loc = error_obj.location.dot(Field::pRenderingInfo);
 
     if (pRenderingInfo->viewMask == 0 && pRenderingInfo->layerCount == 0) {
-        skip |= LogError("VUID-VkRenderingInfo-viewMask-06069", commandBuffer, loc, "viewMask and layerCount are both zero");
+        skip |= LogError("VUID-VkRenderingInfo-viewMask-06069", commandBuffer, rendering_info_loc,
+                         "viewMask and layerCount are both zero");
     }
 
     if (pRenderingInfo->colorAttachmentCount > device_limits.maxColorAttachments) {
-        skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-06106", commandBuffer, loc.dot(Field::colorAttachmentCount),
+        skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-06106", commandBuffer,
+                         rendering_info_loc.dot(Field::colorAttachmentCount),
                          "(%" PRIu32
                          ") must be less than or equal to "
                          "maxColorAttachments (%" PRIu32 ").",
@@ -402,22 +404,23 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
         (rendering_fragment_shading_rate_attachment_info->imageView != VK_NULL_HANDLE)) {
         if (UniqueRenderingInfoImageViews(pRenderingInfo, rendering_fragment_shading_rate_attachment_info->imageView) == false) {
             skip |= LogError("VUID-VkRenderingInfo-imageView-06125", commandBuffer,
-                             loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView), "is %s.",
-                             FormatHandle(rendering_fragment_shading_rate_attachment_info->imageView).c_str());
+                             rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::imageView),
+                             "is %s.", FormatHandle(rendering_fragment_shading_rate_attachment_info->imageView).c_str());
         }
 
         const VkImageLayout image_layout = rendering_fragment_shading_rate_attachment_info->imageLayout;
         if (image_layout != VK_IMAGE_LAYOUT_GENERAL &&
             image_layout != VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR) {
             skip |= LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06147", commandBuffer,
-                             loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::layout), "is (%s).",
-                             string_VkImageLayout(image_layout));
+                             rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::layout),
+                             "is (%s).", string_VkImageLayout(image_layout));
         }
 
         if (!IsPowerOfTwo(rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width)) {
             skip |=
                 LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06149", commandBuffer,
-                         loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
+                         rendering_info_loc
+                             .pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
                              .dot(Field::width),
                          "(%" PRIu32 ") must be a power of two.",
                          rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width);
@@ -428,7 +431,8 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
         if (rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width > max_frs_attach_texel_width) {
             skip |= LogError(
                 "VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06150", commandBuffer,
-                loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
+                rendering_info_loc
+                    .pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
                     .dot(Field::width),
                 "(%" PRIu32
                 ") must be less than or equal to "
@@ -441,7 +445,8 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
         if (rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width < min_frs_attach_texel_width) {
             skip |= LogError(
                 "VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06151", commandBuffer,
-                loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
+                rendering_info_loc
+                    .pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
                     .dot(Field::width),
                 "(%" PRIu32
                 ") must be greater than or equal to "
@@ -452,7 +457,8 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
         if (!IsPowerOfTwo(rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height)) {
             skip |=
                 LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06152", commandBuffer,
-                         loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
+                         rendering_info_loc
+                             .pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
                              .dot(Field::height),
                          "(%" PRIu32 ") must be a power of two.",
                          rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height);
@@ -463,7 +469,8 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
         if (rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height > max_frs_attach_texel_height) {
             skip |=
                 LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06153", commandBuffer,
-                         loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
+                         rendering_info_loc
+                             .pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
                              .dot(Field::height),
                          "(%" PRIu32
                          ") must be less than or equal to "
@@ -477,7 +484,8 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
         if (rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height < min_frs_attach_texel_height) {
             skip |=
                 LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06154", commandBuffer,
-                         loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
+                         rendering_info_loc
+                             .pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize)
                              .dot(Field::height),
                          "(%" PRIu32
                          ") must be greater than or equal to "
@@ -491,29 +499,29 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
         if ((rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width /
              rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height) >
             max_frs_attach_texel_aspect_ratio) {
-            skip |=
-                LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06155", commandBuffer,
-                         loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize),
-                         "the quotient of width (%" PRIu32 ") and height (%" PRIu32
-                         ") "
-                         "must be less than or equal to maxFragmentShadingRateAttachmentTexelSizeAspectRatio (%" PRIu32 ").",
-                         rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width,
-                         rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height,
-                         max_frs_attach_texel_aspect_ratio);
+            skip |= LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06155", commandBuffer,
+                             rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR,
+                                                      Field::shadingRateAttachmentTexelSize),
+                             "the quotient of width (%" PRIu32 ") and height (%" PRIu32
+                             ") "
+                             "must be less than or equal to maxFragmentShadingRateAttachmentTexelSizeAspectRatio (%" PRIu32 ").",
+                             rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width,
+                             rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height,
+                             max_frs_attach_texel_aspect_ratio);
         }
 
         if ((rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height /
              rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width) >
             max_frs_attach_texel_aspect_ratio) {
-            skip |=
-                LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06156", commandBuffer,
-                         loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR, Field::shadingRateAttachmentTexelSize),
-                         "the quotient of height (%" PRIu32 ") and width (%" PRIu32
-                         ") "
-                         "must be less than or equal to maxFragmentShadingRateAttachmentTexelSizeAspectRatio (%" PRIu32 ").",
-                         rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height,
-                         rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width,
-                         max_frs_attach_texel_aspect_ratio);
+            skip |= LogError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06156", commandBuffer,
+                             rendering_info_loc.pNext(Struct::VkRenderingFragmentShadingRateAttachmentInfoKHR,
+                                                      Field::shadingRateAttachmentTexelSize),
+                             "the quotient of height (%" PRIu32 ") and width (%" PRIu32
+                             ") "
+                             "must be less than or equal to maxFragmentShadingRateAttachmentTexelSizeAspectRatio (%" PRIu32 ").",
+                             rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.height,
+                             rendering_fragment_shading_rate_attachment_info->shadingRateAttachmentTexelSize.width,
+                             max_frs_attach_texel_aspect_ratio);
         }
     }
 
@@ -522,14 +530,14 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
     if (fragment_density_map_attachment_info && (fragment_density_map_attachment_info->imageView != VK_NULL_HANDLE)) {
         if (UniqueRenderingInfoImageViews(pRenderingInfo, fragment_density_map_attachment_info->imageView) == false) {
             skip |= LogError("VUID-VkRenderingInfo-imageView-06116", commandBuffer,
-                             loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView), "is %s.",
-                             FormatHandle(fragment_density_map_attachment_info->imageView).c_str());
+                             rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
+                             "is %s.", FormatHandle(fragment_density_map_attachment_info->imageView).c_str());
         }
 
         if (fragment_density_map_attachment_info->imageLayout != VK_IMAGE_LAYOUT_GENERAL &&
             fragment_density_map_attachment_info->imageLayout != VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT) {
             skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06157", commandBuffer,
-                             loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
+                             rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                              "is %s, but "
                              "VkRenderingFragmentDensityMapAttachmentInfoEXT::imageLayout is %s.",
                              FormatHandle(fragment_density_map_attachment_info->imageView).c_str(),
@@ -539,7 +547,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
         if (rendering_fragment_shading_rate_attachment_info &&
             (rendering_fragment_shading_rate_attachment_info->imageView == fragment_density_map_attachment_info->imageView)) {
             skip |= LogError("VUID-VkRenderingInfo-imageView-06126", commandBuffer,
-                             loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
+                             rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
                              "and VkRenderingFragmentShadingRateAttachmentInfoKHR::imageView are the same (%s).",
                              FormatHandle(fragment_density_map_attachment_info->imageView).c_str());
         }
@@ -547,7 +555,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
 
     for (uint32_t j = 0; j < pRenderingInfo->colorAttachmentCount; ++j) {
         if (pRenderingInfo->pColorAttachments[j].imageView != VK_NULL_HANDLE) {
-            const Location attachment_loc = loc.dot(Field::pColorAttachments, j);
+            const Location attachment_loc = rendering_info_loc.dot(Field::pColorAttachments, j);
             const VkImageLayout image_layout = pRenderingInfo->pColorAttachments[j].imageLayout;
             const VkResolveModeFlagBits resolve_mode = pRenderingInfo->pColorAttachments[j].resolveMode;
             const VkImageLayout resolve_image_layout = pRenderingInfo->pColorAttachments[j].resolveImageLayout;
@@ -600,7 +608,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
     }
 
     if (pRenderingInfo->pDepthAttachment && pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) {
-        const Location attachment_loc = loc.dot(Field::pDepthAttachment);
+        const Location attachment_loc = rendering_info_loc.dot(Field::pDepthAttachment);
         const VkImageLayout layout = pRenderingInfo->pDepthAttachment->imageLayout;
         if (layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
             skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06092", commandBuffer, attachment_loc.dot(Field::imageLayout),
@@ -643,7 +651,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBeginRendering(VkCommandBuffe
     }
 
     if (pRenderingInfo->pStencilAttachment != nullptr && pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) {
-        const Location attachment_loc = loc.dot(Field::pStencilAttachment);
+        const Location attachment_loc = rendering_info_loc.dot(Field::pStencilAttachment);
         const VkImageLayout layout = pRenderingInfo->pStencilAttachment->imageLayout;
         if (layout == VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL) {
             skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06094", commandBuffer, attachment_loc.dot(Field::imageLayout),
@@ -727,17 +735,18 @@ bool StatelessValidation::manual_PreCallValidateCmdClearAttachments(VkCommandBuf
                                                                     const VkClearRect *pRects, const ErrorObject &error_obj) const {
     bool skip = false;
     for (uint32_t rect = 0; rect < rectCount; rect++) {
-        const Location loc = error_obj.location.dot(Field::pRects, rect);
+        const Location rect_loc = error_obj.location.dot(Field::pRects, rect);
         if (pRects[rect].layerCount == 0) {
-            skip |= LogError("VUID-vkCmdClearAttachments-layerCount-01934", commandBuffer, loc.dot(Field::layerCount), "is zero.");
+            skip |=
+                LogError("VUID-vkCmdClearAttachments-layerCount-01934", commandBuffer, rect_loc.dot(Field::layerCount), "is zero.");
         }
         if (pRects[rect].rect.extent.width == 0) {
             skip |= LogError("VUID-vkCmdClearAttachments-rect-02682", commandBuffer,
-                             loc.dot(Field::rect).dot(Field::extent).dot(Field::width), "is zero.");
+                             rect_loc.dot(Field::rect).dot(Field::extent).dot(Field::width), "is zero.");
         }
         if (pRects[rect].rect.extent.height == 0) {
             skip |= LogError("VUID-vkCmdClearAttachments-rect-02683", commandBuffer,
-                             loc.dot(Field::rect).dot(Field::extent).dot(Field::height), "is zero.");
+                             rect_loc.dot(Field::rect).dot(Field::extent).dot(Field::height), "is zero.");
         }
     }
     return skip;

--- a/layers/stateless/sl_cmd_buffer_dynamic.cpp
+++ b/layers/stateless/sl_cmd_buffer_dynamic.cpp
@@ -97,29 +97,29 @@ bool StatelessValidation::ValidateCmdSetScissorWithCount(VkCommandBuffer command
 
     if (pScissors) {
         for (uint32_t scissor_i = 0; scissor_i < scissorCount; ++scissor_i) {
-            const Location loc = error_obj.location.dot(Field::pScissors, scissor_i);
+            const Location scissor_loc = error_obj.location.dot(Field::pScissors, scissor_i);
             const auto &scissor = pScissors[scissor_i];  // will crash on invalid ptr
 
             if (scissor.offset.x < 0) {
-                skip |= LogError("VUID-vkCmdSetScissorWithCount-x-03399", commandBuffer, loc.dot(Field::offset).dot(Field::x),
-                                 "(%" PRId32 ") is negative.", scissor.offset.x);
+                skip |= LogError("VUID-vkCmdSetScissorWithCount-x-03399", commandBuffer,
+                                 scissor_loc.dot(Field::offset).dot(Field::x), "(%" PRId32 ") is negative.", scissor.offset.x);
             }
 
             if (scissor.offset.y < 0) {
-                skip |= LogError("VUID-vkCmdSetScissorWithCount-x-03399", commandBuffer, loc.dot(Field::offset).dot(Field::y),
-                                 "(%" PRId32 ") is negative.", scissor.offset.y);
+                skip |= LogError("VUID-vkCmdSetScissorWithCount-x-03399", commandBuffer,
+                                 scissor_loc.dot(Field::offset).dot(Field::y), "(%" PRId32 ") is negative.", scissor.offset.y);
             }
 
             const int64_t x_sum = static_cast<int64_t>(scissor.offset.x) + static_cast<int64_t>(scissor.extent.width);
             if (x_sum > vvl::kI32Max) {
-                skip |= LogError("VUID-vkCmdSetScissorWithCount-offset-03400", commandBuffer, loc,
+                skip |= LogError("VUID-vkCmdSetScissorWithCount-offset-03400", commandBuffer, scissor_loc,
                                  "offset.x (%" PRId32 ") + extent.width (%" PRIu32 ") is %" PRIi64 " which will overflow int32_t.",
                                  scissor.offset.x, scissor.extent.width, x_sum);
             }
 
             const int64_t y_sum = static_cast<int64_t>(scissor.offset.y) + static_cast<int64_t>(scissor.extent.height);
             if (y_sum > vvl::kI32Max) {
-                skip |= LogError("VUID-vkCmdSetScissorWithCount-offset-03401", commandBuffer, loc,
+                skip |= LogError("VUID-vkCmdSetScissorWithCount-offset-03401", commandBuffer, scissor_loc,
                                  "offset.y (%" PRId32 ") + extent.height (%" PRIu32 ") is %" PRIi64 " which will overflow int32_t.",
                                  scissor.offset.y, scissor.extent.height, y_sum);
             }
@@ -212,29 +212,31 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
     }
 
     for (uint32_t binding = 0; binding < vertexBindingDescriptionCount; ++binding) {
-        const Location loc = error_obj.location.dot(Field::pVertexBindingDescriptions, binding);
+        const Location binding_loc = error_obj.location.dot(Field::pVertexBindingDescriptions, binding);
         if (pVertexBindingDescriptions[binding].binding > device_limits.maxVertexInputBindings) {
-            skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-binding-04796", commandBuffer, loc.dot(Field::binding),
-                             "(%" PRIu32 ") is greater than maxVertexInputBindings (%" PRIu32 ").",
+            skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-binding-04796", commandBuffer,
+                             binding_loc.dot(Field::binding), "(%" PRIu32 ") is greater than maxVertexInputBindings (%" PRIu32 ").",
                              pVertexBindingDescriptions[binding].binding, device_limits.maxVertexInputBindings);
         }
 
         if (pVertexBindingDescriptions[binding].stride > device_limits.maxVertexInputBindingStride) {
-            skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-stride-04797", commandBuffer, loc.dot(Field::stride),
+            skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-stride-04797", commandBuffer, binding_loc.dot(Field::stride),
                              "(%" PRIu32 ") is greater than maxVertexInputBindingStride (%" PRIu32 ").",
                              pVertexBindingDescriptions[binding].stride, device_limits.maxVertexInputBindingStride);
         }
 
         if (pVertexBindingDescriptions[binding].divisor == 0 &&
             (!vertex_attribute_divisor_features || !vertex_attribute_divisor_features->vertexAttributeInstanceRateZeroDivisor)) {
-            skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-divisor-04798", commandBuffer, loc.dot(Field::divisor),
-                             "is zero but "
-                             "vertexAttributeInstanceRateZeroDivisor feature was not enabled");
+            skip |=
+                LogError("VUID-VkVertexInputBindingDescription2EXT-divisor-04798", commandBuffer, binding_loc.dot(Field::divisor),
+                         "is zero but "
+                         "vertexAttributeInstanceRateZeroDivisor feature was not enabled");
         }
 
         if (pVertexBindingDescriptions[binding].divisor > 1) {
             if (!vertex_attribute_divisor_features || !vertex_attribute_divisor_features->vertexAttributeInstanceRateDivisor) {
-                skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-divisor-04799", commandBuffer, loc.dot(Field::divisor),
+                skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-divisor-04799", commandBuffer,
+                                 binding_loc.dot(Field::divisor),
                                  "is %" PRIu32
                                  " (greater than 1) but "
                                  "vertexAttributeInstanceRateDivisor feature was not enabled",
@@ -243,14 +245,15 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
                 if (pVertexBindingDescriptions[binding].divisor >
                     phys_dev_ext_props.vertex_attribute_divisor_props.maxVertexAttribDivisor) {
                     skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-divisor-06226", commandBuffer,
-                                     loc.dot(Field::divisor), "(%" PRIu32 ") is greater than maxVertexAttribDivisor (%" PRIu32 ")",
+                                     binding_loc.dot(Field::divisor),
+                                     "(%" PRIu32 ") is greater than maxVertexAttribDivisor (%" PRIu32 ")",
                                      pVertexBindingDescriptions[binding].divisor,
                                      phys_dev_ext_props.vertex_attribute_divisor_props.maxVertexAttribDivisor);
                 }
 
                 if (pVertexBindingDescriptions[binding].inputRate != VK_VERTEX_INPUT_RATE_INSTANCE) {
                     skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-divisor-06227", commandBuffer,
-                                     loc.dot(Field::divisor), "is %" PRIu32 " (greater than 1) but inputRate is %s.",
+                                     binding_loc.dot(Field::divisor), "is %" PRIu32 " (greater than 1) but inputRate is %s.",
                                      pVertexBindingDescriptions[binding].divisor,
                                      string_VkVertexInputRate(pVertexBindingDescriptions[binding].inputRate));
                 }
@@ -259,33 +262,37 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
     }
 
     for (uint32_t attribute = 0; attribute < vertexAttributeDescriptionCount; ++attribute) {
-        const Location loc = error_obj.location.dot(Field::pVertexAttributeDescriptions, attribute);
+        const Location attribute_loc = error_obj.location.dot(Field::pVertexAttributeDescriptions, attribute);
         if (pVertexAttributeDescriptions[attribute].location > device_limits.maxVertexInputAttributes) {
-            skip |= LogError("VUID-VkVertexInputAttributeDescription2EXT-location-06228", commandBuffer, loc.dot(Field::location),
+            skip |= LogError("VUID-VkVertexInputAttributeDescription2EXT-location-06228", commandBuffer,
+                             attribute_loc.dot(Field::location),
                              "(%" PRIu32 ") is greater than maxVertexInputAttributes (%" PRIu32 ").",
                              pVertexAttributeDescriptions[attribute].location, device_limits.maxVertexInputAttributes);
         }
 
         if (pVertexAttributeDescriptions[attribute].binding > device_limits.maxVertexInputBindings) {
-            skip |= LogError("VUID-VkVertexInputAttributeDescription2EXT-binding-06229", commandBuffer, loc.dot(Field::binding),
-                             "(%" PRIu32 ") is greater than maxVertexInputBindings (%" PRIu32 ").",
-                             pVertexAttributeDescriptions[attribute].binding, device_limits.maxVertexInputBindings);
+            skip |=
+                LogError("VUID-VkVertexInputAttributeDescription2EXT-binding-06229", commandBuffer,
+                         attribute_loc.dot(Field::binding), "(%" PRIu32 ") is greater than maxVertexInputBindings (%" PRIu32 ").",
+                         pVertexAttributeDescriptions[attribute].binding, device_limits.maxVertexInputBindings);
         }
 
         if (pVertexAttributeDescriptions[attribute].offset > device_limits.maxVertexInputAttributeOffset) {
-            skip |= LogError("VUID-VkVertexInputAttributeDescription2EXT-offset-06230", commandBuffer, loc.dot(Field::offset),
-                             "(%" PRIu32 ") is greater than maxVertexInputAttributeOffset (%" PRIu32 ").",
-                             pVertexAttributeDescriptions[attribute].offset, device_limits.maxVertexInputAttributeOffset);
+            skip |=
+                LogError("VUID-VkVertexInputAttributeDescription2EXT-offset-06230", commandBuffer, attribute_loc.dot(Field::offset),
+                         "(%" PRIu32 ") is greater than maxVertexInputAttributeOffset (%" PRIu32 ").",
+                         pVertexAttributeDescriptions[attribute].offset, device_limits.maxVertexInputAttributeOffset);
         }
 
         VkFormatProperties properties;
         DispatchGetPhysicalDeviceFormatProperties(physical_device, pVertexAttributeDescriptions[attribute].format, &properties);
         if ((properties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
-            skip |= LogError("VUID-VkVertexInputAttributeDescription2EXT-format-04805", commandBuffer, loc.dot(Field::format),
-                             "(%s) is not a "
-                             "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT supported format. (supported bufferFeatures: %s)",
-                             string_VkFormat(pVertexAttributeDescriptions[attribute].format),
-                             string_VkFormatFeatureFlags2(properties.bufferFeatures).c_str());
+            skip |=
+                LogError("VUID-VkVertexInputAttributeDescription2EXT-format-04805", commandBuffer, attribute_loc.dot(Field::format),
+                         "(%s) is not a "
+                         "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT supported format. (supported bufferFeatures: %s)",
+                         string_VkFormat(pVertexAttributeDescriptions[attribute].format),
+                         string_VkFormatFeatureFlags2(properties.bufferFeatures).c_str());
         }
     }
 
@@ -389,29 +396,29 @@ bool StatelessValidation::manual_PreCallValidateCmdSetExclusiveScissorNV(VkComma
 
     if (pExclusiveScissors) {
         for (uint32_t scissor_i = 0; scissor_i < exclusiveScissorCount; ++scissor_i) {
-            const Location loc = error_obj.location.dot(Field::pExclusiveScissors, scissor_i);
+            const Location scissor_loc = error_obj.location.dot(Field::pExclusiveScissors, scissor_i);
             const auto &scissor = pExclusiveScissors[scissor_i];  // will crash on invalid ptr
 
             if (scissor.offset.x < 0) {
-                skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-x-02037", commandBuffer, loc.dot(Field::offset).dot(Field::x),
-                                 "(%" PRId32 ") is negative.", scissor.offset.x);
+                skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-x-02037", commandBuffer,
+                                 scissor_loc.dot(Field::offset).dot(Field::x), "(%" PRId32 ") is negative.", scissor.offset.x);
             }
 
             if (scissor.offset.y < 0) {
-                skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-x-02037", commandBuffer, loc.dot(Field::offset).dot(Field::y),
-                                 "(%" PRId32 ") is negative.", scissor.offset.y);
+                skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-x-02037", commandBuffer,
+                                 scissor_loc.dot(Field::offset).dot(Field::y), "(%" PRId32 ") is negative.", scissor.offset.y);
             }
 
             const int64_t x_sum = static_cast<int64_t>(scissor.offset.x) + static_cast<int64_t>(scissor.extent.width);
             if (x_sum > vvl::kI32Max) {
-                skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-offset-02038", commandBuffer, loc,
+                skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-offset-02038", commandBuffer, scissor_loc,
                                  "offset.x (%" PRId32 ") + extent.width (%" PRIu32 ") is %" PRIi64 " which will overflow int32_t.",
                                  scissor.offset.x, scissor.extent.width, x_sum);
             }
 
             const int64_t y_sum = static_cast<int64_t>(scissor.offset.y) + static_cast<int64_t>(scissor.extent.height);
             if (y_sum > vvl::kI32Max) {
-                skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-offset-02039", commandBuffer, loc,
+                skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-offset-02039", commandBuffer, scissor_loc,
                                  "offset.y (%" PRId32 ") + extent.height (%" PRIu32 ") is %" PRIi64 " which will overflow int32_t.",
                                  scissor.offset.y, scissor.extent.height, y_sum);
             }
@@ -548,29 +555,29 @@ bool StatelessValidation::manual_PreCallValidateCmdSetScissor(VkCommandBuffer co
 
     if (pScissors) {
         for (uint32_t scissor_i = 0; scissor_i < scissorCount; ++scissor_i) {
-            const Location loc = error_obj.location.dot(Field::pScissors, scissor_i);
+            const Location scissor_loc = error_obj.location.dot(Field::pScissors, scissor_i);
             const auto &scissor = pScissors[scissor_i];  // will crash on invalid ptr
 
             if (scissor.offset.x < 0) {
-                skip |= LogError("VUID-vkCmdSetScissor-x-00595", commandBuffer, loc.dot(Field::offset).dot(Field::x),
+                skip |= LogError("VUID-vkCmdSetScissor-x-00595", commandBuffer, scissor_loc.dot(Field::offset).dot(Field::x),
                                  "(%" PRId32 ") is negative.", scissor.offset.x);
             }
 
             if (scissor.offset.y < 0) {
-                skip |= LogError("VUID-vkCmdSetScissor-x-00595", commandBuffer, loc.dot(Field::offset).dot(Field::y),
+                skip |= LogError("VUID-vkCmdSetScissor-x-00595", commandBuffer, scissor_loc.dot(Field::offset).dot(Field::y),
                                  "(%" PRId32 ") is negative.", scissor.offset.y);
             }
 
             const int64_t x_sum = static_cast<int64_t>(scissor.offset.x) + static_cast<int64_t>(scissor.extent.width);
             if (x_sum > vvl::kI32Max) {
-                skip |= LogError("VUID-vkCmdSetScissor-offset-00596", commandBuffer, loc,
+                skip |= LogError("VUID-vkCmdSetScissor-offset-00596", commandBuffer, scissor_loc,
                                  "offset.x (%" PRId32 ") + extent.width (%" PRIu32 ") is %" PRIi64 " which will overflow int32_t.",
                                  scissor.offset.x, scissor.extent.width, x_sum);
             }
 
             const int64_t y_sum = static_cast<int64_t>(scissor.offset.y) + static_cast<int64_t>(scissor.extent.height);
             if (y_sum > vvl::kI32Max) {
-                skip |= LogError("VUID-vkCmdSetScissor-offset-00597", commandBuffer, loc,
+                skip |= LogError("VUID-vkCmdSetScissor-offset-00597", commandBuffer, scissor_loc,
                                  "offset.y (%" PRId32 ") + extent.height (%" PRIu32 ") is %" PRIi64 " which will overflow int32_t.",
                                  scissor.offset.y, scissor.extent.height, y_sum);
             }

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -125,20 +125,22 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
     bool skip = false;
 
     if (pCreateInfo != nullptr) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfo);
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
         const auto &features = physical_device_features;
         const auto &limits = device_limits;
 
         if (pCreateInfo->anisotropyEnable == VK_TRUE) {
             if (!IsBetweenInclusive(pCreateInfo->maxAnisotropy, 1.0F, limits.maxSamplerAnisotropy)) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-anisotropyEnable-01071", device, loc.dot(Field::maxAnisotropy),
-                                 "is %f but must be in the range of [1.0, %f] (maxSamplerAnistropy).", pCreateInfo->maxAnisotropy,
-                                 limits.maxSamplerAnisotropy);
+                skip |=
+                    LogError("VUID-VkSamplerCreateInfo-anisotropyEnable-01071", device, create_info_loc.dot(Field::maxAnisotropy),
+                             "is %f but must be in the range of [1.0, %f] (maxSamplerAnistropy).", pCreateInfo->maxAnisotropy,
+                             limits.maxSamplerAnisotropy);
             }
 
             // Anistropy cannot be enabled in sampler unless enabled as a feature
             if (features.samplerAnisotropy == VK_FALSE) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-anisotropyEnable-01070", device, loc.dot(Field::anisotropyEnable),
+                skip |= LogError("VUID-VkSamplerCreateInfo-anisotropyEnable-01070", device,
+                                 create_info_loc.dot(Field::anisotropyEnable),
                                  "is VK_TRUE but the samplerAnisotropy feature was not enabled.");
             }
         }
@@ -146,37 +148,39 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
         if (pCreateInfo->unnormalizedCoordinates == VK_TRUE) {
             if (pCreateInfo->minFilter != pCreateInfo->magFilter) {
                 skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01072", device,
-                                 loc.dot(Field::unnormalizedCoordinates),
+                                 create_info_loc.dot(Field::unnormalizedCoordinates),
                                  "is VK_TRUE, but minFilter (%s) is different then magFilter (%s).",
                                  string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
             }
             if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
                 skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01073", device,
-                                 loc.dot(Field::unnormalizedCoordinates),
+                                 create_info_loc.dot(Field::unnormalizedCoordinates),
                                  "is VK_TRUE, but mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
                                  string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
             }
             if (pCreateInfo->minLod != 0.0f || pCreateInfo->maxLod != 0.0f) {
-                skip |= LogError(
-                    "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01074", device, loc.dot(Field::unnormalizedCoordinates),
-                    "is VK_TRUE, but minLod (%f) and maxLod (%f) must both be zero.", pCreateInfo->minLod, pCreateInfo->maxLod);
+                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01074", device,
+                                 create_info_loc.dot(Field::unnormalizedCoordinates),
+                                 "is VK_TRUE, but minLod (%f) and maxLod (%f) must both be zero.", pCreateInfo->minLod,
+                                 pCreateInfo->maxLod);
             }
             if ((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE &&
                  pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
                 (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE &&
                  pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) {
-                skip |= LogError(
-                    "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01075", device, loc.dot(Field::unnormalizedCoordinates),
-                    "is VK_TRUE, but addressModeU (%s) and addressModeV (%s) must both be "
-                    "CLAMP_TO_EDGE or CLAMP_TO_BORDER.",
-                    string_VkSamplerAddressMode(pCreateInfo->addressModeU), string_VkSamplerAddressMode(pCreateInfo->addressModeV));
+                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01075", device,
+                                 create_info_loc.dot(Field::unnormalizedCoordinates),
+                                 "is VK_TRUE, but addressModeU (%s) and addressModeV (%s) must both be "
+                                 "CLAMP_TO_EDGE or CLAMP_TO_BORDER.",
+                                 string_VkSamplerAddressMode(pCreateInfo->addressModeU),
+                                 string_VkSamplerAddressMode(pCreateInfo->addressModeV));
             }
             if (pCreateInfo->anisotropyEnable == VK_TRUE) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01076", device, loc,
+                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01076", device, create_info_loc,
                                  "anisotropyEnable and unnormalizedCoordinates are both VK_TRUE.");
             }
             if (pCreateInfo->compareEnable == VK_TRUE) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01077", device, loc,
+                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01077", device, create_info_loc,
                                  "compareEnable and unnormalizedCoordinates are both VK_TRUE.");
             }
         }
@@ -189,7 +193,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
             if (sampler_reduction != nullptr) {
                 if (sampler_reduction->reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE) {
                     skip |= LogError("VUID-VkSamplerCreateInfo-compareEnable-01423", device,
-                                     loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
+                                     create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
                                      "is %s but compareEnable is VK_TRUE.",
                                      string_VkSamplerReductionMode(sampler_reduction->reductionMode));
                 }
@@ -199,7 +203,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
             if (!IsExtEnabled(device_extensions.vk_ext_filter_cubic)) {
                 if (pCreateInfo->magFilter == VK_FILTER_CUBIC_EXT || pCreateInfo->minFilter == VK_FILTER_CUBIC_EXT) {
                     skip |= LogError("VUID-VkSamplerCreateInfo-magFilter-07911", device,
-                                     loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
+                                     create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
                                      "is %s, magFilter is %s and minFilter is %s, but "
                                      "extension %s is not enabled.",
                                      string_VkSamplerReductionMode(sampler_reduction->reductionMode),
@@ -222,7 +226,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
         if (IsExtEnabled(device_extensions.vk_img_filter_cubic)) {
             if ((pCreateInfo->anisotropyEnable == VK_TRUE) &&
                 ((pCreateInfo->minFilter == VK_FILTER_CUBIC_IMG) || (pCreateInfo->magFilter == VK_FILTER_CUBIC_IMG))) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-magFilter-01081", device, loc,
+                skip |= LogError("VUID-VkSamplerCreateInfo-magFilter-01081", device, create_info_loc,
                                  "anisotropyEnable is VK_TRUE, but minFilter = %s and magFilter = %s",
                                  string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
             }
@@ -230,13 +234,13 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
 
         // Check for valid Lod range
         if (pCreateInfo->minLod > pCreateInfo->maxLod) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-maxLod-01973", device, loc, "minLod (%f) is greater than maxLod (%f)",
-                             pCreateInfo->minLod, pCreateInfo->maxLod);
+            skip |= LogError("VUID-VkSamplerCreateInfo-maxLod-01973", device, create_info_loc,
+                             "minLod (%f) is greater than maxLod (%f)", pCreateInfo->minLod, pCreateInfo->maxLod);
         }
 
         // Check mipLodBias to device limit
         if (pCreateInfo->mipLodBias > limits.maxSamplerLodBias) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-mipLodBias-01069", device, loc.dot(Field::mipLodBias),
+            skip |= LogError("VUID-VkSamplerCreateInfo-mipLodBias-01069", device, create_info_loc.dot(Field::mipLodBias),
                              "(%f) is greater than maxSamplerLodBias (%f)", pCreateInfo->mipLodBias, limits.maxSamplerLodBias);
         }
 
@@ -247,7 +251,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
                 (pCreateInfo->addressModeW != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||
                 (pCreateInfo->anisotropyEnable != VK_FALSE) || (pCreateInfo->unnormalizedCoordinates != VK_FALSE)) {
                 skip |= LogError(
-                    "VUID-VkSamplerCreateInfo-addressModeU-01646", device, loc,
+                    "VUID-VkSamplerCreateInfo-addressModeU-01646", device, create_info_loc,
                     "vkCreateSampler():  SamplerYCbCrConversion is enabled: "
                     "addressModeU (%s), addressModeV (%s), addressModeW (%s) must be CLAMP_TO_EDGE, and anisotropyEnable (%s) "
                     "and unnormalizedCoordinates (%s) must be VK_FALSE.",
@@ -259,19 +263,19 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
 
         if (pCreateInfo->flags & VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT) {
             if (pCreateInfo->minFilter != pCreateInfo->magFilter) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02574", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02574", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
                                  "minFilter (%s) and magFilter (%s) must be equal.",
                                  string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
             }
             if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02575", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02575", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
                                  "mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
                                  string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
             }
             if (pCreateInfo->minLod != 0.0 || pCreateInfo->maxLod != 0.0) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02576", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02576", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
                                  "minLod (%f) and maxLod (%f) must be zero.",
                                  pCreateInfo->minLod, pCreateInfo->maxLod);
@@ -280,7 +284,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
                  (pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) ||
                 ((pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
                  (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER))) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02577", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02577", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
                                  "addressModeU (%s) and addressModeV (%s) must be "
                                  "CLAMP_TO_EDGE or CLAMP_TO_BORDER",
@@ -288,17 +292,17 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
                                  string_VkSamplerAddressMode(pCreateInfo->addressModeV));
             }
             if (pCreateInfo->anisotropyEnable) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02578", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02578", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
                                  "but anisotropyEnable is VK_TRUE.");
             }
             if (pCreateInfo->compareEnable) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02579", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02579", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
                                  "but compareEnable is VK_TRUE.");
             }
             if (pCreateInfo->unnormalizedCoordinates) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02580", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02580", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
                                  "but unnormalizedCoordinates is VK_TRUE.");
             }
@@ -307,13 +311,13 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
         if (pCreateInfo->borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
             pCreateInfo->borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) {
             if (!IsExtEnabled(device_extensions.vk_ext_custom_border_color)) {
-                skip |=
-                    LogError(kVUID_PVError_ExtensionNotEnabled, device, loc.dot(Field::borderColor), "is %s but %s is not enabled.",
-                             string_VkBorderColor(pCreateInfo->borderColor), VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
+                skip |= LogError(kVUID_PVError_ExtensionNotEnabled, device, create_info_loc.dot(Field::borderColor),
+                                 "is %s but %s is not enabled.", string_VkBorderColor(pCreateInfo->borderColor),
+                                 VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
             }
             auto custom_create_info = LvlFindInChain<VkSamplerCustomBorderColorCreateInfoEXT>(pCreateInfo->pNext);
             if (!custom_create_info) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-borderColor-04011", device, loc.dot(Field::borderColor),
+                skip |= LogError("VUID-VkSamplerCreateInfo-borderColor-04011", device, create_info_loc.dot(Field::borderColor),
                                  "is %s but there is no VkSamplerCustomBorderColorCreateInfoEXT "
                                  "struct in pNext chain.",
                                  string_VkBorderColor(pCreateInfo->borderColor));
@@ -324,7 +328,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
                      (pCreateInfo->borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT &&
                       !FormatIsSampledFloat(custom_create_info->format)))) {
                     skip |= LogError("VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-07605", device,
-                                     loc.pNext(Struct::VkSamplerCustomBorderColorCreateInfoEXT, Field::format),
+                                     create_info_loc.pNext(Struct::VkSamplerCustomBorderColorCreateInfoEXT, Field::format),
                                      "%s does not match borderColor (%s).", string_VkFormat(custom_create_info->format),
                                      string_VkBorderColor(pCreateInfo->borderColor));
                 }
@@ -339,7 +343,8 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
             bool border_color_swizzle_features_enabled =
                 border_color_swizzle_features && border_color_swizzle_features->borderColorSwizzle;
             if (!border_color_swizzle_features_enabled) {
-                skip |= LogError("VUID-VkSamplerBorderColorComponentMappingCreateInfoEXT-borderColorSwizzle-06437", device, loc,
+                skip |= LogError("VUID-VkSamplerBorderColorComponentMappingCreateInfoEXT-borderColorSwizzle-06437", device,
+                                 create_info_loc,
                                  "The borderColorSwizzle feature must be enabled to use "
                                  "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT");
             }
@@ -348,20 +353,20 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
         // VK_QCOM_image_processing
         if ((pCreateInfo->flags & VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM) != 0) {
             if ((pCreateInfo->minFilter != VK_FILTER_NEAREST) || (pCreateInfo->magFilter != VK_FILTER_NEAREST)) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06964", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06964", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
                                  "minFilter (%s) must be VK_FILTER_NEAREST and "
                                  "magFilter (%s) must be VK_FILTER_NEAREST.",
                                  string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
             }
             if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06965", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06965", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
                                  "mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
                                  string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
             }
             if ((pCreateInfo->minLod != 0) || (pCreateInfo->maxLod != 0)) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06966", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06966", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
                                  "minLod (%f) and maxLod (%f) must be 0.",
                                  pCreateInfo->minLod, pCreateInfo->maxLod);
@@ -370,7 +375,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
                  (pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) ||
                 ((pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
                  (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER))) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06967", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06967", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
                                  "addressModeU (%s) and addressModeV (%s) must be either "
                                  "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE or VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER.",
@@ -380,7 +385,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
             if (((pCreateInfo->addressModeU == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
                  (pCreateInfo->addressModeV == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) &&
                 (pCreateInfo->borderColor != VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK)) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06968", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06968", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
                                  "and if addressModeU (%s) or addressModeV (%s) are "
                                  "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, then"
@@ -390,12 +395,12 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
                                  string_VkBorderColor(pCreateInfo->borderColor));
             }
             if (pCreateInfo->anisotropyEnable) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06969", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06969", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
                                  "but anisotropyEnable is VK_TRUE.");
             }
             if (pCreateInfo->compareEnable) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06970", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06970", device, create_info_loc.dot(Field::flags),
                                  "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
                                  "but compareEnable is VK_TRUE.");
             }
@@ -486,12 +491,12 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorSetLayout(VkDevi
         LvlFindInChain<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>(device_createinfo_pnext);
     bool mutable_descriptor_type_features_enabled =
         mutable_descriptor_type_features && mutable_descriptor_type_features->mutableDescriptorType == VK_TRUE;
-    const Location loc = error_obj.location.dot(Field::pCreateInfo);
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
 
     // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
     if (pCreateInfo->pBindings != nullptr) {
         for (uint32_t i = 0; i < pCreateInfo->bindingCount; ++i) {
-            const Location binding_loc = loc.dot(Field::pBindings, i);
+            const Location binding_loc = create_info_loc.dot(Field::pBindings, i);
             if (pCreateInfo->pBindings[i].descriptorCount != 0) {
                 // If descriptorCount is not 0, stageFlags must be a valid combination of VkShaderStageFlagBits values
                 if ((pCreateInfo->pBindings[i].stageFlags != 0) &&
@@ -559,7 +564,7 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorSetLayout(VkDevi
         }
 
         if (mutable_descriptor_type) {
-            skip |= ValidateMutableDescriptorTypeCreateInfo(*pCreateInfo, *mutable_descriptor_type, loc);
+            skip |= ValidateMutableDescriptorTypeCreateInfo(*pCreateInfo, *mutable_descriptor_type, create_info_loc);
         }
     }
 
@@ -584,35 +589,35 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorSetLayout(VkDevi
 
     if ((pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR) &&
         (pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_HOST_ONLY_POOL_BIT_EXT)) {
-        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-04590", device, loc.dot(Field::flags), "is %s.",
+        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-04590", device, create_info_loc.dot(Field::flags), "is %s.",
                          string_VkDescriptorSetLayoutCreateFlags(pCreateInfo->flags).c_str());
     }
     if ((pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT) &&
         (pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_HOST_ONLY_POOL_BIT_EXT)) {
-        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-04592", device, loc.dot(Field::flags), "is %s.",
+        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-04592", device, create_info_loc.dot(Field::flags), "is %s.",
                          string_VkDescriptorSetLayoutCreateFlags(pCreateInfo->flags).c_str());
     }
     if (pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_HOST_ONLY_POOL_BIT_EXT && !mutable_descriptor_type_features_enabled) {
-        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-04596", device, loc.dot(Field::flags),
+        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-04596", device, create_info_loc.dot(Field::flags),
                          "is %s, but mutableDescriptorType feature was not enabled.",
                          string_VkDescriptorSetLayoutCreateFlags(pCreateInfo->flags).c_str());
     }
 
     if ((pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT) &&
         !(pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT)) {
-        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-08001", device, loc.dot(Field::flags), "is %s.",
+        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-08001", device, create_info_loc.dot(Field::flags), "is %s.",
                          string_VkDescriptorSetLayoutCreateFlags(pCreateInfo->flags).c_str());
     }
 
     if ((pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) &&
         (pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT)) {
-        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-08002", device, loc.dot(Field::flags), "is %s.",
+        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-08002", device, create_info_loc.dot(Field::flags), "is %s.",
                          string_VkDescriptorSetLayoutCreateFlags(pCreateInfo->flags).c_str());
     }
 
     if ((pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) &&
         (pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_HOST_ONLY_POOL_BIT_VALVE)) {
-        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-08003", device, loc.dot(Field::flags), "is %s.",
+        skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-08003", device, create_info_loc.dot(Field::flags), "is %s.",
                          string_VkDescriptorSetLayoutCreateFlags(pCreateInfo->flags).c_str());
     }
 
@@ -931,9 +936,10 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorPool(VkDevice de
     bool skip = false;
 
     if (pCreateInfo) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfo);
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
         if (pCreateInfo->maxSets <= 0) {
-            skip |= LogError("VUID-VkDescriptorPoolCreateInfo-maxSets-00301", device, loc.dot(Field::maxSets), "is zero.");
+            skip |=
+                LogError("VUID-VkDescriptorPoolCreateInfo-maxSets-00301", device, create_info_loc.dot(Field::maxSets), "is zero.");
         }
 
         const auto *mutable_descriptor_type_features =
@@ -943,7 +949,7 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorPool(VkDevice de
 
         if (pCreateInfo->pPoolSizes) {
             for (uint32_t i = 0; i < pCreateInfo->poolSizeCount; ++i) {
-                const Location pool_loc = loc.dot(Field::pPoolSizes, i);
+                const Location pool_loc = create_info_loc.dot(Field::pPoolSizes, i);
                 if (pCreateInfo->pPoolSizes[i].descriptorCount <= 0) {
                     skip |= LogError("VUID-VkDescriptorPoolSize-descriptorCount-00302", device,
                                      pool_loc.dot(Field::descriptorCount), "is zero.");
@@ -979,13 +985,13 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorPool(VkDevice de
         }
 
         if (pCreateInfo->flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT && (!mutable_descriptor_type_enabled)) {
-            skip |= LogError("VUID-VkDescriptorPoolCreateInfo-flags-04609", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkDescriptorPoolCreateInfo-flags-04609", device, create_info_loc.dot(Field::flags),
                              "includes VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT, "
                              "but mutableDescriptorType feature was not enabled.");
         }
         if ((pCreateInfo->flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) &&
             (pCreateInfo->flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT)) {
-            skip |= LogError("VUID-VkDescriptorPoolCreateInfo-flags-04607", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkDescriptorPoolCreateInfo-flags-04607", device, create_info_loc.dot(Field::flags),
                              "includes both "
                              "VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT and VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT");
         }
@@ -1001,18 +1007,19 @@ bool StatelessValidation::manual_PreCallValidateCreateQueryPool(VkDevice device,
 
     // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
     if (pCreateInfo != nullptr) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfo);
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
         // If queryType is VK_QUERY_TYPE_PIPELINE_STATISTICS, pipelineStatistics must be a valid combination of
         // VkQueryPipelineStatisticFlagBits values
         if ((pCreateInfo->queryType == VK_QUERY_TYPE_PIPELINE_STATISTICS) && (pCreateInfo->pipelineStatistics != 0) &&
             ((pCreateInfo->pipelineStatistics & (~AllVkQueryPipelineStatisticFlagBits)) != 0)) {
-            skip |= LogError("VUID-VkQueryPoolCreateInfo-queryType-00792", device, loc.dot(Field::queryType),
+            skip |= LogError("VUID-VkQueryPoolCreateInfo-queryType-00792", device, create_info_loc.dot(Field::queryType),
                              "is VK_QUERY_TYPE_PIPELINE_STATISTICS, but "
                              "pCreateInfo->pipelineStatistics must be a valid combination of VkQueryPipelineStatisticFlagBits "
                              "values.");
         }
         if (pCreateInfo->queryCount == 0) {
-            skip |= LogError("VUID-VkQueryPoolCreateInfo-queryCount-02763", device, loc.dot(Field::queryCount), "is zero.");
+            skip |=
+                LogError("VUID-VkQueryPoolCreateInfo-queryCount-02763", device, create_info_loc.dot(Field::queryCount), "is zero.");
         }
     }
     return skip;
@@ -1043,7 +1050,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversion(VkD
 #endif
 
     const VkFormat format = pCreateInfo->format;
-    const Location loc = error_obj.location.dot(Field::pCreateInfo);
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
 
     // If there is a VkExternalFormatANDROID with externalFormat != 0, the value of components is ignored.
     if (!is_external_format) {
@@ -1051,7 +1058,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversion(VkD
         // XChroma Subsampled is same as "the format has a _422 or _420 suffix" from spec
         if (FormatIsXChromaSubsampled(format) == true) {
             if ((components.g != VK_COMPONENT_SWIZZLE_G) && (components.g != VK_COMPONENT_SWIZZLE_IDENTITY)) {
-                skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-components-02581", device, loc,
+                skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-components-02581", device, create_info_loc,
                                  "When using a XChroma subsampled format (%s) the components.g needs to be VK_COMPONENT_SWIZZLE_G "
                                  "or VK_COMPONENT_SWIZZLE_IDENTITY, but is %s.",
                                  string_VkFormat(format), string_VkComponentSwizzle(components.g));
@@ -1060,7 +1067,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversion(VkD
             if ((components.a != VK_COMPONENT_SWIZZLE_A) && (components.a != VK_COMPONENT_SWIZZLE_IDENTITY) &&
                 (components.a != VK_COMPONENT_SWIZZLE_ONE) && (components.a != VK_COMPONENT_SWIZZLE_ZERO)) {
                 skip |=
-                    LogError("VUID-VkSamplerYcbcrConversionCreateInfo-components-02582", device, loc,
+                    LogError("VUID-VkSamplerYcbcrConversionCreateInfo-components-02582", device, create_info_loc,
                              " When using a XChroma subsampled format (%s) the components.a needs to be VK_COMPONENT_SWIZZLE_A or "
                              "VK_COMPONENT_SWIZZLE_IDENTITY or VK_COMPONENT_SWIZZLE_ONE or VK_COMPONENT_SWIZZLE_ZERO, but is %s.",
                              string_VkFormat(format), string_VkComponentSwizzle(components.a));
@@ -1068,7 +1075,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversion(VkD
 
             if ((components.r != VK_COMPONENT_SWIZZLE_R) && (components.r != VK_COMPONENT_SWIZZLE_IDENTITY) &&
                 (components.r != VK_COMPONENT_SWIZZLE_B)) {
-                skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-components-02583", device, loc,
+                skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-components-02583", device, create_info_loc,
                                  "When using a XChroma subsampled format (%s) the components.r needs to be VK_COMPONENT_SWIZZLE_R "
                                  "or VK_COMPONENT_SWIZZLE_IDENTITY or VK_COMPONENT_SWIZZLE_B, but is %s.",
                                  string_VkFormat(format), string_VkComponentSwizzle(components.r));
@@ -1076,7 +1083,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversion(VkD
 
             if ((components.b != VK_COMPONENT_SWIZZLE_B) && (components.b != VK_COMPONENT_SWIZZLE_IDENTITY) &&
                 (components.b != VK_COMPONENT_SWIZZLE_R)) {
-                skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-components-02584", device, loc,
+                skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-components-02584", device, create_info_loc,
                                  "When using a XChroma subsampled format (%s) the components.b needs to be VK_COMPONENT_SWIZZLE_B "
                                  "or VK_COMPONENT_SWIZZLE_IDENTITY or VK_COMPONENT_SWIZZLE_R, but is %s.",
                                  string_VkFormat(format), string_VkComponentSwizzle(components.b));
@@ -1086,7 +1093,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversion(VkD
             const bool r_identity = ((components.r == VK_COMPONENT_SWIZZLE_R) || (components.r == VK_COMPONENT_SWIZZLE_IDENTITY));
             const bool b_identity = ((components.b == VK_COMPONENT_SWIZZLE_B) || (components.b == VK_COMPONENT_SWIZZLE_IDENTITY));
             if ((r_identity != b_identity) && ((r_identity == true) || (b_identity == true))) {
-                skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-components-02585", device, loc,
+                skip |= LogError("VUID-VkSamplerYcbcrConversionCreateInfo-components-02585", device, create_info_loc,
                                  "When using a XChroma subsampled format (%s) if either the components.r (%s) or components.b (%s) "
                                  "are an identity swizzle, then both need to be an identity swizzle.",
                                  string_VkFormat(format), string_VkComponentSwizzle(components.r),
@@ -1101,7 +1108,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversion(VkD
                 (components.g == VK_COMPONENT_SWIZZLE_ONE) || (components.g == VK_COMPONENT_SWIZZLE_ZERO) ||
                 (components.b == VK_COMPONENT_SWIZZLE_ONE) || (components.b == VK_COMPONENT_SWIZZLE_ZERO)) {
                 skip |= LogError(
-                    vuid, device, loc,
+                    vuid, device, create_info_loc,
                     "The ycbcrModel (%s) is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
                     "components.g (%s), nor components.b (%s) can't be VK_COMPONENT_SWIZZLE_ZERO or VK_COMPONENT_SWIZZLE_ONE.",
                     string_VkSamplerYcbcrModelConversion(pCreateInfo->ycbcrModel), string_VkComponentSwizzle(components.r),
@@ -1119,7 +1126,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversion(VkD
             if ((component_count < 4) && ((components.r == VK_COMPONENT_SWIZZLE_A) || (components.g == VK_COMPONENT_SWIZZLE_A) ||
                                           (components.b == VK_COMPONENT_SWIZZLE_A))) {
                 skip |=
-                    LogError(vuid, device, loc,
+                    LogError(vuid, device, create_info_loc,
                              "The ycbcrModel (%s) is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
                              "components.g (%s), or components.b (%s) can't be VK_COMPONENT_SWIZZLE_A.",
                              string_VkSamplerYcbcrModelConversion(pCreateInfo->ycbcrModel), string_VkComponentSwizzle(components.r),
@@ -1128,7 +1135,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversion(VkD
                        ((components.r == VK_COMPONENT_SWIZZLE_B) || (components.g == VK_COMPONENT_SWIZZLE_B) ||
                         (components.b == VK_COMPONENT_SWIZZLE_B) || (components.b == VK_COMPONENT_SWIZZLE_IDENTITY))) {
                 skip |=
-                    LogError(vuid, device, loc,
+                    LogError(vuid, device, create_info_loc,
                              "The ycbcrModel (%s) is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
                              "components.g (%s), or components.b (%s) can't be VK_COMPONENT_SWIZZLE_B "
                              "(components.b also can't be VK_COMPONENT_SWIZZLE_IDENTITY).",
@@ -1138,7 +1145,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSamplerYcbcrConversion(VkD
                        ((components.r == VK_COMPONENT_SWIZZLE_G) || (components.g == VK_COMPONENT_SWIZZLE_G) ||
                         (components.g == VK_COMPONENT_SWIZZLE_IDENTITY) || (components.b == VK_COMPONENT_SWIZZLE_G))) {
                 skip |=
-                    LogError(vuid, device, loc,
+                    LogError(vuid, device, create_info_loc,
                              "The ycbcrModel (%s) is not VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY so components.r (%s), "
                              "components.g (%s), or components.b (%s) can't be VK_COMPONENT_SWIZZLE_G "
                              "(components.g also can't be VK_COMPONENT_SWIZZLE_IDENTITY).",

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -25,7 +25,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
     bool skip = false;
 
     if (pCreateInfo != nullptr) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfo);
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
         const VkFormat image_format = pCreateInfo->format;
         const VkImageCreateFlags image_flags = pCreateInfo->flags;
         // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
@@ -33,40 +33,41 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             // If sharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1
             auto const queue_family_index_count = pCreateInfo->queueFamilyIndexCount;
             if (queue_family_index_count <= 1) {
-                skip |= LogError("VUID-VkImageCreateInfo-sharingMode-00942", device, loc.dot(Field::queueFamilyIndexCount),
-                                 "is %" PRIu32 ".", queue_family_index_count);
+                skip |= LogError("VUID-VkImageCreateInfo-sharingMode-00942", device,
+                                 create_info_loc.dot(Field::queueFamilyIndexCount), "is %" PRIu32 ".", queue_family_index_count);
             }
 
             // If sharingMode is VK_SHARING_MODE_CONCURRENT, pQueueFamilyIndices must be a pointer to an array of
             // queueFamilyIndexCount uint32_t values
             if (pCreateInfo->pQueueFamilyIndices == nullptr) {
-                skip |=
-                    LogError("VUID-VkImageCreateInfo-sharingMode-00941", device, loc.dot(Field::pQueueFamilyIndices), "is NULL.");
+                skip |= LogError("VUID-VkImageCreateInfo-sharingMode-00941", device,
+                                 create_info_loc.dot(Field::pQueueFamilyIndices), "is NULL.");
             }
         }
 
         skip |= ValidateNotZero(pCreateInfo->extent.width == 0, "VUID-VkImageCreateInfo-extent-00944",
-                                loc.dot(Field::extent).dot(Field::width));
+                                create_info_loc.dot(Field::extent).dot(Field::width));
         skip |= ValidateNotZero(pCreateInfo->extent.height == 0, "VUID-VkImageCreateInfo-extent-00945",
-                                loc.dot(Field::extent).dot(Field::height));
+                                create_info_loc.dot(Field::extent).dot(Field::height));
         skip |= ValidateNotZero(pCreateInfo->extent.depth == 0, "VUID-VkImageCreateInfo-extent-00946",
-                                loc.dot(Field::extent).dot(Field::depth));
+                                create_info_loc.dot(Field::extent).dot(Field::depth));
 
-        skip |= ValidateNotZero(pCreateInfo->mipLevels == 0, "VUID-VkImageCreateInfo-mipLevels-00947", loc.dot(Field::mipLevels));
-        skip |=
-            ValidateNotZero(pCreateInfo->arrayLayers == 0, "VUID-VkImageCreateInfo-arrayLayers-00948", loc.dot(Field::arrayLayers));
+        skip |= ValidateNotZero(pCreateInfo->mipLevels == 0, "VUID-VkImageCreateInfo-mipLevels-00947",
+                                create_info_loc.dot(Field::mipLevels));
+        skip |= ValidateNotZero(pCreateInfo->arrayLayers == 0, "VUID-VkImageCreateInfo-arrayLayers-00948",
+                                create_info_loc.dot(Field::arrayLayers));
 
         // InitialLayout must be PREINITIALIZED or UNDEFINED
         if ((pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) &&
             (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_PREINITIALIZED)) {
-            skip |= LogError("VUID-VkImageCreateInfo-initialLayout-00993", device, loc.dot(Field::initialLayout),
+            skip |= LogError("VUID-VkImageCreateInfo-initialLayout-00993", device, create_info_loc.dot(Field::initialLayout),
                              "is %s, but must be UNDEFINED or PREINITIALIZED.", string_VkImageLayout(pCreateInfo->initialLayout));
         }
 
         // If imageType is VK_IMAGE_TYPE_1D, both extent.height and extent.depth must be 1
         if ((pCreateInfo->imageType == VK_IMAGE_TYPE_1D) &&
             ((pCreateInfo->extent.height != 1) || (pCreateInfo->extent.depth != 1))) {
-            skip |= LogError("VUID-VkImageCreateInfo-imageType-00956", device, loc,
+            skip |= LogError("VUID-VkImageCreateInfo-imageType-00956", device, create_info_loc,
                              "if pCreateInfo->imageType is VK_IMAGE_TYPE_1D, both pCreateInfo->extent.height and "
                              "pCreateInfo->extent.depth must be 1.");
         }
@@ -77,32 +78,32 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             const auto height = pCreateInfo->extent.height;
             if (type != VK_IMAGE_TYPE_2D) {
                 skip |=
-                    LogError("VUID-VkImageCreateInfo-flags-00949", device, loc,
+                    LogError("VUID-VkImageCreateInfo-flags-00949", device, create_info_loc,
                              "Image type %s is incompatible with VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT.", string_VkImageType(type));
             }
 
             if (width != height) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-08865", device, loc,
+                skip |= LogError("VUID-VkImageCreateInfo-flags-08865", device, create_info_loc,
                                  "extent.width (=%" PRIu32 ") not equal to extent.height (=%" PRIu32 ").",
                                  pCreateInfo->extent.width, pCreateInfo->extent.height);
             }
 
             if (pCreateInfo->arrayLayers < 6) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-08866", device, loc, "arrayLayers (=%" PRIu32 ") is less than 6.",
-                                 pCreateInfo->arrayLayers);
+                skip |= LogError("VUID-VkImageCreateInfo-flags-08866", device, create_info_loc,
+                                 "arrayLayers (=%" PRIu32 ") is less than 6.", pCreateInfo->arrayLayers);
             }
         }
 
         if (pCreateInfo->imageType == VK_IMAGE_TYPE_2D) {
             if (pCreateInfo->extent.depth != 1) {
-                skip |= LogError("VUID-VkImageCreateInfo-imageType-00957", device, loc,
+                skip |= LogError("VUID-VkImageCreateInfo-imageType-00957", device, create_info_loc,
                                  "if pCreateInfo->imageType is VK_IMAGE_TYPE_2D, pCreateInfo->extent.depth must be 1.");
             }
         }
 
         // 3D image may have only 1 layer
         if ((pCreateInfo->imageType == VK_IMAGE_TYPE_3D) && (pCreateInfo->arrayLayers != 1)) {
-            skip |= LogError("VUID-VkImageCreateInfo-imageType-00961", device, loc,
+            skip |= LogError("VUID-VkImageCreateInfo-imageType-00961", device, create_info_loc,
                              "if pCreateInfo->imageType is VK_IMAGE_TYPE_3D, pCreateInfo->arrayLayers must be 1.");
         }
 
@@ -111,13 +112,13 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                                              VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
             // At least one of the legal attachment bits must be set
             if (0 == (pCreateInfo->usage & legal_flags)) {
-                skip |= LogError("VUID-VkImageCreateInfo-usage-00966", device, loc,
+                skip |= LogError("VUID-VkImageCreateInfo-usage-00966", device, create_info_loc,
                                  "Transient attachment image without a compatible attachment flag set.");
             }
             // No flags other than the legal attachment bits may be set
             legal_flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
             if (0 != (pCreateInfo->usage & ~legal_flags)) {
-                skip |= LogError("VUID-VkImageCreateInfo-usage-00963", device, loc,
+                skip |= LogError("VUID-VkImageCreateInfo-usage-00963", device, create_info_loc,
                                  "Transient attachment image with incompatible usage flags set.");
             }
         }
@@ -130,33 +131,33 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                                       : static_cast<uint32_t>(floor(log2(max_dim)) + 1);
         if (max_dim > 0 && pCreateInfo->mipLevels > max_mip_levels) {
             skip |=
-                LogError("VUID-VkImageCreateInfo-mipLevels-00958", device, loc,
+                LogError("VUID-VkImageCreateInfo-mipLevels-00958", device, create_info_loc,
                          "pCreateInfo->mipLevels must be less than or equal to "
                          "floor(log2(max(pCreateInfo->extent.width, pCreateInfo->extent.height, pCreateInfo->extent.depth)))+1.");
         }
 
         if ((image_flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT) && (pCreateInfo->imageType != VK_IMAGE_TYPE_3D)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-00950", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageCreateInfo-flags-00950", device, create_info_loc.dot(Field::flags),
                              "includes VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT but "
                              "imageType is %s.",
                              string_VkImageType(pCreateInfo->imageType));
         }
 
         if ((image_flags & VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT) && (pCreateInfo->imageType != VK_IMAGE_TYPE_3D)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-07755", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageCreateInfo-flags-07755", device, create_info_loc.dot(Field::flags),
                              "includes VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT but "
                              "imageType is %s.",
                              string_VkImageType(pCreateInfo->imageType));
         }
 
         if ((image_flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) && (!physical_device_features.sparseBinding)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-00969", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageCreateInfo-flags-00969", device, create_info_loc.dot(Field::flags),
                              "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT, but the "
                              "sparseBinding feature was not enabled.");
         }
 
         if ((image_flags & VK_IMAGE_CREATE_SPARSE_ALIASED_BIT) && (!physical_device_features.sparseResidencyAliased)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-01924", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageCreateInfo-flags-01924", device, create_info_loc.dot(Field::flags),
                              "includes VK_IMAGE_CREATE_SPARSE_ALIASED_BIT but the sparseResidencyAliased feature was not enabled.");
         }
 
@@ -164,7 +165,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
         // VK_IMAGE_CREATE_SPARSE_BINDING_BIT
         if (((image_flags & (VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_ALIASED_BIT)) != 0) &&
             ((image_flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != VK_IMAGE_CREATE_SPARSE_BINDING_BIT)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-00987", device, loc.dot(Field::flags), "is %s.",
+            skip |= LogError("VUID-VkImageCreateInfo-flags-00987", device, create_info_loc.dot(Field::flags), "is %s.",
                              string_VkImageCreateFlags(image_flags).c_str());
         }
 
@@ -172,26 +173,26 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
         if ((image_flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0) {
             // Linear tiling is unsupported
             if (VK_IMAGE_TILING_LINEAR == pCreateInfo->tiling) {
-                skip |= LogError("VUID-VkImageCreateInfo-tiling-04121", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-tiling-04121", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT but tiling is VK_IMAGE_TILING_LINEAR.");
             }
 
             // Sparse 1D image isn't valid
             if (VK_IMAGE_TYPE_1D == pCreateInfo->imageType) {
-                skip |= LogError("VUID-VkImageCreateInfo-imageType-00970", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-imageType-00970", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT but imageType is VK_IMAGE_TYPE_1D.");
             }
 
             // Sparse 2D image when device doesn't support it
             if ((!physical_device_features.sparseResidencyImage2D) && (VK_IMAGE_TYPE_2D == pCreateInfo->imageType)) {
-                skip |= LogError("VUID-VkImageCreateInfo-imageType-00971", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-imageType-00971", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D, but "
                                  "sparseResidencyImage2D feature was not enabled.");
             }
 
             // Sparse 3D image when device doesn't support it
             if ((!physical_device_features.sparseResidencyImage3D) && (VK_IMAGE_TYPE_3D == pCreateInfo->imageType)) {
-                skip |= LogError("VUID-VkImageCreateInfo-imageType-00972", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-imageType-00972", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_3D, but "
                                  "sparseResidencyImage3D feature was not enabled.");
             }
@@ -199,20 +200,20 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             // Multi-sample 2D image when device doesn't support it
             if (VK_IMAGE_TYPE_2D == pCreateInfo->imageType) {
                 if ((!physical_device_features.sparseResidency2Samples) && (VK_SAMPLE_COUNT_2_BIT == pCreateInfo->samples)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00973", device, loc.dot(Field::flags),
+                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00973", device, create_info_loc.dot(Field::flags),
                                      "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
                                      "VK_SAMPLE_COUNT_2_BIT, but sparseResidency2Samples feature was not enabled.");
                 } else if ((!physical_device_features.sparseResidency4Samples) && (VK_SAMPLE_COUNT_4_BIT == pCreateInfo->samples)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00974", device, loc.dot(Field::flags),
+                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00974", device, create_info_loc.dot(Field::flags),
                                      "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
                                      "VK_SAMPLE_COUNT_4_BIT, but sparseResidency4Samples feature was not enabled.");
                 } else if ((!physical_device_features.sparseResidency8Samples) && (VK_SAMPLE_COUNT_8_BIT == pCreateInfo->samples)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00975", device, loc.dot(Field::flags),
+                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00975", device, create_info_loc.dot(Field::flags),
                                      "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
                                      "VK_SAMPLE_COUNT_8_BIT, but sparseResidency8Samples feature was not enabled.");
                 } else if ((!physical_device_features.sparseResidency16Samples) &&
                            (VK_SAMPLE_COUNT_16_BIT == pCreateInfo->samples)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00976", device, loc.dot(Field::flags),
+                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00976", device, create_info_loc.dot(Field::flags),
                                      "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
                                      "VK_SAMPLE_COUNT_16_BIT, but sparseResidency16Samples feature was not enabled.");
                 }
@@ -222,13 +223,13 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
         // alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV
         if (pCreateInfo->usage & VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) {
             if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
-                skip |= LogError("VUID-VkImageCreateInfo-imageType-02082", device, loc.dot(Field::usage),
+                skip |= LogError("VUID-VkImageCreateInfo-imageType-02082", device, create_info_loc.dot(Field::usage),
                                  "includes VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR (or the "
                                  "alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV), but imageType is %s.",
                                  string_VkImageType(pCreateInfo->imageType));
             }
             if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
-                skip |= LogError("VUID-VkImageCreateInfo-samples-02083", device, loc.dot(Field::usage),
+                skip |= LogError("VUID-VkImageCreateInfo-samples-02083", device, create_info_loc.dot(Field::usage),
                                  "includes VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR (or the "
                                  "alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV), but samples is %s.",
                                  string_VkSampleCountFlagBits(pCreateInfo->samples));
@@ -238,7 +239,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             if (shading_rate_image_features && shading_rate_image_features->shadingRateImage &&
                 pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
                 // KHR flag can be non-optimal
-                skip |= LogError("VUID-VkImageCreateInfo-shadingRateImage-07727", device, loc.dot(Field::usage),
+                skip |= LogError("VUID-VkImageCreateInfo-shadingRateImage-07727", device, create_info_loc.dot(Field::usage),
                                  "includes VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, tiling must be "
                                  "VK_IMAGE_TILING_OPTIMAL.");
             }
@@ -246,14 +247,14 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 
         if (image_flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) {
             if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D && pCreateInfo->imageType != VK_IMAGE_TYPE_3D) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02050", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-flags-02050", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV, "
                                  "but imageType is %s.",
                                  string_VkImageType(pCreateInfo->imageType));
             }
 
             if ((image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) || FormatIsDepthOrStencil(image_format)) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02051", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-flags-02051", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV, "
                                  "it must not also contain VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT and format (%s) must not be a "
                                  "depth/stencil format.",
@@ -261,13 +262,13 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             }
 
             if (pCreateInfo->imageType == VK_IMAGE_TYPE_2D && (pCreateInfo->extent.width == 1 || pCreateInfo->extent.height == 1)) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02052", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-flags-02052", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and "
                                  "imageType is VK_IMAGE_TYPE_2D, extent.width and extent.height must be "
                                  "greater than 1.");
             } else if (pCreateInfo->imageType == VK_IMAGE_TYPE_3D &&
                        (pCreateInfo->extent.width == 1 || pCreateInfo->extent.height == 1 || pCreateInfo->extent.depth == 1)) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02053", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-flags-02053", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and "
                                  "imageType is VK_IMAGE_TYPE_3D, extent.width, extent.height, and extent.depth "
                                  "must be greater than 1.");
@@ -276,7 +277,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 
         if (((image_flags & VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) != 0) &&
             (FormatHasDepth(image_format) == false)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-01533", device, loc.dot(Field::flags),
+            skip |= LogError("VUID-VkImageCreateInfo-flags-01533", device, create_info_loc.dot(Field::flags),
                              "includes VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT the "
                              "format (%s) must be a depth or depth/stencil format.",
                              string_VkFormat(image_format));
@@ -290,7 +291,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                 legal_flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
                 if ((image_stencil_struct->stencilUsage & ~legal_flags) != 0) {
                     skip |= LogError("VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539", device,
-                                     loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage), "is %s.",
+                                     create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage), "is %s.",
                                      string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
                 }
             }
@@ -299,7 +300,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                 if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) != 0) {
                     if (pCreateInfo->extent.width > device_limits.maxFramebufferWidth) {
                         skip |= LogError("VUID-VkImageCreateInfo-Format-02536", device,
-                                         loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
+                                         create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
                                          "includes VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image width (%" PRIu32
                                          ") exceeds device "
                                          "maxFramebufferWidth (%" PRIu32 ")",
@@ -308,7 +309,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 
                     if (pCreateInfo->extent.height > device_limits.maxFramebufferHeight) {
                         skip |= LogError("VUID-VkImageCreateInfo-format-02537", device,
-                                         loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
+                                         create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
                                          "includes VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image height (%" PRIu32
                                          ") exceeds device "
                                          "maxFramebufferHeight (%" PRIu32 ")",
@@ -320,7 +321,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                     ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
                     (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT)) {
                     skip |= LogError("VUID-VkImageCreateInfo-format-02538", device,
-                                     loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
+                                     create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
                                      "includes VK_IMAGE_USAGE_STORAGE_BIT and format is %s and samples is %s, but "
                                      "shaderStorageImageMultisample feature was not enabled.",
                                      string_VkFormat(image_format), string_VkSampleCountFlagBits(pCreateInfo->samples));
@@ -328,41 +329,45 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 
                 if (((pCreateInfo->usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0) &&
                     ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-format-02795", device, loc.dot(Field::usage),
-                                     "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
-                                     string_VkFormat(image_format),
-                                     loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
-                                     string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
+                    skip |=
+                        LogError("VUID-VkImageCreateInfo-format-02795", device, create_info_loc.dot(Field::usage),
+                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
+                                 string_VkFormat(image_format),
+                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
+                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
                 } else if (((pCreateInfo->usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) &&
                            ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-format-02796", device, loc.dot(Field::usage),
-                                     "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
-                                     string_VkFormat(image_format),
-                                     loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
-                                     string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
+                    skip |=
+                        LogError("VUID-VkImageCreateInfo-format-02796", device, create_info_loc.dot(Field::usage),
+                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
+                                 string_VkFormat(image_format),
+                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
+                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
                 }
 
                 if (((pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0) &&
                     ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) == 0)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-format-02797", device, loc.dot(Field::usage),
-                                     "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
-                                     string_VkFormat(image_format),
-                                     loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
-                                     string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
+                    skip |=
+                        LogError("VUID-VkImageCreateInfo-format-02797", device, create_info_loc.dot(Field::usage),
+                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
+                                 string_VkFormat(image_format),
+                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
+                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
                 } else if (((pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) == 0) &&
                            ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-format-02798", device, loc.dot(Field::usage),
-                                     "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
-                                     string_VkFormat(image_format),
-                                     loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
-                                     string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
+                    skip |=
+                        LogError("VUID-VkImageCreateInfo-format-02798", device, create_info_loc.dot(Field::usage),
+                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
+                                 string_VkFormat(image_format),
+                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
+                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
                 }
             }
         }
 
         if ((!physical_device_features.shaderStorageImageMultisample) && ((pCreateInfo->usage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
             (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT)) {
-            skip |= LogError("VUID-VkImageCreateInfo-usage-00968", device, loc.dot(Field::usage),
+            skip |= LogError("VUID-VkImageCreateInfo-usage-00968", device, create_info_loc.dot(Field::usage),
                              "includes VK_IMAGE_USAGE_STORAGE_BIT and imageType is %s, but shaderStorageImageMultisample feature "
                              "was not enabled.",
                              string_VkSampleCountFlagBits(pCreateInfo->samples));
@@ -375,7 +380,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             if (pCreateInfo->tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
                 if (((drm_format_mod_list != nullptr) && (drm_format_mod_explict != nullptr)) ||
                     ((drm_format_mod_list == nullptr) && (drm_format_mod_explict == nullptr))) {
-                    skip |= LogError("VUID-VkImageCreateInfo-tiling-02261", device, loc.dot(Field::tiling),
+                    skip |= LogError("VUID-VkImageCreateInfo-tiling-02261", device, create_info_loc.dot(Field::tiling),
                                      "VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT but pNext must have "
                                      "either VkImageDrmFormatModifierListCreateInfoEXT or "
                                      "VkImageDrmFormatModifierExplicitCreateInfoEXT in the pNext chain");
@@ -387,12 +392,12 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                     }
                 }
             } else if (drm_format_mod_list) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-02262", device, loc.dot(Field::tiling),
+                skip |= LogError("VUID-VkImageCreateInfo-pNext-02262", device, create_info_loc.dot(Field::tiling),
                                  "is %s, but there is a "
                                  "VkImageDrmFormatModifierListCreateInfoEXT in the pNext chain",
                                  string_VkImageTiling(pCreateInfo->tiling));
             } else if (drm_format_mod_explict) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-02262", device, loc.dot(Field::tiling),
+                skip |= LogError("VUID-VkImageCreateInfo-pNext-02262", device, create_info_loc.dot(Field::tiling),
                                  "is %s, but there is a VkImageDrmFormatModifierExplicitCreateInfoEXT "
                                  "in the pNext chain",
                                  string_VkImageTiling(pCreateInfo->tiling));
@@ -401,7 +406,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             if (drm_format_mod_explict && drm_format_mod_explict->pPlaneLayouts != nullptr) {
                 for (uint32_t i = 0; i < drm_format_mod_explict->drmFormatModifierPlaneCount; ++i) {
                     const Location drm_loc =
-                        loc.pNext(Struct::VkImageDrmFormatModifierExplicitCreateInfoEXT, Field::pPlaneLayouts, i);
+                        create_info_loc.pNext(Struct::VkImageDrmFormatModifierExplicitCreateInfoEXT, Field::pPlaneLayouts, i);
                     if (drm_format_mod_explict->pPlaneLayouts[i].size != 0) {
                         skip |=
                             LogError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-size-02267", device,
@@ -437,7 +442,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
         if ((pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) &&
             ((pCreateInfo->imageType != VK_IMAGE_TYPE_2D) || (image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ||
              (pCreateInfo->mipLevels != 1) || image_create_maybe_linear)) {
-            skip |= LogError("VUID-VkImageCreateInfo-samples-02257", device, loc,
+            skip |= LogError("VUID-VkImageCreateInfo-samples-02257", device, create_info_loc,
                              "image created with\n"
                              "samples = %s\n"
                              "imageType = %s\n"
@@ -452,7 +457,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
         if ((image_flags & VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT) &&
             ((pCreateInfo->mipLevels != 1) || (pCreateInfo->arrayLayers != 1) || (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) ||
              image_create_maybe_linear)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-02259", device, loc,
+            skip |= LogError("VUID-VkImageCreateInfo-flags-02259", device, create_info_loc,
                              "image created with\n"
                              "imageType = %s\n"
                              "flags = %s (contains VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT)\n"
@@ -467,35 +472,35 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 
         if (pCreateInfo->usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) {
             if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02557", device, loc.dot(Field::usage),
+                skip |= LogError("VUID-VkImageCreateInfo-flags-02557", device, create_info_loc.dot(Field::usage),
                                  "includes VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT, but imageType is %s.",
                                  string_VkImageType(pCreateInfo->imageType));
             }
             if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
-                skip |= LogError("VUID-VkImageCreateInfo-samples-02558", device, loc.dot(Field::usage),
+                skip |= LogError("VUID-VkImageCreateInfo-samples-02558", device, create_info_loc.dot(Field::usage),
                                  "includes VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT, but samples is %s.",
                                  string_VkSampleCountFlagBits(pCreateInfo->samples));
             }
         }
         if (image_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
             if (pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02565", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-flags-02565", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, but tiling is %s.",
                                  string_VkImageTiling(pCreateInfo->tiling));
             }
             if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02566", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-flags-02566", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, but imageType is %s.",
                                  string_VkImageType(pCreateInfo->imageType));
             }
             if (image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02567", device, loc.dot(Field::flags),
+                skip |= LogError("VUID-VkImageCreateInfo-flags-02567", device, create_info_loc.dot(Field::flags),
                                  "is %s, which contains SUBSAMPLED_BIT and CUBE_COMPATIBLE.",
                                  string_VkImageCreateFlags(image_flags).c_str());
             }
             if (pCreateInfo->mipLevels != 1) {
                 skip |=
-                    LogError("VUID-VkImageCreateInfo-flags-02568", device, loc.dot(Field::flags),
+                    LogError("VUID-VkImageCreateInfo-flags-02568", device, create_info_loc.dot(Field::flags),
                              "includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, but mipLevels is %" PRIu32 ".", pCreateInfo->mipLevels);
             }
         }
@@ -507,7 +512,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                 // table in #swapchain-wsi-image-create-info. Breaking up into multiple checks allows for more useful information
                 // returned why this error occured. Check for matching Swapchain flags is done later in state tracking validation
                 const char *vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
-                const Location swapchain_loc = loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain);
+                const Location swapchain_loc = create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain);
 
                 if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
                     // also implicitly forces the check above that extent.depth is 1
@@ -546,13 +551,13 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 
         // If Chroma subsampled format ( _420_ or _422_ )
         if (FormatIsXChromaSubsampled(image_format) && (SafeModulo(pCreateInfo->extent.width, 2) != 0)) {
-            skip |= LogError("VUID-VkImageCreateInfo-format-04712", device, loc.dot(Field::format),
+            skip |= LogError("VUID-VkImageCreateInfo-format-04712", device, create_info_loc.dot(Field::format),
                              "(%s) is X Chroma Subsampled (has _422 or _420 suffix) so the width (%" PRIu32
                              ") must be a multiple of 2.",
                              string_VkFormat(image_format), pCreateInfo->extent.width);
         }
         if (FormatIsYChromaSubsampled(image_format) && (SafeModulo(pCreateInfo->extent.height, 2) != 0)) {
-            skip |= LogError("VUID-VkImageCreateInfo-format-04713", device, loc.dot(Field::format),
+            skip |= LogError("VUID-VkImageCreateInfo-format-04713", device, create_info_loc.dot(Field::format),
                              "(%s) is Y Chroma Subsampled (has _420 suffix) so the height (%" PRIu32 ") must be a multiple of 2.",
                              string_VkFormat(image_format), pCreateInfo->extent.height);
         }
@@ -562,7 +567,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             const uint32_t viewFormatCount = format_list_info->viewFormatCount;
             if (((image_flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) == 0) && (viewFormatCount > 1)) {
                 skip |= LogError("VUID-VkImageCreateInfo-flags-04738", device,
-                                 loc.pNext(Struct::VkImageFormatListCreateInfo, Field::viewFormatCount),
+                                 create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::viewFormatCount),
                                  "is %" PRIu32 " but flag (%s) does not include VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.",
                                  viewFormatCount, string_VkImageCreateFlags(image_flags).c_str());
             }
@@ -577,13 +582,13 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                             FormatElementSize(format_list_info->pViewFormats[i]) == FormatElementSize(image_format);
                         if (!size_compatible) {
                             skip |= LogError("VUID-VkImageCreateInfo-pNext-06722", device,
-                                             loc.pNext(Struct::VkImageFormatListCreateInfo, Field::pViewFormats, i),
+                                             create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::pViewFormats, i),
                                              "(%s) and VkImageCreateInfo::format (%s) are not compatible or size-compatible.",
                                              string_VkFormat(format_list_info->pViewFormats[i]), string_VkFormat(image_format));
                         }
                     } else {
                         skip |= LogError("VUID-VkImageCreateInfo-pNext-06722", device,
-                                         loc.pNext(Struct::VkImageFormatListCreateInfo, Field::pViewFormats, i),
+                                         create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::pViewFormats, i),
                                          "(%s) and VkImageCreateInfo::format (%s) are not compatible.",
                                          string_VkFormat(format_list_info->pViewFormats[i]), string_VkFormat(image_format));
                     }
@@ -599,10 +604,10 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 
             if (image_compression_control->flags == VK_IMAGE_COMPRESSION_FIXED_RATE_EXPLICIT_EXT &&
                 !image_compression_control->pFixedRateFlags) {
-                skip |=
-                    LogError("VUID-VkImageCompressionControlEXT-flags-06748", device,
-                             loc.pNext(Struct::VkImageCompressionControlEXT, Field::flags), "is %s, but pFixedRateFlags is NULL.",
-                             string_VkImageCompressionFlagsEXT(image_compression_control->flags).c_str());
+                skip |= LogError("VUID-VkImageCompressionControlEXT-flags-06748", device,
+                                 create_info_loc.pNext(Struct::VkImageCompressionControlEXT, Field::flags),
+                                 "is %s, but pFixedRateFlags is NULL.",
+                                 string_VkImageCompressionFlagsEXT(image_compression_control->flags).c_str());
             }
         }
 #ifdef VK_USE_PLATFORM_METAL_EXT
@@ -611,7 +616,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             if ((export_metal_object_info->exportObjectType != VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT) &&
                 (export_metal_object_info->exportObjectType != VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT)) {
                 skip |= LogError("VUID-VkImageCreateInfo-pNext-06783", device,
-                                 loc.pNext(Struct::VkExportMetalObjectCreateInfoEXT, Field::exportObjectType),
+                                 create_info_loc.pNext(Struct::VkExportMetalObjectCreateInfoEXT, Field::exportObjectType),
                                  "is %s, but only VkExportMetalObjectCreateInfoEXT structs with exportObjectType of "
                                  "VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT or "
                                  "VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT are allowed",
@@ -621,25 +626,25 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
         }
         auto import_metal_texture_info = LvlFindInChain<VkImportMetalTextureInfoEXT>(pCreateInfo->pNext);
         while (import_metal_texture_info) {
-            const Location info_loc = loc.pNext(Struct::VkImportMetalTextureInfoEXT, Field::plane);
+            const Location texture_info_loc = create_info_loc.pNext(Struct::VkImportMetalTextureInfoEXT, Field::plane);
             if ((import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_0_BIT) &&
                 (import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_1_BIT) &&
                 (import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_2_BIT)) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-06784", device, info_loc,
+                skip |= LogError("VUID-VkImageCreateInfo-pNext-06784", device, texture_info_loc,
                                  "is %s, but only VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT, or "
                                  "VK_IMAGE_ASPECT_PLANE_2_BIT are allowed",
                                  string_VkImageAspectFlags(import_metal_texture_info->plane).c_str());
             }
             auto format_plane_count = FormatPlaneCount(pCreateInfo->format);
             if ((format_plane_count <= 1) && (import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_0_BIT)) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-06785", device, info_loc,
+                skip |= LogError("VUID-VkImageCreateInfo-pNext-06785", device, texture_info_loc,
                                  "is %s, but only VK_IMAGE_ASPECT_PLANE_0_BIT is allowed for an image created with format %s, "
                                  "which is not multiplaner",
                                  string_VkImageAspectFlags(import_metal_texture_info->plane).c_str(),
                                  string_VkFormat(pCreateInfo->format));
             }
             if ((format_plane_count == 2) && (import_metal_texture_info->plane == VK_IMAGE_ASPECT_PLANE_2_BIT)) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-06786", device, info_loc,
+                skip |= LogError("VUID-VkImageCreateInfo-pNext-06786", device, texture_info_loc,
                                  "is VK_IMAGE_ASPECT_PLANE_2_BIT, which is not allowed for an image created with format %s, "
                                  "which has only 2 planes",
                                  string_VkFormat(pCreateInfo->format));
@@ -658,10 +663,10 @@ bool StatelessValidation::manual_PreCallValidateCreateImageView(VkDevice device,
     bool skip = false;
 
     if (pCreateInfo != nullptr) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfo);
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
         // Validate feature set if using CUBE_ARRAY
         if ((pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) && (physical_device_features.imageCubeArray == false)) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-viewType-01004", pCreateInfo->image, loc.dot(Field::viewType),
+            skip |= LogError("VUID-VkImageViewCreateInfo-viewType-01004", pCreateInfo->image, create_info_loc.dot(Field::viewType),
                              "is VK_IMAGE_VIEW_TYPE_CUBE_ARRAY but the imageCubeArray feature is not enabled.");
         }
 
@@ -669,12 +674,12 @@ bool StatelessValidation::manual_PreCallValidateCreateImageView(VkDevice device,
             if (pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE && pCreateInfo->subresourceRange.layerCount != 6) {
                 skip |=
                     LogError("VUID-VkImageViewCreateInfo-viewType-02960", pCreateInfo->image,
-                             loc.dot(Field::subresourceRange).dot(Field::layerCount),
+                             create_info_loc.dot(Field::subresourceRange).dot(Field::layerCount),
                              " (%" PRIu32 ") must be 6 or VK_REMAINING_ARRAY_LAYERS.", pCreateInfo->subresourceRange.layerCount);
             }
             if (pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY && (pCreateInfo->subresourceRange.layerCount % 6) != 0) {
                 skip |= LogError("VUID-VkImageViewCreateInfo-viewType-02961", pCreateInfo->image,
-                                 loc.dot(Field::subresourceRange).dot(Field::layerCount),
+                                 create_info_loc.dot(Field::subresourceRange).dot(Field::layerCount),
                                  "(%" PRIu32 ") must be a multiple of 6 or VK_REMAINING_ARRAY_LAYERS.",
                                  pCreateInfo->subresourceRange.layerCount);
             }
@@ -686,12 +691,13 @@ bool StatelessValidation::manual_PreCallValidateCreateImageView(VkDevice device,
                 (astc_decode_mode->decodeMode != VK_FORMAT_R8G8B8A8_UNORM) &&
                 (astc_decode_mode->decodeMode != VK_FORMAT_E5B9G9R9_UFLOAT_PACK32)) {
                 skip |= LogError("VUID-VkImageViewASTCDecodeModeEXT-decodeMode-02230", pCreateInfo->image,
-                                 loc.pNext(Struct::VkImageViewASTCDecodeModeEXT, Field::decodeMode), "is %s.",
+                                 create_info_loc.pNext(Struct::VkImageViewASTCDecodeModeEXT, Field::decodeMode), "is %s.",
                                  string_VkFormat(astc_decode_mode->decodeMode));
             }
             if ((FormatIsCompressed_ASTC_LDR(pCreateInfo->format) == false) &&
                 (FormatIsCompressed_ASTC_HDR(pCreateInfo->format) == false)) {
-                skip |= LogError("VUID-VkImageViewASTCDecodeModeEXT-format-04084", pCreateInfo->image, loc.dot(Field::format),
+                skip |= LogError("VUID-VkImageViewASTCDecodeModeEXT-format-04084", pCreateInfo->image,
+                                 create_info_loc.dot(Field::format),
                                  "%s is  not an ASTC format (because VkImageViewASTCDecodeModeEXT was passed in the pNext chain).",
                                  string_VkFormat(pCreateInfo->format));
             }
@@ -702,7 +708,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImageView(VkDevice device,
             if (ycbcr_conversion->conversion != VK_NULL_HANDLE) {
                 if (IsIdentitySwizzle(pCreateInfo->components) == false) {
                     skip |= LogError(
-                        "VUID-VkImageViewCreateInfo-pNext-01970", pCreateInfo->image, loc,
+                        "VUID-VkImageViewCreateInfo-pNext-01970", pCreateInfo->image, create_info_loc,
                         "If there is a VkSamplerYcbcrConversion, the imageView must "
                         "be created with the identity swizzle. Here are the actual swizzle values:\n"
                         "r swizzle = %s\n"

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -716,7 +716,7 @@ bool StatelessValidation::manual_PreCallValidateGetPhysicalDeviceImageFormatProp
     bool skip = false;
 
     if (pImageFormatInfo != nullptr) {
-        const Location loc = error_obj.location.dot(Field::pImageFormatInfo);
+        const Location format_info_loc = error_obj.location.dot(Field::pImageFormatInfo);
         const auto image_stencil_struct = LvlFindInChain<VkImageStencilUsageCreateInfo>(pImageFormatInfo->pNext);
         if (image_stencil_struct != nullptr) {
             if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0) {
@@ -725,7 +725,7 @@ bool StatelessValidation::manual_PreCallValidateGetPhysicalDeviceImageFormatProp
                 legal_flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
                 if ((image_stencil_struct->stencilUsage & ~legal_flags) != 0) {
                     skip |= LogError("VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539", physicalDevice,
-                                     loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage), "is %s.",
+                                     format_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage), "is %s.",
                                      string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
                 }
             }
@@ -733,19 +733,21 @@ bool StatelessValidation::manual_PreCallValidateGetPhysicalDeviceImageFormatProp
         const auto image_drm_format = LvlFindInChain<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(pImageFormatInfo->pNext);
         if (image_drm_format) {
             if (pImageFormatInfo->tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
-                skip |= LogError("VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249", physicalDevice, loc.dot(Field::tiling),
+                skip |= LogError("VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249", physicalDevice,
+                                 format_info_loc.dot(Field::tiling),
                                  "(%s) but no VkPhysicalDeviceImageDrmFormatModifierInfoEXT in pNext chain.",
                                  string_VkImageTiling(pImageFormatInfo->tiling));
             }
             if (image_drm_format->sharingMode == VK_SHARING_MODE_CONCURRENT && image_drm_format->queueFamilyIndexCount <= 1) {
                 skip |= LogError("VUID-VkPhysicalDeviceImageDrmFormatModifierInfoEXT-sharingMode-02315", physicalDevice,
-                                 loc.pNext(Struct::VkPhysicalDeviceImageDrmFormatModifierInfoEXT, Field::sharingMode),
+                                 format_info_loc.pNext(Struct::VkPhysicalDeviceImageDrmFormatModifierInfoEXT, Field::sharingMode),
                                  "is VK_SHARING_MODE_CONCURRENT, but queueFamilyIndexCount is %" PRIu32 ".",
                                  image_drm_format->queueFamilyIndexCount);
             }
         } else {
             if (pImageFormatInfo->tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
-                skip |= LogError("VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249", physicalDevice, loc.dot(Field::tiling),
+                skip |= LogError("VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249", physicalDevice,
+                                 format_info_loc.dot(Field::tiling),
                                  "is VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT, but pNext chain not include "
                                  "VkPhysicalDeviceImageDrmFormatModifierInfoEXT.");
             }
@@ -755,7 +757,7 @@ bool StatelessValidation::manual_PreCallValidateGetPhysicalDeviceImageFormatProp
             const auto format_list = LvlFindInChain<VkImageFormatListCreateInfo>(pImageFormatInfo->pNext);
             if (!format_list || format_list->viewFormatCount == 0) {
                 skip |= LogError(
-                    "VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02313", physicalDevice, loc,
+                    "VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02313", physicalDevice, format_info_loc,
                     "tiling is VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT and flags contain VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT "
                     "bit, but the pNext chain does not include VkImageFormatListCreateInfo with non-zero viewFormatCount.");
             }
@@ -798,18 +800,18 @@ bool StatelessValidation::manual_PreCallValidateSetDebugUtilsObjectNameEXT(VkDev
                                                                            const VkDebugUtilsObjectNameInfoEXT *pNameInfo,
                                                                            const ErrorObject &error_obj) const {
     bool skip = false;
-    const Location loc = error_obj.location.dot(Field::pNameInfo);
+    const Location name_info_loc = error_obj.location.dot(Field::pNameInfo);
     if (pNameInfo->objectType == VK_OBJECT_TYPE_UNKNOWN) {
-        skip |= LogError("VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-02587", device, loc.dot(Field::objectType),
+        skip |= LogError("VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-02587", device, name_info_loc.dot(Field::objectType),
                          "cannot be VK_OBJECT_TYPE_UNKNOWN.");
     }
     if (pNameInfo->objectHandle == HandleToUint64(VK_NULL_HANDLE)) {
-        skip |= LogError("VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-02588", device, loc.dot(Field::objectHandle),
+        skip |= LogError("VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-02588", device, name_info_loc.dot(Field::objectHandle),
                          "cannot be VK_NULL_HANDLE.");
     }
 
     if ((pNameInfo->objectType == VK_OBJECT_TYPE_UNKNOWN) && (pNameInfo->objectHandle == HandleToUint64(VK_NULL_HANDLE))) {
-        skip |= LogError("VUID-VkDebugUtilsObjectNameInfoEXT-objectType-02589", device, loc.dot(Field::objectType),
+        skip |= LogError("VUID-VkDebugUtilsObjectNameInfoEXT-objectType-02589", device, name_info_loc.dot(Field::objectType),
                          "is VK_OBJECT_TYPE_UNKNOWN but objectHandle is VK_NULL_HANDLE");
     }
 

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -214,32 +214,33 @@ bool StatelessValidation::manual_PreCallValidateCreateAccelerationStructureKHR(
                          "accelerationStructure feature was not enabled.");
     }
     if (pCreateInfo) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfo);
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
         if (pCreateInfo->createFlags & VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR &&
             (!acceleration_structure_features ||
              (acceleration_structure_features &&
               acceleration_structure_features->accelerationStructureCaptureReplay == VK_FALSE))) {
-            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-createFlags-03613", device, loc.dot(Field::createFlags),
+            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-createFlags-03613", device,
+                             create_info_loc.dot(Field::createFlags),
                              "includes "
                              "VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR, "
                              "but accelerationStructureCaptureReplay feature is not enabled.");
         }
         if (pCreateInfo->deviceAddress &&
             !(pCreateInfo->createFlags & VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR)) {
-            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-03612", device, loc.dot(Field::createFlags),
-                             "is %s, but deviceAddress (%" PRIu64 ") is not zero.",
+            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-03612", device,
+                             create_info_loc.dot(Field::createFlags), "is %s, but deviceAddress (%" PRIu64 ") is not zero.",
                              string_VkAccelerationStructureCreateFlagsKHR(pCreateInfo->createFlags).c_str(),
                              pCreateInfo->deviceAddress);
         }
         if (pCreateInfo->deviceAddress && (!acceleration_structure_features ||
                                            (acceleration_structure_features &&
                                             acceleration_structure_features->accelerationStructureCaptureReplay == VK_FALSE))) {
-            skip |= LogError("VUID-vkCreateAccelerationStructureKHR-deviceAddress-03488", device, loc.dot(Field::deviceAddress),
-                             "is %" PRIu64 " but accelerationStructureCaptureReplay feature was not enabled.",
-                             pCreateInfo->deviceAddress);
+            skip |= LogError(
+                "VUID-vkCreateAccelerationStructureKHR-deviceAddress-03488", device, create_info_loc.dot(Field::deviceAddress),
+                "is %" PRIu64 " but accelerationStructureCaptureReplay feature was not enabled.", pCreateInfo->deviceAddress);
         }
         if (SafeModulo(pCreateInfo->offset, 256) != 0) {
-            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-offset-03734", device, loc.dot(Field::offset),
+            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-offset-03734", device, create_info_loc.dot(Field::offset),
                              "%" PRIu64 " must be a multiple of 256 bytes", pCreateInfo->offset);
         }
 
@@ -248,7 +249,8 @@ bool StatelessValidation::manual_PreCallValidateCreateAccelerationStructureKHR(
         if ((pCreateInfo->createFlags & VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) &&
             (!descriptor_buffer_features ||
              (descriptor_buffer_features && descriptor_buffer_features->descriptorBufferCaptureReplay == VK_FALSE))) {
-            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-createFlags-08108", device, loc.dot(Field::createFlags),
+            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-createFlags-08108", device,
+                             create_info_loc.dot(Field::createFlags),
                              "includes VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT, but the "
                              "descriptorBufferCaptureReplay feature was not enabled.");
         }
@@ -257,9 +259,10 @@ bool StatelessValidation::manual_PreCallValidateCreateAccelerationStructureKHR(
             LvlFindInChain<VkOpaqueCaptureDescriptorDataCreateInfoEXT>(pCreateInfo->pNext);
         if (opaque_capture_descriptor_buffer &&
             !(pCreateInfo->createFlags & VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
-            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-pNext-08109", device, loc.dot(Field::createFlags),
-                             "includes VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT, but  "
-                             "VkOpaqueCaptureDescriptorDataCreateInfoEXT is in pNext chain.");
+            skip |=
+                LogError("VUID-VkAccelerationStructureCreateInfoKHR-pNext-08109", device, create_info_loc.dot(Field::createFlags),
+                         "includes VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT, but  "
+                         "VkOpaqueCaptureDescriptorDataCreateInfoEXT is in pNext chain.");
         }
     }
     return skip;
@@ -295,9 +298,10 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesNV(
     bool skip = false;
 
     for (uint32_t i = 0; i < createInfoCount; i++) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfos, i);
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
         for (uint32_t stage_index = 0; stage_index < pCreateInfos[i].stageCount; ++stage_index) {
-            ValidatePipelineShaderStageCreateInfo(&pCreateInfos[i].pStages[stage_index], loc.dot(Field::pStages, stage_index));
+            ValidatePipelineShaderStageCreateInfo(&pCreateInfos[i].pStages[stage_index],
+                                                  create_info_loc.dot(Field::pStages, stage_index));
         }
         auto feedback_struct = LvlFindInChain<VkPipelineCreationFeedbackCreateInfoEXT>(pCreateInfos[i].pNext);
         if ((feedback_struct != nullptr) && (feedback_struct->pipelineStageCreationFeedbackCount != 0) &&
@@ -432,9 +436,9 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
                          "The rayTracingPipeline feature was not enabled.");
     }
     for (uint32_t i = 0; i < createInfoCount; i++) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfos, i);
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
         for (uint32_t stage_index = 0; stage_index < pCreateInfos[i].stageCount; ++stage_index) {
-            const Location stage_loc = loc.dot(Field::pStages, stage_index);
+            const Location stage_loc = create_info_loc.dot(Field::pStages, stage_index);
             ValidatePipelineShaderStageCreateInfo(&pCreateInfos[i].pStages[stage_index], stage_loc);
 
             const auto stage = pCreateInfos[i].pStages[stage_index].stage;
@@ -450,21 +454,24 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
         if (!raytracing_features || (raytracing_features && raytracing_features->rayTraversalPrimitiveCulling == VK_FALSE)) {
             if (pCreateInfos[i].flags & VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR) {
                 skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-rayTraversalPrimitiveCulling-03596", device,
-                                 loc.dot(Field::flags), "is %s.", string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
+                                 create_info_loc.dot(Field::flags), "is %s.",
+                                 string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
             }
             if (pCreateInfos[i].flags & VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR) {
                 skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-rayTraversalPrimitiveCulling-03597", device,
-                                 loc.dot(Field::flags), "is %s.", string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
+                                 create_info_loc.dot(Field::flags), "is %s.",
+                                 string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
             }
         }
 
         auto feedback_struct = LvlFindInChain<VkPipelineCreationFeedbackCreateInfo>(pCreateInfos[i].pNext);
         if ((feedback_struct != nullptr) && (feedback_struct->pipelineStageCreationFeedbackCount != 0) &&
             (feedback_struct->pipelineStageCreationFeedbackCount != pCreateInfos[i].stageCount)) {
-            skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pipelineStageCreationFeedbackCount-06652", device,
-                             loc.pNext(Struct::VkPipelineCreationFeedbackCreateInfo, Field::pipelineStageCreationFeedbackCount),
-                             "(%" PRIu32 ") is not equal to %s (%" PRIu32 ").", feedback_struct->pipelineStageCreationFeedbackCount,
-                             loc.Fields().c_str(), pCreateInfos[i].stageCount);
+            skip |= LogError(
+                "VUID-VkRayTracingPipelineCreateInfoKHR-pipelineStageCreationFeedbackCount-06652", device,
+                create_info_loc.pNext(Struct::VkPipelineCreationFeedbackCreateInfo, Field::pipelineStageCreationFeedbackCount),
+                "(%" PRIu32 ") is not equal to %s (%" PRIu32 ").", feedback_struct->pipelineStageCreationFeedbackCount,
+                create_info_loc.Fields().c_str(), pCreateInfos[i].stageCount);
         }
 
         const auto *vulkan_13_features = LvlFindInChain<VkPhysicalDeviceVulkan13Features>(device_createinfo_pnext);
@@ -475,41 +482,42 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
             if (pCreateInfos[i].flags & (VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_EXT |
                                          VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT_EXT)) {
                 skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pipelineCreationCacheControl-02905", device,
-                                 loc.dot(Field::flags), "vkCreateRayTracingPipelinesKHR(): pCreateInfos[%" PRIu32 "].flags is %s.",
-                                 i, string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
+                                 create_info_loc.dot(Field::flags),
+                                 "vkCreateRayTracingPipelinesKHR(): pCreateInfos[%" PRIu32 "].flags is %s.", i,
+                                 string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
             }
         }
 
         if (pCreateInfos[i].flags & VK_PIPELINE_CREATE_INDIRECT_BINDABLE_BIT_NV) {
-            skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-02904", device, loc.dot(Field::flags), "is %s.",
-                             string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
+            skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-02904", device, create_info_loc.dot(Field::flags),
+                             "is %s.", string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
         }
         if (pCreateInfos[i].flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) {
             if (pCreateInfos[i].pLibraryInterface == NULL) {
-                skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-03465", device, loc.dot(Field::flags), "is %s.",
-                                 string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
+                skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-03465", device, create_info_loc.dot(Field::flags),
+                                 "is %s.", string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
             }
         }
         if (pCreateInfos[i].flags & VK_PIPELINE_CREATE_DISPATCH_BASE) {
-            skip |= LogError("VUID-vkCreateRayTracingPipelinesKHR-flags-03816", device, loc.dot(Field::flags), "is %s.",
+            skip |= LogError("VUID-vkCreateRayTracingPipelinesKHR-flags-03816", device, create_info_loc.dot(Field::flags), "is %s.",
                              string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
         }
 
         for (uint32_t group_index = 0; group_index < pCreateInfos[i].groupCount; ++group_index) {
-            const Location group_loc = loc.dot(Field::pGroups, group_index);
+            const Location group_loc = create_info_loc.dot(Field::pGroups, group_index);
             if ((pCreateInfos[i].pGroups[group_index].type == VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR) ||
                 (pCreateInfos[i].pGroups[group_index].type == VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_KHR)) {
                 if ((pCreateInfos[i].flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR) &&
                     (pCreateInfos[i].pGroups[group_index].anyHitShader == VK_SHADER_UNUSED_KHR)) {
-                    skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-03470", device, loc.dot(Field::flags),
-                                     "is %s, but %s is VK_SHADER_UNUSED_KHR.",
+                    skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-03470", device,
+                                     create_info_loc.dot(Field::flags), "is %s, but %s is VK_SHADER_UNUSED_KHR.",
                                      string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str(),
                                      group_loc.dot(Field::anyHitShader).Fields().c_str());
                 }
                 if ((pCreateInfos[i].flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR) &&
                     (pCreateInfos[i].pGroups[group_index].closestHitShader == VK_SHADER_UNUSED_KHR)) {
-                    skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-03471", device, loc.dot(Field::flags),
-                                     "is %s, but %s is VK_SHADER_UNUSED_KHR.",
+                    skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-03471", device,
+                                     create_info_loc.dot(Field::flags), "is %s, but %s is VK_SHADER_UNUSED_KHR.",
                                      string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str(),
                                      group_loc.dot(Field::closestHitShader).Fields().c_str());
                 }
@@ -519,7 +527,7 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
                 if (!(pCreateInfos[i].flags & VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR)) {
                     skip |= LogError(
                         "VUID-VkRayTracingPipelineCreateInfoKHR-rayTracingPipelineShaderGroupHandleCaptureReplay-03599", device,
-                        loc.dot(Field::flags), "vis %s.", string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
+                        create_info_loc.dot(Field::flags), "vis %s.", string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
                 }
             }
         }
@@ -527,20 +535,21 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
         if (pCreateInfos[i].flags & VK_PIPELINE_CREATE_DERIVATIVE_BIT) {
             if (pCreateInfos[i].basePipelineIndex != -1) {
                 if (pCreateInfos[i].basePipelineHandle != VK_NULL_HANDLE) {
-                    skip |=
-                        LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-07986", device, loc.dot(Field::basePipelineIndex),
-                                 "is %" PRId32 " and basePipelineHandle is not VK_NULL_HANDLE.", pCreateInfos[i].basePipelineIndex);
+                    skip |= LogError(
+                        "VUID-VkRayTracingPipelineCreateInfoKHR-flags-07986", device, create_info_loc.dot(Field::basePipelineIndex),
+                        "is %" PRId32 " and basePipelineHandle is not VK_NULL_HANDLE.", pCreateInfos[i].basePipelineIndex);
                 }
                 if (pCreateInfos[i].basePipelineIndex > static_cast<int32_t>(i)) {
-                    skip |= LogError("VUID-vkCreateRayTracingPipelinesKHR-flags-03415", device, loc.dot(Field::basePipelineIndex),
-                                     "is %" PRId32 ".", pCreateInfos[i].basePipelineIndex);
+                    skip |= LogError("VUID-vkCreateRayTracingPipelinesKHR-flags-03415", device,
+                                     create_info_loc.dot(Field::basePipelineIndex), "is %" PRId32 ".",
+                                     pCreateInfos[i].basePipelineIndex);
                 }
             }
             if (pCreateInfos[i].basePipelineHandle == VK_NULL_HANDLE) {
                 if (pCreateInfos[i].basePipelineIndex < 0 ||
                     static_cast<uint32_t>(pCreateInfos[i].basePipelineIndex) >= createInfoCount) {
                     skip |=
-                        LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-07985", device, loc.dot(Field::flags),
+                        LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-07985", device, create_info_loc.dot(Field::flags),
                                  "is %s but basePipelineIndex has invalid index value %" PRId32 ".",
                                  string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str(), pCreateInfos[i].basePipelineIndex);
                 }
@@ -549,47 +558,49 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
 
         if (pCreateInfos[i].flags & VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR &&
             (raytracing_features && raytracing_features->rayTracingPipelineShaderGroupHandleCaptureReplay == VK_FALSE)) {
-            skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-03598", device, loc.dot(Field::flags), "is %s.",
-                             string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
+            skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-03598", device, create_info_loc.dot(Field::flags),
+                             "is %s.", string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
         }
 
         const bool library_enabled = IsExtEnabled(device_extensions.vk_khr_pipeline_library);
         if (!library_enabled) {
             if (pCreateInfos[i].pLibraryInfo) {
-                skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03595", device, loc.dot(Field::pLibraryInfo),
-                                 "is not NULL.");
+                skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03595", device,
+                                 create_info_loc.dot(Field::pLibraryInfo), "is not NULL.");
             }
             if (pCreateInfos[i].pLibraryInterface) {
                 skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03595", device,
-                                 loc.dot(Field::pLibraryInterface), "is not NULL.");
+                                 create_info_loc.dot(Field::pLibraryInterface), "is not NULL.");
             }
         }
 
         if (pCreateInfos[i].pLibraryInfo) {
             if ((pCreateInfos[i].pLibraryInfo->libraryCount > 0) && (pCreateInfos[i].pLibraryInterface == nullptr)) {
                 skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03590", device,
-                                 loc.dot(Field::pLibraryInfo).dot(Field::libraryCount),
+                                 create_info_loc.dot(Field::pLibraryInfo).dot(Field::libraryCount),
                                  "%" PRIu32 ", but pLibraryInterface is NULL.", pCreateInfos[i].pLibraryInfo->libraryCount);
             }
         }
 
         if (pCreateInfos[i].pLibraryInfo == nullptr) {
             if (pCreateInfos[i].stageCount == 0) {
-                skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-07999", device, loc.dot(Field::pLibraryInfo),
-                                 "is NULL and stageCount is zero.");
+                skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-07999", device,
+                                 create_info_loc.dot(Field::pLibraryInfo), "is NULL and stageCount is zero.");
             }
             if (((pCreateInfos[i].flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) && (pCreateInfos[i].groupCount == 0)) {
-                skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-08700", device, loc.dot(Field::pLibraryInfo),
-                                 " is NULL and flags is %s.", string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
+                skip |=
+                    LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-08700", device, create_info_loc.dot(Field::pLibraryInfo),
+                             " is NULL and flags is %s.", string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
             }
         } else if (pCreateInfos[i].pLibraryInfo->libraryCount == 0) {
             if (pCreateInfos[i].stageCount == 0) {
-                skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-07999", device,
-                                 loc.dot(Field::pLibraryInfo).dot(Field::libraryCount), "is zero and stageCount is zero.");
+                skip |=
+                    LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-07999", device,
+                             create_info_loc.dot(Field::pLibraryInfo).dot(Field::libraryCount), "is zero and stageCount is zero.");
             }
             if (((pCreateInfos[i].flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) && (pCreateInfos[i].groupCount == 0)) {
                 skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-08700", device,
-                                 loc.dot(Field::pLibraryInfo).dot(Field::libraryCount), "is zero and flags is %s.",
+                                 create_info_loc.dot(Field::pLibraryInfo).dot(Field::libraryCount), "is zero and flags is %s.",
                                  string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
             }
         }
@@ -599,7 +610,7 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
                 phys_dev_ext_props.ray_tracing_props_khr.maxRayHitAttributeSize) {
                 skip |= LogError(
                     "VUID-VkRayTracingPipelineInterfaceCreateInfoKHR-maxPipelineRayHitAttributeSize-03605", device,
-                    loc.dot(Field::pLibraryInterface).dot(Field::maxPipelineRayHitAttributeSize),
+                    create_info_loc.dot(Field::pLibraryInterface).dot(Field::maxPipelineRayHitAttributeSize),
                     "(%" PRIu32 ") is larger than VkPhysicalDeviceRayTracingPipelinePropertiesKHR::maxRayHitAttributeSize (%" PRIu32
                     ").",
                     pCreateInfos[i].pLibraryInterface->maxPipelineRayHitAttributeSize,
@@ -609,8 +620,8 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
 
         if (deferredOperation != VK_NULL_HANDLE) {
             if (pCreateInfos[i].flags & VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT_EXT) {
-                skip |= LogError("VUID-vkCreateRayTracingPipelinesKHR-deferredOperation-03587", device, loc.dot(Field::flags),
-                                 "is %s, but deferredOperation is not VK_NULL_HANDLE.",
+                skip |= LogError("VUID-vkCreateRayTracingPipelinesKHR-deferredOperation-03587", device,
+                                 create_info_loc.dot(Field::flags), "is %s, but deferredOperation is not VK_NULL_HANDLE.",
                                  string_VkPipelineCreateFlags(pCreateInfos[i].flags).c_str());
             }
         }
@@ -619,7 +630,7 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
             for (uint32_t j = 0; j < pCreateInfos[i].pDynamicState->dynamicStateCount; ++j) {
                 if (pCreateInfos[i].pDynamicState->pDynamicStates[j] != VK_DYNAMIC_STATE_RAY_TRACING_PIPELINE_STACK_SIZE_KHR) {
                     skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pDynamicStates-03602", device,
-                                     loc.dot(Field::pDynamicState).dot(Field::pDynamicStates, j), "is %s.",
+                                     create_info_loc.dot(Field::pDynamicState).dot(Field::pDynamicStates, j), "is %s.",
                                      string_VkDynamicState(pCreateInfos[i].pDynamicState->pDynamicStates[j]));
                 }
             }
@@ -633,9 +644,9 @@ bool StatelessValidation::manual_PreCallValidateCopyAccelerationStructureToMemor
     VkDevice device, VkDeferredOperationKHR deferredOperation, const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo,
     const ErrorObject &error_obj) const {
     bool skip = false;
-    const Location loc = error_obj.location.dot(Field::pInfo);
+    const Location info_loc = error_obj.location.dot(Field::pInfo);
     if (pInfo->mode != VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR) {
-        skip |= LogError("VUID-VkCopyAccelerationStructureToMemoryInfoKHR-mode-03412", device, loc.dot(Field::mode), "is %s.",
+        skip |= LogError("VUID-VkCopyAccelerationStructureToMemoryInfoKHR-mode-03412", device, info_loc.dot(Field::mode), "is %s.",
                          string_VkCopyAccelerationStructureModeKHR(pInfo->mode));
     }
     const auto *acc_struct_features = LvlFindInChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(device_createinfo_pnext);
@@ -646,9 +657,9 @@ bool StatelessValidation::manual_PreCallValidateCopyAccelerationStructureToMemor
     skip |= ValidateRequiredPointer(error_obj.location, "pInfo->dst.hostAddress", pInfo->dst.hostAddress,
                                     "VUID-vkCopyAccelerationStructureToMemoryKHR-pInfo-03732");
     if (SafeModulo((VkDeviceSize)pInfo->dst.hostAddress, 16) != 0) {
-        skip |=
-            LogError("VUID-vkCopyAccelerationStructureToMemoryKHR-pInfo-03751", device, loc.dot(Field::dst).dot(Field::hostAddress),
-                     "(0x%" PRIx64 ") must be aligned to 16 bytes.", (VkDeviceAddress)pInfo->dst.hostAddress);
+        skip |= LogError("VUID-vkCopyAccelerationStructureToMemoryKHR-pInfo-03751", device,
+                         info_loc.dot(Field::dst).dot(Field::hostAddress), "(0x%" PRIx64 ") must be aligned to 16 bytes.",
+                         (VkDeviceAddress)pInfo->dst.hostAddress);
     }
     return skip;
 }
@@ -656,15 +667,15 @@ bool StatelessValidation::manual_PreCallValidateCopyAccelerationStructureToMemor
 bool StatelessValidation::manual_PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(
     VkCommandBuffer commandBuffer, const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo, const ErrorObject &error_obj) const {
     bool skip = false;
-    const Location loc = error_obj.location.dot(Field::pInfo);
+    const Location info_loc = error_obj.location.dot(Field::pInfo);
     if (pInfo->mode != VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR) {
         skip |=  // to update VUID to VkCmdCopyAccelerationStructureToMemoryInfoKHR after spec update
-            LogError("VUID-VkCopyAccelerationStructureToMemoryInfoKHR-mode-03412", commandBuffer, loc.dot(Field::mode), "is %s.",
-                     string_VkCopyAccelerationStructureModeKHR(pInfo->mode));
+            LogError("VUID-VkCopyAccelerationStructureToMemoryInfoKHR-mode-03412", commandBuffer, info_loc.dot(Field::mode),
+                     "is %s.", string_VkCopyAccelerationStructureModeKHR(pInfo->mode));
     }
     if (SafeModulo(pInfo->dst.deviceAddress, 256) != 0) {
         skip |= LogError("VUID-vkCmdCopyAccelerationStructureToMemoryKHR-pInfo-03740", commandBuffer,
-                         loc.dot(Field::dst).dot(Field::deviceAddress), "(0x%" PRIx64 ") must be aligned to 256 bytes.",
+                         info_loc.dot(Field::dst).dot(Field::deviceAddress), "(0x%" PRIx64 ") must be aligned to 256 bytes.",
                          pInfo->dst.deviceAddress);
     }
     return skip;
@@ -734,11 +745,11 @@ bool StatelessValidation::manual_PreCallValidateCopyMemoryToAccelerationStructur
 bool StatelessValidation::manual_PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(
     VkCommandBuffer commandBuffer, const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo, const ErrorObject &error_obj) const {
     bool skip = false;
-    const Location loc = error_obj.location.dot(Field::pInfo);
-    skip |= ValidateCopyMemoryToAccelerationStructureInfoKHR(pInfo, error_obj.handle, loc);
+    const Location info_loc = error_obj.location.dot(Field::pInfo);
+    skip |= ValidateCopyMemoryToAccelerationStructureInfoKHR(pInfo, error_obj.handle, info_loc);
     if (SafeModulo(pInfo->src.deviceAddress, 256) != 0) {
         skip |= LogError("VUID-vkCmdCopyMemoryToAccelerationStructureKHR-pInfo-03743", commandBuffer,
-                         loc.dot(Field::src).dot(Field::deviceAddress), "(0x%" PRIx64 ") must be aligned to 256 bytes.",
+                         info_loc.dot(Field::src).dot(Field::deviceAddress), "(0x%" PRIx64 ") must be aligned to 256 bytes.",
                          pInfo->src.deviceAddress);
     }
     return skip;

--- a/layers/stateless/sl_shader_object.cpp
+++ b/layers/stateless/sl_shader_object.cpp
@@ -23,22 +23,22 @@ bool StatelessValidation::manual_PreCallValidateCreateShadersEXT(VkDevice device
     bool skip = false;
 
     for (uint32_t i = 0; i < createInfoCount; ++i) {
-        const Location loc = error_obj.location.dot(Field::pCreateInfos, i);
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
         const VkShaderCreateInfoEXT &createInfo = pCreateInfos[i];
         if (createInfo.codeType == VK_SHADER_CODE_TYPE_SPIRV_EXT && SafeModulo(createInfo.codeSize, 4) != 0) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-codeSize-08735", device, loc.dot(Field::codeSize),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-codeSize-08735", device, create_info_loc.dot(Field::codeSize),
                              "(%" PRIu64 ") is not a multiple of 4.", static_cast<uint64_t>(createInfo.codeSize));
         }
 
         auto pCode = reinterpret_cast<std::uintptr_t>(createInfo.pCode);
         if (createInfo.codeType == VK_SHADER_CODE_TYPE_BINARY_EXT) {
             if (SafeModulo(pCode, 16 * sizeof(unsigned char)) != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-pCode-08492", device, loc.dot(Field::codeType),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-pCode-08492", device, create_info_loc.dot(Field::codeType),
                                  "is VK_SHADER_CODE_TYPE_BINARY_EXT, but pCodde is not aligned to 16 bytes.");
             }
         } else if (createInfo.codeType == VK_SHADER_CODE_TYPE_SPIRV_EXT) {
             if (SafeModulo(pCode, 4 * sizeof(unsigned char)) != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-pCode-08493", device, loc.dot(Field::codeType),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-pCode-08493", device, create_info_loc.dot(Field::codeType),
                                  "is VK_SHADER_CODE_TYPE_SPIRV_EXT, but pCodde is not aligned to 4 bytes.");
             }
         }
@@ -48,99 +48,100 @@ bool StatelessValidation::manual_PreCallValidateCreateShadersEXT(VkDevice device
                                                 VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT |
                                                 VK_SHADER_STAGE_FRAGMENT_BIT;
         if ((createInfo.stage & linkedStages) == 0 && (createInfo.flags & VK_SHADER_CREATE_LINK_STAGE_BIT_EXT) != 0) {
-            skip |=
-                LogError("VUID-VkShaderCreateInfoEXT-flags-08412", device, loc.dot(Field::flags), "is %s and stage is %s.",
-                         string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(), string_VkShaderStageFlagBits(createInfo.stage));
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08412", device, create_info_loc.dot(Field::flags),
+                             "is %s and stage is %s.", string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
+                             string_VkShaderStageFlagBits(createInfo.stage));
         }
         if ((createInfo.stage != VK_SHADER_STAGE_COMPUTE_BIT) &&
             ((createInfo.flags & VK_SHADER_CREATE_DISPATCH_BASE_BIT_EXT) != 0)) {
-            skip |=
-                LogError("VUID-VkShaderCreateInfoEXT-flags-08485", device, loc.dot(Field::flags), "is %s and stage is %s.",
-                         string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(), string_VkShaderStageFlagBits(createInfo.stage));
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08485", device, create_info_loc.dot(Field::flags),
+                             "is %s and stage is %s.", string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
+                             string_VkShaderStageFlagBits(createInfo.stage));
         }
         if (createInfo.stage != VK_SHADER_STAGE_FRAGMENT_BIT) {
             if ((createInfo.flags & VK_SHADER_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_EXT) != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08486", device, loc.dot(Field::flags), "is %s and stage is %s.",
-                                 string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08486", device, create_info_loc.dot(Field::flags),
+                                 "is %s and stage is %s.", string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
                                  string_VkShaderStageFlagBits(createInfo.stage));
             }
             if ((createInfo.flags & VK_SHADER_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT) != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08488", device, loc.dot(Field::flags), "is %s and stage is %s.",
-                                 string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08488", device, create_info_loc.dot(Field::flags),
+                                 "is %s and stage is %s.", string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
                                  string_VkShaderStageFlagBits(createInfo.stage));
             }
         }
 
         if (createInfo.stage != VK_SHADER_STAGE_MESH_BIT_EXT && (createInfo.flags & VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT) != 0) {
-            skip |=
-                LogError("VUID-VkShaderCreateInfoEXT-flags-08414", device, loc.dot(Field::flags), "is %s and stage is %s.",
-                         string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(), string_VkShaderStageFlagBits(createInfo.stage));
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08414", device, create_info_loc.dot(Field::flags),
+                             "is %s and stage is %s.", string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
+                             string_VkShaderStageFlagBits(createInfo.stage));
         }
 
         if (createInfo.stage == VK_SHADER_STAGE_VERTEX_BIT) {
             if ((createInfo.nextStage &
                  ~(VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_GEOMETRY_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)) != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08427", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08427", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_VERTEX_BIT, but nextStage is %s.",
                                  string_VkShaderStageFlags(createInfo.nextStage).c_str());
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT) {
             if ((createInfo.nextStage & ~(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)) != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08430", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08430", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, but nextStage is %s.",
                                  string_VkShaderStageFlags(createInfo.nextStage).c_str());
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) {
             if ((createInfo.nextStage & ~(VK_SHADER_STAGE_GEOMETRY_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)) != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08431", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08431", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, but nextStage is %s.",
                                  string_VkShaderStageFlags(createInfo.nextStage).c_str());
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_GEOMETRY_BIT) {
             if ((createInfo.nextStage & ~VK_SHADER_STAGE_FRAGMENT_BIT) != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08433", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08433", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_GEOMETRY_BIT, but nextStage is %s.",
                                  string_VkShaderStageFlags(createInfo.nextStage).c_str());
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_FRAGMENT_BIT || createInfo.stage == VK_SHADER_STAGE_COMPUTE_BIT) {
             if (createInfo.nextStage != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08434", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08434", device, create_info_loc.dot(Field::stage),
                                  "is %s, but nextStage is %s.", string_VkShaderStageFlagBits(createInfo.stage),
                                  string_VkShaderStageFlags(createInfo.nextStage).c_str());
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_TASK_BIT_EXT) {
             if ((createInfo.nextStage & ~VK_SHADER_STAGE_MESH_BIT_EXT) != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08435", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08435", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_TASK_BIT_EXT, but nextStage is %s.",
                                  string_VkShaderStageFlags(createInfo.nextStage).c_str());
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_MESH_BIT_EXT) {
             if ((createInfo.nextStage & ~VK_SHADER_STAGE_FRAGMENT_BIT) != 0) {
-                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08436", device, loc.dot(Field::stage),
+                skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08436", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_MESH_BIT_EXT, but nextStage is %s.",
                                  string_VkShaderStageFlags(createInfo.nextStage).c_str());
             }
         } else if (createInfo.stage == VK_SHADER_STAGE_ALL_GRAPHICS) {
             // string_VkShaderStageFlagBits can't print these, so list manually
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08418", device, loc.dot(Field::stage),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08418", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_ALL_GRAPHICS.");
         } else if (createInfo.stage == VK_SHADER_STAGE_ALL) {
             // string_VkShaderStageFlagBits can't print these, so list manually
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08418", device, loc.dot(Field::stage), "is VK_SHADER_STAGE_ALL.");
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08418", device, create_info_loc.dot(Field::stage),
+                             "is VK_SHADER_STAGE_ALL.");
         } else if (createInfo.stage == VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08425", device, loc.dot(Field::stage),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08425", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI.");
         } else if (createInfo.stage == VK_SHADER_STAGE_CLUSTER_CULLING_BIT_HUAWEI) {
-            skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08426", device, loc.dot(Field::stage),
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08426", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_CLUSTER_CULLING_BIT_HUAWEI.");
         }
 
         if (((createInfo.flags & VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT) != 0) &&
             ((createInfo.stage & (VK_SHADER_STAGE_MESH_BIT_EXT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_COMPUTE_BIT)) ==
              0)) {
-            skip |=
-                LogError("VUID-VkShaderCreateInfoEXT-flags-08992", device, loc.dot(Field::flags), "is %s, but stage is %s.",
-                         string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(), string_VkShaderStageFlagBits(createInfo.stage));
+            skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08992", device, create_info_loc.dot(Field::flags),
+                             "is %s, but stage is %s.", string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
+                             string_VkShaderStageFlagBits(createInfo.stage));
         }
     }
 

--- a/layers/stateless/sl_wsi.cpp
+++ b/layers/stateless/sl_wsi.cpp
@@ -187,8 +187,8 @@ bool StatelessValidation::manual_PreCallValidateCreateDisplayModeKHR(VkPhysicalD
     bool skip = false;
 
     const VkDisplayModeParametersKHR display_mode_parameters = pCreateInfo->parameters;
-    const Location loc = error_obj.location.dot(Field::pCreateInfo);
-    const Location param_loc = loc.dot(Field::parameters);
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
+    const Location param_loc = create_info_loc.dot(Field::parameters);
 
     skip |= ValidateNotZero(display_mode_parameters.visibleRegion.width == 0, "VUID-VkDisplayModeParametersKHR-width-01990",
                             param_loc.dot(Field::visibleRegion).dot(Field::width));

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -6111,12 +6111,12 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
     assert(context);
     if (!context) return skip;
 
-    const Location loc = error_obj.location.dot(Field::pResolveImageInfo);
+    const Location image_info_loc = error_obj.location.dot(Field::pResolveImageInfo);
     auto src_image = Get<ImageState>(pResolveImageInfo->srcImage);
     auto dst_image = Get<ImageState>(pResolveImageInfo->dstImage);
 
     for (uint32_t region = 0; region < pResolveImageInfo->regionCount; region++) {
-        const Location region_loc = loc.dot(Field::pRegions, region);
+        const Location region_loc = image_info_loc.dot(Field::pRegions, region);
         const auto &resolve_region = pResolveImageInfo->pRegions[region];
         if (src_image) {
             auto hazard = context->DetectHazard(*src_image, SYNC_RESOLVE_TRANSFER_READ, resolve_region.srcSubresource,


### PR DESCRIPTION
as @arno-lunarg pointed out `loc` is sometimes a really aweful name with no information. I wen through and got most the low hanging fruit

Sometimes in Functions you really don't know where the `Location` is coming from and that can be a benefit of using `loc`, but for the top level cases from `error_obj` it can be more explicit in the name