### PR TITLE
layers: Fix issue 6461

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -469,13 +469,6 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
         AddChild(base);
     }
 
-    void AddChildren(vvl::span<BUFFER_STATE *> &child_nodes) {
-        for (auto &child_node : child_nodes) {
-            auto child_node_shared_ptr = child_node->shared_from_this();
-            AddChild(child_node_shared_ptr);
-        }
-    }
-
     void RemoveChild(std::shared_ptr<BASE_NODE> &base_node);
     template <typename StateObject>
     void RemoveChild(std::shared_ptr<StateObject> &child_node) {

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3067,55 +3067,10 @@ void ValidationStateTracker::RecordDeviceAccelerationStructureBuildInfo(CMD_BUFF
     if (src_as_state) {
         cb_state.AddChild(src_as_state);
     }
-    auto scratch_buffers = GetBuffersByAddress(info.scratchData.deviceAddress);
-    if (!scratch_buffers.empty()) {
-        cb_state.AddChildren(scratch_buffers);
-    }
 
-    for (uint32_t i = 0; i < info.geometryCount; i++) {
-        // only one of pGeometries and ppGeometries can be non-null
-        const auto &geom = info.pGeometries ? info.pGeometries[i] : *info.ppGeometries[i];
-        switch (geom.geometryType) {
-            case VK_GEOMETRY_TYPE_TRIANGLES_KHR: {
-                auto vertex_buffers = GetBuffersByAddress(geom.geometry.triangles.vertexData.deviceAddress);
-                if (!vertex_buffers.empty()) {
-                    cb_state.AddChildren(vertex_buffers);
-                }
-                auto index_buffers = GetBuffersByAddress(geom.geometry.triangles.indexData.deviceAddress);
-                if (!index_buffers.empty()) {
-                    cb_state.AddChildren(index_buffers);
-                }
-                auto transform_buffers = GetBuffersByAddress(geom.geometry.triangles.transformData.deviceAddress);
-                if (!transform_buffers.empty()) {
-                    cb_state.AddChildren(transform_buffers);
-                }
-                const auto *motion_data = LvlFindInChain<VkAccelerationStructureGeometryMotionTrianglesDataNV>(info.pNext);
-                if (motion_data) {
-                    auto motion_buffers = GetBuffersByAddress(motion_data->vertexData.deviceAddress);
-                    if (!motion_buffers.empty()) {
-                        cb_state.AddChildren(motion_buffers);
-                    }
-                }
-            } break;
-            case VK_GEOMETRY_TYPE_AABBS_KHR: {
-                auto data_buffers = GetBuffersByAddress(geom.geometry.aabbs.data.deviceAddress);
-                if (!data_buffers.empty()) {
-                    cb_state.AddChildren(data_buffers);
-                }
-            } break;
-            case VK_GEOMETRY_TYPE_INSTANCES_KHR: {
-                // NOTE: if arrayOfPointers is true, we don't track the pointers in the array. That would
-                // require that data buffer be mapped to the CPU so that we could walk through it. We can't
-                // easily ensure that's true.
-                auto data_buffers = GetBuffersByAddress(geom.geometry.instances.data.deviceAddress);
-                if (!data_buffers.empty()) {
-                    cb_state.AddChildren(data_buffers);
-                }
-            } break;
-            default:
-                break;
-        }
-    }
+    // Issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6461
+    // showed that it is incorrect to try to add buffers obtained through a call to GetBuffersByAddress as children to a command
+    // buffer
 }
 
 void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructuresKHR(
@@ -3143,12 +3098,9 @@ void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructuresIndirec
     cb_state->RecordCmd(record_obj.location.function);
     for (uint32_t i = 0; i < infoCount; i++) {
         RecordDeviceAccelerationStructureBuildInfo(*cb_state, pInfos[i]);
-        if (!disabled[command_buffer_state]) {
-            auto indirect_buffer = GetBuffersByAddress(pIndirectDeviceAddresses[i]);
-            if (!indirect_buffer.empty()) {
-                cb_state->AddChildren(indirect_buffer);
-            }
-        }
+        // Issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6461
+        // showed that it is incorrect to try to add buffers obtained through a call to GetBuffersByAddress as children to a command
+        // buffer
     }
     cb_state->has_build_as_cmd = true;
 }
@@ -5328,10 +5280,9 @@ void ValidationStateTracker::PostCallRecordCmdCopyAccelerationStructureToMemoryK
         if (!disabled[command_buffer_state]) {
             cb_state->AddChild(src_as_state);
         }
-        auto dst_buffers = GetBuffersByAddress(pInfo->dst.deviceAddress);
-        if (!dst_buffers.empty()) {
-            cb_state->AddChildren(dst_buffers);
-        }
+        // Issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6461
+        // showed that it is incorrect to try to add buffers obtained through a call to GetBuffersByAddress as children to a command
+        // buffer
     }
 }
 
