### PR TITLE
layers: Add pnext chain extraction logic and use it when validating image creation

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -373,6 +373,8 @@ source_set("vulkan_layer_utils") {
     "$vulkan_headers_dir/include/vulkan/vulkan.h",
     "layers/utils/android_ndk_types.h",
     "layers/utils/cast_utils.h",
+    "layers/vulkan/generated/pnext_chain_extraction.cpp",
+    "layers/vulkan/generated/pnext_chain_extraction.h",
     "layers/vulkan/generated/vk_api_version.h",
     "layers/vulkan/generated/vk_extension_helper.h",
     "layers/vulkan/generated/vk_format_utils.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -32,6 +32,8 @@ target_sources(VkLayer_utils PRIVATE
     external/xxhash.cpp
     ${API_TYPE}/generated/error_location_helper.cpp
     ${API_TYPE}/generated/error_location_helper.h
+    ${API_TYPE}/generated/pnext_chain_extraction.cpp
+    ${API_TYPE}/generated/pnext_chain_extraction.h
     ${API_TYPE}/generated/vk_function_pointers.cpp
     ${API_TYPE}/generated/vk_function_pointers.h
     ${API_TYPE}/generated/vk_format_utils.h

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -497,10 +497,12 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                 string_VkImageTiling(image_format_info.tiling), string_VkImageUsageFlags(image_format_info.usage).c_str(),
                 string_VkImageCreateFlags(image_format_info.flags).c_str(), string_VkResult(result));
         } else if ((external_memory_create_info->handleTypes & compatible_types) != external_memory_create_info->handleTypes) {
-            skip |= LogError("VUID-VkImageCreateInfo-pNext-00990", device,
-                             create_info_loc.pNext(Struct::VkExternalMemoryImageCreateInfo, Field::handleTypes),
-                             "(%s) is not reported as compatible by vkGetPhysicalDeviceImageFormatProperties2.",
-                             string_VkExternalMemoryHandleTypeFlags(external_memory_create_info->handleTypes).c_str());
+            skip |= LogError(
+                "VUID-VkImageCreateInfo-pNext-00990", device,
+                create_info_loc.pNext(Struct::VkExternalMemoryImageCreateInfo, Field::handleTypes),
+                "(%s) is not reported as compatible by vkGetPhysicalDeviceImageFormatProperties2. Compatible types are %s.",
+                string_VkExternalMemoryHandleTypeFlags(external_memory_create_info->handleTypes).c_str(),
+                string_VkExternalMemoryHandleTypeFlags(compatible_types).c_str());
         }
     } else if (external_memory_create_info_nv && external_memory_create_info_nv->handleTypes != 0) {
         if (pCreateInfo->initialLayout != VK_IMAGE_LAYOUT_UNDEFINED) {

--- a/layers/vulkan/generated/pnext_chain_extraction.cpp
+++ b/layers/vulkan/generated/pnext_chain_extraction.cpp
@@ -1,0 +1,162 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See pnext_chain_extraction_generator.py for modifications
+
+/***************************************************************************
+*
+* Copyright (c) 2023 The Khronos Group Inc.
+* Copyright (c) 2023 Valve Corporation
+* Copyright (c) 2023 LunarG, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+****************************************************************************/
+
+// NOLINTBEGIN
+
+
+#include "pnext_chain_extraction.h"
+
+#include "vk_typemap_helper.h"
+
+namespace vvl {
+       
+void* PnextChainAdd(void *chain, void *new_struct) {
+    assert(chain);
+    assert(new_struct);
+    void *chain_end = LvlFindLastInChain(chain);
+    auto *vk_base_struct = static_cast<VkBaseOutStructure*>(chain_end);
+    assert(!vk_base_struct->pNext);
+    vk_base_struct->pNext = static_cast<VkBaseOutStructure*>(new_struct);
+    return new_struct;
+}
+
+void PnextChainRemoveLast(void *chain) {
+    if (!chain) {
+        return;
+    }
+    auto *current = static_cast<VkBaseOutStructure *>(chain);
+    auto *prev = current;
+    while (current->pNext) {
+        prev = current;
+        current = static_cast<VkBaseOutStructure *>(current->pNext);
+    }
+    prev->pNext = nullptr;
+}
+
+
+template <>
+void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceImageFormatInfo2 &out) {
+    void *chain_begin = nullptr;
+    void *chain_end = nullptr;
+
+    if (auto *chain_struct = LvlFindInChain<VkImageCompressionControlEXT>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkImageCompressionControlEXT>(out);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+        if (!chain_begin) {
+            chain_begin = &out_chain_struct;
+            chain_end = chain_begin;
+        } else {
+            chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+        }
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkImageFormatListCreateInfo>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkImageFormatListCreateInfo>(out);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+        if (!chain_begin) {
+            chain_begin = &out_chain_struct;
+            chain_end = chain_begin;
+        } else {
+            chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+        }
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkImageStencilUsageCreateInfo>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkImageStencilUsageCreateInfo>(out);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+        if (!chain_begin) {
+            chain_begin = &out_chain_struct;
+            chain_end = chain_begin;
+        } else {
+            chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+        }
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkOpticalFlowImageFormatInfoNV>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkOpticalFlowImageFormatInfoNV>(out);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+        if (!chain_begin) {
+            chain_begin = &out_chain_struct;
+            chain_end = chain_begin;
+        } else {
+            chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+        }
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkPhysicalDeviceExternalImageFormatInfo>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkPhysicalDeviceExternalImageFormatInfo>(out);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+        if (!chain_begin) {
+            chain_begin = &out_chain_struct;
+            chain_end = chain_begin;
+        } else {
+            chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+        }
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(out);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+        if (!chain_begin) {
+            chain_begin = &out_chain_struct;
+            chain_end = chain_begin;
+        } else {
+            chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+        }
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkPhysicalDeviceImageViewImageFormatInfoEXT>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkPhysicalDeviceImageViewImageFormatInfoEXT>(out);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+        if (!chain_begin) {
+            chain_begin = &out_chain_struct;
+            chain_end = chain_begin;
+        } else {
+            chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+        }
+    }
+
+    if (auto *chain_struct = LvlFindInChain<VkVideoProfileListInfoKHR>(in_pnext_chain)) {
+    	auto &out_chain_struct = std::get<VkVideoProfileListInfoKHR>(out);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+        if (!chain_begin) {
+            chain_begin = &out_chain_struct;
+            chain_end = chain_begin;
+        } else {
+            chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+        }
+    }
+
+	return chain_begin;
+}
+
+}
+
+// NOLINTEND

--- a/layers/vulkan/generated/pnext_chain_extraction.h
+++ b/layers/vulkan/generated/pnext_chain_extraction.h
@@ -1,0 +1,81 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See pnext_chain_extraction_generator.py for modifications
+
+/***************************************************************************
+*
+* Copyright (c) 2023 The Khronos Group Inc.
+* Copyright (c) 2023 Valve Corporation
+* Copyright (c) 2023 LunarG, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+****************************************************************************/
+
+// NOLINTBEGIN
+
+#pragma once
+
+#include <cassert>
+#include <tuple>
+
+#include "vulkan/vulkan.h"
+
+namespace vvl {
+
+// Add element to the end of a pNext chain
+void* PnextChainAdd(void *chain, void *new_struct);
+
+// Remove last element from a pNext chain 
+void PnextChainRemoveLast(void *chain);
+
+// Helper class relying on RAII to help with adding and removing an element from a pNext chain
+class PnextChainScopedAdd {
+  public:
+    PnextChainScopedAdd(void *chain, void *new_struct) : chain(chain) {
+        PnextChainAdd(chain, new_struct);
+    }
+    ~PnextChainScopedAdd() {
+        PnextChainRemoveLast(chain);
+    }
+
+  private:
+    void *chain = nullptr;
+};
+
+// Utility to make a selective copy of a pNext chain.
+// Structs listed in the returned tuple type are the one extending some reference Vulkan structs, like VkPhysicalDeviceImageFormatInfo2.
+// The copied structs are the one mentioned in the returned tuple type and found in the pNext chain `in_pnext_chain`.
+// In the returned tuple, each struct is NOT a deep copy of the corresponding struct in in_pnext_chain,
+// so be mindful of pointers copies.
+// The first element of the extracted pNext chain is returned by this function. It can be nullptr.
+template <typename T>
+void *PnextChainExtract(const void */*in_pnext_chain*/, T &/*out*/) { assert(false); return nullptr; }
+
+// Hereinafter are the available PnextChainExtract functions.
+// To add a new one, find scripts/generators/pnext_chain_extraction_generator.py
+// and add your reference struct to the `target_structs` list at the beginning of the file.
+
+using PnextChainVkPhysicalDeviceImageFormatInfo2 = std::tuple<
+	VkImageCompressionControlEXT,
+	VkImageFormatListCreateInfo,
+	VkImageStencilUsageCreateInfo,
+	VkOpticalFlowImageFormatInfoNV,
+	VkPhysicalDeviceExternalImageFormatInfo,
+	VkPhysicalDeviceImageDrmFormatModifierInfoEXT,
+	VkPhysicalDeviceImageViewImageFormatInfoEXT,
+	VkVideoProfileListInfoKHR>;
+template <>
+void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceImageFormatInfo2 &out);
+
+}
+
+// NOLINTEND

