### PR TITLE
layers: Error location improvements

### DIFF
--- a/layers/error_message/error_location.cpp
+++ b/layers/error_message/error_location.cpp
@@ -27,10 +27,10 @@ void Location::AppendFields(std::ostream& out) const {
             out << ((prev->index == kNoIndex && IsFieldPointer(prev->field)) ? "->" : ".");
         }
     }
+    if (isPNext && structure != vvl::Struct::Empty) {
+        out << "pNext<" << vvl::String(structure) << (field != vvl::Field::Empty ? ">." : ">");
+    }
     if (field != vvl::Field::Empty) {
-        if (isPNext && structure != vvl::Struct::Empty) {
-            out << "pNext<" << vvl::String(structure) << ">.";
-        }
         out << vvl::String(field);
         if (index != kNoIndex) {
             out << "[" << index << "]";

--- a/layers/error_message/error_location.h
+++ b/layers/error_message/error_location.h
@@ -53,12 +53,8 @@ struct Location {
 
     // the dot() method is for walking down into a structure that is being validated
     // eg:  loc.dot(Field::pMemoryBarriers, 5).dot(Field::srcStagemask)
-    Location dot(vvl::Struct s, vvl::Field sub_field, uint32_t sub_index) const {
+    Location dot(vvl::Struct s, vvl::Field sub_field, uint32_t sub_index = kNoIndex) const {
         Location result(*this, s, sub_field, sub_index, false);
-        return result;
-    }
-    Location dot(vvl::Struct s, vvl::Field sub_field) const {
-        Location result(*this, s, sub_field, kNoIndex, false);
         return result;
     }
     Location dot(vvl::Field sub_field, uint32_t sub_index = kNoIndex) const {
@@ -67,12 +63,8 @@ struct Location {
     }
 
     // same as dot() but will mark these were part of a pNext struct
-    Location pNext(vvl::Struct s, vvl::Field sub_field, uint32_t sub_index) const {
+    Location pNext(vvl::Struct s, vvl::Field sub_field = vvl::Field::Empty, uint32_t sub_index = kNoIndex) const {
         Location result(*this, s, sub_field, sub_index, true);
-        return result;
-    }
-    Location pNext(vvl::Struct s, vvl::Field sub_field) const {
-        Location result(*this, s, sub_field, kNoIndex, true);
         return result;
     }
 


### PR DESCRIPTION
This PR allows a Location object to point to an entire structure within the pNext chain, which is necessary in order to allow a function to accept structure locations indifferent of whether they are specified as a member of another structure or chained to another structure.