### PR TITLE
corechecks: Fix perf regression from shader object validation

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -139,12 +139,12 @@ bool CoreChecks::VerifySetLayoutCompatibility(const DescriptorSetLayout &layout_
 // pipelineLayout[layoutIndex]
 bool CoreChecks::VerifySetLayoutCompatibility(
     const cvdescriptorset::DescriptorSet &descriptor_set,
-    const std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>> &set_layouts, const std::string &handle,
+    const std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>> &set_layouts, const VulkanTypedHandle &handle,
     const uint32_t layoutIndex, std::string &errorMsg) const {
     auto num_sets = set_layouts.size();
     if (layoutIndex >= num_sets) {
         std::stringstream error_str;
-        error_str << handle << ") only contains " << num_sets << " setLayouts corresponding to sets 0-" << num_sets - 1
+        error_str << FormatHandle(handle) << ") only contains " << num_sets << " setLayouts corresponding to sets 0-" << num_sets - 1
                   << ", but you're attempting to bind set to index " << layoutIndex;
         errorMsg = error_str.str();
         return false;
@@ -194,7 +194,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
         if (descriptor_set) {
             // Verify that set being bound is compatible with overlapping setLayout of pipelineLayout
             if (!VerifySetLayoutCompatibility(*descriptor_set, pipeline_layout->set_layouts,
-                                              FormatHandle(pipeline_layout->Handle()), set_idx + firstSet, error_string)) {
+                                              pipeline_layout->Handle(), set_idx + firstSet, error_string)) {
                 skip |= LogError("VUID-vkCmdBindDescriptorSets-pDescriptorSets-00358", pDescriptorSets[set_idx], set_loc,
                                  "(%s) being bound is not compatible with overlapping "
                                  "descriptorSetLayout at index %" PRIu32

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -5545,7 +5545,7 @@ bool CoreChecks::ValidateActionState(const CMD_BUFFER_STATE &cb_state, const VkP
                                          "%s uses set #%" PRIu32 " but that set is not bound.", FormatHandle(*pipeline).c_str(),
                                          set_index);
                     } else if (!VerifySetLayoutCompatibility(*set_info.bound_descriptor_set, pipeline_layout->set_layouts,
-                                                             FormatHandle(pipeline_layout->Handle()), set_index, error_string)) {
+                                                             pipeline_layout->Handle(), set_index, error_string)) {
                         // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
                         VkDescriptorSet set_handle = set_info.bound_descriptor_set->GetSet();
                         LogObjectList objlist = cb_state.GetObjectList(bind_point);
@@ -5641,7 +5641,7 @@ bool CoreChecks::ValidateActionState(const CMD_BUFFER_STATE &cb_state, const VkP
                                          "%s uses set #%" PRIu32 " but that set is not bound.",
                                          FormatHandle(shader_state->shader()).c_str(), set_index);
                     } else if (!VerifySetLayoutCompatibility(*set_info.bound_descriptor_set, shader_state->set_layouts,
-                                                             FormatHandle(shader_state->shader()), set_index, error_string)) {
+                                                             shader_state->Handle(), set_index, error_string)) {
                         // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
                         VkDescriptorSet set_handle = set_info.bound_descriptor_set->GetSet();
                         const LogObjectList objlist(cb_state.commandBuffer(), set_handle, shader_state->shader());

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -864,7 +864,7 @@ class CoreChecks : public ValidationStateTracker {
 
     bool VerifySetLayoutCompatibility(const cvdescriptorset::DescriptorSet& descriptor_set,
                                       const std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>>& set_layouts,
-                                      const std::string& handle, const uint32_t layoutIndex, std::string& errorMsg) const;
+                                      const VulkanTypedHandle& handle, const uint32_t layoutIndex, std::string& errorMsg) const;
 
     bool VerifySetLayoutCompatibility(const PIPELINE_LAYOUT_STATE& layout_a, const PIPELINE_LAYOUT_STATE& layout_b,
                                       std::string& errorMsg) const;


### PR DESCRIPTION
FormatHandle() creates a string which adds malloc() overhead in per-draw call code paths. Don't do this unless an error is detected.

This fixes a perf regression from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6291