### PR TITLE
layers: Fix CoreCheck RenderPass to return earlier

### DIFF
--- a/layers/stateless/sl_framebuffer.cpp
+++ b/layers/stateless/sl_framebuffer.cpp
@@ -27,5 +27,19 @@ bool StatelessValidation::manual_PreCallValidateCreateFramebuffer(VkDevice devic
         skip |= ValidateArray(error_obj.location, "attachmentCount", "pAttachments", pCreateInfo->attachmentCount,
                               &pCreateInfo->pAttachments, false, true, kVUIDUndefined, "VUID-VkFramebufferCreateInfo-flags-02778");
     }
+
+    // Verify FB dimensions are greater than zero
+    if (pCreateInfo->width == 0) {
+        skip |= LogError("VUID-VkFramebufferCreateInfo-width-00885", device,
+                         error_obj.location.dot(Field::pCreateInfo).dot(Field::width), "is zero.");
+    }
+    if (pCreateInfo->height == 0) {
+        skip |= LogError("VUID-VkFramebufferCreateInfo-height-00887", device,
+                         error_obj.location.dot(Field::pCreateInfo).dot(Field::height), "is zero.");
+    }
+    if (pCreateInfo->layers == 0) {
+        skip |= LogError("VUID-VkFramebufferCreateInfo-layers-00889", device,
+                         error_obj.location.dot(Field::pCreateInfo).dot(Field::layers), "is zero.");
+    }
     return skip;
 }

--- a/tests/unit/renderpass.cpp
+++ b/tests/unit/renderpass.cpp
@@ -4655,6 +4655,22 @@ TEST_F(NegativeRenderPass, BeginInfoWithoutRenderPass) {
     m_renderPassBeginInfo.renderPass = CastFromUint64<VkRenderPass>(0xFFFFEEEE);
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-GeneralParameterError-RequiredParameter");
+    m_renderPassBeginInfo.renderPass = VK_NULL_HANDLE;
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}
+
+TEST_F(NegativeRenderPass, BeginInfoWithoutFramebuffer) {
+    TEST_DESCRIPTION("call VkRenderPassBeginInfo with invalid framebuffer");
+    ASSERT_NO_FATAL_FAILURE(Init());
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassBeginInfo-framebuffer-parameter");
+    m_renderPassBeginInfo.framebuffer = CastFromUint64<VkFramebuffer>(0xFFFFEEEE);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    m_errorMonitor->VerifyFound();
     m_commandBuffer->end();
 }
 


### PR DESCRIPTION
This cleans up a lot of functions in the `cc_render_pass.cpp` that get very nested, but realize we can just be returning early (or `continue` of `for` loops) more

Most of this is just shifting things over to the left