### PR TITLE
layers: Improve nesting by returning back sooner

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -3172,336 +3172,331 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
     auto cb_state_ptr = GetRead<CMD_BUFFER_STATE>(commandBuffer);
     auto src_image_state = Get<IMAGE_STATE>(srcImage);
     auto dst_image_state = Get<IMAGE_STATE>(dstImage);
+    if (!cb_state_ptr || !src_image_state || !src_image_state) {
+        return skip;
+    }
 
     const bool is_2 = loc.function == Func::vkCmdBlitImage2 || loc.function == Func::vkCmdBlitImage2KHR;
     const Location src_image_loc = loc.dot(Field::srcImage);
     const Location dst_image_loc = loc.dot(Field::dstImage);
 
-    if (cb_state_ptr && src_image_state && dst_image_state) {
-        const CMD_BUFFER_STATE &cb_state = *cb_state_ptr;
-        skip |= ValidateCmd(cb_state, loc);
+    const CMD_BUFFER_STATE &cb_state = *cb_state_ptr;
+    skip |= ValidateCmd(cb_state, loc);
 
-        const char *vuid;
-        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00233" : "VUID-vkCmdBlitImage-srcImage-00233";
-        skip |= ValidateImageSampleCount(commandBuffer, *src_image_state, VK_SAMPLE_COUNT_1_BIT, src_image_loc, vuid);
-        vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00234" : "VUID-vkCmdBlitImage-dstImage-00234";
-        skip |= ValidateImageSampleCount(commandBuffer, *dst_image_state, VK_SAMPLE_COUNT_1_BIT, dst_image_loc, vuid);
-        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00220" : "VUID-vkCmdBlitImage-srcImage-00220";
-        skip |= ValidateMemoryIsBoundToImage(LogObjectList(device, srcImage), *src_image_state, src_image_loc, vuid);
-        vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00225" : "VUID-vkCmdBlitImage-dstImage-00225";
-        skip |= ValidateMemoryIsBoundToImage(LogObjectList(device, dstImage), *dst_image_state, dst_image_loc, vuid);
-        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00219" : "VUID-vkCmdBlitImage-srcImage-00219";
-        skip |=
-            ValidateImageUsageFlags(commandBuffer, *src_image_state, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, true, vuid, src_image_loc);
-        vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00224" : "VUID-vkCmdBlitImage-dstImage-00224";
-        skip |=
-            ValidateImageUsageFlags(commandBuffer, *dst_image_state, VK_IMAGE_USAGE_TRANSFER_DST_BIT, true, vuid, dst_image_loc);
-        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-01999" : "VUID-vkCmdBlitImage-srcImage-01999";
-        skip |=
-            ValidateImageFormatFeatureFlags(commandBuffer, *src_image_state, VK_FORMAT_FEATURE_2_BLIT_SRC_BIT, src_image_loc, vuid);
-        vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-02000" : "VUID-vkCmdBlitImage-dstImage-02000";
-        skip |=
-            ValidateImageFormatFeatureFlags(commandBuffer, *dst_image_state, VK_FORMAT_FEATURE_2_BLIT_DST_BIT, dst_image_loc, vuid);
-        vuid = is_2 ? "VUID-vkCmdBlitImage2-commandBuffer-01834" : "VUID-vkCmdBlitImage-commandBuffer-01834";
-        skip |= ValidateProtectedImage(cb_state, *src_image_state, src_image_loc, vuid);
-        vuid = is_2 ? "VUID-vkCmdBlitImage2-commandBuffer-01835" : "VUID-vkCmdBlitImage-commandBuffer-01835";
-        skip |= ValidateProtectedImage(cb_state, *dst_image_state, dst_image_loc, vuid);
-        vuid = is_2 ? "VUID-vkCmdBlitImage2-commandBuffer-01836" : "VUID-vkCmdBlitImage-commandBuffer-01836";
-        skip |= ValidateUnprotectedImage(cb_state, *dst_image_state, dst_image_loc, vuid);
+    const char *vuid;
+    vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00233" : "VUID-vkCmdBlitImage-srcImage-00233";
+    skip |= ValidateImageSampleCount(commandBuffer, *src_image_state, VK_SAMPLE_COUNT_1_BIT, src_image_loc, vuid);
+    vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00234" : "VUID-vkCmdBlitImage-dstImage-00234";
+    skip |= ValidateImageSampleCount(commandBuffer, *dst_image_state, VK_SAMPLE_COUNT_1_BIT, dst_image_loc, vuid);
+    vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00220" : "VUID-vkCmdBlitImage-srcImage-00220";
+    skip |= ValidateMemoryIsBoundToImage(LogObjectList(device, srcImage), *src_image_state, src_image_loc, vuid);
+    vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00225" : "VUID-vkCmdBlitImage-dstImage-00225";
+    skip |= ValidateMemoryIsBoundToImage(LogObjectList(device, dstImage), *dst_image_state, dst_image_loc, vuid);
+    vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00219" : "VUID-vkCmdBlitImage-srcImage-00219";
+    skip |= ValidateImageUsageFlags(commandBuffer, *src_image_state, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, true, vuid, src_image_loc);
+    vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00224" : "VUID-vkCmdBlitImage-dstImage-00224";
+    skip |= ValidateImageUsageFlags(commandBuffer, *dst_image_state, VK_IMAGE_USAGE_TRANSFER_DST_BIT, true, vuid, dst_image_loc);
+    vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-01999" : "VUID-vkCmdBlitImage-srcImage-01999";
+    skip |= ValidateImageFormatFeatureFlags(commandBuffer, *src_image_state, VK_FORMAT_FEATURE_2_BLIT_SRC_BIT, src_image_loc, vuid);
+    vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-02000" : "VUID-vkCmdBlitImage-dstImage-02000";
+    skip |= ValidateImageFormatFeatureFlags(commandBuffer, *dst_image_state, VK_FORMAT_FEATURE_2_BLIT_DST_BIT, dst_image_loc, vuid);
+    vuid = is_2 ? "VUID-vkCmdBlitImage2-commandBuffer-01834" : "VUID-vkCmdBlitImage-commandBuffer-01834";
+    skip |= ValidateProtectedImage(cb_state, *src_image_state, src_image_loc, vuid);
+    vuid = is_2 ? "VUID-vkCmdBlitImage2-commandBuffer-01835" : "VUID-vkCmdBlitImage-commandBuffer-01835";
+    skip |= ValidateProtectedImage(cb_state, *dst_image_state, dst_image_loc, vuid);
+    vuid = is_2 ? "VUID-vkCmdBlitImage2-commandBuffer-01836" : "VUID-vkCmdBlitImage-commandBuffer-01836";
+    skip |= ValidateUnprotectedImage(cb_state, *dst_image_state, dst_image_loc, vuid);
 
-        const LogObjectList src_objlist(commandBuffer, srcImage);
-        const LogObjectList dst_objlist(commandBuffer, dstImage);
-        const LogObjectList all_objlist(commandBuffer, srcImage, dstImage);
-        // Validation for VK_EXT_fragment_density_map
-        if (src_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-02545" : "VUID-vkCmdBlitImage-dstImage-02545";
-            skip |= LogError(vuid, src_objlist, src_image_loc, "was created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
-        }
-        if (dst_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-02545" : "VUID-vkCmdBlitImage-dstImage-02545";
-            skip |= LogError(vuid, dst_objlist, dst_image_loc, "was created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
-        }
+    const LogObjectList src_objlist(commandBuffer, srcImage);
+    const LogObjectList dst_objlist(commandBuffer, dstImage);
+    const LogObjectList all_objlist(commandBuffer, srcImage, dstImage);
+    // Validation for VK_EXT_fragment_density_map
+    if (src_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-02545" : "VUID-vkCmdBlitImage-dstImage-02545";
+        skip |= LogError(vuid, src_objlist, src_image_loc, "was created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
+    }
+    if (dst_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-02545" : "VUID-vkCmdBlitImage-dstImage-02545";
+        skip |= LogError(vuid, dst_objlist, dst_image_loc, "was created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
+    }
 
-        // TODO: Need to validate image layouts, which will include layout validation for shared presentable images
+    // TODO: Need to validate image layouts, which will include layout validation for shared presentable images
 
-        VkFormat src_format = src_image_state->createInfo.format;
-        VkFormat dst_format = dst_image_state->createInfo.format;
-        VkImageType src_type = src_image_state->createInfo.imageType;
-        VkImageType dst_type = dst_image_state->createInfo.imageType;
+    VkFormat src_format = src_image_state->createInfo.format;
+    VkFormat dst_format = dst_image_state->createInfo.format;
+    VkImageType src_type = src_image_state->createInfo.imageType;
+    VkImageType dst_type = dst_image_state->createInfo.imageType;
 
-        if (VK_FILTER_LINEAR == filter) {
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-filter-02001" : "VUID-vkCmdBlitImage-filter-02001";
-            skip |= ValidateImageFormatFeatureFlags(commandBuffer, *src_image_state,
-                                                    VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT, src_image_loc, vuid);
-        } else if (VK_FILTER_CUBIC_IMG == filter) {
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-filter-02002" : "VUID-vkCmdBlitImage-filter-02002";
-            skip |= ValidateImageFormatFeatureFlags(commandBuffer, *src_image_state,
-                                                    VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT, src_image_loc, vuid);
-        }
+    if (VK_FILTER_LINEAR == filter) {
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-filter-02001" : "VUID-vkCmdBlitImage-filter-02001";
+        skip |= ValidateImageFormatFeatureFlags(commandBuffer, *src_image_state,
+                                                VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT, src_image_loc, vuid);
+    } else if (VK_FILTER_CUBIC_IMG == filter) {
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-filter-02002" : "VUID-vkCmdBlitImage-filter-02002";
+        skip |= ValidateImageFormatFeatureFlags(commandBuffer, *src_image_state, VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT,
+                                                src_image_loc, vuid);
+    }
 
-        if (FormatRequiresYcbcrConversionExplicitly(src_format)) {
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-06421" : "VUID-vkCmdBlitImage-srcImage-06421";
-            skip |= LogError(vuid, src_objlist, src_image_loc,
-                             "format (%s) must not be one of the formats requiring sampler YCBCR "
-                             "conversion for VK_IMAGE_ASPECT_COLOR_BIT image views",
-                             string_VkFormat(src_format));
-        }
+    if (FormatRequiresYcbcrConversionExplicitly(src_format)) {
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-06421" : "VUID-vkCmdBlitImage-srcImage-06421";
+        skip |= LogError(vuid, src_objlist, src_image_loc,
+                         "format (%s) must not be one of the formats requiring sampler YCBCR "
+                         "conversion for VK_IMAGE_ASPECT_COLOR_BIT image views",
+                         string_VkFormat(src_format));
+    }
 
-        if (FormatRequiresYcbcrConversionExplicitly(dst_format)) {
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-06422" : "VUID-vkCmdBlitImage-dstImage-06422";
-            skip |= LogError(vuid, dst_objlist, dst_image_loc,
-                             "format (%s) must not be one of the formats requiring sampler YCBCR "
-                             "conversion for VK_IMAGE_ASPECT_COLOR_BIT image views",
-                             string_VkFormat(dst_format));
-        }
+    if (FormatRequiresYcbcrConversionExplicitly(dst_format)) {
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-06422" : "VUID-vkCmdBlitImage-dstImage-06422";
+        skip |= LogError(vuid, dst_objlist, dst_image_loc,
+                         "format (%s) must not be one of the formats requiring sampler YCBCR "
+                         "conversion for VK_IMAGE_ASPECT_COLOR_BIT image views",
+                         string_VkFormat(dst_format));
+    }
 
-        if ((VK_FILTER_CUBIC_IMG == filter) && (VK_IMAGE_TYPE_2D != src_type)) {
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-filter-00237" : "VUID-vkCmdBlitImage-filter-00237";
-            skip |= LogError(vuid, src_objlist, loc.dot(Field::filter), "is VK_FILTER_CUBIC_IMG but srcImage was created with %s.",
-                             string_VkImageType(src_type));
-        }
+    if ((VK_FILTER_CUBIC_IMG == filter) && (VK_IMAGE_TYPE_2D != src_type)) {
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-filter-00237" : "VUID-vkCmdBlitImage-filter-00237";
+        skip |= LogError(vuid, src_objlist, loc.dot(Field::filter), "is VK_FILTER_CUBIC_IMG but srcImage was created with %s.",
+                         string_VkImageType(src_type));
+    }
 
-        // Validate consistency for unsigned formats
-        if (FormatIsUINT(src_format) != FormatIsUINT(dst_format)) {
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00230" : "VUID-vkCmdBlitImage-srcImage-00230";
+    // Validate consistency for unsigned formats
+    if (FormatIsUINT(src_format) != FormatIsUINT(dst_format)) {
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00230" : "VUID-vkCmdBlitImage-srcImage-00230";
+        skip |= LogError(vuid, all_objlist, loc, "srcImage format %s is different than dstImage format %s.",
+                         string_VkFormat(src_format), string_VkFormat(dst_format));
+    }
+
+    // Validate consistency for signed formats
+    if (FormatIsSINT(src_format) != FormatIsSINT(dst_format)) {
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00229" : "VUID-vkCmdBlitImage-srcImage-00229";
+        skip |= LogError(vuid, all_objlist, loc, "srcImage format %s is different than dstImage format %s.",
+                         string_VkFormat(src_format), string_VkFormat(dst_format));
+    }
+
+    // Validate filter for Depth/Stencil formats
+    if (FormatIsDepthOrStencil(src_format) && (filter != VK_FILTER_NEAREST)) {
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00232" : "VUID-vkCmdBlitImage-srcImage-00232";
+        skip |= LogError(vuid, src_objlist, src_image_loc, "has depth-stencil format %s but filter is %s.",
+                         string_VkFormat(src_format), string_VkFilter(filter));
+    }
+
+    // Validate aspect bits and formats for depth/stencil images
+    if (FormatIsDepthOrStencil(src_format) || FormatIsDepthOrStencil(dst_format)) {
+        if (src_format != dst_format) {
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00231" : "VUID-vkCmdBlitImage-srcImage-00231";
             skip |= LogError(vuid, all_objlist, loc, "srcImage format %s is different than dstImage format %s.",
                              string_VkFormat(src_format), string_VkFormat(dst_format));
         }
+    }
 
-        // Validate consistency for signed formats
-        if (FormatIsSINT(src_format) != FormatIsSINT(dst_format)) {
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00229" : "VUID-vkCmdBlitImage-srcImage-00229";
-            skip |= LogError(vuid, all_objlist, loc, "srcImage format %s is different than dstImage format %s.",
-                             string_VkFormat(src_format), string_VkFormat(dst_format));
+    // Do per-region checks
+    const char *invalid_src_layout_vuid =
+        is_2 ? "VUID-VkBlitImageInfo2-srcImageLayout-01398" : "VUID-vkCmdBlitImage-srcImageLayout-01398";
+    const char *invalid_dst_layout_vuid =
+        is_2 ? "VUID-VkBlitImageInfo2-dstImageLayout-01399" : "VUID-vkCmdBlitImage-dstImageLayout-01399";
+
+    const bool same_image = (src_image_state == dst_image_state);
+    for (uint32_t i = 0; i < regionCount; i++) {
+        const Location region_loc = loc.dot(Field::pRegions, i);
+        const Location src_subresource_loc = region_loc.dot(Field::srcSubresource);
+        const Location dst_subresource_loc = region_loc.dot(Field::dstSubresource);
+        const RegionType region = pRegions[i];
+        bool hit_error = false;
+
+        // When performing blit from and to same subresource, VK_IMAGE_LAYOUT_GENERAL is the only option
+        const auto &src_sub = region.srcSubresource;
+        const auto &dst_sub = region.dstSubresource;
+        bool same_subresource =
+            (same_image && (src_sub.mipLevel == dst_sub.mipLevel) && (src_sub.baseArrayLayer == dst_sub.baseArrayLayer));
+        VkImageLayout source_optimal = (same_subresource ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+        VkImageLayout destination_optimal = (same_subresource ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImageLayout-00221" : "VUID-vkCmdBlitImage-srcImageLayout-00221";
+        skip |= VerifyImageLayout(cb_state, *src_image_state, region.srcSubresource, srcImageLayout, source_optimal, src_image_loc,
+                                  invalid_src_layout_vuid, vuid, &hit_error);
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImageLayout-00226" : "VUID-vkCmdBlitImage-dstImageLayout-00226";
+        skip |= VerifyImageLayout(cb_state, *dst_image_state, region.dstSubresource, dstImageLayout, destination_optimal,
+                                  dst_image_loc, invalid_dst_layout_vuid, vuid, &hit_error);
+        skip |= ValidateImageSubresourceLayers(cb_state.commandBuffer(), &region.srcSubresource, src_subresource_loc);
+        skip |= ValidateImageSubresourceLayers(cb_state.commandBuffer(), &region.dstSubresource, dst_subresource_loc);
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcSubresource-01705" : "VUID-vkCmdBlitImage-srcSubresource-01705";
+        skip |= ValidateImageMipLevel(commandBuffer, *src_image_state, region.srcSubresource.mipLevel,
+                                      src_subresource_loc.dot(Field::mipLevel), vuid);
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-dstSubresource-01706" : "VUID-vkCmdBlitImage-dstSubresource-01706";
+        skip |= ValidateImageMipLevel(commandBuffer, *dst_image_state, region.dstSubresource.mipLevel,
+                                      dst_subresource_loc.dot(Field::mipLevel), vuid);
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-srcSubresource-01707" : "VUID-vkCmdBlitImage-srcSubresource-01707";
+        skip |= ValidateImageArrayLayerRange(commandBuffer, *src_image_state, region.srcSubresource.baseArrayLayer,
+                                             region.srcSubresource.layerCount, src_subresource_loc, vuid);
+        vuid = is_2 ? "VUID-VkBlitImageInfo2-dstSubresource-01708" : "VUID-vkCmdBlitImage-dstSubresource-01708";
+        skip |= ValidateImageArrayLayerRange(commandBuffer, *dst_image_state, region.dstSubresource.baseArrayLayer,
+                                             region.dstSubresource.layerCount, dst_subresource_loc, vuid);
+        // Check that src/dst layercounts match
+        if (region.srcSubresource.layerCount != region.dstSubresource.layerCount) {
+            vuid = is_2 ? "VUID-VkImageBlit2-layerCount-00239" : "VUID-VkImageBlit-layerCount-00239";
+            skip |= LogError(vuid, all_objlist, src_subresource_loc.dot(Field::layerCount),
+                             "(%" PRIu32 ") does not match %s (%" PRIu32 ").", region.srcSubresource.layerCount,
+                             dst_subresource_loc.dot(Field::layerCount).Fields().c_str(), region.dstSubresource.layerCount);
         }
 
-        // Validate filter for Depth/Stencil formats
-        if (FormatIsDepthOrStencil(src_format) && (filter != VK_FILTER_NEAREST)) {
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00232" : "VUID-vkCmdBlitImage-srcImage-00232";
-            skip |= LogError(vuid, src_objlist, src_image_loc, "has depth-stencil format %s but filter is %s.",
-                             string_VkFormat(src_format), string_VkFilter(filter));
+        if (region.srcSubresource.aspectMask != region.dstSubresource.aspectMask) {
+            vuid = is_2 ? "VUID-VkImageBlit2-aspectMask-00238" : "VUID-VkImageBlit-aspectMask-00238";
+            skip |= LogError(vuid, all_objlist, src_subresource_loc.dot(Field::aspectMask), "(%s) does not match %s (%s).",
+                             string_VkImageAspectFlags(region.srcSubresource.aspectMask).c_str(),
+                             dst_subresource_loc.dot(Field::aspectMask).Fields().c_str(),
+                             string_VkImageAspectFlags(region.dstSubresource.aspectMask).c_str());
         }
 
-        // Validate aspect bits and formats for depth/stencil images
-        if (FormatIsDepthOrStencil(src_format) || FormatIsDepthOrStencil(dst_format)) {
-            if (src_format != dst_format) {
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00231" : "VUID-vkCmdBlitImage-srcImage-00231";
-                skip |= LogError(vuid, all_objlist, loc, "srcImage format %s is different than dstImage format %s.",
-                                 string_VkFormat(src_format), string_VkFormat(dst_format));
+        if (!VerifyAspectsPresent(region.srcSubresource.aspectMask, src_format)) {
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-aspectMask-00241" : "VUID-vkCmdBlitImage-aspectMask-00241";
+            skip |= LogError(vuid, src_objlist, src_subresource_loc.dot(Field::aspectMask),
+                             "(%s) cannot specify aspects not present in source image (%s).",
+                             string_VkImageAspectFlags(region.srcSubresource.aspectMask).c_str(), string_VkFormat(src_format));
+        }
+
+        if (!VerifyAspectsPresent(region.dstSubresource.aspectMask, dst_format)) {
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-aspectMask-00242" : "VUID-vkCmdBlitImage-aspectMask-00242";
+            skip |= LogError(vuid, dst_objlist, dst_subresource_loc.dot(Field::aspectMask),
+                             "(%s) cannot specify aspects not present in destination image (%s).",
+                             string_VkImageAspectFlags(region.srcSubresource.aspectMask).c_str(), string_VkFormat(src_format));
+        }
+
+        // Validate source image offsets
+        VkExtent3D src_extent = src_image_state->GetEffectiveSubresourceExtent(region.srcSubresource);
+        if (VK_IMAGE_TYPE_1D == src_type) {
+            if ((0 != region.srcOffsets[0].y) || (1 != region.srcOffsets[1].y)) {
+                vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00245" : "VUID-vkCmdBlitImage-srcImage-00245";
+                skip |=
+                    LogError(vuid, src_objlist, region_loc,
+                             "srcOffsets[0].y is %" PRId32 " and srcOffsets[1].y is %" PRId32 " but srcImage is VK_IMAGE_TYPE_1D.",
+                             region.srcOffsets[0].y, region.srcOffsets[1].y);
             }
-        }  // Depth or Stencil
+        }
 
-        // Do per-region checks
-        const char *invalid_src_layout_vuid =
-            is_2 ? "VUID-VkBlitImageInfo2-srcImageLayout-01398" : "VUID-vkCmdBlitImage-srcImageLayout-01398";
-        const char *invalid_dst_layout_vuid =
-            is_2 ? "VUID-VkBlitImageInfo2-dstImageLayout-01399" : "VUID-vkCmdBlitImage-dstImageLayout-01399";
-
-        const bool same_image = (src_image_state == dst_image_state);
-        for (uint32_t i = 0; i < regionCount; i++) {
-            const Location region_loc = loc.dot(Field::pRegions, i);
-            const Location src_subresource_loc = region_loc.dot(Field::srcSubresource);
-            const Location dst_subresource_loc = region_loc.dot(Field::dstSubresource);
-            const RegionType region = pRegions[i];
-            bool hit_error = false;
-
-            // When performing blit from and to same subresource, VK_IMAGE_LAYOUT_GENERAL is the only option
-            const auto &src_sub = region.srcSubresource;
-            const auto &dst_sub = region.dstSubresource;
-            bool same_subresource =
-                (same_image && (src_sub.mipLevel == dst_sub.mipLevel) && (src_sub.baseArrayLayer == dst_sub.baseArrayLayer));
-            VkImageLayout source_optimal = (same_subresource ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
-            VkImageLayout destination_optimal = (same_subresource ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImageLayout-00221" : "VUID-vkCmdBlitImage-srcImageLayout-00221";
-            skip |= VerifyImageLayout(cb_state, *src_image_state, region.srcSubresource, srcImageLayout, source_optimal,
-                                      src_image_loc, invalid_src_layout_vuid, vuid, &hit_error);
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImageLayout-00226" : "VUID-vkCmdBlitImage-dstImageLayout-00226";
-            skip |= VerifyImageLayout(cb_state, *dst_image_state, region.dstSubresource, dstImageLayout, destination_optimal,
-                                      dst_image_loc, invalid_dst_layout_vuid, vuid, &hit_error);
-            skip |= ValidateImageSubresourceLayers(cb_state.commandBuffer(), &region.srcSubresource, src_subresource_loc);
-            skip |= ValidateImageSubresourceLayers(cb_state.commandBuffer(), &region.dstSubresource, dst_subresource_loc);
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcSubresource-01705" : "VUID-vkCmdBlitImage-srcSubresource-01705";
-            skip |= ValidateImageMipLevel(commandBuffer, *src_image_state, region.srcSubresource.mipLevel,
-                                          src_subresource_loc.dot(Field::mipLevel), vuid);
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-dstSubresource-01706" : "VUID-vkCmdBlitImage-dstSubresource-01706";
-            skip |= ValidateImageMipLevel(commandBuffer, *dst_image_state, region.dstSubresource.mipLevel,
-                                          dst_subresource_loc.dot(Field::mipLevel), vuid);
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcSubresource-01707" : "VUID-vkCmdBlitImage-srcSubresource-01707";
-            skip |= ValidateImageArrayLayerRange(commandBuffer, *src_image_state, region.srcSubresource.baseArrayLayer,
-                                                 region.srcSubresource.layerCount, src_subresource_loc, vuid);
-            vuid = is_2 ? "VUID-VkBlitImageInfo2-dstSubresource-01708" : "VUID-vkCmdBlitImage-dstSubresource-01708";
-            skip |= ValidateImageArrayLayerRange(commandBuffer, *dst_image_state, region.dstSubresource.baseArrayLayer,
-                                                 region.dstSubresource.layerCount, dst_subresource_loc, vuid);
-            // Check that src/dst layercounts match
-            if (region.srcSubresource.layerCount != region.dstSubresource.layerCount) {
-                vuid = is_2 ? "VUID-VkImageBlit2-layerCount-00239" : "VUID-VkImageBlit-layerCount-00239";
-                skip |= LogError(vuid, all_objlist, src_subresource_loc.dot(Field::layerCount),
-                                 "(%" PRIu32 ") does not match %s (%" PRIu32 ").", region.srcSubresource.layerCount,
-                                 dst_subresource_loc.dot(Field::layerCount).Fields().c_str(), region.dstSubresource.layerCount);
-            }
-
-            if (region.srcSubresource.aspectMask != region.dstSubresource.aspectMask) {
-                vuid = is_2 ? "VUID-VkImageBlit2-aspectMask-00238" : "VUID-VkImageBlit-aspectMask-00238";
-                skip |= LogError(vuid, all_objlist, src_subresource_loc.dot(Field::aspectMask), "(%s) does not match %s (%s).",
-                                 string_VkImageAspectFlags(region.srcSubresource.aspectMask).c_str(),
-                                 dst_subresource_loc.dot(Field::aspectMask).Fields().c_str(),
-                                 string_VkImageAspectFlags(region.dstSubresource.aspectMask).c_str());
-            }
-
-            if (!VerifyAspectsPresent(region.srcSubresource.aspectMask, src_format)) {
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-aspectMask-00241" : "VUID-vkCmdBlitImage-aspectMask-00241";
-                skip |= LogError(vuid, src_objlist, src_subresource_loc.dot(Field::aspectMask),
-                                 "(%s) cannot specify aspects not present in source image (%s).",
-                                 string_VkImageAspectFlags(region.srcSubresource.aspectMask).c_str(), string_VkFormat(src_format));
-            }
-
-            if (!VerifyAspectsPresent(region.dstSubresource.aspectMask, dst_format)) {
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-aspectMask-00242" : "VUID-vkCmdBlitImage-aspectMask-00242";
-                skip |= LogError(vuid, dst_objlist, dst_subresource_loc.dot(Field::aspectMask),
-                                 "(%s) cannot specify aspects not present in destination image (%s).",
-                                 string_VkImageAspectFlags(region.srcSubresource.aspectMask).c_str(), string_VkFormat(src_format));
-            }
-
-            // Validate source image offsets
-            VkExtent3D src_extent = src_image_state->GetEffectiveSubresourceExtent(region.srcSubresource);
-            if (VK_IMAGE_TYPE_1D == src_type) {
-                if ((0 != region.srcOffsets[0].y) || (1 != region.srcOffsets[1].y)) {
-                    vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00245" : "VUID-vkCmdBlitImage-srcImage-00245";
-                    skip |= LogError(vuid, src_objlist, region_loc,
-                                     "srcOffsets[0].y is %" PRId32 " and srcOffsets[1].y is %" PRId32
-                                     " but srcImage is VK_IMAGE_TYPE_1D.",
-                                     region.srcOffsets[0].y, region.srcOffsets[1].y);
-                }
-            }
-
-            if ((VK_IMAGE_TYPE_1D == src_type) || (VK_IMAGE_TYPE_2D == src_type)) {
-                if ((0 != region.srcOffsets[0].z) || (1 != region.srcOffsets[1].z)) {
-                    vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00247" : "VUID-vkCmdBlitImage-srcImage-00247";
-                    skip |= LogError(vuid, src_objlist, region_loc,
-                                     "srcOffsets[0].z is %" PRId32 " and srcOffsets[1].z is %" PRId32 " but srcImage is %s.",
-                                     region.srcOffsets[0].z, region.srcOffsets[1].z, string_VkImageType(src_type));
-                }
-            }
-
-            bool oob = false;
-            if ((region.srcOffsets[0].x < 0) || (region.srcOffsets[0].x > static_cast<int32_t>(src_extent.width)) ||
-                (region.srcOffsets[1].x < 0) || (region.srcOffsets[1].x > static_cast<int32_t>(src_extent.width))) {
-                oob = true;
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-srcOffset-00243" : "VUID-vkCmdBlitImage-srcOffset-00243";
+        if ((VK_IMAGE_TYPE_1D == src_type) || (VK_IMAGE_TYPE_2D == src_type)) {
+            if ((0 != region.srcOffsets[0].z) || (1 != region.srcOffsets[1].z)) {
+                vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00247" : "VUID-vkCmdBlitImage-srcImage-00247";
                 skip |= LogError(vuid, src_objlist, region_loc,
-                                 "srcOffsets[0].x is %" PRId32 " and srcOffsets[1].x is %" PRId32
-                                 " which exceed srcSubresource width extent (%" PRIu32 ").",
-                                 region.srcOffsets[0].x, region.srcOffsets[1].x, src_extent.width);
+                                 "srcOffsets[0].z is %" PRId32 " and srcOffsets[1].z is %" PRId32 " but srcImage is %s.",
+                                 region.srcOffsets[0].z, region.srcOffsets[1].z, string_VkImageType(src_type));
             }
-            if ((region.srcOffsets[0].y < 0) || (region.srcOffsets[0].y > static_cast<int32_t>(src_extent.height)) ||
-                (region.srcOffsets[1].y < 0) || (region.srcOffsets[1].y > static_cast<int32_t>(src_extent.height))) {
-                oob = true;
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-srcOffset-00244" : "VUID-vkCmdBlitImage-srcOffset-00244";
-                skip |= LogError(vuid, src_objlist, region_loc,
-                                 "srcOffsets[0].y is %" PRId32 " and srcOffsets[1].y is %" PRId32
-                                 " which exceed srcSubresource height extent (%" PRIu32 ").",
-                                 region.srcOffsets[0].y, region.srcOffsets[1].y, src_extent.height);
-            }
-            if ((region.srcOffsets[0].z < 0) || (region.srcOffsets[0].z > static_cast<int32_t>(src_extent.depth)) ||
-                (region.srcOffsets[1].z < 0) || (region.srcOffsets[1].z > static_cast<int32_t>(src_extent.depth))) {
-                oob = true;
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-srcOffset-00246" : "VUID-vkCmdBlitImage-srcOffset-00246";
-                skip |= LogError(vuid, src_objlist, region_loc,
-                                 "srcOffsets[0].z is %" PRId32 " and srcOffsets[1].z is %" PRId32
-                                 " which exceed srcSubresource depth extent (%" PRIu32 ").",
-                                 region.srcOffsets[0].z, region.srcOffsets[1].z, src_extent.depth);
-            }
-            if (oob) {
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-pRegions-00215" : "VUID-vkCmdBlitImage-pRegions-00215";
-                skip |= LogError(vuid, src_objlist, region_loc, "source image blit region exceeds image dimensions.");
-            }
+        }
 
-            // Validate dest image offsets
-            VkExtent3D dst_extent = dst_image_state->GetEffectiveSubresourceExtent(region.dstSubresource);
-            if (VK_IMAGE_TYPE_1D == dst_type) {
-                if ((0 != region.dstOffsets[0].y) || (1 != region.dstOffsets[1].y)) {
-                    vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00250" : "VUID-vkCmdBlitImage-dstImage-00250";
-                    skip |= LogError(vuid, dst_objlist, region_loc,
-                                     "dstOffsets[0].y is %" PRId32 " and dstOffsets[1].y is %" PRId32
-                                     " but dstImage is VK_IMAGE_TYPE_1D.",
-                                     region.dstOffsets[0].y, region.dstOffsets[1].y);
-                }
-            }
+        bool oob = false;
+        if ((region.srcOffsets[0].x < 0) || (region.srcOffsets[0].x > static_cast<int32_t>(src_extent.width)) ||
+            (region.srcOffsets[1].x < 0) || (region.srcOffsets[1].x > static_cast<int32_t>(src_extent.width))) {
+            oob = true;
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcOffset-00243" : "VUID-vkCmdBlitImage-srcOffset-00243";
+            skip |= LogError(vuid, src_objlist, region_loc,
+                             "srcOffsets[0].x is %" PRId32 " and srcOffsets[1].x is %" PRId32
+                             " which exceed srcSubresource width extent (%" PRIu32 ").",
+                             region.srcOffsets[0].x, region.srcOffsets[1].x, src_extent.width);
+        }
+        if ((region.srcOffsets[0].y < 0) || (region.srcOffsets[0].y > static_cast<int32_t>(src_extent.height)) ||
+            (region.srcOffsets[1].y < 0) || (region.srcOffsets[1].y > static_cast<int32_t>(src_extent.height))) {
+            oob = true;
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcOffset-00244" : "VUID-vkCmdBlitImage-srcOffset-00244";
+            skip |= LogError(vuid, src_objlist, region_loc,
+                             "srcOffsets[0].y is %" PRId32 " and srcOffsets[1].y is %" PRId32
+                             " which exceed srcSubresource height extent (%" PRIu32 ").",
+                             region.srcOffsets[0].y, region.srcOffsets[1].y, src_extent.height);
+        }
+        if ((region.srcOffsets[0].z < 0) || (region.srcOffsets[0].z > static_cast<int32_t>(src_extent.depth)) ||
+            (region.srcOffsets[1].z < 0) || (region.srcOffsets[1].z > static_cast<int32_t>(src_extent.depth))) {
+            oob = true;
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-srcOffset-00246" : "VUID-vkCmdBlitImage-srcOffset-00246";
+            skip |= LogError(vuid, src_objlist, region_loc,
+                             "srcOffsets[0].z is %" PRId32 " and srcOffsets[1].z is %" PRId32
+                             " which exceed srcSubresource depth extent (%" PRIu32 ").",
+                             region.srcOffsets[0].z, region.srcOffsets[1].z, src_extent.depth);
+        }
+        if (oob) {
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-pRegions-00215" : "VUID-vkCmdBlitImage-pRegions-00215";
+            skip |= LogError(vuid, src_objlist, region_loc, "source image blit region exceeds image dimensions.");
+        }
 
-            if ((VK_IMAGE_TYPE_1D == dst_type) || (VK_IMAGE_TYPE_2D == dst_type)) {
-                if ((0 != region.dstOffsets[0].z) || (1 != region.dstOffsets[1].z)) {
-                    vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00252" : "VUID-vkCmdBlitImage-dstImage-00252";
-                    skip |= LogError(vuid, dst_objlist, region_loc,
-                                     "dstOffsets[0].z is %" PRId32 " and dstOffsets[1].z is %" PRId32 " but dstImage is %s.",
-                                     region.dstOffsets[0].z, region.dstOffsets[1].z, string_VkImageType(dst_type));
-                }
+        // Validate dest image offsets
+        VkExtent3D dst_extent = dst_image_state->GetEffectiveSubresourceExtent(region.dstSubresource);
+        if (VK_IMAGE_TYPE_1D == dst_type) {
+            if ((0 != region.dstOffsets[0].y) || (1 != region.dstOffsets[1].y)) {
+                vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00250" : "VUID-vkCmdBlitImage-dstImage-00250";
+                skip |=
+                    LogError(vuid, dst_objlist, region_loc,
+                             "dstOffsets[0].y is %" PRId32 " and dstOffsets[1].y is %" PRId32 " but dstImage is VK_IMAGE_TYPE_1D.",
+                             region.dstOffsets[0].y, region.dstOffsets[1].y);
             }
+        }
 
-            oob = false;
-            if ((region.dstOffsets[0].x < 0) || (region.dstOffsets[0].x > static_cast<int32_t>(dst_extent.width)) ||
-                (region.dstOffsets[1].x < 0) || (region.dstOffsets[1].x > static_cast<int32_t>(dst_extent.width))) {
-                oob = true;
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-dstOffset-00248" : "VUID-vkCmdBlitImage-dstOffset-00248";
+        if ((VK_IMAGE_TYPE_1D == dst_type) || (VK_IMAGE_TYPE_2D == dst_type)) {
+            if ((0 != region.dstOffsets[0].z) || (1 != region.dstOffsets[1].z)) {
+                vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-00252" : "VUID-vkCmdBlitImage-dstImage-00252";
                 skip |= LogError(vuid, dst_objlist, region_loc,
-                                 "dstOffsets[0].x is %" PRId32 " and dstOffsets[1].x is %" PRId32
-                                 " which exceed dstSubresource width extent (%" PRIu32 ").",
-                                 region.dstOffsets[0].x, region.dstOffsets[1].x, dst_extent.width);
+                                 "dstOffsets[0].z is %" PRId32 " and dstOffsets[1].z is %" PRId32 " but dstImage is %s.",
+                                 region.dstOffsets[0].z, region.dstOffsets[1].z, string_VkImageType(dst_type));
             }
-            if ((region.dstOffsets[0].y < 0) || (region.dstOffsets[0].y > static_cast<int32_t>(dst_extent.height)) ||
-                (region.dstOffsets[1].y < 0) || (region.dstOffsets[1].y > static_cast<int32_t>(dst_extent.height))) {
-                oob = true;
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-dstOffset-00249" : "VUID-vkCmdBlitImage-dstOffset-00249";
-                skip |= LogError(vuid, dst_objlist, region_loc,
-                                 "dstOffsets[0].y is %" PRId32 " and dstOffsets[1].y is %" PRId32
-                                 " which exceed dstSubresource height extent (%" PRIu32 ").",
-                                 region.dstOffsets[0].x, region.dstOffsets[1].x, dst_extent.height);
-            }
-            if ((region.dstOffsets[0].z < 0) || (region.dstOffsets[0].z > static_cast<int32_t>(dst_extent.depth)) ||
-                (region.dstOffsets[1].z < 0) || (region.dstOffsets[1].z > static_cast<int32_t>(dst_extent.depth))) {
-                oob = true;
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-dstOffset-00251" : "VUID-vkCmdBlitImage-dstOffset-00251";
-                skip |= LogError(vuid, dst_objlist, region_loc,
-                                 "dstOffsets[0].z is %" PRId32 " and dstOffsets[1].z is %" PRId32
-                                 " which exceed dstSubresource depth extent (%" PRIu32 ").",
-                                 region.dstOffsets[0].z, region.dstOffsets[1].z, dst_extent.depth);
-            }
-            if (oob) {
-                vuid = is_2 ? "VUID-VkBlitImageInfo2-pRegions-00216" : "VUID-vkCmdBlitImage-pRegions-00216";
-                skip |= LogError(vuid, dst_objlist, region_loc, "destination image blit region exceeds image dimensions.");
-            }
+        }
 
-            if ((VK_IMAGE_TYPE_3D == src_type) || (VK_IMAGE_TYPE_3D == dst_type)) {
-                if ((0 != region.srcSubresource.baseArrayLayer) || (1 != region.srcSubresource.layerCount) ||
-                    (0 != region.dstSubresource.baseArrayLayer) || (1 != region.dstSubresource.layerCount)) {
-                    vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00240" : "VUID-vkCmdBlitImage-srcImage-00240";
-                    skip |= LogError(vuid, all_objlist, region_loc,
-                                     "srcImage %s\n"
-                                     "dstImage %s\n"
-                                     "srcSubresource (baseArrayLayer = %" PRIu32 ", layerCount = %" PRIu32
-                                     ")\n"
-                                     "dstSubresource (baseArrayLayer = %" PRIu32 ", layerCount = %" PRIu32 ")\n",
-                                     string_VkImageType(src_type), string_VkImageType(dst_type),
-                                     region.srcSubresource.baseArrayLayer, region.srcSubresource.layerCount,
-                                     region.dstSubresource.baseArrayLayer, region.dstSubresource.layerCount);
+        oob = false;
+        if ((region.dstOffsets[0].x < 0) || (region.dstOffsets[0].x > static_cast<int32_t>(dst_extent.width)) ||
+            (region.dstOffsets[1].x < 0) || (region.dstOffsets[1].x > static_cast<int32_t>(dst_extent.width))) {
+            oob = true;
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-dstOffset-00248" : "VUID-vkCmdBlitImage-dstOffset-00248";
+            skip |= LogError(vuid, dst_objlist, region_loc,
+                             "dstOffsets[0].x is %" PRId32 " and dstOffsets[1].x is %" PRId32
+                             " which exceed dstSubresource width extent (%" PRIu32 ").",
+                             region.dstOffsets[0].x, region.dstOffsets[1].x, dst_extent.width);
+        }
+        if ((region.dstOffsets[0].y < 0) || (region.dstOffsets[0].y > static_cast<int32_t>(dst_extent.height)) ||
+            (region.dstOffsets[1].y < 0) || (region.dstOffsets[1].y > static_cast<int32_t>(dst_extent.height))) {
+            oob = true;
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-dstOffset-00249" : "VUID-vkCmdBlitImage-dstOffset-00249";
+            skip |= LogError(vuid, dst_objlist, region_loc,
+                             "dstOffsets[0].y is %" PRId32 " and dstOffsets[1].y is %" PRId32
+                             " which exceed dstSubresource height extent (%" PRIu32 ").",
+                             region.dstOffsets[0].x, region.dstOffsets[1].x, dst_extent.height);
+        }
+        if ((region.dstOffsets[0].z < 0) || (region.dstOffsets[0].z > static_cast<int32_t>(dst_extent.depth)) ||
+            (region.dstOffsets[1].z < 0) || (region.dstOffsets[1].z > static_cast<int32_t>(dst_extent.depth))) {
+            oob = true;
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-dstOffset-00251" : "VUID-vkCmdBlitImage-dstOffset-00251";
+            skip |= LogError(vuid, dst_objlist, region_loc,
+                             "dstOffsets[0].z is %" PRId32 " and dstOffsets[1].z is %" PRId32
+                             " which exceed dstSubresource depth extent (%" PRIu32 ").",
+                             region.dstOffsets[0].z, region.dstOffsets[1].z, dst_extent.depth);
+        }
+        if (oob) {
+            vuid = is_2 ? "VUID-VkBlitImageInfo2-pRegions-00216" : "VUID-vkCmdBlitImage-pRegions-00216";
+            skip |= LogError(vuid, dst_objlist, region_loc, "destination image blit region exceeds image dimensions.");
+        }
+
+        if ((VK_IMAGE_TYPE_3D == src_type) || (VK_IMAGE_TYPE_3D == dst_type)) {
+            if ((0 != region.srcSubresource.baseArrayLayer) || (1 != region.srcSubresource.layerCount) ||
+                (0 != region.dstSubresource.baseArrayLayer) || (1 != region.dstSubresource.layerCount)) {
+                vuid = is_2 ? "VUID-VkBlitImageInfo2-srcImage-00240" : "VUID-vkCmdBlitImage-srcImage-00240";
+                skip |= LogError(vuid, all_objlist, region_loc,
+                                 "srcImage %s\n"
+                                 "dstImage %s\n"
+                                 "srcSubresource (baseArrayLayer = %" PRIu32 ", layerCount = %" PRIu32
+                                 ")\n"
+                                 "dstSubresource (baseArrayLayer = %" PRIu32 ", layerCount = %" PRIu32 ")\n",
+                                 string_VkImageType(src_type), string_VkImageType(dst_type), region.srcSubresource.baseArrayLayer,
+                                 region.srcSubresource.layerCount, region.dstSubresource.baseArrayLayer,
+                                 region.dstSubresource.layerCount);
+            }
+        }
+
+        // The union of all source regions, and the union of all destination regions, specified by the elements of regions,
+        // must not overlap in memory
+        if (srcImage == dstImage) {
+            for (uint32_t j = 0; j < regionCount; j++) {
+                if (RegionIntersectsBlit(&region, &pRegions[j], src_image_state->createInfo.imageType,
+                                         FormatIsMultiplane(src_format))) {
+                    vuid = is_2 ? "VUID-VkBlitImageInfo2-pRegions-00217" : "VUID-vkCmdBlitImage-pRegions-00217";
+                    skip |=
+                        LogError(vuid, all_objlist, loc, "pRegion[%" PRIu32 "] src overlaps with pRegions[%" PRIu32 "] dst.", i, j);
                 }
             }
-
-            // The union of all source regions, and the union of all destination regions, specified by the elements of regions,
-            // must not overlap in memory
-            if (srcImage == dstImage) {
-                for (uint32_t j = 0; j < regionCount; j++) {
-                    if (RegionIntersectsBlit(&region, &pRegions[j], src_image_state->createInfo.imageType,
-                                             FormatIsMultiplane(src_format))) {
-                        vuid = is_2 ? "VUID-VkBlitImageInfo2-pRegions-00217" : "VUID-vkCmdBlitImage-pRegions-00217";
-                        skip |= LogError(vuid, all_objlist, loc,
-                                         "pRegion[%" PRIu32 "] src overlaps with pRegions[%" PRIu32 "] dst.", i, j);
-                    }
-                }
-            }
-        }  // per-region checks
-    } else {
-        assert(0);
+        }
     }
     return skip;
 }
@@ -3571,260 +3566,254 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
     auto cb_state_ptr = GetRead<CMD_BUFFER_STATE>(commandBuffer);
     auto src_image_state = Get<IMAGE_STATE>(srcImage);
     auto dst_image_state = Get<IMAGE_STATE>(dstImage);
+    if (!cb_state_ptr || !src_image_state || !dst_image_state) {
+        return skip;
+    }
 
     const bool is_2 = loc.function == Func::vkCmdResolveImage2 || loc.function == Func::vkCmdResolveImage2KHR;
     const char *vuid;
     const Location src_image_loc = loc.dot(Field::srcImage);
     const Location dst_image_loc = loc.dot(Field::dstImage);
 
-    if (cb_state_ptr && src_image_state && dst_image_state) {
-        const CMD_BUFFER_STATE &cb_state = *cb_state_ptr;
-        vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00256" : "VUID-vkCmdResolveImage-srcImage-00256";
-        skip |= ValidateMemoryIsBoundToImage(LogObjectList(commandBuffer, srcImage), *src_image_state, src_image_loc, vuid);
-        vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00258" : "VUID-vkCmdResolveImage-dstImage-00258";
-        skip |= ValidateMemoryIsBoundToImage(LogObjectList(commandBuffer, dstImage), *dst_image_state, dst_image_loc, vuid);
-        skip |= ValidateCmd(cb_state, loc);
-        vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-02003" : "VUID-vkCmdResolveImage-dstImage-02003";
-        skip |= ValidateImageFormatFeatureFlags(commandBuffer, *dst_image_state, VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT,
-                                                dst_image_loc, vuid);
-        vuid = is_2 ? "VUID-vkCmdResolveImage2-commandBuffer-01837" : "VUID-vkCmdResolveImage-commandBuffer-01837";
-        skip |= ValidateProtectedImage(cb_state, *src_image_state, src_image_loc, vuid);
-        vuid = is_2 ? "VUID-vkCmdResolveImage2-commandBuffer-01838" : "VUID-vkCmdResolveImage-commandBuffer-01838";
-        skip |= ValidateProtectedImage(cb_state, *dst_image_state, dst_image_loc, vuid);
-        vuid = is_2 ? "VUID-vkCmdResolveImage2-commandBuffer-01839" : "VUID-vkCmdResolveImage-commandBuffer-01839";
-        skip |= ValidateUnprotectedImage(cb_state, *dst_image_state, dst_image_loc, vuid);
-        vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-06762" : "VUID-vkCmdResolveImage-srcImage-06762";
-        skip |=
-            ValidateImageUsageFlags(commandBuffer, *src_image_state, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, true, vuid, src_image_loc);
-        vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-06763" : "VUID-vkCmdResolveImage-srcImage-06763";
-        skip |= ValidateImageFormatFeatureFlags(commandBuffer, *src_image_state, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT, src_image_loc,
-                                                vuid);
-        vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-06764" : "VUID-vkCmdResolveImage-dstImage-06764";
-        skip |=
-            ValidateImageUsageFlags(commandBuffer, *dst_image_state, VK_IMAGE_USAGE_TRANSFER_DST_BIT, true, vuid, dst_image_loc);
-        vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-06765" : "VUID-vkCmdResolveImage-dstImage-06765";
-        skip |= ValidateImageFormatFeatureFlags(commandBuffer, *dst_image_state, VK_FORMAT_FEATURE_TRANSFER_DST_BIT, dst_image_loc,
-                                                vuid);
+    const CMD_BUFFER_STATE &cb_state = *cb_state_ptr;
+    vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00256" : "VUID-vkCmdResolveImage-srcImage-00256";
+    skip |= ValidateMemoryIsBoundToImage(LogObjectList(commandBuffer, srcImage), *src_image_state, src_image_loc, vuid);
+    vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00258" : "VUID-vkCmdResolveImage-dstImage-00258";
+    skip |= ValidateMemoryIsBoundToImage(LogObjectList(commandBuffer, dstImage), *dst_image_state, dst_image_loc, vuid);
+    skip |= ValidateCmd(cb_state, loc);
+    vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-02003" : "VUID-vkCmdResolveImage-dstImage-02003";
+    skip |= ValidateImageFormatFeatureFlags(commandBuffer, *dst_image_state, VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT,
+                                            dst_image_loc, vuid);
+    vuid = is_2 ? "VUID-vkCmdResolveImage2-commandBuffer-01837" : "VUID-vkCmdResolveImage-commandBuffer-01837";
+    skip |= ValidateProtectedImage(cb_state, *src_image_state, src_image_loc, vuid);
+    vuid = is_2 ? "VUID-vkCmdResolveImage2-commandBuffer-01838" : "VUID-vkCmdResolveImage-commandBuffer-01838";
+    skip |= ValidateProtectedImage(cb_state, *dst_image_state, dst_image_loc, vuid);
+    vuid = is_2 ? "VUID-vkCmdResolveImage2-commandBuffer-01839" : "VUID-vkCmdResolveImage-commandBuffer-01839";
+    skip |= ValidateUnprotectedImage(cb_state, *dst_image_state, dst_image_loc, vuid);
+    vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-06762" : "VUID-vkCmdResolveImage-srcImage-06762";
+    skip |= ValidateImageUsageFlags(commandBuffer, *src_image_state, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, true, vuid, src_image_loc);
+    vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-06763" : "VUID-vkCmdResolveImage-srcImage-06763";
+    skip |=
+        ValidateImageFormatFeatureFlags(commandBuffer, *src_image_state, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT, src_image_loc, vuid);
+    vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-06764" : "VUID-vkCmdResolveImage-dstImage-06764";
+    skip |= ValidateImageUsageFlags(commandBuffer, *dst_image_state, VK_IMAGE_USAGE_TRANSFER_DST_BIT, true, vuid, dst_image_loc);
+    vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-06765" : "VUID-vkCmdResolveImage-dstImage-06765";
+    skip |=
+        ValidateImageFormatFeatureFlags(commandBuffer, *dst_image_state, VK_FORMAT_FEATURE_TRANSFER_DST_BIT, dst_image_loc, vuid);
 
-        // Validation for VK_EXT_fragment_density_map
-        if (src_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
-            const LogObjectList objlist(commandBuffer, srcImage);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-02546" : "VUID-vkCmdResolveImage-dstImage-02546";
-            skip |= LogError(vuid, objlist, src_image_loc,
-                             "must not have been created with flags containing "
-                             "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT");
-        }
-        if (dst_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
-            const LogObjectList objlist(commandBuffer, dstImage);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-02546" : "VUID-vkCmdResolveImage-dstImage-02546";
-            skip |= LogError(vuid, objlist, dst_image_loc,
-                             "must not have been created with flags containing "
-                             "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT");
-        }
+    // Validation for VK_EXT_fragment_density_map
+    if (src_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+        const LogObjectList objlist(commandBuffer, srcImage);
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-02546" : "VUID-vkCmdResolveImage-dstImage-02546";
+        skip |= LogError(vuid, objlist, src_image_loc,
+                         "must not have been created with flags containing "
+                         "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT");
+    }
+    if (dst_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+        const LogObjectList objlist(commandBuffer, dstImage);
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-02546" : "VUID-vkCmdResolveImage-dstImage-02546";
+        skip |= LogError(vuid, objlist, dst_image_loc,
+                         "must not have been created with flags containing "
+                         "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT");
+    }
 
-        bool hit_error = false;
-        const char *invalid_src_layout_vuid =
-            is_2 ? "VUID-VkResolveImageInfo2-srcImageLayout-01400" : "VUID-vkCmdResolveImage-srcImageLayout-01400";
-        const char *invalid_dst_layout_vuid =
-            is_2 ? "VUID-VkResolveImageInfo2-dstImageLayout-01401" : "VUID-vkCmdResolveImage-dstImageLayout-01401";
-        // For each region, the number of layers in the image subresource should not be zero
-        // For each region, src and dest image aspect must be color only
-        for (uint32_t i = 0; i < regionCount; i++) {
-            const Location region_loc = loc.dot(Field::pRegions, i);
-            const Location src_subresource_loc = region_loc.dot(Field::srcSubresource);
-            const Location dst_subresource_loc = region_loc.dot(Field::dstSubresource);
-            const RegionType region = pRegions[i];
-            const VkImageSubresourceLayers src_subresource = region.srcSubresource;
-            const VkImageSubresourceLayers dst_subresource = region.dstSubresource;
+    bool hit_error = false;
+    const char *invalid_src_layout_vuid =
+        is_2 ? "VUID-VkResolveImageInfo2-srcImageLayout-01400" : "VUID-vkCmdResolveImage-srcImageLayout-01400";
+    const char *invalid_dst_layout_vuid =
+        is_2 ? "VUID-VkResolveImageInfo2-dstImageLayout-01401" : "VUID-vkCmdResolveImage-dstImageLayout-01401";
+    // For each region, the number of layers in the image subresource should not be zero
+    // For each region, src and dest image aspect must be color only
+    for (uint32_t i = 0; i < regionCount; i++) {
+        const Location region_loc = loc.dot(Field::pRegions, i);
+        const Location src_subresource_loc = region_loc.dot(Field::srcSubresource);
+        const Location dst_subresource_loc = region_loc.dot(Field::dstSubresource);
+        const RegionType region = pRegions[i];
+        const VkImageSubresourceLayers src_subresource = region.srcSubresource;
+        const VkImageSubresourceLayers dst_subresource = region.dstSubresource;
 
-            skip |= ValidateImageSubresourceLayers(cb_state.commandBuffer(), &src_subresource, src_subresource_loc);
-            skip |= ValidateImageSubresourceLayers(cb_state.commandBuffer(), &dst_subresource, dst_subresource_loc);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImageLayout-00260" : "VUID-vkCmdResolveImage-srcImageLayout-00260";
-            skip |=
-                VerifyImageLayout(cb_state, *src_image_state, src_subresource, srcImageLayout, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        skip |= ValidateImageSubresourceLayers(cb_state.commandBuffer(), &src_subresource, src_subresource_loc);
+        skip |= ValidateImageSubresourceLayers(cb_state.commandBuffer(), &dst_subresource, dst_subresource_loc);
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImageLayout-00260" : "VUID-vkCmdResolveImage-srcImageLayout-00260";
+        skip |= VerifyImageLayout(cb_state, *src_image_state, src_subresource, srcImageLayout, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                   src_image_loc, invalid_src_layout_vuid, vuid, &hit_error);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImageLayout-00262" : "VUID-vkCmdResolveImage-dstImageLayout-00262";
-            skip |=
-                VerifyImageLayout(cb_state, *dst_image_state, dst_subresource, dstImageLayout, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImageLayout-00262" : "VUID-vkCmdResolveImage-dstImageLayout-00262";
+        skip |= VerifyImageLayout(cb_state, *dst_image_state, dst_subresource, dstImageLayout, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                                   dst_image_loc, invalid_dst_layout_vuid, vuid, &hit_error);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-srcSubresource-01709" : "VUID-vkCmdResolveImage-srcSubresource-01709";
-            skip |= ValidateImageMipLevel(commandBuffer, *src_image_state, src_subresource.mipLevel,
-                                          src_subresource_loc.dot(Field::mipLevel), vuid);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-dstSubresource-01710" : "VUID-vkCmdResolveImage-dstSubresource-01710";
-            skip |= ValidateImageMipLevel(commandBuffer, *dst_image_state, dst_subresource.mipLevel,
-                                          dst_subresource_loc.dot(Field::mipLevel), vuid);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-srcSubresource-01711" : "VUID-vkCmdResolveImage-srcSubresource-01711";
-            skip |= ValidateImageArrayLayerRange(commandBuffer, *src_image_state, src_subresource.baseArrayLayer,
-                                                 src_subresource.layerCount, src_subresource_loc, vuid);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-dstSubresource-01712" : "VUID-vkCmdResolveImage-dstSubresource-01712";
-            skip |= ValidateImageArrayLayerRange(commandBuffer, *dst_image_state, dst_subresource.baseArrayLayer,
-                                                 dst_subresource.layerCount, dst_subresource_loc, vuid);
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-srcSubresource-01709" : "VUID-vkCmdResolveImage-srcSubresource-01709";
+        skip |= ValidateImageMipLevel(commandBuffer, *src_image_state, src_subresource.mipLevel,
+                                      src_subresource_loc.dot(Field::mipLevel), vuid);
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-dstSubresource-01710" : "VUID-vkCmdResolveImage-dstSubresource-01710";
+        skip |= ValidateImageMipLevel(commandBuffer, *dst_image_state, dst_subresource.mipLevel,
+                                      dst_subresource_loc.dot(Field::mipLevel), vuid);
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-srcSubresource-01711" : "VUID-vkCmdResolveImage-srcSubresource-01711";
+        skip |= ValidateImageArrayLayerRange(commandBuffer, *src_image_state, src_subresource.baseArrayLayer,
+                                             src_subresource.layerCount, src_subresource_loc, vuid);
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-dstSubresource-01712" : "VUID-vkCmdResolveImage-dstSubresource-01712";
+        skip |= ValidateImageArrayLayerRange(commandBuffer, *dst_image_state, dst_subresource.baseArrayLayer,
+                                             dst_subresource.layerCount, dst_subresource_loc, vuid);
 
-            // layer counts must match
-            if (src_subresource.layerCount != dst_subresource.layerCount) {
-                const LogObjectList objlist(commandBuffer, srcImage, dstImage);
-                vuid = is_2 ? "VUID-VkImageResolve2-layerCount-00267" : "VUID-VkImageResolve-layerCount-00267";
-                skip |= LogError(vuid, objlist, src_subresource_loc.dot(Field::layerCount),
-                                 "(%" PRIu32 ") does not match %s (%" PRIu32 ").", region.srcSubresource.layerCount,
-                                 dst_subresource_loc.dot(Field::layerCount).Fields().c_str(), region.dstSubresource.layerCount);
-            }
-            // For each region, src and dest image aspect must be color only
-            if ((src_subresource.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT) ||
-                (dst_subresource.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT)) {
-                const LogObjectList objlist(commandBuffer, srcImage, dstImage);
-                vuid = is_2 ? "VUID-VkImageResolve2-aspectMask-00266" : "VUID-VkImageResolve-aspectMask-00266";
-                skip |= LogError(vuid, objlist, src_subresource_loc.dot(Field::aspectMask),
-                                 "(%s) and dstSubresource.aspectMask (%s) must only be VK_IMAGE_ASPECT_COLOR_BIT.",
-                                 string_VkImageAspectFlags(src_subresource.aspectMask).c_str(),
-                                 string_VkImageAspectFlags(dst_subresource.aspectMask).c_str());
-            }
-
-            const VkImageType src_image_type = src_image_state->createInfo.imageType;
-            const VkImageType dst_image_type = dst_image_state->createInfo.imageType;
-
-            if (VK_IMAGE_TYPE_3D == dst_image_type) {
-                if (src_subresource.layerCount != 1) {
-                    const LogObjectList objlist(commandBuffer, srcImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-04446" : "VUID-vkCmdResolveImage-srcImage-04446";
-                    skip |= LogError(vuid, objlist, src_subresource_loc.dot(Field::layerCount),
-                                     "is %" PRIu32 " but dstImage is 3D.", src_subresource.layerCount);
-                }
-                if ((dst_subresource.baseArrayLayer != 0) || (dst_subresource.layerCount != 1)) {
-                    const LogObjectList objlist(commandBuffer, dstImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-04447" : "VUID-vkCmdResolveImage-srcImage-04447";
-                    skip |= LogError(vuid, objlist, dst_subresource_loc.dot(Field::baseArrayLayer),
-                                     "is %" PRIu32 " and layerCount is  %" PRIu32 " but dstImage 3D.",
-                                     dst_subresource.baseArrayLayer, dst_subresource.layerCount);
-                }
-            }
-
-            if (VK_IMAGE_TYPE_1D == src_image_type) {
-                if ((region.srcOffset.y != 0) || (region.extent.height != 1)) {
-                    const LogObjectList objlist(commandBuffer, srcImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00271" : "VUID-vkCmdResolveImage-srcImage-00271";
-                    skip |= LogError(vuid, objlist, region_loc,
-                                     "srcOffset.y is %" PRId32 ", extent.height is %" PRIu32 ", but srcImage (%s) is 1D.",
-                                     region.srcOffset.y, region.extent.height, FormatHandle(src_image_state->image()).c_str());
-                }
-            }
-            if ((VK_IMAGE_TYPE_1D == src_image_type) || (VK_IMAGE_TYPE_2D == src_image_type)) {
-                if ((region.srcOffset.z != 0) || (region.extent.depth != 1)) {
-                    const LogObjectList objlist(commandBuffer, srcImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00273" : "VUID-vkCmdResolveImage-srcImage-00273";
-                    skip |= LogError(vuid, objlist, region_loc,
-                                     "srcOffset.z is %" PRId32 ", extent.depth is %" PRIu32 ", but srcImage (%s) is 2D.",
-                                     region.srcOffset.z, region.extent.depth, FormatHandle(src_image_state->image()).c_str());
-                }
-            }
-
-            if (VK_IMAGE_TYPE_1D == dst_image_type) {
-                if ((region.dstOffset.y != 0) || (region.extent.height != 1)) {
-                    const LogObjectList objlist(commandBuffer, dstImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00276" : "VUID-vkCmdResolveImage-dstImage-00276";
-                    skip |= LogError(vuid, objlist, region_loc,
-                                     "dstOffset.y is %" PRId32 ", extent.height is %" PRIu32 ", but dstImage (%s) is 1D.",
-                                     region.dstOffset.y, region.extent.height, FormatHandle(dst_image_state->image()).c_str());
-                }
-            }
-            if ((VK_IMAGE_TYPE_1D == dst_image_type) || (VK_IMAGE_TYPE_2D == dst_image_type)) {
-                if ((region.dstOffset.z != 0) || (region.extent.depth != 1)) {
-                    const LogObjectList objlist(commandBuffer, dstImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00278" : "VUID-vkCmdResolveImage-dstImage-00278";
-                    skip |= LogError(vuid, objlist, region_loc,
-                                     "dstOffset.z is %" PRId32 ", extent.depth is %" PRIu32 ", but dstImage (%s) is 2D.",
-                                     region.dstOffset.z, region.extent.depth, FormatHandle(dst_image_state->image()).c_str());
-                }
-            }
-
-            // Each srcImage dimension offset + extent limits must fall with image subresource extent
-            VkExtent3D subresource_extent = src_image_state->GetEffectiveSubresourceExtent(src_subresource);
-            // MipLevel bound is checked already and adding extra errors with a "subresource extent of zero" is confusing to
-            // developer
-            if (src_subresource.mipLevel < src_image_state->createInfo.mipLevels) {
-                uint32_t extent_check = ExceedsBounds(&(region.srcOffset), &(region.extent), &subresource_extent);
-                if ((extent_check & kXBit) != 0) {
-                    const LogObjectList objlist(commandBuffer, srcImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-srcOffset-00269" : "VUID-vkCmdResolveImage-srcOffset-00269";
-                    skip |= LogError(vuid, objlist, region_loc,
-                                     "srcOffset.x (%" PRId32 ") + extent.width (%" PRIu32
-                                     ") exceeds srcSubresource.extent.width (%" PRIu32 ").",
-                                     region.srcOffset.x, region.extent.width, subresource_extent.width);
-                }
-
-                if ((extent_check & kYBit) != 0) {
-                    const LogObjectList objlist(commandBuffer, srcImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-srcOffset-00270" : "VUID-vkCmdResolveImage-srcOffset-00270";
-                    skip |= LogError(vuid, objlist, region_loc,
-                                     "srcOffset.x (%" PRId32 ") + extent.height (%" PRIu32
-                                     ") exceeds srcSubresource.extent.height (%" PRIu32 ").",
-                                     region.srcOffset.y, region.extent.height, subresource_extent.height);
-                }
-
-                if ((extent_check & kZBit) != 0) {
-                    const LogObjectList objlist(commandBuffer, srcImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-srcOffset-00272" : "VUID-vkCmdResolveImage-srcOffset-00272";
-                    skip |= LogError(vuid, objlist, region_loc,
-                                     "srcOffset.x (%" PRId32 ") + extent.depth (%" PRIu32
-                                     ") exceeds srcSubresource.extent.depth (%" PRIu32 ").",
-                                     region.srcOffset.z, region.extent.depth, subresource_extent.depth);
-                }
-            }
-
-            // Each dstImage dimension offset + extent limits must fall with image subresource extent
-            subresource_extent = dst_image_state->GetEffectiveSubresourceExtent(dst_subresource);
-            // MipLevel bound is checked already and adding extra errors with a "subresource extent of zero" is confusing to
-            // developer
-            if (dst_subresource.mipLevel < dst_image_state->createInfo.mipLevels) {
-                uint32_t extent_check = ExceedsBounds(&(region.dstOffset), &(region.extent), &subresource_extent);
-                if ((extent_check & kXBit) != 0) {
-                    const LogObjectList objlist(commandBuffer, dstImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-dstOffset-00274" : "VUID-vkCmdResolveImage-dstOffset-00274";
-                    skip |= LogError(vuid, objlist, region_loc,
-                                     "dstOffset.x (%" PRId32 ") + extent.width (%" PRIu32
-                                     ") exceeds dstSubresource.extent.width (%" PRIu32 ").",
-                                     region.dstOffset.x, region.extent.width, subresource_extent.width);
-                }
-
-                if ((extent_check & kYBit) != 0) {
-                    const LogObjectList objlist(commandBuffer, dstImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-dstOffset-00275" : "VUID-vkCmdResolveImage-dstOffset-00275";
-                    skip |= LogError(vuid, objlist, region_loc,
-                                     "dstOffset.x (%" PRId32 ") + extent.height (%" PRIu32
-                                     ") exceeds dstSubresource.extent.height (%" PRIu32 ").",
-                                     region.dstOffset.x, region.extent.height, subresource_extent.height);
-                }
-
-                if ((extent_check & kZBit) != 0) {
-                    const LogObjectList objlist(commandBuffer, dstImage);
-                    vuid = is_2 ? "VUID-VkResolveImageInfo2-dstOffset-00277" : "VUID-vkCmdResolveImage-dstOffset-00277";
-                    skip |= LogError(vuid, objlist, region_loc,
-                                     "dstOffset.x (%" PRId32 ") + extent.depth (%" PRIu32
-                                     ") exceeds dstSubresource.extent.depth (%" PRIu32 ").",
-                                     region.dstOffset.x, region.extent.depth, subresource_extent.depth);
-                }
-            }
-        }
-
-        if (src_image_state->createInfo.format != dst_image_state->createInfo.format) {
+        // layer counts must match
+        if (src_subresource.layerCount != dst_subresource.layerCount) {
             const LogObjectList objlist(commandBuffer, srcImage, dstImage);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-01386" : "VUID-vkCmdResolveImage-srcImage-01386";
-            skip |=
-                LogError(vuid, objlist, src_image_loc, "was created with format %s but dstImage format is %s.",
+            vuid = is_2 ? "VUID-VkImageResolve2-layerCount-00267" : "VUID-VkImageResolve-layerCount-00267";
+            skip |= LogError(vuid, objlist, src_subresource_loc.dot(Field::layerCount),
+                             "(%" PRIu32 ") does not match %s (%" PRIu32 ").", region.srcSubresource.layerCount,
+                             dst_subresource_loc.dot(Field::layerCount).Fields().c_str(), region.dstSubresource.layerCount);
+        }
+        // For each region, src and dest image aspect must be color only
+        if ((src_subresource.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT) ||
+            (dst_subresource.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT)) {
+            const LogObjectList objlist(commandBuffer, srcImage, dstImage);
+            vuid = is_2 ? "VUID-VkImageResolve2-aspectMask-00266" : "VUID-VkImageResolve-aspectMask-00266";
+            skip |= LogError(vuid, objlist, src_subresource_loc.dot(Field::aspectMask),
+                             "(%s) and dstSubresource.aspectMask (%s) must only be VK_IMAGE_ASPECT_COLOR_BIT.",
+                             string_VkImageAspectFlags(src_subresource.aspectMask).c_str(),
+                             string_VkImageAspectFlags(dst_subresource.aspectMask).c_str());
+        }
+
+        const VkImageType src_image_type = src_image_state->createInfo.imageType;
+        const VkImageType dst_image_type = dst_image_state->createInfo.imageType;
+
+        if (VK_IMAGE_TYPE_3D == dst_image_type) {
+            if (src_subresource.layerCount != 1) {
+                const LogObjectList objlist(commandBuffer, srcImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-04446" : "VUID-vkCmdResolveImage-srcImage-04446";
+                skip |= LogError(vuid, objlist, src_subresource_loc.dot(Field::layerCount), "is %" PRIu32 " but dstImage is 3D.",
+                                 src_subresource.layerCount);
+            }
+            if ((dst_subresource.baseArrayLayer != 0) || (dst_subresource.layerCount != 1)) {
+                const LogObjectList objlist(commandBuffer, dstImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-04447" : "VUID-vkCmdResolveImage-srcImage-04447";
+                skip |= LogError(vuid, objlist, dst_subresource_loc.dot(Field::baseArrayLayer),
+                                 "is %" PRIu32 " and layerCount is  %" PRIu32 " but dstImage 3D.", dst_subresource.baseArrayLayer,
+                                 dst_subresource.layerCount);
+            }
+        }
+
+        if (VK_IMAGE_TYPE_1D == src_image_type) {
+            if ((region.srcOffset.y != 0) || (region.extent.height != 1)) {
+                const LogObjectList objlist(commandBuffer, srcImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00271" : "VUID-vkCmdResolveImage-srcImage-00271";
+                skip |= LogError(vuid, objlist, region_loc,
+                                 "srcOffset.y is %" PRId32 ", extent.height is %" PRIu32 ", but srcImage (%s) is 1D.",
+                                 region.srcOffset.y, region.extent.height, FormatHandle(src_image_state->image()).c_str());
+            }
+        }
+        if ((VK_IMAGE_TYPE_1D == src_image_type) || (VK_IMAGE_TYPE_2D == src_image_type)) {
+            if ((region.srcOffset.z != 0) || (region.extent.depth != 1)) {
+                const LogObjectList objlist(commandBuffer, srcImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00273" : "VUID-vkCmdResolveImage-srcImage-00273";
+                skip |= LogError(vuid, objlist, region_loc,
+                                 "srcOffset.z is %" PRId32 ", extent.depth is %" PRIu32 ", but srcImage (%s) is 2D.",
+                                 region.srcOffset.z, region.extent.depth, FormatHandle(src_image_state->image()).c_str());
+            }
+        }
+
+        if (VK_IMAGE_TYPE_1D == dst_image_type) {
+            if ((region.dstOffset.y != 0) || (region.extent.height != 1)) {
+                const LogObjectList objlist(commandBuffer, dstImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00276" : "VUID-vkCmdResolveImage-dstImage-00276";
+                skip |= LogError(vuid, objlist, region_loc,
+                                 "dstOffset.y is %" PRId32 ", extent.height is %" PRIu32 ", but dstImage (%s) is 1D.",
+                                 region.dstOffset.y, region.extent.height, FormatHandle(dst_image_state->image()).c_str());
+            }
+        }
+        if ((VK_IMAGE_TYPE_1D == dst_image_type) || (VK_IMAGE_TYPE_2D == dst_image_type)) {
+            if ((region.dstOffset.z != 0) || (region.extent.depth != 1)) {
+                const LogObjectList objlist(commandBuffer, dstImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00278" : "VUID-vkCmdResolveImage-dstImage-00278";
+                skip |= LogError(vuid, objlist, region_loc,
+                                 "dstOffset.z is %" PRId32 ", extent.depth is %" PRIu32 ", but dstImage (%s) is 2D.",
+                                 region.dstOffset.z, region.extent.depth, FormatHandle(dst_image_state->image()).c_str());
+            }
+        }
+
+        // Each srcImage dimension offset + extent limits must fall with image subresource extent
+        VkExtent3D subresource_extent = src_image_state->GetEffectiveSubresourceExtent(src_subresource);
+        // MipLevel bound is checked already and adding extra errors with a "subresource extent of zero" is confusing to
+        // developer
+        if (src_subresource.mipLevel < src_image_state->createInfo.mipLevels) {
+            uint32_t extent_check = ExceedsBounds(&(region.srcOffset), &(region.extent), &subresource_extent);
+            if ((extent_check & kXBit) != 0) {
+                const LogObjectList objlist(commandBuffer, srcImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-srcOffset-00269" : "VUID-vkCmdResolveImage-srcOffset-00269";
+                skip |= LogError(vuid, objlist, region_loc,
+                                 "srcOffset.x (%" PRId32 ") + extent.width (%" PRIu32
+                                 ") exceeds srcSubresource.extent.width (%" PRIu32 ").",
+                                 region.srcOffset.x, region.extent.width, subresource_extent.width);
+            }
+
+            if ((extent_check & kYBit) != 0) {
+                const LogObjectList objlist(commandBuffer, srcImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-srcOffset-00270" : "VUID-vkCmdResolveImage-srcOffset-00270";
+                skip |= LogError(vuid, objlist, region_loc,
+                                 "srcOffset.x (%" PRId32 ") + extent.height (%" PRIu32
+                                 ") exceeds srcSubresource.extent.height (%" PRIu32 ").",
+                                 region.srcOffset.y, region.extent.height, subresource_extent.height);
+            }
+
+            if ((extent_check & kZBit) != 0) {
+                const LogObjectList objlist(commandBuffer, srcImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-srcOffset-00272" : "VUID-vkCmdResolveImage-srcOffset-00272";
+                skip |= LogError(vuid, objlist, region_loc,
+                                 "srcOffset.x (%" PRId32 ") + extent.depth (%" PRIu32
+                                 ") exceeds srcSubresource.extent.depth (%" PRIu32 ").",
+                                 region.srcOffset.z, region.extent.depth, subresource_extent.depth);
+            }
+        }
+
+        // Each dstImage dimension offset + extent limits must fall with image subresource extent
+        subresource_extent = dst_image_state->GetEffectiveSubresourceExtent(dst_subresource);
+        // MipLevel bound is checked already and adding extra errors with a "subresource extent of zero" is confusing to
+        // developer
+        if (dst_subresource.mipLevel < dst_image_state->createInfo.mipLevels) {
+            uint32_t extent_check = ExceedsBounds(&(region.dstOffset), &(region.extent), &subresource_extent);
+            if ((extent_check & kXBit) != 0) {
+                const LogObjectList objlist(commandBuffer, dstImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-dstOffset-00274" : "VUID-vkCmdResolveImage-dstOffset-00274";
+                skip |= LogError(vuid, objlist, region_loc,
+                                 "dstOffset.x (%" PRId32 ") + extent.width (%" PRIu32
+                                 ") exceeds dstSubresource.extent.width (%" PRIu32 ").",
+                                 region.dstOffset.x, region.extent.width, subresource_extent.width);
+            }
+
+            if ((extent_check & kYBit) != 0) {
+                const LogObjectList objlist(commandBuffer, dstImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-dstOffset-00275" : "VUID-vkCmdResolveImage-dstOffset-00275";
+                skip |= LogError(vuid, objlist, region_loc,
+                                 "dstOffset.x (%" PRId32 ") + extent.height (%" PRIu32
+                                 ") exceeds dstSubresource.extent.height (%" PRIu32 ").",
+                                 region.dstOffset.x, region.extent.height, subresource_extent.height);
+            }
+
+            if ((extent_check & kZBit) != 0) {
+                const LogObjectList objlist(commandBuffer, dstImage);
+                vuid = is_2 ? "VUID-VkResolveImageInfo2-dstOffset-00277" : "VUID-vkCmdResolveImage-dstOffset-00277";
+                skip |= LogError(vuid, objlist, region_loc,
+                                 "dstOffset.x (%" PRId32 ") + extent.depth (%" PRIu32
+                                 ") exceeds dstSubresource.extent.depth (%" PRIu32 ").",
+                                 region.dstOffset.x, region.extent.depth, subresource_extent.depth);
+            }
+        }
+    }
+
+    if (src_image_state->createInfo.format != dst_image_state->createInfo.format) {
+        const LogObjectList objlist(commandBuffer, srcImage, dstImage);
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-01386" : "VUID-vkCmdResolveImage-srcImage-01386";
+        skip |= LogError(vuid, objlist, src_image_loc, "was created with format %s but dstImage format is %s.",
                          string_VkFormat(src_image_state->createInfo.format), string_VkFormat(dst_image_state->createInfo.format));
-        }
-        if (src_image_state->createInfo.samples == VK_SAMPLE_COUNT_1_BIT) {
-            const LogObjectList objlist(commandBuffer, srcImage);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00257" : "VUID-vkCmdResolveImage-srcImage-00257";
-            skip |= LogError(vuid, objlist, src_image_loc, "was created with sample count VK_SAMPLE_COUNT_1_BIT.");
-        }
-        if (dst_image_state->createInfo.samples != VK_SAMPLE_COUNT_1_BIT) {
-            const LogObjectList objlist(commandBuffer, dstImage);
-            vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00259" : "VUID-vkCmdResolveImage-dstImage-00259";
-            skip |= LogError(vuid, objlist, dst_image_loc, "was created with sample count (%s) (not VK_SAMPLE_COUNT_1_BIT).",
-                             string_VkSampleCountFlagBits(dst_image_state->createInfo.samples));
-        }
-    } else {
-        assert(0);
+    }
+    if (src_image_state->createInfo.samples == VK_SAMPLE_COUNT_1_BIT) {
+        const LogObjectList objlist(commandBuffer, srcImage);
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00257" : "VUID-vkCmdResolveImage-srcImage-00257";
+        skip |= LogError(vuid, objlist, src_image_loc, "was created with sample count VK_SAMPLE_COUNT_1_BIT.");
+    }
+    if (dst_image_state->createInfo.samples != VK_SAMPLE_COUNT_1_BIT) {
+        const LogObjectList objlist(commandBuffer, dstImage);
+        vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00259" : "VUID-vkCmdResolveImage-dstImage-00259";
+        skip |= LogError(vuid, objlist, dst_image_loc, "was created with sample count (%s) (not VK_SAMPLE_COUNT_1_BIT).",
+                         string_VkSampleCountFlagBits(dst_image_state->createInfo.samples));
     }
     return skip;
 }

--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -24,68 +24,67 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
                                                              const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (pCreateInfo != nullptr) {
-        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-        skip |= ValidateNotZero(pCreateInfo->size == 0, "VUID-VkBufferCreateInfo-size-00912", create_info_loc.dot(Field::size));
+    if (!pCreateInfo) {
+        return skip;
+    }
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
+    skip |= ValidateNotZero(pCreateInfo->size == 0, "VUID-VkBufferCreateInfo-size-00912", create_info_loc.dot(Field::size));
 
-        // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
-        if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT) {
-            // If sharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1
-            if (pCreateInfo->queueFamilyIndexCount <= 1) {
-                skip |= LogError("VUID-VkBufferCreateInfo-sharingMode-00914", device, create_info_loc.dot(Field::sharingMode),
-                                 "VK_SHARING_MODE_CONCURRENT, but queueFamilyIndexCount is %" PRIu32 ".",
-                                 pCreateInfo->queueFamilyIndexCount);
-            }
-
-            // If sharingMode is VK_SHARING_MODE_CONCURRENT, pQueueFamilyIndices must be a pointer to an array of
-            // queueFamilyIndexCount uint32_t values
-            if (pCreateInfo->pQueueFamilyIndices == nullptr) {
-                skip |= LogError("VUID-VkBufferCreateInfo-sharingMode-00913", device, create_info_loc.dot(Field::sharingMode),
-                                 "is VK_SHARING_MODE_CONCURRENT, but pQueueFamilyIndices is NULL.");
-            }
+    // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
+    if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT) {
+        // If sharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1
+        if (pCreateInfo->queueFamilyIndexCount <= 1) {
+            skip |= LogError("VUID-VkBufferCreateInfo-sharingMode-00914", device, create_info_loc.dot(Field::sharingMode),
+                             "VK_SHARING_MODE_CONCURRENT, but queueFamilyIndexCount is %" PRIu32 ".",
+                             pCreateInfo->queueFamilyIndexCount);
         }
 
-        if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) && (!physical_device_features.sparseBinding)) {
-            skip |= LogError("VUID-VkBufferCreateInfo-flags-00915", device, create_info_loc.dot(Field::flags),
-                             "includes VK_BUFFER_CREATE_SPARSE_BINDING_BIT, but the sparseBinding feature is not enabled.");
+        // If sharingMode is VK_SHARING_MODE_CONCURRENT, pQueueFamilyIndices must be a pointer to an array of
+        // queueFamilyIndexCount uint32_t values
+        if (pCreateInfo->pQueueFamilyIndices == nullptr) {
+            skip |= LogError("VUID-VkBufferCreateInfo-sharingMode-00913", device, create_info_loc.dot(Field::sharingMode),
+                             "is VK_SHARING_MODE_CONCURRENT, but pQueueFamilyIndices is NULL.");
         }
+    }
 
-        if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) && (!physical_device_features.sparseResidencyBuffer)) {
-            skip |=
-                LogError("VUID-VkBufferCreateInfo-flags-00916", device, create_info_loc.dot(Field::flags),
+    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) && (!physical_device_features.sparseBinding)) {
+        skip |= LogError("VUID-VkBufferCreateInfo-flags-00915", device, create_info_loc.dot(Field::flags),
+                         "includes VK_BUFFER_CREATE_SPARSE_BINDING_BIT, but the sparseBinding feature is not enabled.");
+    }
+
+    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) && (!physical_device_features.sparseResidencyBuffer)) {
+        skip |= LogError("VUID-VkBufferCreateInfo-flags-00916", device, create_info_loc.dot(Field::flags),
                          "includes VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT, but the sparseResidencyBuffer feature is not enabled.");
-        }
+    }
 
-        if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_ALIASED_BIT) && (!physical_device_features.sparseResidencyAliased)) {
-            skip |=
-                LogError("VUID-VkBufferCreateInfo-flags-00917", device, create_info_loc.dot(Field::flags),
+    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_ALIASED_BIT) && (!physical_device_features.sparseResidencyAliased)) {
+        skip |= LogError("VUID-VkBufferCreateInfo-flags-00917", device, create_info_loc.dot(Field::flags),
                          "includes VK_BUFFER_CREATE_SPARSE_ALIASED_BIT, but the sparseResidencyAliased feature is not enabled.");
-        };
+    };
 
-        // If flags contains VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT or VK_BUFFER_CREATE_SPARSE_ALIASED_BIT, it must also contain
-        // VK_BUFFER_CREATE_SPARSE_BINDING_BIT
-        if (((pCreateInfo->flags & (VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_ALIASED_BIT)) != 0) &&
-            ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != VK_BUFFER_CREATE_SPARSE_BINDING_BIT)) {
-            skip |= LogError("VUID-VkBufferCreateInfo-flags-00918", device, create_info_loc.dot(Field::flags), "is %s.",
-                             string_VkBufferCreateFlags(pCreateInfo->flags).c_str());
-        }
+    // If flags contains VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT or VK_BUFFER_CREATE_SPARSE_ALIASED_BIT, it must also contain
+    // VK_BUFFER_CREATE_SPARSE_BINDING_BIT
+    if (((pCreateInfo->flags & (VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_ALIASED_BIT)) != 0) &&
+        ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != VK_BUFFER_CREATE_SPARSE_BINDING_BIT)) {
+        skip |= LogError("VUID-VkBufferCreateInfo-flags-00918", device, create_info_loc.dot(Field::flags), "is %s.",
+                         string_VkBufferCreateFlags(pCreateInfo->flags).c_str());
+    }
 
-        const auto *maintenance4_features = LvlFindInChain<VkPhysicalDeviceMaintenance4FeaturesKHR>(device_createinfo_pnext);
-        if (maintenance4_features && maintenance4_features->maintenance4) {
-            if (pCreateInfo->size > phys_dev_ext_props.maintenance4_props.maxBufferSize) {
-                skip |= LogError("VUID-VkBufferCreateInfo-size-06409", device, create_info_loc.dot(Field::size),
-                                 "(%" PRIu64
-                                 ") is larger than the maximum allowed buffer size "
-                                 "VkPhysicalDeviceMaintenance4Properties.maxBufferSize (%" PRIu64 ").",
-                                 pCreateInfo->size, phys_dev_ext_props.maintenance4_props.maxBufferSize);
-            }
+    const auto *maintenance4_features = LvlFindInChain<VkPhysicalDeviceMaintenance4FeaturesKHR>(device_createinfo_pnext);
+    if (maintenance4_features && maintenance4_features->maintenance4) {
+        if (pCreateInfo->size > phys_dev_ext_props.maintenance4_props.maxBufferSize) {
+            skip |= LogError("VUID-VkBufferCreateInfo-size-06409", device, create_info_loc.dot(Field::size),
+                             "(%" PRIu64
+                             ") is larger than the maximum allowed buffer size "
+                             "VkPhysicalDeviceMaintenance4Properties.maxBufferSize (%" PRIu64 ").",
+                             pCreateInfo->size, phys_dev_ext_props.maintenance4_props.maxBufferSize);
         }
+    }
 
-        if (!LvlFindInChain<VkBufferUsageFlags2CreateInfoKHR>(pCreateInfo->pNext)) {
-            skip |= ValidateFlags(error_obj.location, "pCreateInfo->usage", "VkBufferUsageFlagBits", AllVkBufferUsageFlagBits,
-                                  pCreateInfo->usage, kRequiredFlags, "VUID-VkBufferCreateInfo-None-09205",
-                                  "VUID-VkBufferCreateInfo-None-09206");
-        }
+    if (!LvlFindInChain<VkBufferUsageFlags2CreateInfoKHR>(pCreateInfo->pNext)) {
+        skip |= ValidateFlags(error_obj.location, "pCreateInfo->usage", "VkBufferUsageFlagBits", AllVkBufferUsageFlagBits,
+                              pCreateInfo->usage, kRequiredFlags, "VUID-VkBufferCreateInfo-None-09205",
+                              "VUID-VkBufferCreateInfo-None-09206");
     }
 
     return skip;

--- a/layers/stateless/sl_cmd_buffer_dynamic.cpp
+++ b/layers/stateless/sl_cmd_buffer_dynamic.cpp
@@ -306,25 +306,25 @@ bool StatelessValidation::manual_PreCallValidateCmdSetDiscardRectangleEXT(VkComm
                                                                           const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (pDiscardRectangles) {
-        for (uint32_t i = 0; i < discardRectangleCount; ++i) {
-            const Location loc = error_obj.location.dot(Field::pDiscardRectangles, i);
-            const int64_t x_sum =
-                static_cast<int64_t>(pDiscardRectangles[i].offset.x) + static_cast<int64_t>(pDiscardRectangles[i].extent.width);
-            if (x_sum > std::numeric_limits<int32_t>::max()) {
-                skip |= LogError("VUID-vkCmdSetDiscardRectangleEXT-offset-00588", commandBuffer, loc,
-                                 "offset.x (%" PRId32 ") + extent.width (%" PRIu32 ") is %" PRIi64 ") which will overflow int32_t.",
-                                 pDiscardRectangles[i].offset.x, pDiscardRectangles[i].extent.width, x_sum);
-            }
+    if (!pDiscardRectangles) {
+        return skip;
+    }
+    for (uint32_t i = 0; i < discardRectangleCount; ++i) {
+        const Location loc = error_obj.location.dot(Field::pDiscardRectangles, i);
+        const int64_t x_sum =
+            static_cast<int64_t>(pDiscardRectangles[i].offset.x) + static_cast<int64_t>(pDiscardRectangles[i].extent.width);
+        if (x_sum > std::numeric_limits<int32_t>::max()) {
+            skip |= LogError("VUID-vkCmdSetDiscardRectangleEXT-offset-00588", commandBuffer, loc,
+                             "offset.x (%" PRId32 ") + extent.width (%" PRIu32 ") is %" PRIi64 ") which will overflow int32_t.",
+                             pDiscardRectangles[i].offset.x, pDiscardRectangles[i].extent.width, x_sum);
+        }
 
-            const int64_t y_sum =
-                static_cast<int64_t>(pDiscardRectangles[i].offset.y) + static_cast<int64_t>(pDiscardRectangles[i].extent.height);
-            if (y_sum > std::numeric_limits<int32_t>::max()) {
-                skip |=
-                    LogError("VUID-vkCmdSetDiscardRectangleEXT-offset-00589", commandBuffer, loc,
+        const int64_t y_sum =
+            static_cast<int64_t>(pDiscardRectangles[i].offset.y) + static_cast<int64_t>(pDiscardRectangles[i].extent.height);
+        if (y_sum > std::numeric_limits<int32_t>::max()) {
+            skip |= LogError("VUID-vkCmdSetDiscardRectangleEXT-offset-00589", commandBuffer, loc,
                              "offset.y (%" PRId32 ") + extent.height (%" PRIu32 ") is %" PRIi64 ") which will overflow int32_t.",
                              pDiscardRectangles[i].offset.y, pDiscardRectangles[i].extent.height, y_sum);
-            }
         }
     }
 

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -124,286 +124,285 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
                                                               const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (pCreateInfo != nullptr) {
-        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-        const auto &features = physical_device_features;
-        const auto &limits = device_limits;
+    if (pCreateInfo == nullptr) {
+        return skip;
+    }
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
+    const auto &features = physical_device_features;
+    const auto &limits = device_limits;
 
-        if (pCreateInfo->anisotropyEnable == VK_TRUE) {
-            if (!IsBetweenInclusive(pCreateInfo->maxAnisotropy, 1.0F, limits.maxSamplerAnisotropy)) {
-                skip |=
-                    LogError("VUID-VkSamplerCreateInfo-anisotropyEnable-01071", device, create_info_loc.dot(Field::maxAnisotropy),
+    if (pCreateInfo->anisotropyEnable == VK_TRUE) {
+        if (!IsBetweenInclusive(pCreateInfo->maxAnisotropy, 1.0F, limits.maxSamplerAnisotropy)) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-anisotropyEnable-01071", device, create_info_loc.dot(Field::maxAnisotropy),
                              "is %f but must be in the range of [1.0, %f] (maxSamplerAnistropy).", pCreateInfo->maxAnisotropy,
                              limits.maxSamplerAnisotropy);
-            }
-
-            // Anistropy cannot be enabled in sampler unless enabled as a feature
-            if (features.samplerAnisotropy == VK_FALSE) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-anisotropyEnable-01070", device,
-                                 create_info_loc.dot(Field::anisotropyEnable),
-                                 "is VK_TRUE but the samplerAnisotropy feature was not enabled.");
-            }
         }
 
-        if (pCreateInfo->unnormalizedCoordinates == VK_TRUE) {
-            if (pCreateInfo->minFilter != pCreateInfo->magFilter) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01072", device,
-                                 create_info_loc.dot(Field::unnormalizedCoordinates),
-                                 "is VK_TRUE, but minFilter (%s) is different then magFilter (%s).",
-                                 string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
-            }
-            if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01073", device,
-                                 create_info_loc.dot(Field::unnormalizedCoordinates),
-                                 "is VK_TRUE, but mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
-                                 string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
-            }
-            if (pCreateInfo->minLod != 0.0f || pCreateInfo->maxLod != 0.0f) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01074", device,
-                                 create_info_loc.dot(Field::unnormalizedCoordinates),
-                                 "is VK_TRUE, but minLod (%f) and maxLod (%f) must both be zero.", pCreateInfo->minLod,
-                                 pCreateInfo->maxLod);
-            }
-            if ((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE &&
-                 pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
-                (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE &&
-                 pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01075", device,
-                                 create_info_loc.dot(Field::unnormalizedCoordinates),
-                                 "is VK_TRUE, but addressModeU (%s) and addressModeV (%s) must both be "
-                                 "CLAMP_TO_EDGE or CLAMP_TO_BORDER.",
-                                 string_VkSamplerAddressMode(pCreateInfo->addressModeU),
-                                 string_VkSamplerAddressMode(pCreateInfo->addressModeV));
-            }
-            if (pCreateInfo->anisotropyEnable == VK_TRUE) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01076", device, create_info_loc,
-                                 "anisotropyEnable and unnormalizedCoordinates are both VK_TRUE.");
-            }
-            if (pCreateInfo->compareEnable == VK_TRUE) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01077", device, create_info_loc,
-                                 "compareEnable and unnormalizedCoordinates are both VK_TRUE.");
-            }
+        // Anistropy cannot be enabled in sampler unless enabled as a feature
+        if (features.samplerAnisotropy == VK_FALSE) {
+            skip |=
+                LogError("VUID-VkSamplerCreateInfo-anisotropyEnable-01070", device, create_info_loc.dot(Field::anisotropyEnable),
+                         "is VK_TRUE but the samplerAnisotropy feature was not enabled.");
         }
+    }
 
-        // If compareEnable is VK_TRUE, compareOp must be a valid VkCompareOp value
-        const auto *sampler_reduction = LvlFindInChain<VkSamplerReductionModeCreateInfo>(pCreateInfo->pNext);
+    if (pCreateInfo->unnormalizedCoordinates == VK_TRUE) {
+        if (pCreateInfo->minFilter != pCreateInfo->magFilter) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01072", device,
+                             create_info_loc.dot(Field::unnormalizedCoordinates),
+                             "is VK_TRUE, but minFilter (%s) is different then magFilter (%s).",
+                             string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
+        }
+        if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01073", device,
+                             create_info_loc.dot(Field::unnormalizedCoordinates),
+                             "is VK_TRUE, but mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
+                             string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
+        }
+        if (pCreateInfo->minLod != 0.0f || pCreateInfo->maxLod != 0.0f) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01074", device,
+                             create_info_loc.dot(Field::unnormalizedCoordinates),
+                             "is VK_TRUE, but minLod (%f) and maxLod (%f) must both be zero.", pCreateInfo->minLod,
+                             pCreateInfo->maxLod);
+        }
+        if ((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE &&
+             pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
+            (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE &&
+             pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01075", device,
+                             create_info_loc.dot(Field::unnormalizedCoordinates),
+                             "is VK_TRUE, but addressModeU (%s) and addressModeV (%s) must both be "
+                             "CLAMP_TO_EDGE or CLAMP_TO_BORDER.",
+                             string_VkSamplerAddressMode(pCreateInfo->addressModeU),
+                             string_VkSamplerAddressMode(pCreateInfo->addressModeV));
+        }
+        if (pCreateInfo->anisotropyEnable == VK_TRUE) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01076", device, create_info_loc,
+                             "anisotropyEnable and unnormalizedCoordinates are both VK_TRUE.");
+        }
         if (pCreateInfo->compareEnable == VK_TRUE) {
-            skip |= ValidateRangedEnum(error_obj.location, "pCreateInfo->compareOp", "VkCompareOp", pCreateInfo->compareOp,
-                                       "VUID-VkSamplerCreateInfo-compareEnable-01080");
-            if (sampler_reduction != nullptr) {
-                if (sampler_reduction->reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE) {
-                    skip |= LogError("VUID-VkSamplerCreateInfo-compareEnable-01423", device,
-                                     create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
-                                     "is %s but compareEnable is VK_TRUE.",
-                                     string_VkSamplerReductionMode(sampler_reduction->reductionMode));
-                }
-            }
+            skip |= LogError("VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01077", device, create_info_loc,
+                             "compareEnable and unnormalizedCoordinates are both VK_TRUE.");
         }
-        if (sampler_reduction && sampler_reduction->reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE) {
-            if (!IsExtEnabled(device_extensions.vk_ext_filter_cubic)) {
-                if (pCreateInfo->magFilter == VK_FILTER_CUBIC_EXT || pCreateInfo->minFilter == VK_FILTER_CUBIC_EXT) {
-                    skip |= LogError("VUID-VkSamplerCreateInfo-magFilter-07911", device,
-                                     create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
-                                     "is %s, magFilter is %s and minFilter is %s, but "
-                                     "extension %s is not enabled.",
-                                     string_VkSamplerReductionMode(sampler_reduction->reductionMode),
-                                     string_VkFilter(pCreateInfo->magFilter), string_VkFilter(pCreateInfo->minFilter),
-                                     VK_EXT_FILTER_CUBIC_EXTENSION_NAME);
-                }
-            }
-        }
+    }
 
-        // If any of addressModeU, addressModeV or addressModeW are VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, borderColor must be a
-        // valid VkBorderColor value
-        if ((pCreateInfo->addressModeU == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
-            (pCreateInfo->addressModeV == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
-            (pCreateInfo->addressModeW == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) {
-            skip |= ValidateRangedEnum(error_obj.location, "pCreateInfo->borderColor", "VkBorderColor", pCreateInfo->borderColor,
-                                       "VUID-VkSamplerCreateInfo-addressModeU-01078");
-        }
-
-        // Checks for the IMG cubic filtering extension
-        if (IsExtEnabled(device_extensions.vk_img_filter_cubic)) {
-            if ((pCreateInfo->anisotropyEnable == VK_TRUE) &&
-                ((pCreateInfo->minFilter == VK_FILTER_CUBIC_IMG) || (pCreateInfo->magFilter == VK_FILTER_CUBIC_IMG))) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-magFilter-01081", device, create_info_loc,
-                                 "anisotropyEnable is VK_TRUE, but minFilter = %s and magFilter = %s",
-                                 string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
+    // If compareEnable is VK_TRUE, compareOp must be a valid VkCompareOp value
+    const auto *sampler_reduction = LvlFindInChain<VkSamplerReductionModeCreateInfo>(pCreateInfo->pNext);
+    if (pCreateInfo->compareEnable == VK_TRUE) {
+        skip |= ValidateRangedEnum(error_obj.location, "pCreateInfo->compareOp", "VkCompareOp", pCreateInfo->compareOp,
+                                   "VUID-VkSamplerCreateInfo-compareEnable-01080");
+        if (sampler_reduction != nullptr) {
+            if (sampler_reduction->reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE) {
+                skip |= LogError("VUID-VkSamplerCreateInfo-compareEnable-01423", device,
+                                 create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
+                                 "is %s but compareEnable is VK_TRUE.",
+                                 string_VkSamplerReductionMode(sampler_reduction->reductionMode));
             }
         }
-
-        // Check for valid Lod range
-        if (pCreateInfo->minLod > pCreateInfo->maxLod) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-maxLod-01973", device, create_info_loc,
-                             "minLod (%f) is greater than maxLod (%f)", pCreateInfo->minLod, pCreateInfo->maxLod);
-        }
-
-        // Check mipLodBias to device limit
-        if (pCreateInfo->mipLodBias > limits.maxSamplerLodBias) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-mipLodBias-01069", device, create_info_loc.dot(Field::mipLodBias),
-                             "(%f) is greater than maxSamplerLodBias (%f)", pCreateInfo->mipLodBias, limits.maxSamplerLodBias);
-        }
-
-        const auto *sampler_conversion = LvlFindInChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
-        if (sampler_conversion != nullptr) {
-            if ((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||
-                (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||
-                (pCreateInfo->addressModeW != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||
-                (pCreateInfo->anisotropyEnable != VK_FALSE) || (pCreateInfo->unnormalizedCoordinates != VK_FALSE)) {
-                skip |= LogError(
-                    "VUID-VkSamplerCreateInfo-addressModeU-01646", device, create_info_loc,
-                    "vkCreateSampler():  SamplerYCbCrConversion is enabled: "
-                    "addressModeU (%s), addressModeV (%s), addressModeW (%s) must be CLAMP_TO_EDGE, and anisotropyEnable (%s) "
-                    "and unnormalizedCoordinates (%s) must be VK_FALSE.",
-                    string_VkSamplerAddressMode(pCreateInfo->addressModeU), string_VkSamplerAddressMode(pCreateInfo->addressModeV),
-                    string_VkSamplerAddressMode(pCreateInfo->addressModeW), pCreateInfo->anisotropyEnable ? "VK_TRUE" : "VK_FALSE",
-                    pCreateInfo->unnormalizedCoordinates ? "VK_TRUE" : "VK_FALSE");
+    }
+    if (sampler_reduction && sampler_reduction->reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE) {
+        if (!IsExtEnabled(device_extensions.vk_ext_filter_cubic)) {
+            if (pCreateInfo->magFilter == VK_FILTER_CUBIC_EXT || pCreateInfo->minFilter == VK_FILTER_CUBIC_EXT) {
+                skip |= LogError("VUID-VkSamplerCreateInfo-magFilter-07911", device,
+                                 create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
+                                 "is %s, magFilter is %s and minFilter is %s, but "
+                                 "extension %s is not enabled.",
+                                 string_VkSamplerReductionMode(sampler_reduction->reductionMode),
+                                 string_VkFilter(pCreateInfo->magFilter), string_VkFilter(pCreateInfo->minFilter),
+                                 VK_EXT_FILTER_CUBIC_EXTENSION_NAME);
             }
         }
+    }
 
-        if (pCreateInfo->flags & VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT) {
-            if (pCreateInfo->minFilter != pCreateInfo->magFilter) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02574", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
-                                 "minFilter (%s) and magFilter (%s) must be equal.",
-                                 string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
-            }
-            if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02575", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
-                                 "mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
-                                 string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
-            }
-            if (pCreateInfo->minLod != 0.0 || pCreateInfo->maxLod != 0.0) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02576", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
-                                 "minLod (%f) and maxLod (%f) must be zero.",
-                                 pCreateInfo->minLod, pCreateInfo->maxLod);
-            }
-            if (((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
-                 (pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) ||
-                ((pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
-                 (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER))) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02577", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
-                                 "addressModeU (%s) and addressModeV (%s) must be "
-                                 "CLAMP_TO_EDGE or CLAMP_TO_BORDER",
-                                 string_VkSamplerAddressMode(pCreateInfo->addressModeU),
-                                 string_VkSamplerAddressMode(pCreateInfo->addressModeV));
-            }
-            if (pCreateInfo->anisotropyEnable) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02578", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
-                                 "but anisotropyEnable is VK_TRUE.");
-            }
-            if (pCreateInfo->compareEnable) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02579", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
-                                 "but compareEnable is VK_TRUE.");
-            }
-            if (pCreateInfo->unnormalizedCoordinates) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-02580", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
-                                 "but unnormalizedCoordinates is VK_TRUE.");
-            }
+    // If any of addressModeU, addressModeV or addressModeW are VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, borderColor must be a
+    // valid VkBorderColor value
+    if ((pCreateInfo->addressModeU == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
+        (pCreateInfo->addressModeV == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
+        (pCreateInfo->addressModeW == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) {
+        skip |= ValidateRangedEnum(error_obj.location, "pCreateInfo->borderColor", "VkBorderColor", pCreateInfo->borderColor,
+                                   "VUID-VkSamplerCreateInfo-addressModeU-01078");
+    }
+
+    // Checks for the IMG cubic filtering extension
+    if (IsExtEnabled(device_extensions.vk_img_filter_cubic)) {
+        if ((pCreateInfo->anisotropyEnable == VK_TRUE) &&
+            ((pCreateInfo->minFilter == VK_FILTER_CUBIC_IMG) || (pCreateInfo->magFilter == VK_FILTER_CUBIC_IMG))) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-magFilter-01081", device, create_info_loc,
+                             "anisotropyEnable is VK_TRUE, but minFilter = %s and magFilter = %s",
+                             string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
         }
+    }
 
-        if (pCreateInfo->borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
-            pCreateInfo->borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) {
-            if (!IsExtEnabled(device_extensions.vk_ext_custom_border_color)) {
-                skip |= LogError(kVUID_PVError_ExtensionNotEnabled, device, create_info_loc.dot(Field::borderColor),
-                                 "is %s but %s is not enabled.", string_VkBorderColor(pCreateInfo->borderColor),
-                                 VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
-            }
-            auto custom_create_info = LvlFindInChain<VkSamplerCustomBorderColorCreateInfoEXT>(pCreateInfo->pNext);
-            if (!custom_create_info) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-borderColor-04011", device, create_info_loc.dot(Field::borderColor),
-                                 "is %s but there is no VkSamplerCustomBorderColorCreateInfoEXT "
-                                 "struct in pNext chain.",
-                                 string_VkBorderColor(pCreateInfo->borderColor));
-            } else {
-                if ((custom_create_info->format != VK_FORMAT_UNDEFINED) && !FormatIsDepthAndStencil(custom_create_info->format) &&
-                    ((pCreateInfo->borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT &&
-                      !FormatIsSampledInt(custom_create_info->format)) ||
-                     (pCreateInfo->borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT &&
-                      !FormatIsSampledFloat(custom_create_info->format)))) {
-                    skip |= LogError("VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-07605", device,
-                                     create_info_loc.pNext(Struct::VkSamplerCustomBorderColorCreateInfoEXT, Field::format),
-                                     "%s does not match borderColor (%s).", string_VkFormat(custom_create_info->format),
-                                     string_VkBorderColor(pCreateInfo->borderColor));
-                }
-            }
+    // Check for valid Lod range
+    if (pCreateInfo->minLod > pCreateInfo->maxLod) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-maxLod-01973", device, create_info_loc,
+                         "minLod (%f) is greater than maxLod (%f)", pCreateInfo->minLod, pCreateInfo->maxLod);
+    }
+
+    // Check mipLodBias to device limit
+    if (pCreateInfo->mipLodBias > limits.maxSamplerLodBias) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-mipLodBias-01069", device, create_info_loc.dot(Field::mipLodBias),
+                         "(%f) is greater than maxSamplerLodBias (%f)", pCreateInfo->mipLodBias, limits.maxSamplerLodBias);
+    }
+
+    const auto *sampler_conversion = LvlFindInChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
+    if (sampler_conversion != nullptr) {
+        if ((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||
+            (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||
+            (pCreateInfo->addressModeW != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) || (pCreateInfo->anisotropyEnable != VK_FALSE) ||
+            (pCreateInfo->unnormalizedCoordinates != VK_FALSE)) {
+            skip |= LogError(
+                "VUID-VkSamplerCreateInfo-addressModeU-01646", device, create_info_loc,
+                "vkCreateSampler():  SamplerYCbCrConversion is enabled: "
+                "addressModeU (%s), addressModeV (%s), addressModeW (%s) must be CLAMP_TO_EDGE, and anisotropyEnable (%s) "
+                "and unnormalizedCoordinates (%s) must be VK_FALSE.",
+                string_VkSamplerAddressMode(pCreateInfo->addressModeU), string_VkSamplerAddressMode(pCreateInfo->addressModeV),
+                string_VkSamplerAddressMode(pCreateInfo->addressModeW), pCreateInfo->anisotropyEnable ? "VK_TRUE" : "VK_FALSE",
+                pCreateInfo->unnormalizedCoordinates ? "VK_TRUE" : "VK_FALSE");
         }
+    }
 
-        const auto *border_color_component_mapping =
-            LvlFindInChain<VkSamplerBorderColorComponentMappingCreateInfoEXT>(pCreateInfo->pNext);
-        if (border_color_component_mapping) {
-            const auto *border_color_swizzle_features =
-                LvlFindInChain<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT>(device_createinfo_pnext);
-            bool border_color_swizzle_features_enabled =
-                border_color_swizzle_features && border_color_swizzle_features->borderColorSwizzle;
-            if (!border_color_swizzle_features_enabled) {
-                skip |= LogError("VUID-VkSamplerBorderColorComponentMappingCreateInfoEXT-borderColorSwizzle-06437", device,
-                                 create_info_loc,
-                                 "The borderColorSwizzle feature must be enabled to use "
-                                 "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT");
-            }
+    if (pCreateInfo->flags & VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT) {
+        if (pCreateInfo->minFilter != pCreateInfo->magFilter) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02574", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
+                             "minFilter (%s) and magFilter (%s) must be equal.",
+                             string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
         }
+        if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02575", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
+                             "mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
+                             string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
+        }
+        if (pCreateInfo->minLod != 0.0 || pCreateInfo->maxLod != 0.0) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02576", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
+                             "minLod (%f) and maxLod (%f) must be zero.",
+                             pCreateInfo->minLod, pCreateInfo->maxLod);
+        }
+        if (((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
+             (pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) ||
+            ((pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
+             (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER))) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02577", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
+                             "addressModeU (%s) and addressModeV (%s) must be "
+                             "CLAMP_TO_EDGE or CLAMP_TO_BORDER",
+                             string_VkSamplerAddressMode(pCreateInfo->addressModeU),
+                             string_VkSamplerAddressMode(pCreateInfo->addressModeV));
+        }
+        if (pCreateInfo->anisotropyEnable) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02578", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
+                             "but anisotropyEnable is VK_TRUE.");
+        }
+        if (pCreateInfo->compareEnable) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02579", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
+                             "but compareEnable is VK_TRUE.");
+        }
+        if (pCreateInfo->unnormalizedCoordinates) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02580", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
+                             "but unnormalizedCoordinates is VK_TRUE.");
+        }
+    }
 
-        // VK_QCOM_image_processing
-        if ((pCreateInfo->flags & VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM) != 0) {
-            if ((pCreateInfo->minFilter != VK_FILTER_NEAREST) || (pCreateInfo->magFilter != VK_FILTER_NEAREST)) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06964", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                                 "minFilter (%s) must be VK_FILTER_NEAREST and "
-                                 "magFilter (%s) must be VK_FILTER_NEAREST.",
-                                 string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
-            }
-            if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06965", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                                 "mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
-                                 string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
-            }
-            if ((pCreateInfo->minLod != 0) || (pCreateInfo->maxLod != 0)) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06966", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                                 "minLod (%f) and maxLod (%f) must be 0.",
-                                 pCreateInfo->minLod, pCreateInfo->maxLod);
-            }
-            if (((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
-                 (pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) ||
-                ((pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
-                 (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER))) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06967", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                                 "addressModeU (%s) and addressModeV (%s) must be either "
-                                 "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE or VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER.",
-                                 string_VkSamplerAddressMode(pCreateInfo->addressModeU),
-                                 string_VkSamplerAddressMode(pCreateInfo->addressModeV));
-            }
-            if (((pCreateInfo->addressModeU == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
-                 (pCreateInfo->addressModeV == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) &&
-                (pCreateInfo->borderColor != VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK)) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06968", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                                 "and if addressModeU (%s) or addressModeV (%s) are "
-                                 "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, then"
-                                 "borderColor (%s) must be VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK.",
-                                 string_VkSamplerAddressMode(pCreateInfo->addressModeU),
-                                 string_VkSamplerAddressMode(pCreateInfo->addressModeV),
+    if (pCreateInfo->borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
+        pCreateInfo->borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) {
+        if (!IsExtEnabled(device_extensions.vk_ext_custom_border_color)) {
+            skip |= LogError(kVUID_PVError_ExtensionNotEnabled, device, create_info_loc.dot(Field::borderColor),
+                             "is %s but %s is not enabled.", string_VkBorderColor(pCreateInfo->borderColor),
+                             VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME);
+        }
+        auto custom_create_info = LvlFindInChain<VkSamplerCustomBorderColorCreateInfoEXT>(pCreateInfo->pNext);
+        if (!custom_create_info) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-borderColor-04011", device, create_info_loc.dot(Field::borderColor),
+                             "is %s but there is no VkSamplerCustomBorderColorCreateInfoEXT "
+                             "struct in pNext chain.",
+                             string_VkBorderColor(pCreateInfo->borderColor));
+        } else {
+            if ((custom_create_info->format != VK_FORMAT_UNDEFINED) && !FormatIsDepthAndStencil(custom_create_info->format) &&
+                ((pCreateInfo->borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT && !FormatIsSampledInt(custom_create_info->format)) ||
+                 (pCreateInfo->borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT &&
+                  !FormatIsSampledFloat(custom_create_info->format)))) {
+                skip |= LogError("VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-07605", device,
+                                 create_info_loc.pNext(Struct::VkSamplerCustomBorderColorCreateInfoEXT, Field::format),
+                                 "%s does not match borderColor (%s).", string_VkFormat(custom_create_info->format),
                                  string_VkBorderColor(pCreateInfo->borderColor));
             }
-            if (pCreateInfo->anisotropyEnable) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06969", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                                 "but anisotropyEnable is VK_TRUE.");
-            }
-            if (pCreateInfo->compareEnable) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-flags-06970", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                                 "but compareEnable is VK_TRUE.");
-            }
+        }
+    }
+
+    const auto *border_color_component_mapping =
+        LvlFindInChain<VkSamplerBorderColorComponentMappingCreateInfoEXT>(pCreateInfo->pNext);
+    if (border_color_component_mapping) {
+        const auto *border_color_swizzle_features =
+            LvlFindInChain<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT>(device_createinfo_pnext);
+        bool border_color_swizzle_features_enabled =
+            border_color_swizzle_features && border_color_swizzle_features->borderColorSwizzle;
+        if (!border_color_swizzle_features_enabled) {
+            skip |=
+                LogError("VUID-VkSamplerBorderColorComponentMappingCreateInfoEXT-borderColorSwizzle-06437", device, create_info_loc,
+                         "The borderColorSwizzle feature must be enabled to use "
+                         "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT");
+        }
+    }
+
+    // VK_QCOM_image_processing
+    if ((pCreateInfo->flags & VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM) != 0) {
+        if ((pCreateInfo->minFilter != VK_FILTER_NEAREST) || (pCreateInfo->magFilter != VK_FILTER_NEAREST)) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06964", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
+                             "minFilter (%s) must be VK_FILTER_NEAREST and "
+                             "magFilter (%s) must be VK_FILTER_NEAREST.",
+                             string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
+        }
+        if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06965", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
+                             "mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
+                             string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
+        }
+        if ((pCreateInfo->minLod != 0) || (pCreateInfo->maxLod != 0)) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06966", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
+                             "minLod (%f) and maxLod (%f) must be 0.",
+                             pCreateInfo->minLod, pCreateInfo->maxLod);
+        }
+        if (((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
+             (pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) ||
+            ((pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
+             (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER))) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06967", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
+                             "addressModeU (%s) and addressModeV (%s) must be either "
+                             "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE or VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER.",
+                             string_VkSamplerAddressMode(pCreateInfo->addressModeU),
+                             string_VkSamplerAddressMode(pCreateInfo->addressModeV));
+        }
+        if (((pCreateInfo->addressModeU == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
+             (pCreateInfo->addressModeV == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) &&
+            (pCreateInfo->borderColor != VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK)) {
+            skip |=
+                LogError("VUID-VkSamplerCreateInfo-flags-06968", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
+                         "and if addressModeU (%s) or addressModeV (%s) are "
+                         "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, then"
+                         "borderColor (%s) must be VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK.",
+                         string_VkSamplerAddressMode(pCreateInfo->addressModeU),
+                         string_VkSamplerAddressMode(pCreateInfo->addressModeV), string_VkBorderColor(pCreateInfo->borderColor));
+        }
+        if (pCreateInfo->anisotropyEnable) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06969", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
+                             "but anisotropyEnable is VK_TRUE.");
+        }
+        if (pCreateInfo->compareEnable) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06970", device, create_info_loc.dot(Field::flags),
+                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
+                             "but compareEnable is VK_TRUE.");
         }
     }
 
@@ -639,214 +638,209 @@ bool StatelessValidation::ValidateWriteDescriptorSet(const Location &loc, const 
                                                      const VkWriteDescriptorSet *pDescriptorWrites,
                                                      const bool isPushDescriptor) const {
     bool skip = false;
+    if (!pDescriptorWrites) {
+        return skip;
+    }
     const char *vkCallingFunction = loc.StringFunc();
-    if (pDescriptorWrites != NULL) {
-        for (uint32_t i = 0; i < descriptorWriteCount; ++i) {
-            // descriptorCount must be greater than 0
-            if (pDescriptorWrites[i].descriptorCount == 0) {
-                skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorCount-arraylength",
-                                 "%s(): parameter pDescriptorWrites[%" PRIu32 "].descriptorCount must be greater than 0.",
-                                 vkCallingFunction, i);
-            }
+    for (uint32_t i = 0; i < descriptorWriteCount; ++i) {
+        // descriptorCount must be greater than 0
+        if (pDescriptorWrites[i].descriptorCount == 0) {
+            skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorCount-arraylength",
+                             "%s(): parameter pDescriptorWrites[%" PRIu32 "].descriptorCount must be greater than 0.",
+                             vkCallingFunction, i);
+        }
 
-            // If called from vkCmdPushDescriptorSetKHR, the dstSet member is ignored.
-            if (!isPushDescriptor) {
-                // dstSet must be a valid VkDescriptorSet handle
-                skip |= ValidateRequiredHandle(loc, ParameterName("pDescriptorWrites[%i].dstSet", ParameterName::IndexVector{i}),
-                                               pDescriptorWrites[i].dstSet);
-            }
+        // If called from vkCmdPushDescriptorSetKHR, the dstSet member is ignored.
+        if (!isPushDescriptor) {
+            // dstSet must be a valid VkDescriptorSet handle
+            skip |= ValidateRequiredHandle(loc, ParameterName("pDescriptorWrites[%i].dstSet", ParameterName::IndexVector{i}),
+                                           pDescriptorWrites[i].dstSet);
+        }
 
-            if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER) ||
-                (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) ||
-                (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) ||
-                (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) ||
-                (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
-                if (pDescriptorWrites[i].pImageInfo == nullptr) {
-                    if (!isPushDescriptor) {
-                        // If descriptorType is VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-                        // VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or
-                        // VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, pImageInfo must be a pointer to an array of descriptorCount valid
-                        // VkDescriptorImageInfo structures. Valid imageView handles are checked in
-                        // ObjectLifetimes::ValidateDescriptorWrite.
-                        skip |= LogError(
-                            device, "VUID-vkUpdateDescriptorSets-pDescriptorWrites-06493",
-                            "%s(): if pDescriptorWrites[%" PRIu32
-                            "].descriptorType is VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, "
-                            "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or "
-                            "VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, pDescriptorWrites[%" PRIu32 "].pImageInfo must not be NULL.",
-                            vkCallingFunction, i, i);
-                    } else if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) ||
-                               (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) ||
-                               (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
-                        // If called from vkCmdPushDescriptorSetKHR, pImageInfo is only requred for descriptor types
-                        // VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, and
-                        // VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT
-                        skip |= LogError(device, "VUID-vkCmdPushDescriptorSetKHR-pDescriptorWrites-06494",
-                                         "%s(): if pDescriptorWrites[%" PRIu32
-                                         "].descriptorType is VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE "
-                                         "or VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, pDescriptorWrites[%" PRIu32
-                                         "].pImageInfo must not be NULL.",
-                                         vkCallingFunction, i, i);
-                    }
-                } else if (pDescriptorWrites[i].descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER) {
-                    // If descriptorType is VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-                    // VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, the imageLayout
-                    // member of any given element of pImageInfo must be a valid VkImageLayout
+        if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER) ||
+            (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) ||
+            (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) ||
+            (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) ||
+            (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
+            if (pDescriptorWrites[i].pImageInfo == nullptr) {
+                if (!isPushDescriptor) {
+                    // If descriptorType is VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                    // VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or
+                    // VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, pImageInfo must be a pointer to an array of descriptorCount valid
+                    // VkDescriptorImageInfo structures. Valid imageView handles are checked in
+                    // ObjectLifetimes::ValidateDescriptorWrite.
+                    skip |=
+                        LogError(device, "VUID-vkUpdateDescriptorSets-pDescriptorWrites-06493",
+                                 "%s(): if pDescriptorWrites[%" PRIu32
+                                 "].descriptorType is VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, "
+                                 "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or "
+                                 "VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, pDescriptorWrites[%" PRIu32 "].pImageInfo must not be NULL.",
+                                 vkCallingFunction, i, i);
+                } else if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) ||
+                           (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) ||
+                           (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
+                    // If called from vkCmdPushDescriptorSetKHR, pImageInfo is only requred for descriptor types
+                    // VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, and
+                    // VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT
+                    skip |= LogError(device, "VUID-vkCmdPushDescriptorSetKHR-pDescriptorWrites-06494",
+                                     "%s(): if pDescriptorWrites[%" PRIu32
+                                     "].descriptorType is VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE "
+                                     "or VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, pDescriptorWrites[%" PRIu32
+                                     "].pImageInfo must not be NULL.",
+                                     vkCallingFunction, i, i);
+                }
+            } else if (pDescriptorWrites[i].descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER) {
+                // If descriptorType is VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                // VK_DESCRIPTOR_TYPE_STORAGE_IMAGE or VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, the imageLayout
+                // member of any given element of pImageInfo must be a valid VkImageLayout
+                for (uint32_t descriptor_index = 0; descriptor_index < pDescriptorWrites[i].descriptorCount; ++descriptor_index) {
+                    skip |= ValidateRangedEnum(loc,
+                                               ParameterName("pDescriptorWrites[%i].pImageInfo[%i].imageLayout",
+                                                             ParameterName::IndexVector{i, descriptor_index}),
+                                               "VkImageLayout", pDescriptorWrites[i].pImageInfo[descriptor_index].imageLayout,
+                                               kVUIDUndefined);
+                }
+            }
+        } else if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) ||
+                   (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) ||
+                   (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) ||
+                   (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)) {
+            // If descriptorType is VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+            // VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC or VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, pBufferInfo must be a
+            // pointer to an array of descriptorCount valid VkDescriptorBufferInfo structures
+            // Valid buffer handles are checked in ObjectLifetimes::ValidateDescriptorWrite.
+            if (pDescriptorWrites[i].pBufferInfo == nullptr) {
+                skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00324",
+                                 "%s(): if pDescriptorWrites[%" PRIu32
+                                 "].descriptorType is "
+                                 "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, "
+                                 "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC or VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, "
+                                 "pDescriptorWrites[%" PRIu32 "].pBufferInfo must not be NULL.",
+                                 vkCallingFunction, i, i);
+            } else {
+                const auto *robustness2_features = LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
+                if (robustness2_features && robustness2_features->nullDescriptor) {
                     for (uint32_t descriptor_index = 0; descriptor_index < pDescriptorWrites[i].descriptorCount;
                          ++descriptor_index) {
-                        skip |= ValidateRangedEnum(loc,
-                                                   ParameterName("pDescriptorWrites[%i].pImageInfo[%i].imageLayout",
-                                                                 ParameterName::IndexVector{i, descriptor_index}),
-                                                   "VkImageLayout", pDescriptorWrites[i].pImageInfo[descriptor_index].imageLayout,
-                                                   kVUIDUndefined);
-                    }
-                }
-            } else if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) ||
-                       (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) ||
-                       (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) ||
-                       (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)) {
-                // If descriptorType is VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-                // VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC or VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, pBufferInfo must be a
-                // pointer to an array of descriptorCount valid VkDescriptorBufferInfo structures
-                // Valid buffer handles are checked in ObjectLifetimes::ValidateDescriptorWrite.
-                if (pDescriptorWrites[i].pBufferInfo == nullptr) {
-                    skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00324",
-                                     "%s(): if pDescriptorWrites[%" PRIu32
-                                     "].descriptorType is "
-                                     "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, "
-                                     "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC or VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, "
-                                     "pDescriptorWrites[%" PRIu32 "].pBufferInfo must not be NULL.",
-                                     vkCallingFunction, i, i);
-                } else {
-                    const auto *robustness2_features =
-                        LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
-                    if (robustness2_features && robustness2_features->nullDescriptor) {
-                        for (uint32_t descriptor_index = 0; descriptor_index < pDescriptorWrites[i].descriptorCount;
-                             ++descriptor_index) {
-                            if (pDescriptorWrites[i].pBufferInfo[descriptor_index].buffer == VK_NULL_HANDLE &&
-                                (pDescriptorWrites[i].pBufferInfo[descriptor_index].offset != 0 ||
-                                 pDescriptorWrites[i].pBufferInfo[descriptor_index].range != VK_WHOLE_SIZE)) {
-                                skip |= LogError(device, "VUID-VkDescriptorBufferInfo-buffer-02999",
-                                                 "%s(): if pDescriptorWrites[%" PRIu32
-                                                 "].buffer is VK_NULL_HANDLE, "
-                                                 "offset (%" PRIu64 ") must be zero and range (%" PRIu64 ") must be VK_WHOLE_SIZE.",
-                                                 vkCallingFunction, i, pDescriptorWrites[i].pBufferInfo[descriptor_index].offset,
-                                                 pDescriptorWrites[i].pBufferInfo[descriptor_index].range);
-                            }
+                        if (pDescriptorWrites[i].pBufferInfo[descriptor_index].buffer == VK_NULL_HANDLE &&
+                            (pDescriptorWrites[i].pBufferInfo[descriptor_index].offset != 0 ||
+                             pDescriptorWrites[i].pBufferInfo[descriptor_index].range != VK_WHOLE_SIZE)) {
+                            skip |= LogError(device, "VUID-VkDescriptorBufferInfo-buffer-02999",
+                                             "%s(): if pDescriptorWrites[%" PRIu32
+                                             "].buffer is VK_NULL_HANDLE, "
+                                             "offset (%" PRIu64 ") must be zero and range (%" PRIu64 ") must be VK_WHOLE_SIZE.",
+                                             vkCallingFunction, i, pDescriptorWrites[i].pBufferInfo[descriptor_index].offset,
+                                             pDescriptorWrites[i].pBufferInfo[descriptor_index].range);
                         }
                     }
                 }
-            } else if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) ||
-                       (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)) {
-                // Valid bufferView handles are checked in ObjectLifetimes::ValidateDescriptorWrite.
             }
