### PR TITLE
layers: Fix VUIDs for image copies

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -329,22 +329,13 @@ bool CoreChecks::ValidateImageArrayLayerRange(const HandleT handle, const IMAGE_
 static const char *GetBufferMemoryImageCopyCommandVUID(const std::string &id, bool from_image, bool copy2, bool is_memory = false) {
     // clang-format off
     static const std::map<std::string, std::array<const char *, 6>> copy_imagebuffermemory_vuid = {
-        {"07974", {
-            "VUID-vkCmdCopyBufferToImage-dstImage-07974",    // !copy2 & !from_image
-            "VUID-vkCmdCopyImageToBuffer-srcImage-07974",    // !copy2 &  from_image
-            "VUID-VkCopyBufferToImageInfo2-dstImage-07974",  //  copy2 & !from_image
-            "VUID-VkCopyImageToBufferInfo2-srcImage-07974",  //  copy2 &  from_image
-            kVUIDUndefined,                                  //  memory & !from_image
-            kVUIDUndefined,                                  //  memory & from_image
-
-        }},
         {"06659", {
-            "VUID-VkBufferImageCopy-imageExtent-06659",
-            "VUID-VkBufferImageCopy-imageExtent-06659",
-            "VUID-VkBufferImageCopy2-imageExtent-06659",
-            "VUID-VkBufferImageCopy2-imageExtent-06659",
-            "VUID-VkMemoryToImageCopyEXT-imageExtent-06659",
-            "VUID-VkImageToMemoryCopyEXT-imageExtent-06659",
+            "VUID-VkBufferImageCopy-imageExtent-06659",      // !copy2  & !from_image
+            "VUID-VkBufferImageCopy-imageExtent-06659",      // !copy2  &  from_image
+            "VUID-VkBufferImageCopy2-imageExtent-06659",     //  copy2  & !from_image
+            "VUID-VkBufferImageCopy2-imageExtent-06659",     //  copy2  &  from_image
+            "VUID-VkMemoryToImageCopyEXT-imageExtent-06659", //  memory & !from_image
+            "VUID-VkImageToMemoryCopyEXT-imageExtent-06659", //  memory &  from_image
         }},
         {"06660", {
             "VUID-VkBufferImageCopy-imageExtent-06660",
@@ -459,28 +450,28 @@ static const char *GetBufferMemoryImageCopyCommandVUID(const std::string &id, bo
             "VUID-VkCopyImageToMemoryInfoEXT-memoryImageHeight-09107",
         }},
         {"07274", {
-            "VUID-vkCmdCopyBufferToImage-pRegions-07274",
-            "VUID-vkCmdCopyImageToBuffer-pRegions-07274",
-            "VUID-VkCopyBufferToImageInfo2-pRegions-07274",
-            "VUID-VkCopyImageToBufferInfo2-pRegions-07274",
-            "VUID-VkCopyMemoryToImageInfoEXT-pRegions-07274",
-            "VUID-VkCopyImageToMemoryInfoEXT-pRegions-07274",
+            "VUID-vkCmdCopyBufferToImage-dstImage-07274",
+            "VUID-vkCmdCopyImageToBuffer-srcImage-07274",
+            "VUID-VkCopyBufferToImageInfo2-dstImage-07274",
+            "VUID-VkCopyImageToBufferInfo2-srcImage-07274",
+            "VUID-VkCopyMemoryToImageInfoEXT-dstImage-07274",
+            "VUID-VkCopyImageToMemoryInfoEXT-srcImage-07274",
         }},
         {"07275", {
-            "VUID-vkCmdCopyBufferToImage-pRegions-07275",
-            "VUID-vkCmdCopyImageToBuffer-pRegions-07275",
-            "VUID-VkCopyBufferToImageInfo2-pRegions-07275",
-            "VUID-VkCopyImageToBufferInfo2-pRegions-07275",
-            "VUID-VkCopyMemoryToImageInfoEXT-pRegions-07275",
-            "VUID-VkCopyImageToMemoryInfoEXT-pRegions-07275",
+            "VUID-vkCmdCopyBufferToImage-dstImage-07275",
+            "VUID-vkCmdCopyImageToBuffer-srcImage-07275",
+            "VUID-VkCopyBufferToImageInfo2-dstImage-07275",
+            "VUID-VkCopyImageToBufferInfo2-srcImage-07275",
+            "VUID-VkCopyMemoryToImageInfoEXT-dstImage-07275",
+            "VUID-VkCopyImageToMemoryInfoEXT-srcImage-07275",
         }},
         {"07276", {
-            "VUID-vkCmdCopyBufferToImage-pRegions-07276",
-            "VUID-vkCmdCopyImageToBuffer-pRegions-07276",
-            "VUID-VkCopyBufferToImageInfo2-pRegions-07276",
-            "VUID-VkCopyImageToBufferInfo2-pRegions-07276",
-            "VUID-VkCopyMemoryToImageInfoEXT-pRegions-07276",
-            "VUID-VkCopyImageToMemoryInfoEXT-pRegions-07276",
+            "VUID-vkCmdCopyBufferToImage-dstImage-07276",
+            "VUID-vkCmdCopyImageToBuffer-srcImage-07276",
+            "VUID-VkCopyBufferToImageInfo2-dstImage-07276",
+            "VUID-VkCopyImageToBufferInfo2-srcImage-07276",
+            "VUID-VkCopyMemoryToImageInfoEXT-dstImage-07276",
+            "VUID-VkCopyImageToMemoryInfoEXT-srcImage-07276",
         }},
         {"09108", {
             "VUID-vkCmdCopyBufferToImage-bufferRowLength-09108",
@@ -491,28 +482,28 @@ static const char *GetBufferMemoryImageCopyCommandVUID(const std::string &id, bo
             "VUID-VkCopyImageToMemoryInfoEXT-memoryRowLength-09108",
         }},
         {"00207", {
-            "VUID-vkCmdCopyBufferToImage-imageExtent-00207",
-            "VUID-vkCmdCopyImageToBuffer-imageExtent-00207",
-            "VUID-VkCopyBufferToImageInfo2-imageExtent-00207",
-            "VUID-VkCopyImageToBufferInfo2-imageExtent-00207",
-            "VUID-VkCopyMemoryToImageInfoEXT-imageExtent-00207",
-            "VUID-VkCopyImageToMemoryInfoEXT-imageExtent-00207",
+            "VUID-vkCmdCopyBufferToImage-dstImage-00207",
+            "VUID-vkCmdCopyImageToBuffer-srcImage-00207",
+            "VUID-VkCopyBufferToImageInfo2-dstImage-00207",
+            "VUID-VkCopyImageToBufferInfo2-srcImage-00207",
+            "VUID-VkCopyMemoryToImageInfoEXT-dstImage-00207",
+            "VUID-VkCopyImageToMemoryInfoEXT-srcImage-00207",
         }},
         {"00208", {
-            "VUID-vkCmdCopyBufferToImage-imageExtent-00208",
-            "VUID-vkCmdCopyImageToBuffer-imageExtent-00208",
-            "VUID-VkCopyBufferToImageInfo2-imageExtent-00208",
-            "VUID-VkCopyImageToBufferInfo2-imageExtent-00208",
-            "VUID-VkCopyMemoryToImageInfoEXT-imageExtent-00208",
-            "VUID-VkCopyImageToMemoryInfoEXT-imageExtent-00208",
+            "VUID-vkCmdCopyBufferToImage-dstImage-00208",
+            "VUID-vkCmdCopyImageToBuffer-srcImage-00208",
+            "VUID-VkCopyBufferToImageInfo2-dstImage-00208",
+            "VUID-VkCopyImageToBufferInfo2-srcImage-00208",
+            "VUID-VkCopyMemoryToImageInfoEXT-dstImage-00208",
+            "VUID-VkCopyImageToMemoryInfoEXT-srcImage-00208",
         }},
         {"00209", {
-            "VUID-vkCmdCopyBufferToImage-imageExtent-00209",
-            "VUID-vkCmdCopyImageToBuffer-imageExtent-00209",
-            "VUID-VkCopyBufferToImageInfo2-imageExtent-00209",
-            "VUID-VkCopyImageToBufferInfo2-imageExtent-00209",
-            "VUID-VkCopyMemoryToImageInfoEXT-imageExtent-00209",
-            "VUID-VkCopyImageToMemoryInfoEXT-imageExtent-00209",
+            "VUID-vkCmdCopyBufferToImage-dstImage-00209",
+            "VUID-vkCmdCopyImageToBuffer-srcImage-00209",
+            "VUID-VkCopyBufferToImageInfo2-dstImage-00209",
+            "VUID-VkCopyImageToBufferInfo2-srcImage-00209",
+            "VUID-VkCopyMemoryToImageInfoEXT-dstImage-00209",
+            "VUID-VkCopyImageToMemoryInfoEXT-srcImage-00209",
         }},
         {"09105", {
             "VUID-vkCmdCopyBufferToImage-imageSubresource-09105",
@@ -1203,32 +1194,32 @@ static const char *GetImageCopyVUID(const std::string &id, bool copy2, bool host
         {"07278", {
             "VUID-vkCmdCopyImage-pRegions-07278",
             "VUID-VkCopyImageInfo2-pRegions-07278",
-            "VUID-VkCopyImageToImageInfoEXT-pRegions-07274",
+            "VUID-VkCopyImageToImageInfoEXT-srcImage-07274",
         }},
         {"07279", {
             "VUID-vkCmdCopyImage-pRegions-07279",
             "VUID-VkCopyImageInfo2-pRegions-07279",
-            "VUID-VkCopyImageToImageInfoEXT-pRegions-07275",
+            "VUID-VkCopyImageToImageInfoEXT-srcImage-07275",
         }},
         {"07280", {
             "VUID-vkCmdCopyImage-pRegions-07280",
             "VUID-VkCopyImageInfo2-pRegions-07280",
-            "VUID-VkCopyImageToImageInfoEXT-pRegions-07276",
+            "VUID-VkCopyImageToImageInfoEXT-srcImage-07276",
         }},
         {"01728", {
             "VUID-vkCmdCopyImage-srcImage-01728",
             "VUID-VkCopyImageInfo2-srcImage-01728",
-            "VUID-VkCopyImageToImageInfoEXT-imageExtent-00207",
+            "VUID-VkCopyImageToImageInfoEXT-srcImage-00207",
         }},
         {"01729", {
             "VUID-vkCmdCopyImage-srcImage-01729",
             "VUID-VkCopyImageInfo2-srcImage-01729",
-            "VUID-VkCopyImageToImageInfoEXT-imageExtent-00208",
+            "VUID-VkCopyImageToImageInfoEXT-srcImage-00208",
         }},
         {"01730", {
             "VUID-vkCmdCopyImage-srcImage-01730",
             "VUID-VkCopyImageInfo2-srcImage-01730",
-            "VUID-VkCopyImageToImageInfoEXT-imageExtent-00209",
+            "VUID-VkCopyImageToImageInfoEXT-srcImage-00209",
         }},
         {"00152", {
             "VUID-vkCmdCopyImage-dstImage-00152",
@@ -1253,35 +1244,35 @@ static const char *GetImageCopyVUID(const std::string &id, bool copy2, bool host
        {"07281", {
             "VUID-vkCmdCopyImage-pRegions-07281",
             "VUID-VkCopyImageInfo2-pRegions-07281",
-            "VUID-VkCopyImageToImageInfoEXT-pRegions-07274",
+            "VUID-VkCopyImageToImageInfoEXT-dstImage-07274",
        }},
        {"07282", {
             "VUID-vkCmdCopyImage-pRegions-07282",
             "VUID-VkCopyImageInfo2-pRegions-07282",
-            "VUID-VkCopyImageToImageInfoEXT-pRegions-07275",
+            "VUID-VkCopyImageToImageInfoEXT-dstImage-07275",
        }},
        {"07283", {
             "VUID-vkCmdCopyImage-pRegions-07283",
             "VUID-VkCopyImageInfo2-pRegions-07283",
-            "VUID-VkCopyImageToImageInfoEXT-pRegions-07276",
+            "VUID-VkCopyImageToImageInfoEXT-dstImage-07276",
        }},
        {"01732", {
             "VUID-vkCmdCopyImage-dstImage-01732",
             "VUID-VkCopyImageInfo2-dstImage-01732",
-            "VUID-VkCopyImageToImageInfoEXT-imageExtent-00207",
+            "VUID-VkCopyImageToImageInfoEXT-dstImage-00207",
        }},
        {"01733", {
             "VUID-vkCmdCopyImage-dstImage-01733",
             "VUID-VkCopyImageInfo2-dstImage-01733",
-            "VUID-VkCopyImageToImageInfoEXT-imageExtent-00208",
+            "VUID-VkCopyImageToImageInfoEXT-dstImage-00208",
        }},
        {"01734", {
             "VUID-vkCmdCopyImage-dstImage-01734",
             "VUID-VkCopyImageInfo2-dstImage-01734",
-            "VUID-VkCopyImageToImageInfoEXT-imageExtent-00209",
+            "VUID-VkCopyImageToImageInfoEXT-dstImage-00209",
        }},
        {"07967src", {
-            "VUID-VkCmdCopyImage-srcSubresource-07967",
+            "VUID-vkCmdCopyImage-srcSubresource-07967",
             "VUID-VkCopyImageInfo2-srcSubresource-07967",
             "VUID-VkCopyImageToImageInfoEXT-srcSubresource-07967",
        }},
@@ -2903,8 +2894,8 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(VkDevice device, InfoPointer info
             }
             const VkExtent3D subresource_extent = image_state->GetEffectiveSubresourceExtent(region.imageSubresource);
             if (!IsExtentEqual(region.imageExtent, subresource_extent)) {
-                const char *vuid = from_image ? "VUID-VkCopyImageToMemoryInfoEXT-imageExtent-09115"
-                                              : "VUID-VkCopyMemoryToImageInfoEXT-imageExtent-09115";
+                const char *vuid = from_image ? "VUID-VkCopyImageToMemoryInfoEXT-srcImage-09115"
+                                              : "VUID-VkCopyMemoryToImageInfoEXT-dstImage-09115";
                 LogObjectList objlist(device, image_state->image());
                 skip |= LogError(vuid, objlist, loc,
                                  "pRegion[%" PRIu32 "].imageExtent (w=%" PRIu32 ", h=%" PRIu32 ", d=%" PRIu32
@@ -3056,7 +3047,8 @@ bool CoreChecks::ValidateMemcpyExtents(VkDevice device, const VkImageCopy2 regio
                          region.srcOffset.x, region.srcOffset.y, region.srcOffset.z);
     }
     if (!IsExtentEqual(region.extent, image_state.createInfo.extent)) {
-        const char *vuid = is_src ? "VUID-VkCopyImageToImageInfoEXT-extent-09115" : "VUID-VkCopyImageToImageInfoEXT-extent-09115";
+        const char *vuid =
+            is_src ? "VUID-VkCopyImageToImageInfoEXT-srcImage-09115" : "VUID-VkCopyImageToImageInfoEXT-dstImage-09115";
         const LogObjectList objlist(device, image_state.image());
         skip |= LogError(vuid, objlist, region_loc.dot(Field::imageExtent),
                          "(w = %" PRIu32 ", h = %" PRIu32 ", d = %" PRIu32

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -1339,14 +1339,14 @@ TEST_F(NegativeCommand, CompressedImageMipCopy) {
     region.imageExtent = {1, 2, 1};
     region.imageSubresource.mipLevel = 4;
     // width not a multiple of compressed block width
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyImageToBuffer-imageExtent-00207");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyImageToBuffer-srcImage-00207");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyImageToBuffer-imageOffset-07747");  // image transfer granularity
     vk::CmdCopyImageToBuffer(m_commandBuffer->handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer_16.handle(), 1, &region);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(
-        kErrorBit, "VUID-vkCmdCopyBufferToImage-imageExtent-00207");  // width not a multiple of compressed block width
+        kErrorBit, "VUID-vkCmdCopyBufferToImage-dstImage-00207");  // width not a multiple of compressed block width
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyBufferToImage-imageOffset-07738");  // image transfer granularity
     vk::CmdCopyBufferToImage(m_commandBuffer->handle(), buffer_16.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
@@ -1355,14 +1355,14 @@ TEST_F(NegativeCommand, CompressedImageMipCopy) {
     // Copy height < compressed block size but not the full mip height
     region.imageExtent = {2, 1, 1};
     m_errorMonitor->SetDesiredFailureMsg(
-        kErrorBit, "VUID-vkCmdCopyImageToBuffer-imageExtent-00208");  // height not a multiple of compressed block width
+        kErrorBit, "VUID-vkCmdCopyImageToBuffer-srcImage-00208");  // height not a multiple of compressed block width
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyImageToBuffer-imageOffset-07747");  // image transfer granularity
     vk::CmdCopyImageToBuffer(m_commandBuffer->handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer_16.handle(), 1, &region);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(
-        kErrorBit, "VUID-vkCmdCopyBufferToImage-imageExtent-00208");  // height not a multiple of compressed block width
+        kErrorBit, "VUID-vkCmdCopyBufferToImage-dstImage-00208");  // height not a multiple of compressed block width
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyBufferToImage-imageOffset-07738");  // image transfer granularity
     vk::CmdCopyBufferToImage(m_commandBuffer->handle(), buffer_16.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
@@ -1372,16 +1372,16 @@ TEST_F(NegativeCommand, CompressedImageMipCopy) {
     region.imageOffset = {1, 1, 0};
     region.imageExtent = {1, 1, 1};
     // imageOffset not a multiple of block size
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyImageToBuffer-pRegions-07274");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyImageToBuffer-pRegions-07275");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyImageToBuffer-srcImage-07274");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyImageToBuffer-srcImage-07275");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyImageToBuffer-imageOffset-07747");  // image transfer granularity
     vk::CmdCopyImageToBuffer(m_commandBuffer->handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer_16.handle(), 1, &region);
     m_errorMonitor->VerifyFound();
 
     // imageOffset not a multiple of block size
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBufferToImage-pRegions-07274");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBufferToImage-pRegions-07275");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBufferToImage-dstImage-07274");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyBufferToImage-dstImage-07275");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyBufferToImage-imageOffset-07738");  // image transfer granularity
     vk::CmdCopyBufferToImage(m_commandBuffer->handle(), buffer_16.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
@@ -1405,8 +1405,8 @@ TEST_F(NegativeCommand, CompressedImageMipCopy) {
                                                                         1,
                                                                         &region2};
         // imageOffset not a multiple of block size
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyBufferToImageInfo2-pRegions-07274");
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyBufferToImageInfo2-pRegions-07275");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyBufferToImageInfo2-dstImage-07274");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyBufferToImageInfo2-dstImage-07275");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                              "VUID-vkCmdCopyBufferToImage2-imageOffset-07738");  // image transfer granularity
         vk::CmdCopyBufferToImage2KHR(m_commandBuffer->handle(), &copy_buffer_to_image_info2);
@@ -1431,14 +1431,14 @@ TEST_F(NegativeCommand, CompressedImageMipCopy) {
     // Offset + extent width < mip width and not a multiple of block width - should fail
     region.imageExtent = {3, 3, 1};
     m_errorMonitor->SetDesiredFailureMsg(
-        kErrorBit, "VUID-vkCmdCopyImageToBuffer-imageExtent-00208");  // offset+extent not a multiple of block width
+        kErrorBit, "VUID-vkCmdCopyImageToBuffer-srcImage-00208");  // offset+extent not a multiple of block width
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyImageToBuffer-imageOffset-07747");  // image transfer granularity
     vk::CmdCopyImageToBuffer(m_commandBuffer->handle(), odd_image.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer_16.handle(), 1,
                              &region);
     m_errorMonitor->VerifyFound();
     m_errorMonitor->SetDesiredFailureMsg(
-        kErrorBit, "VUID-vkCmdCopyBufferToImage-imageExtent-00208");  // offset+extent not a multiple of block width
+        kErrorBit, "VUID-vkCmdCopyBufferToImage-dstImage-00208");  // offset+extent not a multiple of block width
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyBufferToImage-imageOffset-07738");  // image transfer granularity
     vk::CmdCopyBufferToImage(m_commandBuffer->handle(), buffer_16.handle(), odd_image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1,
@@ -1944,7 +1944,7 @@ TEST_F(NegativeCommand, ImageBufferCopy) {
 
             // extents that are not a multiple of compressed block size
             m_errorMonitor->SetDesiredFailureMsg(
-                kErrorBit, "VUID-vkCmdCopyImageToBuffer-imageExtent-00207");  // extent width not a multiple of block size
+                kErrorBit, "VUID-vkCmdCopyImageToBuffer-srcImage-00207");  // extent width not a multiple of block size
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                                  "VUID-vkCmdCopyImageToBuffer-imageOffset-07747");  // image transfer granularity
             region.imageExtent.width = 66;
@@ -1954,7 +1954,7 @@ TEST_F(NegativeCommand, ImageBufferCopy) {
             region.imageExtent.width = 128;
 
             m_errorMonitor->SetDesiredFailureMsg(
-                kErrorBit, "VUID-vkCmdCopyImageToBuffer-imageExtent-00208");  // extent height not a multiple of block size
+                kErrorBit, "VUID-vkCmdCopyImageToBuffer-srcImage-00208");  // extent height not a multiple of block size
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                                  "VUID-vkCmdCopyImageToBuffer-imageOffset-07747");  // image transfer granularity
             region.imageExtent.height = 2;

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -103,7 +103,7 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToFromMemory) {
     // image dimensions (09115). Pick the one with MEMCPY flag set and test for both here.
     region_to_image.imageExtent.width = width - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-imageOffset-09114");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-imageExtent-09115");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-dstImage-09115");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
 
@@ -111,7 +111,7 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToFromMemory) {
     region_from_image.imageOffset.x = 1;
     region_from_image.imageExtent.width = width - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-imageOffset-09114");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-imageExtent-09115");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-srcImage-09115");
     vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
     m_errorMonitor->VerifyFound();
 
@@ -367,16 +367,16 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToFromMemory) {
             region_to_image.imageExtent = {1, 1, 1};
             region_to_image.imageSubresource.mipLevel = 4;
             copy_to_image.dstImage = image_compressed;
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-pRegions-07274");
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-pRegions-07275");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-dstImage-07274");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-dstImage-07275");
             vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
             m_errorMonitor->VerifyFound();
             region_from_image.imageOffset = {1, 1, 0};
             region_from_image.imageExtent = {1, 1, 1};
             region_from_image.imageSubresource.mipLevel = 4;
             copy_from_image.srcImage = image_compressed;
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-pRegions-07274");
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-pRegions-07275");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-srcImage-07274");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-srcImage-07275");
             vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
             m_errorMonitor->VerifyFound();
             region_to_image.imageOffset = {0, 0, 0};
@@ -384,21 +384,21 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToFromMemory) {
 
             // width not a multiple of compressed block width
             region_to_image.imageExtent = {1, 2, 1};
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-imageExtent-00207");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-dstImage-00207");
             vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
             m_errorMonitor->VerifyFound();
             region_from_image.imageExtent = {1, 2, 1};
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-imageExtent-00207");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-srcImage-00207");
             vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
             m_errorMonitor->VerifyFound();
 
             // Copy height < compressed block size but not the full mip height
             region_to_image.imageExtent = {2, 1, 1};
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-imageExtent-00208");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyMemoryToImageInfoEXT-dstImage-00208");
             vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
             m_errorMonitor->VerifyFound();
             region_from_image.imageExtent = {2, 1, 1};
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-imageExtent-00208");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToMemoryInfoEXT-srcImage-00208");
             vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
             m_errorMonitor->VerifyFound();
 
@@ -808,8 +808,8 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToImage) {
     image_copy_2.extent.width = width - 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-dstOffset-09114");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-srcOffset-09114");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-extent-09115");
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-extent-09115");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-srcImage-09115");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-dstImage-09115");
     vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
     m_errorMonitor->VerifyFound();
 
