### PR TITLE
layers: Use Location for Update Descriptor checks

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1767,7 +1767,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                             // TODO - combine this logic
                             skip |= LogError("VUID-VkImageViewCreateInfo-image-06728", pCreateInfo->image,
                                              create_info_loc.dot(Field::viewType),
-                                             "(VK)_IMAGE_VIEW_TYPE_2D is not compatible "
+                                             "VK_IMAGE_VIEW_TYPE_2D is not compatible "
                                              "with image type "
                                              "%s since the image doesn't have VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT flag set.",
                                              string_VkImageType(image_type));

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -907,32 +907,31 @@ class CoreChecks : public ValidationStateTracker {
 
     // Validate contents of a CopyUpdate
     using DescriptorSet = cvdescriptorset::DescriptorSet;
-    bool ValidateCopyUpdate(const VkCopyDescriptorSet* update, const DescriptorSet* dst_set, const DescriptorSet* src_set,
-                            const char* func_name, std::string* error_code, std::string* error_msg) const;
-    bool VerifyCopyUpdateContents(const VkCopyDescriptorSet* update, const DescriptorSet* src_set, VkDescriptorType src_type,
-                                  uint32_t src_index, const DescriptorSet* dst_set, VkDescriptorType dst_type, uint32_t dst_index,
-                                  const char* func_name, std::string* error_code, std::string* error_msg) const;
+    bool ValidateCopyUpdate(const VkCopyDescriptorSet& update, const Location& copy_loc) const;
+    bool VerifyCopyUpdateContents(const VkCopyDescriptorSet& update, const DescriptorSet& src_set, VkDescriptorType src_type,
+                                  uint32_t src_index, const DescriptorSet& dst_set, VkDescriptorType dst_type, uint32_t dst_index,
+                                  const Location& copy_loc) const;
+    bool VerifyUpdateConsistency(const DescriptorSet& set, uint32_t binding, uint32_t offset, uint32_t update_count,
+                                 const char* vuid, const Location& set_loc) const;
     // Validate contents of a WriteUpdate
-    bool ValidateWriteUpdate(const DescriptorSet* descriptor_set, const VkWriteDescriptorSet* update, const char* func_name,
-                             std::string* error_code, std::string* error_msg, bool push) const;
-    bool VerifyWriteUpdateContents(const DescriptorSet* dest_set, const VkWriteDescriptorSet* update, const uint32_t index,
-                                   const char* func_name, std::string* error_code, std::string* error_msg, bool push) const;
+    bool ValidateWriteUpdate(const DescriptorSet& dst_set, const VkWriteDescriptorSet& update, const Location& write_loc,
+                             bool push) const;
+    bool VerifyWriteUpdateContents(const DescriptorSet& dst_set, const VkWriteDescriptorSet& update, const uint32_t index,
+                                   const Location& write_loc, bool push) const;
     // Shared helper functions - These are useful because the shared sampler image descriptor type
     //  performs common functions with both sampler and image descriptors so they can share their common functions
-    bool ValidateImageUpdate(VkImageView, VkImageLayout, VkDescriptorType, const char* func_name, std::string*, std::string*) const;
+    bool ValidateImageUpdate(VkImageView image_view, VkImageLayout image_layout, VkDescriptorType type,
+                             const Location& image_info_loc) const;
     // Validate contents of a push descriptor update
-    bool ValidatePushDescriptorsUpdate(const DescriptorSet* push_set, uint32_t write_count, const VkWriteDescriptorSet* p_wds,
-                                       const char* func_name) const;
+    bool ValidatePushDescriptorsUpdate(const DescriptorSet& push_set, uint32_t descriptorWriteCount,
+                                       const VkWriteDescriptorSet* pDescriptorWrites, const Location& loc) const;
     // Descriptor Set Validation Functions
     bool ValidateSampler(VkSampler) const;
-    bool ValidateBufferUpdate(VkDescriptorBufferInfo const* buffer_info, VkDescriptorType type, const char* func_name,
-                              std::string* error_code, std::string* error_msg) const;
-    template <typename T>
-    bool ValidateAccelerationStructureUpdate(T acc, const char* func_name, std::string* error_code, std::string* error_msg) const;
-    bool ValidateUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet, const UPDATE_TEMPLATE_STATE* template_state,
-                                                     const void* pData) const;
-    bool ValidateUpdateDescriptorSets(uint32_t write_count, const VkWriteDescriptorSet* p_wds, uint32_t copy_count,
-                                      const VkCopyDescriptorSet* p_cds, const char* func_name) const;
+    bool ValidateBufferUsage(const BUFFER_STATE& buffer_state, VkDescriptorType type, const Location& buffer_loc) const;
+    bool ValidateBufferUpdate(const VkDescriptorBufferInfo& buffer_info, VkDescriptorType type,
+                              const Location& buffer_info_loc) const;
+    bool ValidateUpdateDescriptorSets(uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
+                                      const VkCopyDescriptorSet* pDescriptorCopies, const Location& loc) const;
 
     // Stuff from shader_validation
     bool ValidateGraphicsPipelineShaderState(const PIPELINE_STATE& pipeline, const Location& loc) const;

--- a/tests/unit/descriptor_indexing.cpp
+++ b/tests/unit/descriptor_indexing.cpp
@@ -401,7 +401,7 @@ TEST_F(NegativeDescriptorIndexing, SetLayout) {
             VkDescriptorSet ds;
             VkResult err = vk::AllocateDescriptorSets(m_device->handle(), &ds_alloc_info, &ds);
             ASSERT_VK_SUCCESS(err);
-            VkBufferObj buffer(*m_device, 128 * 128, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+            VkBufferObj buffer(*m_device, 128 * 128, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
             VkDescriptorBufferInfo buffer_info[3] = {};
             for (int i = 0; i < 3; i++) {
                 buffer_info[i].buffer = buffer.handle();


### PR DESCRIPTION
The Update Descriptor logic is quite old and is nothing like any other part of the code base, it used this `std::string *error_code, std::string *error_msg` system which was awful.

This change doesn't change any of the logic (except a few places it was wrong actually) and mainly just redid all the `LogError` to use the new `Location` 

The new error message provide better Object handle and info then before, **but** I do plan to come back through as there is a LOT that could still be cleaned up about this code