+        } else if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) ||
+                   (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)) {
+            // Valid bufferView handles are checked in ObjectLifetimes::ValidateDescriptorWrite.
+        }
 
-            if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) ||
-                (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)) {
-                VkDeviceSize uniform_alignment = device_limits.minUniformBufferOffsetAlignment;
-                for (uint32_t j = 0; j < pDescriptorWrites[i].descriptorCount; j++) {
-                    if (pDescriptorWrites[i].pBufferInfo != NULL) {
-                        if (SafeModulo(pDescriptorWrites[i].pBufferInfo[j].offset, uniform_alignment) != 0) {
-                            skip |=
-                                LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00327",
+        if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) ||
+            (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)) {
+            VkDeviceSize uniform_alignment = device_limits.minUniformBufferOffsetAlignment;
+            for (uint32_t j = 0; j < pDescriptorWrites[i].descriptorCount; j++) {
+                if (pDescriptorWrites[i].pBufferInfo != NULL) {
+                    if (SafeModulo(pDescriptorWrites[i].pBufferInfo[j].offset, uniform_alignment) != 0) {
+                        skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00327",
                                          "%s(): pDescriptorWrites[%" PRIu32 "].pBufferInfo[%" PRIu32 "].offset (0x%" PRIxLEAST64
                                          ") must be a multiple of device limit minUniformBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
                                          vkCallingFunction, i, j, pDescriptorWrites[i].pBufferInfo[j].offset, uniform_alignment);
-                        }
                     }
                 }
-            } else if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) ||
-                       (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)) {
-                VkDeviceSize storage_alignment = device_limits.minStorageBufferOffsetAlignment;
-                for (uint32_t j = 0; j < pDescriptorWrites[i].descriptorCount; j++) {
-                    if (pDescriptorWrites[i].pBufferInfo != NULL) {
-                        if (SafeModulo(pDescriptorWrites[i].pBufferInfo[j].offset, storage_alignment) != 0) {
-                            skip |=
-                                LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00328",
+            }
+        } else if ((pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) ||
+                   (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)) {
+            VkDeviceSize storage_alignment = device_limits.minStorageBufferOffsetAlignment;
+            for (uint32_t j = 0; j < pDescriptorWrites[i].descriptorCount; j++) {
+                if (pDescriptorWrites[i].pBufferInfo != NULL) {
+                    if (SafeModulo(pDescriptorWrites[i].pBufferInfo[j].offset, storage_alignment) != 0) {
+                        skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00328",
                                          "%s(): pDescriptorWrites[%" PRIu32 "].pBufferInfo[%" PRIu32 "].offset (0x%" PRIxLEAST64
                                          ") must be a multiple of device limit minStorageBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
                                          vkCallingFunction, i, j, pDescriptorWrites[i].pBufferInfo[j].offset, storage_alignment);
+                    }
+                }
+            }
+        }
+        // pNext chain must be either NULL or a pointer to a valid instance of VkWriteDescriptorSetAccelerationStructureKHR
+        // or VkWriteDescriptorSetInlineUniformBlockEX
+        if (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR) {
+            const auto *pnext_struct = LvlFindInChain<VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites[i].pNext);
+            if (!pnext_struct || (pnext_struct->accelerationStructureCount != pDescriptorWrites[i].descriptorCount)) {
+                skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-02382",
+                                 "%s(): If descriptorType is VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, the pNext"
+                                 "chain must include a VkWriteDescriptorSetAccelerationStructureKHR structure whose "
+                                 "accelerationStructureCount %" PRIu32 " member equals descriptorCount %" PRIu32 ".",
+                                 vkCallingFunction, pnext_struct ? pnext_struct->accelerationStructureCount : -1,
+                                 pDescriptorWrites[i].descriptorCount);
+            }
+            // further checks only if we have right structtype
+            if (pnext_struct) {
+                if (pnext_struct->accelerationStructureCount != pDescriptorWrites[i].descriptorCount) {
+                    skip |=
+                        LogError(device, "VUID-VkWriteDescriptorSetAccelerationStructureKHR-accelerationStructureCount-02236",
+                                 "%s(): accelerationStructureCount %" PRIu32 " must be equal to descriptorCount %" PRIu32
+                                 " in the extended structure "
+                                 ".",
+                                 vkCallingFunction, pnext_struct->accelerationStructureCount, pDescriptorWrites[i].descriptorCount);
+                }
+                if (pnext_struct->accelerationStructureCount == 0) {
+                    skip |=
+                        LogError(device, "VUID-VkWriteDescriptorSetAccelerationStructureKHR-accelerationStructureCount-arraylength",
+                                 "%s(): accelerationStructureCount must be greater than 0 .", vkCallingFunction);
+                }
+                const auto *robustness2_features = LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
+                if (robustness2_features && robustness2_features->nullDescriptor == VK_FALSE) {
+                    for (uint32_t j = 0; j < pnext_struct->accelerationStructureCount; ++j) {
+                        if (pnext_struct->pAccelerationStructures[j] == VK_NULL_HANDLE) {
+                            skip |=
+                                LogError(device, "VUID-VkWriteDescriptorSetAccelerationStructureKHR-pAccelerationStructures-03580",
+                                         "%s(): If the nullDescriptor feature is not enabled, each member of "
+                                         "pAccelerationStructures must not be VK_NULL_HANDLE.",
+                                         vkCallingFunction);
                         }
                     }
                 }
             }
