### PR TITLE
layers: Check correct flag for SetColorBlendEnable

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -666,7 +666,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LAST_BOUND_STATE& la
                     const auto attachment = (*cb_state.active_attachments)[i];
                     if (attachment && FormatIsColor(attachment->create_info.format) &&
                         (attachment->format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) == 0 &&
-                        cb_state.dynamic_state_value.color_blend_enable_attachments[i] == VK_TRUE) {
+                        cb_state.dynamic_state_value.color_blend_enabled[i] == VK_TRUE) {
                         skip |= LogError(vuid.set_color_blend_enable_08643, cb_state.commandBuffer(), loc,
                                          "Render pass attachment %" PRIu32
                                          " has format %s, which does not have VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT, but "


### PR DESCRIPTION
The SetColorBlendEnable check VUID-08643 should check for the relevant `pColorBlendEnables[i]` bit set, which is tracked by `cb_state->dynamic_state_value.color_blend_enabled` in [state_tracker.cpp:5830-5843](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/bea5beb302dc1add1bb9b52c8de37c0b92687159/layers/state_tracker/state_tracker.cpp#L5830-L5843)
Instead, it checks `cb_state->dynamic_state_value.color_blend_enable_attachments` which is set unconditionally.

Thus, with a color attachment that doesn't support `VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT`, this validation check always fails even when `VK_FALSE` is correctly passed to `vkCmdSetColorBlendEnableEXT` for the relevant attachment.