--- a/layers/vulkan/generated/vk_typemap_helper.h
+++ b/layers/vulkan/generated/vk_typemap_helper.h
@@ -7618,6 +7618,17 @@ template <typename T> const T *LvlFindInChain(const void *next) {
     return found;
 }
 
+// Find last element of pNext chain
+inline VkBaseOutStructure *LvlFindLastInChain(void *next) {
+    auto *current = reinterpret_cast<VkBaseOutStructure *>(next);
+    auto *prev = current;
+    while (current) {
+        prev = current;
+        current = reinterpret_cast<VkBaseOutStructure *>(current->pNext);
+    }
+    return prev;
+}
+
 // Find an entry of the given type in the pNext chain
 template <typename T> T *LvlFindModInChain(void *next) {
     VkBaseOutStructure *current = reinterpret_cast<VkBaseOutStructure *>(next);

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -64,6 +64,7 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, targetF
     from generators.valid_enum_values_generator import ValidEnumValuesOutputGenerator
     from generators.spirv_tool_commit_id_generator import SpirvToolCommitIdOutputGenerator
     from generators.error_location_helper_generator import ErrorLocationHelperOutputGenerator
+    from generators.pnext_chain_extraction_generator import PnextChainExtractionGenerator
 
     # These set fields that are needed by both OutputGenerator and BaseGenerator,
     # but are uniform and don't need to be set at a per-generated file level
@@ -265,6 +266,14 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, targetF
         },
         'vk_format_utils.cpp' : {
             'generator' : FormatUtilsOutputGenerator,
+            'genCombined': True,
+        },
+        'pnext_chain_extraction.h' : {
+            'generator' : PnextChainExtractionGenerator,
+            'genCombined': True,
+        },
+        'pnext_chain_extraction.cpp' : {
+            'generator' : PnextChainExtractionGenerator,
             'genCombined': True,
         },
     }

