### PR TITLE
tests: Use Pipeline Helper class everywhere

### DIFF
--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -3627,36 +3627,28 @@ TEST_F(NegativeDynamicState, ViewportAndScissorUndefinedDrawState) {
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    const VkPipelineLayoutObj pipeline_layout(m_device);
+    CreatePipelineHelper pipeline_dyn_vp(*this);
+    pipeline_dyn_vp.InitState();
+    pipeline_dyn_vp.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT);
+    pipeline_dyn_vp.CreateGraphicsPipeline();
 
-    VkPipelineObj pipeline_dyn_vp(m_device);
-    pipeline_dyn_vp.AddShader(&vs);
-    pipeline_dyn_vp.AddShader(&fs);
-    pipeline_dyn_vp.AddDefaultColorAttachment();
-    pipeline_dyn_vp.MakeDynamic(VK_DYNAMIC_STATE_VIEWPORT);
-    pipeline_dyn_vp.SetScissor(m_scissors);
-    ASSERT_VK_SUCCESS(pipeline_dyn_vp.CreateVKPipeline(pipeline_layout.handle(), m_renderPass));
-
-    VkPipelineObj pipeline_dyn_sc(m_device);
-    pipeline_dyn_sc.AddShader(&vs);
-    pipeline_dyn_sc.AddShader(&fs);
-    pipeline_dyn_sc.AddDefaultColorAttachment();
-    pipeline_dyn_sc.SetViewport(m_viewports);
-    pipeline_dyn_sc.MakeDynamic(VK_DYNAMIC_STATE_SCISSOR);
-    ASSERT_VK_SUCCESS(pipeline_dyn_sc.CreateVKPipeline(pipeline_layout.handle(), m_renderPass));
+    CreatePipelineHelper pipeline_dyn_sc(*this);
+    pipeline_dyn_sc.InitState();
+    pipeline_dyn_sc.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR);
+    pipeline_dyn_sc.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-07831");
-    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_dyn_vp.handle());
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_dyn_vp.Handle());
     vk::CmdSetViewport(m_commandBuffer->handle(), 1, 1,
                        &m_viewports[0]);  // Forgetting to set needed 0th viewport (PSO viewportCount == 1)
     m_commandBuffer->Draw(1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-07832");
-    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_dyn_sc.handle());
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_dyn_sc.Handle());
     vk::CmdSetScissor(m_commandBuffer->handle(), 1, 1,
                       &m_scissors[0]);  // Forgetting to set needed 0th scissor (PSO scissorCount == 1)
     m_commandBuffer->Draw(1, 0, 0, 0);

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -559,23 +559,15 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampEnabled) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-    ASSERT_NO_FATAL_FAILURE(InitViewport());
 
     // Create a pipeline with a dynamically set depth bias
-    const VkPipelineLayoutObj pl(m_device);
-    VkPipelineObj pipe(m_device);
-    pipe.AddDefaultColorAttachment();
-    VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
-    pipe.AddShader(&vs);
-    VkShaderObj fs(this, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
-    pipe.AddShader(&fs);
-    pipe.SetViewport(m_viewports);
-    pipe.SetScissor(m_scissors);
-    pipe.MakeDynamic(VK_DYNAMIC_STATE_DEPTH_BIAS);
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
     auto raster_state = vku::InitStruct<VkPipelineRasterizationStateCreateInfo>();
     raster_state.depthBiasEnable = VK_TRUE;
-    pipe.SetRasterization(&raster_state);
-    pipe.CreateVKPipeline(pl.handle(), m_renderPass);
+    pipe.rs_state_ci_ = raster_state;
+    pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
 
@@ -588,7 +580,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampEnabled) {
     vk::CmdSetDepthBias2EXT(m_commandBuffer->handle(), &depth_bias_info);
 
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
-    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0,
                 0);  // Without correct state tracking, VUID-vkCmdDraw-None-07834 would be thrown here
     m_commandBuffer->EndRenderPass();
