### PR TITLE
layers: Revert "Simplify BINDABLE class hierarchy"

### DIFF
--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -969,12 +969,12 @@ class BestPractices : public ValidationStateTracker {
     }
     std::shared_ptr<IMAGE_STATE> CreateImageState(VkImage img, const VkImageCreateInfo* pCreateInfo,
                                                   VkFormatFeatureFlags2KHR features) final {
-        return std::make_shared<bp_state::Image>(this, img, pCreateInfo, features);
+        return CreateImageStateImpl<ImageStateBindingTraits<bp_state::Image>>(img, pCreateInfo, features);
     }
 
     std::shared_ptr<IMAGE_STATE> CreateImageState(VkImage img, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
                                                   uint32_t swapchain_index, VkFormatFeatureFlags2KHR features) final {
-        return std::make_shared<bp_state::Image>(this, img, pCreateInfo, swapchain, swapchain_index, features);
+        return CreateImageStateImpl<ImageStateBindingTraits<bp_state::Image>>(img, pCreateInfo, swapchain, swapchain_index, features);
     }
 
     std::shared_ptr<DESCRIPTOR_POOL_STATE> CreateDescriptorPoolState(VkDescriptorPool pool,

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -44,16 +44,8 @@ BUFFER_STATE::BUFFER_STATE(ValidationStateTracker *dev_data, VkBuffer buff, cons
       createInfo(*safe_create_info.ptr()),
       requirements(GetMemoryRequirements(dev_data, buff)),
       usage(GetBufferUsageFlags(createInfo)),
-      supported_video_profiles(dev_data->video_profile_cache_.Get(dev_data, LvlFindInChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
-    if (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
-        tracker_.emplace<BindableSparseMemoryTracker>(&requirements,
-                                                      (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) != 0);
-        SetMemoryTracker(&std::get<BindableSparseMemoryTracker>(tracker_));
-    } else {
-        tracker_.emplace<BindableLinearMemoryTracker>(&requirements);
-        SetMemoryTracker(&std::get<BindableLinearMemoryTracker>(tracker_));
-    }
-}
+      supported_video_profiles(
+          dev_data->video_profile_cache_.Get(dev_data, LvlFindInChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {}
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
 static bool GetMetalExport(const VkBufferViewCreateInfo *info) {

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 #pragma once
-#include <variant>
 #include "state_tracker/device_memory_state.h"
 #include "containers/range_vector.h"
 
@@ -30,6 +29,7 @@ class BUFFER_STATE : public BINDABLE {
     const safe_VkBufferCreateInfo safe_create_info;
     const VkBufferCreateInfo &createInfo;
     const VkMemoryRequirements requirements;
+    const VkMemoryRequirements *const memory_requirements_pointer = &requirements;
     VkDeviceAddress deviceAddress = 0;
     // VkBufferUsageFlags2CreateInfoKHR can be used instead over the VkBufferCreateInfo::usage
     const VkBufferUsageFlags2KHR usage;
@@ -54,10 +54,11 @@ class BUFFER_STATE : public BINDABLE {
     }
 
     sparse_container::range<VkDeviceAddress> DeviceAddressRange() const { return {deviceAddress, deviceAddress + createInfo.size}; }
-
-  private:
-    std::variant<std::monostate, BindableLinearMemoryTracker, BindableSparseMemoryTracker> tracker_;
 };
+
+using BUFFER_STATE_LINEAR = MEMORY_TRACKED_RESOURCE_STATE<BUFFER_STATE, BindableLinearMemoryTracker>;
+template <bool IS_RESIDENT>
+using BUFFER_STATE_SPARSE = MEMORY_TRACKED_RESOURCE_STATE<BUFFER_STATE, BindableSparseMemoryTracker<IS_RESIDENT>>;
 
 class BUFFER_VIEW_STATE : public BASE_NODE {
   public:

--- a/layers/state_tracker/device_memory_state.cpp
+++ b/layers/state_tracker/device_memory_state.cpp
@@ -19,10 +19,6 @@
 #include "state_tracker/device_memory_state.h"
 #include "state_tracker/image_state.h"
 
-using MemoryRange = BindableMemoryTracker::MemoryRange;
-using BoundMemoryRange = BindableMemoryTracker::BoundMemoryRange;
-using DeviceMemoryState = BindableMemoryTracker::DeviceMemoryState;
-
 // It is allowed to export memory into the handles of different types,
 // that's why we use set of flags (VkExternalMemoryHandleTypeFlags)
 static VkExternalMemoryHandleTypeFlags GetExportHandleTypes(const VkMemoryAllocateInfo *p_alloc_info) {
@@ -103,6 +99,12 @@ DEVICE_MEMORY_STATE::DEVICE_MEMORY_STATE(VkDeviceMemory memory, const VkMemoryAl
       fake_base_address(fake_address) {
 }
 
+VkDeviceSize BINDABLE::GetFakeBaseAddress() const {
+    assert(!sparse);  // not implemented yet
+    const auto *binding = Binding();
+    return binding ? binding->memory_offset + binding->memory_state->fake_base_address : 0;
+}
+
 void BindableLinearMemoryTracker::BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem_state,
                                              VkDeviceSize memory_offset, VkDeviceSize resource_offset, VkDeviceSize size) {
     if (!mem_state) return;
@@ -111,207 +113,15 @@ void BindableLinearMemoryTracker::BindMemory(BASE_NODE *parent, std::shared_ptr<
     binding_ = {mem_state, memory_offset, 0u};
 }
 
-DeviceMemoryState BindableLinearMemoryTracker::GetBoundMemoryStates() const {
+BindableMemoryTracker::DeviceMemoryState BindableLinearMemoryTracker::GetBoundMemoryStates() const {
     return binding_.memory_state ? DeviceMemoryState{binding_.memory_state} : DeviceMemoryState{};
 }
 
-BoundMemoryRange BindableLinearMemoryTracker::GetBoundMemoryRange(const MemoryRange &range) const {
+BindableMemoryTracker::BoundMemoryRange BindableLinearMemoryTracker::GetBoundMemoryRange(
+    const sparse_container::range<VkDeviceSize> &range) const {
     return binding_.memory_state ? BoundMemoryRange{BoundMemoryRange::value_type{
                                        binding_.memory_state->deviceMemory(),
                                        BoundMemoryRange::value_type::second_type{
                                            {binding_.memory_offset + range.begin, binding_.memory_offset + range.end}}}}
                                  : BoundMemoryRange{};
 }
-
-unsigned BindableSparseMemoryTracker::CountDeviceMemory(VkDeviceMemory memory) const {
-    unsigned count = 0u;
-    auto guard = ReadLockGuard{binding_lock_};
-    for (const auto &range_state : binding_map_) {
-        count += (range_state.second.memory_state && range_state.second.memory_state->deviceMemory() == memory);
-    }
-    return count;
-}
-
-bool BindableSparseMemoryTracker::HasFullRangeBound() const {
-    if (!is_resident_) {
-        VkDeviceSize current_offset = 0u;
-        {
-            auto guard = ReadLockGuard{binding_lock_};
-            for (const auto &range : binding_map_) {
-                if (current_offset != range.first.begin || !range.second.memory_state || range.second.memory_state->Invalid()) {
-                    return false;
-                }
-                current_offset = range.first.end;
-            }
-        }
-
-        if (current_offset != resource_size_) return false;
-    }
-
-    return true;
-}
-
-void BindableSparseMemoryTracker::BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem_state, VkDeviceSize memory_offset,
-                                             VkDeviceSize resource_offset, VkDeviceSize size) {
-    MEM_BINDING memory_data{mem_state, memory_offset, resource_offset};
-    BindingMap::value_type item{{resource_offset, resource_offset + size}, memory_data};
-
-    auto guard = WriteLockGuard{binding_lock_};
-
-    // Since we don't know which ranges will be removed, we need to unbind everything and rebind later
-    for (auto &value_pair : binding_map_) {
-        if (value_pair.second.memory_state) value_pair.second.memory_state->RemoveParent(parent);
-    }
-    binding_map_.overwrite_range(item);
-
-    for (auto &value_pair : binding_map_) {
-        if (value_pair.second.memory_state) value_pair.second.memory_state->AddParent(parent);
-    }
-}
-
-BoundMemoryRange BindableSparseMemoryTracker::GetBoundMemoryRange(const MemoryRange &range) const {
-    BoundMemoryRange mem_ranges;
-    auto guard = ReadLockGuard{binding_lock_};
-    auto range_bounds = binding_map_.bounds(range);
-
-    for (auto it = range_bounds.begin; it != range_bounds.end; ++it) {
-        const auto &[resource_range, memory_data] = *it;
-        if (memory_data.memory_state && memory_data.memory_state->deviceMemory() != VK_NULL_HANDLE) {
-            const VkDeviceSize memory_range_start = std::max(range.begin, memory_data.resource_offset) -
-                memory_data.resource_offset + memory_data.memory_offset;
-            const VkDeviceSize memory_range_end =
-                std::min(range.end, memory_data.resource_offset + resource_range.distance()) - memory_data.resource_offset +
-                memory_data.memory_offset;
-
-            mem_ranges[memory_data.memory_state->deviceMemory()].emplace_back(memory_range_start, memory_range_end);
-        }
-    }
-    return mem_ranges;
-}
-
-DeviceMemoryState BindableSparseMemoryTracker::GetBoundMemoryStates() const {
-    DeviceMemoryState dev_mem_states;
-
-    {
-        auto guard = ReadLockGuard{binding_lock_};
-        for (auto &binding : binding_map_) {
-            if (binding.second.memory_state) dev_mem_states.emplace(binding.second.memory_state);
-        }
-    }
-
-    return dev_mem_states;
-}
-
-
-BindableMultiplanarMemoryTracker::BindableMultiplanarMemoryTracker(const VkMemoryRequirements *requirements, uint32_t num_planes)
-    : planes_(num_planes) {
-    for (unsigned i = 0; i < num_planes; ++i) {
-        planes_[i].size = requirements[i].size;
-    }
-}
-unsigned BindableMultiplanarMemoryTracker::CountDeviceMemory(VkDeviceMemory memory) const {
-    unsigned count = 0u;
-    for (size_t i = 0u; i < planes_.size(); i++) {
-        const auto &plane = planes_[i];
-        count += (plane.binding.memory_state && plane.binding.memory_state->deviceMemory() == memory);
-    }
-
-    return count;
-}
-
-bool BindableMultiplanarMemoryTracker::HasFullRangeBound() const {
-    bool full_range_bound = true;
-
-    for (unsigned i = 0u; i < planes_.size(); ++i) {
-        full_range_bound &= (planes_[i].binding.memory_state != nullptr);
-    }
-
-    return full_range_bound;
-}
-
-// resource_offset is the plane index
-void BindableMultiplanarMemoryTracker::BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem_state,
-                                                  VkDeviceSize memory_offset, VkDeviceSize resource_offset, VkDeviceSize size) {
-    if (!mem_state) return;
-
-    assert(resource_offset < planes_.size());
-    mem_state->AddParent(parent);
-    planes_[static_cast<size_t>(resource_offset)].binding = {mem_state, memory_offset, 0u};
-}
-
-// range needs to be between [0, planes_[0].size + planes_[1].size + planes_[2].size)
-// To access plane 0 range must be [0, planes_[0].size)
-// To access plane 1 range must be [planes_[0].size, planes_[1].size)
-// To access plane 2 range must be [planes_[1].size, planes_[2].size)
-BoundMemoryRange BindableMultiplanarMemoryTracker::GetBoundMemoryRange(const MemoryRange &range) const {
-    BoundMemoryRange mem_ranges;
-    VkDeviceSize start_offset = 0u;
-    for (unsigned i = 0u; i < planes_.size(); ++i) {
-        const auto &plane = planes_[i];
-        MemoryRange plane_range{start_offset, start_offset + plane.size};
-        if (plane.binding.memory_state && range.intersects(plane_range)) {
-            VkDeviceSize range_end = range.end > plane_range.end ? plane_range.end : range.end;
-            const auto &dev_mem = plane.binding.memory_state->deviceMemory();
-            mem_ranges[dev_mem].emplace_back(MemoryRange{plane.binding.memory_offset + range.begin,
-                                                                                   plane.binding.memory_offset + range_end});
-        }
-        start_offset += plane.size;
-    }
-
-    return mem_ranges;
-}
-
-DeviceMemoryState BindableMultiplanarMemoryTracker::GetBoundMemoryStates() const {
-    DeviceMemoryState dev_mem_states;
-
-    for (unsigned i = 0u; i < planes_.size(); ++i) {
-        if (planes_[i].binding.memory_state) {
-            dev_mem_states.insert(planes_[i].binding.memory_state);
-        }
-    }
-
-    return dev_mem_states;
-}
-
-std::pair<VkDeviceMemory, MemoryRange> BINDABLE::GetResourceMemoryOverlap(
-        const MemoryRange &memory_region, const BINDABLE *other_resource,
-        const MemoryRange &other_memory_region) const {
-    if (!other_resource) return {VK_NULL_HANDLE, {}};
-
-    auto ranges = GetBoundMemoryRange(memory_region);
-    auto other_ranges = other_resource->GetBoundMemoryRange(other_memory_region);
-
-    for (const auto &[memory, memory_ranges] : ranges) {
-        // Check if we have memory from same VkDeviceMemory bound
-        auto it = other_ranges.find(memory);
-        if (it != other_ranges.end()) {
-            // Check if any of the bound memory ranges overlap
-            for (const auto &memory_range : memory_ranges) {
-                for (const auto &other_memory_range : it->second) {
-                    if (other_memory_range.intersects(memory_range)) {
-                        auto memory_space_intersection = other_memory_range & memory_range;
-                        return {memory, memory_space_intersection};
-                    }
-                }
-            }
-        }
-    }
-    return {VK_NULL_HANDLE, {}};
-}
-
-VkDeviceSize BINDABLE::GetFakeBaseAddress() const {
-    assert(!sparse);  // not implemented yet
-    const auto *binding = Binding();
-    return binding ? binding->memory_offset + binding->memory_state->fake_base_address : 0;
-}
-
-void BINDABLE::CacheInvalidMemory() const {
-    need_to_recache_invalid_memory_ = false;
-    cached_invalid_memory_.clear();
-    for (auto const &bindable : GetBoundMemoryStates()) {
-        if (bindable->Invalid()) {
-            cached_invalid_memory_.insert(bindable);
-        }
-    }
-}
-

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -90,20 +90,8 @@ struct MEM_BINDING {
 
 class BindableMemoryTracker {
   public:
-    using MemoryRange = sparse_container::range<VkDeviceSize>;
-    using BoundMemoryRange = std::map<VkDeviceMemory, std::vector<MemoryRange>>;
+    using BoundMemoryRange = std::map<VkDeviceMemory, std::vector<sparse_container::range<VkDeviceSize>>>;
     using DeviceMemoryState = vvl::unordered_set<std::shared_ptr<DEVICE_MEMORY_STATE>>;
-
-    virtual ~BindableMemoryTracker() {}
-    // kept for backwards compatibility, only useful with the Linear tracker
-    virtual const MEM_BINDING *Binding() const = 0;
-    virtual unsigned CountDeviceMemory(VkDeviceMemory memory) const = 0;
-    virtual bool HasFullRangeBound() const = 0;
-
-    virtual void BindMemory(BASE_NODE *, std::shared_ptr<DEVICE_MEMORY_STATE> &, VkDeviceSize, VkDeviceSize, VkDeviceSize) = 0;
-
-    virtual BoundMemoryRange GetBoundMemoryRange(const MemoryRange &) const = 0;
-    virtual DeviceMemoryState GetBoundMemoryStates() const = 0;
 };
 
 // Dummy memory tracker for swapchains
@@ -111,16 +99,18 @@ class BindableNoMemoryTracker : public BindableMemoryTracker {
   public:
     BindableNoMemoryTracker(const VkMemoryRequirements *) {}
 
-    const MEM_BINDING *Binding() const override { return nullptr; }
+    //----------------------------------------------------------------------------------------------------
+    // Kept for backwards compatibility
+    const MEM_BINDING *Binding() const { return nullptr; }
+    unsigned CountDeviceMemory(VkDeviceMemory memory) const { return 0; }
+    //----------------------------------------------------------------------------------------------------
 
-    unsigned CountDeviceMemory(VkDeviceMemory memory) const override { return 0; }
+    bool HasFullRangeBound() const { return true; }
 
-    bool HasFullRangeBound() const override { return true; }
+    void BindMemory(BASE_NODE *, std::shared_ptr<DEVICE_MEMORY_STATE> &, VkDeviceSize, VkDeviceSize, VkDeviceSize) {}
 
-    void BindMemory(BASE_NODE *, std::shared_ptr<DEVICE_MEMORY_STATE> &, VkDeviceSize, VkDeviceSize, VkDeviceSize) override {}
-
-    BoundMemoryRange GetBoundMemoryRange(const MemoryRange &) const override { return BoundMemoryRange{}; }
-    DeviceMemoryState GetBoundMemoryStates() const override { return DeviceMemoryState{}; }
+    BoundMemoryRange GetBoundMemoryRange(const sparse_container::range<VkDeviceSize> &) const { return BoundMemoryRange{}; }
+    DeviceMemoryState GetBoundMemoryStates() const { return DeviceMemoryState{}; }
 };
 
 // Non sparse bindable memory tracker
@@ -128,18 +118,21 @@ class BindableLinearMemoryTracker : public BindableMemoryTracker {
   public:
     BindableLinearMemoryTracker(const VkMemoryRequirements *) {}
 
-    const MEM_BINDING *Binding() const override { return binding_.memory_state ? &binding_ : nullptr; }
-    unsigned CountDeviceMemory(VkDeviceMemory memory) const override {
+    //----------------------------------------------------------------------------------------------------
+    // Kept for backwards compatibility
+    const MEM_BINDING *Binding() const { return binding_.memory_state ? &binding_ : nullptr; }
+    unsigned CountDeviceMemory(VkDeviceMemory memory) const {
         return binding_.memory_state && binding_.memory_state->deviceMemory() == memory ? 1 : 0;
     }
+    //----------------------------------------------------------------------------------------------------
 
-    bool HasFullRangeBound() const override { return binding_.memory_state != nullptr; }
+    bool HasFullRangeBound() const { return binding_.memory_state != nullptr; }
 
     void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem_state, VkDeviceSize memory_offset,
-                    VkDeviceSize resource_offset, VkDeviceSize size) override;
+                    VkDeviceSize resource_offset, VkDeviceSize size);
 
-    BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
-    DeviceMemoryState GetBoundMemoryStates() const override;
+    BoundMemoryRange GetBoundMemoryRange(const sparse_container::range<VkDeviceSize> &range) const;
+    DeviceMemoryState GetBoundMemoryStates() const;
 
   private:
     MEM_BINDING binding_;
@@ -147,57 +140,184 @@ class BindableLinearMemoryTracker : public BindableMemoryTracker {
 
 // Sparse bindable memory tracker
 // Does not contemplate the idea of multiplanar sparse images
+template <bool IS_RESIDENT>
 class BindableSparseMemoryTracker : public BindableMemoryTracker {
   public:
-    BindableSparseMemoryTracker(const VkMemoryRequirements *requirements, bool is_resident)
-        : resource_size_(requirements->size), is_resident_(is_resident) {}
+    BindableSparseMemoryTracker(const VkMemoryRequirements *requirements) : resource_size_(requirements->size) {}
 
-    const MEM_BINDING *Binding() const override { return nullptr; }
+    //----------------------------------------------------------------------------------------------------
+    // Kept for backwards compatibility
+    const MEM_BINDING *Binding() const { return nullptr; }
+    unsigned CountDeviceMemory(VkDeviceMemory memory) const {
+        unsigned count = 0u;
+        {
+            auto guard = ReadLockGuard{binding_lock_};
+            for (const auto &range_state : binding_map_) {
+                count += (range_state.second.memory_state && range_state.second.memory_state->deviceMemory() == memory);
+            }
+        }
 
-    unsigned CountDeviceMemory(VkDeviceMemory memory) const override;
+        return count;
+    }
+    //----------------------------------------------------------------------------------------------------
 
-    bool HasFullRangeBound() const override;
+    bool HasFullRangeBound() const {
+        if (!IS_RESIDENT) {
+            VkDeviceSize current_offset = 0u;
+            {
+                auto guard = ReadLockGuard{binding_lock_};
+                for (const auto &range : binding_map_) {
+                    if (current_offset != range.first.begin || !range.second.memory_state || range.second.memory_state->Invalid()) {
+                        return false;
+                    }
+                    current_offset = range.first.end;
+                }
+            }
+
+            if (current_offset != resource_size_) return false;
+        }
+
+        return true;
+    }
 
     void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem_state, VkDeviceSize memory_offset,
-                    VkDeviceSize resource_offset, VkDeviceSize size) override;
+                    VkDeviceSize resource_offset, VkDeviceSize size) {
+        MEM_BINDING memory_data{mem_state, memory_offset, resource_offset};
+        BindingMap::value_type item{{resource_offset, resource_offset + size}, memory_data};
 
-    BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
+        auto guard = WriteLockGuard{binding_lock_};
 
-    DeviceMemoryState GetBoundMemoryStates() const override;
+        // Since we don't know which ranges will be removed, we need to unbind everything and rebind later
+        for (auto &value_pair : binding_map_) {
+            if (value_pair.second.memory_state) value_pair.second.memory_state->RemoveParent(parent);
+        }
+        binding_map_.overwrite_range(item);
+
+        for (auto &value_pair : binding_map_) {
+            if (value_pair.second.memory_state) value_pair.second.memory_state->AddParent(parent);
+        }
+    }
+
+    BoundMemoryRange GetBoundMemoryRange(const sparse_container::range<VkDeviceSize> &range) const {
+        BoundMemoryRange mem_ranges;
+        {
+            auto guard = ReadLockGuard{binding_lock_};
+            auto range_bounds = binding_map_.bounds(range);
+
+            for (auto it = range_bounds.begin; it != range_bounds.end; ++it) {
+                const auto &[resource_range, memory_data] = *it;
+                if (memory_data.memory_state && memory_data.memory_state->deviceMemory() != VK_NULL_HANDLE) {
+                    const VkDeviceSize memory_range_start = std::max(range.begin, memory_data.resource_offset) -
+                                                            memory_data.resource_offset + memory_data.memory_offset;
+                    const VkDeviceSize memory_range_end =
+                        std::min(range.end, memory_data.resource_offset + resource_range.distance()) - memory_data.resource_offset +
+                        memory_data.memory_offset;
+
+                    mem_ranges[memory_data.memory_state->deviceMemory()].emplace_back(memory_range_start, memory_range_end);
+                }
+            }
+        }
+        return mem_ranges;
+    }
+
+    DeviceMemoryState GetBoundMemoryStates() const {
+        DeviceMemoryState dev_mem_states;
+
+        {
+            auto guard = ReadLockGuard{binding_lock_};
+            for (auto &binding : binding_map_) {
+                if (binding.second.memory_state) dev_mem_states.emplace(binding.second.memory_state);
+            }
+        }
+
+        return dev_mem_states;
+    }
 
   private:
     // This range map uses the range in resource space to know the size of the bound memory
     using BindingMap = sparse_container::range_map<VkDeviceSize, MEM_BINDING>;
     BindingMap binding_map_;
-    mutable std::shared_mutex binding_lock_;
     VkDeviceSize resource_size_;
-    bool is_resident_;
+    mutable std::shared_mutex binding_lock_;
 };
 
 // Non sparse multi planar bindable memory tracker
+template <unsigned TRACKING_COUNT>
 class BindableMultiplanarMemoryTracker : public BindableMemoryTracker {
   public:
-    BindableMultiplanarMemoryTracker(const VkMemoryRequirements *requirements, uint32_t num_planes);
+    BindableMultiplanarMemoryTracker(const VkMemoryRequirements *requirements) {
+        for (unsigned i = 0; i < TRACKING_COUNT; ++i) {
+            plane_size_[i] = requirements[i].size;
+        }
+    }
 
-    const MEM_BINDING *Binding() const override { return nullptr; }
+    //----------------------------------------------------------------------------------------------------
+    // Kept for backwards compatibility
+    const MEM_BINDING *Binding() const { return nullptr; }
+    unsigned CountDeviceMemory(VkDeviceMemory memory) const {
+        unsigned count = 0u;
+        for (unsigned i = 0u; i < TRACKING_COUNT; ++i) {
+            count += (bindings_[i].memory_state && bindings_[i].memory_state->deviceMemory() == memory);
+        }
 
-    unsigned CountDeviceMemory(VkDeviceMemory memory) const override;
+        return count;
+    }
+    //----------------------------------------------------------------------------------------------------
 
-    bool HasFullRangeBound() const override;
+    bool HasFullRangeBound() const {
+        bool full_range_bound = true;
 
+        for (unsigned i = 0u; i < TRACKING_COUNT; ++i) {
+            full_range_bound &= (bindings_[i].memory_state != nullptr);
+        }
+
+        return full_range_bound;
+    }
+
+    // resource_offset is the plane index
     void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem_state, VkDeviceSize memory_offset,
-                    VkDeviceSize resource_offset, VkDeviceSize size) override;
+                    VkDeviceSize resource_offset, VkDeviceSize size) {
+        if (!mem_state) return;
 
-    BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
+        mem_state->AddParent(parent);
+        bindings_[resource_offset] = {mem_state, memory_offset, 0u};
+    }
 
-    DeviceMemoryState GetBoundMemoryStates() const override;
+    // range needs to be between [0, resource_size_[0] + resource_size_[1] + resource_size_[2])
+    // To access plane 0 range must be [0, plane_size_[0])
+    // To access plane 1 range must be [plane_size_[0], plane_size_[1])
+    // To access plane 2 range must be [plane_size_[1], plane_size_[2])
+    BoundMemoryRange GetBoundMemoryRange(const sparse_container::range<VkDeviceSize> &range) const {
+        BoundMemoryRange mem_ranges;
+        VkDeviceSize start_offset = 0u;
+        for (unsigned i = 0u; i < TRACKING_COUNT; ++i) {
+            sparse_container::range<VkDeviceSize> plane_range{start_offset, start_offset + plane_size_[i]};
+            if (bindings_[i].memory_state && range.intersects(plane_range)) {
+                VkDeviceSize range_end = range.end > plane_range.end ? plane_range.end : range.end;
+                mem_ranges[bindings_[i].memory_state->deviceMemory()].emplace_back(sparse_container::range<VkDeviceSize>{
+                    bindings_[i].memory_offset + range.begin, bindings_[i].memory_offset + range_end});
+            }
+            start_offset += plane_size_[i];
+        }
+
+        return mem_ranges;
+    }
+
+    DeviceMemoryState GetBoundMemoryStates() const {
+        DeviceMemoryState dev_mem_states;
+
+        for (unsigned i = 0u; i < TRACKING_COUNT; ++i) {
+            if (bindings_[i].memory_state) {
+                dev_mem_states.insert(bindings_[i].memory_state);
+            }
+        }
+
+        return dev_mem_states;
+    }
 
   private:
-    struct Plane {
-        MEM_BINDING binding;
-        VkDeviceSize size;
-    };
-    std::vector<Plane> planes_;
+    MEM_BINDING bindings_[TRACKING_COUNT];
+    VkDeviceSize plane_size_[TRACKING_COUNT];
 };
 
 // Superclass for bindable object state (currently images, buffers and acceleration structures)
@@ -205,8 +325,7 @@ class BINDABLE : public BASE_NODE {
   public:
     template <typename Handle>
     BINDABLE(Handle h, VulkanObjectType t, bool is_sparse, bool is_unprotected, VkExternalMemoryHandleTypeFlags handle_types)
-        : BASE_NODE(h, t), external_memory_handle_types(handle_types), sparse(is_sparse), unprotected(is_unprotected),
-          memory_tracker_(nullptr) {}
+        : BASE_NODE(h, t), external_memory_handle_types(handle_types), sparse(is_sparse), unprotected(is_unprotected) {}
 
     virtual ~BINDABLE() {
         if (!Destroyed()) {
@@ -214,13 +333,7 @@ class BINDABLE : public BASE_NODE {
         }
     }
 
-    void Destroy() override {
-        for (auto &state : memory_tracker_->GetBoundMemoryStates()) {
-            state->RemoveParent(this);
-        }
-
-        BASE_NODE::Destroy();
-    }
+    void Destroy() override { BASE_NODE::Destroy(); }
 
     bool IsExternalAHB() const {
         return (external_memory_handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) != 0;
@@ -259,48 +372,113 @@ class BINDABLE : public BASE_NODE {
     }
 
     // Implemented by template class MemoryTrackedResource that has a BindableMemoryTracker with each needed function
-    void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem, const VkDeviceSize memory_offset,
-                            const VkDeviceSize resource_offset, const VkDeviceSize mem_size) {
-        memory_tracker_->BindMemory(parent, mem, memory_offset, resource_offset, mem_size);
-    }
-
-    bool HasFullRangeBound() const { return memory_tracker_->HasFullRangeBound(); }
-
-    std::pair<VkDeviceMemory, BindableMemoryTracker::MemoryRange> GetResourceMemoryOverlap(
-        const BindableMemoryTracker::MemoryRange &memory_region, const BINDABLE *other_resource,
-        const BindableMemoryTracker::MemoryRange &other_memory_region) const;
-
-    bool DoesResourceMemoryOverlap(const BindableMemoryTracker::MemoryRange &memory_region, const BINDABLE *other_resource,
-                                   const BindableMemoryTracker::MemoryRange &other_memory_region) const {
+    virtual void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem, const VkDeviceSize memory_offset,
+                            const VkDeviceSize resource_offset, const VkDeviceSize mem_size) = 0;
+    virtual bool HasFullRangeBound() const = 0;
+    virtual std::pair<VkDeviceMemory, sparse_container::range<VkDeviceSize>> GetResourceMemoryOverlap(
+        const sparse_container::range<VkDeviceSize> &memory_region, const BINDABLE *other_resource,
+        const sparse_container::range<VkDeviceSize> &other_memory_region) const = 0;
+    bool DoesResourceMemoryOverlap(const sparse_container::range<VkDeviceSize> &memory_region, const BINDABLE *other_resource,
+                                   const sparse_container::range<VkDeviceSize> &other_memory_region) const {
         return GetResourceMemoryOverlap(memory_region, other_resource, other_memory_region).first != VK_NULL_HANDLE;
     }
-
-    BindableMemoryTracker::BoundMemoryRange GetBoundMemoryRange(const BindableMemoryTracker::MemoryRange &range) const {
-        return memory_tracker_->GetBoundMemoryRange(range);
-    }
-
-    BindableMemoryTracker::DeviceMemoryState GetBoundMemoryStates() const {
-        return memory_tracker_->GetBoundMemoryStates();
-    }
-
+    virtual BindableMemoryTracker::BoundMemoryRange GetBoundMemoryRange(
+        const sparse_container::range<VkDeviceSize> &range) const = 0;
+    virtual BindableMemoryTracker::DeviceMemoryState GetBoundMemoryStates() const = 0;
     // Kept for compatibility
-    const MEM_BINDING *Binding() const { return memory_tracker_->Binding(); }
-
-    unsigned CountDeviceMemory(VkDeviceMemory memory) const { return memory_tracker_->CountDeviceMemory(memory); }
+    virtual const MEM_BINDING *Binding() const = 0;
+    virtual unsigned CountDeviceMemory(VkDeviceMemory memory) const = 0;
 
   protected:
-    void CacheInvalidMemory() const;
+    virtual void CacheInvalidMemory() const = 0;
 
     mutable BindableMemoryTracker::DeviceMemoryState cached_invalid_memory_;
 
-    void SetMemoryTracker(BindableMemoryTracker *tracker) { memory_tracker_ = tracker; }
   public:
     // Tracks external memory types creating resource
     const VkExternalMemoryHandleTypeFlags external_memory_handle_types;
     const bool sparse;       // Is this object being bound with sparse memory or not?
     const bool unprotected;  // can't be used for protected memory
-  private:
+  protected:
     mutable bool need_to_recache_invalid_memory_ = false;
-    BindableMemoryTracker *memory_tracker_;
 };
 
+template <typename BaseClass, typename MemoryTracker>
+class MEMORY_TRACKED_RESOURCE_STATE : public BaseClass {
+  public:
+    template <typename... Args>
+    MEMORY_TRACKED_RESOURCE_STATE(Args... args)
+        : BaseClass(std::forward<Args>(args)...), memory_tracker_(BaseClass::memory_requirements_pointer) {}
+
+    virtual ~MEMORY_TRACKED_RESOURCE_STATE() {
+        if (!BaseClass::Destroyed()) Destroy();
+    }
+
+    void Destroy() override {
+        for (auto &state : GetBoundMemoryStates()) {
+            state->RemoveParent(this);
+        }
+
+        BaseClass::Destroy();
+    }
+
+    void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &memory_state, const VkDeviceSize memory_offset,
+                    const VkDeviceSize resource_offset, const VkDeviceSize memory_size) override {
+        memory_tracker_.BindMemory(parent, memory_state, memory_offset, resource_offset, memory_size);
+    }
+
+    bool HasFullRangeBound() const override { return memory_tracker_.HasFullRangeBound(); }
+
+    std::pair<VkDeviceMemory, sparse_container::range<VkDeviceSize>> GetResourceMemoryOverlap(
+        const sparse_container::range<VkDeviceSize> &memory_region, const BINDABLE *other_resource,
+        const sparse_container::range<VkDeviceSize> &other_memory_region) const override {
+        if (!other_resource) return {VK_NULL_HANDLE, {}};
+
+        auto ranges = GetBoundMemoryRange(memory_region);
+        auto other_ranges = other_resource->GetBoundMemoryRange(other_memory_region);
+
+        for (const auto &[memory, memory_ranges] : ranges) {
+            // Check if we have memory from same VkDeviceMemory bound
+            auto it = other_ranges.find(memory);
+            if (it != other_ranges.end()) {
+                // Check if any of the bound memory ranges overlap
+                for (const auto &memory_range : memory_ranges) {
+                    for (const auto &other_memory_range : it->second) {
+                        if (other_memory_range.intersects(memory_range)) {
+                            auto memory_space_intersection = other_memory_range & memory_range;
+                            return {memory, memory_space_intersection};
+                        }
+                    }
+                }
+            }
+        }
+
+        return {VK_NULL_HANDLE, {}};
+    }
+
+    BindableMemoryTracker::BoundMemoryRange GetBoundMemoryRange(const sparse_container::range<VkDeviceSize> &range) const override {
+        return memory_tracker_.GetBoundMemoryRange(range);
+    }
+
+    BindableMemoryTracker::DeviceMemoryState GetBoundMemoryStates() const override {
+        return memory_tracker_.GetBoundMemoryStates();
+    }
+
+    const MEM_BINDING *Binding() const override { return memory_tracker_.Binding(); }
+
+    unsigned CountDeviceMemory(VkDeviceMemory memory) const override { return memory_tracker_.CountDeviceMemory(memory); }
+
+  protected:
+    void CacheInvalidMemory() const override {
+        BaseClass::need_to_recache_invalid_memory_ = false;
+        BaseClass::cached_invalid_memory_.clear();
+        for (auto const &bindable : GetBoundMemoryStates()) {
+            if (bindable->Invalid()) {
+                BaseClass::cached_invalid_memory_.insert(bindable);
+            }
+        }
+    }
+
+  private:
+    MemoryTracker memory_tracker_;
+};

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -215,17 +215,6 @@ IMAGE_STATE::IMAGE_STATE(const ValidationStateTracker *dev_data, VkImage img, co
       store_device_as_workaround(dev_data->device),  // TODO REMOVE WHEN encoder can be const
       supported_video_profiles(
           dev_data->video_profile_cache_.Get(dev_data, LvlFindInChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
-    if (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) {
-        bool is_resident = (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0;
-        tracker_.emplace<BindableSparseMemoryTracker>(requirements.data(), is_resident);
-        SetMemoryTracker(&std::get<BindableSparseMemoryTracker>(tracker_));
-    } else if (pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT) {
-        tracker_.emplace<BindableMultiplanarMemoryTracker>(requirements.data(), FormatPlaneCount(pCreateInfo->format));
-        SetMemoryTracker(&std::get<BindableMultiplanarMemoryTracker>(tracker_));
-    } else {
-        tracker_.emplace<BindableLinearMemoryTracker>(requirements.data());
-        SetMemoryTracker(&std::get<BindableLinearMemoryTracker>(tracker_));
-    }
 }
 
 IMAGE_STATE::IMAGE_STATE(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo,
@@ -260,9 +249,6 @@ IMAGE_STATE::IMAGE_STATE(const ValidationStateTracker *dev_data, VkImage img, co
           dev_data->video_profile_cache_.Get(dev_data, LvlFindInChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
     fragment_encoder =
         std::unique_ptr<const subresource_adapter::ImageRangeEncoder>(new subresource_adapter::ImageRangeEncoder(*this));
-
-    tracker_.emplace<BindableNoMemoryTracker>(requirements.data());
-    SetMemoryTracker(&std::get<BindableNoMemoryTracker>(tracker_));
 }
 
 void IMAGE_STATE::Destroy() {

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -30,10 +30,7 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
           build_scratch_memory_requirements(
               GetMemReqs(device, as, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV)),
           update_scratch_memory_requirements(
-              GetMemReqs(device, as, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV)),
-          tracker_(&memory_requirements) {
-              BINDABLE::SetMemoryTracker(&tracker_);
-    }
+              GetMemReqs(device, as, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV)) {}
     ACCELERATION_STRUCTURE_STATE(const ACCELERATION_STRUCTURE_STATE &rh_obj) = delete;
 
     VkAccelerationStructureNV acceleration_structure() const { return handle_.Cast<VkAccelerationStructureNV>(); }
@@ -48,6 +45,7 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
     const VkMemoryRequirements memory_requirements;
     const VkMemoryRequirements build_scratch_memory_requirements;
     const VkMemoryRequirements update_scratch_memory_requirements;
+    const VkMemoryRequirements *const memory_requirements_pointer = &memory_requirements;
     uint64_t opaque_handle = 0;
     bool memory_requirements_checked = false;
     bool build_scratch_memory_requirements_checked = false;
@@ -64,8 +62,10 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
         DispatchGetAccelerationStructureMemoryRequirementsNV(device, &req_info, &requirements);
         return requirements.memoryRequirements;
     }
-    BindableLinearMemoryTracker tracker_;
 };
+
+using ACCELERATION_STRUCTURE_STATE_LINEAR =
+    MEMORY_TRACKED_RESOURCE_STATE<ACCELERATION_STRUCTURE_STATE, BindableLinearMemoryTracker>;
 
 class ACCELERATION_STRUCTURE_STATE_KHR : public BASE_NODE {
   public:

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -60,8 +60,8 @@ class SAMPLER_STATE : public BASE_NODE {
     const VkSamplerYcbcrConversion samplerConversion;
     const VkSamplerCustomBorderColorCreateInfoEXT customCreateInfo;
 
-    SAMPLER_STATE(const VkSampler s, const VkSamplerCreateInfo *pci)
-        : BASE_NODE(s, kVulkanObjectTypeSampler),
+    SAMPLER_STATE(const VkSampler *ps, const VkSamplerCreateInfo *pci)
+        : BASE_NODE(*ps, kVulkanObjectTypeSampler),
           createInfo(*pci),
           samplerConversion(GetConversion(pci)),
           customCreateInfo(GetCustomCreateInfo(pci)) {}

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -185,13 +185,13 @@ VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device
 
 std::shared_ptr<IMAGE_STATE> ValidationStateTracker::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
                                                                       VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<IMAGE_STATE>(this, img, pCreateInfo, features);
+    return CreateImageStateImpl<ImageStateBindingTraits<IMAGE_STATE>>(img, pCreateInfo, features);
 }
 
 std::shared_ptr<IMAGE_STATE> ValidationStateTracker::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
                                                                       VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                                       VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<IMAGE_STATE>(this, img, pCreateInfo, swapchain, swapchain_index, features);
+    return CreateImageStateImpl<ImageStateBindingTraits<IMAGE_STATE>>(img, pCreateInfo, swapchain, swapchain_index, features);
 }
 
 void ValidationStateTracker::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
@@ -340,16 +340,21 @@ struct BufferAddressInfillUpdateOps {
     const Mapped &insert_value;
 };
 
-std::shared_ptr<BUFFER_STATE> ValidationStateTracker::CreateBufferState(VkBuffer buf, const VkBufferCreateInfo* pCreateInfo) {
-    return std::make_shared<BUFFER_STATE>(this, buf, pCreateInfo);
-}
-
 void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
                                                         const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer,
                                                         const RecordObject &record_obj) {
     if (record_obj.result != VK_SUCCESS) return;
 
-    std::shared_ptr<BUFFER_STATE> buffer_state = CreateBufferState(*pBuffer, pCreateInfo);
+    std::shared_ptr<BUFFER_STATE> buffer_state;
+    if (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
+        if (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) {
+            buffer_state = std::make_shared<BUFFER_STATE_SPARSE<true>>(this, *pBuffer, pCreateInfo);
+        } else {
+            buffer_state = std::make_shared<BUFFER_STATE_SPARSE<false>>(this, *pBuffer, pCreateInfo);
+        }
+    } else {
+        buffer_state = std::make_shared<BUFFER_STATE_LINEAR>(this, *pBuffer, pCreateInfo);
+    }
 
     if (pCreateInfo) {
         const auto *opaque_capture_address = LvlFindInChain<VkBufferOpaqueCaptureAddressCreateInfo>(pCreateInfo->pNext);
@@ -379,13 +384,6 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
     Add(std::move(buffer_state));
 }
 
-std::shared_ptr<BUFFER_VIEW_STATE> ValidationStateTracker::CreateBufferViewState(const std::shared_ptr<BUFFER_STATE> &bf,
-                                                                                 VkBufferView bv,
-                                                                                 const VkBufferViewCreateInfo *ci,
-                                                                                 VkFormatFeatureFlags2KHR buf_ff) {
-    return std::make_shared<BUFFER_VIEW_STATE>(bf, bv, ci, buf_ff);
-}
-
 void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
                                                             const VkAllocationCallbacks *pAllocator, VkBufferView *pView,
                                                             const RecordObject &record_obj) {
@@ -405,13 +403,7 @@ void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, con
         buffer_features = format_properties.bufferFeatures;
     }
 
-    Add(CreateBufferViewState(buffer_state, *pView, pCreateInfo, buffer_features));
-}
-
-std::shared_ptr<IMAGE_VIEW_STATE> ValidationStateTracker::CreateImageViewState(
-    const std::shared_ptr<IMAGE_STATE> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci, VkFormatFeatureFlags2KHR ff,
-    const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props) {
-    return std::make_shared<IMAGE_VIEW_STATE>(image_state, iv, ci, ff, cubic_props);
+    Add(std::make_shared<BUFFER_VIEW_STATE>(buffer_state, *pView, pCreateInfo, buffer_features));
 }
 
 void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
@@ -448,7 +440,7 @@ void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, cons
         DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_format_properties);
     }
 
-    Add(CreateImageViewState(image_state, *pView, pCreateInfo, format_features, filter_cubic_props));
+    Add(std::make_shared<IMAGE_VIEW_STATE>(image_state, *pView, pCreateInfo, format_features, filter_cubic_props));
 }
 
 void ValidationStateTracker::PreCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
@@ -2691,14 +2683,10 @@ void ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice
     crtpl_state->pipe_state.clear();
 }
 
-std::shared_ptr<SAMPLER_STATE> ValidationStateTracker::CreateSamplerState(VkSampler s, const VkSamplerCreateInfo *ci) {
-    return std::make_shared<SAMPLER_STATE>(s, ci);
-}
-
 void ValidationStateTracker::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
                                                          const VkAllocationCallbacks *pAllocator, VkSampler *pSampler,
                                                          const RecordObject &record_obj) {
-    Add(CreateSamplerState(*pSampler, pCreateInfo));
+    Add(std::make_shared<SAMPLER_STATE>(pSampler, pCreateInfo));
     if (pCreateInfo->borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
         pCreateInfo->borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) {
         custom_border_color_sampler_count++;
@@ -3005,24 +2993,15 @@ void ValidationStateTracker::PostCallRecordCmdSetViewportShadingRatePaletteNV(Vk
     cb_state->dynamic_state_value.shading_rate_palette_count = viewportCount;
 }
 
-std::shared_ptr<ACCELERATION_STRUCTURE_STATE> ValidationStateTracker::CreateAccelerationStructureState(
-    VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV *ci) {
-    return std::make_shared<ACCELERATION_STRUCTURE_STATE>(device, as, ci);
-}
-
 void ValidationStateTracker::PostCallRecordCreateAccelerationStructureNV(VkDevice device,
                                                                          const VkAccelerationStructureCreateInfoNV *pCreateInfo,
                                                                          const VkAllocationCallbacks *pAllocator,
                                                                          VkAccelerationStructureNV *pAccelerationStructure,
                                                                          const RecordObject &record_obj) {
     if (VK_SUCCESS != record_obj.result) return;
-    Add(CreateAccelerationStructureState(*pAccelerationStructure, pCreateInfo));
-}
-
-std::shared_ptr<ACCELERATION_STRUCTURE_STATE_KHR> ValidationStateTracker::CreateAccelerationStructureState(
-    VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci, std::shared_ptr<BUFFER_STATE> &&buf_state,
-    VkDeviceAddress address) {
-    return std::make_shared<ACCELERATION_STRUCTURE_STATE_KHR>(as, ci, std::move(buf_state), address);
+    std::shared_ptr<ACCELERATION_STRUCTURE_STATE> state =
+        std::make_shared<ACCELERATION_STRUCTURE_STATE_LINEAR>(device, *pAccelerationStructure, pCreateInfo);
+    Add(std::move(state));
 }
 
 void ValidationStateTracker::PostCallRecordCreateAccelerationStructureKHR(VkDevice device,
@@ -3035,7 +3014,8 @@ void ValidationStateTracker::PostCallRecordCreateAccelerationStructureKHR(VkDevi
     auto as_address_info = LvlInitStruct<VkAccelerationStructureDeviceAddressInfoKHR>();
     as_address_info.accelerationStructure = *pAccelerationStructure;
     const VkDeviceAddress as_address = DispatchGetAccelerationStructureDeviceAddressKHR(device, &as_address_info);
-    Add(CreateAccelerationStructureState(*pAccelerationStructure, pCreateInfo, std::move(buffer_state), as_address));
+    Add(std::make_shared<ACCELERATION_STRUCTURE_STATE_KHR>(*pAccelerationStructure, pCreateInfo, std::move(buffer_state),
+                                                           as_address));
 }
 
 void ValidationStateTracker::PostCallRecordBuildAccelerationStructuresKHR(

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -4344,13 +4344,13 @@ std::shared_ptr<SWAPCHAIN_NODE> SyncValidator::CreateSwapchainState(const VkSwap
 
 std::shared_ptr<IMAGE_STATE> SyncValidator::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
                                                              VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<ImageState>(this, img, pCreateInfo, features);
+    return CreateImageStateImpl<ImageStateBindingTraits<ImageState>>(img, pCreateInfo, features);
 }
 
 std::shared_ptr<IMAGE_STATE> SyncValidator::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
                                                              VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                              VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<ImageState>(this, img, pCreateInfo, swapchain, swapchain_index, features);
+    return CreateImageStateImpl<ImageStateBindingTraits<ImageState>>(img, pCreateInfo, swapchain, swapchain_index, features);
 }
 
 bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,


### PR DESCRIPTION
This reverts commit 1d1317e5761d926560a9ce11815483c6d73efeaa.

It is causing crashes in some internal tests.