--- a/scripts/generators/pnext_chain_extraction_generator.py
+++ b/scripts/generators/pnext_chain_extraction_generator.py
@@ -1,0 +1,185 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2015-2023 The Khronos Group Inc.
+# Copyright (c) 2015-2023 Valve Corporation
+# Copyright (c) 2015-2023 LunarG, Inc.
+# Copyright (c) 2015-2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from generators.base_generator import BaseGenerator
+
+class PnextChainExtractionGenerator(BaseGenerator):
+    def __init__(self):
+        BaseGenerator.__init__(self)
+
+        # List of Vulkan structures that a pnext chain extraction function will be generated for
+        self.target_structs = [
+            'VkPhysicalDeviceImageFormatInfo2'
+            ]
+    
+    def generate(self):
+        out = []
+        out.append(f'''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See {os.path.basename(__file__)} for modifications
+
+/***************************************************************************
+*
+* Copyright (c) 2023 The Khronos Group Inc.
+* Copyright (c) 2023 Valve Corporation
+* Copyright (c) 2023 LunarG, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+****************************************************************************/\n\n''')
+        out.append('// NOLINTBEGIN\n\n') # Wrap for clang-tidy to ignore
+
+        if self.filename == 'pnext_chain_extraction.h':
+            out.append(self.generateHeader())
+        elif self.filename == 'pnext_chain_extraction.cpp':
+            out.append(self.generateSource())
+        else:
+            out.append(f'\nFile name {self.filename} has no code to generate\n')
+
+        out.append('\n// NOLINTEND') # Wrap for clang-tidy to ignore
+        self.write("".join(out))
+
+    def generateHeader(self):
+        out = []
+        out.append('''#pragma once
+
+#include <cassert>
+#include <tuple>
+
+#include "vulkan/vulkan.h"
+
+namespace vvl {
+
+// Add element to the end of a pNext chain
+void* PnextChainAdd(void *chain, void *new_struct);
+
+// Remove last element from a pNext chain 
+void PnextChainRemoveLast(void *chain);
+
+// Helper class relying on RAII to help with adding and removing an element from a pNext chain
+class PnextChainScopedAdd {
+  public:
+    PnextChainScopedAdd(void *chain, void *new_struct) : chain(chain) {
+        PnextChainAdd(chain, new_struct);
+    }
+    ~PnextChainScopedAdd() {
+        PnextChainRemoveLast(chain);
+    }
+
+  private:
+    void *chain = nullptr;
+};
+
+// Utility to make a selective copy of a pNext chain.
+// Structs listed in the returned tuple type are the one extending some reference Vulkan structs, like VkPhysicalDeviceImageFormatInfo2.
+// The copied structs are the one mentioned in the returned tuple type and found in the pNext chain `in_pnext_chain`.
+// In the returned tuple, each struct is NOT a deep copy of the corresponding struct in in_pnext_chain,
+// so be mindful of pointers copies.
+// The first element of the extracted pNext chain is returned by this function. It can be nullptr.
+template <typename T>
+void *PnextChainExtract(const void */*in_pnext_chain*/, T &/*out*/) { assert(false); return nullptr; }
+
+// Hereinafter are the available PnextChainExtract functions.
+// To add a new one, find scripts/generators/pnext_chain_extraction_generator.py
+// and add your reference struct to the `target_structs` list at the beginning of the file.
+''')
+        # Declare functions
+        for struct_name in self.target_structs:
+            struct = self.vk.structs[struct_name]
+            out.append(f'\nusing PnextChain{struct_name} = std::tuple<\n\t')
+            out.append(',\n\t'.join(struct.extendedBy))
+            out.append('>;\n')
+            out.append('template <>\n')
+            out.append(f'void *PnextChainExtract(const void *in_pnext_chain, PnextChain{struct_name} &out);\n\n')
+
+        out.append('}\n')
+        return "".join(out)
+
+    def generateSource(self):
+        out = []
+        out.append(f'''
+#include "pnext_chain_extraction.h"
+
+#include "vk_typemap_helper.h"
+
+namespace vvl {{
+       
+void* PnextChainAdd(void *chain, void *new_struct) {{
+    assert(chain);
+    assert(new_struct);
+    void *chain_end = LvlFindLastInChain(chain);
+    auto *vk_base_struct = static_cast<VkBaseOutStructure*>(chain_end);
+    assert(!vk_base_struct->pNext);
+    vk_base_struct->pNext = static_cast<VkBaseOutStructure*>(new_struct);
+    return new_struct;
+}}
+
+void PnextChainRemoveLast(void *chain) {{
+    if (!chain) {{
+        return;
+    }}
+    auto *current = static_cast<VkBaseOutStructure *>(chain);
+    auto *prev = current;
+    while (current->pNext) {{
+        prev = current;
+        current = static_cast<VkBaseOutStructure *>(current->pNext);
+    }}
+    prev->pNext = nullptr;
+}}
+
+''')
+
+        # Define functions
+        for struct_name in self.target_structs:
+            struct = self.vk.structs[struct_name]
+            out.append('\ntemplate <>\n')
+            out.append(f'void *PnextChainExtract(const void *in_pnext_chain, PnextChain{struct_name} &out) {{')
+            
+            out.append(f'''
+    void *chain_begin = nullptr;
+    void *chain_end = nullptr;\n''')
+
+            # Add extraction logic for each struct extending target struct
+            for extending_struct in struct.extendedBy:
+                out.append(f'''
+    if (auto *chain_struct = LvlFindInChain<{extending_struct}>(in_pnext_chain)) {{
+    	auto &out_chain_struct = std::get<{extending_struct}>(out);
+    	out_chain_struct = *chain_struct;
+        out_chain_struct.pNext = nullptr;
+        if (!chain_begin) {{
+            chain_begin = &out_chain_struct;
+            chain_end = chain_begin;
+        }} else {{
+            chain_end = PnextChainAdd(chain_end, &out_chain_struct);
+        }}
+    }}\n''')
+            out.append('\n\treturn chain_begin;\n}\n')
+
+        out.append('\n}\n')
+        return "".join(out)

