### PR TITLE
layers: Remove ValidateDeviceObject

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -28,6 +28,8 @@
 #include "external/xxhash.h"
 #include "error_location.h"
 
+[[maybe_unused]] const char *kVUIDUndefined = "VUID_Undefined";
+
 VKAPI_ATTR void SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks, debug_report_data *debug_data) {
     // For all callback in list, return their complete set of severities and modes
     for (const auto &item : callbacks) {

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -38,7 +38,7 @@
 [[maybe_unused]] static const char *kForceDefaultCallbackKey = "debug.vvl.forcelayerlog";
 #endif
 
-[[maybe_unused]] static const char *kVUIDUndefined = "VUID_Undefined";
+extern const char *kVUIDUndefined;
 
 typedef enum DebugCallbackStatusBits {
     DEBUG_CALLBACK_UTILS = 0x00000001,     // This struct describes a VK_EXT_debug_utils callback

--- a/layers/object_tracker/object_lifetime_validation.h
+++ b/layers/object_tracker/object_lifetime_validation.h
@@ -111,7 +111,6 @@ class ObjectLifetimes : public ValidationObject {
     void CreateSwapchainImageObject(VkImage swapchain_image, VkSwapchainKHR swapchain);
     void DestroyLeakedInstanceObjects();
     void DestroyLeakedDeviceObjects();
-    bool ValidateDeviceObject(const VulkanTypedHandle &device_typed, const char *invalid_handle_code, const Location &loc) const;
     void DestroyQueueDataStructures();
     bool ValidateCommandBuffer(VkCommandPool command_pool, VkCommandBuffer command_buffer, const Location &loc) const;
     bool ValidateDescriptorSet(VkDescriptorPool descriptor_pool, VkDescriptorSet descriptor_set, const Location &loc) const;
@@ -179,11 +178,6 @@ class ObjectLifetimes : public ValidationObject {
         if (null_allowed && (object == VK_NULL_HANDLE)) {
             return false;
         }
-
-        if (object_type == kVulkanObjectTypeDevice) {
-            return ValidateDeviceObject(VulkanTypedHandle(object, object_type), invalid_handle_code, loc);
-        }
-
         return CheckObjectValidity(HandleToUint64(object), object_type, invalid_handle_code, wrong_device_code, loc);
     }
 

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -53,29 +53,11 @@ void ObjectLifetimes::DestroyUndestroyedObjects(VulkanObjectType object_type) {
     }
 }
 
-// Look for this device object in any of the instance child devices lists.
-// NOTE: This is of dubious value. In most circumstances Vulkan will die a flaming death if a dispatchable object is invalid.
-// However, if this layer is loaded first and GetProcAddress is used to make API calls, it will detect bad DOs.
-bool ObjectLifetimes::ValidateDeviceObject(const VulkanTypedHandle &device_typed, const char *invalid_handle_code,
-                                           const Location &loc) const {
-    auto instance_data = GetLayerDataPtr(get_dispatch_key(instance), layer_data_map);
-    auto instance_object_lifetime_data = instance_data->GetValidationObject<ObjectLifetimes>();
-    if (instance_object_lifetime_data->object_map[kVulkanObjectTypeDevice].contains(device_typed.handle)) {
-        return false;
-    }
-    return LogError(invalid_handle_code, instance, loc, "Invalid %s.", FormatHandle(device_typed).c_str());
-}
-
 bool ObjectLifetimes::ValidateAnonymousObject(uint64_t object, VkObjectType core_object_type, bool null_allowed,
                                               const char *invalid_handle_code, const char *wrong_device_code,
                                               const Location &loc) const {
     if (null_allowed && (object == HandleToUint64(VK_NULL_HANDLE))) return false;
     auto object_type = ConvertCoreObjectToVulkanObject(core_object_type);
-
-    if (object_type == kVulkanObjectTypeDevice) {
-        return ValidateDeviceObject(VulkanTypedHandle(reinterpret_cast<VkDevice>(object), object_type), invalid_handle_code, loc);
-    }
-
     return CheckObjectValidity(object, object_type, invalid_handle_code, wrong_device_code, loc);
 }
 


### PR DESCRIPTION
This function is no-op after chassis was introduced (years ago).

The chassis retrieves `ValidationObject` using a key derived from the dispatchable handle. This guarantees that there cannot be a mismatch between `ValidationObject` and the first dispatchable parameter.

If the dispatchable handle is invalid, this will be detected early by the chassis code (likely a crash during dereferencing in `get_dispatch_key`), and if it reaches `ValidationObject` callback then we know the validation object was created/initialized based on this dispatchable handle.

`ValidateDeviceObject` was added in the period when each validation object was a separate layer. For configurations where `ObjectLifetimes` was _the first layer in the chain_, `ValidateDeviceObject` had early opportunity to scan through dispatchable object map before `get_dispatch_key` is called. With the current design it's the chassis that calls `get_dispatch_key`. If original 2017 behavior is desired, then the validity and reporting of the first dispatchable handle should be done at the chassis level. 

The original 2017 design did validation of the dispatchable handle only if `ObjectLifetimes` was registered as the first layer in the chain. I guess, the standard configurations included stateless/thread-safety as the first layers, in that case invalid handles also resulted in a crash.

Current design worked for the last few years, if there were no issues with it, then it might be a practical solution. That said, current PR  does not change behavior and is rather a clean up of the code that became inactive long time ago.

<details>
<summary>Extra information for documentation purposes. The code snippet from 2017.</summary>
Top level API call:

```
VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
                                                const VkWriteDescriptorSet *pDescriptorWrites, uint32_t descriptorCopyCount,
                                                const VkCopyDescriptorSet *pDescriptorCopies) {
    bool skip = false;
    {
        std::lock_guard<std::mutex> lock(global_lock);
        skip |=
            ValidateObject(device, device, kVulkanObjectTypeDevice, false, VALIDATION_ERROR_33c05601, VALIDATION_ERROR_UNDEFINED);
...
```
`ValidateObject` looked like this:
```
template <typename T1, typename T2>
bool ValidateObject(T1 dispatchable_object, T2 object, VulkanObjectType object_type, bool null_allowed,
                    enum UNIQUE_VALIDATION_ERROR_CODE invalid_handle_code, enum UNIQUE_VALIDATION_ERROR_CODE wrong_device_code) {
    .....
    if (object_type == kVulkanObjectTypeDevice) {
        return ValidateDeviceObject(object_handle, invalid_handle_code, wrong_device_code);
    }

    ......
    // POINT OF INTEREST: get_dispatach_key is being called only after ValidateDeviceObject had a chance to check device handle
    layer_data *device_data = GetLayerDataPtr(get_dispatch_key(dispatchable_object), layer_data_map);
```

and `ValidateDeviceObject`:
```
// Look for this device object in any of the instance child devices lists.
// NOTE: This is of dubious value. In most circumstances Vulkan will die a flaming death if a dispatchable object is invalid.
// However, if this layer is loaded first and GetProcAddress is used to make API calls, it will detect bad DOs.
bool ValidateDeviceObject(uint64_t device_handle, enum UNIQUE_VALIDATION_ERROR_CODE invalid_handle_code,
                          enum UNIQUE_VALIDATION_ERROR_CODE wrong_device_code) {
    VkInstance last_instance = nullptr;
    for (auto layer_data : layer_data_map) {
        for (auto object : layer_data.second->object_map[kVulkanObjectTypeDevice]) {
            // Grab last instance to use for possible error message
            last_instance = layer_data.second->instance;
            if (object.second->handle == device_handle) return false;
        }
    }
    ...
}
```
In the above example `ValidateDeviceObject` had a chance to check if dispatchable handle was registered before before calling `get_dispatch_key` that will likely crash for invalid handle.

</details>