### PR TITLE
build: Add --asan option

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -54,6 +54,10 @@ if (UPDATE_DEPS)
     list(APPEND update_dep_command "--dir" )
     list(APPEND update_dep_command "${UPDATE_DEPS_DIR}")
 
+    if (VVL_ENABLE_ASAN)
+        list(APPEND update_dep_command "--asan" )
+    endif()
+
     if (NOT BUILD_TESTS)
         list(APPEND update_dep_command "--optional=tests")
     endif()


### PR DESCRIPTION
Add --asan option for update_deps.py, allowing to build dependencies with ASAN enabled.
Augment VVL build option VVL_ENABLE_ASAN to automatically pass --asan option to update_deps.py when this build option is used in conjonction with UPDATE_DEPS