### PR TITLE
layers: Untemplate image related methods

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -907,9 +907,8 @@ bool CoreChecks::VerifyClearImageLayout(const CMD_BUFFER_STATE &cb_state, const 
     return skip;
 }
 
-template <typename ImgBarrier>
 bool CoreChecks::UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE *cb_state, const Location &loc,
-                                                   const ImgBarrier &img_barrier, const CommandBufferImageLayoutMap &current_map,
+                                                   const ImageBarrier &img_barrier, const CommandBufferImageLayoutMap &current_map,
                                                    CommandBufferImageLayoutMap &layout_updates) const {
     bool skip = false;
     auto image_state = Get<IMAGE_STATE>(img_barrier.image);
@@ -957,15 +956,6 @@ bool CoreChecks::UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE *cb_st
     }
     return skip;
 }
-
-template bool CoreChecks::UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE *cb_state, const Location &loc,
-                                                            const VkImageMemoryBarrier &img_barrier,
-                                                            const CommandBufferImageLayoutMap &current_map,
-                                                            CommandBufferImageLayoutMap &layout_updates) const;
-template bool CoreChecks::UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE *cb_state, const Location &loc,
-                                                            const VkImageMemoryBarrier2KHR &img_barrier,
-                                                            const CommandBufferImageLayoutMap &current_map,
-                                                            CommandBufferImageLayoutMap &layout_updates) const;
 
 bool CoreChecks::FindLayouts(const IMAGE_STATE &image_state, std::vector<VkImageLayout> &layouts) const {
     const auto *layout_range_map = image_state.layout_range_map.get();

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -48,19 +48,6 @@ WriteLockGuard CoreChecks::WriteLock() {
     }
 }
 
-extern template void CoreChecks::TransitionImageLayouts(CMD_BUFFER_STATE *cb_state, uint32_t barrier_count,
-                                                        const VkImageMemoryBarrier *barrier);
-extern template void CoreChecks::TransitionImageLayouts(CMD_BUFFER_STATE *cb_state, uint32_t barrier_count,
-                                                        const VkImageMemoryBarrier2KHR *barrier);
-extern template bool CoreChecks::UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE *cb_state, const Location &loc,
-                                                                   const VkImageMemoryBarrier &img_barrier,
-                                                                   const CommandBufferImageLayoutMap &current_map,
-                                                                   CommandBufferImageLayoutMap &layout_updates) const;
-extern template bool CoreChecks::UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE *cb_state, const Location &loc,
-                                                                   const VkImageMemoryBarrier2KHR &img_barrier,
-                                                                   const CommandBufferImageLayoutMap &current_map,
-                                                                   CommandBufferImageLayoutMap &layout_updates) const;
-
 bool CoreChecks::ValidateStageMaskHost(const Location &loc, VkPipelineStageFlags2KHR stageMask) const {
     bool skip = false;
     if ((stageMask & VK_PIPELINE_STAGE_HOST_BIT) != 0) {
@@ -1120,7 +1107,7 @@ void CoreChecks::PreCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint3
                                              pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers,
                                              imageMemoryBarrierCount, pImageMemoryBarriers);
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
-    TransitionImageLayouts(cb_state.get(), imageMemoryBarrierCount, pImageMemoryBarriers);
+    TransitionImageLayouts(cb_state.get(), imageMemoryBarrierCount, pImageMemoryBarriers, sourceStageMask, dstStageMask);
 }
 
 void CoreChecks::RecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
@@ -1263,7 +1250,7 @@ void CoreChecks::PreCallRecordCmdPipelineBarrier(VkCommandBuffer commandBuffer, 
 
     RecordBarriers(Func::vkCmdPipelineBarrier, cb_state.get(), srcStageMask, dstStageMask, bufferMemoryBarrierCount,
                    pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
-    TransitionImageLayouts(cb_state.get(), imageMemoryBarrierCount, pImageMemoryBarriers);
+    TransitionImageLayouts(cb_state.get(), imageMemoryBarrierCount, pImageMemoryBarriers, srcStageMask, dstStageMask);
 }
 
 void CoreChecks::PreCallRecordCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfoKHR *pDependencyInfo) {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1146,16 +1146,14 @@ class CoreChecks : public ValidationStateTracker {
 
     void TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE* cb_state, const RENDER_PASS_STATE& render_pass_state);
 
-    template <typename ImgBarrier>
-    bool UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE* cb_state, const Location& loc, const ImgBarrier& img_barrier,
+    bool UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE* cb_state, const Location& loc, const ImageBarrier& img_barrier,
                                            const CommandBufferImageLayoutMap& current_map,
                                            CommandBufferImageLayoutMap& layout_updates) const;
 
     bool ValidateBarrierLayoutToImageUsage(const Location& loc, VkImage image, VkImageLayout layout, VkImageUsageFlags usage) const;
 