--- a/scripts/generators/typemap_helper_generator.py
+++ b/scripts/generators/typemap_helper_generator.py
@@ -90,6 +90,17 @@ template <typename T> const T *LvlFindInChain(const void *next) {
     return found;
 }
 
+// Find last element of pNext chain
+inline VkBaseOutStructure *LvlFindLastInChain(void *next) {
+    auto *current = reinterpret_cast<VkBaseOutStructure *>(next);
+    auto *prev = current;
+    while (current) {
+        prev = current;
+        current = reinterpret_cast<VkBaseOutStructure *>(current->pNext);
+    }
+    return prev;
+}
+
 // Find an entry of the given type in the pNext chain
 template <typename T> T *LvlFindModInChain(void *next) {
     VkBaseOutStructure *current = reinterpret_cast<VkBaseOutStructure *>(next);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,7 +160,8 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/wsi_positive.cpp
     unit/ycbcr.cpp
     unit/ycbcr_positive.cpp
-    containers/small_vector.cpp
+    vvl_utils/small_vector.cpp
+    vvl_utils/pnext_chain_extraction.cpp
 )
 get_target_property(TEST_SOURCES vk_layer_validation_tests SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${TEST_SOURCES})

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -1199,6 +1199,11 @@ TEST_F(PositiveImage, CreateDrmImageWithExternalMemory) {
             result != VK_SUCCESS) {
             GTEST_SKIP() << "Unable to create image. VkResult = " << string_VkResult(result);
         }
