### PR TITLE
layers: Add templated GetValidationObject

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -815,8 +815,7 @@ class CoreChecks : public ValidationStateTracker {
                                        VkPipelineStageFlags2KHR sourceStageMask, EventToStageMap* localEventToStageMap);
     bool ValidateQueueFamilyIndices(const Location& loc, const CMD_BUFFER_STATE& cb_state, VkQueue queue) const;
     VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,
-                                               const VkAllocationCallbacks* pAllocator,
-                                               VkValidationCacheEXT* pValidationCache) override;
+                                               const VkAllocationCallbacks* pAllocator, VkValidationCacheEXT* pValidationCache);
     void CoreLayerDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache,
                                             const VkAllocationCallbacks* pAllocator) override;
     VkResult CoreLayerMergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -661,7 +661,7 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
 
     // The current object represents the VkInstance, look up / create the object for the device.
     ValidationObject *device_object = GetLayerDataPtr(get_dispatch_key(*pDevice), layer_data_map);
-    ValidationObject *validation_data = GetValidationObject(device_object->object_dispatch, this->container_type);
+    ValidationObject *validation_data = device_object->GetValidationObject(this->container_type);
     ValidationStateTracker *device_state = static_cast<ValidationStateTracker *>(validation_data);
 
     device_state->instance_state = this;

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -259,8 +259,7 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
                                                      const RecordObject &record_obj) {
     auto device_data = GetLayerDataPtr(get_dispatch_key(*pDevice), layer_data_map);
     if (record_obj.result != VK_SUCCESS) return;
-    ValidationObject *validation_data = GetValidationObject(device_data->object_dispatch, LayerObjectTypeParameterValidation);
-    StatelessValidation *stateless_validation = static_cast<StatelessValidation *>(validation_data);
+    auto stateless_validation = device_data->GetValidationObject<StatelessValidation>();
 
     // Parmeter validation also uses extension data
     stateless_validation->device_extensions = this->device_extensions;

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -793,6 +793,13 @@ const typename T::value_type *DataOrNull(const T &container) {
     return nullptr;
 }
 
+
+// Workaround for static_assert(false) before C++ 23 arrives
+// https://en.cppreference.com/w/cpp/language/static_assert
+// https://cplusplus.github.io/CWG/issues/2518.html
+template <typename>
+inline constexpr bool dependent_false_v = false;
+
 }  // namespace vvl
 
 #endif

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2328,7 +2328,7 @@ class ValidationObject {
         }
     }
 
-    ValidationObject* GetValidationObject(std::vector<ValidationObject*>& object_dispatch, LayerObjectTypeId object_type) {
+    ValidationObject* GetValidationObject(LayerObjectTypeId object_type) const {
         for (auto validation_object : object_dispatch) {
             if (validation_object->container_type == object_type) {
                 return validation_object;
@@ -2336,6 +2336,9 @@ class ValidationObject {
         }
         return nullptr;
     }
+
+    template <typename ValidationObjectType>
+    ValidationObjectType* GetValidationObject() const;
 
     // Debug Logging Helpers
     // deprecated LogError - moving to use one with Location
@@ -4530,7 +4533,6 @@ class ValidationObject {
         virtual void PreCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride) {};
         virtual void PostCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount, uint32_t stride, const RecordObject& record_obj) {};
 
-        virtual VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkValidationCacheEXT* pValidationCache) { return VK_SUCCESS; };
         virtual void CoreLayerDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache, const VkAllocationCallbacks* pAllocator) {};
         virtual VkResult CoreLayerMergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount, const VkValidationCacheEXT* pSrcCaches)  { return VK_SUCCESS; };
         virtual VkResult CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize, void* pData)  { return VK_SUCCESS; };


### PR DESCRIPTION
Further simplification of `CheckObjectValidity`.
Removes the need to manualy `static_cast` returned value  when object type is known at compile time.
Before:
```
ValidationObject *validation_data = GetValidationObject(instance_data->object_dispatch, LayerObjectTypeObjectTracker);
ObjectLifetimes *object_lifetimes = static_cast<ObjectLifetimes *>(validation_data);
```
After:
```
auto object_lifetimes = instance_data->GetValidationObject<ObjectLifetimes>();
```
