### PR TITLE
corechecks: Make QNX buffer import validation according to spec

### DIFF
--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -403,7 +403,7 @@ bool CoreChecks::ValidateGetImageMemoryRequirementsANDROID(const VkImage image, 
 
     auto image_state = Get<IMAGE_STATE>(image);
     if (image_state != nullptr) {
-        if (image_state->IsExternalAHB() && (0 == image_state->GetBoundMemoryStates().size())) {
+        if (image_state->IsExternalBuffer() && (0 == image_state->GetBoundMemoryStates().size())) {
             const char *vuid = loc.function == Func::vkGetImageMemoryRequirements
                                    ? "VUID-vkGetImageMemoryRequirements-image-04004"
                                    : "VUID-VkImageMemoryRequirementsInfo2-image-01897";

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -60,7 +60,7 @@ bool CoreChecks::ValidateMemoryIsBoundToImage(const LogObjectList &objlist, cons
                          FormatHandle(image_state).c_str(), FormatHandle(image_state.create_from_swapchain).c_str(),
                          FormatHandle(image_state.bind_swapchain->Handle()).c_str());
         }
-    } else if (image_state.IsExternalAHB()) {
+    } else if (image_state.IsExternalBuffer()) {
         // TODO look into how to properly check for a valid bound memory for an external AHB
     } else if (!image_state.sparse) {
         // No need to optimize this since the size will only be 3 at most
@@ -256,15 +256,23 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
         }
     }
 
-    bool imported_ahb = false;
+    bool imported_buffer = false;
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     //  "memory is not an imported Android Hardware Buffer" refers to VkImportAndroidHardwareBufferInfoANDROID with a non-NULL
     //  buffer value. Memory imported has another VUID to check size and allocationSize match up
     if (auto imported_ahb_info = LvlFindInChain<VkImportAndroidHardwareBufferInfoANDROID>(pAllocateInfo->pNext);
         imported_ahb_info != nullptr) {
-        imported_ahb = imported_ahb_info->buffer != nullptr;
+        imported_buffer = imported_ahb_info->buffer != nullptr;
     }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
+#if defined(VK_USE_PLATFORM_SCREEN_QNX)
+    //  "memory is not an imported Android Hardware Buffer" refers to VkImportAndroidHardwareBufferInfoANDROID with a non-NULL
+    //  buffer value. Memory imported has another VUID to check size and allocationSize match up
+    if (auto imported_buffer_info = LvlFindInChain<VkImportScreenBufferInfoQNX>(pAllocateInfo->pNext);
+        imported_buffer_info != nullptr) {
+        imported_buffer = imported_buffer_info->buffer != nullptr;
+    }
+#endif  // VK_USE_PLATFORM_SCREEN_QNX
     auto dedicated_allocate_info = LvlFindInChain<VkMemoryDedicatedAllocateInfo>(pAllocateInfo->pNext);
     if (dedicated_allocate_info) {
         if ((dedicated_allocate_info->buffer != VK_NULL_HANDLE) && (dedicated_allocate_info->image != VK_NULL_HANDLE)) {
@@ -283,7 +291,7 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
                                  FormatHandle(dedicated_allocate_info->image).c_str());
             } else {
                 if (!IsZeroAllocationSizeAllowed(pAllocateInfo) &&
-                    (pAllocateInfo->allocationSize != image_state->requirements[0].size) && (imported_ahb == false)) {
+                    (pAllocateInfo->allocationSize != image_state->requirements[0].size) && (imported_buffer == false)) {
                     skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-02964", objlist,
                                      allocate_info_loc.dot(Field::allocationSize),
                                      "(%" PRIu64 ") needs to be equal to %s (%s) VkMemoryRequirements::size (%" PRIu64 ").",
@@ -302,7 +310,7 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
             const Location buffer_loc = allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::buffer);
             auto buffer_state = Get<BUFFER_STATE>(dedicated_allocate_info->buffer);
             if (!IsZeroAllocationSizeAllowed(pAllocateInfo) && (pAllocateInfo->allocationSize != buffer_state->requirements.size) &&
-                (imported_ahb == false)) {
+                (imported_buffer == false)) {
                 skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-02965", objlist,
                                  allocate_info_loc.dot(Field::allocationSize),
                                  "(%" PRIu64 ") needs to be equal to %s (%s) VkMemoryRequirements::size (%" PRIu64 ").",
@@ -1027,7 +1035,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                 // Check non-disjoint images VkMemoryRequirements
 
                 // All validation using the image_state->requirements for external AHB is check in android only section
-                if (image_state->IsExternalAHB() == false) {
+                if (image_state->IsExternalBuffer() == false) {
                     const VkMemoryRequirements &mem_req = image_state->requirements[0];
 
                     // Validate memory requirements alignment
@@ -1085,7 +1093,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                 int plane = 0;
 
                 // All validation using the image_state->plane*_requirements for external AHB is check in android only section
-                if (image_state->IsExternalAHB() == false) {
+                if (image_state->IsExternalBuffer() == false) {
                     const VkImageAspectFlagBits aspect = plane_info->planeAspect;
                     plane = GetPlaneIndex(aspect);
                     const VkMemoryRequirements &disjoint_mem_req = image_state->requirements[plane];

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -2201,7 +2201,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const IMAGE_STATE &image_stat
         }
     }
 
-    if (image_state.IsExternalAHB() && image_state.GetBoundMemoryStates().empty()) {
+    if (image_state.IsExternalBuffer() && image_state.GetBoundMemoryStates().empty()) {
         const char *vuid =
             is_2 ? "VUID-vkGetImageSubresourceLayout2KHR-image-01895" : "VUID-vkGetImageSubresourceLayout-image-01895";
         skip |= LogError(vuid, image_state.image(), subresource_loc,

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -222,8 +222,9 @@ class BINDABLE : public BASE_NODE {
         BASE_NODE::Destroy();
     }
 
-    bool IsExternalAHB() const {
-        return (external_memory_handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) != 0;
+    bool IsExternalBuffer() const {
+        return ((external_memory_handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID) != 0) ||
+               ((external_memory_handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_SCREEN_BUFFER_BIT_QNX) != 0);
     }
 
     const DEVICE_MEMORY_STATE *MemState() const {

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -200,7 +200,7 @@ IMAGE_STATE::IMAGE_STATE(const ValidationStateTracker *dev_data, VkImage img, co
       swapchain_image_index(0),
       format_features(ff),
       disjoint((pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT) != 0),
-      requirements(GetMemoryRequirements(dev_data, img, pCreateInfo, disjoint, IsExternalAHB())),
+      requirements(GetMemoryRequirements(dev_data, img, pCreateInfo, disjoint, IsExternalBuffer())),
       sparse_residency((pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0),
       sparse_requirements(GetSparseRequirements(dev_data, img, sparse_residency)),
       sparse_metadata_required(SparseMetaDataRequired(sparse_requirements)),

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3999,7 +3999,7 @@ void ValidationStateTracker::UpdateBindImageMemoryState(const VkBindImageMemoryI
             auto mem_info = Get<DEVICE_MEMORY_STATE>(bindInfo.memory);
             if (mem_info) {
                 VkDeviceSize plane_index = 0u;
-                if (image_state->disjoint && image_state->IsExternalAHB() == false) {
+                if (image_state->disjoint && image_state->IsExternalBuffer() == false) {
                     auto plane_info = LvlFindInChain<VkBindImagePlaneMemoryInfo>(bindInfo.pNext);
                     plane_index = GetPlaneIndex(plane_info->planeAspect);
                 }


### PR DESCRIPTION
Add QNX buffer extension support for allocated memory size validation.

Validation message has mention of QNX, but not in the code:

ERROR : VALIDATION - Message Id Number: 1700101245 | Message Id Name: VUID-VkMemoryDedicatedAllocateInfo-image-02964
Validation Error: [ VUID-VkMemoryDedicatedAllocateInfo-image-02964 ] | MessageID = 0x65557c7d |
vkAllocateMemory: Allocation Size (8355840) needs to be equal to VkImage VkImage 0x2cfba2000000001c[]
VkMemoryRequirements::size (8896880) The Vulkan spec states: If image is not VK_NULL_HANDLE and the
memory is not an imported Android Hardware Buffer or an imported QNX Screen buffer,
VkMemoryAllocateInfo::allocationSize must equal the VkMemoryRequirements::size of the image
(https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkMemoryDedicatedAllocateInfo-image-02964)

With this patch this message will be suppressed.

The VK_QNX_external_memory_screen_buffer was created as a copycat of Android extension to make Vulkan drivers porting much faster using Android functionality as the template. Also this patch covers some other validation check for Android and add support for QNX extension as well.

P.S. Sorry for the mess with the previous patch - I had to close the PR.

Thank you!