-            // pNext chain must be either NULL or a pointer to a valid instance of VkWriteDescriptorSetAccelerationStructureKHR
-            // or VkWriteDescriptorSetInlineUniformBlockEX
-            if (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR) {
-                const auto *pnext_struct = LvlFindInChain<VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites[i].pNext);
-                if (!pnext_struct || (pnext_struct->accelerationStructureCount != pDescriptorWrites[i].descriptorCount)) {
-                    skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-02382",
-                                     "%s(): If descriptorType is VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, the pNext"
-                                     "chain must include a VkWriteDescriptorSetAccelerationStructureKHR structure whose "
-                                     "accelerationStructureCount %" PRIu32 " member equals descriptorCount %" PRIu32 ".",
-                                     vkCallingFunction, pnext_struct ? pnext_struct->accelerationStructureCount : -1,
-                                     pDescriptorWrites[i].descriptorCount);
+        } else if (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV) {
+            const auto *pnext_struct = LvlFindInChain<VkWriteDescriptorSetAccelerationStructureNV>(pDescriptorWrites[i].pNext);
+            if (!pnext_struct || (pnext_struct->accelerationStructureCount != pDescriptorWrites[i].descriptorCount)) {
+                skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-03817",
+                                 "%s(): If descriptorType is VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV, the pNext"
+                                 "chain must include a VkWriteDescriptorSetAccelerationStructureNV structure whose "
+                                 "accelerationStructureCount %" PRIu32 " member equals descriptorCount %" PRIu32 ".",
+                                 vkCallingFunction, pnext_struct ? pnext_struct->accelerationStructureCount : -1,
+                                 pDescriptorWrites[i].descriptorCount);
+            }
+            // further checks only if we have right structtype
+            if (pnext_struct) {
+                if (pnext_struct->accelerationStructureCount != pDescriptorWrites[i].descriptorCount) {
+                    skip |=
+                        LogError(device, "VUID-VkWriteDescriptorSetAccelerationStructureNV-accelerationStructureCount-03747",
+                                 "%s(): accelerationStructureCount %" PRIu32 " must be equal to descriptorCount %" PRIu32
+                                 " in the extended structure "
+                                 ".",
+                                 vkCallingFunction, pnext_struct->accelerationStructureCount, pDescriptorWrites[i].descriptorCount);
                 }
-                // further checks only if we have right structtype
-                if (pnext_struct) {
-                    if (pnext_struct->accelerationStructureCount != pDescriptorWrites[i].descriptorCount) {
-                        skip |= LogError(
-                            device, "VUID-VkWriteDescriptorSetAccelerationStructureKHR-accelerationStructureCount-02236",
-                            "%s(): accelerationStructureCount %" PRIu32 " must be equal to descriptorCount %" PRIu32
-                            " in the extended structure "
-                            ".",
-                            vkCallingFunction, pnext_struct->accelerationStructureCount, pDescriptorWrites[i].descriptorCount);
-                    }
-                    if (pnext_struct->accelerationStructureCount == 0) {
-                        skip |= LogError(device,
-                                         "VUID-VkWriteDescriptorSetAccelerationStructureKHR-accelerationStructureCount-arraylength",
-                                         "%s(): accelerationStructureCount must be greater than 0 .", vkCallingFunction);
-                    }
-                    const auto *robustness2_features =
-                        LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
-                    if (robustness2_features && robustness2_features->nullDescriptor == VK_FALSE) {
-                        for (uint32_t j = 0; j < pnext_struct->accelerationStructureCount; ++j) {
-                            if (pnext_struct->pAccelerationStructures[j] == VK_NULL_HANDLE) {
-                                skip |= LogError(device,
-                                                 "VUID-VkWriteDescriptorSetAccelerationStructureKHR-pAccelerationStructures-03580",
-                                                 "%s(): If the nullDescriptor feature is not enabled, each member of "
-                                                 "pAccelerationStructures must not be VK_NULL_HANDLE.",
-                                                 vkCallingFunction);
-                            }
-                        }
-                    }
+                if (pnext_struct->accelerationStructureCount == 0) {
+                    skip |=
+                        LogError(device, "VUID-VkWriteDescriptorSetAccelerationStructureNV-accelerationStructureCount-arraylength",
+                                 "%s(): accelerationStructureCount must be greater than 0 .", vkCallingFunction);
                 }
-            } else if (pDescriptorWrites[i].descriptorType == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV) {
-                const auto *pnext_struct = LvlFindInChain<VkWriteDescriptorSetAccelerationStructureNV>(pDescriptorWrites[i].pNext);
-                if (!pnext_struct || (pnext_struct->accelerationStructureCount != pDescriptorWrites[i].descriptorCount)) {
-                    skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-03817",
-                                     "%s(): If descriptorType is VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV, the pNext"
-                                     "chain must include a VkWriteDescriptorSetAccelerationStructureNV structure whose "
-                                     "accelerationStructureCount %" PRIu32 " member equals descriptorCount %" PRIu32 ".",
-                                     vkCallingFunction, pnext_struct ? pnext_struct->accelerationStructureCount : -1,
-                                     pDescriptorWrites[i].descriptorCount);
-                }
-                // further checks only if we have right structtype
-                if (pnext_struct) {
-                    if (pnext_struct->accelerationStructureCount != pDescriptorWrites[i].descriptorCount) {
-                        skip |= LogError(
-                            device, "VUID-VkWriteDescriptorSetAccelerationStructureNV-accelerationStructureCount-03747",
-                            "%s(): accelerationStructureCount %" PRIu32 " must be equal to descriptorCount %" PRIu32
-                            " in the extended structure "
-                            ".",
-                            vkCallingFunction, pnext_struct->accelerationStructureCount, pDescriptorWrites[i].descriptorCount);
-                    }
-                    if (pnext_struct->accelerationStructureCount == 0) {
-                        skip |= LogError(device,
-                                         "VUID-VkWriteDescriptorSetAccelerationStructureNV-accelerationStructureCount-arraylength",
-                                         "%s(): accelerationStructureCount must be greater than 0 .", vkCallingFunction);
-                    }
-                    const auto *robustness2_features =
-                        LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
-                    if (robustness2_features && robustness2_features->nullDescriptor == VK_FALSE) {
-                        for (uint32_t j = 0; j < pnext_struct->accelerationStructureCount; ++j) {
-                            if (pnext_struct->pAccelerationStructures[j] == VK_NULL_HANDLE) {
-                                skip |= LogError(device,
-                                                 "VUID-VkWriteDescriptorSetAccelerationStructureNV-pAccelerationStructures-03749",
-                                                 "%s(): If the nullDescriptor feature is not enabled, each member of "
-                                                 "pAccelerationStructures must not be VK_NULL_HANDLE.",
-                                                 vkCallingFunction);
-                            }
+                const auto *robustness2_features = LvlFindInChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
+                if (robustness2_features && robustness2_features->nullDescriptor == VK_FALSE) {
+                    for (uint32_t j = 0; j < pnext_struct->accelerationStructureCount; ++j) {
+                        if (pnext_struct->pAccelerationStructures[j] == VK_NULL_HANDLE) {
+                            skip |=
+                                LogError(device, "VUID-VkWriteDescriptorSetAccelerationStructureNV-pAccelerationStructures-03749",
+                                         "%s(): If the nullDescriptor feature is not enabled, each member of "
+                                         "pAccelerationStructures must not be VK_NULL_HANDLE.",
+                                         vkCallingFunction);
                         }
                     }
                 }
@@ -935,66 +929,63 @@ bool StatelessValidation::manual_PreCallValidateCreateDescriptorPool(VkDevice de
                                                                      const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (pCreateInfo) {
-        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-        if (pCreateInfo->maxSets <= 0) {
-            skip |=
-                LogError("VUID-VkDescriptorPoolCreateInfo-maxSets-00301", device, create_info_loc.dot(Field::maxSets), "is zero.");
-        }
+    if (!pCreateInfo) {
+        return skip;
+    }
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
+    if (pCreateInfo->maxSets <= 0) {
+        skip |= LogError("VUID-VkDescriptorPoolCreateInfo-maxSets-00301", device, create_info_loc.dot(Field::maxSets), "is zero.");
+    }
 
-        const auto *mutable_descriptor_type_features =
-            LvlFindInChain<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>(device_createinfo_pnext);
-        bool mutable_descriptor_type_enabled =
-            mutable_descriptor_type_features && mutable_descriptor_type_features->mutableDescriptorType == VK_TRUE;
+    const auto *mutable_descriptor_type_features =
+        LvlFindInChain<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>(device_createinfo_pnext);
+    bool mutable_descriptor_type_enabled =
+        mutable_descriptor_type_features && mutable_descriptor_type_features->mutableDescriptorType == VK_TRUE;
 
-        if (pCreateInfo->pPoolSizes) {
-            for (uint32_t i = 0; i < pCreateInfo->poolSizeCount; ++i) {
-                const Location pool_loc = create_info_loc.dot(Field::pPoolSizes, i);
-                if (pCreateInfo->pPoolSizes[i].descriptorCount <= 0) {
-                    skip |= LogError("VUID-VkDescriptorPoolSize-descriptorCount-00302", device,
-                                     pool_loc.dot(Field::descriptorCount), "is zero.");
-                }
-                if (pCreateInfo->pPoolSizes[i].type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT &&
-                    (pCreateInfo->pPoolSizes[i].descriptorCount % 4) != 0) {
-                    skip |=
-                        LogError("VUID-VkDescriptorPoolSize-type-02218", device, pool_loc.dot(Field::descriptorCount),
+    if (pCreateInfo->pPoolSizes) {
+        for (uint32_t i = 0; i < pCreateInfo->poolSizeCount; ++i) {
+            const Location pool_loc = create_info_loc.dot(Field::pPoolSizes, i);
+            if (pCreateInfo->pPoolSizes[i].descriptorCount <= 0) {
+                skip |= LogError("VUID-VkDescriptorPoolSize-descriptorCount-00302", device, pool_loc.dot(Field::descriptorCount),
+                                 "is zero.");
+            }
+            if (pCreateInfo->pPoolSizes[i].type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT &&
+                (pCreateInfo->pPoolSizes[i].descriptorCount % 4) != 0) {
+                skip |= LogError("VUID-VkDescriptorPoolSize-type-02218", device, pool_loc.dot(Field::descriptorCount),
                                  "is %" PRIu32 " (not a multiple of 4), but type is VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT.",
                                  pCreateInfo->pPoolSizes[i].descriptorCount);
-                }
-                if (pCreateInfo->pPoolSizes[i].type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT && !mutable_descriptor_type_enabled) {
-                    skip |=
-                        LogError("VUID-VkDescriptorPoolCreateInfo-mutableDescriptorType-04608", device, pool_loc.dot(Field::type),
+            }
+            if (pCreateInfo->pPoolSizes[i].type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT && !mutable_descriptor_type_enabled) {
+                skip |= LogError("VUID-VkDescriptorPoolCreateInfo-mutableDescriptorType-04608", device, pool_loc.dot(Field::type),
                                  "is VK_DESCRIPTOR_TYPE_MUTABLE_EXT "
                                  ", but mutableDescriptorType feature was not enabled.");
-                }
-                if (pCreateInfo->pPoolSizes[i].type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
-                    for (uint32_t j = i + 1; j < pCreateInfo->poolSizeCount; ++j) {
-                        if (pCreateInfo->pPoolSizes[j].type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
-                            if (MutableDescriptorTypePartialOverlap(pCreateInfo, i, j)) {
-                                skip |=
-                                    LogError("VUID-VkDescriptorPoolCreateInfo-pPoolSizes-04787", device, pool_loc.dot(Field::type),
+            }
+            if (pCreateInfo->pPoolSizes[i].type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
+                for (uint32_t j = i + 1; j < pCreateInfo->poolSizeCount; ++j) {
+                    if (pCreateInfo->pPoolSizes[j].type == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
+                        if (MutableDescriptorTypePartialOverlap(pCreateInfo, i, j)) {
+                            skip |= LogError("VUID-VkDescriptorPoolCreateInfo-pPoolSizes-04787", device, pool_loc.dot(Field::type),
                                              "and pCreateInfo->pPoolSizes[%" PRIu32
                                              "].type are both VK_DESCRIPTOR_TYPE_MUTABLE_EXT "
                                              " and have sets which partially overlap.",
                                              j);
-                            }
                         }
                     }
                 }
             }
         }
+    }
 
-        if (pCreateInfo->flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT && (!mutable_descriptor_type_enabled)) {
-            skip |= LogError("VUID-VkDescriptorPoolCreateInfo-flags-04609", device, create_info_loc.dot(Field::flags),
-                             "includes VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT, "
-                             "but mutableDescriptorType feature was not enabled.");
-        }
-        if ((pCreateInfo->flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) &&
-            (pCreateInfo->flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT)) {
-            skip |= LogError("VUID-VkDescriptorPoolCreateInfo-flags-04607", device, create_info_loc.dot(Field::flags),
-                             "includes both "
-                             "VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT and VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT");
-        }
+    if (pCreateInfo->flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT && (!mutable_descriptor_type_enabled)) {
+        skip |= LogError("VUID-VkDescriptorPoolCreateInfo-flags-04609", device, create_info_loc.dot(Field::flags),
+                         "includes VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT, "
+                         "but mutableDescriptorType feature was not enabled.");
+    }
+    if ((pCreateInfo->flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) &&
+        (pCreateInfo->flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT)) {
+        skip |= LogError("VUID-VkDescriptorPoolCreateInfo-flags-04607", device, create_info_loc.dot(Field::flags),
+                         "includes both "
+                         "VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT and VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT");
     }
 
     return skip;
@@ -1006,21 +997,21 @@ bool StatelessValidation::manual_PreCallValidateCreateQueryPool(VkDevice device,
     bool skip = false;
 
     // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
-    if (pCreateInfo != nullptr) {
-        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-        // If queryType is VK_QUERY_TYPE_PIPELINE_STATISTICS, pipelineStatistics must be a valid combination of
-        // VkQueryPipelineStatisticFlagBits values
-        if ((pCreateInfo->queryType == VK_QUERY_TYPE_PIPELINE_STATISTICS) && (pCreateInfo->pipelineStatistics != 0) &&
-            ((pCreateInfo->pipelineStatistics & (~AllVkQueryPipelineStatisticFlagBits)) != 0)) {
-            skip |= LogError("VUID-VkQueryPoolCreateInfo-queryType-00792", device, create_info_loc.dot(Field::queryType),
-                             "is VK_QUERY_TYPE_PIPELINE_STATISTICS, but "
-                             "pCreateInfo->pipelineStatistics must be a valid combination of VkQueryPipelineStatisticFlagBits "
-                             "values.");
-        }
-        if (pCreateInfo->queryCount == 0) {
-            skip |=
-                LogError("VUID-VkQueryPoolCreateInfo-queryCount-02763", device, create_info_loc.dot(Field::queryCount), "is zero.");
-        }
+    if (!pCreateInfo) {
+        return skip;
+    }
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
+    // If queryType is VK_QUERY_TYPE_PIPELINE_STATISTICS, pipelineStatistics must be a valid combination of
+    // VkQueryPipelineStatisticFlagBits values
+    if ((pCreateInfo->queryType == VK_QUERY_TYPE_PIPELINE_STATISTICS) && (pCreateInfo->pipelineStatistics != 0) &&
+        ((pCreateInfo->pipelineStatistics & (~AllVkQueryPipelineStatisticFlagBits)) != 0)) {
+        skip |= LogError("VUID-VkQueryPoolCreateInfo-queryType-00792", device, create_info_loc.dot(Field::queryType),
+                         "is VK_QUERY_TYPE_PIPELINE_STATISTICS, but "
+                         "pCreateInfo->pipelineStatistics must be a valid combination of VkQueryPipelineStatisticFlagBits "
+                         "values.");
+    }
+    if (pCreateInfo->queryCount == 0) {
+        skip |= LogError("VUID-VkQueryPoolCreateInfo-queryCount-02763", device, create_info_loc.dot(Field::queryCount), "is zero.");
     }
     return skip;
 }

--- a/layers/stateless/sl_device_memory.cpp
+++ b/layers/stateless/sl_device_memory.cpp
@@ -73,112 +73,112 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
                                                                const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (pAllocateInfo) {
-        const Location allocate_info_loc = error_obj.location.dot(Field::pAllocateInfo);
-        auto chained_prio_struct = LvlFindInChain<VkMemoryPriorityAllocateInfoEXT>(pAllocateInfo->pNext);
-        if (chained_prio_struct && (chained_prio_struct->priority < 0.0f || chained_prio_struct->priority > 1.0f)) {
-            skip |= LogError("VUID-VkMemoryPriorityAllocateInfoEXT-priority-02602", device,
-                             allocate_info_loc.pNext(Struct::VkMemoryPriorityAllocateInfoEXT, Field::priority), "is %f",
-                             chained_prio_struct->priority);
+    if (!pAllocateInfo) {
+        return skip;
+    }
+    const Location allocate_info_loc = error_obj.location.dot(Field::pAllocateInfo);
+    auto chained_prio_struct = LvlFindInChain<VkMemoryPriorityAllocateInfoEXT>(pAllocateInfo->pNext);
+    if (chained_prio_struct && (chained_prio_struct->priority < 0.0f || chained_prio_struct->priority > 1.0f)) {
+        skip |= LogError("VUID-VkMemoryPriorityAllocateInfoEXT-priority-02602", device,
+                         allocate_info_loc.pNext(Struct::VkMemoryPriorityAllocateInfoEXT, Field::priority), "is %f",
+                         chained_prio_struct->priority);
+    }
+
+    VkMemoryAllocateFlags flags = 0;
+    auto flags_info = LvlFindInChain<VkMemoryAllocateFlagsInfo>(pAllocateInfo->pNext);
+    if (flags_info) {
+        flags = flags_info->flags;
+    }
+
+    const ImportOperationsInfo import_info = GetNumberOfImportInfo(pAllocateInfo);
+
+    auto opaque_alloc_info = LvlFindInChain<VkMemoryOpaqueCaptureAddressAllocateInfo>(pAllocateInfo->pNext);
+    if (opaque_alloc_info && opaque_alloc_info->opaqueCaptureAddress != 0) {
+        const Location address_loc =
+            allocate_info_loc.pNext(Struct::VkMemoryOpaqueCaptureAddressAllocateInfo, Field::opaqueCaptureAddress);
+        if (!(flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT)) {
+            skip |= LogError("VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03329", device, address_loc,
+                             "is non-zero (%" PRIu64
+                             ") so VkMemoryAllocateFlagsInfo::flags must include "
+                             "VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT.",
+                             opaque_alloc_info->opaqueCaptureAddress);
         }
 
-        VkMemoryAllocateFlags flags = 0;
-        auto flags_info = LvlFindInChain<VkMemoryAllocateFlagsInfo>(pAllocateInfo->pNext);
-        if (flags_info) {
-            flags = flags_info->flags;
-        }
-
-        const ImportOperationsInfo import_info = GetNumberOfImportInfo(pAllocateInfo);
-
-        auto opaque_alloc_info = LvlFindInChain<VkMemoryOpaqueCaptureAddressAllocateInfo>(pAllocateInfo->pNext);
-        if (opaque_alloc_info && opaque_alloc_info->opaqueCaptureAddress != 0) {
-            const Location address_loc =
-                allocate_info_loc.pNext(Struct::VkMemoryOpaqueCaptureAddressAllocateInfo, Field::opaqueCaptureAddress);
-            if (!(flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT)) {
-                skip |= LogError("VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03329", device, address_loc,
-                                 "is non-zero (%" PRIu64
-                                 ") so VkMemoryAllocateFlagsInfo::flags must include "
-                                 "VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT.",
-                                 opaque_alloc_info->opaqueCaptureAddress);
-            }
-
-            if (import_info.host_pointer_info_ext) {
-                skip |=
-                    LogError("VUID-VkMemoryAllocateInfo-pNext-03332", device, address_loc,
+        if (import_info.host_pointer_info_ext) {
+            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-03332", device, address_loc,
                              "is non-zero (%" PRIu64 ") but the pNext chain includes a VkImportMemoryHostPointerInfoEXT structure.",
                              opaque_alloc_info->opaqueCaptureAddress);
-            }
-
-            if (import_info.total_import_ops > 0) {
-                skip |= LogError("VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03333", device, address_loc,
-                                 "is non-zero (%" PRIu64 ") but an import operation is defined.",
-                                 opaque_alloc_info->opaqueCaptureAddress);
-            }
         }
 
-        if (import_info.total_import_ops > 1) {
-            skip |= LogError("VUID-VkMemoryAllocateInfo-None-06657", device, allocate_info_loc,
-                             "%" PRIu32 " import operations are defined", import_info.total_import_ops);
+        if (import_info.total_import_ops > 0) {
+            skip |=
+                LogError("VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03333", device, address_loc,
+                         "is non-zero (%" PRIu64 ") but an import operation is defined.", opaque_alloc_info->opaqueCaptureAddress);
         }
-
-        auto export_memory = LvlFindInChain<VkExportMemoryAllocateInfo>(pAllocateInfo->pNext);
-        if (export_memory) {
-            auto export_memory_nv = LvlFindInChain<VkExportMemoryAllocateInfoNV>(pAllocateInfo->pNext);
-            if (export_memory_nv) {
-                skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-00640", device, allocate_info_loc,
-                                 "pNext chain includes both VkExportMemoryAllocateInfo and "
-                                 "VkExportMemoryAllocateInfoNV");
-            }
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-            auto export_memory_win32_nv = LvlFindInChain<VkExportMemoryWin32HandleInfoNV>(pAllocateInfo->pNext);
-            if (export_memory_win32_nv) {
-                skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-00640", device, allocate_info_loc,
-                                 "pNext chain includes both VkExportMemoryAllocateInfo and "
-                                 "VkExportMemoryWin32HandleInfoNV");
-            }
-#endif
-        }
-
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-        if (LvlFindInChain<VkImportMemoryWin32HandleInfoKHR>(pAllocateInfo->pNext) &&
-            LvlFindInChain<VkImportMemoryWin32HandleInfoNV>(pAllocateInfo->pNext)) {
-            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-00641", device, allocate_info_loc,
-                             "pNext chain includes both VkImportMemoryWin32HandleInfoKHR and "
-                             "VkImportMemoryWin32HandleInfoNV");
-        }
-#endif
-
-        if (flags) {
-            const Location flags_loc = allocate_info_loc.pNext(Struct::VkMemoryAllocateFlagsInfo, Field::flags);
-            VkBool32 capture_replay = false;
-            VkBool32 buffer_device_address = false;
-            const auto *vulkan_12_features = LvlFindInChain<VkPhysicalDeviceVulkan12Features>(device_createinfo_pnext);
-            if (vulkan_12_features) {
-                capture_replay = vulkan_12_features->bufferDeviceAddressCaptureReplay;
-                buffer_device_address = vulkan_12_features->bufferDeviceAddress;
-            } else {
-                const auto *bda_features = LvlFindInChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(device_createinfo_pnext);
-                if (bda_features) {
-                    capture_replay = bda_features->bufferDeviceAddressCaptureReplay;
-                    buffer_device_address = bda_features->bufferDeviceAddress;
-                }
-            }
-            if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT) && !capture_replay) {
-                skip |= LogError("VUID-VkMemoryAllocateInfo-flags-03330", device, flags_loc,
-                                 "has VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT set, but"
-                                 "bufferDeviceAddressCaptureReplay feature is not enabled.");
-            }
-            if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT) && !buffer_device_address) {
-                skip |= LogError("VUID-VkMemoryAllocateInfo-flags-03331", device, flags_loc,
-                                 "has VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT set, but bufferDeviceAddress feature is not enabled.");
-            }
-        }
-#ifdef VK_USE_PLATFORM_METAL_EXT
-        skip |= ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT,
-                                            "VUID-VkMemoryAllocateInfo-pNext-06780", error_obj.location,
-                                            "VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT", pAllocateInfo->pNext);
-#endif  // VK_USE_PLATFORM_METAL_EXT
     }
+
+    if (import_info.total_import_ops > 1) {
+        skip |= LogError("VUID-VkMemoryAllocateInfo-None-06657", device, allocate_info_loc,
+                         "%" PRIu32 " import operations are defined", import_info.total_import_ops);
+    }
+
+    auto export_memory = LvlFindInChain<VkExportMemoryAllocateInfo>(pAllocateInfo->pNext);
+    if (export_memory) {
+        auto export_memory_nv = LvlFindInChain<VkExportMemoryAllocateInfoNV>(pAllocateInfo->pNext);
+        if (export_memory_nv) {
+            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-00640", device, allocate_info_loc,
+                             "pNext chain includes both VkExportMemoryAllocateInfo and "
+                             "VkExportMemoryAllocateInfoNV");
+        }
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+        auto export_memory_win32_nv = LvlFindInChain<VkExportMemoryWin32HandleInfoNV>(pAllocateInfo->pNext);
+        if (export_memory_win32_nv) {
+            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-00640", device, allocate_info_loc,
+                             "pNext chain includes both VkExportMemoryAllocateInfo and "
+                             "VkExportMemoryWin32HandleInfoNV");
+        }
+#endif
+    }
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    if (LvlFindInChain<VkImportMemoryWin32HandleInfoKHR>(pAllocateInfo->pNext) &&
+        LvlFindInChain<VkImportMemoryWin32HandleInfoNV>(pAllocateInfo->pNext)) {
+        skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-00641", device, allocate_info_loc,
+                         "pNext chain includes both VkImportMemoryWin32HandleInfoKHR and "
+                         "VkImportMemoryWin32HandleInfoNV");
+    }
+#endif
+
+    if (flags) {
+        const Location flags_loc = allocate_info_loc.pNext(Struct::VkMemoryAllocateFlagsInfo, Field::flags);
+        VkBool32 capture_replay = false;
+        VkBool32 buffer_device_address = false;
+        const auto *vulkan_12_features = LvlFindInChain<VkPhysicalDeviceVulkan12Features>(device_createinfo_pnext);
+        if (vulkan_12_features) {
+            capture_replay = vulkan_12_features->bufferDeviceAddressCaptureReplay;
+            buffer_device_address = vulkan_12_features->bufferDeviceAddress;
+        } else {
+            const auto *bda_features = LvlFindInChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(device_createinfo_pnext);
+            if (bda_features) {
+                capture_replay = bda_features->bufferDeviceAddressCaptureReplay;
+                buffer_device_address = bda_features->bufferDeviceAddress;
+            }
+        }
+        if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT) && !capture_replay) {
+            skip |= LogError("VUID-VkMemoryAllocateInfo-flags-03330", device, flags_loc,
+                             "has VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT set, but"
+                             "bufferDeviceAddressCaptureReplay feature is not enabled.");
+        }
+        if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT) && !buffer_device_address) {
+            skip |= LogError("VUID-VkMemoryAllocateInfo-flags-03331", device, flags_loc,
+                             "has VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT set, but bufferDeviceAddress feature is not enabled.");
+        }
+    }
+#ifdef VK_USE_PLATFORM_METAL_EXT
+    skip |=
+        ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT, "VUID-VkMemoryAllocateInfo-pNext-06780",
+                                    error_obj.location, "VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT", pAllocateInfo->pNext);
+#endif  // VK_USE_PLATFORM_METAL_EXT
     return skip;
 }
 
@@ -186,37 +186,38 @@ bool StatelessValidation::ValidateDeviceImageMemoryRequirements(VkDevice device,
                                                                 const Location &loc) const {
     bool skip = false;
 
-    if (pInfo && pInfo->pCreateInfo) {
-        const auto &create_info = *(pInfo->pCreateInfo);
-        if (LvlFindInChain<VkImageSwapchainCreateInfoKHR>(create_info.pNext)) {
-            skip |= LogError("VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06416", device, loc,
-                             "pNext chain contains VkImageSwapchainCreateInfoKHR.");
-        }
-        if (LvlFindInChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(create_info.pNext)) {
-            skip |= LogError("VUID-VkDeviceImageMemoryRequirements-pCreateInfo-06776", device, loc,
-                             "pNext chain contains VkImageDrmFormatModifierExplicitCreateInfoEXT.");
-        }
-
-        if (FormatIsMultiplane(create_info.format) && (create_info.flags & VK_IMAGE_CREATE_DISJOINT_BIT) != 0) {
-            if (pInfo->planeAspect == VK_IMAGE_ASPECT_NONE_KHR) {
-                skip |= LogError("VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06417", device, loc.dot(Field::planeAspect),
-                                 "is VK_IMAGE_ASPECT_NONE_KHR with a multi-planar format and disjoint flag.");
-            } else if ((create_info.tiling == VK_IMAGE_TILING_LINEAR || create_info.tiling == VK_IMAGE_TILING_OPTIMAL) &&
-                       !IsOnlyOneValidPlaneAspect(create_info.format, pInfo->planeAspect)) {
-                skip |= LogError("VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06419", device, loc.dot(Field::planeAspect),
-                                 "is %s but is invalid for %s.", string_VkImageAspectFlags(pInfo->planeAspect).c_str(),
-                                 string_VkFormat(create_info.format));
-            }
-        }
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
-        const auto *external_format = LvlFindInChain<VkExternalFormatANDROID>(pInfo->pCreateInfo);
-        if (external_format && external_format->externalFormat) {
-            skip |= LogError("VUID-VkDeviceImageMemoryRequirements-pNext-06996", device, loc.dot(Field::pCreateInfo),
-                             "pNext chain contains VkExternalFormatANDROID with externalFormat %" PRIu64 ".",
-                             external_format->externalFormat);
-        }
-#endif  // VK_USE_PLATFORM_ANDROID_KHR
+    if (!pInfo || !pInfo->pCreateInfo) {
+        return skip;
     }
+    const auto &create_info = *(pInfo->pCreateInfo);
+    if (LvlFindInChain<VkImageSwapchainCreateInfoKHR>(create_info.pNext)) {
+        skip |= LogError("VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06416", device, loc,
+                         "pNext chain contains VkImageSwapchainCreateInfoKHR.");
+    }
+    if (LvlFindInChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(create_info.pNext)) {
+        skip |= LogError("VUID-VkDeviceImageMemoryRequirements-pCreateInfo-06776", device, loc,
+                         "pNext chain contains VkImageDrmFormatModifierExplicitCreateInfoEXT.");
+    }
+
+    if (FormatIsMultiplane(create_info.format) && (create_info.flags & VK_IMAGE_CREATE_DISJOINT_BIT) != 0) {
+        if (pInfo->planeAspect == VK_IMAGE_ASPECT_NONE_KHR) {
+            skip |= LogError("VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06417", device, loc.dot(Field::planeAspect),
+                             "is VK_IMAGE_ASPECT_NONE_KHR with a multi-planar format and disjoint flag.");
+        } else if ((create_info.tiling == VK_IMAGE_TILING_LINEAR || create_info.tiling == VK_IMAGE_TILING_OPTIMAL) &&
+                   !IsOnlyOneValidPlaneAspect(create_info.format, pInfo->planeAspect)) {
+            skip |= LogError("VUID-VkDeviceImageMemoryRequirementsKHR-pCreateInfo-06419", device, loc.dot(Field::planeAspect),
+                             "is %s but is invalid for %s.", string_VkImageAspectFlags(pInfo->planeAspect).c_str(),
+                             string_VkFormat(create_info.format));
+        }
+    }
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    const auto *external_format = LvlFindInChain<VkExternalFormatANDROID>(pInfo->pCreateInfo);
+    if (external_format && external_format->externalFormat) {
+        skip |= LogError("VUID-VkDeviceImageMemoryRequirements-pNext-06996", device, loc.dot(Field::pCreateInfo),
+                         "pNext chain contains VkExternalFormatANDROID with externalFormat %" PRIu64 ".",
+                         external_format->externalFormat);
+    }
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
 
     return skip;
 }

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -24,635 +24,625 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                                                             const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (pCreateInfo != nullptr) {
-        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-        const VkFormat image_format = pCreateInfo->format;
-        const VkImageCreateFlags image_flags = pCreateInfo->flags;
-        // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
-        if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT) {
-            // If sharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1
-            auto const queue_family_index_count = pCreateInfo->queueFamilyIndexCount;
-            if (queue_family_index_count <= 1) {
-                skip |= LogError("VUID-VkImageCreateInfo-sharingMode-00942", device,
-                                 create_info_loc.dot(Field::queueFamilyIndexCount), "is %" PRIu32 ".", queue_family_index_count);
-            }
-
-            // If sharingMode is VK_SHARING_MODE_CONCURRENT, pQueueFamilyIndices must be a pointer to an array of
-            // queueFamilyIndexCount uint32_t values
-            if (pCreateInfo->pQueueFamilyIndices == nullptr) {
-                skip |= LogError("VUID-VkImageCreateInfo-sharingMode-00941", device,
-                                 create_info_loc.dot(Field::pQueueFamilyIndices), "is NULL.");
-            }
+    if (pCreateInfo == nullptr) {
+        return skip;
+    }
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
+    const VkFormat image_format = pCreateInfo->format;
+    const VkImageCreateFlags image_flags = pCreateInfo->flags;
+    // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
+    if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT) {
+        // If sharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1
+        auto const queue_family_index_count = pCreateInfo->queueFamilyIndexCount;
+        if (queue_family_index_count <= 1) {
+            skip |= LogError("VUID-VkImageCreateInfo-sharingMode-00942", device, create_info_loc.dot(Field::queueFamilyIndexCount),
+                             "is %" PRIu32 ".", queue_family_index_count);
         }
 
-        skip |= ValidateNotZero(pCreateInfo->extent.width == 0, "VUID-VkImageCreateInfo-extent-00944",
-                                create_info_loc.dot(Field::extent).dot(Field::width));
-        skip |= ValidateNotZero(pCreateInfo->extent.height == 0, "VUID-VkImageCreateInfo-extent-00945",
-                                create_info_loc.dot(Field::extent).dot(Field::height));
-        skip |= ValidateNotZero(pCreateInfo->extent.depth == 0, "VUID-VkImageCreateInfo-extent-00946",
-                                create_info_loc.dot(Field::extent).dot(Field::depth));
-
-        skip |= ValidateNotZero(pCreateInfo->mipLevels == 0, "VUID-VkImageCreateInfo-mipLevels-00947",
-                                create_info_loc.dot(Field::mipLevels));
-        skip |= ValidateNotZero(pCreateInfo->arrayLayers == 0, "VUID-VkImageCreateInfo-arrayLayers-00948",
-                                create_info_loc.dot(Field::arrayLayers));
-
-        // InitialLayout must be PREINITIALIZED or UNDEFINED
-        if ((pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) &&
-            (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_PREINITIALIZED)) {
-            skip |= LogError("VUID-VkImageCreateInfo-initialLayout-00993", device, create_info_loc.dot(Field::initialLayout),
-                             "is %s, but must be UNDEFINED or PREINITIALIZED.", string_VkImageLayout(pCreateInfo->initialLayout));
+        // If sharingMode is VK_SHARING_MODE_CONCURRENT, pQueueFamilyIndices must be a pointer to an array of
+        // queueFamilyIndexCount uint32_t values
+        if (pCreateInfo->pQueueFamilyIndices == nullptr) {
+            skip |= LogError("VUID-VkImageCreateInfo-sharingMode-00941", device, create_info_loc.dot(Field::pQueueFamilyIndices),
+                             "is NULL.");
         }
+    }
 
-        // If imageType is VK_IMAGE_TYPE_1D, both extent.height and extent.depth must be 1
-        if ((pCreateInfo->imageType == VK_IMAGE_TYPE_1D) &&
-            ((pCreateInfo->extent.height != 1) || (pCreateInfo->extent.depth != 1))) {
-            skip |= LogError("VUID-VkImageCreateInfo-imageType-00956", device, create_info_loc,
-                             "if pCreateInfo->imageType is VK_IMAGE_TYPE_1D, both pCreateInfo->extent.height and "
-                             "pCreateInfo->extent.depth must be 1.");
-        }
+    skip |= ValidateNotZero(pCreateInfo->extent.width == 0, "VUID-VkImageCreateInfo-extent-00944",
+                            create_info_loc.dot(Field::extent).dot(Field::width));
+    skip |= ValidateNotZero(pCreateInfo->extent.height == 0, "VUID-VkImageCreateInfo-extent-00945",
+                            create_info_loc.dot(Field::extent).dot(Field::height));
+    skip |= ValidateNotZero(pCreateInfo->extent.depth == 0, "VUID-VkImageCreateInfo-extent-00946",
+                            create_info_loc.dot(Field::extent).dot(Field::depth));
 
-        if (pCreateInfo->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) {
-            const VkImageType type = pCreateInfo->imageType;
-            const auto width = pCreateInfo->extent.width;
-            const auto height = pCreateInfo->extent.height;
-            if (type != VK_IMAGE_TYPE_2D) {
-                skip |=
-                    LogError("VUID-VkImageCreateInfo-flags-00949", device, create_info_loc,
+    skip |= ValidateNotZero(pCreateInfo->mipLevels == 0, "VUID-VkImageCreateInfo-mipLevels-00947",
+                            create_info_loc.dot(Field::mipLevels));
+    skip |= ValidateNotZero(pCreateInfo->arrayLayers == 0, "VUID-VkImageCreateInfo-arrayLayers-00948",
+                            create_info_loc.dot(Field::arrayLayers));
+
+    // InitialLayout must be PREINITIALIZED or UNDEFINED
+    if ((pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) &&
+        (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_PREINITIALIZED)) {
+        skip |= LogError("VUID-VkImageCreateInfo-initialLayout-00993", device, create_info_loc.dot(Field::initialLayout),
+                         "is %s, but must be UNDEFINED or PREINITIALIZED.", string_VkImageLayout(pCreateInfo->initialLayout));
+    }
+
+    // If imageType is VK_IMAGE_TYPE_1D, both extent.height and extent.depth must be 1
+    if ((pCreateInfo->imageType == VK_IMAGE_TYPE_1D) && ((pCreateInfo->extent.height != 1) || (pCreateInfo->extent.depth != 1))) {
+        skip |= LogError("VUID-VkImageCreateInfo-imageType-00956", device, create_info_loc,
+                         "if pCreateInfo->imageType is VK_IMAGE_TYPE_1D, both pCreateInfo->extent.height and "
+                         "pCreateInfo->extent.depth must be 1.");
+    }
+
+    if (pCreateInfo->flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) {
+        const VkImageType type = pCreateInfo->imageType;
+        const auto width = pCreateInfo->extent.width;
+        const auto height = pCreateInfo->extent.height;
+        if (type != VK_IMAGE_TYPE_2D) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-00949", device, create_info_loc,
                              "Image type %s is incompatible with VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT.", string_VkImageType(type));
-            }
-
-            if (width != height) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-08865", device, create_info_loc,
-                                 "extent.width (=%" PRIu32 ") not equal to extent.height (=%" PRIu32 ").",
-                                 pCreateInfo->extent.width, pCreateInfo->extent.height);
-            }
-
-            if (pCreateInfo->arrayLayers < 6) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-08866", device, create_info_loc,
-                                 "arrayLayers (=%" PRIu32 ") is less than 6.", pCreateInfo->arrayLayers);
-            }
         }
 
-        if (pCreateInfo->imageType == VK_IMAGE_TYPE_2D) {
-            if (pCreateInfo->extent.depth != 1) {
-                skip |= LogError("VUID-VkImageCreateInfo-imageType-00957", device, create_info_loc,
-                                 "if pCreateInfo->imageType is VK_IMAGE_TYPE_2D, pCreateInfo->extent.depth must be 1.");
-            }
+        if (width != height) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-08865", device, create_info_loc,
+                             "extent.width (=%" PRIu32 ") not equal to extent.height (=%" PRIu32 ").", pCreateInfo->extent.width,
+                             pCreateInfo->extent.height);
         }
 
