### PR TITLE
vscode: Don't use CMakePresets.json workflow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.useCMakePresets": "never"
+}


### PR DESCRIPTION
Our repo doesn't work well with the CMakePresets.json workflow vscode encourages, and can be actively confusing/hindering to new contributors.

We actually discussed this a while ago internally.

Provide this default settings.json so vscode uses the default CMake workflow.