### PR TITLE
layers: Add explicit VkBufferCreateInfo usage flag VUs

### DIFF
--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "stateless/stateless_validation.h"
+#include "generated/enum_flag_bits.h"
 
 bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
                                                              const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer,
@@ -78,6 +79,12 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
                                  "VkPhysicalDeviceMaintenance4Properties.maxBufferSize (%" PRIu64 ").",
                                  pCreateInfo->size, phys_dev_ext_props.maintenance4_props.maxBufferSize);
             }
+        }
+
+        if (!LvlFindInChain<VkBufferUsageFlags2CreateInfoKHR>(pCreateInfo->pNext)) {
+            skip |= ValidateFlags(error_obj.location, "pCreateInfo->usage", "VkBufferUsageFlagBits", AllVkBufferUsageFlagBits,
+                                  pCreateInfo->usage, kRequiredFlags, "VUID-VkBufferCreateInfo-None-09205",
+                                  "VUID-VkBufferCreateInfo-None-09206");
         }
     }
 

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -784,6 +784,19 @@ TEST_F(NegativeBuffer, BufferUsageFlags2) {
     CreateBufferViewTest(*this, &buffer_view_ci, {"VUID-VkBufferViewCreateInfo-pNext-08780"});
 }
 
+TEST_F(NegativeBuffer, BufferUsageFlagsUsage) {
+    TEST_DESCRIPTION("Use bad buffer usage flag.");
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    auto buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
+    buffer_ci.size = 32;
+    buffer_ci.usage = 0;
+    CreateBufferTest(*this, &buffer_ci, {"VUID-VkBufferCreateInfo-None-09206"});
+
+    buffer_ci.usage = 0xBAD0000;
+    CreateBufferTest(*this, &buffer_ci, {"VUID-VkBufferCreateInfo-None-09205"});
+}
+
 TEST_F(NegativeBuffer, BufferUsageFlags2Subset) {
     TEST_DESCRIPTION("VkBufferUsageFlags2CreateInfoKHR that are not a subset of the Buffer.");
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -304,10 +304,8 @@ TEST_F(PositiveBuffer, BufferUsageFlags2Ignore) {
     CreateBufferTest(*this, &buffer_ci, {});
 }
 
-// Need to get VkBufferCreateInfo::usage removed from auto code generation
-// https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6066
-TEST_F(PositiveBuffer, DISABLED_BufferUsageFlags2BadUsage) {
-    TEST_DESCRIPTION("Ignore old flags if using VkBufferUsageFlags2CreateInfoKHR.");
+TEST_F(PositiveBuffer, BufferUsageFlags2Usage) {
+    TEST_DESCRIPTION("Ignore old flags if using VkBufferUsageFlags2CreateInfoKHR, even if bad.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -226,7 +226,7 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
     // Don't set VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT.
     {
         auto info = LvlInitStruct<VkBufferCreateInfo>();
-        // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
+        info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
         info.size = 4;
         VkBufferObj const buffer_obj(*m_device, info);
 
@@ -325,7 +325,7 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackEXT) {
     // Don't set VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT.
     {
         auto info = LvlInitStruct<VkBufferCreateInfo>();
-        // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
+        info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         info.size = 4;
         VkBufferObj const buffer_obj(*m_device, info);
 
@@ -420,7 +420,7 @@ TEST_F(NegativeTransformFeedback, CmdEndTransformFeedbackEXT) {
             // Don't set VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT.
             {
                 auto info = LvlInitStruct<VkBufferCreateInfo>();
-                // info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
+                info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
                 info.size = 4;
                 VkBufferObj const buffer_obj(*m_device, info);
 


### PR DESCRIPTION
redo of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6363 (realized I didn't fix the transform feedback tests)

The 1.3.262 spec removes the implicit VUs and made `VUID-VkBufferCreateInfo-None-09205` and `VUID-VkBufferCreateInfo-None-09206`