### PR TITLE
cmake: Impending BUILD_LAYER_SUPPORT_FILES deprecation

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -88,27 +88,16 @@ if (USE_ROBIN_HOOD_HASHING)
     target_compile_definitions(robin_hood::robin_hood INTERFACE USE_ROBIN_HOOD_HASHING)
 endif()
 
-# TODO: This should be removed once the official "Vulkan-Utility-Libraries" library is available for consumption
 if(BUILD_LAYER_SUPPORT_FILES)
-    install(FILES ${CMAKE_SOURCE_DIR}/layers/containers/custom_containers.h
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan/containers)
-    install(DIRECTORY ${CMAKE_SOURCE_DIR}/layers/error_message
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan
-            FILES_MATCHING PATTERN "logging.*")
-    install(DIRECTORY ${CMAKE_SOURCE_DIR}/layers/external
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan
-            FILES_MATCHING PATTERN "xxhash.*")
+    message(WARNING "BUILD_LAYER_SUPPORT_FILES will be deprecated! See https://github.com/KhronosGroup/Vulkan-Utility-Libraries/issues/18")
+    install(FILES ${CMAKE_SOURCE_DIR}/layers/containers/custom_containers.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan/containers)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/layers/error_message DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan FILES_MATCHING PATTERN "logging.h")
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/layers/external DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan FILES_MATCHING PATTERN "xxhash.h")
     install(FILES ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_format_utils.h
-                  ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_format_utils.cpp
                   ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_validation_error_messages.h
                   ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_layer_dispatch_table.h
                   ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_dispatch_table_helper.h
                   ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_safe_struct.h
-                  ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_safe_struct_utils.cpp
-                  ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_safe_struct_core.cpp
-                  ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_safe_struct_khr.cpp
-                  ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_safe_struct_ext.cpp
-                  ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_safe_struct_vendor.cpp
                   ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_object_types.h
                   ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_api_version.h
                   ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated/vk_extension_helper.h
@@ -117,16 +106,11 @@ if(BUILD_LAYER_SUPPORT_FILES)
     install(FILES ${CMAKE_SOURCE_DIR}/layers/utils/cast_utils.h
                   ${CMAKE_SOURCE_DIR}/layers/utils/hash_util.h
                   ${CMAKE_SOURCE_DIR}/layers/utils/hash_vk_types.h
-                  ${CMAKE_SOURCE_DIR}/layers/utils/vk_layer_extension_utils.cpp
                   ${CMAKE_SOURCE_DIR}/layers/utils/vk_layer_extension_utils.h
-                  ${CMAKE_SOURCE_DIR}/layers/utils/ray_tracing_utils.cpp
                   ${CMAKE_SOURCE_DIR}/layers/utils/ray_tracing_utils.h
-                  ${CMAKE_SOURCE_DIR}/layers/utils/vk_layer_utils.cpp
                   ${CMAKE_SOURCE_DIR}/layers/utils/vk_layer_utils.h
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan/utils)
-    install(FILES vk_layer_config.h
-                  vk_layer_config.cpp
-            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan)
+    install(FILES vk_layer_config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan)
     install(TARGETS VkLayer_utils)
 endif()
 

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -56,22 +56,3 @@ target_include_directories(foobar PRIVATE
 )
 
 target_sources(foobar PRIVATE main.cpp)
-
-# See LunarG/VulkanTools build-android/jni/Android.mk
-# https://github.com/LunarG/VulkanTools/blob/main/build-android/jni/Android.mk
-
-if (NOT EXISTS "${VVL_SOURCE_DIR}/layers/vk_layer_config.cpp")
-    message(FATAL_ERROR "vk_layer_config.cpp is missing - update LunarG/VulkanTools")
-endif()
-
-if (NOT EXISTS "${VVL_SOURCE_DIR}/layers/error_message/logging.cpp")
-    message(FATAL_ERROR "logging.cpp is missing - update LunarG/VulkanTools")
-endif()
-
-if (NOT EXISTS "${VVL_SOURCE_DIR}/layers/utils/vk_layer_utils.cpp")
-    message(FATAL_ERROR "vk_layer_utils.cpp is missing - update LunarG/VulkanTools")
-endif()
-
-if (NOT EXISTS "${VVL_SOURCE_DIR}/layers/vulkan/generated/vk_format_utils.cpp")
-    message(FATAL_ERROR "vk_format_utils.cpp is missing - update LunarG/VulkanTools")
-endif()

--- a/tests/integration/main.cpp
+++ b/tests/integration/main.cpp
@@ -2,5 +2,4 @@
 #include <containers/custom_containers.h>
 #include <utils/vk_layer_extension_utils.h>
 #include <utils/vk_layer_utils.h>
-#include <generated/vk_dispatch_table_helper.h>
 #include <generated/vk_extension_helper.h>


### PR DESCRIPTION
The utility libraries are ramping up and soon LunarG/VulkanTools will no longer depend on the validation layers.

Update the integration/installation code to reflect progress made in LunarG/VulkanTools.

We no longer need to install source files.