@@ -5341,12 +5292,12 @@ void ValidationStateTracker::PostCallRecordCmdCopyMemoryToAccelerationStructureK
     if (cb_state) {
         cb_state->RecordCmd(record_obj.location.function);
         if (!disabled[command_buffer_state]) {
-            auto src_buffers = GetBuffersByAddress(pInfo->src.deviceAddress);
-            if (!src_buffers.empty()) {
-                cb_state->AddChildren(src_buffers);
-            }
             auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->dst);
             cb_state->AddChild(dst_as_state);
+
+            // Issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6461
+            // showed that it is incorrect to try to add buffers obtained through a call to GetBuffersByAddress as children to a
+            // command buffer
         }
     }
 }

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -3064,18 +3064,13 @@ TEST_F(NegativeRayTracing, ObjInUseCmdBuildAccelerationStructureKHR) {
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyBuffer-buffer-00922");
-    vk::DestroyBuffer(m_device->handle(), build_geometry_info.GetGeometries()[0].GetTriangles().device_vertex_buffer.handle(),
-                      nullptr);
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyBuffer-buffer-00922");
-    vk::DestroyBuffer(m_device->handle(), build_geometry_info.GetGeometries()[0].GetTriangles().device_index_buffer.handle(),
-                      nullptr);
+    // This test used to destroy buffers used for building the acceleration structure,
+    // to see if there life span was correctly tracked.
+    // Following issue 6461, buffers associated to a device address are not tracked anymore, as it is impossible
+    // to track the "correct" one: there is not a 1 to 1 mapping between a buffer and a device address.
+
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyAccelerationStructureKHR-accelerationStructure-02442");
     vk::DestroyAccelerationStructureKHR(m_device->handle(), build_geometry_info.GetDstAS()->handle(), nullptr);
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyBuffer-buffer-00922");
-    vk::DestroyBuffer(m_device->handle(), build_geometry_info.GetDstAS()->GetBuffer().handle(), nullptr);
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkDestroyBuffer-buffer-00922");
-    vk::DestroyBuffer(m_device->handle(), build_geometry_info.GetScratchBuffer()->handle(), nullptr);
     m_errorMonitor->VerifyFound();
 
     vk::QueueWaitIdle(m_device->m_queue);

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -342,8 +342,6 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     m_commandBuffer->PipelineBarrier2KHR(&dependency_info);
 
     m_commandBuffer->end();
-
-    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabledRTXEnabled) {
@@ -417,8 +415,6 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     m_commandBuffer->PipelineBarrier2KHR(&dependency_info);
 
     m_commandBuffer->end();
-
-    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(PositiveRayTracing, BarrierSync1NoCrash) {
@@ -511,7 +507,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
     auto alloc_flags = LvlInitStruct<VkMemoryAllocateFlagsInfo>();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = LvlInitStruct<VkMemoryAllocateInfo>(&alloc_flags);
-    alloc_info.allocationSize = 8192 * 3;
+    alloc_info.allocationSize = 8192 * build_info_count;
     vk_testing::DeviceMemory buffer_memory(*m_device, alloc_info);
 
     // Test using non overlapping memory chunks from the same buffer in multiple builds
@@ -519,7 +515,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
     {
         auto scratch_buffer_ci = LvlInitStruct<VkBufferCreateInfo>();
         scratch_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-        scratch_buffer_ci.size = 8192 * 3;
+        scratch_buffer_ci.size = 8192 * build_info_count;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
                                   VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
@@ -537,6 +533,5 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
         m_commandBuffer->begin();
         rt::as::BuildAccelerationStructuresKHR(*m_device, m_commandBuffer->handle(), build_infos);
         m_commandBuffer->end();
-        m_errorMonitor->VerifyFound();
     }
 }


### PR DESCRIPTION
- Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6461

The situation described in the issue showed that it is incorrect to add buffers obtained through a call do `GetBuffersByAddress` as children to a command buffer, given that there is no 1 to 1 mapping between a buffer and a device address. It can lead to false positives when tracking resources life span.

Add a regression test, `PositiveRayTracing.AccelerationStructuresReuseScratchMemory`:
It simulates 3 frames, where in each frame a new acceleration structure is built. Building an acceleration structure requires a _scratch_ buffer. Each frames has its own buffer, but they are all bound to the same memory.
When starting the last frame, the fence from the first frame is waited upon, then resources from frame 0 are released. It used to trigger `VUID-vkDestroyBuffer-buffer-00922`.
The issue was that when recording a acceleration structure build command, any buffer indirectly mentioned through a device address was added using a call to `GetBuffersByAddress`. When recording the build happening on frame 1, given that all scratch buffers have the same base device address, `scratch_buffer_frame_0` will *also* be added as a child to `cmd_buffer_frame_1`. So when destroying it, at the beginning of frame 2, since frame 1 is still in flight, `scratch_buffer_frame_0` is still considered in use, so 00922 is triggered.