-        // 3D image may have only 1 layer
-        if ((pCreateInfo->imageType == VK_IMAGE_TYPE_3D) && (pCreateInfo->arrayLayers != 1)) {
-            skip |= LogError("VUID-VkImageCreateInfo-imageType-00961", device, create_info_loc,
-                             "if pCreateInfo->imageType is VK_IMAGE_TYPE_3D, pCreateInfo->arrayLayers must be 1.");
+        if (pCreateInfo->arrayLayers < 6) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-08866", device, create_info_loc,
+                             "arrayLayers (=%" PRIu32 ") is less than 6.", pCreateInfo->arrayLayers);
         }
+    }
 
-        if (0 != (pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT)) {
-            VkImageUsageFlags legal_flags = (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-                                             VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
-            // At least one of the legal attachment bits must be set
-            if (0 == (pCreateInfo->usage & legal_flags)) {
-                skip |= LogError("VUID-VkImageCreateInfo-usage-00966", device, create_info_loc,
-                                 "Transient attachment image without a compatible attachment flag set.");
-            }
-            // No flags other than the legal attachment bits may be set
-            legal_flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
-            if (0 != (pCreateInfo->usage & ~legal_flags)) {
-                skip |= LogError("VUID-VkImageCreateInfo-usage-00963", device, create_info_loc,
-                                 "Transient attachment image with incompatible usage flags set.");
-            }
+    if (pCreateInfo->imageType == VK_IMAGE_TYPE_2D) {
+        if (pCreateInfo->extent.depth != 1) {
+            skip |= LogError("VUID-VkImageCreateInfo-imageType-00957", device, create_info_loc,
+                             "if pCreateInfo->imageType is VK_IMAGE_TYPE_2D, pCreateInfo->extent.depth must be 1.");
         }
+    }
 
-        // mipLevels must be less than or equal to the number of levels in the complete mipmap chain
-        uint32_t max_dim = std::max(std::max(pCreateInfo->extent.width, pCreateInfo->extent.height), pCreateInfo->extent.depth);
-        // Max mip levels is different for corner-sampled images vs normal images.
-        uint32_t max_mip_levels = (image_flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV)
-                                      ? static_cast<uint32_t>(ceil(log2(max_dim)))
-                                      : static_cast<uint32_t>(floor(log2(max_dim)) + 1);
-        if (max_dim > 0 && pCreateInfo->mipLevels > max_mip_levels) {
-            skip |=
-                LogError("VUID-VkImageCreateInfo-mipLevels-00958", device, create_info_loc,
+    // 3D image may have only 1 layer
+    if ((pCreateInfo->imageType == VK_IMAGE_TYPE_3D) && (pCreateInfo->arrayLayers != 1)) {
+        skip |= LogError("VUID-VkImageCreateInfo-imageType-00961", device, create_info_loc,
+                         "if pCreateInfo->imageType is VK_IMAGE_TYPE_3D, pCreateInfo->arrayLayers must be 1.");
+    }
+
+    if (0 != (pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT)) {
+        VkImageUsageFlags legal_flags = (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+                                         VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
+        // At least one of the legal attachment bits must be set
+        if (0 == (pCreateInfo->usage & legal_flags)) {
+            skip |= LogError("VUID-VkImageCreateInfo-usage-00966", device, create_info_loc,
+                             "Transient attachment image without a compatible attachment flag set.");
+        }
+        // No flags other than the legal attachment bits may be set
+        legal_flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
+        if (0 != (pCreateInfo->usage & ~legal_flags)) {
+            skip |= LogError("VUID-VkImageCreateInfo-usage-00963", device, create_info_loc,
+                             "Transient attachment image with incompatible usage flags set.");
+        }
+    }
+
+    // mipLevels must be less than or equal to the number of levels in the complete mipmap chain
+    uint32_t max_dim = std::max(std::max(pCreateInfo->extent.width, pCreateInfo->extent.height), pCreateInfo->extent.depth);
+    // Max mip levels is different for corner-sampled images vs normal images.
+    uint32_t max_mip_levels = (image_flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV)
+                                  ? static_cast<uint32_t>(ceil(log2(max_dim)))
+                                  : static_cast<uint32_t>(floor(log2(max_dim)) + 1);
+    if (max_dim > 0 && pCreateInfo->mipLevels > max_mip_levels) {
+        skip |= LogError("VUID-VkImageCreateInfo-mipLevels-00958", device, create_info_loc,
                          "pCreateInfo->mipLevels must be less than or equal to "
                          "floor(log2(max(pCreateInfo->extent.width, pCreateInfo->extent.height, pCreateInfo->extent.depth)))+1.");
+    }
+
+    if ((image_flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT) && (pCreateInfo->imageType != VK_IMAGE_TYPE_3D)) {
+        skip |= LogError("VUID-VkImageCreateInfo-flags-00950", device, create_info_loc.dot(Field::flags),
+                         "includes VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT but "
+                         "imageType is %s.",
+                         string_VkImageType(pCreateInfo->imageType));
+    }
+
+    if ((image_flags & VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT) && (pCreateInfo->imageType != VK_IMAGE_TYPE_3D)) {
+        skip |= LogError("VUID-VkImageCreateInfo-flags-07755", device, create_info_loc.dot(Field::flags),
+                         "includes VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT but "
+                         "imageType is %s.",
+                         string_VkImageType(pCreateInfo->imageType));
+    }
+
+    if ((image_flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) && (!physical_device_features.sparseBinding)) {
+        skip |= LogError("VUID-VkImageCreateInfo-flags-00969", device, create_info_loc.dot(Field::flags),
+                         "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT, but the "
+                         "sparseBinding feature was not enabled.");
+    }
+
+    if ((image_flags & VK_IMAGE_CREATE_SPARSE_ALIASED_BIT) && (!physical_device_features.sparseResidencyAliased)) {
+        skip |= LogError("VUID-VkImageCreateInfo-flags-01924", device, create_info_loc.dot(Field::flags),
+                         "includes VK_IMAGE_CREATE_SPARSE_ALIASED_BIT but the sparseResidencyAliased feature was not enabled.");
+    }
+
+    // If flags contains VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT or VK_IMAGE_CREATE_SPARSE_ALIASED_BIT, it must also contain
+    // VK_IMAGE_CREATE_SPARSE_BINDING_BIT
+    if (((image_flags & (VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_ALIASED_BIT)) != 0) &&
+        ((image_flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != VK_IMAGE_CREATE_SPARSE_BINDING_BIT)) {
+        skip |= LogError("VUID-VkImageCreateInfo-flags-00987", device, create_info_loc.dot(Field::flags), "is %s.",
+                         string_VkImageCreateFlags(image_flags).c_str());
+    }
+
+    // Check for combinations of attributes that are incompatible with having VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT set
+    if ((image_flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0) {
+        // Linear tiling is unsupported
+        if (VK_IMAGE_TILING_LINEAR == pCreateInfo->tiling) {
+            skip |= LogError("VUID-VkImageCreateInfo-tiling-04121", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT but tiling is VK_IMAGE_TILING_LINEAR.");
         }
 
-        if ((image_flags & VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT) && (pCreateInfo->imageType != VK_IMAGE_TYPE_3D)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-00950", device, create_info_loc.dot(Field::flags),
-                             "includes VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT but "
-                             "imageType is %s.",
+        // Sparse 1D image isn't valid
+        if (VK_IMAGE_TYPE_1D == pCreateInfo->imageType) {
+            skip |= LogError("VUID-VkImageCreateInfo-imageType-00970", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT but imageType is VK_IMAGE_TYPE_1D.");
+        }
+
+        // Sparse 2D image when device doesn't support it
+        if ((!physical_device_features.sparseResidencyImage2D) && (VK_IMAGE_TYPE_2D == pCreateInfo->imageType)) {
+            skip |= LogError("VUID-VkImageCreateInfo-imageType-00971", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D, but "
+                             "sparseResidencyImage2D feature was not enabled.");
+        }
+
+        // Sparse 3D image when device doesn't support it
+        if ((!physical_device_features.sparseResidencyImage3D) && (VK_IMAGE_TYPE_3D == pCreateInfo->imageType)) {
+            skip |= LogError("VUID-VkImageCreateInfo-imageType-00972", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_3D, but "
+                             "sparseResidencyImage3D feature was not enabled.");
+        }
+
+        // Multi-sample 2D image when device doesn't support it
+        if (VK_IMAGE_TYPE_2D == pCreateInfo->imageType) {
+            if ((!physical_device_features.sparseResidency2Samples) && (VK_SAMPLE_COUNT_2_BIT == pCreateInfo->samples)) {
+                skip |= LogError("VUID-VkImageCreateInfo-imageType-00973", device, create_info_loc.dot(Field::flags),
+                                 "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
+                                 "VK_SAMPLE_COUNT_2_BIT, but sparseResidency2Samples feature was not enabled.");
+            } else if ((!physical_device_features.sparseResidency4Samples) && (VK_SAMPLE_COUNT_4_BIT == pCreateInfo->samples)) {
+                skip |= LogError("VUID-VkImageCreateInfo-imageType-00974", device, create_info_loc.dot(Field::flags),
+                                 "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
+                                 "VK_SAMPLE_COUNT_4_BIT, but sparseResidency4Samples feature was not enabled.");
+            } else if ((!physical_device_features.sparseResidency8Samples) && (VK_SAMPLE_COUNT_8_BIT == pCreateInfo->samples)) {
+                skip |= LogError("VUID-VkImageCreateInfo-imageType-00975", device, create_info_loc.dot(Field::flags),
+                                 "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
+                                 "VK_SAMPLE_COUNT_8_BIT, but sparseResidency8Samples feature was not enabled.");
+            } else if ((!physical_device_features.sparseResidency16Samples) && (VK_SAMPLE_COUNT_16_BIT == pCreateInfo->samples)) {
+                skip |= LogError("VUID-VkImageCreateInfo-imageType-00976", device, create_info_loc.dot(Field::flags),
+                                 "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
+                                 "VK_SAMPLE_COUNT_16_BIT, but sparseResidency16Samples feature was not enabled.");
+            }
+        }
+    }
+
+    // alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV
+    if (pCreateInfo->usage & VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) {
+        if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
+            skip |= LogError("VUID-VkImageCreateInfo-imageType-02082", device, create_info_loc.dot(Field::usage),
+                             "includes VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR (or the "
+                             "alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV), but imageType is %s.",
+                             string_VkImageType(pCreateInfo->imageType));
+        }
+        if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
+            skip |= LogError("VUID-VkImageCreateInfo-samples-02083", device, create_info_loc.dot(Field::usage),
+                             "includes VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR (or the "
+                             "alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV), but samples is %s.",
+                             string_VkSampleCountFlagBits(pCreateInfo->samples));
+        }
+        const auto *shading_rate_image_features =
+            LvlFindInChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(device_createinfo_pnext);
+        if (shading_rate_image_features && shading_rate_image_features->shadingRateImage &&
+            pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
+            // KHR flag can be non-optimal
+            skip |= LogError("VUID-VkImageCreateInfo-shadingRateImage-07727", device, create_info_loc.dot(Field::usage),
+                             "includes VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, tiling must be "
+                             "VK_IMAGE_TILING_OPTIMAL.");
+        }
+    }
+
+    if (image_flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) {
+        if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D && pCreateInfo->imageType != VK_IMAGE_TYPE_3D) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-02050", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV, "
+                             "but imageType is %s.",
                              string_VkImageType(pCreateInfo->imageType));
         }
 
-        if ((image_flags & VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT) && (pCreateInfo->imageType != VK_IMAGE_TYPE_3D)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-07755", device, create_info_loc.dot(Field::flags),
-                             "includes VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT but "
-                             "imageType is %s.",
-                             string_VkImageType(pCreateInfo->imageType));
-        }
-
-        if ((image_flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) && (!physical_device_features.sparseBinding)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-00969", device, create_info_loc.dot(Field::flags),
-                             "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT, but the "
-                             "sparseBinding feature was not enabled.");
-        }
-
-        if ((image_flags & VK_IMAGE_CREATE_SPARSE_ALIASED_BIT) && (!physical_device_features.sparseResidencyAliased)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-01924", device, create_info_loc.dot(Field::flags),
-                             "includes VK_IMAGE_CREATE_SPARSE_ALIASED_BIT but the sparseResidencyAliased feature was not enabled.");
-        }
-
-        // If flags contains VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT or VK_IMAGE_CREATE_SPARSE_ALIASED_BIT, it must also contain
-        // VK_IMAGE_CREATE_SPARSE_BINDING_BIT
-        if (((image_flags & (VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_ALIASED_BIT)) != 0) &&
-            ((image_flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != VK_IMAGE_CREATE_SPARSE_BINDING_BIT)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-00987", device, create_info_loc.dot(Field::flags), "is %s.",
-                             string_VkImageCreateFlags(image_flags).c_str());
-        }
-
-        // Check for combinations of attributes that are incompatible with having VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT set
-        if ((image_flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0) {
-            // Linear tiling is unsupported
-            if (VK_IMAGE_TILING_LINEAR == pCreateInfo->tiling) {
-                skip |= LogError("VUID-VkImageCreateInfo-tiling-04121", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT but tiling is VK_IMAGE_TILING_LINEAR.");
-            }
-
-            // Sparse 1D image isn't valid
-            if (VK_IMAGE_TYPE_1D == pCreateInfo->imageType) {
-                skip |= LogError("VUID-VkImageCreateInfo-imageType-00970", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT but imageType is VK_IMAGE_TYPE_1D.");
-            }
-
-            // Sparse 2D image when device doesn't support it
-            if ((!physical_device_features.sparseResidencyImage2D) && (VK_IMAGE_TYPE_2D == pCreateInfo->imageType)) {
-                skip |= LogError("VUID-VkImageCreateInfo-imageType-00971", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D, but "
-                                 "sparseResidencyImage2D feature was not enabled.");
-            }
-
-            // Sparse 3D image when device doesn't support it
-            if ((!physical_device_features.sparseResidencyImage3D) && (VK_IMAGE_TYPE_3D == pCreateInfo->imageType)) {
-                skip |= LogError("VUID-VkImageCreateInfo-imageType-00972", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_3D, but "
-                                 "sparseResidencyImage3D feature was not enabled.");
-            }
-
-            // Multi-sample 2D image when device doesn't support it
-            if (VK_IMAGE_TYPE_2D == pCreateInfo->imageType) {
-                if ((!physical_device_features.sparseResidency2Samples) && (VK_SAMPLE_COUNT_2_BIT == pCreateInfo->samples)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00973", device, create_info_loc.dot(Field::flags),
-                                     "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
-                                     "VK_SAMPLE_COUNT_2_BIT, but sparseResidency2Samples feature was not enabled.");
-                } else if ((!physical_device_features.sparseResidency4Samples) && (VK_SAMPLE_COUNT_4_BIT == pCreateInfo->samples)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00974", device, create_info_loc.dot(Field::flags),
-                                     "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
-                                     "VK_SAMPLE_COUNT_4_BIT, but sparseResidency4Samples feature was not enabled.");
-                } else if ((!physical_device_features.sparseResidency8Samples) && (VK_SAMPLE_COUNT_8_BIT == pCreateInfo->samples)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00975", device, create_info_loc.dot(Field::flags),
-                                     "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
-                                     "VK_SAMPLE_COUNT_8_BIT, but sparseResidency8Samples feature was not enabled.");
-                } else if ((!physical_device_features.sparseResidency16Samples) &&
-                           (VK_SAMPLE_COUNT_16_BIT == pCreateInfo->samples)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-imageType-00976", device, create_info_loc.dot(Field::flags),
-                                     "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
-                                     "VK_SAMPLE_COUNT_16_BIT, but sparseResidency16Samples feature was not enabled.");
-                }
-            }
-        }
-
-        // alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV
-        if (pCreateInfo->usage & VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) {
-            if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
-                skip |= LogError("VUID-VkImageCreateInfo-imageType-02082", device, create_info_loc.dot(Field::usage),
-                                 "includes VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR (or the "
-                                 "alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV), but imageType is %s.",
-                                 string_VkImageType(pCreateInfo->imageType));
-            }
-            if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
-                skip |= LogError("VUID-VkImageCreateInfo-samples-02083", device, create_info_loc.dot(Field::usage),
-                                 "includes VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR (or the "
-                                 "alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV), but samples is %s.",
-                                 string_VkSampleCountFlagBits(pCreateInfo->samples));
-            }
-            const auto *shading_rate_image_features =
-                LvlFindInChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(device_createinfo_pnext);
-            if (shading_rate_image_features && shading_rate_image_features->shadingRateImage &&
-                pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
-                // KHR flag can be non-optimal
-                skip |= LogError("VUID-VkImageCreateInfo-shadingRateImage-07727", device, create_info_loc.dot(Field::usage),
-                                 "includes VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, tiling must be "
-                                 "VK_IMAGE_TILING_OPTIMAL.");
-            }
-        }
-
-        if (image_flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) {
-            if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D && pCreateInfo->imageType != VK_IMAGE_TYPE_3D) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02050", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV, "
-                                 "but imageType is %s.",
-                                 string_VkImageType(pCreateInfo->imageType));
-            }
-
-            if ((image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) || FormatIsDepthOrStencil(image_format)) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02051", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV, "
-                                 "it must not also contain VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT and format (%s) must not be a "
-                                 "depth/stencil format.",
-                                 string_VkFormat(image_format));
-            }
-
-            if (pCreateInfo->imageType == VK_IMAGE_TYPE_2D && (pCreateInfo->extent.width == 1 || pCreateInfo->extent.height == 1)) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02052", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and "
-                                 "imageType is VK_IMAGE_TYPE_2D, extent.width and extent.height must be "
-                                 "greater than 1.");
-            } else if (pCreateInfo->imageType == VK_IMAGE_TYPE_3D &&
-                       (pCreateInfo->extent.width == 1 || pCreateInfo->extent.height == 1 || pCreateInfo->extent.depth == 1)) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02053", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and "
-                                 "imageType is VK_IMAGE_TYPE_3D, extent.width, extent.height, and extent.depth "
-                                 "must be greater than 1.");
-            }
-        }
-
-        if (((image_flags & VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) != 0) &&
-            (FormatHasDepth(image_format) == false)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-01533", device, create_info_loc.dot(Field::flags),
-                             "includes VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT the "
-                             "format (%s) must be a depth or depth/stencil format.",
+        if ((image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) || FormatIsDepthOrStencil(image_format)) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-02051", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV, "
+                             "it must not also contain VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT and format (%s) must not be a "
+                             "depth/stencil format.",
                              string_VkFormat(image_format));
         }
 
