### PR TITLE
Validate DRM Disjoint MultiPlanar PlaneAspect

### DIFF
--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -2186,9 +2186,6 @@ TEST_F(NegativeMemory, MemoryRequirements) {
         m_errorMonitor->VerifyFound();
 
         vk::DestroyImage(m_device->device(), image, nullptr);
-
-        // TODO - Test needs to use a real drm format and not try using ALIAS_BIT
-        // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4793#issuecomment-1312724486
     }
 }
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5632
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6467

This will catch the most likely error case of using `VK_IMAGE_ASPECT_PLANE_0_BIT` and not  `VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT`

Plan to add proper support for `drmFormatModifierPlaneCount` but need to first confirm spec related questions around it