-    template <typename ImgBarrier>
-    bool ValidateBarriersToImages(const Location& loc, const CMD_BUFFER_STATE* cb_state, uint32_t imageMemoryBarrierCount,
-                                  const ImgBarrier* pImageMemoryBarriers) const;
+    bool ValidateBarriersToImages(const Location& loc, const CMD_BUFFER_STATE* cb_state, const ImageBarrier& image_barrier,
+                                  CommandBufferImageLayoutMap& layout_updates_state) const;
 
     void RecordQueuedQFOTransfers(CMD_BUFFER_STATE* cb_state);
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -571,11 +571,18 @@ class CoreChecks : public ValidationStateTracker {
                           uint32_t bufferBarrierCount, const VkBufferMemoryBarrier* pBufferMemBarriers,
                           uint32_t imageMemBarrierCount, const VkImageMemoryBarrier* pImageMemBarriers) const;
 
-    template <typename Barrier>
-    bool ValidateBarriersForShaderTileImage(const LogObjectList& objlist, const Location& outer_loc,
-                                            VkDependencyFlags dependencyFlags, uint32_t memBarrierCount,
-                                            const Barrier* pMemBarriers, uint32_t bufferBarrierCount, uint32_t imageMemBarrierCount,
-                                            VkPipelineStageFlags src_stage_mask = 0, VkPipelineStageFlags dst_stage_mask = 0) const;
+    bool ValidateShaderTileImageBarriers(const LogObjectList& objlist, const Location& outer_loc,
+                                         const VkDependencyInfo& dep_info) const;
+
+    bool ValidateShaderTileImageBarriers(const LogObjectList& objlist, const Location& outer_loc,
+                                         VkDependencyFlags dependency_flags, uint32_t memory_barrier_count,
+                                         const VkMemoryBarrier* memory_barriers, uint32_t buffer_barrier_count,
+                                         uint32_t image_barrier_count, VkPipelineStageFlags src_stage_mask,
+                                         VkPipelineStageFlags dst_stage_mask) const;
+
+    bool ValidateShaderTimeImageCommon(const LogObjectList& objlist, const Location& outer_loc,
+                                       const std::string& barrier_error_vuid, VkDependencyFlags dependency_flags,
+                                       uint32_t buffer_barrier_count, uint32_t image_barrier_count) const;
 
     bool ValidatePipelineStageFeatureEnables(const LogObjectList& objlist, const Location& loc,
                                              VkPipelineStageFlags2KHR stage_mask) const;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1157,12 +1157,11 @@ class CoreChecks : public ValidationStateTracker {
 
     void RecordQueuedQFOTransfers(CMD_BUFFER_STATE* cb_state);
 
-    template <typename ImgBarrier>
-    void TransitionImageLayouts(CMD_BUFFER_STATE* cb_state, uint32_t barrier_count, const ImgBarrier* barrier);
+    void TransitionImageLayouts(CMD_BUFFER_STATE* cb_state, uint32_t barrier_count, const VkImageMemoryBarrier2* image_barriers);
+    void TransitionImageLayouts(CMD_BUFFER_STATE* cb_state, uint32_t barrier_count, const VkImageMemoryBarrier* image_barriers,
+                                VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask);
 
-    template <typename ImgBarrier>
-    void RecordTransitionImageLayout(CMD_BUFFER_STATE* cb_state, const IMAGE_STATE& image_state, const ImgBarrier& img_barrier,
-                                     bool is_release_op);
+    void RecordTransitionImageLayout(CMD_BUFFER_STATE* cb_state, const ImageBarrier& image_barrier);
     void RecordBarriers(Func func_name, CMD_BUFFER_STATE* cb_state, VkPipelineStageFlags src_stage_mask,
                         VkPipelineStageFlags dst_stage_mask, uint32_t bufferBarrierCount,
                         const VkBufferMemoryBarrier* pBufferMemBarriers, uint32_t imageMemBarrierCount,


### PR DESCRIPTION
Similar to the previous PR, and some cleanup. 

It looks there are few patterns how this can be done. Some (non-coherent) notes about approaches.

**Big template function -> Big non-template function + small dispatch functions**:
`RecordTransitionImageLayout` is an example where the main part of the algorithm can become a regular method that works with specific type, and there is a helper/thin wrapper (`TransitionImageLayouts`) that delegates requests and maps types from what was previously parameterized to our custom types.  We already had `TransitionImageLayouts`, so this update was cheap with regard to introducing new abstractions.

**Bit template function handles few type-specific scenarios -> extract scenarios into separate functions + common code**:
That's `ValidateShaderTileImageBarriers`. There is a "common" logic shared between sync1 and sync2, but half of the functionality is sync1/sync2-specific control flow. In the original version two types of control flow were interleaved in a single function. New `ValidateShaderTileImageBarriers` overloads show explicitly how control flow differs between sync1 and sync2 and common logic is moved to a separate function.

**Template handles array of types -> handle single element and move loop outside to avoid allocation**:
`ValidateBarriersToImages` worked with array of barriers. Because the caller already has the same loop, and in that loop it has already constructed `ImageBarrier` object, `ValidateBarriersToImages` was updated to process single object and to be called from the caller's loop. Cons: additional function call in the caller's loop. Pros: minus one loop over barriers, no additional time spent on `ImageBarrier` object construction, `ValidateBarriersToImages` is now called in the same way as other functions that validate image barriers, code became more regular.