### PR TITLE
layers: Add period automatically at end of message

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -432,6 +432,12 @@ VKAPI_ATTR bool LogMsg(const debug_report_data *debug_data, VkFlags msg_flags, c
                 }
             };
 
+            // Add period at end if forgotten
+            // This provides better seperation between error message and spec text
+            if (str_plus_spec_text.back() != '.') {
+                str_plus_spec_text.append(".");
+            }
+
             str_plus_spec_text.append(" The Vulkan spec states: ");
             str_plus_spec_text.append(spec_text);
             if (0 == spec_type.compare("default")) {


### PR DESCRIPTION
While it would be nice to add the period at the end of all error messages, rather just have it be added then having to go and update ALL the error messages (and nit pick PRs)