### PR TITLE
scripts: Fix extra whitespace in VU messages

### DIFF
--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -656,6 +656,8 @@ static const vuid_spec_text_pair vuid_spec_text[] = {
                 db_text = re.sub(html_remove_tags, '', db_text)
                 # In future we could use the `/n` to add new lines to a pretty print in the console
                 db_text = db_text.replace('\n', ' ')
+                # Remove multiple whitespaces
+                db_text = re.sub(' +', ' ', db_text)
                 hfile.write('    {"%s", "%s", "%s"},\n' % (vuid, db_text, spec_url_id))
                 # For multiply-defined VUIDs, include versions with extension appended
                 if len(self.vj.vuid_db[vuid]) > 1:


### PR DESCRIPTION
Removes multiple whitespace artifacts from the `validusage.json` file