### PR TITLE
ci: Fix Windows CI

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -30,14 +30,15 @@ on:
 
 env:
   CMAKE_GENERATOR: Ninja
-  CMAKE_C_COMPILER_LAUNCHER: ccache
-  CMAKE_CXX_COMPILER_LAUNCHER: ccache
 
 permissions:
   contents: read
 
 jobs:
   linux:
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -146,6 +147,9 @@ jobs:
         run: python scripts/tests.py --test
 
   android:
+      env:
+        CMAKE_C_COMPILER_LAUNCHER: ccache
+        CMAKE_CXX_COMPILER_LAUNCHER: ccache
       runs-on: ubuntu-22.04
       strategy:
         matrix:
@@ -182,6 +186,9 @@ jobs:
           run: ctest --output-on-failure -C Debug
 
   macos:
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     runs-on: macos-latest
     strategy:
       matrix:
@@ -200,6 +207,9 @@ jobs:
         run: python3 scripts/macos.py --config release --osx ${{ matrix.macos_version }}
 
   mingw:
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     runs-on: windows-latest
     defaults:
       run:


### PR DESCRIPTION
This should fix following CMake failure we have been seeing

```
CMake Error at C:/Program Files/CMake/share/cmake-3.27/Modules/CMakeTestCXXCompiler.cmake:60 (message):
  The C++ compiler

    "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.35.32215/bin/HostX64/x86/cl.exe"

  is not able to compile a simple test program.
-- Configuring incomplete, errors occurred!

  It fails with the following output:

    Change Dir: 'D:/a/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/vvl/CMakeFiles/CMakeScratch/TryCompile-fbwgkz'
    
    Run Build Command(s): C:/PROGRA~1/MICROS~2/2022/ENTERP~1/Common7/IDE/COMMON~1/MICROS~1/CMake/Ninja/ninja.exe -v cmTC_03c13
    [1/2] ccache C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1435~1.322\bin\HostX64\x86\cl.exe  /nologo /TP   /DWIN32 /D_WINDOWS /GR /EHsc  /Zi /Ob0 /Od /RTC1 -MDd /showIncludes /FoCMakeFiles\cmTC_03c13.dir\testCXXCompiler.cxx.obj /FdCMakeFiles\cmTC_03c13.dir\ /FS -c D:\a\Vulkan-ValidationLayers\Vulkan-ValidationLayers\build-ci\vvl\CMakeFiles\CMakeScratch\TryCompile-fbwgkz\testCXXCompiler.cxx
    FAILED: CMakeFiles/cmTC_03c13.dir/testCXXCompiler.cxx.obj 
    ccache C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1435~1.322\bin\HostX64\x86\cl.exe  /nologo /TP   /DWIN32 /D_WINDOWS /GR /EHsc  /Zi /Ob0 /Od /RTC1 -MDd /showIncludes /FoCMakeFiles\cmTC_03c13.dir\testCXXCompiler.cxx.obj /FdCMakeFiles\cmTC_03c13.dir\ /FS -c D:\a\Vulkan-ValidationLayers\Vulkan-ValidationLayers\build-ci\vvl\CMakeFiles\CMakeScratch\TryCompile-fbwgkz\testCXXCompiler.cxx
    CreateProcess failed: The system cannot find the file specified.
    ninja: build stopped: subcommand failed.
```

The main part to notice is `CreateProcess failed: The system cannot find the file specified.`

This is referencing how ccache does not exist on the system. I'm not sure why this worked before. Perhaps CMake became stricter with checking this value? I'm currently investigating why this started happening all of a sudden.