### PR TITLE
layers: Hash ResourceInterfaceVariable descriptor members

### DIFF
--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -349,7 +349,7 @@ bool BestPractices::ValidateCreateComputePipelineArm(const VkComputePipelineCrea
     // or we may have a linearly tiled image, but these cases are quite unlikely in practice.
     bool accesses_2d = false;
     for (const auto& variable : entrypoint->resource_interface_variables) {
-        if (variable.image_dim != spv::Dim1D && variable.image_dim != spv::DimBuffer) {
+        if (variable.info.image_dim != spv::Dim1D && variable.info.image_dim != spv::DimBuffer) {
             accesses_2d = true;
             break;
         }

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2437,7 +2437,7 @@ bool CoreChecks::PreCallValidateCreateShaderModule(VkDevice device, const VkShad
             cache = CastFromHandle<ValidationCache *>(core_validation_cache);
         }
         if (cache) {
-            hash = hash_util::shader_hash(pCreateInfo->pCode, pCreateInfo->codeSize);
+            hash = hash_util::ShaderHash(pCreateInfo->pCode, pCreateInfo->codeSize);
             if (cache->Contains(hash)) {
                 return false;
             }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -879,7 +879,7 @@ class CoreChecks : public ValidationStateTracker {
         bool record_time_validate;
         std::optional<vvl::unordered_map<VkImageView, VkImageLayout>>& checked_layouts;
     };
-    using DescriptorBindingInfo = std::pair<const uint32_t, DescriptorRequirement>;
+    using DescriptorBindingInfo = vvl::map_entry<uint32_t, DescriptorRequirement>;
 
     bool ValidateDescriptorSetBindingData(const DescriptorContext& context, const DescriptorBindingInfo& binding_info,
                                           const cvdescriptorset::DescriptorBinding& binding) const;

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -140,7 +140,7 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
         object_name_infos.push_back(object_name_info);
     }
 
-    const uint32_t message_id_number = text_vuid ? hash_util::vuid_hash(text_vuid) : 0U;
+    const uint32_t message_id_number = text_vuid ? hash_util::VuidHash(text_vuid) : 0U;
 
     VkDebugUtilsMessengerCallbackDataEXT callback_data = vku::InitStructHelper();
     callback_data.flags = 0;
@@ -341,7 +341,7 @@ static bool LogMsgEnabled(const debug_report_data *debug_data, std::string_view 
         return false;
     }
     // If message is in filter list, bail out very early
-    const uint32_t message_id = hash_util::vuid_hash(vuid_text);
+    const uint32_t message_id = hash_util::VuidHash(vuid_text);
     if (debug_data->filter_message_ids.find(message_id) != debug_data->filter_message_ids.end()) {
         return false;
     }

--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -1006,7 +1006,7 @@ void GpuAssistedBase::PreCallRecordPipelineCreations(uint32_t count, const Creat
                         bool pass = false;
                         if (gpuav_settings.cache_instrumented_shaders) {
                             csm_state.unique_shader_id =
-                                hash_util::shader_hash(module_state->spirv->words_.data(), module_state->spirv->words_.size());
+                                hash_util::ShaderHash(module_state->spirv->words_.data(), module_state->spirv->words_.size());
                             auto it = instrumented_shaders.find(csm_state.unique_shader_id);
                             if (it != instrumented_shaders.end()) {
                                 csm_state.instrumented_spirv = it->second.second;

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -1246,7 +1246,7 @@ void GpuAssisted::PreCallRecordCreateShaderModule(VkDevice device, const VkShade
     if (gpuav_settings.select_instrumented_shaders && !CheckForGpuAvEnabled(pCreateInfo->pNext)) return;
     uint32_t shader_id;
     if (gpuav_settings.cache_instrumented_shaders) {
-        const uint32_t shader_hash = hash_util::shader_hash(pCreateInfo->pCode, pCreateInfo->codeSize);
+        const uint32_t shader_hash = hash_util::ShaderHash(pCreateInfo->pCode, pCreateInfo->codeSize);
         if (gpuav_settings.cache_instrumented_shaders && CheckForCachedInstrumentedShader(shader_hash, csm_state)) {
             return;
         }
@@ -1278,7 +1278,7 @@ void GpuAssisted::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t create
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         if (gpuav_settings.select_instrumented_shaders && !CheckForGpuAvEnabled(pCreateInfos[i].pNext)) continue;
         if (gpuav_settings.cache_instrumented_shaders) {
-            const uint32_t shader_hash = hash_util::shader_hash(pCreateInfos[i].pCode, pCreateInfos[i].codeSize);
+            const uint32_t shader_hash = hash_util::ShaderHash(pCreateInfos[i].pCode, pCreateInfos[i].codeSize);
             if (CheckForCachedInstrumentedShader(i, csm_state->unique_shader_ids[i], csm_state)) {
                 continue;
             }

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -290,7 +290,7 @@ void CreateFilterMessageIdList(std::string raw_id_list, const std::string &delim
         token = GetNextToken(&raw_id_list, delimiter, &pos);
         uint32_t int_id = TokenToUint(token);
         if (int_id == 0) {
-            const uint32_t id_hash = hash_util::vuid_hash(token);
+            const uint32_t id_hash = hash_util::VuidHash(token);
             if (id_hash != 0) {
                 int_id = id_hash;
             }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -328,7 +328,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     std::shared_ptr<const CMD_BUFFER_STATE> shared_from_this() const { return SharedFromThisImpl(this); }
     std::shared_ptr<CMD_BUFFER_STATE> shared_from_this() { return SharedFromThisImpl(this); }
 
-    using DescriptorBindingInfo = std::pair<const uint32_t, DescriptorRequirement>;
+    using DescriptorBindingInfo = vvl::map_entry<uint32_t, DescriptorRequirement>;
     struct CmdDrawDispatchInfo {
         Func command;
         std::vector<DescriptorBindingInfo> binding_infos;

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -175,7 +175,7 @@ using DescriptorSetLayoutId = cvdescriptorset::DescriptorSetLayoutId;
 cvdescriptorset::DescriptorSetLayoutDict descriptor_set_layout_dict;
 
 DescriptorSetLayoutId GetCanonicalId(const VkDescriptorSetLayoutCreateInfo *p_create_info) {
-    return descriptor_set_layout_dict.look_up(DescriptorSetLayoutDef(p_create_info));
+    return descriptor_set_layout_dict.LookUp(DescriptorSetLayoutDef(p_create_info));
 }
 
 // Construct DescriptorSetLayout instance from given create info

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -65,7 +65,7 @@ bool PipelineLayoutCompatDef::operator==(const PipelineLayoutCompatDef &other) c
 
 static PipelineLayoutCompatId GetCanonicalId(const uint32_t set_index, const PushConstantRangesId &pcr_id,
                                              const PipelineLayoutSetLayoutsId &set_layouts_id) {
-    return pipeline_layout_compat_dict.look_up(PipelineLayoutCompatDef(set_index, pcr_id, set_layouts_id));
+    return pipeline_layout_compat_dict.LookUp(PipelineLayoutCompatDef(set_index, pcr_id, set_layouts_id));
 }
 
 // For repeatable sorting, not very useful for "memory in range" search
@@ -86,7 +86,7 @@ struct PushConstantRangeCompare {
 PushConstantRangesId GetCanonicalId(uint32_t pushConstantRangeCount, const VkPushConstantRange *pPushConstantRanges) {
     if (!pPushConstantRanges) {
         // Hand back the empty entry (creating as needed)...
-        return push_constant_ranges_dict.look_up(PushConstantRanges());
+        return push_constant_ranges_dict.LookUp(PushConstantRanges());
     }
 
     // Sort the input ranges to ensure equivalent ranges map to the same id
@@ -100,7 +100,7 @@ PushConstantRangesId GetCanonicalId(uint32_t pushConstantRangeCount, const VkPus
     for (const auto *range : sorted) {
         ranges.emplace_back(*range);
     }
-    return push_constant_ranges_dict.look_up(std::move(ranges));
+    return push_constant_ranges_dict.LookUp(std::move(ranges));
 }
 
 static PushConstantRangesId GetPushConstantRangesFromLayouts(const vvl::span<const PIPELINE_LAYOUT_STATE *const> &layouts) {
@@ -172,7 +172,7 @@ std::vector<PipelineLayoutCompatId> GetCompatForSet(
             set_layout_ids[i] = set_layouts[i]->GetLayoutId();
         }
     }
-    auto set_layouts_id = pipeline_layout_set_layouts_dict.look_up(set_layout_ids);
+    auto set_layouts_id = pipeline_layout_set_layouts_dict.LookUp(set_layout_ids);
 
     std::vector<PipelineLayoutCompatId> set_compat_ids;
     set_compat_ids.reserve(set_layouts.size());

--- a/layers/utils/hash_util.cpp
+++ b/layers/utils/hash_util.cpp
@@ -32,14 +32,19 @@ static_assert(XXH_VERSION_RELEASE == 2);
 
 namespace hash_util {
 
-uint32_t vuid_hash(std::string_view vuid) {
+uint32_t VuidHash(std::string_view vuid) {
     constexpr uint32_t seed = 8;
     return XXH32(vuid.data(), vuid.size(), seed);
 }
 
-uint32_t shader_hash(const void *pCode, const size_t codeSize) {
+uint32_t ShaderHash(const void *pCode, const size_t codeSize) {
     constexpr uint32_t seed = 0;
     return XXH32(pCode, codeSize, seed);
+}
+
+uint64_t DescriptorVariableHash(const void *info, const size_t info_size) {
+    constexpr uint64_t seed = 0;
+    return XXH64(info, info_size, seed);
 }
 
 }  // namespace hash_util

--- a/layers/utils/hash_util.h
+++ b/layers/utils/hash_util.h
@@ -32,7 +32,7 @@ namespace hash_util {
 
 // True iff both pointers are null or both are non-null
 template <typename T>
-bool similar_for_nullity(const T *const lhs, const T *const rhs) {
+bool SimilarForNullity(const T *const lhs, const T *const rhs) {
     return ((lhs != nullptr) && (rhs != nullptr)) || ((lhs == nullptr) && (rhs == nullptr));
 }
 
@@ -133,7 +133,7 @@ class Dictionary {
     // Find the unique entry match the provided value, adding if needed
     // TODO: segregate lookup from insert, using reader/write locks to reduce contention -- if needed
     template <typename U = T>
-    Id look_up(U &&value) {
+    Id LookUp(U &&value) {
         // We create an Id from the value, which will either be retained by dict (if new) or deleted on return (if extant)
         Id from_input = std::make_shared<T>(std::forward<U>(value));
 
@@ -158,8 +158,10 @@ class Dictionary {
     Dict dict;
 };
 
-uint32_t vuid_hash(std::string_view vuid);
+uint32_t VuidHash(std::string_view vuid);
 
-uint32_t shader_hash(const void *pCode, const size_t codeSize);
+uint32_t ShaderHash(const void *pCode, const size_t codeSize);
+
+uint64_t DescriptorVariableHash(const void *info, const size_t info_size);
 
 }  // namespace hash_util

--- a/layers/utils/hash_vk_types.h
+++ b/layers/utils/hash_vk_types.h
@@ -30,7 +30,7 @@
 static inline bool operator==(const safe_VkDescriptorSetLayoutBinding &lhs, const safe_VkDescriptorSetLayoutBinding &rhs) {
     if ((lhs.binding != rhs.binding) || (lhs.descriptorType != rhs.descriptorType) ||
         (lhs.descriptorCount != rhs.descriptorCount) || (lhs.stageFlags != rhs.stageFlags) ||
-        !hash_util::similar_for_nullity(lhs.pImmutableSamplers, rhs.pImmutableSamplers)) {
+        !hash_util::SimilarForNullity(lhs.pImmutableSamplers, rhs.pImmutableSamplers)) {
         return false;
     }
     if (lhs.pImmutableSamplers) {  // either one will do as they *are* similar for nullity (i.e. either both null or both non-null)

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -82,37 +82,7 @@ void GetActiveSlots(ActiveSlotMap &active_slots, const std::shared_ptr<const Ent
         // While validating shaders capture which slots are used by the pipeline
         auto &entry = active_slots[variable.decorations.set][variable.decorations.binding];
         entry.variable = &variable;
-
-        auto &reqs = entry.reqs;
-        if (variable.is_atomic_operation) reqs |= DESCRIPTOR_REQ_VIEW_ATOMIC_OPERATION;
-        if (variable.is_sampler_sampled) reqs |= DESCRIPTOR_REQ_SAMPLER_SAMPLED;
-        if (variable.is_sampler_implicitLod_dref_proj) reqs |= DESCRIPTOR_REQ_SAMPLER_IMPLICITLOD_DREF_PROJ;
-        if (variable.is_sampler_bias_offset) reqs |= DESCRIPTOR_REQ_SAMPLER_BIAS_OFFSET;
-        if (variable.is_read_without_format) reqs |= DESCRIPTOR_REQ_IMAGE_READ_WITHOUT_FORMAT;
-        if (variable.is_write_without_format) reqs |= DESCRIPTOR_REQ_IMAGE_WRITE_WITHOUT_FORMAT;
-        if (variable.is_dref) reqs |= DESCRIPTOR_REQ_IMAGE_DREF;
-
-        if (variable.image_format_type == NumericTypeFloat) reqs |= DESCRIPTOR_REQ_COMPONENT_TYPE_FLOAT;
-        if (variable.image_format_type == NumericTypeSint) reqs |= DESCRIPTOR_REQ_COMPONENT_TYPE_SINT;
-        if (variable.image_format_type == NumericTypeUint) reqs |= DESCRIPTOR_REQ_COMPONENT_TYPE_UINT;
-
-        if (variable.image_dim == spv::Dim1D) {
-            reqs |= (variable.is_image_array) ? DESCRIPTOR_REQ_VIEW_TYPE_1D_ARRAY : DESCRIPTOR_REQ_VIEW_TYPE_1D;
-        }
-
-        if (variable.image_dim == spv::Dim2D) {
-            reqs |= (variable.is_multisampled) ? DESCRIPTOR_REQ_MULTI_SAMPLE : DESCRIPTOR_REQ_SINGLE_SAMPLE;
-            reqs |= (variable.is_image_array) ? DESCRIPTOR_REQ_VIEW_TYPE_2D_ARRAY : DESCRIPTOR_REQ_VIEW_TYPE_2D;
-        }
-
-        if (variable.image_dim == spv::Dim3D) reqs |= DESCRIPTOR_REQ_VIEW_TYPE_3D;
-
-        if (variable.image_dim == spv::DimCube) {
-            reqs |= (variable.is_image_array) ? DESCRIPTOR_REQ_VIEW_TYPE_CUBE_ARRAY : DESCRIPTOR_REQ_VIEW_TYPE_CUBE;
-        }
-        if (variable.image_dim == spv::DimSubpassData) {
-            reqs |= (variable.is_multisampled) ? DESCRIPTOR_REQ_MULTI_SAMPLE : DESCRIPTOR_REQ_SINGLE_SAMPLE;
-        }
+        entry.revalidate_hash = variable.descriptor_hash;
     }
 }
 

--- a/layers/utils/shader_utils.h
+++ b/layers/utils/shader_utils.h
@@ -32,40 +32,12 @@ struct DeviceFeatures;
 struct DeviceExtensions;
 class APIVersion;
 
-enum DescriptorReqBits {
-    DESCRIPTOR_REQ_VIEW_TYPE_1D = 1 << VK_IMAGE_VIEW_TYPE_1D,
-    DESCRIPTOR_REQ_VIEW_TYPE_1D_ARRAY = 1 << VK_IMAGE_VIEW_TYPE_1D_ARRAY,
-    DESCRIPTOR_REQ_VIEW_TYPE_2D = 1 << VK_IMAGE_VIEW_TYPE_2D,
-    DESCRIPTOR_REQ_VIEW_TYPE_2D_ARRAY = 1 << VK_IMAGE_VIEW_TYPE_2D_ARRAY,
-    DESCRIPTOR_REQ_VIEW_TYPE_3D = 1 << VK_IMAGE_VIEW_TYPE_3D,
-    DESCRIPTOR_REQ_VIEW_TYPE_CUBE = 1 << VK_IMAGE_VIEW_TYPE_CUBE,
-    DESCRIPTOR_REQ_VIEW_TYPE_CUBE_ARRAY = 1 << VK_IMAGE_VIEW_TYPE_CUBE_ARRAY,
-
-    DESCRIPTOR_REQ_ALL_VIEW_TYPE_BITS = (1 << (VK_IMAGE_VIEW_TYPE_CUBE_ARRAY + 1)) - 1,
-
-    DESCRIPTOR_REQ_SINGLE_SAMPLE = 2 << VK_IMAGE_VIEW_TYPE_CUBE_ARRAY,
-    DESCRIPTOR_REQ_MULTI_SAMPLE = DESCRIPTOR_REQ_SINGLE_SAMPLE << 1,
-
-    DESCRIPTOR_REQ_COMPONENT_TYPE_FLOAT = DESCRIPTOR_REQ_MULTI_SAMPLE << 1,
-    DESCRIPTOR_REQ_COMPONENT_TYPE_SINT = DESCRIPTOR_REQ_COMPONENT_TYPE_FLOAT << 1,
-    DESCRIPTOR_REQ_COMPONENT_TYPE_UINT = DESCRIPTOR_REQ_COMPONENT_TYPE_SINT << 1,
-
-    DESCRIPTOR_REQ_VIEW_ATOMIC_OPERATION = DESCRIPTOR_REQ_COMPONENT_TYPE_UINT << 1,
-    DESCRIPTOR_REQ_SAMPLER_SAMPLED = DESCRIPTOR_REQ_VIEW_ATOMIC_OPERATION << 1,
-    DESCRIPTOR_REQ_SAMPLER_IMPLICITLOD_DREF_PROJ = DESCRIPTOR_REQ_SAMPLER_SAMPLED << 1,
-    DESCRIPTOR_REQ_SAMPLER_BIAS_OFFSET = DESCRIPTOR_REQ_SAMPLER_IMPLICITLOD_DREF_PROJ << 1,
-    DESCRIPTOR_REQ_IMAGE_READ_WITHOUT_FORMAT = DESCRIPTOR_REQ_SAMPLER_BIAS_OFFSET << 1,
-    DESCRIPTOR_REQ_IMAGE_WRITE_WITHOUT_FORMAT = DESCRIPTOR_REQ_IMAGE_READ_WITHOUT_FORMAT << 1,
-    DESCRIPTOR_REQ_IMAGE_DREF = DESCRIPTOR_REQ_IMAGE_WRITE_WITHOUT_FORMAT << 1,
-};
-typedef uint32_t DescriptorReqFlags;
-
 struct ResourceInterfaceVariable;
 
 struct DescriptorRequirement {
-    DescriptorReqFlags reqs;
+    uint64_t revalidate_hash;
     const ResourceInterfaceVariable *variable;
-    DescriptorRequirement() : reqs(0) {}
+    DescriptorRequirement() : revalidate_hash(0) {}
 };
 
 enum class ShaderObjectStage : uint32_t {
@@ -107,12 +79,16 @@ inline ShaderObjectStage VkShaderStageToShaderObjectStage(VkShaderStageFlagBits 
     return ShaderObjectStage::LAST;
 }
 
-inline bool operator==(const DescriptorRequirement &a, const DescriptorRequirement &b) noexcept { return a.reqs == b.reqs; }
+inline bool operator==(const DescriptorRequirement &a, const DescriptorRequirement &b) noexcept {
+    return a.revalidate_hash == b.revalidate_hash;
+}
 
-inline bool operator<(const DescriptorRequirement &a, const DescriptorRequirement &b) noexcept { return a.reqs < b.reqs; }
+inline bool operator<(const DescriptorRequirement &a, const DescriptorRequirement &b) noexcept {
+    return a.revalidate_hash < b.revalidate_hash;
+}
 
 // < binding index (of descriptor set) : meta data >
-typedef std::map<uint32_t, DescriptorRequirement> BindingVariableMap;
+typedef vvl::unordered_map<uint32_t, DescriptorRequirement> BindingVariableMap;
 
 // Capture which slots (set#->bindings) are actually used by the shaders of this pipeline
 using ActiveSlotMap = vvl::unordered_map<uint32_t, BindingVariableMap>;

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -356,7 +356,7 @@ TEST_F(VkLayerTest, VuidCheckForHashCollisions) {
     std::vector<uint32_t> hashes;
     hashes.reserve(num_vuids);
     for (const auto &vuid_spec_text_pair : vuid_spec_text) {
-        const uint32_t hash = hash_util::vuid_hash(vuid_spec_text_pair.vuid);
+        const uint32_t hash = hash_util::VuidHash(vuid_spec_text_pair.vuid);
         hashes.push_back(hash);
     }
     std::sort(hashes.begin(), hashes.end());
@@ -366,12 +366,12 @@ TEST_F(VkLayerTest, VuidCheckForHashCollisions) {
 
 TEST_F(VkLayerTest, VuidHashStability) {
     TEST_DESCRIPTION("Ensure stability of VUID hashes clients rely on for filtering");
-    ASSERT_TRUE(hash_util::vuid_hash("VUID-VkRenderPassCreateInfo-pNext-01963") == 0xa19880e3);
-    ASSERT_TRUE(hash_util::vuid_hash("VUID-BaryCoordKHR-BaryCoordKHR-04154") == 0xcc72e520);
-    ASSERT_TRUE(hash_util::vuid_hash("VUID-FragDepth-FragDepth-04213") == 0x840af838);
-    ASSERT_TRUE(hash_util::vuid_hash("VUID-RayTmaxKHR-RayTmaxKHR-04349") == 0x8e67514c);
-    ASSERT_TRUE(hash_util::vuid_hash("VUID-RuntimeSpirv-SubgroupUniformControlFlowKHR-06379") == 0x2f574188);
-    ASSERT_TRUE(hash_util::vuid_hash("VUID-StandaloneSpirv-MeshEXT-07111") == 0xee813cd2);
+    ASSERT_TRUE(hash_util::VuidHash("VUID-VkRenderPassCreateInfo-pNext-01963") == 0xa19880e3);
+    ASSERT_TRUE(hash_util::VuidHash("VUID-BaryCoordKHR-BaryCoordKHR-04154") == 0xcc72e520);
+    ASSERT_TRUE(hash_util::VuidHash("VUID-FragDepth-FragDepth-04213") == 0x840af838);
+    ASSERT_TRUE(hash_util::VuidHash("VUID-RayTmaxKHR-RayTmaxKHR-04349") == 0x8e67514c);
+    ASSERT_TRUE(hash_util::VuidHash("VUID-RuntimeSpirv-SubgroupUniformControlFlowKHR-06379") == 0x2f574188);
+    ASSERT_TRUE(hash_util::VuidHash("VUID-StandaloneSpirv-MeshEXT-07111") == 0xee813cd2);
 }
 
 TEST_F(VkLayerTest, VuidIdFilterString) {


### PR DESCRIPTION
This is a rehash of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5703 for removing the `DescriptorReqFlags` as it is currently a trap to not realize if some `ResourceInterfaceVariable` are changed they may not be updated and when being validated at draw time