### PR TITLE
layers: Print command buffer handle from InUse

### DIFF
--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -785,9 +785,11 @@ bool CoreChecks::ValidateObjectNotInUse(const BASE_NODE *obj_node, const Locatio
     if (disabled[object_in_use]) return false;
     auto obj_struct = obj_node->Handle();
     bool skip = false;
-    if (obj_node->InUse()) {
-        skip |= LogError(error_code, device, loc, "can't be called on %s that is currently in use by a command buffer.",
-                         FormatHandle(obj_struct).c_str());
+
+    const auto *used_handle = obj_node->InUse();
+    if (used_handle) {
+        skip |= LogError(error_code, device, loc, "can't be called on %s that is currently in use by %s.",
+                         FormatHandle(obj_struct).c_str(), FormatHandle(*used_handle).c_str());
     }
     return skip;
 }

--- a/layers/state_tracker/base_node.cpp
+++ b/layers/state_tracker/base_node.cpp
@@ -25,22 +25,20 @@ void BASE_NODE::Destroy() {
     destroyed_ = true;
 }
 
-bool BASE_NODE::InUse() const {
+const VulkanTypedHandle* BASE_NODE::InUse() const {
     // NOTE: for performance reasons, this method calls up the tree
     // with the read lock held.
     auto guard = ReadLockTree();
-    bool result = false;
     for (auto& item : parent_nodes_) {
         auto node = item.second.lock();
         if (!node) {
             continue;
         }
-        result |= node->InUse();
-        if (result) {
-            break;
+        if (node->InUse()) {
+            return &node->Handle();
         }
     }
-    return result;
+    return nullptr;
 }
 
 bool BASE_NODE::AddParent(BASE_NODE* parent_node) {

--- a/layers/state_tracker/base_node.h
+++ b/layers/state_tracker/base_node.h
@@ -78,7 +78,7 @@ class BASE_NODE : public std::enable_shared_from_this<BASE_NODE>, public TypedHa
     static VulkanTypedHandle Handle(const BASE_NODE *node) { return (node) ? node->Handle() : VulkanTypedHandle(); }
     static VulkanTypedHandle Handle(const std::shared_ptr<const BASE_NODE> &node) { return Handle(node.get()); }
 
-    virtual bool InUse() const;
+    virtual const VulkanTypedHandle* InUse() const;
 
     virtual bool AddParent(BASE_NODE *parent_node);
     virtual void RemoveParent(BASE_NODE *parent_node);
@@ -133,5 +133,5 @@ class REFCOUNTED_NODE : public BASE_NODE {
 
     void EndUse() { in_use_.fetch_sub(1); }
 
-    bool InUse() const override { return (in_use_.load() > 0) || BASE_NODE::InUse(); }
+    const VulkanTypedHandle* InUse() const override { return ((in_use_.load() > 0) || BASE_NODE::InUse()) ? &Handle() : nullptr; }
 };

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -101,15 +101,15 @@ void DESCRIPTOR_POOL_STATE::Reset() {
     available_sets_ = maxSets;
 }
 
-bool DESCRIPTOR_POOL_STATE::InUse() const {
+const VulkanTypedHandle *DESCRIPTOR_POOL_STATE::InUse() const {
     auto guard = ReadLock();
     for (const auto &entry : sets_) {
         const auto *ds = entry.second;
-        if (ds && ds->InUse()) {
-            return true;
+        if (ds) {
+            return ds->InUse();
         }
     }
-    return false;
+    return nullptr;
 }
 
 void DESCRIPTOR_POOL_STATE::Destroy() {

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -59,7 +59,7 @@ class DESCRIPTOR_POOL_STATE : public BASE_NODE {
     void Reset();
     void Destroy() override;
 
-    bool InUse() const override;
+    const VulkanTypedHandle *InUse() const override;
     uint32_t GetAvailableCount(uint32_t type) const {
         auto guard = ReadLock();
         auto iter = available_counts_.find(type);


### PR DESCRIPTION
currently we have error messages like

> Validation Error: [ VUID-vkUpdateDescriptorSets-None-03047 ] Object 0: handle = 0xec4bec000000000b, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; Object 1: handle = 0xcfef35000000000a, type = VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT; | MessageID = 0x35d7ea98 | vkUpdateDescriptorSets(): pDescriptorWrites[0].dstBinding (0) was created with VkDescriptorBindingFlags(0), but VkDescriptorSet 0xec4bec000000000b[] is in use by a command buffer.

the ` is in use by a command buffer.` is not helpful

with the change to `InUse` to return a handle pointer instead of `bool`, we have error messages like

> ..., but VkDescriptorSet 0xec4bec000000000b[] is in use by VkCommandBuffer 0x55bad2cc4c20[].