### PR TITLE
layers: Untemplate some barrier methods

### DIFF
--- a/layers/containers/qfo_transfer.h
+++ b/layers/containers/qfo_transfer.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 #include "custom_containers.h"
+#include "sync/sync_utils.h"
 #include "utils/hash_util.h"
 
 // Types to store queue family ownership (QFO) Transfers
@@ -58,17 +59,13 @@ struct QFOTransferBarrierBase {
 // Image barrier specific implementation
 struct QFOImageTransferBarrier : public QFOTransferBarrierBase<VkImage> {
     using BaseType = QFOTransferBarrierBase<VkImage>;
+    using ImageBarrier = sync_utils::ImageBarrier;
     VkImageLayout oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     VkImageLayout newLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     VkImageSubresourceRange subresourceRange;
 
     QFOImageTransferBarrier() = default;
-    QFOImageTransferBarrier(const VkImageMemoryBarrier &barrier)
-        : BaseType(barrier.image, barrier.srcQueueFamilyIndex, barrier.dstQueueFamilyIndex),
-          oldLayout(barrier.oldLayout),
-          newLayout(barrier.newLayout),
-          subresourceRange(barrier.subresourceRange) {}
-    QFOImageTransferBarrier(const VkImageMemoryBarrier2KHR &barrier)
+    QFOImageTransferBarrier(const ImageBarrier &barrier)
         : BaseType(barrier.image, barrier.srcQueueFamilyIndex, barrier.dstQueueFamilyIndex),
           oldLayout(barrier.oldLayout),
           newLayout(barrier.newLayout),
@@ -99,14 +96,11 @@ struct QFOImageTransferBarrier : public QFOTransferBarrierBase<VkImage> {
 // Buffer barrier specific implementation
 struct QFOBufferTransferBarrier : public QFOTransferBarrierBase<VkBuffer> {
     using BaseType = QFOTransferBarrierBase<VkBuffer>;
+    using BufferBarrier = sync_utils::BufferBarrier;
     VkDeviceSize offset = 0;
     VkDeviceSize size = 0;
     QFOBufferTransferBarrier() = default;
-    QFOBufferTransferBarrier(const VkBufferMemoryBarrier &barrier)
-        : BaseType(barrier.buffer, barrier.srcQueueFamilyIndex, barrier.dstQueueFamilyIndex),
-          offset(barrier.offset),
-          size(barrier.size) {}
-    QFOBufferTransferBarrier(const VkBufferMemoryBarrier2KHR &barrier)
+    QFOBufferTransferBarrier(const BufferBarrier &barrier)
         : BaseType(barrier.buffer, barrier.srcQueueFamilyIndex, barrier.dstQueueFamilyIndex),
           offset(barrier.offset),
           size(barrier.size) {}

--- a/layers/containers/qfo_transfer.h
+++ b/layers/containers/qfo_transfer.h
@@ -21,28 +21,13 @@
 #include "utils/hash_util.h"
 
 // Types to store queue family ownership (QFO) Transfers
-class COMMAND_POOL_STATE;
 
 template <typename Barrier>
 inline bool IsTransferOp(const Barrier &barrier) {
     return barrier.srcQueueFamilyIndex != barrier.dstQueueFamilyIndex;
 }
 
-// specializations for barriers that cannot do queue family ownership transfers
-template <>
-constexpr bool IsTransferOp(const VkMemoryBarrier &barrier) {
-    return false;
-}
-template <>
-constexpr bool IsTransferOp(const VkMemoryBarrier2KHR &barrier) {
-    return false;
-}
-template <>
-constexpr bool IsTransferOp(const VkSubpassDependency2 &barrier) {
-    return false;
-}
-
-static inline bool QueueFamilyIsExternal(const uint32_t queue_family_index) {
+static inline bool IsQueueFamilyExternal(const uint32_t queue_family_index) {
     return (queue_family_index == VK_QUEUE_FAMILY_EXTERNAL) || (queue_family_index == VK_QUEUE_FAMILY_FOREIGN_EXT);
 }
 

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -1003,7 +1003,7 @@ void CoreChecks::RecordTransitionImageLayout(CMD_BUFFER_STATE *cb_state, const I
     VkImageLayout new_layout = NormalizeSynchronization2Layout(mem_barrier.subresourceRange.aspectMask, mem_barrier.newLayout);
 
     // Layout transitions in external instance are not tracked, so don't validate initial layout.
-    if (QueueFamilyIsExternal(mem_barrier.srcQueueFamilyIndex)) {
+    if (IsQueueFamilyExternal(mem_barrier.srcQueueFamilyIndex)) {
         initial_layout = VK_IMAGE_LAYOUT_UNDEFINED;
     }
 

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -25,8 +25,7 @@
 #include "core_validation.h"
 #include "sync/sync_vuid_maps.h"
 
-bool VerifyAspectsPresent(VkImageAspectFlags aspect_mask,
-                          VkFormat format);
+bool VerifyAspectsPresent(VkImageAspectFlags aspect_mask, VkFormat format);
 
 using LayoutRange = image_layout_map::ImageSubresourceLayoutMap::RangeType;
 using LayoutEntry = image_layout_map::ImageSubresourceLayoutMap::LayoutEntry;
@@ -908,9 +907,9 @@ bool CoreChecks::VerifyClearImageLayout(const CMD_BUFFER_STATE &cb_state, const 
     return skip;
 }
 
-template <typename ImageBarrier>
+template <typename ImgBarrier>
 bool CoreChecks::UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE *cb_state, const Location &loc,
-                                                   const ImageBarrier &img_barrier, const CommandBufferImageLayoutMap &current_map,
+                                                   const ImgBarrier &img_barrier, const CommandBufferImageLayoutMap &current_map,
                                                    CommandBufferImageLayoutMap &layout_updates) const {
     bool skip = false;
     auto image_state = Get<IMAGE_STATE>(img_barrier.image);

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1502,9 +1502,9 @@ bool CoreChecks::ValidateBarrierLayoutToImageUsage(const Location &loc, VkImage 
 }
 
 // Verify image barriers are compatible with the images they reference.
-template <typename ImageBarrier>
+template <typename ImgBarrier>
 bool CoreChecks::ValidateBarriersToImages(const Location &outer_loc, const CMD_BUFFER_STATE *cb_state,
-                                          uint32_t imageMemoryBarrierCount, const ImageBarrier *pImageMemoryBarriers) const {
+                                          uint32_t imageMemoryBarrierCount, const ImgBarrier *pImageMemoryBarriers) const {
     bool skip = false;
     using sync_vuid_maps::GetImageBarrierVUID;
     using sync_vuid_maps::ImageError;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1156,16 +1156,16 @@ class CoreChecks : public ValidationStateTracker {
 
     void TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE* cb_state, const RENDER_PASS_STATE& render_pass_state);
 
-    template <typename ImageBarrier>
-    bool UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE* cb_state, const Location& loc, const ImageBarrier& img_barrier,
+    template <typename ImgBarrier>
+    bool UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE* cb_state, const Location& loc, const ImgBarrier& img_barrier,
                                            const CommandBufferImageLayoutMap& current_map,
                                            CommandBufferImageLayoutMap& layout_updates) const;
 
     bool ValidateBarrierLayoutToImageUsage(const Location& loc, VkImage image, VkImageLayout layout, VkImageUsageFlags usage) const;
 
-    template <typename ImageBarrier>
+    template <typename ImgBarrier>
     bool ValidateBarriersToImages(const Location& loc, const CMD_BUFFER_STATE* cb_state, uint32_t imageMemoryBarrierCount,
-                                  const ImageBarrier* pImageMemoryBarriers) const;
+                                  const ImgBarrier* pImageMemoryBarriers) const;
 
     void RecordQueuedQFOTransfers(CMD_BUFFER_STATE* cb_state);
 

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -681,11 +681,19 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
 
 // specializations for barriers that cannot do queue family ownership transfers
 template <>
+inline bool CMD_BUFFER_STATE::IsReleaseOp(const sync_utils::MemoryBarrier &barrier) const {
+    return false;
+}
+template <>
 inline bool CMD_BUFFER_STATE::IsReleaseOp(const VkMemoryBarrier &barrier) const {
     return false;
 }
 template <>
 inline bool CMD_BUFFER_STATE::IsReleaseOp(const VkMemoryBarrier2KHR &barrier) const {
+    return false;
+}
+template <>
+inline bool CMD_BUFFER_STATE::IsAcquireOp(const sync_utils::MemoryBarrier &barrier) const {
     return false;
 }
 template <>

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -689,18 +689,10 @@ inline bool CMD_BUFFER_STATE::IsReleaseOp(const VkMemoryBarrier2KHR &barrier) co
     return false;
 }
 template <>
-inline bool CMD_BUFFER_STATE::IsReleaseOp(const VkSubpassDependency2 &barrier) const {
-    return false;
-}
-template <>
 inline bool CMD_BUFFER_STATE::IsAcquireOp(const VkMemoryBarrier &barrier) const {
     return false;
 }
 template <>
 inline bool CMD_BUFFER_STATE::IsAcquireOp(const VkMemoryBarrier2KHR &barrier) const {
-    return false;
-}
-template <>
-inline bool CMD_BUFFER_STATE::IsAcquireOp(const VkSubpassDependency2 &barrier) const {
     return false;
 }

--- a/layers/sync/sync_utils.cpp
+++ b/layers/sync/sync_utils.cpp
@@ -293,4 +293,12 @@ ShaderStageAccesses GetShaderStageAccesses(VkShaderStageFlagBits shader_stage) {
     return it->second;
 }
 
+const std::shared_ptr<const BUFFER_STATE> BufferBarrier::GetResourceState(const ValidationStateTracker &state_tracker) const {
+    return state_tracker.Get<BUFFER_STATE>(buffer);
+}
+
+const std::shared_ptr<const IMAGE_STATE> ImageBarrier::GetResourceState(const ValidationStateTracker &state_tracker) const {
+    return state_tracker.Get<IMAGE_STATE>(image);
+}
+
 }  // namespace sync_utils

--- a/layers/sync/sync_utils.h
+++ b/layers/sync/sync_utils.h
@@ -17,10 +17,20 @@
 
 #pragma once
 #include "generated/sync_validation_types.h"
+#include "generated/vk_object_types.h"
 #include <vulkan/vulkan.h>
 #include <string>
 
+// Remove Windows trojan macro that prevents usage of this name in any scope of the program.
+// For example, nested namespace type sync_utils::MemoryBarrier won't compile because of this.
+#if defined(VK_USE_PLATFORM_WIN32_KHR) && defined(MemoryBarrier)
+#undef MemoryBarrier
+#endif
+
 struct DeviceFeatures;
+class ValidationStateTracker;
+class BUFFER_STATE;
+class IMAGE_STATE;
 
 namespace sync_utils {
 
@@ -58,5 +68,111 @@ struct ShaderStageAccesses {
     SyncStageAccessIndex uniform_read;
 };
 ShaderStageAccesses GetShaderStageAccesses(VkShaderStageFlagBits shader_stage);
+
+struct MemoryBarrier {
+    VkPipelineStageFlags2 srcStageMask;
+    VkAccessFlags2 srcAccessMask;
+    VkPipelineStageFlags2 dstStageMask;
+    VkAccessFlags2 dstAccessMask;
+
+    explicit MemoryBarrier(const VkMemoryBarrier2& barrier)
+        : srcStageMask(barrier.srcStageMask),
+          srcAccessMask(barrier.srcAccessMask),
+          dstStageMask(barrier.dstStageMask),
+          dstAccessMask(barrier.dstAccessMask) {}
+    explicit MemoryBarrier(const VkBufferMemoryBarrier2& barrier)
+        : srcStageMask(barrier.srcStageMask),
+          srcAccessMask(barrier.srcAccessMask),
+          dstStageMask(barrier.dstStageMask),
+          dstAccessMask(barrier.dstAccessMask) {}
+    explicit MemoryBarrier(const VkImageMemoryBarrier2& barrier)
+        : srcStageMask(barrier.srcStageMask),
+          srcAccessMask(barrier.srcAccessMask),
+          dstStageMask(barrier.dstStageMask),
+          dstAccessMask(barrier.dstAccessMask) {}
+    MemoryBarrier(const VkMemoryBarrier& barrier, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask)
+        : srcStageMask(src_stage_mask),
+          srcAccessMask(barrier.srcAccessMask),
+          dstStageMask(dst_stage_mask),
+          dstAccessMask(barrier.dstAccessMask) {}
+    MemoryBarrier(const VkBufferMemoryBarrier& barrier, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask)
+        : srcStageMask(src_stage_mask),
+          srcAccessMask(barrier.srcAccessMask),
+          dstStageMask(dst_stage_mask),
+          dstAccessMask(barrier.dstAccessMask) {}
+    MemoryBarrier(const VkImageMemoryBarrier& barrier, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask)
+        : srcStageMask(src_stage_mask),
+          srcAccessMask(barrier.srcAccessMask),
+          dstStageMask(dst_stage_mask),
+          dstAccessMask(barrier.dstAccessMask) {}
+};
+
+// QueueFamilyBarrier is not a real barrier (there are no queue family barriers in vulkan),
+// but is part of a buffer/image barrier structure (still can be created separately if needed).
+// This type (and also MemoryBarrier) can be used by the functionality that does not need
+// buffer/image specific information.
+struct QueueFamilyBarrier : MemoryBarrier {
+    uint32_t srcQueueFamilyIndex;
+    uint32_t dstQueueFamilyIndex;
+
+    QueueFamilyBarrier(const VkBufferMemoryBarrier2& barrier)
+        : MemoryBarrier(barrier),
+          srcQueueFamilyIndex(barrier.srcQueueFamilyIndex),
+          dstQueueFamilyIndex(barrier.dstQueueFamilyIndex) {}
+    QueueFamilyBarrier(const VkBufferMemoryBarrier& barrier, VkPipelineStageFlags src_stage_mask,
+                       VkPipelineStageFlags dst_stage_mask)
+        : MemoryBarrier(barrier, src_stage_mask, dst_stage_mask),
+          srcQueueFamilyIndex(barrier.srcQueueFamilyIndex),
+          dstQueueFamilyIndex(barrier.dstQueueFamilyIndex) {}
+    QueueFamilyBarrier(const VkImageMemoryBarrier2& barrier)
+        : MemoryBarrier(barrier),
+          srcQueueFamilyIndex(barrier.srcQueueFamilyIndex),
+          dstQueueFamilyIndex(barrier.dstQueueFamilyIndex) {}
+    QueueFamilyBarrier(const VkImageMemoryBarrier& barrier, VkPipelineStageFlags src_stage_mask,
+                       VkPipelineStageFlags dst_stage_mask)
+        : MemoryBarrier(barrier, src_stage_mask, dst_stage_mask),
+          srcQueueFamilyIndex(barrier.srcQueueFamilyIndex),
+          dstQueueFamilyIndex(barrier.dstQueueFamilyIndex) {}
+};
+
+struct BufferBarrier : QueueFamilyBarrier {
+    VkBuffer buffer;
+    VkDeviceSize offset;
+    VkDeviceSize size;
+
+    explicit BufferBarrier(const VkBufferMemoryBarrier2& barrier)
+        : QueueFamilyBarrier(barrier), buffer(barrier.buffer), offset(barrier.offset), size(barrier.size) {}
+    BufferBarrier(const VkBufferMemoryBarrier& barrier, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask)
+        : QueueFamilyBarrier(barrier, src_stage_mask, dst_stage_mask),
+          buffer(barrier.buffer),
+          offset(barrier.offset),
+          size(barrier.size) {}
+
+    VulkanTypedHandle GetTypedHandle() const { return VulkanTypedHandle(buffer, kVulkanObjectTypeBuffer); }
+    const std::shared_ptr<const BUFFER_STATE> GetResourceState(const ValidationStateTracker& state_tracker) const;
+};
+
+struct ImageBarrier : QueueFamilyBarrier {
+    VkImageLayout oldLayout;
+    VkImageLayout newLayout;
+    VkImage image;
+    VkImageSubresourceRange subresourceRange;
+
+    explicit ImageBarrier(const VkImageMemoryBarrier2& barrier)
+        : QueueFamilyBarrier(barrier),
+          oldLayout(barrier.oldLayout),
+          newLayout(barrier.newLayout),
+          image(barrier.image),
+          subresourceRange(barrier.subresourceRange) {}
+    ImageBarrier(const VkImageMemoryBarrier& barrier, VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask)
+        : QueueFamilyBarrier(barrier, src_stage_mask, dst_stage_mask),
+          oldLayout(barrier.oldLayout),
+          newLayout(barrier.newLayout),
+          image(barrier.image),
+          subresourceRange(barrier.subresourceRange) {}
+
+    VulkanTypedHandle GetTypedHandle() const { return VulkanTypedHandle(image, kVulkanObjectTypeImage); }
+    const std::shared_ptr<const IMAGE_STATE> GetResourceState(const ValidationStateTracker& state_tracker) const;
+};
 
 }  // namespace sync_utils


### PR DESCRIPTION
The problem with templated methods is that parameterized barrier types have to be the most common denominator for sync1/sync2, so they do not include stage masks. Stage masks parameters have to be added where needed or new overloads are introduced.

This PR introduces helper barrier structures and converts some existing methods to untemplated form (more to follow). I started with the methods I worked with recently and had troubles with extending them due to the fact that stage mask is not included. Code got more compact in most cases too.

New types are similar to sync2 types with a benefit of hierarchical data organization. For example, `BufferBarrier can` also be used by the apis that accept `QueueFamilyBarrier` or `MemoryBarrier` types. New barrier types can be initialized with both sync2 and sync1 types.  For sync1 types, stage masks should be additionally provided.

`sType/pNext` are not included. Currently it's not needed for validation and if there is a need the idea to pass that information using higher level concepts or separately.

Initialization of new structures is efficient. Comparing to `Location` structure, initialization of barrier structures on average takes 1x-2x more instructions, but barrier structures are less common. GCC/Clang compilers generates 16-byte moves for initialization code, and for example, initialization of `BufferBarrier` from `VkBufferMemoryBarrier2` it's 4 16-byte moves. MSVC compiler does not do this. There is a way to do this with `memcpy` but I decided not to include this because it complicates code and CGG/Clang already do this, which limits the benefits (example implementation with optimized  wide moves for all compilers is here https://github.com/artem-lunarg/Vulkan-ValidationLayers/commit/09ccc39932f1bc2c86883fdb77996b3724a4a0eb)