### PR TITLE
layers: Fix Location dot with index

### DIFF
--- a/layers/error_message/error_location.cpp
+++ b/layers/error_message/error_location.cpp
@@ -21,10 +21,16 @@
 
 void Location::AppendFields(std::ostream& out) const {
     if (prev) {
-        prev->AppendFields(out);
+        // When apply a .dot(sub_index) we duplicate the field item
+        // Instead of dealing with partial non-const Location, just do the check here
+        const Location& prev_loc = (prev->field == field && prev->index == kNoIndex && prev->prev) ? *prev->prev : *prev;
+
+        // Work back and print for Locaiton first
+        prev_loc.AppendFields(out);
+
         // check if need connector from last item
-        if (prev->structure != vvl::Struct::Empty || prev->field != vvl::Field::Empty) {
-            out << ((prev->index == kNoIndex && IsFieldPointer(prev->field)) ? "->" : ".");
+        if (prev_loc.structure != vvl::Struct::Empty || prev_loc.field != vvl::Field::Empty) {
+            out << ((prev_loc.index == kNoIndex && IsFieldPointer(prev_loc.field)) ? "->" : ".");
         }
     }
     if (isPNext && structure != vvl::Struct::Empty) {

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -4074,6 +4074,25 @@ TEST_F(NegativeImage, ImageFormatList) {
     CreateImageViewTest(*this, &imageViewInfo, {});
 }
 
+TEST_F(NegativeImage, ImageFormatListEnum) {
+    TEST_DESCRIPTION("VkImageFormatListCreateInfo with bad enum");
+    AddRequiredExtensions(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState());
+
+    const VkFormat formats[2] = {VK_FORMAT_R8G8B8A8_UNORM, VkFormat(0xBAD00000)};
+    VkImageFormatListCreateInfo formatList = vku::InitStructHelper(nullptr);
+    formatList.viewFormatCount = 2;
+    formatList.pViewFormats = formats;
+    VkImageCreateInfo image_ci = DefaultImageInfo();
+    image_ci.pNext = &formatList;
+
+    CreateImageTest(*this, &image_ci, "UNASSIGNED-GeneralParameterError-UnrecognizedValue");
+}
+
 TEST_F(NegativeImage, ImageFormatListSizeCompatible) {
     TEST_DESCRIPTION("Tests for VK_KHR_image_format_list with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT");
 


### PR DESCRIPTION
currently we print

> vkCreateImage(): pCreateInfo->pNext\<VkImageFormatListCreateInfo\>.pViewFormats->pViewFormats[1]

but we really want

> vkCreateImage(): pCreateInfo->pNext\<VkImageFormatListCreateInfo\>.pViewFormats[1]

The issue is related to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6464#discussion_r1321556117 (cc @artem-lunarg)

playing around with the code, rather put this edge case in the `AppendFields` then have `index` be non-const or some other random function to add more confusion to a new developer trying to add the correct Location