@@ -629,20 +621,13 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
     ASSERT_NO_FATAL_FAILURE(InitViewport());
 
     // Create a pipeline with a dynamically set depth bias
-    const VkPipelineLayoutObj pl(m_device);
-    VkPipelineObj pipe(m_device);
-    pipe.AddDefaultColorAttachment();
-    VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
-    pipe.AddShader(&vs);
-    VkShaderObj fs(this, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
-    pipe.AddShader(&fs);
-    pipe.SetViewport(m_viewports);
-    pipe.SetScissor(m_scissors);
-    pipe.MakeDynamic(VK_DYNAMIC_STATE_DEPTH_BIAS);
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
     auto raster_state = vku::InitStruct<VkPipelineRasterizationStateCreateInfo>();
     raster_state.depthBiasEnable = VK_TRUE;
-    pipe.SetRasterization(&raster_state);
-    pipe.CreateVKPipeline(pl.handle(), m_renderPass);
+    pipe.rs_state_ci_ = raster_state;
+    pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
 
@@ -655,7 +640,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
     vk::CmdSetDepthBias2EXT(m_commandBuffer->handle(), &depth_bias_info);
 
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
-    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0,
                 0);  // Without correct state tracking, VUID-vkCmdDraw-None-07834 would be thrown here
     m_commandBuffer->EndRenderPass();
@@ -706,21 +691,13 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentatio
     ASSERT_NO_FATAL_FAILURE(InitViewport());
 
     // Create a pipeline with a dynamically set depth bias
-    const VkPipelineLayoutObj pl(m_device);
-    VkPipelineObj pipe(m_device);
-    pipe.AddDefaultColorAttachment();
-    VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
-    pipe.AddShader(&vs);
-    VkShaderObj fs(this, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
-    pipe.AddShader(&fs);
-    pipe.SetViewport(m_viewports);
-    pipe.SetScissor(m_scissors);
-    pipe.MakeDynamic(VK_DYNAMIC_STATE_DEPTH_BIAS);
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
     auto raster_state = vku::InitStruct<VkPipelineRasterizationStateCreateInfo>();
     raster_state.depthBiasEnable = VK_TRUE;
-    pipe.SetRasterization(&raster_state);
-    pipe.CreateVKPipeline(pl.handle(), m_renderPass);
-
+    pipe.rs_state_ci_ = raster_state;
+    pipe.CreateGraphicsPipeline();
     m_commandBuffer->begin();
 
     vk::CmdSetDepthBiasEnableEXT(m_commandBuffer->handle(), VK_TRUE);
@@ -732,7 +709,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentatio
     vk::CmdSetDepthBias2EXT(m_commandBuffer->handle(), &depth_bias_info);
 
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
-    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     // Without correct state tracking, VUID-vkCmdDraw-None-07834 would be thrown here and in the follow-up calls
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
     auto depth_bias_representation = vku::InitStruct<VkDepthBiasRepresentationInfoEXT>();

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -945,22 +945,18 @@ TEST_F(NegativePipelineLayout, UniformBlockNotProvided) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07988");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-
-    VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
-    VkShaderObj fs(this, kFragmentUniformGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
-
-    VkPipelineObj pipe(m_device);
-    pipe.AddShader(&vs);
-    pipe.AddShader(&fs);
-
-    /* set up CB 0; type is UNORM by default */
-    pipe.AddDefaultColorAttachment();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
+
+    VkShaderObj fs(this, kFragmentUniformGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.shader_stages_[1] = fs.GetStageCreateInfo();
 
     VkDescriptorSetObj descriptorSet(m_device);
     descriptorSet.CreateVKDescriptorSet(m_commandBuffer);
 
-    pipe.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderPass());
+    pipe.gp_ci_.layout = descriptorSet.GetPipelineLayout();
+    pipe.CreateGraphicsPipeline();
 
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -965,23 +965,17 @@ TEST_F(PositiveShaderSpirv, GeometryShaderPassthroughNV) {
         }
     )glsl";
 
-    const VkPipelineLayoutObj pl(m_device);
-
-    VkPipelineObj pipe(m_device);
-    pipe.AddDefaultColorAttachment();
-
     VkShaderObj vs(this, vs_src, VK_SHADER_STAGE_VERTEX_BIT);
-    pipe.AddShader(&vs);
-
     VkShaderObj gs(this, gs_src, VK_SHADER_STAGE_GEOMETRY_BIT);
-    pipe.AddShader(&gs);
-
     VkShaderObj fs(this, fs_src, VK_SHADER_STAGE_FRAGMENT_BIT);
-    pipe.AddShader(&fs);
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
 
     // Create pipeline and make sure that the usage of NV_geometry_shader_passthrough
     // in the fragment shader does not cause any errors.
-    pipe.CreateVKPipeline(pl.handle(), renderPass());
+    pipe.CreateGraphicsPipeline();
 }
 
 TEST_F(PositiveShaderSpirv, SpecializeInt8) {

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -3910,13 +3910,14 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     )glsl";
 
     VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT);
