### PR TITLE
layers: Fix not checking for dynamic depth test state

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -203,12 +203,12 @@ bool CoreChecks::ValidateDynamicStateSetStatus(const LAST_BOUND_STATE& last_boun
                                           vuid.dynamic_blend_constants_07835);
     }
 
-    if (const auto *ds_state = pipeline.DepthStencilState(); ds_state) {
-        if (ds_state->depthBoundsTestEnable == VK_TRUE) {
+    if (pipeline.DepthStencilState()) {
+        if (last_bound_state.IsDepthBoundTestEnable()) {
             skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_DEPTH_BOUNDS, objlist, loc,
                                               vuid.dynamic_depth_bounds_07836);
         }
-        if (ds_state->stencilTestEnable == VK_TRUE) {
+        if (last_bound_state.IsStencilTestEnable()) {
             skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_STENCIL_COMPARE_MASK, objlist, loc,
                                               vuid.dynamic_stencil_compare_mask_07837);
             skip |= ValidateDynamicStateIsSet(state_status_cb, CB_DYNAMIC_STATE_STENCIL_WRITE_MASK, objlist, loc,

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -818,6 +818,12 @@ bool LAST_BOUND_STATE::IsDepthTestEnable() const {
                                                                          : pipeline_state->DepthStencilState()->depthTestEnable;
 }
 
+bool LAST_BOUND_STATE::IsDepthBoundTestEnable() const {
+    return pipeline_state->IsDynamic(VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE)
+               ? cb_state.dynamic_state_value.depth_bounds_test_enable
+               : pipeline_state->DepthStencilState()->depthBoundsTestEnable;
+}
+
 bool LAST_BOUND_STATE::IsDepthWriteEnable() const {
     // "Depth writes are always disabled when depthTestEnable is VK_FALSE"
     if (!IsDepthTestEnable()) {

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -790,6 +790,7 @@ struct LAST_BOUND_STATE {
 
     // Dynamic State helpers that require both the Pipeline and CommandBuffer state are here
     bool IsDepthTestEnable() const;
+    bool IsDepthBoundTestEnable() const;
     bool IsDepthWriteEnable() const;
     bool IsStencilTestEnable() const;
     VkStencilOpState GetStencilOpStateFront() const;

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -3944,6 +3944,43 @@ TEST_F(NegativeDynamicState, DepthRangeUnrestricted) {
     m_commandBuffer->end();
 }
 
+TEST_F(NegativeDynamicState, DepthBoundsTestEnableState) {
+    TEST_DESCRIPTION("Dynamically set depthBoundsTestEnable and not call vkCmdSetDepthBounds before the draw");
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
+    ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
+    if (!AreRequiredExtensionsEnabled()) {
+        GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
+    }
+    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
+
+    // Need to set format framework uses for InitRenderTarget
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+
+    m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt,
+                         VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.ds_ci_ = vku::InitStructHelper();
+    pipe.ds_ci_.depthTestEnable = VK_FALSE;  // ignored
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BOUNDS);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE);
+    pipe.CreateGraphicsPipeline();
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
+    vk::CmdSetDepthBoundsTestEnableEXT(m_commandBuffer->handle(), VK_TRUE);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-07836");
+    vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+    m_commandBuffer->EndRenderPass();
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}
+
 TEST_F(NegativeDynamicState, ViewportStateIgnored) {
     TEST_DESCRIPTION("Ignore null pViewportState");
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);


### PR DESCRIPTION
it was confirmed in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6132 that we need to check for `depthBoundsTestEnable`/`stencilTestEnable`, but those values can be set dynamically but we currently were checking it from the pipeline