### PR TITLE
layers: Improve dynamic state feature messages

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -914,7 +914,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineMultisampleState(const PIPELINE_STATE& pipeline, const safe_VkSubpassDescription2* subpass_desc,
                                                   const Location& loc) const;
     bool ValidateGraphicsPipelineDepthStencilState(const PIPELINE_STATE& pipeline, const Location& loc) const;
-    bool ValidateGraphicsPipelineDynamicState(const PIPELINE_STATE& pipeline) const;
+    bool ValidateGraphicsPipelineDynamicState(const PIPELINE_STATE& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineFragmentShadingRateState(const PIPELINE_STATE& pipeline, const Location& loc) const;
     bool ValidateGraphicsPipelineDynamicRendering(const PIPELINE_STATE& pipeline, const Location& loc) const;
     bool ValidateComputePipelineShaderState(const PIPELINE_STATE& pipeline, const Location& create_info_loc) const;


### PR DESCRIPTION
The messages before never told you where to look for your dynamic state, new errors look like

>  vkCreateGraphicsPipelines(): pCreateInfos[1].pDynamicState.pDynamicStates[3] is VK_DYNAMIC_STATE_LOGIC_OP_EXT, but the extendedDynamicState2LogicOp feature was not enabled.