### PR TITLE
Fix GPU-AV recovery in ray tracing

### DIFF
--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -769,8 +769,14 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice device, VkD
                                                              &(crtpl_state[intercept->container_type]));
     }
 
-    VkResult result = DispatchCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos,
-                                                           pAllocator, pPipelines);
+    auto usepCreateInfos = (!crtpl_state[LayerObjectTypeGpuAssisted].pCreateInfos)
+                               ? pCreateInfos
+                               : crtpl_state[LayerObjectTypeGpuAssisted].pCreateInfos;
+    if (crtpl_state[LayerObjectTypeDebugPrintf].pCreateInfos)
+        usepCreateInfos = crtpl_state[LayerObjectTypeDebugPrintf].pCreateInfos;
+
+    VkResult result = DispatchCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount,
+                                                           usepCreateInfos, pAllocator, pPipelines);
 
     RecordObject record_obj(vvl::Func::vkCreateRayTracingPipelinesKHR, result);
     for (ValidationObject* intercept : layer_data->object_dispatch) {

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1476,8 +1476,14 @@ class LayerChassisOutputGenerator(BaseGenerator):
                                                                         &(crtpl_state[intercept->container_type]));
                 }
 
-                VkResult result = DispatchCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos,
-                                                                    pAllocator, pPipelines);
+                auto usepCreateInfos = (!crtpl_state[LayerObjectTypeGpuAssisted].pCreateInfos)
+                             ? pCreateInfos
+                             : crtpl_state[LayerObjectTypeGpuAssisted].pCreateInfos;
+                if (crtpl_state[LayerObjectTypeDebugPrintf].pCreateInfos)
+                    usepCreateInfos = crtpl_state[LayerObjectTypeDebugPrintf].pCreateInfos;
+
+                VkResult result = DispatchCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount,
+                                                                       usepCreateInfos, pAllocator, pPipelines);
 
                 RecordObject record_obj(vvl::Func::vkCreateRayTracingPipelinesKHR, result);
                 for (ValidationObject* intercept : layer_data->object_dispatch) {


### PR DESCRIPTION
Chassis needs to use modified createInfos especially if there aren't enough descriptor sets to do GPU-AV
Fixes crash in dEQP-VK.binding_model.descriptorset_random.sets32.noarray.ubolimitlow.sbolimitlow.sampledimglow.outimgtexlow.noiub.uab.sect.noia.0 