### PR TITLE
layers: Redo "Simplify BINDABLE class hierarchy""

### DIFF
--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -969,12 +969,12 @@ class BestPractices : public ValidationStateTracker {
     }
     std::shared_ptr<IMAGE_STATE> CreateImageState(VkImage img, const VkImageCreateInfo* pCreateInfo,
                                                   VkFormatFeatureFlags2KHR features) final {
-        return CreateImageStateImpl<ImageStateBindingTraits<bp_state::Image>>(img, pCreateInfo, features);
+        return std::make_shared<bp_state::Image>(this, img, pCreateInfo, features);
     }
 
     std::shared_ptr<IMAGE_STATE> CreateImageState(VkImage img, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
                                                   uint32_t swapchain_index, VkFormatFeatureFlags2KHR features) final {
-        return CreateImageStateImpl<ImageStateBindingTraits<bp_state::Image>>(img, pCreateInfo, swapchain, swapchain_index, features);
+        return std::make_shared<bp_state::Image>(this, img, pCreateInfo, swapchain, swapchain_index, features);
     }
 
     std::shared_ptr<DESCRIPTOR_POOL_STATE> CreateDescriptorPoolState(VkDescriptorPool pool,

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -44,8 +44,16 @@ BUFFER_STATE::BUFFER_STATE(ValidationStateTracker *dev_data, VkBuffer buff, cons
       createInfo(*safe_create_info.ptr()),
       requirements(GetMemoryRequirements(dev_data, buff)),
       usage(GetBufferUsageFlags(createInfo)),
-      supported_video_profiles(
-          dev_data->video_profile_cache_.Get(dev_data, LvlFindInChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {}
+      supported_video_profiles(dev_data->video_profile_cache_.Get(dev_data, LvlFindInChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
+    if (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
+        tracker_.emplace<BindableSparseMemoryTracker>(&requirements,
+                                                      (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) != 0);
+        SetMemoryTracker(&std::get<BindableSparseMemoryTracker>(tracker_));
+    } else {
+        tracker_.emplace<BindableLinearMemoryTracker>(&requirements);
+        SetMemoryTracker(&std::get<BindableLinearMemoryTracker>(tracker_));
+    }
+}
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
 static bool GetMetalExport(const VkBufferViewCreateInfo *info) {

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -90,8 +90,20 @@ struct MEM_BINDING {
 
 class BindableMemoryTracker {
   public:
-    using BoundMemoryRange = std::map<VkDeviceMemory, std::vector<sparse_container::range<VkDeviceSize>>>;
+    using MemoryRange = sparse_container::range<VkDeviceSize>;
+    using BoundMemoryRange = std::map<VkDeviceMemory, std::vector<MemoryRange>>;
     using DeviceMemoryState = vvl::unordered_set<std::shared_ptr<DEVICE_MEMORY_STATE>>;
+
+    virtual ~BindableMemoryTracker() {}
+    // kept for backwards compatibility, only useful with the Linear tracker
+    virtual const MEM_BINDING *Binding() const = 0;
+    virtual unsigned CountDeviceMemory(VkDeviceMemory memory) const = 0;
+    virtual bool HasFullRangeBound() const = 0;
+
+    virtual void BindMemory(BASE_NODE *, std::shared_ptr<DEVICE_MEMORY_STATE> &, VkDeviceSize, VkDeviceSize, VkDeviceSize) = 0;
+
+    virtual BoundMemoryRange GetBoundMemoryRange(const MemoryRange &) const = 0;
+    virtual DeviceMemoryState GetBoundMemoryStates() const = 0;
 };
 
 // Dummy memory tracker for swapchains
@@ -99,18 +111,16 @@ class BindableNoMemoryTracker : public BindableMemoryTracker {
   public:
     BindableNoMemoryTracker(const VkMemoryRequirements *) {}
 
-    //----------------------------------------------------------------------------------------------------
-    // Kept for backwards compatibility
-    const MEM_BINDING *Binding() const { return nullptr; }
-    unsigned CountDeviceMemory(VkDeviceMemory memory) const { return 0; }
-    //----------------------------------------------------------------------------------------------------
+    const MEM_BINDING *Binding() const override { return nullptr; }
 
-    bool HasFullRangeBound() const { return true; }
+    unsigned CountDeviceMemory(VkDeviceMemory memory) const override { return 0; }
 
-    void BindMemory(BASE_NODE *, std::shared_ptr<DEVICE_MEMORY_STATE> &, VkDeviceSize, VkDeviceSize, VkDeviceSize) {}
+    bool HasFullRangeBound() const override { return true; }
 
-    BoundMemoryRange GetBoundMemoryRange(const sparse_container::range<VkDeviceSize> &) const { return BoundMemoryRange{}; }
-    DeviceMemoryState GetBoundMemoryStates() const { return DeviceMemoryState{}; }
+    void BindMemory(BASE_NODE *, std::shared_ptr<DEVICE_MEMORY_STATE> &, VkDeviceSize, VkDeviceSize, VkDeviceSize) override {}
+
+    BoundMemoryRange GetBoundMemoryRange(const MemoryRange &) const override { return BoundMemoryRange{}; }
+    DeviceMemoryState GetBoundMemoryStates() const override { return DeviceMemoryState{}; }
 };
 
 // Non sparse bindable memory tracker
@@ -118,21 +128,18 @@ class BindableLinearMemoryTracker : public BindableMemoryTracker {
   public:
     BindableLinearMemoryTracker(const VkMemoryRequirements *) {}
 
-    //----------------------------------------------------------------------------------------------------
-    // Kept for backwards compatibility
-    const MEM_BINDING *Binding() const { return binding_.memory_state ? &binding_ : nullptr; }
-    unsigned CountDeviceMemory(VkDeviceMemory memory) const {
+    const MEM_BINDING *Binding() const override { return binding_.memory_state ? &binding_ : nullptr; }
+    unsigned CountDeviceMemory(VkDeviceMemory memory) const override {
         return binding_.memory_state && binding_.memory_state->deviceMemory() == memory ? 1 : 0;
     }
-    //----------------------------------------------------------------------------------------------------
 
-    bool HasFullRangeBound() const { return binding_.memory_state != nullptr; }
+    bool HasFullRangeBound() const override { return binding_.memory_state != nullptr; }
 
     void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem_state, VkDeviceSize memory_offset,
-                    VkDeviceSize resource_offset, VkDeviceSize size);
+                    VkDeviceSize resource_offset, VkDeviceSize size) override;
 
-    BoundMemoryRange GetBoundMemoryRange(const sparse_container::range<VkDeviceSize> &range) const;
-    DeviceMemoryState GetBoundMemoryStates() const;
+    BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
+    DeviceMemoryState GetBoundMemoryStates() const override;
 
   private:
     MEM_BINDING binding_;
@@ -140,184 +147,57 @@ class BindableLinearMemoryTracker : public BindableMemoryTracker {
 
 // Sparse bindable memory tracker
 // Does not contemplate the idea of multiplanar sparse images
-template <bool IS_RESIDENT>
 class BindableSparseMemoryTracker : public BindableMemoryTracker {
   public:
-    BindableSparseMemoryTracker(const VkMemoryRequirements *requirements) : resource_size_(requirements->size) {}
+    BindableSparseMemoryTracker(const VkMemoryRequirements *requirements, bool is_resident)
+        : resource_size_(requirements->size), is_resident_(is_resident) {}
 
-    //----------------------------------------------------------------------------------------------------
-    // Kept for backwards compatibility
-    const MEM_BINDING *Binding() const { return nullptr; }
-    unsigned CountDeviceMemory(VkDeviceMemory memory) const {
-        unsigned count = 0u;
-        {
-            auto guard = ReadLockGuard{binding_lock_};
-            for (const auto &range_state : binding_map_) {
-                count += (range_state.second.memory_state && range_state.second.memory_state->deviceMemory() == memory);
-            }
-        }
+    const MEM_BINDING *Binding() const override { return nullptr; }
 
-        return count;
-    }
-    //----------------------------------------------------------------------------------------------------
+    unsigned CountDeviceMemory(VkDeviceMemory memory) const override;
 
-    bool HasFullRangeBound() const {
-        if (!IS_RESIDENT) {
-            VkDeviceSize current_offset = 0u;
-            {
-                auto guard = ReadLockGuard{binding_lock_};
-                for (const auto &range : binding_map_) {
-                    if (current_offset != range.first.begin || !range.second.memory_state || range.second.memory_state->Invalid()) {
-                        return false;
-                    }
-                    current_offset = range.first.end;
-                }
-            }
-
-            if (current_offset != resource_size_) return false;
-        }
-
-        return true;
-    }
+    bool HasFullRangeBound() const override;
 
     void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem_state, VkDeviceSize memory_offset,
-                    VkDeviceSize resource_offset, VkDeviceSize size) {
-        MEM_BINDING memory_data{mem_state, memory_offset, resource_offset};
-        BindingMap::value_type item{{resource_offset, resource_offset + size}, memory_data};
+                    VkDeviceSize resource_offset, VkDeviceSize size) override;
 
-        auto guard = WriteLockGuard{binding_lock_};
+    BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
 
-        // Since we don't know which ranges will be removed, we need to unbind everything and rebind later
-        for (auto &value_pair : binding_map_) {
-            if (value_pair.second.memory_state) value_pair.second.memory_state->RemoveParent(parent);
-        }
-        binding_map_.overwrite_range(item);
-
-        for (auto &value_pair : binding_map_) {
-            if (value_pair.second.memory_state) value_pair.second.memory_state->AddParent(parent);
-        }
-    }
-
-    BoundMemoryRange GetBoundMemoryRange(const sparse_container::range<VkDeviceSize> &range) const {
-        BoundMemoryRange mem_ranges;
-        {
-            auto guard = ReadLockGuard{binding_lock_};
-            auto range_bounds = binding_map_.bounds(range);
-
-            for (auto it = range_bounds.begin; it != range_bounds.end; ++it) {
-                const auto &[resource_range, memory_data] = *it;
-                if (memory_data.memory_state && memory_data.memory_state->deviceMemory() != VK_NULL_HANDLE) {
-                    const VkDeviceSize memory_range_start = std::max(range.begin, memory_data.resource_offset) -
-                                                            memory_data.resource_offset + memory_data.memory_offset;
-                    const VkDeviceSize memory_range_end =
-                        std::min(range.end, memory_data.resource_offset + resource_range.distance()) - memory_data.resource_offset +
-                        memory_data.memory_offset;
-
-                    mem_ranges[memory_data.memory_state->deviceMemory()].emplace_back(memory_range_start, memory_range_end);
-                }
-            }
-        }
-        return mem_ranges;
-    }
-
-    DeviceMemoryState GetBoundMemoryStates() const {
-        DeviceMemoryState dev_mem_states;
-
-        {
-            auto guard = ReadLockGuard{binding_lock_};
-            for (auto &binding : binding_map_) {
-                if (binding.second.memory_state) dev_mem_states.emplace(binding.second.memory_state);
-            }
-        }
-
-        return dev_mem_states;
-    }
+    DeviceMemoryState GetBoundMemoryStates() const override;
 
   private:
     // This range map uses the range in resource space to know the size of the bound memory
     using BindingMap = sparse_container::range_map<VkDeviceSize, MEM_BINDING>;
     BindingMap binding_map_;
-    VkDeviceSize resource_size_;
     mutable std::shared_mutex binding_lock_;
+    VkDeviceSize resource_size_;
+    bool is_resident_;
 };
 
 // Non sparse multi planar bindable memory tracker
-template <unsigned TRACKING_COUNT>
 class BindableMultiplanarMemoryTracker : public BindableMemoryTracker {
   public:
-    BindableMultiplanarMemoryTracker(const VkMemoryRequirements *requirements) {
-        for (unsigned i = 0; i < TRACKING_COUNT; ++i) {
-            plane_size_[i] = requirements[i].size;
-        }
-    }
+    BindableMultiplanarMemoryTracker(const VkMemoryRequirements *requirements, uint32_t num_planes);
 
-    //----------------------------------------------------------------------------------------------------
-    // Kept for backwards compatibility
-    const MEM_BINDING *Binding() const { return nullptr; }
-    unsigned CountDeviceMemory(VkDeviceMemory memory) const {
-        unsigned count = 0u;
-        for (unsigned i = 0u; i < TRACKING_COUNT; ++i) {
-            count += (bindings_[i].memory_state && bindings_[i].memory_state->deviceMemory() == memory);
-        }
+    const MEM_BINDING *Binding() const override { return nullptr; }
 
-        return count;
-    }
-    //----------------------------------------------------------------------------------------------------
+    unsigned CountDeviceMemory(VkDeviceMemory memory) const override;
 
-    bool HasFullRangeBound() const {
-        bool full_range_bound = true;
+    bool HasFullRangeBound() const override;
 
-        for (unsigned i = 0u; i < TRACKING_COUNT; ++i) {
-            full_range_bound &= (bindings_[i].memory_state != nullptr);
-        }
-
-        return full_range_bound;
-    }
-
-    // resource_offset is the plane index
     void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem_state, VkDeviceSize memory_offset,
-                    VkDeviceSize resource_offset, VkDeviceSize size) {
-        if (!mem_state) return;
+                    VkDeviceSize resource_offset, VkDeviceSize size) override;
 
-        mem_state->AddParent(parent);
-        bindings_[resource_offset] = {mem_state, memory_offset, 0u};
-    }
+    BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
 
-    // range needs to be between [0, resource_size_[0] + resource_size_[1] + resource_size_[2])
-    // To access plane 0 range must be [0, plane_size_[0])
-    // To access plane 1 range must be [plane_size_[0], plane_size_[1])
-    // To access plane 2 range must be [plane_size_[1], plane_size_[2])
-    BoundMemoryRange GetBoundMemoryRange(const sparse_container::range<VkDeviceSize> &range) const {
-        BoundMemoryRange mem_ranges;
-        VkDeviceSize start_offset = 0u;
-        for (unsigned i = 0u; i < TRACKING_COUNT; ++i) {
-            sparse_container::range<VkDeviceSize> plane_range{start_offset, start_offset + plane_size_[i]};
-            if (bindings_[i].memory_state && range.intersects(plane_range)) {
-                VkDeviceSize range_end = range.end > plane_range.end ? plane_range.end : range.end;
-                mem_ranges[bindings_[i].memory_state->deviceMemory()].emplace_back(sparse_container::range<VkDeviceSize>{
-                    bindings_[i].memory_offset + range.begin, bindings_[i].memory_offset + range_end});
-            }
-            start_offset += plane_size_[i];
-        }
-
-        return mem_ranges;
-    }
-
-    DeviceMemoryState GetBoundMemoryStates() const {
-        DeviceMemoryState dev_mem_states;
-
-        for (unsigned i = 0u; i < TRACKING_COUNT; ++i) {
-            if (bindings_[i].memory_state) {
-                dev_mem_states.insert(bindings_[i].memory_state);
-            }
-        }
-
-        return dev_mem_states;
-    }
+    DeviceMemoryState GetBoundMemoryStates() const override;
 
   private:
-    MEM_BINDING bindings_[TRACKING_COUNT];
-    VkDeviceSize plane_size_[TRACKING_COUNT];
+    struct Plane {
+        MEM_BINDING binding;
+        VkDeviceSize size;
+    };
+    std::vector<Plane> planes_;
 };
 
 // Superclass for bindable object state (currently images, buffers and acceleration structures)
@@ -325,7 +205,8 @@ class BINDABLE : public BASE_NODE {
   public:
     template <typename Handle>
     BINDABLE(Handle h, VulkanObjectType t, bool is_sparse, bool is_unprotected, VkExternalMemoryHandleTypeFlags handle_types)
-        : BASE_NODE(h, t), external_memory_handle_types(handle_types), sparse(is_sparse), unprotected(is_unprotected) {}
+        : BASE_NODE(h, t), external_memory_handle_types(handle_types), sparse(is_sparse), unprotected(is_unprotected),
+          memory_tracker_(nullptr) {}
 
     virtual ~BINDABLE() {
         if (!Destroyed()) {
@@ -333,7 +214,13 @@ class BINDABLE : public BASE_NODE {
         }
     }
 
-    void Destroy() override { BASE_NODE::Destroy(); }
+    void Destroy() override {
+        for (auto &state : memory_tracker_->GetBoundMemoryStates()) {
+            state->RemoveParent(this);
+        }
+
+        BASE_NODE::Destroy();
+    }
 
     bool IsExternalAHB() const {
         return (external_memory_handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) != 0;
@@ -372,113 +259,48 @@ class BINDABLE : public BASE_NODE {
     }
 
     // Implemented by template class MemoryTrackedResource that has a BindableMemoryTracker with each needed function
-    virtual void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem, const VkDeviceSize memory_offset,
-                            const VkDeviceSize resource_offset, const VkDeviceSize mem_size) = 0;
-    virtual bool HasFullRangeBound() const = 0;
-    virtual std::pair<VkDeviceMemory, sparse_container::range<VkDeviceSize>> GetResourceMemoryOverlap(
-        const sparse_container::range<VkDeviceSize> &memory_region, const BINDABLE *other_resource,
-        const sparse_container::range<VkDeviceSize> &other_memory_region) const = 0;
-    bool DoesResourceMemoryOverlap(const sparse_container::range<VkDeviceSize> &memory_region, const BINDABLE *other_resource,
-                                   const sparse_container::range<VkDeviceSize> &other_memory_region) const {
+    void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &mem, const VkDeviceSize memory_offset,
+                            const VkDeviceSize resource_offset, const VkDeviceSize mem_size) {
+        memory_tracker_->BindMemory(parent, mem, memory_offset, resource_offset, mem_size);
+    }
+
+    bool HasFullRangeBound() const { return memory_tracker_->HasFullRangeBound(); }
+
+    std::pair<VkDeviceMemory, BindableMemoryTracker::MemoryRange> GetResourceMemoryOverlap(
+        const BindableMemoryTracker::MemoryRange &memory_region, const BINDABLE *other_resource,
+        const BindableMemoryTracker::MemoryRange &other_memory_region) const;
+
+    bool DoesResourceMemoryOverlap(const BindableMemoryTracker::MemoryRange &memory_region, const BINDABLE *other_resource,
+                                   const BindableMemoryTracker::MemoryRange &other_memory_region) const {
         return GetResourceMemoryOverlap(memory_region, other_resource, other_memory_region).first != VK_NULL_HANDLE;
     }
-    virtual BindableMemoryTracker::BoundMemoryRange GetBoundMemoryRange(
-        const sparse_container::range<VkDeviceSize> &range) const = 0;
-    virtual BindableMemoryTracker::DeviceMemoryState GetBoundMemoryStates() const = 0;
+
+    BindableMemoryTracker::BoundMemoryRange GetBoundMemoryRange(const BindableMemoryTracker::MemoryRange &range) const {
+        return memory_tracker_->GetBoundMemoryRange(range);
+    }
+
+    BindableMemoryTracker::DeviceMemoryState GetBoundMemoryStates() const {
+        return memory_tracker_->GetBoundMemoryStates();
+    }
+
     // Kept for compatibility
-    virtual const MEM_BINDING *Binding() const = 0;
-    virtual unsigned CountDeviceMemory(VkDeviceMemory memory) const = 0;
+    const MEM_BINDING *Binding() const { return memory_tracker_->Binding(); }
+
+    unsigned CountDeviceMemory(VkDeviceMemory memory) const { return memory_tracker_->CountDeviceMemory(memory); }
 
   protected:
-    virtual void CacheInvalidMemory() const = 0;
+    void CacheInvalidMemory() const;
 
     mutable BindableMemoryTracker::DeviceMemoryState cached_invalid_memory_;
 
+    void SetMemoryTracker(BindableMemoryTracker *tracker) { memory_tracker_ = tracker; }
   public:
     // Tracks external memory types creating resource
     const VkExternalMemoryHandleTypeFlags external_memory_handle_types;
     const bool sparse;       // Is this object being bound with sparse memory or not?
     const bool unprotected;  // can't be used for protected memory
-  protected:
-    mutable bool need_to_recache_invalid_memory_ = false;
-};
-
-template <typename BaseClass, typename MemoryTracker>
-class MEMORY_TRACKED_RESOURCE_STATE : public BaseClass {
-  public:
-    template <typename... Args>
-    MEMORY_TRACKED_RESOURCE_STATE(Args... args)
-        : BaseClass(std::forward<Args>(args)...), memory_tracker_(BaseClass::memory_requirements_pointer) {}
-
-    virtual ~MEMORY_TRACKED_RESOURCE_STATE() {
-        if (!BaseClass::Destroyed()) Destroy();
-    }
-
-    void Destroy() override {
-        for (auto &state : GetBoundMemoryStates()) {
-            state->RemoveParent(this);
-        }
-
-        BaseClass::Destroy();
-    }
-
-    void BindMemory(BASE_NODE *parent, std::shared_ptr<DEVICE_MEMORY_STATE> &memory_state, const VkDeviceSize memory_offset,
-                    const VkDeviceSize resource_offset, const VkDeviceSize memory_size) override {
-        memory_tracker_.BindMemory(parent, memory_state, memory_offset, resource_offset, memory_size);
-    }
-
-    bool HasFullRangeBound() const override { return memory_tracker_.HasFullRangeBound(); }
-
-    std::pair<VkDeviceMemory, sparse_container::range<VkDeviceSize>> GetResourceMemoryOverlap(
-        const sparse_container::range<VkDeviceSize> &memory_region, const BINDABLE *other_resource,
-        const sparse_container::range<VkDeviceSize> &other_memory_region) const override {
-        if (!other_resource) return {VK_NULL_HANDLE, {}};
-
-        auto ranges = GetBoundMemoryRange(memory_region);
-        auto other_ranges = other_resource->GetBoundMemoryRange(other_memory_region);
-
-        for (const auto &[memory, memory_ranges] : ranges) {
-            // Check if we have memory from same VkDeviceMemory bound
-            auto it = other_ranges.find(memory);
-            if (it != other_ranges.end()) {
-                // Check if any of the bound memory ranges overlap
-                for (const auto &memory_range : memory_ranges) {
-                    for (const auto &other_memory_range : it->second) {
-                        if (other_memory_range.intersects(memory_range)) {
-                            auto memory_space_intersection = other_memory_range & memory_range;
-                            return {memory, memory_space_intersection};
-                        }
-                    }
-                }
-            }
-        }
-
-        return {VK_NULL_HANDLE, {}};
-    }
-
-    BindableMemoryTracker::BoundMemoryRange GetBoundMemoryRange(const sparse_container::range<VkDeviceSize> &range) const override {
-        return memory_tracker_.GetBoundMemoryRange(range);
-    }
-
-    BindableMemoryTracker::DeviceMemoryState GetBoundMemoryStates() const override {
-        return memory_tracker_.GetBoundMemoryStates();
-    }
-
-    const MEM_BINDING *Binding() const override { return memory_tracker_.Binding(); }
-
-    unsigned CountDeviceMemory(VkDeviceMemory memory) const override { return memory_tracker_.CountDeviceMemory(memory); }
-
-  protected:
-    void CacheInvalidMemory() const override {
-        BaseClass::need_to_recache_invalid_memory_ = false;
-        BaseClass::cached_invalid_memory_.clear();
-        for (auto const &bindable : GetBoundMemoryStates()) {
-            if (bindable->Invalid()) {
-                BaseClass::cached_invalid_memory_.insert(bindable);
-            }
-        }
-    }
-
   private:
-    MemoryTracker memory_tracker_;
+    mutable bool need_to_recache_invalid_memory_ = false;
+    BindableMemoryTracker *memory_tracker_;
 };
+

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -215,6 +215,17 @@ IMAGE_STATE::IMAGE_STATE(const ValidationStateTracker *dev_data, VkImage img, co
       store_device_as_workaround(dev_data->device),  // TODO REMOVE WHEN encoder can be const
       supported_video_profiles(
           dev_data->video_profile_cache_.Get(dev_data, LvlFindInChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
+    if (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) {
+        bool is_resident = (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0;
+        tracker_.emplace<BindableSparseMemoryTracker>(requirements.data(), is_resident);
+        SetMemoryTracker(&std::get<BindableSparseMemoryTracker>(tracker_));
+    } else if (pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT) {
+        tracker_.emplace<BindableMultiplanarMemoryTracker>(requirements.data(), FormatPlaneCount(pCreateInfo->format));
+        SetMemoryTracker(&std::get<BindableMultiplanarMemoryTracker>(tracker_));
+    } else {
+        tracker_.emplace<BindableLinearMemoryTracker>(requirements.data());
+        SetMemoryTracker(&std::get<BindableLinearMemoryTracker>(tracker_));
+    }
 }
 
 IMAGE_STATE::IMAGE_STATE(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo,
@@ -249,6 +260,9 @@ IMAGE_STATE::IMAGE_STATE(const ValidationStateTracker *dev_data, VkImage img, co
           dev_data->video_profile_cache_.Get(dev_data, LvlFindInChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
     fragment_encoder =
         std::unique_ptr<const subresource_adapter::ImageRangeEncoder>(new subresource_adapter::ImageRangeEncoder(*this));
+
+    tracker_.emplace<BindableNoMemoryTracker>(requirements.data());
+    SetMemoryTracker(&std::get<BindableNoMemoryTracker>(tracker_));
 }
 
 void IMAGE_STATE::Destroy() {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <utility>
+#include <variant>
 
 #include "state_tracker/device_memory_state.h"
 #include "state_tracker/image_layout_map.h"
@@ -111,7 +112,6 @@ class IMAGE_STATE : public BINDABLE {
     static constexpr int MAX_PLANES = 3;
     using MemoryReqs = std::array<VkMemoryRequirements, MAX_PLANES>;
     const MemoryReqs requirements;
-    const VkMemoryRequirements *const memory_requirements_pointer = &requirements[0];
     std::array<bool, MAX_PLANES> memory_requirements_checked = {};
 
     const bool sparse_residency;
@@ -256,16 +256,13 @@ class IMAGE_STATE : public BINDABLE {
         }
         return false;
     }
-};
 
-template <typename ImageState>
-struct ImageStateBindingTraits {
-    using NoBinding = MEMORY_TRACKED_RESOURCE_STATE<ImageState, BindableNoMemoryTracker>;
-    using Linear = MEMORY_TRACKED_RESOURCE_STATE<ImageState, BindableLinearMemoryTracker>;
-    template <bool IS_RESIDENT>
-    using Sparse = MEMORY_TRACKED_RESOURCE_STATE<ImageState, BindableSparseMemoryTracker<IS_RESIDENT>>;
-    template <unsigned PLANE_COUNT>
-    using Multiplanar = MEMORY_TRACKED_RESOURCE_STATE<ImageState, BindableMultiplanarMemoryTracker<PLANE_COUNT>>;
+  private:
+    std::variant<std::monostate,
+                 BindableNoMemoryTracker,
+                 BindableLinearMemoryTracker,
+                 BindableSparseMemoryTracker,
+                 BindableMultiplanarMemoryTracker> tracker_;
 };
 
 // State for VkImageView objects.

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -30,7 +30,10 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
           build_scratch_memory_requirements(
               GetMemReqs(device, as, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV)),
           update_scratch_memory_requirements(
-              GetMemReqs(device, as, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV)) {}
+              GetMemReqs(device, as, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV)),
+          tracker_(&memory_requirements) {
+              BINDABLE::SetMemoryTracker(&tracker_);
+    }
     ACCELERATION_STRUCTURE_STATE(const ACCELERATION_STRUCTURE_STATE &rh_obj) = delete;
 
     VkAccelerationStructureNV acceleration_structure() const { return handle_.Cast<VkAccelerationStructureNV>(); }
@@ -45,7 +48,6 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
     const VkMemoryRequirements memory_requirements;
     const VkMemoryRequirements build_scratch_memory_requirements;
     const VkMemoryRequirements update_scratch_memory_requirements;
-    const VkMemoryRequirements *const memory_requirements_pointer = &memory_requirements;
     uint64_t opaque_handle = 0;
     bool memory_requirements_checked = false;
     bool build_scratch_memory_requirements_checked = false;
@@ -62,10 +64,8 @@ class ACCELERATION_STRUCTURE_STATE : public BINDABLE {
         DispatchGetAccelerationStructureMemoryRequirementsNV(device, &req_info, &requirements);
         return requirements.memoryRequirements;
     }
+    BindableLinearMemoryTracker tracker_;
 };
-
-using ACCELERATION_STRUCTURE_STATE_LINEAR =
-    MEMORY_TRACKED_RESOURCE_STATE<ACCELERATION_STRUCTURE_STATE, BindableLinearMemoryTracker>;
 
 class ACCELERATION_STRUCTURE_STATE_KHR : public BASE_NODE {
   public:

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -60,8 +60,8 @@ class SAMPLER_STATE : public BASE_NODE {
     const VkSamplerYcbcrConversion samplerConversion;
     const VkSamplerCustomBorderColorCreateInfoEXT customCreateInfo;
 
-    SAMPLER_STATE(const VkSampler *ps, const VkSamplerCreateInfo *pci)
-        : BASE_NODE(*ps, kVulkanObjectTypeSampler),
+    SAMPLER_STATE(const VkSampler s, const VkSamplerCreateInfo *pci)
+        : BASE_NODE(s, kVulkanObjectTypeSampler),
           createInfo(*pci),
           samplerConversion(GetConversion(pci)),
           customCreateInfo(GetCustomCreateInfo(pci)) {}

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -649,6 +649,7 @@ class ValidationStateTracker : public ValidationObject {
 
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) override;
 
+    virtual std::shared_ptr<ACCELERATION_STRUCTURE_STATE> CreateAccelerationStructureState(VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV* pCreateInfo);
     void PostCallRecordCreateAccelerationStructureNV(VkDevice device, const VkAccelerationStructureCreateInfoNV* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator,
                                                      VkAccelerationStructureNV* pAccelerationStructure,
@@ -656,6 +657,8 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroyAccelerationStructureNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
                                                      const VkAllocationCallbacks* pAllocator) override;
 
+    virtual std::shared_ptr<ACCELERATION_STRUCTURE_STATE_KHR> CreateAccelerationStructureState(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR * pCreateInfo,
+                                                                                               std::shared_ptr<BUFFER_STATE> &&buf_state, VkDeviceAddress address);
     void PostCallRecordCreateAccelerationStructureKHR(VkDevice device, const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator,
                                                       VkAccelerationStructureKHR* pAccelerationStructure,
@@ -680,9 +683,12 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroyAccelerationStructureKHR(VkDevice device, VkAccelerationStructureKHR accelerationStructure,
                                                       const VkAllocationCallbacks* pAllocator) override;
 
+    virtual std::shared_ptr<BUFFER_STATE> CreateBufferState(VkBuffer buf, const VkBufferCreateInfo* pCreateInfo);
     void PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                     VkBuffer* pBuffer, const RecordObject& record_obj) override;
     void PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator) override;
+
+    virtual std::shared_ptr<BUFFER_VIEW_STATE> CreateBufferViewState(const std::shared_ptr<BUFFER_STATE> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci, VkFormatFeatureFlags2KHR buf_ff);
     void PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
                                         const VkAllocationCallbacks* pAllocator, VkBufferView* pView,
                                         const RecordObject& record_obj) override;
@@ -791,6 +797,10 @@ class ValidationStateTracker : public ValidationObject {
     void PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                    VkImage* pImage, const RecordObject& record_obj) override;
     void PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator) override;
+
+
+    virtual std::shared_ptr<IMAGE_VIEW_STATE> CreateImageViewState(const std::shared_ptr<IMAGE_STATE> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci,
+                                                                   VkFormatFeatureFlags2KHR ff, const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props);
     void PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkImageView* pView,
                                        const RecordObject& record_obj) override;
@@ -866,6 +876,8 @@ class ValidationStateTracker : public ValidationObject {
                                                        const RecordObject& record_obj) override;
     void PreCallRecordDestroyVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters,
                                                        const VkAllocationCallbacks* pAllocator) override;
+
+    virtual std::shared_ptr<SAMPLER_STATE> CreateSamplerState(VkSampler s, const VkSamplerCreateInfo *ci);
     void PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
                                      const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
                                      const RecordObject& record_obj) override;
@@ -1807,14 +1819,6 @@ class ValidationStateTracker : public ValidationObject {
     mutable std::shared_mutex win32_handle_map_lock_;
 #endif
 
-  protected:
-    template <typename ImageStateTraits>
-    std::shared_ptr<IMAGE_STATE> CreateImageStateImpl(VkImage img, const VkImageCreateInfo* pCreateInfo,
-                                                      VkFormatFeatureFlags2KHR features);
-    template <typename ImageStateTraits>
-    std::shared_ptr<IMAGE_STATE> CreateImageStateImpl(VkImage img, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
-                                                      uint32_t swapchain_index, VkFormatFeatureFlags2KHR features);
-
   private:
     VALSTATETRACK_MAP_AND_TRAITS(VkQueue, QUEUE_STATE, queue_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE, acceleration_structure_nv_map_)
@@ -1867,43 +1871,3 @@ class ValidationStateTracker : public ValidationObject {
     FakeAllocator fake_memory;
 };
 
-template <typename ImageStateTraits>
-std::shared_ptr<IMAGE_STATE> ValidationStateTracker::CreateImageStateImpl(VkImage img, const VkImageCreateInfo* pCreateInfo,
-                                                                          VkFormatFeatureFlags2KHR features) {
-    std::shared_ptr<IMAGE_STATE> state;
-
-    if (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) {
-        if (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) {
-            state = std::make_shared<typename ImageStateTraits::template Sparse<true>>(this, img, pCreateInfo, features);
-        } else {
-            state = std::make_shared<typename ImageStateTraits::template Sparse<false>>(this, img, pCreateInfo, features);
-        }
-    } else if (pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT) {
-        uint32_t plane_count = FormatPlaneCount(pCreateInfo->format);
-        switch (plane_count) {
-            case 3:
-                state = std::make_shared<typename ImageStateTraits::template Multiplanar<3>>(this, img, pCreateInfo, features);
-                break;
-            case 2:
-                state = std::make_shared<typename ImageStateTraits::template Multiplanar<2>>(this, img, pCreateInfo, features);
-                break;
-            case 1:
-                state = std::make_shared<typename ImageStateTraits::template Multiplanar<1>>(this, img, pCreateInfo, features);
-                break;
-            default:
-                // Not supported
-                assert(false);
-        }
-    } else {
-        state = std::make_shared<typename ImageStateTraits::Linear>(this, img, pCreateInfo, features);
-    }
-
-    return state;
-}
-
-template <typename ImageStateTraits>
-std::shared_ptr<IMAGE_STATE> ValidationStateTracker::CreateImageStateImpl(VkImage img, const VkImageCreateInfo* pCreateInfo,
-                                                                          VkSwapchainKHR swapchain, uint32_t swapchain_index,
-                                                                          VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<typename ImageStateTraits::NoBinding>(this, img, pCreateInfo, swapchain, swapchain_index, features);
-}

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -4344,13 +4344,13 @@ std::shared_ptr<SWAPCHAIN_NODE> SyncValidator::CreateSwapchainState(const VkSwap
 
 std::shared_ptr<IMAGE_STATE> SyncValidator::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
                                                              VkFormatFeatureFlags2KHR features) {
-    return CreateImageStateImpl<ImageStateBindingTraits<ImageState>>(img, pCreateInfo, features);
+    return std::make_shared<ImageState>(this, img, pCreateInfo, features);
 }
 
 std::shared_ptr<IMAGE_STATE> SyncValidator::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
                                                              VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                              VkFormatFeatureFlags2KHR features) {
-    return CreateImageStateImpl<ImageStateBindingTraits<ImageState>>(img, pCreateInfo, swapchain, swapchain_index, features);
+    return std::make_shared<ImageState>(this, img, pCreateInfo, swapchain, swapchain_index, features);
 }
 
 bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,


### PR DESCRIPTION
The earlier version of this change needed to add BUFFER_STATE::Destroy() because of interactions between the memory tracker and the BINDABLE base class.