### PR TITLE
Fixed incorrect member variable "polygonMode" referenced in validation error, instead of "lineWidth".

### DIFF
--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -1434,7 +1434,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                 if (!vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_LINE_WIDTH) && !physical_device_features.wideLines &&
                     (create_info.pRasterizationState->lineWidth != 1.0f)) {
                     skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749", device,
-                                     rasterization_loc.dot(Field::polygonMode),
+                                     rasterization_loc.dot(Field::lineWidth),
                                      "is %f, but the line width state is static (pCreateInfos[%" PRIu32
                                      "].pDynamicState->pDynamicStates does not contain VK_DYNAMIC_STATE_LINE_WIDTH) and "
                                      "wideLines feature was not enabled.",


### PR DESCRIPTION
When incorrectly setting `lineWidth` to zero in `VkPipelineRasterizationStateCreateInfo`, the following validation error was produced, referencing `polygonMode` as the issue:

> Validation Error: [ VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749 ] | MessageID = 0x1b1ca73 | vkCreateGraphicsPipelines(): pCreateInfos[0].pRasterizationState->polygonMode is 0.000000, but the line width state is static (pCreateInfos[0].pDynamicState->pDynamicStates does not contain VK_DYNAMIC_STATE_LINE_WIDTH) and wideLines feature was not enabled. The Vulkan spec states: If the pipeline requires pre-rasterization shader state, and the wideLines feature is not enabled, and no element of the pDynamicStates member of pDynamicState is VK_DYNAMIC_STATE_LINE_WIDTH, the lineWidth member of pRasterizationState must be 1.0 (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749)
 
This pull request changes the validation error to:

> Validation Error: [ VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749 ] | MessageID = 0x1b1ca73 | vkCreateGraphicsPipelines(): pCreateInfos[0].pRasterizationState->lineWidth is 0.000000, but the line width state is static (pCreateInfos[0].pDynamicState->pDynamicStates does not contain VK_DYNAMIC_STATE_LINE_WIDTH) and wideLines feature was not enabled. The Vulkan spec states: If the pipeline requires pre-rasterization shader state, and the wideLines feature is not enabled, and no element of the pDynamicStates member of pDynamicState is VK_DYNAMIC_STATE_LINE_WIDTH, the lineWidth member of pRasterizationState must be 1.0 (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749)