-        const auto image_stencil_struct = LvlFindInChain<VkImageStencilUsageCreateInfo>(pCreateInfo->pNext);
-        if (image_stencil_struct != nullptr) {
-            if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0) {
-                VkImageUsageFlags legal_flags = (VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
-                // No flags other than the legal attachment bits may be set
-                legal_flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
-                if ((image_stencil_struct->stencilUsage & ~legal_flags) != 0) {
-                    skip |= LogError("VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539", device,
-                                     create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage), "is %s.",
-                                     string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
-                }
-            }
+        if (pCreateInfo->imageType == VK_IMAGE_TYPE_2D && (pCreateInfo->extent.width == 1 || pCreateInfo->extent.height == 1)) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-02052", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and "
+                             "imageType is VK_IMAGE_TYPE_2D, extent.width and extent.height must be "
+                             "greater than 1.");
+        } else if (pCreateInfo->imageType == VK_IMAGE_TYPE_3D &&
+                   (pCreateInfo->extent.width == 1 || pCreateInfo->extent.height == 1 || pCreateInfo->extent.depth == 1)) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-02053", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and "
+                             "imageType is VK_IMAGE_TYPE_3D, extent.width, extent.height, and extent.depth "
+                             "must be greater than 1.");
+        }
+    }
 
-            if (FormatIsDepthOrStencil(image_format)) {
-                if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) != 0) {
-                    if (pCreateInfo->extent.width > device_limits.maxFramebufferWidth) {
-                        skip |= LogError("VUID-VkImageCreateInfo-Format-02536", device,
-                                         create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
-                                         "includes VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image width (%" PRIu32
-                                         ") exceeds device "
-                                         "maxFramebufferWidth (%" PRIu32 ")",
-                                         pCreateInfo->extent.width, device_limits.maxFramebufferWidth);
-                    }
+    if (((image_flags & VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) != 0) &&
+        (FormatHasDepth(image_format) == false)) {
+        skip |= LogError("VUID-VkImageCreateInfo-flags-01533", device, create_info_loc.dot(Field::flags),
+                         "includes VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT the "
+                         "format (%s) must be a depth or depth/stencil format.",
+                         string_VkFormat(image_format));
+    }
 
-                    if (pCreateInfo->extent.height > device_limits.maxFramebufferHeight) {
-                        skip |= LogError("VUID-VkImageCreateInfo-format-02537", device,
-                                         create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
-                                         "includes VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image height (%" PRIu32
-                                         ") exceeds device "
-                                         "maxFramebufferHeight (%" PRIu32 ")",
-                                         pCreateInfo->extent.height, device_limits.maxFramebufferHeight);
-                    }
-                }
-
-                if (!physical_device_features.shaderStorageImageMultisample &&
-                    ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
-                    (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT)) {
-                    skip |= LogError("VUID-VkImageCreateInfo-format-02538", device,
-                                     create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
-                                     "includes VK_IMAGE_USAGE_STORAGE_BIT and format is %s and samples is %s, but "
-                                     "shaderStorageImageMultisample feature was not enabled.",
-                                     string_VkFormat(image_format), string_VkSampleCountFlagBits(pCreateInfo->samples));
-                }
-
-                if (((pCreateInfo->usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0) &&
-                    ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0)) {
-                    skip |=
-                        LogError("VUID-VkImageCreateInfo-format-02795", device, create_info_loc.dot(Field::usage),
-                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
-                                 string_VkFormat(image_format),
-                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
+    const auto image_stencil_struct = LvlFindInChain<VkImageStencilUsageCreateInfo>(pCreateInfo->pNext);
+    if (image_stencil_struct != nullptr) {
+        if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0) {
+            VkImageUsageFlags legal_flags = (VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
+            // No flags other than the legal attachment bits may be set
+            legal_flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
+            if ((image_stencil_struct->stencilUsage & ~legal_flags) != 0) {
+                skip |= LogError("VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539", device,
+                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage), "is %s.",
                                  string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
-                } else if (((pCreateInfo->usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) &&
-                           ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0)) {
-                    skip |=
-                        LogError("VUID-VkImageCreateInfo-format-02796", device, create_info_loc.dot(Field::usage),
-                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
-                                 string_VkFormat(image_format),
-                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
-                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
-                }
-
-                if (((pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0) &&
-                    ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) == 0)) {
-                    skip |=
-                        LogError("VUID-VkImageCreateInfo-format-02797", device, create_info_loc.dot(Field::usage),
-                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
-                                 string_VkFormat(image_format),
-                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
-                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
-                } else if (((pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) == 0) &&
-                           ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0)) {
-                    skip |=
-                        LogError("VUID-VkImageCreateInfo-format-02798", device, create_info_loc.dot(Field::usage),
-                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
-                                 string_VkFormat(image_format),
-                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
-                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
-                }
             }
         }
 
-        if ((!physical_device_features.shaderStorageImageMultisample) && ((pCreateInfo->usage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
-            (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT)) {
-            skip |= LogError("VUID-VkImageCreateInfo-usage-00968", device, create_info_loc.dot(Field::usage),
-                             "includes VK_IMAGE_USAGE_STORAGE_BIT and imageType is %s, but shaderStorageImageMultisample feature "
-                             "was not enabled.",
+        if (FormatIsDepthOrStencil(image_format)) {
+            if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) != 0) {
+                if (pCreateInfo->extent.width > device_limits.maxFramebufferWidth) {
+                    skip |= LogError("VUID-VkImageCreateInfo-Format-02536", device,
+                                     create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
+                                     "includes VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image width (%" PRIu32
+                                     ") exceeds device "
+                                     "maxFramebufferWidth (%" PRIu32 ")",
+                                     pCreateInfo->extent.width, device_limits.maxFramebufferWidth);
+                }
+
+                if (pCreateInfo->extent.height > device_limits.maxFramebufferHeight) {
+                    skip |= LogError("VUID-VkImageCreateInfo-format-02537", device,
+                                     create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
+                                     "includes VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image height (%" PRIu32
+                                     ") exceeds device "
+                                     "maxFramebufferHeight (%" PRIu32 ")",
+                                     pCreateInfo->extent.height, device_limits.maxFramebufferHeight);
+                }
+            }
+
+            if (!physical_device_features.shaderStorageImageMultisample &&
+                ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
+                (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT)) {
+                skip |= LogError("VUID-VkImageCreateInfo-format-02538", device,
+                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
+                                 "includes VK_IMAGE_USAGE_STORAGE_BIT and format is %s and samples is %s, but "
+                                 "shaderStorageImageMultisample feature was not enabled.",
+                                 string_VkFormat(image_format), string_VkSampleCountFlagBits(pCreateInfo->samples));
+            }
+
+            if (((pCreateInfo->usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0) &&
+                ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0)) {
+                skip |= LogError("VUID-VkImageCreateInfo-format-02795", device, create_info_loc.dot(Field::usage),
+                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
+                                 string_VkFormat(image_format),
+                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
+                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
+            } else if (((pCreateInfo->usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) &&
+                       ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0)) {
+                skip |= LogError("VUID-VkImageCreateInfo-format-02796", device, create_info_loc.dot(Field::usage),
+                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
+                                 string_VkFormat(image_format),
+                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
+                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
+            }
+
+            if (((pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0) &&
+                ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) == 0)) {
+                skip |= LogError("VUID-VkImageCreateInfo-format-02797", device, create_info_loc.dot(Field::usage),
+                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
+                                 string_VkFormat(image_format),
+                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
+                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
+            } else if (((pCreateInfo->usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) == 0) &&
+                       ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0)) {
+                skip |= LogError("VUID-VkImageCreateInfo-format-02798", device, create_info_loc.dot(Field::usage),
+                                 "is (%s), format is %s, and %s is %s", string_VkImageUsageFlags(pCreateInfo->usage).c_str(),
+                                 string_VkFormat(image_format),
+                                 create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage).Fields().c_str(),
+                                 string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
+            }
+        }
+    }
+
+    if ((!physical_device_features.shaderStorageImageMultisample) && ((pCreateInfo->usage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
+        (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT)) {
+        skip |= LogError("VUID-VkImageCreateInfo-usage-00968", device, create_info_loc.dot(Field::usage),
+                         "includes VK_IMAGE_USAGE_STORAGE_BIT and imageType is %s, but shaderStorageImageMultisample feature "
+                         "was not enabled.",
+                         string_VkSampleCountFlagBits(pCreateInfo->samples));
+    }
+
+    std::vector<uint64_t> image_create_drm_format_modifiers;
+    if (IsExtEnabled(device_extensions.vk_ext_image_drm_format_modifier)) {
+        const auto drm_format_mod_list = LvlFindInChain<VkImageDrmFormatModifierListCreateInfoEXT>(pCreateInfo->pNext);
+        const auto drm_format_mod_explict = LvlFindInChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pCreateInfo->pNext);
+        if (pCreateInfo->tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+            if (((drm_format_mod_list != nullptr) && (drm_format_mod_explict != nullptr)) ||
+                ((drm_format_mod_list == nullptr) && (drm_format_mod_explict == nullptr))) {
+                skip |= LogError("VUID-VkImageCreateInfo-tiling-02261", device, create_info_loc.dot(Field::tiling),
+                                 "VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT but pNext must have "
+                                 "either VkImageDrmFormatModifierListCreateInfoEXT or "
+                                 "VkImageDrmFormatModifierExplicitCreateInfoEXT in the pNext chain");
+            } else if (drm_format_mod_explict != nullptr) {
+                image_create_drm_format_modifiers.push_back(drm_format_mod_explict->drmFormatModifier);
+            } else if (drm_format_mod_list != nullptr) {
+                for (uint32_t i = 0; i < drm_format_mod_list->drmFormatModifierCount; i++) {
+                    image_create_drm_format_modifiers.push_back(*drm_format_mod_list->pDrmFormatModifiers);
+                }
+            }
+        } else if (drm_format_mod_list) {
+            skip |= LogError("VUID-VkImageCreateInfo-pNext-02262", device, create_info_loc.dot(Field::tiling),
+                             "is %s, but there is a "
+                             "VkImageDrmFormatModifierListCreateInfoEXT in the pNext chain",
+                             string_VkImageTiling(pCreateInfo->tiling));
+        } else if (drm_format_mod_explict) {
+            skip |= LogError("VUID-VkImageCreateInfo-pNext-02262", device, create_info_loc.dot(Field::tiling),
+                             "is %s, but there is a VkImageDrmFormatModifierExplicitCreateInfoEXT "
+                             "in the pNext chain",
+                             string_VkImageTiling(pCreateInfo->tiling));
+        }
+
+        if (drm_format_mod_explict && drm_format_mod_explict->pPlaneLayouts != nullptr) {
+            for (uint32_t i = 0; i < drm_format_mod_explict->drmFormatModifierPlaneCount; ++i) {
+                const Location drm_loc =
+                    create_info_loc.pNext(Struct::VkImageDrmFormatModifierExplicitCreateInfoEXT, Field::pPlaneLayouts, i);
+                if (drm_format_mod_explict->pPlaneLayouts[i].size != 0) {
+                    skip |= LogError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-size-02267", device,
+                                     drm_loc.dot(Field::size), "is %" PRIu64 ".", drm_format_mod_explict->pPlaneLayouts[i].size);
+                }
+                if (pCreateInfo->arrayLayers == 1 && drm_format_mod_explict->pPlaneLayouts[i].arrayPitch != 0) {
+                    skip |= LogError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-arrayPitch-02268", device,
+                                     drm_loc.dot(Field::arrayPitch), "is %" PRIu64 " and arrayLayers is 1.",
+                                     drm_format_mod_explict->pPlaneLayouts[i].arrayPitch);
+                }
+                if (pCreateInfo->extent.depth == 1 && drm_format_mod_explict->pPlaneLayouts[i].depthPitch != 0) {
+                    skip |= LogError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-depthPitch-02269", device,
+                                     drm_loc.dot(Field::depthPitch), "is %" PRIu64 " and extext.depth is 1.",
+                                     drm_format_mod_explict->pPlaneLayouts[i].depthPitch);
+                }
+            }
+        }
+    }
+
+    static const uint64_t drm_format_mod_linear = 0;
+    bool image_create_maybe_linear = false;
+    if (pCreateInfo->tiling == VK_IMAGE_TILING_LINEAR) {
+        image_create_maybe_linear = true;
+    } else if (pCreateInfo->tiling == VK_IMAGE_TILING_OPTIMAL) {
+        image_create_maybe_linear = false;
+    } else if (pCreateInfo->tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+        image_create_maybe_linear = (std::find(image_create_drm_format_modifiers.begin(), image_create_drm_format_modifiers.end(),
+                                               drm_format_mod_linear) != image_create_drm_format_modifiers.end());
+    }
+
+    // If multi-sample, validate type, usage, tiling and mip levels.
+    if ((pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) &&
+        ((pCreateInfo->imageType != VK_IMAGE_TYPE_2D) || (image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ||
+         (pCreateInfo->mipLevels != 1) || image_create_maybe_linear)) {
+        skip |= LogError("VUID-VkImageCreateInfo-samples-02257", device, create_info_loc,
+                         "image created with\n"
+                         "samples = %s\n"
+                         "imageType = %s\n"
+                         "flags = %s (contains VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)\n"
+                         "mipLevels = %" PRIu32
+                         "\n"
+                         "which is not valid.",
+                         string_VkSampleCountFlagBits(pCreateInfo->samples), string_VkImageType(pCreateInfo->imageType),
+                         string_VkImageCreateFlags(image_flags).c_str(), pCreateInfo->mipLevels);
+    }
+
+    if ((image_flags & VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT) &&
+        ((pCreateInfo->mipLevels != 1) || (pCreateInfo->arrayLayers != 1) || (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) ||
+         image_create_maybe_linear)) {
+        skip |= LogError("VUID-VkImageCreateInfo-flags-02259", device, create_info_loc,
+                         "image created with\n"
+                         "imageType = %s\n"
+                         "flags = %s (contains VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT)\n"
+                         "arrayLayers = %" PRIu32
+                         "\n"
+                         "mipLevels = %" PRIu32
+                         "\n"
+                         "which is not valid.",
+                         string_VkImageType(pCreateInfo->imageType), string_VkImageCreateFlags(image_flags).c_str(),
+                         pCreateInfo->arrayLayers, pCreateInfo->mipLevels);
+    }
+
+    if (pCreateInfo->usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) {
+        if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-02557", device, create_info_loc.dot(Field::usage),
+                             "includes VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT, but imageType is %s.",
+                             string_VkImageType(pCreateInfo->imageType));
+        }
+        if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
+            skip |= LogError("VUID-VkImageCreateInfo-samples-02558", device, create_info_loc.dot(Field::usage),
+                             "includes VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT, but samples is %s.",
                              string_VkSampleCountFlagBits(pCreateInfo->samples));
         }
-
-        std::vector<uint64_t> image_create_drm_format_modifiers;
-        if (IsExtEnabled(device_extensions.vk_ext_image_drm_format_modifier)) {
-            const auto drm_format_mod_list = LvlFindInChain<VkImageDrmFormatModifierListCreateInfoEXT>(pCreateInfo->pNext);
-            const auto drm_format_mod_explict = LvlFindInChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pCreateInfo->pNext);
-            if (pCreateInfo->tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
-                if (((drm_format_mod_list != nullptr) && (drm_format_mod_explict != nullptr)) ||
-                    ((drm_format_mod_list == nullptr) && (drm_format_mod_explict == nullptr))) {
-                    skip |= LogError("VUID-VkImageCreateInfo-tiling-02261", device, create_info_loc.dot(Field::tiling),
-                                     "VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT but pNext must have "
-                                     "either VkImageDrmFormatModifierListCreateInfoEXT or "
-                                     "VkImageDrmFormatModifierExplicitCreateInfoEXT in the pNext chain");
-                } else if (drm_format_mod_explict != nullptr) {
-                    image_create_drm_format_modifiers.push_back(drm_format_mod_explict->drmFormatModifier);
-                } else if (drm_format_mod_list != nullptr) {
-                    for (uint32_t i = 0; i < drm_format_mod_list->drmFormatModifierCount; i++) {
-                        image_create_drm_format_modifiers.push_back(*drm_format_mod_list->pDrmFormatModifiers);
-                    }
-                }
-            } else if (drm_format_mod_list) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-02262", device, create_info_loc.dot(Field::tiling),
-                                 "is %s, but there is a "
-                                 "VkImageDrmFormatModifierListCreateInfoEXT in the pNext chain",
-                                 string_VkImageTiling(pCreateInfo->tiling));
-            } else if (drm_format_mod_explict) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-02262", device, create_info_loc.dot(Field::tiling),
-                                 "is %s, but there is a VkImageDrmFormatModifierExplicitCreateInfoEXT "
-                                 "in the pNext chain",
-                                 string_VkImageTiling(pCreateInfo->tiling));
-            }
-
-            if (drm_format_mod_explict && drm_format_mod_explict->pPlaneLayouts != nullptr) {
-                for (uint32_t i = 0; i < drm_format_mod_explict->drmFormatModifierPlaneCount; ++i) {
-                    const Location drm_loc =
-                        create_info_loc.pNext(Struct::VkImageDrmFormatModifierExplicitCreateInfoEXT, Field::pPlaneLayouts, i);
-                    if (drm_format_mod_explict->pPlaneLayouts[i].size != 0) {
-                        skip |=
-                            LogError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-size-02267", device,
-                                     drm_loc.dot(Field::size), "is %" PRIu64 ".", drm_format_mod_explict->pPlaneLayouts[i].size);
-                    }
-                    if (pCreateInfo->arrayLayers == 1 && drm_format_mod_explict->pPlaneLayouts[i].arrayPitch != 0) {
-                        skip |= LogError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-arrayPitch-02268", device,
-                                         drm_loc.dot(Field::arrayPitch), "is %" PRIu64 " and arrayLayers is 1.",
-                                         drm_format_mod_explict->pPlaneLayouts[i].arrayPitch);
-                    }
-                    if (pCreateInfo->extent.depth == 1 && drm_format_mod_explict->pPlaneLayouts[i].depthPitch != 0) {
-                        skip |= LogError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-depthPitch-02269", device,
-                                         drm_loc.dot(Field::depthPitch), "is %" PRIu64 " and extext.depth is 1.",
-                                         drm_format_mod_explict->pPlaneLayouts[i].depthPitch);
-                    }
-                }
-            }
+    }
+    if (image_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+        if (pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-02565", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, but tiling is %s.",
+                             string_VkImageTiling(pCreateInfo->tiling));
         }