+
+        if ((external_image_properties.externalMemoryProperties.compatibleHandleTypes & external_info.handleTypes) !=
+            external_info.handleTypes) {
+            GTEST_SKIP() << "Unable to create image, VkExternalMemoryImageCreateInfo::handleTypes not supported";
+        }
     }
 
     CreateImageTest(*this, &ci);

--- a/tests/vvl_utils/pnext_chain_extraction.cpp
+++ b/tests/vvl_utils/pnext_chain_extraction.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/test_common.h"
+
+#include "generated/pnext_chain_extraction.h"
+
+// Return true iff all sTypes are found in chain, in order
+bool FindSTypes(void* chain, const std::vector<VkStructureType>& sTypes_list) {
+    size_t sTypes_list_i = 0;
+    while (chain) {
+        const auto* vk_struct = reinterpret_cast<const VkBaseOutStructure*>(chain);
+        if (vk_struct->sType != sTypes_list[sTypes_list_i++]) {
+            return false;
+        }
+        chain = vk_struct->pNext;
+    }
+    return sTypes_list_i == sTypes_list.size();
+}
+
+// Extract all structs from a pNext chain
+TEST(PnextChainExtract, Extract1) {
+    // Those structs extend VkPhysicalDeviceImageFormatInfo2
+    auto s1 = LvlInitStruct<VkImageCompressionControlEXT>();
+    auto s2 = LvlInitStruct<VkImageFormatListCreateInfo>(&s1);
+    auto s3 = LvlInitStruct<VkImageStencilUsageCreateInfo>(&s2);
+    auto s4 = LvlInitStruct<VkOpticalFlowImageFormatInfoNV>(&s3);
+
+    vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 extracted_chain{};
+    void* chain_begin = vvl::PnextChainExtract(&s4, extracted_chain);
+
+    const std::vector<VkStructureType> expected_sTypes = {s1.sType, s2.sType, s3.sType, s4.sType};
+    ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
+}
+
+// Extract all structs mentioned in tuple vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 and found in input pNext chain
+TEST(PnextChainExtract, Extract2) {
+    // Those structs extend VkPhysicalDeviceImageFormatInfo2
+    auto s1 = LvlInitStruct<VkImageCompressionControlEXT>();
+    auto s2 = LvlInitStruct<VkImageFormatListCreateInfo>(&s1);
+    auto s3 = LvlInitStruct<VkImageStencilUsageCreateInfo>(&s2);
+    auto s4 = LvlInitStruct<VkOpticalFlowImageFormatInfoNV>(&s3);
+
+    // Those do not
+    auto wrong1 = LvlInitStruct<VkExternalMemoryImageCreateInfo>(&s4);
+    auto wrong2 = LvlInitStruct<VkImageDrmFormatModifierListCreateInfoEXT>(&wrong1);
+
+    // And this one does
+    auto s5 = LvlInitStruct<VkVideoProfileListInfoKHR>(&wrong2);
+
+    vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 extracted_chain{};
+    void* chain_begin = vvl::PnextChainExtract(&s5, extracted_chain);
+
+    const std::vector<VkStructureType> expected_sTypes = {s1.sType, s2.sType, s3.sType, s4.sType, s5.sType};
+    ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
+}
+
+// Test that no struct is extracted when no struct from a pNext chain extends the reference struct, here
+// VkPhysicalDeviceImageFormatInfo2
+TEST(PnextChainExtract, Extract3) {
+    // Those structs do not extend VkPhysicalDeviceImageFormatInfo2
+    auto wrong1 = LvlInitStruct<VkExternalMemoryImageCreateInfo>();
+    auto wrong2 = LvlInitStruct<VkImageDrmFormatModifierListCreateInfoEXT>(&wrong1);
+
+    vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 extracted_chain{};
+    void* chain_begin = vvl::PnextChainExtract(&wrong2, extracted_chain);
+
+    const std::vector<VkStructureType> expected_sTypes = {};
+    ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
+}
+
+// Extract all structs from a pNext chain, add a new element, then remove it
+TEST(PnextChainExtract, ExtractAddRemove1) {
+    // Those structs extend VkPhysicalDeviceImageFormatInfo2
+    auto s1 = LvlInitStruct<VkImageCompressionControlEXT>();
+    auto s2 = LvlInitStruct<VkImageFormatListCreateInfo>(&s1);
+    auto s3 = LvlInitStruct<VkImageStencilUsageCreateInfo>(&s2);
+    auto s4 = LvlInitStruct<VkOpticalFlowImageFormatInfoNV>(&s3);
+
+    vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 extracted_chain{};
+    void* chain_begin = vvl::PnextChainExtract(&s4, extracted_chain);
+
+    std::vector<VkStructureType> expected_sTypes = {s1.sType, s2.sType, s3.sType, s4.sType};
+    ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
+
+    {
+        auto s5 = LvlInitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+        vvl::PnextChainScopedAdd scoped_add_s5(chain_begin, &s5);
+        expected_sTypes.emplace_back(s5.sType);
+        ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
+        expected_sTypes.resize(expected_sTypes.size() - 1);
+    }
+
+    ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
+}
+
+// Extract all structs from a pNext chain, add two new elements, in a nested fashion, then remove them
+TEST(PnextChainExtract, ExtractAddRemove2) {
+    // Those structs extend VkPhysicalDeviceImageFormatInfo2
+    auto s1 = LvlInitStruct<VkImageCompressionControlEXT>();
+    auto s2 = LvlInitStruct<VkImageFormatListCreateInfo>(&s1);
+    auto s3 = LvlInitStruct<VkImageStencilUsageCreateInfo>(&s2);
+    auto s4 = LvlInitStruct<VkOpticalFlowImageFormatInfoNV>(&s3);
+
+    vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 extracted_chain{};
+    void* chain_begin = vvl::PnextChainExtract(&s4, extracted_chain);
+
+    std::vector<VkStructureType> expected_sTypes = {s1.sType, s2.sType, s3.sType, s4.sType};
+    ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
+
+    {
+        auto s5 = LvlInitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+        vvl::PnextChainScopedAdd scoped_add_s5(chain_begin, &s5);
+        expected_sTypes.emplace_back(s5.sType);
+        ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
+
+        {
+            auto s6 = LvlInitStruct<VkPhysicalDeviceImageViewImageFormatInfoEXT>();
+            vvl::PnextChainScopedAdd scoped_add_s6(chain_begin, &s6);
+            expected_sTypes.emplace_back(s6.sType);
+            ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
+            expected_sTypes.resize(expected_sTypes.size() - 1);
+        }
+
+        expected_sTypes.resize(expected_sTypes.size() - 1);
+    }
+
+    ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
+}

--- a/tests/vvl_utils/small_vector.cpp
+++ b/tests/vvl_utils/small_vector.cpp
@@ -1,8 +1,7 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6295

- Should close https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6256

Add utilities to make a selective copy of a pNext chain. Selected elements are the structs extending some reference struct.