-    VkPipelineObj pipe(m_device);
-    pipe.AddShader(&vs);
-    pipe.AddDefaultColorAttachment();
-    pipe.CreateVKPipeline(pipeline_layout.handle(), m_renderPass);
-    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.shader_stages_ = {vs.GetStageCreateInfo()};
+    pipe.gp_ci_.layout = pipeline_layout.handle();
+    pipe.CreateGraphicsPipeline();
+    VkCommandBufferBeginInfo begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
     m_commandBuffer->begin(&begin_info);
-    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.handle());
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
@@ -3928,10 +3929,6 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     combined_view.reset();
 
     vk::CmdBindIndexBuffer(m_commandBuffer->handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
-    VkViewport viewport = {0, 0, 16, 16, 0, 1};
-    vk::CmdSetViewport(m_commandBuffer->handle(), 0, 1, &viewport);
-    VkRect2D scissor = {{0, 0}, {16, 16}};
-    vk::CmdSetScissor(m_commandBuffer->handle(), 0, 1, &scissor);
     vk::CmdDrawIndexed(m_commandBuffer->handle(), 1, 1, 0, 0, 0);
     vk::CmdEndRenderPass(m_commandBuffer->handle());
     m_commandBuffer->end();

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -375,24 +375,17 @@ TEST_F(PositiveSyncVal, ShaderReferencesNotBoundSet) {
     const VkPipelineLayoutObj pipeline_layout(m_device, {&set_layout, &set_layout});
     OneOffDescriptorSet set(m_device, {binding});
 
-    VkPipelineObj pipe(m_device);
-    pipe.AddShader(&vs);
-    pipe.AddShader(&fs);
-    pipe.AddDefaultColorAttachment();
-    VkViewport viewport = {0.0f, 0.0f, 64.0f, 64.0f, 0.0f, 1.0f};
-    m_viewports.push_back(viewport);
-    pipe.SetViewport(m_viewports);
-    VkRect2D rect = {{0, 0}, {64, 64}};
-    m_scissors.push_back(rect);
-    pipe.SetScissor(m_scissors);
-    pipe.CreateVKPipeline(pipeline_layout, m_renderPass);
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.gp_ci_.layout = pipeline_layout.handle();
+    pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
     // Bind set 0.
     vk::CmdBindDescriptorSets(*m_commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &set.set_, 0, nullptr);
-    vk::CmdBindPipeline(*m_commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdBindPipeline(*m_commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     // Core checks prevent SyncVal from running when error is found. This test has core checks disabled and also invalid
     // setup where a shader uses not bound set 1.


### PR DESCRIPTION
Replace as many `VkPipelineObj` with the Pipeline Helper class as possible (in order to only have a single way to create RAII pipeline objects)

There are view places remaining, but those will require a bit more effort as they use very one-off hacks in the `VkPipelineObj` class

overall the net-loss in LoC is good to show it is simpler for most cases to use the Pipeline Helper class