### PR TITLE
layers: Check correct flag for SetColorBlendEnable

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -666,7 +666,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LAST_BOUND_STATE& la
                     const auto attachment = (*cb_state.active_attachments)[i];
                     if (attachment && FormatIsColor(attachment->create_info.format) &&
                         (attachment->format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) == 0 &&
-                        cb_state.dynamic_state_value.color_blend_enable_attachments[i] == VK_TRUE) {
+                        cb_state.dynamic_state_value.color_blend_enabled[i] == VK_TRUE) {
                         skip |= LogError(vuid.set_color_blend_enable_08643, cb_state.commandBuffer(), loc,
                                          "Render pass attachment %" PRIu32
                                          " has format %s, which does not have VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT, but "

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -1969,8 +1969,8 @@ TEST_F(NegativeShaderObject, MissingCmdSetLogicOp) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeShaderObject, MissingCmdSetColorBlendEnable) {
-    TEST_DESCRIPTION("Draw with shader objects without setting vkCmdSetColorBlendEnableEXT.");
+TEST_F(NegativeShaderObject, BlendEnableIncompatibleFormat) {
+    TEST_DESCRIPTION("Draw with shader objects with blend enabled for attachment format that does not support blending.");
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08643");
 
@@ -1996,6 +1996,8 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorBlendEnable) {
     m_commandBuffer->BeginRenderingColor(GetDynamicRenderTarget());
     SetDefaultDynamicStates();
     BindVertFragShader(vertShader, fragShader);
+    VkBool32 enabled = VK_TRUE;
+    vk::CmdSetColorBlendEnableEXT(m_commandBuffer->handle(), 0, 1, &enabled);
     vk::CmdDraw(m_commandBuffer->handle(), 4, 1, 0, 0);
     m_commandBuffer->EndRendering();
     m_commandBuffer->end();

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -1969,7 +1969,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetLogicOp) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeShaderObject, BlendEnableIncompatibleFormat) {
+TEST_F(NegativeShaderObject, BlendEnabledWithNonBlendableFormat) {
     TEST_DESCRIPTION("Draw with shader objects with blend enabled for attachment format that does not support blending.");
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08643");


### PR DESCRIPTION
The SetColorBlendEnable check VUID-08643 should check for the relevant `pColorBlendEnables[i]` bit set, which is tracked by `cb_state->dynamic_state_value.color_blend_enabled` in [state_tracker.cpp:5830-5843](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/bea5beb302dc1add1bb9b52c8de37c0b92687159/layers/state_tracker/state_tracker.cpp#L5830-L5843)
Instead, it checks `cb_state->dynamic_state_value.color_blend_enable_attachments` which is set unconditionally.

Thus, with a color attachment that doesn't support `VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT`, this validation check always fails even when `VK_FALSE` is correctly passed to `vkCmdSetColorBlendEnableEXT` for the relevant attachment.