@@ -1030,10 +1030,10 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToImage) {
             image_copy_2.dstSubresource.mipLevel = 4;
             copy_image_to_image.dstImage = image_compressed1;
             copy_image_to_image.srcImage = image_compressed2;
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-pRegions-07274");
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-pRegions-07274");
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-pRegions-07275");
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-pRegions-07275");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-srcImage-07274");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-dstImage-07274");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-srcImage-07275");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-dstImage-07275");
             vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
             m_errorMonitor->VerifyFound();
             image_copy_2.dstOffset = {0, 0, 0};
@@ -1041,15 +1041,15 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToImage) {
 
             // width not a multiple of compressed block width
             image_copy_2.extent = {1, 2, 1};
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-imageExtent-00207");
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-imageExtent-00207");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-srcImage-00207");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-dstImage-00207");
             vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
             m_errorMonitor->VerifyFound();
 
             // Copy height < compressed block size but not the full mip height
             image_copy_2.extent = {2, 1, 1};
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-imageExtent-00208");
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-imageExtent-00208");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-srcImage-00208");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToImageInfoEXT-dstImage-00208");
             vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
             m_errorMonitor->VerifyFound();
             image_copy_2.extent = {width, height, 1};


### PR DESCRIPTION
The 1.3.263 spec removed a lot of bad VUs and this is just cleaning them up