### PR TITLE
layers: Cleanup Location code for Sync Objects

### DIFF
--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -1048,8 +1048,8 @@ bool CoreChecks::PreCallValidateCmdWriteTimestamp(VkCommandBuffer commandBuffer,
     bool skip = false;
     skip |= ValidateCmdWriteTimestamp(*cb_state, queryPool, slot, error_obj.location);
 
-    const Location loc(Func::vkCmdWriteTimestamp, Field::pipelineStage);
-    skip |= ValidatePipelineStage(LogObjectList(commandBuffer), loc, cb_state->GetQueueFlags(), pipelineStage);
+    const Location stage_loc = error_obj.location.dot(Field::pipelineStage);
+    skip |= ValidatePipelineStage(LogObjectList(commandBuffer), stage_loc, cb_state->GetQueueFlags(), pipelineStage);
     return skip;
 }
 

--- a/layers/error_message/error_location.h
+++ b/layers/error_message/error_location.h
@@ -150,8 +150,25 @@ struct Entry {
 // look for a matching VUID in a vector or array-ish table
 template <typename Table>
 static const std::string& FindVUID(const Location& loc, const Table& table) {
+    // TODO - Remove having to squash KHR version here
+    Func f = loc.function;
+    if (f == Func::vkQueueSubmit2KHR) {
+        f = Func::vkQueueSubmit2;
+    } else if (f == Func::vkCmdPipelineBarrier2KHR) {
+        f = Func::vkCmdPipelineBarrier2;
+    } else if (f == Func::vkCmdResetEvent2KHR) {
+        f = Func::vkCmdResetEvent2;
+    } else if (f == Func::vkCmdSetEvent2KHR) {
+        f = Func::vkCmdSetEvent2;
+    } else if (f == Func::vkCmdWaitEvents2KHR) {
+        f = Func::vkCmdWaitEvents2;
+    } else if (f == Func::vkCmdWriteTimestamp2KHR) {
+        f = Func::vkCmdWriteTimestamp2;
+    }
+    const Location core_loc(f, loc.structure, loc.field, loc.index);
+
     static const std::string empty;
-    auto predicate = [&loc](const Entry& entry) { return entry.k == loc; };
+    auto predicate = [&core_loc](const Entry& entry) { return entry.k == core_loc; };
 
     // consistency check: there should never be more than 1 match in a table
     assert(std::count_if(table.begin(), table.end(), predicate) <= 1);

--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -1166,8 +1166,15 @@ static const std::map<SubmitError, std::vector<Entry>> kSubmitErrors{
 
 const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error) {
     const auto &result = FindVUID(error, loc, kSubmitErrors);
-    assert(!result.empty());
     if (result.empty()) {
+        // TODO - Handle better way then Key::recursive to find certain VUs
+        // Can reproduce with NegativeSyncObject.Sync2QueueSubmitTimelineSemaphoreValue
+        if (loc.structure == Struct::VkSubmitInfo2) {
+            if (loc.prev->field == Field::pWaitSemaphoreInfos || loc.prev->field == Field::pSignalSemaphoreInfos) {
+                return FindVUID(error, *loc.prev, kSubmitErrors);
+            }
+        }
+
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-submit-error");
         return unhandled;
     }

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -2102,7 +2102,7 @@ TEST_F(NegativeSyncObject, Sync2LayoutFeature) {
 TEST_F(NegativeSyncObject, SubmitSignaledFence) {
     vk_testing::Fence testFence;
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "submitted in SIGNALED state.  Fences must be reset before being submitted");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkQueueSubmit-fence-00063");
 
     VkFenceCreateInfo fenceInfo = LvlInitStruct<VkFenceCreateInfo>();
     fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;


### PR DESCRIPTION
- Improve the `Location` name for many variables
- Use `Location` in the `LogError`
- Improve some error messages