-
-        static const uint64_t drm_format_mod_linear = 0;
-        bool image_create_maybe_linear = false;
-        if (pCreateInfo->tiling == VK_IMAGE_TILING_LINEAR) {
-            image_create_maybe_linear = true;
-        } else if (pCreateInfo->tiling == VK_IMAGE_TILING_OPTIMAL) {
-            image_create_maybe_linear = false;
-        } else if (pCreateInfo->tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
-            image_create_maybe_linear =
-                (std::find(image_create_drm_format_modifiers.begin(), image_create_drm_format_modifiers.end(),
-                           drm_format_mod_linear) != image_create_drm_format_modifiers.end());
+        if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-02566", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, but imageType is %s.",
+                             string_VkImageType(pCreateInfo->imageType));
         }
-
-        // If multi-sample, validate type, usage, tiling and mip levels.
-        if ((pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) &&
-            ((pCreateInfo->imageType != VK_IMAGE_TYPE_2D) || (image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) ||
-             (pCreateInfo->mipLevels != 1) || image_create_maybe_linear)) {
-            skip |= LogError("VUID-VkImageCreateInfo-samples-02257", device, create_info_loc,
-                             "image created with\n"
-                             "samples = %s\n"
-                             "imageType = %s\n"
-                             "flags = %s (contains VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)\n"
-                             "mipLevels = %" PRIu32
-                             "\n"
-                             "which is not valid.",
-                             string_VkSampleCountFlagBits(pCreateInfo->samples), string_VkImageType(pCreateInfo->imageType),
-                             string_VkImageCreateFlags(image_flags).c_str(), pCreateInfo->mipLevels);
+        if (image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-02567", device, create_info_loc.dot(Field::flags),
+                             "is %s, which contains SUBSAMPLED_BIT and CUBE_COMPATIBLE.",
+                             string_VkImageCreateFlags(image_flags).c_str());
         }
