### PR TITLE
layers: Revert "Add thread safety checks for vkQueuePresentKHR"

### DIFF
--- a/layers/thread_tracker/thread_safety_validation.cpp
+++ b/layers/thread_tracker/thread_safety_validation.cpp
@@ -740,34 +740,3 @@ void ThreadSafety::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, V
         }
     }
 }
-
-void ThreadSafety::PreCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) {
-    StartWriteObject(queue, vvl::Func::vkQueuePresentKHR);
-    uint32_t waitSemaphoreCount = pPresentInfo->waitSemaphoreCount;
-    if (pPresentInfo->pWaitSemaphores != nullptr) {
-        for (uint32_t index = 0; index < waitSemaphoreCount; index++) {
-            StartReadObject(pPresentInfo->pWaitSemaphores[index], vvl::Func::vkQueuePresentKHR);
-        }
-    }
-    if (pPresentInfo->pSwapchains != nullptr) {
-        for (uint32_t index = 0; index < pPresentInfo->swapchainCount; ++index) {
-            StartWriteObjectParentInstance(pPresentInfo->pSwapchains[index], vvl::Func::vkQueuePresentKHR);
-        }
-    }
-}
-
-void ThreadSafety::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo, 
-                                                 const RecordObject& record_obj) {
-    FinishWriteObject(queue, record_obj.location.function);
-    uint32_t waitSemaphoreCount = pPresentInfo->waitSemaphoreCount;
-    if (pPresentInfo->pWaitSemaphores != nullptr) {
-        for (uint32_t index = 0; index < waitSemaphoreCount; index++) {
-            FinishReadObject(pPresentInfo->pWaitSemaphores[index], record_obj.location.function);
-        }
-    }
-    if (pPresentInfo->pSwapchains != nullptr) {
-        for (uint32_t index = 0; index < pPresentInfo->swapchainCount; ++index) {
-            FinishWriteObjectParentInstance(pPresentInfo->pSwapchains[index], record_obj.location.function);
-        }
-    }
-}

--- a/layers/vulkan/generated/thread_safety_commands.h
+++ b/layers/vulkan/generated/thread_safety_commands.h
@@ -2479,15 +2479,6 @@ void PostCallRecordAcquireNextImageKHR(
     uint32_t*                                   pImageIndex,
     const RecordObject&                         record_obj) override;
 
-void PreCallRecordQueuePresentKHR(
-    VkQueue                                     queue,
-    const VkPresentInfoKHR*                     pPresentInfo) override;
-
-void PostCallRecordQueuePresentKHR(
-    VkQueue                                     queue,
-    const VkPresentInfoKHR*                     pPresentInfo,
-    const RecordObject&                         record_obj) override;
-
 void PreCallRecordGetDeviceGroupPresentCapabilitiesKHR(
     VkDevice                                    device,
     VkDeviceGroupPresentCapabilitiesKHR*        pDeviceGroupPresentCapabilities) override;

--- a/scripts/generators/thread_safety_generator.py
+++ b/scripts/generators/thread_safety_generator.py
@@ -66,10 +66,10 @@ class ThreadSafetyOutputGenerator(BaseGenerator):
             'vkDeviceWaitIdle',
             'vkRegisterDisplayEventEXT',
             'vkCreateRayTracingPipelinesKHR',
-            'vkQueuePresentKHR',
         ]
 
         self.blacklist = [
+            'vkQueuePresentKHR',
             # Currently not wrapping debug helper functions
             'vkSetDebugUtilsObjectNameEXT',
             'vkSetDebugUtilsObjectTagEXT',


### PR DESCRIPTION
This reverts commit cea4a9ed5e2bff7388b738d9adfda5ac455ae578.

For the period of investigation of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6447