### PR TITLE
layers: Remove incorrect Dual Source blending VU

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2339,23 +2339,6 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LAST_BOUND_STATE &last_boun
         }
     }
 
-    uint32_t count = cb_state.activeRenderPass->UsesDynamicRendering()
-                         ? cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.colorAttachmentCount
-                         : cb_state.activeRenderPass->createInfo.pSubpasses[cb_state.GetActiveSubpass()].colorAttachmentCount;
-    if ((pipeline && pipeline->DualSourceBlending()) || (!pipeline && cb_state.HasDynamicDualSourceBlend(count))) {
-        if (count > phys_dev_props.limits.maxFragmentDualSrcAttachments) {
-            LogObjectList objlist(cb_state.commandBuffer());
-            if (pipeline) {
-                objlist.add(pipeline->pipeline());
-            }
-            skip |=
-                LogError(objlist, "VUID-RuntimeSpirv-Fragment-06427",
-                         "%s: Dual source blend mode is used, but the number of written fragment shader output attachment (%" PRIu32
-                         ") is greater than maxFragmentDualSrcAttachments (%" PRIu32 ")",
-                         caller, count, phys_dev_props.limits.maxFragmentDualSrcAttachments);
-        }
-    }
-
     bool primitives_generated_query_with_rasterizer_discard =
         enabled_features.primitives_generated_query_features.primitivesGeneratedQueryWithRasterizerDiscard == VK_TRUE;
     bool primitives_generated_query_with_non_zero_streams =

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -6934,7 +6934,8 @@ TEST_F(NegativeShaderObject, MaxMultiviewInstanceIndex) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeShaderObject, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5208
+TEST_F(NegativeShaderObject, DISABLED_MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     TEST_DESCRIPTION(
         "Test drawing with dual source blending with too many fragment output attachments, but using dynamic blending.");
 


### PR DESCRIPTION
https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6104 will soon remove this VU and move it to draw time. This is already being tracked in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5208 as there were known issues

Will come back to this when the new VU lands and make sure all 3 tests (2 are already disabled) work with it