### PR TITLE
layers: Fix DynamicRendering AttachmentCount check

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -766,22 +766,13 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const PIPELINE_STATE &pipeline,
 
 bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const PIPELINE_STATE &pipeline, const Location &create_info_loc) const {
     bool skip = false;
-    const auto *color_blend_state = pipeline.ColorBlendState();
     const auto &rp_state = pipeline.RenderPassState();
-    if (!rp_state || !color_blend_state) {
+    if (!rp_state) {
         return false;
     }
     const Location color_loc = create_info_loc.dot(Field::pColorBlendState);
 
-    if (rp_state->UsesDynamicRendering()) {
-        if (color_blend_state->attachmentCount != rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount) {
-            skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06055", device,
-                             create_info_loc.pNext(Struct::VkPipelineRenderingCreateInfo, Field::colorAttachmentCount),
-                             "(%" PRIu32 ") is different from %s (%" PRIu32 ").",
-                             rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount,
-                             color_loc.dot(Field::attachmentCount).Fields().c_str(), color_blend_state->attachmentCount);
-        }
-    } else {
+    if (!rp_state->UsesDynamicRendering()) {
         const auto subpass = pipeline.Subpass();
         const auto *subpass_desc = &rp_state->createInfo.pSubpasses[subpass];
 

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -499,6 +499,15 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                                     "VUID-VkGraphicsPipelineCreateInfo-renderPass-06580");
                             }
                         }
+
+                        if (create_info.pColorBlendState->attachmentCount != color_attachment_count) {
+                            skip |=
+                                LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06055", device,
+                                         create_info_loc.pNext(Struct::VkPipelineRenderingCreateInfo, Field::colorAttachmentCount),
+                                         "(%" PRIu32 ") is different from %s (%" PRIu32 ").", color_attachment_count,
+                                         create_info_loc.dot(Field::pColorBlendState).dot(Field::attachmentCount).Fields().c_str(),
+                                         create_info.pColorBlendState->attachmentCount);
+                        }
                     }
 
                     // VkAttachmentSampleCountInfoAMD == VkAttachmentSampleCountInfoNV

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -1023,7 +1023,6 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
     VkPipelineObj pipeline_depth(m_device);
     pipeline_depth.AddShader(&vs);
     pipeline_depth.AddShader(&fs);
-    pipeline_depth.AddDefaultColorAttachment();
     pipeline_depth.SetViewport(m_viewports);
     pipeline_depth.SetScissor(m_scissors);
     pipeline_depth.SetDepthStencil(&ds_state);
@@ -1043,7 +1042,6 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
     VkPipelineObj pipeline_stencil(m_device);
     pipeline_stencil.AddShader(&vs);
     pipeline_stencil.AddShader(&fs);
-    pipeline_stencil.AddDefaultColorAttachment();
     pipeline_stencil.SetViewport(m_viewports);
     pipeline_stencil.SetScissor(m_scissors);
     pipeline_stencil.SetDepthStencil(&ds_state);
@@ -1167,7 +1165,6 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     VkPipelineObj pipeline_depth(m_device);
     pipeline_depth.AddShader(&vs);
     pipeline_depth.AddShader(&fs);
-    pipeline_depth.AddDefaultColorAttachment();
     pipeline_depth.SetViewport(m_viewports);
     pipeline_depth.SetScissor(m_scissors);
     pipeline_depth.SetDepthStencil(&ds_state);
@@ -1187,7 +1184,6 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     VkPipelineObj pipeline_stencil(m_device);
     pipeline_stencil.AddShader(&vs);
     pipeline_stencil.AddShader(&fs);
-    pipeline_stencil.AddDefaultColorAttachment();
     pipeline_stencil.SetViewport(m_viewports);
     pipeline_stencil.SetScissor(m_scissors);
     pipeline_stencil.SetDepthStencil(&ds_state);

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -1385,8 +1385,11 @@ TEST_F(NegativeMultiview, DynamicRenderingMaxMultiviewInstanceIndex) {
     VkPhysicalDeviceMultiviewProperties multiview_properties = LvlInitStruct<VkPhysicalDeviceMultiviewProperties>();
     GetPhysicalDeviceProperties2(multiview_properties);
 
+    VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
     VkPipelineRenderingCreateInfo pipeline_rendering_info = LvlInitStruct<VkPipelineRenderingCreateInfo>();
     pipeline_rendering_info.viewMask = 0x1;
+    pipeline_rendering_info.colorAttachmentCount = 1;
+    pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6473
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4856

as stated in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4856 the issue was in `safe_VkGraphicsPipelineCreateInfo::initialize` we go 

```cpp
    if (in_struct->pColorBlendState && ((has_rasterization && uses_color_attachment) || is_graphics_library))
        pColorBlendState = new safe_VkPipelineColorBlendStateCreateInfo(in_struct->pColorBlendState);
    else
        pColorBlendState = nullptr; // original pColorBlendState pointer ignored
```

so it was never checking the `pColorBlendState` , so now it was moved to Stateless where it gets the original information to check