### PR TITLE
layers: Fix double destruction in thread safety

### DIFF
--- a/layers/thread_tracker/thread_safety_validation.h
+++ b/layers/thread_tracker/thread_safety_validation.h
@@ -327,10 +327,7 @@ class ThreadSafety : public ValidationObject {
     void StartReadObject(type object, vvl::Func command) { c_##type.StartRead(object, command); }     \
     void FinishReadObject(type object, vvl::Func command) { c_##type.FinishRead(object, command); }   \
     void CreateObject(type object) { c_##type.CreateObject(object); }                                 \
-    void DestroyObject(type object) {                                                                 \
-        c_##type.DestroyObject(object);                                                               \
-        c_##type.DestroyObject(object);                                                               \
-    }
+    void DestroyObject(type object) { c_##type.DestroyObject(object); }
 
 #define WRAPPER_PARENT_INSTANCE(type)                                                                                           \
     void StartWriteObjectParentInstance(type object, vvl::Func command) {                                                       \


### PR DESCRIPTION
Probably an editing error from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/1557

Does not affect correctness, for the second `DestroyObject` call the hash table's `erase` can't find the key and returns. Also, one fewer `WriteLockGuard` lock.