-
-        if ((image_flags & VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT) &&
-            ((pCreateInfo->mipLevels != 1) || (pCreateInfo->arrayLayers != 1) || (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) ||
-             image_create_maybe_linear)) {
-            skip |= LogError("VUID-VkImageCreateInfo-flags-02259", device, create_info_loc,
-                             "image created with\n"
-                             "imageType = %s\n"
-                             "flags = %s (contains VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT)\n"
-                             "arrayLayers = %" PRIu32
-                             "\n"
-                             "mipLevels = %" PRIu32
-                             "\n"
-                             "which is not valid.",
-                             string_VkImageType(pCreateInfo->imageType), string_VkImageCreateFlags(image_flags).c_str(),
-                             pCreateInfo->arrayLayers, pCreateInfo->mipLevels);
+        if (pCreateInfo->mipLevels != 1) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-02568", device, create_info_loc.dot(Field::flags),
+                             "includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, but mipLevels is %" PRIu32 ".", pCreateInfo->mipLevels);
         }
+    }
 
-        if (pCreateInfo->usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) {
+    const auto swapchain_create_info = LvlFindInChain<VkImageSwapchainCreateInfoKHR>(pCreateInfo->pNext);
+    if (swapchain_create_info != nullptr) {
+        if (swapchain_create_info->swapchain != VK_NULL_HANDLE) {
+            // All the following fall under the same VU that checks that the swapchain image uses parameters limited by the
+            // table in #swapchain-wsi-image-create-info. Breaking up into multiple checks allows for more useful information
+            // returned why this error occured. Check for matching Swapchain flags is done later in state tracking validation
+            const char *vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
+            const Location swapchain_loc = create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain);
+
             if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02557", device, create_info_loc.dot(Field::usage),
-                                 "includes VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT, but imageType is %s.",
+                // also implicitly forces the check above that extent.depth is 1
+                skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
+                                 "must have a imageType value VK_IMAGE_TYPE_2D instead of %s.",
                                  string_VkImageType(pCreateInfo->imageType));
-            }
-            if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
-                skip |= LogError("VUID-VkImageCreateInfo-samples-02558", device, create_info_loc.dot(Field::usage),
-                                 "includes VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT, but samples is %s.",
-                                 string_VkSampleCountFlagBits(pCreateInfo->samples));
-            }
-        }
-        if (image_flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
-            if (pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02565", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, but tiling is %s.",
-                                 string_VkImageTiling(pCreateInfo->tiling));
-            }
-            if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02566", device, create_info_loc.dot(Field::flags),
-                                 "includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, but imageType is %s.",
-                                 string_VkImageType(pCreateInfo->imageType));
-            }
-            if (image_flags & VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-02567", device, create_info_loc.dot(Field::flags),
-                                 "is %s, which contains SUBSAMPLED_BIT and CUBE_COMPATIBLE.",
-                                 string_VkImageCreateFlags(image_flags).c_str());
             }
             if (pCreateInfo->mipLevels != 1) {
-                skip |=
-                    LogError("VUID-VkImageCreateInfo-flags-02568", device, create_info_loc.dot(Field::flags),
-                             "includes VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT, but mipLevels is %" PRIu32 ".", pCreateInfo->mipLevels);
+                skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
+                                 "must have a mipLevels value of 1 instead of %" PRIu32 ".", pCreateInfo->mipLevels);
+            }
+            if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
+                skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
+                                 "must have a samples value of VK_SAMPLE_COUNT_1_BIT instead of %s.",
+                                 string_VkSampleCountFlagBits(pCreateInfo->samples));
+            }
+            if (pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
+                skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
+                                 "must have a tiling value of VK_IMAGE_TILING_OPTIMAL instead of %s.",
+                                 string_VkImageTiling(pCreateInfo->tiling));
+            }
+            if (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
+                skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
+                                 "must have a initialLayout value of VK_IMAGE_LAYOUT_UNDEFINED instead of %s.",
+                                 string_VkImageLayout(pCreateInfo->initialLayout));
+            }
+            const VkImageCreateFlags valid_flags =
+                (VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT | VK_IMAGE_CREATE_PROTECTED_BIT |
+                 VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
+            if ((image_flags & ~valid_flags) != 0) {
+                skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
+                                 "flags are %" PRIu32 "and must only have valid flags set.", image_flags);
             }
         }
+    }
 
-        const auto swapchain_create_info = LvlFindInChain<VkImageSwapchainCreateInfoKHR>(pCreateInfo->pNext);
-        if (swapchain_create_info != nullptr) {
-            if (swapchain_create_info->swapchain != VK_NULL_HANDLE) {
-                // All the following fall under the same VU that checks that the swapchain image uses parameters limited by the
-                // table in #swapchain-wsi-image-create-info. Breaking up into multiple checks allows for more useful information
-                // returned why this error occured. Check for matching Swapchain flags is done later in state tracking validation
-                const char *vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
-                const Location swapchain_loc = create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain);
+    // If Chroma subsampled format ( _420_ or _422_ )
+    if (FormatIsXChromaSubsampled(image_format) && (SafeModulo(pCreateInfo->extent.width, 2) != 0)) {
+        skip |=
+            LogError("VUID-VkImageCreateInfo-format-04712", device, create_info_loc.dot(Field::format),
+                     "(%s) is X Chroma Subsampled (has _422 or _420 suffix) so the width (%" PRIu32 ") must be a multiple of 2.",
+                     string_VkFormat(image_format), pCreateInfo->extent.width);
+    }
+    if (FormatIsYChromaSubsampled(image_format) && (SafeModulo(pCreateInfo->extent.height, 2) != 0)) {
+        skip |= LogError("VUID-VkImageCreateInfo-format-04713", device, create_info_loc.dot(Field::format),
+                         "(%s) is Y Chroma Subsampled (has _420 suffix) so the height (%" PRIu32 ") must be a multiple of 2.",
+                         string_VkFormat(image_format), pCreateInfo->extent.height);
+    }
 
-                if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
-                    // also implicitly forces the check above that extent.depth is 1
-                    skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
-                                     "must have a imageType value VK_IMAGE_TYPE_2D instead of %s.",
-                                     string_VkImageType(pCreateInfo->imageType));
-                }
-                if (pCreateInfo->mipLevels != 1) {
-                    skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
-                                     "must have a mipLevels value of 1 instead of %" PRIu32 ".", pCreateInfo->mipLevels);
-                }
-                if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
-                    skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
-                                     "must have a samples value of VK_SAMPLE_COUNT_1_BIT instead of %s.",
-                                     string_VkSampleCountFlagBits(pCreateInfo->samples));
-                }
-                if (pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
-                    skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
-                                     "must have a tiling value of VK_IMAGE_TILING_OPTIMAL instead of %s.",
-                                     string_VkImageTiling(pCreateInfo->tiling));
-                }
-                if (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
-                    skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
-                                     "must have a initialLayout value of VK_IMAGE_LAYOUT_UNDEFINED instead of %s.",
-                                     string_VkImageLayout(pCreateInfo->initialLayout));
-                }
-                const VkImageCreateFlags valid_flags =
-                    (VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT | VK_IMAGE_CREATE_PROTECTED_BIT |
-                     VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT);
-                if ((image_flags & ~valid_flags) != 0) {
-                    skip |= LogError(vuid, swapchain_create_info->swapchain, swapchain_loc,
-                                     "flags are %" PRIu32 "and must only have valid flags set.", image_flags);
-                }
-            }
+    const auto format_list_info = LvlFindInChain<VkImageFormatListCreateInfo>(pCreateInfo->pNext);
+    if (format_list_info) {
+        const uint32_t viewFormatCount = format_list_info->viewFormatCount;
+        if (((image_flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) == 0) && (viewFormatCount > 1)) {
+            skip |= LogError("VUID-VkImageCreateInfo-flags-04738", device,
+                             create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::viewFormatCount),
+                             "is %" PRIu32 " but flag (%s) does not include VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.", viewFormatCount,
+                             string_VkImageCreateFlags(image_flags).c_str());
         }
-
-        // If Chroma subsampled format ( _420_ or _422_ )
-        if (FormatIsXChromaSubsampled(image_format) && (SafeModulo(pCreateInfo->extent.width, 2) != 0)) {
-            skip |= LogError("VUID-VkImageCreateInfo-format-04712", device, create_info_loc.dot(Field::format),
-                             "(%s) is X Chroma Subsampled (has _422 or _420 suffix) so the width (%" PRIu32
-                             ") must be a multiple of 2.",
-                             string_VkFormat(image_format), pCreateInfo->extent.width);
-        }
-        if (FormatIsYChromaSubsampled(image_format) && (SafeModulo(pCreateInfo->extent.height, 2) != 0)) {
-            skip |= LogError("VUID-VkImageCreateInfo-format-04713", device, create_info_loc.dot(Field::format),
-                             "(%s) is Y Chroma Subsampled (has _420 suffix) so the height (%" PRIu32 ") must be a multiple of 2.",
-                             string_VkFormat(image_format), pCreateInfo->extent.height);
-        }
-
-        const auto format_list_info = LvlFindInChain<VkImageFormatListCreateInfo>(pCreateInfo->pNext);
-        if (format_list_info) {
-            const uint32_t viewFormatCount = format_list_info->viewFormatCount;
-            if (((image_flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) == 0) && (viewFormatCount > 1)) {
-                skip |= LogError("VUID-VkImageCreateInfo-flags-04738", device,
-                                 create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::viewFormatCount),
-                                 "is %" PRIu32 " but flag (%s) does not include VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.",
-                                 viewFormatCount, string_VkImageCreateFlags(image_flags).c_str());
-            }
-            // Check if viewFormatCount is not zero that it is all compatible
-            for (uint32_t i = 0; i < viewFormatCount; i++) {
-                const bool class_compatible =
-                    FormatCompatibilityClass(format_list_info->pViewFormats[i]) == FormatCompatibilityClass(image_format);
-                if (!class_compatible) {
-                    if (image_flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT) {
-                        const bool size_compatible =
-                            !FormatIsCompressed(format_list_info->pViewFormats[i]) &&
-                            FormatElementSize(format_list_info->pViewFormats[i]) == FormatElementSize(image_format);
-                        if (!size_compatible) {
-                            skip |= LogError("VUID-VkImageCreateInfo-pNext-06722", device,
-                                             create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::pViewFormats, i),
-                                             "(%s) and VkImageCreateInfo::format (%s) are not compatible or size-compatible.",
-                                             string_VkFormat(format_list_info->pViewFormats[i]), string_VkFormat(image_format));
-                        }
-                    } else {
+        // Check if viewFormatCount is not zero that it is all compatible
+        for (uint32_t i = 0; i < viewFormatCount; i++) {
+            const bool class_compatible =
+                FormatCompatibilityClass(format_list_info->pViewFormats[i]) == FormatCompatibilityClass(image_format);
+            if (!class_compatible) {
+                if (image_flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT) {
+                    const bool size_compatible =
+                        !FormatIsCompressed(format_list_info->pViewFormats[i]) &&
+                        FormatElementSize(format_list_info->pViewFormats[i]) == FormatElementSize(image_format);
+                    if (!size_compatible) {
                         skip |= LogError("VUID-VkImageCreateInfo-pNext-06722", device,
                                          create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::pViewFormats, i),
-                                         "(%s) and VkImageCreateInfo::format (%s) are not compatible.",
+                                         "(%s) and VkImageCreateInfo::format (%s) are not compatible or size-compatible.",
                                          string_VkFormat(format_list_info->pViewFormats[i]), string_VkFormat(image_format));
                     }
+                } else {
+                    skip |= LogError("VUID-VkImageCreateInfo-pNext-06722", device,
+                                     create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::pViewFormats, i),
+                                     "(%s) and VkImageCreateInfo::format (%s) are not compatible.",
+                                     string_VkFormat(format_list_info->pViewFormats[i]), string_VkFormat(image_format));
                 }
             }
         }
-
-        const auto image_compression_control = LvlFindInChain<VkImageCompressionControlEXT>(pCreateInfo->pNext);
-        if (image_compression_control) {
-            skip |= ValidateFlags(error_obj.location, "VkImageCompressionControlEXT::flags", "VkImageCompressionFlagsEXT",
-                                  AllVkImageCompressionFlagBitsEXT, image_compression_control->flags, kOptionalSingleBit,
-                                  "VUID-VkImageCompressionControlEXT-flags-06747");
-
-            if (image_compression_control->flags == VK_IMAGE_COMPRESSION_FIXED_RATE_EXPLICIT_EXT &&
-                !image_compression_control->pFixedRateFlags) {
-                skip |= LogError("VUID-VkImageCompressionControlEXT-flags-06748", device,
-                                 create_info_loc.pNext(Struct::VkImageCompressionControlEXT, Field::flags),
-                                 "is %s, but pFixedRateFlags is NULL.",
-                                 string_VkImageCompressionFlagsEXT(image_compression_control->flags).c_str());
-            }
-        }
-#ifdef VK_USE_PLATFORM_METAL_EXT
-        auto export_metal_object_info = LvlFindInChain<VkExportMetalObjectCreateInfoEXT>(pCreateInfo->pNext);
-        while (export_metal_object_info) {
-            if ((export_metal_object_info->exportObjectType != VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT) &&
-                (export_metal_object_info->exportObjectType != VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT)) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-06783", device,
-                                 create_info_loc.pNext(Struct::VkExportMetalObjectCreateInfoEXT, Field::exportObjectType),
-                                 "is %s, but only VkExportMetalObjectCreateInfoEXT structs with exportObjectType of "
-                                 "VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT or "
-                                 "VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT are allowed",
-                                 string_VkExportMetalObjectTypeFlagBitsEXT(export_metal_object_info->exportObjectType));
-            }
-            export_metal_object_info = LvlFindInChain<VkExportMetalObjectCreateInfoEXT>(export_metal_object_info->pNext);
-        }
-        auto import_metal_texture_info = LvlFindInChain<VkImportMetalTextureInfoEXT>(pCreateInfo->pNext);
-        while (import_metal_texture_info) {
-            const Location texture_info_loc = create_info_loc.pNext(Struct::VkImportMetalTextureInfoEXT, Field::plane);
-            if ((import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_0_BIT) &&
-                (import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_1_BIT) &&
-                (import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_2_BIT)) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-06784", device, texture_info_loc,
-                                 "is %s, but only VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT, or "
-                                 "VK_IMAGE_ASPECT_PLANE_2_BIT are allowed",
-                                 string_VkImageAspectFlags(import_metal_texture_info->plane).c_str());
-            }
-            auto format_plane_count = FormatPlaneCount(pCreateInfo->format);
-            if ((format_plane_count <= 1) && (import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_0_BIT)) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-06785", device, texture_info_loc,
-                                 "is %s, but only VK_IMAGE_ASPECT_PLANE_0_BIT is allowed for an image created with format %s, "
-                                 "which is not multiplaner",
-                                 string_VkImageAspectFlags(import_metal_texture_info->plane).c_str(),
-                                 string_VkFormat(pCreateInfo->format));
-            }
-            if ((format_plane_count == 2) && (import_metal_texture_info->plane == VK_IMAGE_ASPECT_PLANE_2_BIT)) {
-                skip |= LogError("VUID-VkImageCreateInfo-pNext-06786", device, texture_info_loc,
-                                 "is VK_IMAGE_ASPECT_PLANE_2_BIT, which is not allowed for an image created with format %s, "
-                                 "which has only 2 planes",
-                                 string_VkFormat(pCreateInfo->format));
-            }
-            import_metal_texture_info = LvlFindInChain<VkImportMetalTextureInfoEXT>(import_metal_texture_info->pNext);
-        }
-#endif  // VK_USE_PLATFORM_METAL_EXT
     }
+
+    const auto image_compression_control = LvlFindInChain<VkImageCompressionControlEXT>(pCreateInfo->pNext);
+    if (image_compression_control) {
+        skip |= ValidateFlags(error_obj.location, "VkImageCompressionControlEXT::flags", "VkImageCompressionFlagsEXT",
+                              AllVkImageCompressionFlagBitsEXT, image_compression_control->flags, kOptionalSingleBit,
+                              "VUID-VkImageCompressionControlEXT-flags-06747");
+
+        if (image_compression_control->flags == VK_IMAGE_COMPRESSION_FIXED_RATE_EXPLICIT_EXT &&
+            !image_compression_control->pFixedRateFlags) {
+            skip |= LogError("VUID-VkImageCompressionControlEXT-flags-06748", device,
+                             create_info_loc.pNext(Struct::VkImageCompressionControlEXT, Field::flags),
+                             "is %s, but pFixedRateFlags is NULL.",
+                             string_VkImageCompressionFlagsEXT(image_compression_control->flags).c_str());
+        }
+    }
+#ifdef VK_USE_PLATFORM_METAL_EXT
+    auto export_metal_object_info = LvlFindInChain<VkExportMetalObjectCreateInfoEXT>(pCreateInfo->pNext);
+    while (export_metal_object_info) {
+        if ((export_metal_object_info->exportObjectType != VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT) &&
+            (export_metal_object_info->exportObjectType != VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT)) {
+            skip |= LogError("VUID-VkImageCreateInfo-pNext-06783", device,
+                             create_info_loc.pNext(Struct::VkExportMetalObjectCreateInfoEXT, Field::exportObjectType),
+                             "is %s, but only VkExportMetalObjectCreateInfoEXT structs with exportObjectType of "
+                             "VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT or "
+                             "VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT are allowed",
+                             string_VkExportMetalObjectTypeFlagBitsEXT(export_metal_object_info->exportObjectType));
+        }
+        export_metal_object_info = LvlFindInChain<VkExportMetalObjectCreateInfoEXT>(export_metal_object_info->pNext);
+    }
+    auto import_metal_texture_info = LvlFindInChain<VkImportMetalTextureInfoEXT>(pCreateInfo->pNext);
+    while (import_metal_texture_info) {
+        const Location texture_info_loc = create_info_loc.pNext(Struct::VkImportMetalTextureInfoEXT, Field::plane);
+        if ((import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_0_BIT) &&
+            (import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_1_BIT) &&
+            (import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_2_BIT)) {
+            skip |= LogError("VUID-VkImageCreateInfo-pNext-06784", device, texture_info_loc,
+                             "is %s, but only VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT, or "
+                             "VK_IMAGE_ASPECT_PLANE_2_BIT are allowed",
+                             string_VkImageAspectFlags(import_metal_texture_info->plane).c_str());
+        }
+        auto format_plane_count = FormatPlaneCount(pCreateInfo->format);
+        if ((format_plane_count <= 1) && (import_metal_texture_info->plane != VK_IMAGE_ASPECT_PLANE_0_BIT)) {
+            skip |=
+                LogError("VUID-VkImageCreateInfo-pNext-06785", device, texture_info_loc,
+                         "is %s, but only VK_IMAGE_ASPECT_PLANE_0_BIT is allowed for an image created with format %s, "
+                         "which is not multiplaner",
+                         string_VkImageAspectFlags(import_metal_texture_info->plane).c_str(), string_VkFormat(pCreateInfo->format));
+        }
+        if ((format_plane_count == 2) && (import_metal_texture_info->plane == VK_IMAGE_ASPECT_PLANE_2_BIT)) {
+            skip |= LogError("VUID-VkImageCreateInfo-pNext-06786", device, texture_info_loc,
+                             "is VK_IMAGE_ASPECT_PLANE_2_BIT, which is not allowed for an image created with format %s, "
+                             "which has only 2 planes",
+                             string_VkFormat(pCreateInfo->format));
+        }
+        import_metal_texture_info = LvlFindInChain<VkImportMetalTextureInfoEXT>(import_metal_texture_info->pNext);
+    }
+#endif  // VK_USE_PLATFORM_METAL_EXT
 
     return skip;
 }
@@ -662,69 +652,69 @@ bool StatelessValidation::manual_PreCallValidateCreateImageView(VkDevice device,
                                                                 const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (pCreateInfo != nullptr) {
-        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-        // Validate feature set if using CUBE_ARRAY
-        if ((pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) && (physical_device_features.imageCubeArray == false)) {
-            skip |= LogError("VUID-VkImageViewCreateInfo-viewType-01004", pCreateInfo->image, create_info_loc.dot(Field::viewType),
-                             "is VK_IMAGE_VIEW_TYPE_CUBE_ARRAY but the imageCubeArray feature is not enabled.");
-        }
+    if (pCreateInfo == nullptr) {
+        return skip;
+    }
+    const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
+    // Validate feature set if using CUBE_ARRAY
+    if ((pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) && (physical_device_features.imageCubeArray == false)) {
+        skip |= LogError("VUID-VkImageViewCreateInfo-viewType-01004", pCreateInfo->image, create_info_loc.dot(Field::viewType),
+                         "is VK_IMAGE_VIEW_TYPE_CUBE_ARRAY but the imageCubeArray feature is not enabled.");
+    }
 
-        if (pCreateInfo->subresourceRange.layerCount != VK_REMAINING_ARRAY_LAYERS) {
-            if (pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE && pCreateInfo->subresourceRange.layerCount != 6) {
-                skip |=
-                    LogError("VUID-VkImageViewCreateInfo-viewType-02960", pCreateInfo->image,
+    if (pCreateInfo->subresourceRange.layerCount != VK_REMAINING_ARRAY_LAYERS) {
+        if (pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE && pCreateInfo->subresourceRange.layerCount != 6) {
+            skip |= LogError("VUID-VkImageViewCreateInfo-viewType-02960", pCreateInfo->image,
                              create_info_loc.dot(Field::subresourceRange).dot(Field::layerCount),
                              " (%" PRIu32 ") must be 6 or VK_REMAINING_ARRAY_LAYERS.", pCreateInfo->subresourceRange.layerCount);
-            }
-            if (pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY && (pCreateInfo->subresourceRange.layerCount % 6) != 0) {
-                skip |= LogError("VUID-VkImageViewCreateInfo-viewType-02961", pCreateInfo->image,
-                                 create_info_loc.dot(Field::subresourceRange).dot(Field::layerCount),
-                                 "(%" PRIu32 ") must be a multiple of 6 or VK_REMAINING_ARRAY_LAYERS.",
-                                 pCreateInfo->subresourceRange.layerCount);
-            }
         }
-
-        auto astc_decode_mode = LvlFindInChain<VkImageViewASTCDecodeModeEXT>(pCreateInfo->pNext);
-        if (astc_decode_mode != nullptr) {
-            if ((astc_decode_mode->decodeMode != VK_FORMAT_R16G16B16A16_SFLOAT) &&
-                (astc_decode_mode->decodeMode != VK_FORMAT_R8G8B8A8_UNORM) &&
-                (astc_decode_mode->decodeMode != VK_FORMAT_E5B9G9R9_UFLOAT_PACK32)) {
-                skip |= LogError("VUID-VkImageViewASTCDecodeModeEXT-decodeMode-02230", pCreateInfo->image,
-                                 create_info_loc.pNext(Struct::VkImageViewASTCDecodeModeEXT, Field::decodeMode), "is %s.",
-                                 string_VkFormat(astc_decode_mode->decodeMode));
-            }
-            if ((FormatIsCompressed_ASTC_LDR(pCreateInfo->format) == false) &&
-                (FormatIsCompressed_ASTC_HDR(pCreateInfo->format) == false)) {
-                skip |= LogError("VUID-VkImageViewASTCDecodeModeEXT-format-04084", pCreateInfo->image,
-                                 create_info_loc.dot(Field::format),
-                                 "%s is  not an ASTC format (because VkImageViewASTCDecodeModeEXT was passed in the pNext chain).",
-                                 string_VkFormat(pCreateInfo->format));
-            }
+        if (pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY && (pCreateInfo->subresourceRange.layerCount % 6) != 0) {
+            skip |= LogError("VUID-VkImageViewCreateInfo-viewType-02961", pCreateInfo->image,
+                             create_info_loc.dot(Field::subresourceRange).dot(Field::layerCount),
+                             "(%" PRIu32 ") must be a multiple of 6 or VK_REMAINING_ARRAY_LAYERS.",
+                             pCreateInfo->subresourceRange.layerCount);
         }
-
-        auto ycbcr_conversion = LvlFindInChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
-        if (ycbcr_conversion != nullptr) {
-            if (ycbcr_conversion->conversion != VK_NULL_HANDLE) {
-                if (IsIdentitySwizzle(pCreateInfo->components) == false) {
-                    skip |= LogError(
-                        "VUID-VkImageViewCreateInfo-pNext-01970", pCreateInfo->image, create_info_loc,
-                        "If there is a VkSamplerYcbcrConversion, the imageView must "
-                        "be created with the identity swizzle. Here are the actual swizzle values:\n"
-                        "r swizzle = %s\n"
-                        "g swizzle = %s\n"
-                        "b swizzle = %s\n"
-                        "a swizzle = %s\n",
-                        string_VkComponentSwizzle(pCreateInfo->components.r), string_VkComponentSwizzle(pCreateInfo->components.g),
-                        string_VkComponentSwizzle(pCreateInfo->components.b), string_VkComponentSwizzle(pCreateInfo->components.a));
-                }
-            }
-        }
-#ifdef VK_USE_PLATFORM_METAL_EXT
-        skip |= ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT,
-                                            "VUID-VkImageViewCreateInfo-pNext-06787", error_obj.location,
-                                            "VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT", pCreateInfo->pNext);
-#endif  // VK_USE_PLATFORM_METAL_EXT
     }
+
+    auto astc_decode_mode = LvlFindInChain<VkImageViewASTCDecodeModeEXT>(pCreateInfo->pNext);
+    if (astc_decode_mode != nullptr) {
+        if ((astc_decode_mode->decodeMode != VK_FORMAT_R16G16B16A16_SFLOAT) &&
+            (astc_decode_mode->decodeMode != VK_FORMAT_R8G8B8A8_UNORM) &&
+            (astc_decode_mode->decodeMode != VK_FORMAT_E5B9G9R9_UFLOAT_PACK32)) {
+            skip |= LogError("VUID-VkImageViewASTCDecodeModeEXT-decodeMode-02230", pCreateInfo->image,
+                             create_info_loc.pNext(Struct::VkImageViewASTCDecodeModeEXT, Field::decodeMode), "is %s.",
+                             string_VkFormat(astc_decode_mode->decodeMode));
+        }
+        if ((FormatIsCompressed_ASTC_LDR(pCreateInfo->format) == false) &&
+            (FormatIsCompressed_ASTC_HDR(pCreateInfo->format) == false)) {
+            skip |=
+                LogError("VUID-VkImageViewASTCDecodeModeEXT-format-04084", pCreateInfo->image, create_info_loc.dot(Field::format),
+                         "%s is  not an ASTC format (because VkImageViewASTCDecodeModeEXT was passed in the pNext chain).",
+                         string_VkFormat(pCreateInfo->format));
+        }
+    }
+
+    auto ycbcr_conversion = LvlFindInChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
+    if (ycbcr_conversion != nullptr) {
+        if (ycbcr_conversion->conversion != VK_NULL_HANDLE) {
+            if (IsIdentitySwizzle(pCreateInfo->components) == false) {
+                skip |= LogError(
+                    "VUID-VkImageViewCreateInfo-pNext-01970", pCreateInfo->image, create_info_loc,
+                    "If there is a VkSamplerYcbcrConversion, the imageView must "
+                    "be created with the identity swizzle. Here are the actual swizzle values:\n"
+                    "r swizzle = %s\n"
+                    "g swizzle = %s\n"
+                    "b swizzle = %s\n"
+                    "a swizzle = %s\n",
+                    string_VkComponentSwizzle(pCreateInfo->components.r), string_VkComponentSwizzle(pCreateInfo->components.g),
+                    string_VkComponentSwizzle(pCreateInfo->components.b), string_VkComponentSwizzle(pCreateInfo->components.a));
+            }
+        }
+    }
+#ifdef VK_USE_PLATFORM_METAL_EXT
+    skip |=
+        ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT, "VUID-VkImageViewCreateInfo-pNext-06787",
+                                    error_obj.location, "VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT", pCreateInfo->pNext);
+#endif  // VK_USE_PLATFORM_METAL_EXT
     return skip;
 }

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -288,6 +288,7 @@ TEST_F(NegativeGraphicsLibrary, MissingDSStateWithFragOutputState) {
 
         frag_output_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
         frag_output_lib.gp_ci_.pDepthStencilState = nullptr;
+        frag_output_lib.gp_ci_.pColorBlendState = nullptr;
 
         // Should be fine even though pDepthStencilState is NULL
         frag_output_lib.CreateGraphicsPipeline();


### PR DESCRIPTION
There are some functions that could really make use of an early return at top (or some `continue`) to prevent some deep nesting we have. This commit should have no semantic changes and just ending the function/loop sooner

also plan to add this to `.git-blame-ignore-revs` after