### PR TITLE
layers: Use vku::InitStructHelper

### DIFF
--- a/docs/creating_tests.md
+++ b/docs/creating_tests.md
@@ -262,8 +262,8 @@ if (!LoadDeviceProfileLayer(fpvkSetPhysicalDeviceFormatProperties2EXT, fpvkGetOr
     GTEST_SKIP() << "Failed to load device profile layer.";
 }
 
-auto fmt_props_3 = vku::InitStruct<VkFormatProperties3>();
-auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+VkFormatProperties3 fmt_props_3 = vku::InitStructHelper();
+VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
 // Removes unwanted support
 fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(gpu(), image_format, &fmt_props);

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -198,7 +198,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
         }
 
         // Collect external buffer info
-        auto pdebi = vku::InitStruct<VkPhysicalDeviceExternalBufferInfo>();
+        VkPhysicalDeviceExternalBufferInfo pdebi = vku::InitStructHelper();
         pdebi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
         if (AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE & ahb_desc.usage) {
             pdebi.usage |= ahb_usage_map_a2v[AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE];
@@ -206,16 +206,16 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
         if (AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER & ahb_desc.usage) {
             pdebi.usage |= ahb_usage_map_a2v[AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER];
         }
-        auto ext_buf_props = vku::InitStruct<VkExternalBufferProperties>();
+        VkExternalBufferProperties ext_buf_props = vku::InitStructHelper();
         DispatchGetPhysicalDeviceExternalBufferProperties(physical_device, &pdebi, &ext_buf_props);
 
         //  If buffer is not NULL, Android hardware buffers must be supported for import, as reported by
         //  VkExternalImageFormatProperties or VkExternalBufferProperties.
         if (0 == (ext_buf_props.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
             // Collect external format info
-            auto pdeifi = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
+            VkPhysicalDeviceExternalImageFormatInfo pdeifi = vku::InitStructHelper();
             pdeifi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
-            auto pdifi2 = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&pdeifi);
+            VkPhysicalDeviceImageFormatInfo2 pdifi2 = vku::InitStructHelper(&pdeifi);
             if (0 < ahb_format_map_a2v.count(ahb_desc.format)) pdifi2.format = ahb_format_map_a2v[ahb_desc.format];
             pdifi2.type = VK_IMAGE_TYPE_2D;           // Seems likely
             pdifi2.tiling = VK_IMAGE_TILING_OPTIMAL;  // Ditto
@@ -232,8 +232,8 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
                 pdifi2.flags |= ahb_create_map_a2v[AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT];
             }
 
-            auto ext_img_fmt_props = vku::InitStruct<VkExternalImageFormatProperties>();
-            auto ifp2 = vku::InitStruct<VkImageFormatProperties2>(&ext_img_fmt_props);
+            VkExternalImageFormatProperties ext_img_fmt_props = vku::InitStructHelper();
+            VkImageFormatProperties2 ifp2 = vku::InitStructHelper(&ext_img_fmt_props);
 
             VkResult fmt_lookup_result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &pdifi2, &ifp2);
 
@@ -248,7 +248,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
         }
 
         // Retrieve buffer and format properties of the provided AHardwareBuffer
-        auto ahb_props = vku::InitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
+        VkAndroidHardwareBufferPropertiesANDROID ahb_props = vku::InitStructHelper();
         DispatchGetAndroidHardwareBufferPropertiesANDROID(device, import_ahb_info->buffer, &ahb_props);
 
         // allocationSize must be the size returned by vkGetAndroidHardwareBufferPropertiesANDROID for the Android hardware buffer
@@ -301,8 +301,8 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo *alloc
             if (VK_FORMAT_UNDEFINED != ici->format) {
                 // Mali drivers will not return a valid VkAndroidHardwareBufferPropertiesANDROID::allocationSize if the
                 // FormatPropertiesANDROID is passed in as well so need to query again for the format
-                auto ahb_format_props = vku::InitStruct<VkAndroidHardwareBufferFormatPropertiesANDROID>();
-                auto dummy_ahb_props = vku::InitStruct<VkAndroidHardwareBufferPropertiesANDROID>(&ahb_format_props);
+                VkAndroidHardwareBufferFormatPropertiesANDROID ahb_format_props = vku::InitStructHelper();
+                VkAndroidHardwareBufferPropertiesANDROID dummy_ahb_props = vku::InitStructHelper(&ahb_format_props);
                 DispatchGetAndroidHardwareBufferPropertiesANDROID(device, import_ahb_info->buffer, &dummy_ahb_props);
                 if (ici->format != ahb_format_props.format) {
                     skip |= LogError(

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -274,12 +274,12 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
     auto external_memory_info = vku::FindStructInPNextChain<VkExternalMemoryBufferCreateInfo>(pCreateInfo->pNext);
     if (external_memory_info && external_memory_info->handleTypes) {
         const uint32_t any_type = 1u << MostSignificantBit(external_memory_info->handleTypes);
-        auto external_buffer_info = vku::InitStruct<VkPhysicalDeviceExternalBufferInfo>();
+        VkPhysicalDeviceExternalBufferInfo external_buffer_info = vku::InitStructHelper();
         external_buffer_info.flags = pCreateInfo->flags;
         // for now no VkBufferUsageFlags2KHR flag can be used, so safe to pass in as 32-bit version
         external_buffer_info.usage = VkBufferUsageFlags(pCreateInfo->usage);
         external_buffer_info.handleType = static_cast<VkExternalMemoryHandleTypeFlagBits>(any_type);
-        auto external_buffer_properties = vku::InitStruct<VkExternalBufferProperties>();
+        VkExternalBufferProperties external_buffer_properties = vku::InitStructHelper();
         DispatchGetPhysicalDeviceExternalBufferProperties(physical_device, &external_buffer_info, &external_buffer_properties);
         const auto compatible_types = external_buffer_properties.externalMemoryProperties.compatibleHandleTypes;
 

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -90,13 +90,13 @@ bool CoreChecks::GetPhysicalDeviceImageFormatProperties(IMAGE_STATE &image_state
             image_create_info.usage, image_create_info.flags, &image_state.image_format_properties);
     } else {
         command = Func::vkGetPhysicalDeviceImageFormatProperties2;
-        auto image_format_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>();
+        VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper();
         image_format_info.type = image_create_info.imageType;
         image_format_info.format = image_create_info.format;
         image_format_info.tiling = image_create_info.tiling;
         image_format_info.usage = image_create_info.usage;
         image_format_info.flags = image_create_info.flags;
-        auto image_format_properties = vku::InitStruct<VkImageFormatProperties2>();
+        VkImageFormatProperties2 image_format_properties = vku::InitStructHelper();
         image_properties_result =
             DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_format_properties);
         image_state.image_format_properties = image_format_properties.imageFormatProperties;
@@ -632,8 +632,8 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceImageFormatProperties2KHR(VkPhy
 
 // Access helper functions for external modules
 VkFormatProperties3KHR CoreChecks::GetPDFormatProperties(const VkFormat format) const {
-    auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-    auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+    VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+    VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
 
     if (has_format_feature2) {
         DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -495,11 +495,11 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
         // Validate VkExportMemoryAllocateInfo's VUs that can't be checked during vkAllocateMemory
         // because they require buffer information.
         if (mem_info->IsExport()) {
-            auto external_info = vku::InitStruct<VkPhysicalDeviceExternalBufferInfo>();
+            VkPhysicalDeviceExternalBufferInfo external_info = vku::InitStructHelper();
             external_info.flags = buffer_state->createInfo.flags;
             // for now no VkBufferUsageFlags2KHR flag can be used, so safe to pass in as 32-bit version
             external_info.usage = VkBufferUsageFlags(buffer_state->usage);
-            auto external_properties = vku::InitStruct<VkExternalBufferProperties>();
+            VkExternalBufferProperties external_properties = vku::InitStructHelper();
             bool export_supported = true;
 
             auto validate_export_handle_types = [&](VkExternalMemoryHandleTypeFlagBits flag) {
@@ -1219,26 +1219,26 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
 
                 // Validate export memory handles
                 if (mem_info->IsExport()) {
-                    auto drm_format_modifier = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+                    VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
                     drm_format_modifier.sharingMode = image_state->createInfo.sharingMode;
                     drm_format_modifier.queueFamilyIndexCount = image_state->createInfo.queueFamilyIndexCount;
                     drm_format_modifier.pQueueFamilyIndices = image_state->createInfo.pQueueFamilyIndices;
-                    auto external_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
-                    auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_info);
+                    VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
+                    VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_info);
                     image_info.format = image_state->createInfo.format;
                     image_info.type = image_state->createInfo.imageType;
                     image_info.tiling = image_state->createInfo.tiling;
                     image_info.usage = image_state->createInfo.usage;
                     image_info.flags = image_state->createInfo.flags;
-                    auto external_properties = vku::InitStruct<VkExternalImageFormatProperties>();
-                    auto image_properties = vku::InitStruct<VkImageFormatProperties2>(&external_properties);
+                    VkExternalImageFormatProperties external_properties = vku::InitStructHelper();
+                    VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_properties);
                     bool export_supported = true;
 
                     auto validate_export_handle_types = [&](VkExternalMemoryHandleTypeFlagBits flag) {
                         external_info.handleType = flag;
                         external_info.pNext = NULL;
                         if (image_state->createInfo.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
-                            auto drm_modifier_properties = vku::InitStruct<VkImageDrmFormatModifierPropertiesEXT>();
+                            VkImageDrmFormatModifierPropertiesEXT drm_modifier_properties = vku::InitStructHelper();
                             auto result =
                                 DispatchGetImageDrmFormatModifierPropertiesEXT(device, bind_info.image, &drm_modifier_properties);
                             if (result == VK_SUCCESS) {
@@ -1525,7 +1525,7 @@ bool CoreChecks::PreCallValidateBindImageMemory(VkDevice device, VkImage image, 
         }
     }
 
-    auto bind_info = vku::InitStruct<VkBindImageMemoryInfo>();
+    VkBindImageMemoryInfo bind_info = vku::InitStructHelper();
     bind_info.image = image;
     bind_info.memory = memory;
     bind_info.memoryOffset = memoryOffset;

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -62,8 +62,8 @@ bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo *pCreateInf
             }
         }
 
-        auto fmt_drm_props = vku::InitStruct<VkDrmFormatModifierPropertiesListEXT>();
-        auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_drm_props);
+        VkDrmFormatModifierPropertiesListEXT fmt_drm_props = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_drm_props);
         DispatchGetPhysicalDeviceFormatProperties2(physical_device, image_format, &fmt_props_2);
         std::vector<VkDrmFormatModifierPropertiesEXT> drm_properties;
         drm_properties.resize(fmt_drm_props.drmFormatModifierCount);
@@ -176,8 +176,8 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         }
     }
 
-    auto image_format_properties = vku::InitStruct<VkImageFormatProperties2>();
-    auto image_format_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>();
+    VkImageFormatProperties2 image_format_properties = vku::InitStructHelper();
+    VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper();
     image_format_info.type = pCreateInfo->imageType;
     image_format_info.format = pCreateInfo->format;
     image_format_info.tiling = pCreateInfo->tiling;
@@ -227,7 +227,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     } else {
         auto *modifier_list = vku::FindStructInPNextChain<VkImageDrmFormatModifierListCreateInfoEXT>(pCreateInfo->pNext);
         auto *explicit_modifier = vku::FindStructInPNextChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pCreateInfo->pNext);
-        auto drm_format_modifier = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+        VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
         drm_format_modifier.sharingMode = pCreateInfo->sharingMode;
         drm_format_modifier.queueFamilyIndexCount = pCreateInfo->queueFamilyIndexCount;
         drm_format_modifier.pQueueFamilyIndices = pCreateInfo->pQueueFamilyIndices;
@@ -478,12 +478,12 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         }
         // Check external memory handle types compatibility
         const uint32_t any_type = 1u << MostSignificantBit(external_memory_create_info->handleTypes);
-        auto external_image_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
+        VkPhysicalDeviceExternalImageFormatInfo external_image_info = vku::InitStructHelper();
         external_image_info.handleType = static_cast<VkExternalMemoryHandleTypeFlagBits>(any_type);
         vvl::PnextChainScopedAdd scoped_add_ext_img_info(&image_format_info, &external_image_info);
 
-        auto external_image_properties = vku::InitStruct<VkExternalImageFormatProperties>();
-        auto image_properties = vku::InitStruct<VkImageFormatProperties2>(&external_image_properties);
+        VkExternalImageFormatProperties external_image_properties = vku::InitStructHelper();
+        VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_image_properties);
         VkExternalMemoryHandleTypeFlags compatible_types = 0;
         if (pCreateInfo->tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
             result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_properties);
@@ -491,7 +491,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
         } else {
             auto modifier_list = vku::FindStructInPNextChain<VkImageDrmFormatModifierListCreateInfoEXT>(pCreateInfo->pNext);
             auto explicit_modifier = vku::FindStructInPNextChain<VkImageDrmFormatModifierExplicitCreateInfoEXT>(pCreateInfo->pNext);
-            auto drm_format_modifier = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+            VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
             drm_format_modifier.sharingMode = pCreateInfo->sharingMode;
             drm_format_modifier.queueFamilyIndexCount = pCreateInfo->queueFamilyIndexCount;
             drm_format_modifier.pQueueFamilyIndices = pCreateInfo->pQueueFamilyIndices;
@@ -1457,8 +1457,8 @@ bool CoreChecks::ValidateImageViewFormatFeatures(const IMAGE_STATE &image_state,
         VkImageDrmFormatModifierPropertiesEXT drm_format_properties = vku::InitStructHelper();
         DispatchGetImageDrmFormatModifierPropertiesEXT(device, image_state.image(), &drm_format_properties);
 
-        auto fmt_drm_props = vku::InitStruct<VkDrmFormatModifierPropertiesListEXT>();
-        auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_drm_props);
+        VkDrmFormatModifierPropertiesListEXT fmt_drm_props = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_drm_props);
         DispatchGetPhysicalDeviceFormatProperties2(physical_device, view_format, &fmt_props_2);
 
         std::vector<VkDrmFormatModifierPropertiesEXT> drm_properties;
@@ -2211,11 +2211,11 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const IMAGE_STATE &image_stat
         } else {
             // Parameter validation should catch if this is used without VK_EXT_image_drm_format_modifier
             assert(IsExtEnabled(device_extensions.vk_ext_image_drm_format_modifier));
-            VkImageDrmFormatModifierPropertiesEXT drm_format_properties = vku::InitStruct<VkImageDrmFormatModifierPropertiesEXT>();
+            VkImageDrmFormatModifierPropertiesEXT drm_format_properties = vku::InitStructHelper();
             DispatchGetImageDrmFormatModifierPropertiesEXT(device, image_state.image(), &drm_format_properties);
 
-            auto fmt_drm_props = vku::InitStruct<VkDrmFormatModifierPropertiesListEXT>();
-            auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_drm_props);
+            VkDrmFormatModifierPropertiesListEXT fmt_drm_props = vku::InitStructHelper();
+            VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_drm_props);
             DispatchGetPhysicalDeviceFormatProperties2(physical_device, image_state.createInfo.format, &fmt_props_2);
             std::vector<VkDrmFormatModifierPropertiesEXT> drm_properties{fmt_drm_props.drmFormatModifierCount};
             fmt_drm_props.pDrmFormatModifierProperties = drm_properties.data();

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -169,7 +169,7 @@ bool CoreChecks::ValidatePipelineExecutableInfo(VkDevice device, const VkPipelin
 
     // vkGetPipelineExecutablePropertiesKHR will not have struct to validate further
     if (pExecutableInfo) {
-        auto pi = vku::InitStruct<VkPipelineInfoKHR>();
+        VkPipelineInfoKHR pi = vku::InitStructHelper();
         pi.pipeline = pExecutableInfo->pipeline;
 
         // We could probably cache this instead of fetching it every time

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -1486,7 +1486,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const PIPELINE_STATE &
                 skip |= ValidateSampleLocationsInfo(&sample_location_info, sample_info_loc.dot(Field::sampleLocationsInfo));
                 const VkExtent2D grid_size = sample_location_info.sampleLocationGridSize;
 
-                auto multisample_prop = vku::InitStruct<VkMultisamplePropertiesEXT>();
+                VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
                 DispatchGetPhysicalDeviceMultisamplePropertiesEXT(physical_device, multisample_state->rasterizationSamples,
                                                                   &multisample_prop);
                 const VkExtent2D max_grid_size = multisample_prop.maxSampleLocationGridSize;

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -429,11 +429,11 @@ bool CoreChecks::PreCallValidateCreateFence(VkDevice device, const VkFenceCreate
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     auto fence_export_info = vku::FindStructInPNextChain<VkExportFenceCreateInfo>(pCreateInfo->pNext);
     if (fence_export_info && fence_export_info->handleTypes != 0) {
-        auto external_properties = vku::InitStruct<VkExternalFenceProperties>();
+        VkExternalFenceProperties external_properties = vku::InitStructHelper();
         bool export_supported = true;
         // Check export support
         auto check_export_support = [&](VkExternalFenceHandleTypeFlagBits flag) {
-            auto external_info = vku::InitStruct<VkPhysicalDeviceExternalFenceInfo>();
+            VkPhysicalDeviceExternalFenceInfo external_info = vku::InitStructHelper();
             external_info.handleType = flag;
             DispatchGetPhysicalDeviceExternalFenceProperties(physical_device, &external_info, &external_properties);
             if ((external_properties.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT) == 0) {
@@ -481,11 +481,11 @@ bool CoreChecks::PreCallValidateCreateSemaphore(VkDevice device, const VkSemapho
 
     auto sem_export_info = vku::FindStructInPNextChain<VkExportSemaphoreCreateInfo>(pCreateInfo->pNext);
     if (sem_export_info && sem_export_info->handleTypes != 0) {
-        auto external_properties = vku::InitStruct<VkExternalSemaphoreProperties>();
+        VkExternalSemaphoreProperties external_properties = vku::InitStructHelper();
         bool export_supported = true;
         // Check export support
         auto check_export_support = [&](VkExternalSemaphoreHandleTypeFlagBits flag) {
-            auto external_info = vku::InitStruct<VkPhysicalDeviceExternalSemaphoreInfo>();
+            VkPhysicalDeviceExternalSemaphoreInfo external_info = vku::InitStructHelper();
             external_info.handleType = flag;
             DispatchGetPhysicalDeviceExternalSemaphoreProperties(physical_device, &external_info, &external_properties);
             if ((external_properties.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT) == 0) {
@@ -691,7 +691,7 @@ struct RenderPassDepState {
             return *override_barrier;
         }
 
-        auto barrier = vku::InitStruct<VkMemoryBarrier2>();
+        VkMemoryBarrier2 barrier = vku::InitStructHelper();
         barrier.srcStageMask = dep.srcStageMask;
         barrier.dstStageMask = dep.dstStageMask;
         barrier.srcAccessMask = dep.srcAccessMask;

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -43,7 +43,7 @@ bool CoreChecks::OutsideVideoCodingScope(const CMD_BUFFER_STATE &cb_state, const
 
 std::vector<VkVideoFormatPropertiesKHR> CoreChecks::GetVideoFormatProperties(VkImageUsageFlags image_usage,
                                                                              const VkVideoProfileListInfoKHR *profile_list) const {
-    auto format_info = vku::InitStruct<VkPhysicalDeviceVideoFormatInfoKHR>();
+    VkPhysicalDeviceVideoFormatInfoKHR format_info = vku::InitStructHelper();
     format_info.imageUsage = image_usage;
     format_info.pNext = profile_list;
 
@@ -57,7 +57,7 @@ std::vector<VkVideoFormatPropertiesKHR> CoreChecks::GetVideoFormatProperties(VkI
 
 std::vector<VkVideoFormatPropertiesKHR> CoreChecks::GetVideoFormatProperties(VkImageUsageFlags image_usage,
                                                                              const VkVideoProfileInfoKHR *profile) const {
-    auto profile_list = vku::InitStruct<VkVideoProfileListInfoKHR>();
+    VkVideoProfileListInfoKHR profile_list = vku::InitStructHelper();
     profile_list.profileCount = 1;
     profile_list.pProfiles = profile;
 

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -34,7 +34,7 @@ static bool IsExtentInsideBounds(VkExtent2D extent, VkExtent2D min, VkExtent2D m
 }
 
 static VkImageCreateInfo GetSwapchainImpliedImageCreateInfo(VkSwapchainCreateInfoKHR const *pCreateInfo) {
-    auto result = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo result = vku::InitStructHelper();
 
     if (pCreateInfo->flags & VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR) {
         result.flags |= VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT;
@@ -337,8 +337,8 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
 
     void *surface_caps_query_pnext = nullptr;
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-    auto full_screen_info_copy = vku::InitStruct<VkSurfaceFullScreenExclusiveInfoEXT>();
-    auto win32_full_screen_info_copy = vku::InitStruct<VkSurfaceFullScreenExclusiveWin32InfoEXT>();
+    VkSurfaceFullScreenExclusiveInfoEXT full_screen_info_copy = vku::InitStructHelper();
+    VkSurfaceFullScreenExclusiveWin32InfoEXT win32_full_screen_info_copy = vku::InitStructHelper();
     const auto *full_screen_info = vku::FindStructInPNextChain<VkSurfaceFullScreenExclusiveInfoEXT>(pCreateInfo->pNext);
     if (full_screen_info && full_screen_info->fullScreenExclusive == VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT) {
         full_screen_info_copy = *full_screen_info;
@@ -363,7 +363,7 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
         }
     }
 #endif
-    auto present_mode_info = vku::InitStruct<VkSurfacePresentModeEXT>();
+    VkSurfacePresentModeEXT present_mode_info = vku::InitStructHelper();
     if (IsExtEnabled(device_extensions.vk_ext_surface_maintenance1)) {
         present_mode_info.presentMode = pCreateInfo->presentMode;
         present_mode_info.pNext = surface_caps_query_pnext;

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -104,7 +104,7 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
             continue;
         }
 
-        auto object_name_info = vku::InitStruct<VkDebugUtilsObjectNameInfoEXT>();
+        VkDebugUtilsObjectNameInfoEXT object_name_info = vku::InitStructHelper();
         object_name_info.objectType = ConvertVulkanObjectToCoreObject(objects.object_list[i].type);
         object_name_info.objectHandle = objects.object_list[i].handle;
         object_name_info.pObjectName = nullptr;
@@ -142,7 +142,7 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
 
     const uint32_t message_id_number = text_vuid ? vvl_vuid_hash(text_vuid) : 0U;
 
-    auto callback_data = vku::InitStruct<VkDebugUtilsMessengerCallbackDataEXT>();
+    VkDebugUtilsMessengerCallbackDataEXT callback_data = vku::InitStructHelper();
     callback_data.flags = 0;
     callback_data.pMessageIdName = text_vuid;
     callback_data.messageIdNumber = vvl_bit_cast<int32_t>(message_id_number);

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -114,7 +114,7 @@ struct LoggingLabel {
     bool Empty() const { return name.empty(); }
 
     VkDebugUtilsLabelEXT Export() const {
-        auto out = vku::InitStruct<VkDebugUtilsLabelEXT>();
+        VkDebugUtilsLabelEXT out = vku::InitStructHelper();
         out.pLabelName = name.c_str();
         std::copy(color.cbegin(), color.cend(), out.color);
         return out;

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -699,7 +699,7 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
         vmaUnmapMemory(vmaAllocator, output_block.allocation);
     }
 
-    auto desc_writes = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet desc_writes = vku::InitStructHelper();
     const uint32_t desc_count = 1;
 
     // Write the descriptor

--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -70,7 +70,7 @@ VkResult UtilDescriptorSetManager::GetDescriptorSets(uint32_t count, VkDescripto
             VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
             pool_count * num_bindings_in_set,
         };
-        auto desc_pool_info = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+        VkDescriptorPoolCreateInfo desc_pool_info = vku::InitStructHelper();
         desc_pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
         desc_pool_info.maxSets = pool_count;
         desc_pool_info.poolSizeCount = 1;
@@ -301,7 +301,7 @@ void GpuAssistedBase::PreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDe
                 if (bda_features) {
                     bda_features->bufferDeviceAddress = VK_TRUE;
                 } else {
-                    auto new_bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
+                    VkPhysicalDeviceBufferDeviceAddressFeatures new_bda_features = vku::InitStructHelper();
                     new_bda_features.bufferDeviceAddress = VK_TRUE;
                     new_bda_features.pNext = const_cast<void *>(modified_create_info->pNext);
                     modified_create_info->pNext = new VkPhysicalDeviceBufferDeviceAddressFeatures(new_bda_features);
@@ -336,7 +336,7 @@ void GpuAssistedBase::PreCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDe
             if (bda_features) {
                 bda_features->bufferDeviceAddress = VK_TRUE;
             } else {
-                auto new_bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
+                VkPhysicalDeviceBufferDeviceAddressFeatures new_bda_features = vku::InitStructHelper();
                 new_bda_features.bufferDeviceAddress = VK_TRUE;
                 new_bda_features.pNext = const_cast<void *>(modified_create_info->pNext);
                 modified_create_info->pNext = new VkPhysicalDeviceBufferDeviceAddressFeatures(new_bda_features);
@@ -456,7 +456,7 @@ void gpu_utils_state::Queue::SubmitBarrier() {
     if (barrier_command_pool_ == VK_NULL_HANDLE) {
         VkResult result = VK_SUCCESS;
 
-        auto pool_create_info = vku::InitStruct<VkCommandPoolCreateInfo>();
+        VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
         pool_create_info.queueFamilyIndex = queueFamilyIndex;
         result = DispatchCreateCommandPool(state_.device, &pool_create_info, nullptr, &barrier_command_pool_);
         if (result != VK_SUCCESS) {
@@ -465,7 +465,7 @@ void gpu_utils_state::Queue::SubmitBarrier() {
             return;
         }
 
-        auto buffer_alloc_info = vku::InitStruct<VkCommandBufferAllocateInfo>();
+        VkCommandBufferAllocateInfo buffer_alloc_info = vku::InitStructHelper();
         buffer_alloc_info.commandPool = barrier_command_pool_;
         buffer_alloc_info.commandBufferCount = 1;
         buffer_alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -482,10 +482,10 @@ void gpu_utils_state::Queue::SubmitBarrier() {
         state_.vkSetDeviceLoaderData(state_.device, barrier_command_buffer_);
 
         // Record a global memory barrier to force availability of device memory operations to the host domain.
-        auto command_buffer_begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
+        VkCommandBufferBeginInfo command_buffer_begin_info = vku::InitStructHelper();
         result = DispatchBeginCommandBuffer(barrier_command_buffer_, &command_buffer_begin_info);
         if (result == VK_SUCCESS) {
-            auto memory_barrier = vku::InitStruct<VkMemoryBarrier>();
+            VkMemoryBarrier memory_barrier = vku::InitStructHelper();
             memory_barrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
             memory_barrier.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
             DispatchCmdPipelineBarrier(barrier_command_buffer_, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_HOST_BIT, 0,
@@ -494,7 +494,7 @@ void gpu_utils_state::Queue::SubmitBarrier() {
         }
     }
     if (barrier_command_buffer_ != VK_NULL_HANDLE) {
-        auto submit_info = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &barrier_command_buffer_;
         DispatchQueueSubmit(QUEUE_STATE::Queue(), 1, &submit_info, VK_NULL_HANDLE);
@@ -949,7 +949,7 @@ void GpuAssistedBase::PreCallRecordPipelineCreations(uint32_t count, const Creat
                 const auto &spirv_state = stage.spirv_state;
 
                 VkShaderModule shader_module;
-                auto create_info = vku::InitStruct<VkShaderModuleCreateInfo>();
+                VkShaderModuleCreateInfo create_info = vku::InitStructHelper();
                 create_info.pCode = spirv_state->words_.data();
                 create_info.codeSize = spirv_state->words_.size() * sizeof(uint32_t);
                 VkResult result = DispatchCreateShaderModule(device, &create_info, pAllocator, &shader_module);

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -173,7 +173,7 @@ void GpuAssisted::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
 
     const bool use_linear_output_pool = GpuGetOption("khronos_validation.vma_linear_output", true);
     if (use_linear_output_pool) {
-        auto output_buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo output_buffer_create_info = vku::InitStructHelper();
         output_buffer_create_info.size = output_buffer_size;
         output_buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
         VmaAllocationCreateInfo alloc_create_info = {};
@@ -307,7 +307,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
     VkBuffer vbo = VK_NULL_HANDLE;
     VmaAllocation vbo_allocation = VK_NULL_HANDLE;
     if (result == VK_SUCCESS) {
-        auto vbo_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo vbo_ci = vku::InitStructHelper();
         vbo_ci.size = sizeof(float) * 9;
         vbo_ci.usage = VK_BUFFER_USAGE_RAY_TRACING_BIT_NV;
 
@@ -336,7 +336,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
     VkBuffer ibo = VK_NULL_HANDLE;
     VmaAllocation ibo_allocation = VK_NULL_HANDLE;
     if (result == VK_SUCCESS) {
-        auto ibo_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo ibo_ci = vku::InitStructHelper();
         ibo_ci.size = sizeof(uint32_t) * 3;
         ibo_ci.usage = VK_BUFFER_USAGE_RAY_TRACING_BIT_NV;
 
@@ -362,7 +362,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
         }
     }
 
-    auto geometry = vku::InitStruct<VkGeometryNV>();
+    VkGeometryNV geometry = vku::InitStructHelper();
     geometry.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_NV;
     geometry.geometry.triangles = vku::InitStructHelper();
     geometry.geometry.triangles.vertexData = vbo;
@@ -378,7 +378,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
     geometry.geometry.triangles.transformOffset = 0;
     geometry.geometry.aabbs = vku::InitStructHelper();
 
-    auto as_ci = vku::InitStruct<VkAccelerationStructureCreateInfoNV>();
+    VkAccelerationStructureCreateInfoNV as_ci = vku::InitStructHelper();
     as_ci.info = vku::InitStructHelper();
     as_ci.info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV;
     as_ci.info.instanceCount = 0;
@@ -393,7 +393,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
 
     VkMemoryRequirements2 as_mem_requirements = {};
     if (result == VK_SUCCESS) {
-        auto as_mem_requirements_info = vku::InitStruct<VkAccelerationStructureMemoryRequirementsInfoNV>();
+        VkAccelerationStructureMemoryRequirementsInfoNV as_mem_requirements_info = vku::InitStructHelper();
         as_mem_requirements_info.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV;
         as_mem_requirements_info.accelerationStructure = as_validation_state.replacement_as;
 
@@ -414,7 +414,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
     }
 
     if (result == VK_SUCCESS) {
-        auto as_bind_info = vku::InitStruct<VkBindAccelerationStructureMemoryInfoNV>();
+        VkBindAccelerationStructureMemoryInfoNV as_bind_info = vku::InitStructHelper();
         as_bind_info.accelerationStructure = as_validation_state.replacement_as;
         as_bind_info.memory = as_memory_ai.deviceMemory;
         as_bind_info.memoryOffset = as_memory_ai.offset;
@@ -435,7 +435,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
 
     VkMemoryRequirements2 scratch_mem_requirements = {};
     if (result == VK_SUCCESS) {
-        auto scratch_mem_requirements_info = vku::InitStruct<VkAccelerationStructureMemoryRequirementsInfoNV>();
+        VkAccelerationStructureMemoryRequirementsInfoNV scratch_mem_requirements_info = vku::InitStructHelper();
         scratch_mem_requirements_info.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV;
         scratch_mem_requirements_info.accelerationStructure = as_validation_state.replacement_as;
 
@@ -445,7 +445,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
     VkBuffer scratch = VK_NULL_HANDLE;
     VmaAllocation scratch_allocation = {};
     if (result == VK_SUCCESS) {
-        auto scratch_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo scratch_ci = vku::InitStructHelper();
         scratch_ci.size = scratch_mem_requirements.memoryRequirements.size;
         scratch_ci.usage = VK_BUFFER_USAGE_RAY_TRACING_BIT_NV;
         VmaAllocationCreateInfo scratch_aci = {};
@@ -459,7 +459,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
 
     VkCommandPool command_pool = VK_NULL_HANDLE;
     if (result == VK_SUCCESS) {
-        auto command_pool_ci = vku::InitStruct<VkCommandPoolCreateInfo>();
+        VkCommandPoolCreateInfo command_pool_ci = vku::InitStructHelper();
         command_pool_ci.queueFamilyIndex = 0;
 
         result = DispatchCreateCommandPool(device, &command_pool_ci, nullptr, &command_pool);
@@ -471,7 +471,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
 
     if (result == VK_SUCCESS) {
-        auto command_buffer_ai = vku::InitStruct<VkCommandBufferAllocateInfo>();
+        VkCommandBufferAllocateInfo command_buffer_ai = vku::InitStructHelper();
         command_buffer_ai.commandPool = command_pool;
         command_buffer_ai.commandBufferCount = 1;
         command_buffer_ai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -486,7 +486,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
     }
 
     if (result == VK_SUCCESS) {
-        auto command_buffer_bi = vku::InitStruct<VkCommandBufferBeginInfo>();
+        VkCommandBufferBeginInfo command_buffer_bi = vku::InitStructHelper();
 
         result = DispatchBeginCommandBuffer(command_buffer, &command_buffer_bi);
         if (result != VK_SUCCESS) {
@@ -507,7 +507,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
         // Hook up queue dispatch
         vkSetDeviceLoaderData(device, queue);
 
-        auto submit_info = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &command_buffer;
         result = DispatchQueueSubmit(queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -542,7 +542,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
     }
 
     if (result == VK_SUCCESS) {
-        auto pipeline_layout_ci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+        VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
         pipeline_layout_ci.setLayoutCount = 1;
         pipeline_layout_ci.pSetLayouts = &debug_desc_layout;
         result = DispatchCreatePipelineLayout(device, &pipeline_layout_ci, 0, &as_validation_state.pipeline_layout);
@@ -553,7 +553,7 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
 
     VkShaderModule shader_module = VK_NULL_HANDLE;
     if (result == VK_SUCCESS) {
-        auto shader_module_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+        VkShaderModuleCreateInfo shader_module_ci = vku::InitStructHelper();
         shader_module_ci.codeSize = sizeof(gpu_as_inspection_comp);
         shader_module_ci.pCode = gpu_as_inspection_comp;
 
@@ -564,12 +564,12 @@ void GpuAssisted::CreateAccelerationStructureBuildValidationState(const VkDevice
     }
 
     if (result == VK_SUCCESS) {
-        auto pipeline_stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>();
+        VkPipelineShaderStageCreateInfo pipeline_stage_ci = vku::InitStructHelper();
         pipeline_stage_ci.stage = VK_SHADER_STAGE_COMPUTE_BIT;
         pipeline_stage_ci.module = shader_module;
         pipeline_stage_ci.pName = "main";
 
-        auto pipeline_ci = vku::InitStruct<VkComputePipelineCreateInfo>();
+        VkComputePipelineCreateInfo pipeline_ci = vku::InitStructHelper();
         pipeline_ci.stage = pipeline_stage_ci;
         pipeline_ci.layout = as_validation_state.pipeline_layout;
 
@@ -730,7 +730,7 @@ void GpuAssisted::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer c
         // Two uint for each current valid handle
         (8 * current_valid_handles.size());
 
-    auto validation_buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo validation_buffer_create_info = vku::InitStructHelper();
     validation_buffer_create_info.size = validation_buffer_size;
     validation_buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
@@ -814,7 +814,7 @@ void GpuAssisted::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer c
     DispatchUpdateDescriptorSets(device, 2, descriptor_set_writes, 0, nullptr);
 
     // Issue a memory barrier to make sure anything writing to the instance buffer has finished.
-    auto memory_barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier memory_barrier = vku::InitStructHelper();
     memory_barrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;
     memory_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
     DispatchCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 1,
@@ -832,7 +832,7 @@ void GpuAssisted::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer c
 
     // Issue a buffer memory barrier to make sure that any invalid bottom level acceleration structure handles
     // have been replaced by the validation compute shader before any builds take place.
-    auto instance_buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+    VkBufferMemoryBarrier instance_buffer_barrier = vku::InitStructHelper();
     instance_buffer_barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
     instance_buffer_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_NV;
     instance_buffer_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -1781,18 +1781,18 @@ VkPipeline GpuAssisted::GetValidationPipeline(VkRenderPass render_pass) {
     if (pipeline != VK_NULL_HANDLE) {
         return pipeline;
     }
-    auto pipeline_stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>();
+    VkPipelineShaderStageCreateInfo pipeline_stage_ci = vku::InitStructHelper();
     pipeline_stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
     pipeline_stage_ci.module = pre_draw_validation_state.shader_module;
     pipeline_stage_ci.pName = "main";
 
-    auto pipeline_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
-    auto vertex_input_state = vku::InitStruct<VkPipelineVertexInputStateCreateInfo>();
-    auto input_assembly_state = vku::InitStruct<VkPipelineInputAssemblyStateCreateInfo>();
+    VkGraphicsPipelineCreateInfo pipeline_ci = vku::InitStructHelper();
+    VkPipelineVertexInputStateCreateInfo vertex_input_state = vku::InitStructHelper();
+    VkPipelineInputAssemblyStateCreateInfo input_assembly_state = vku::InitStructHelper();
     input_assembly_state.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
-    auto rasterization_state = vku::InitStruct<VkPipelineRasterizationStateCreateInfo>();
+    VkPipelineRasterizationStateCreateInfo rasterization_state = vku::InitStructHelper();
     rasterization_state.rasterizerDiscardEnable = VK_TRUE;
-    auto color_blend_state = vku::InitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendStateCreateInfo color_blend_state = vku::InitStructHelper();
 
     pipeline_ci.pVertexInputState = &vertex_input_state;
     pipeline_ci.pInputAssemblyState = &input_assembly_state;
@@ -1852,7 +1852,7 @@ void GpuAssisted::AllocatePreDrawValidationResources(const GpuAssistedDeviceMemo
         }
 
         if (use_shader_objects) {
-            auto shader_ci = vku::InitStruct<VkShaderCreateInfoEXT>();
+            VkShaderCreateInfoEXT shader_ci = vku::InitStructHelper();
             shader_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
             shader_ci.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
             shader_ci.codeSize = sizeof(gpu_pre_draw_vert);
@@ -1869,7 +1869,7 @@ void GpuAssisted::AllocatePreDrawValidationResources(const GpuAssistedDeviceMemo
                 return;
             }
         } else {
-            auto shader_module_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+            VkShaderModuleCreateInfo shader_module_ci = vku::InitStructHelper();
             shader_module_ci.codeSize = sizeof(gpu_pre_draw_vert);
             shader_module_ci.pCode = gpu_pre_draw_vert;
             result = DispatchCreateShaderModule(device, &shader_module_ci, nullptr, &pre_draw_validation_state.shader_module);
@@ -1965,7 +1965,7 @@ void GpuAssisted::AllocatePreDispatchValidationResources(const GpuAssistedDevice
         }
 
         if (use_shader_objects) {
-            auto shader_ci = vku::InitStruct<VkShaderCreateInfoEXT>();
+            VkShaderCreateInfoEXT shader_ci = vku::InitStructHelper();
             shader_ci.stage = VK_SHADER_STAGE_COMPUTE_BIT;
             shader_ci.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
             shader_ci.codeSize = sizeof(gpu_pre_dispatch_comp);
@@ -1982,7 +1982,7 @@ void GpuAssisted::AllocatePreDispatchValidationResources(const GpuAssistedDevice
                 return;
             }
         } else {
-            auto shader_module_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+            VkShaderModuleCreateInfo shader_module_ci = vku::InitStructHelper();
             shader_module_ci.codeSize = sizeof(gpu_pre_dispatch_comp);
             shader_module_ci.pCode = gpu_pre_dispatch_comp;
             result = DispatchCreateShaderModule(device, &shader_module_ci, nullptr, &pre_dispatch_validation_state.shader_module);
@@ -1993,12 +1993,12 @@ void GpuAssisted::AllocatePreDispatchValidationResources(const GpuAssistedDevice
             }
 
             // Create pipeline
-            auto pipeline_stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>();
+            VkPipelineShaderStageCreateInfo pipeline_stage_ci = vku::InitStructHelper();
             pipeline_stage_ci.stage = VK_SHADER_STAGE_COMPUTE_BIT;
             pipeline_stage_ci.module = pre_dispatch_validation_state.shader_module;
             pipeline_stage_ci.pName = "main";
 
-            auto pipeline_ci = vku::InitStruct<VkComputePipelineCreateInfo>();
+            VkComputePipelineCreateInfo pipeline_ci = vku::InitStructHelper();
             pipeline_ci.stage = pipeline_stage_ci;
             pipeline_ci.layout = pre_dispatch_validation_state.pipeline_layout;
 

--- a/layers/gpu_validation/gv_descriptor_sets.cpp
+++ b/layers/gpu_validation/gv_descriptor_sets.cpp
@@ -114,7 +114,7 @@ std::shared_ptr<gpuav_state::DescriptorSet::State> gpuav_state::DescriptorSet::G
 
         written_index += binding->count;
     }
-    auto buffer_device_address_info = vku::InitStruct<VkBufferDeviceAddressInfo>();
+    VkBufferDeviceAddressInfo buffer_device_address_info = vku::InitStructHelper();
     buffer_device_address_info.buffer = next_state->buffer;
 
     // We cannot rely on device_extensions here, since we may be enabling BDA support even

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -122,12 +122,12 @@ static IMAGE_STATE::MemoryReqs GetMemoryRequirements(const ValidationStateTracke
             static const std::array<VkImageAspectFlagBits, 3> aspects{VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT,
                                                                       VK_IMAGE_ASPECT_PLANE_2_BIT};
             assert(plane_count <= aspects.size());
-            auto image_plane_req = vku::InitStruct<VkImagePlaneMemoryRequirementsInfo>();
-            auto mem_req_info2 = vku::InitStruct<VkImageMemoryRequirementsInfo2>(&image_plane_req);
+            VkImagePlaneMemoryRequirementsInfo image_plane_req = vku::InitStructHelper();
+            VkImageMemoryRequirementsInfo2 mem_req_info2 = vku::InitStructHelper(&image_plane_req);
             mem_req_info2.image = img;
 
             for (uint32_t i = 0; i < plane_count; i++) {
-                auto mem_reqs2 = vku::InitStruct<VkMemoryRequirements2>();
+                VkMemoryRequirements2 mem_reqs2 = vku::InitStructHelper();
 
                 image_plane_req.planeAspect = aspects[i];
                 switch (dev_data->device_extensions.vk_khr_get_memory_requirements2) {
@@ -511,7 +511,7 @@ bool IMAGE_VIEW_STATE::OverlapSubresource(const IMAGE_VIEW_STATE &compare_view) 
 }
 
 static safe_VkImageCreateInfo GetImageCreateInfo(const VkSwapchainCreateInfoKHR *pCreateInfo) {
-    auto image_ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
     // Pull out the format list only. This stack variable will get copied onto the heap
     // by the 'safe' constructor used to build the return value below.
     VkImageFormatListCreateInfo fmt_info;
@@ -781,7 +781,7 @@ vvl::span<const safe_VkSurfaceFormat2KHR> SURFACE_STATE::GetFormats(bool get_sur
             result.clear();
         } else {
             result.reserve(count);
-            auto format2 = vku::InitStruct<VkSurfaceFormat2KHR>();
+            VkSurfaceFormat2KHR format2 = vku::InitStructHelper();
             for (const auto &format : formats) {
                 format2.surfaceFormat = format;
                 result.emplace_back(safe_VkSurfaceFormat2KHR(&format2));
@@ -815,7 +815,7 @@ safe_VkSurfaceCapabilities2KHR SURFACE_STATE::GetCapabilities(bool get_surface_c
         }
     };
 
-    auto surface_caps2 = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkSurfaceCapabilities2KHR surface_caps2 = vku::InitStructHelper();
     if (get_surface_capabilities2) {
         const auto surface_info2 = GetSurfaceInfo2(surface_info2_pnext);
         if (const VkResult err = DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info2, &surface_caps2);
@@ -870,13 +870,13 @@ std::vector<VkPresentModeKHR> SURFACE_STATE::GetCompatibleModes(VkPhysicalDevice
 
     // Compatible modes not in state tracker, call to get compatible modes
     std::vector<VkPresentModeKHR> result;
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = surface();
-    auto surface_present_mode = vku::InitStruct<VkSurfacePresentModeEXT>();
+    VkSurfacePresentModeEXT surface_present_mode = vku::InitStructHelper();
     surface_present_mode.presentMode = present_mode;
     surface_info.pNext = &surface_present_mode;
-    auto present_mode_compatibility = vku::InitStruct<VkSurfacePresentModeCompatibilityEXT>();
-    auto surface_capabilities = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkSurfacePresentModeCompatibilityEXT present_mode_compatibility = vku::InitStructHelper();
+    VkSurfaceCapabilities2KHR surface_capabilities = vku::InitStructHelper();
     surface_capabilities.pNext = &present_mode_compatibility;
     DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_capabilities);
     result.resize(present_mode_compatibility.presentModeCount);
@@ -912,12 +912,12 @@ VkSurfaceCapabilitiesKHR SURFACE_STATE::GetPresentModeSurfaceCapabilities(VkPhys
     }
 
     // Present mode surface capabilties not in state tracker, call to get surface capabilities
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = surface();
-    auto surface_present_mode = vku::InitStruct<VkSurfacePresentModeEXT>();
+    VkSurfacePresentModeEXT surface_present_mode = vku::InitStructHelper();
     surface_present_mode.presentMode = present_mode;
     surface_info.pNext = &surface_present_mode;
-    auto surface_capabilities = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkSurfaceCapabilities2KHR surface_capabilities = vku::InitStructHelper();
     DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_capabilities);
     return surface_capabilities.surfaceCapabilities;
 }
@@ -935,13 +935,13 @@ VkSurfacePresentScalingCapabilitiesEXT SURFACE_STATE::GetPresentModeScalingCapab
     }
 
     // Present mode scaling capabilties not in state tracker, call to get scaling capabilities
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = surface();
-    auto surface_present_mode = vku::InitStruct<VkSurfacePresentModeEXT>();
+    VkSurfacePresentModeEXT surface_present_mode = vku::InitStructHelper();
     surface_present_mode.presentMode = present_mode;
     surface_info.pNext = &surface_present_mode;
-    auto scaling_caps = vku::InitStruct<VkSurfacePresentScalingCapabilitiesEXT>();
-    auto surface_capabilities = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkSurfacePresentScalingCapabilitiesEXT scaling_caps = vku::InitStructHelper();
+    VkSurfaceCapabilities2KHR surface_capabilities = vku::InitStructHelper();
     surface_capabilities.pNext = &scaling_caps;
     DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_capabilities);
     return scaling_caps;

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -406,7 +406,7 @@ class SURFACE_STATE : public BASE_NODE {
 
     VkSurfaceKHR surface() const { return handle_.Cast<VkSurfaceKHR>(); }
     VkPhysicalDeviceSurfaceInfo2KHR GetSurfaceInfo2(const void *surface_info2_pnext = nullptr) const {
-        auto surface_info2 = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+        VkPhysicalDeviceSurfaceInfo2KHR surface_info2 = vku::InitStructHelper();
         surface_info2.pNext = surface_info2_pnext;
         surface_info2.surface = surface();
         return surface_info2;

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -57,10 +57,10 @@ class ACCELERATION_STRUCTURE_STATE_NV : public BINDABLE {
   private:
     static VkMemoryRequirements GetMemReqs(VkDevice device, VkAccelerationStructureNV as,
                                            VkAccelerationStructureMemoryRequirementsTypeNV mem_type) {
-        auto req_info = vku::InitStruct<VkAccelerationStructureMemoryRequirementsInfoNV>();
+        VkAccelerationStructureMemoryRequirementsInfoNV req_info = vku::InitStructHelper();
         req_info.type = mem_type;
         req_info.accelerationStructure = as;
-        auto requirements = vku::InitStruct<VkMemoryRequirements2>();
+        VkMemoryRequirements2 requirements = vku::InitStructHelper();
         DispatchGetAccelerationStructureMemoryRequirementsNV(device, &req_info, &requirements);
         return requirements.memoryRequirements;
     }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -122,9 +122,9 @@ VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device
     // Add feature support according to Image Format Features (vkspec.html#resources-image-format-features)
     // if format is AHB external format then the features are already set
     if (has_format_feature2) {
-        auto fmt_drm_props = vku::InitStruct<VkDrmFormatModifierPropertiesList2EXT>();
+        VkDrmFormatModifierPropertiesList2EXT fmt_drm_props = vku::InitStructHelper();
         auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>(has_drm_modifiers ? &fmt_drm_props : nullptr);
-        auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
 
         DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
 
@@ -396,8 +396,8 @@ void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, con
 
     VkFormatFeatureFlags2KHR buffer_features;
     if (has_format_feature2) {
-        auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-        auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
         DispatchGetPhysicalDeviceFormatProperties2(physical_device, pCreateInfo->format, &fmt_props_2);
         buffer_features = fmt_props_3.bufferFeatures | fmt_props_2.formatProperties.bufferFeatures;
     } else {
@@ -432,11 +432,11 @@ void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, cons
     }
 
     // filter_cubic_props is used in CmdDraw validation. But it takes a lot of performance if it does in CmdDraw.
-    auto filter_cubic_props = vku::InitStruct<VkFilterCubicImageViewImageFormatPropertiesEXT>();
+    VkFilterCubicImageViewImageFormatPropertiesEXT filter_cubic_props = vku::InitStructHelper();
     if (IsExtEnabled(device_extensions.vk_ext_filter_cubic)) {
-        auto imageview_format_info = vku::InitStruct<VkPhysicalDeviceImageViewImageFormatInfoEXT>();
+        VkPhysicalDeviceImageViewImageFormatInfoEXT imageview_format_info = vku::InitStructHelper();
         imageview_format_info.imageViewType = pCreateInfo->viewType;
-        auto image_format_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&imageview_format_info);
+        VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper(&imageview_format_info);
         image_format_info.type = image_state->createInfo.imageType;
         image_format_info.format = image_state->createInfo.format;
         image_format_info.tiling = image_state->createInfo.tiling;
@@ -444,7 +444,7 @@ void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, cons
         image_format_info.usage = usage_create_info ? usage_create_info->usage : image_state->createInfo.usage;
         image_format_info.flags = image_state->createInfo.flags;
 
-        auto image_format_properties = vku::InitStruct<VkImageFormatProperties2>(&filter_cubic_props);
+        VkImageFormatProperties2 image_format_properties = vku::InitStructHelper(&filter_cubic_props);
 
         DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_format_properties);
     }
@@ -604,10 +604,10 @@ VkFormatFeatureFlags2KHR ValidationStateTracker::GetPotentialFormatFeatures(VkFo
 
     if (format != VK_FORMAT_UNDEFINED) {
         if (has_format_feature2) {
-            auto fmt_drm_props = vku::InitStruct<VkDrmFormatModifierPropertiesList2EXT>();
+            VkDrmFormatModifierPropertiesList2EXT fmt_drm_props = vku::InitStructHelper();
             auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>(
                 IsExtEnabled(device_extensions.vk_ext_image_drm_format_modifier) ? &fmt_drm_props : nullptr);
-            auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+            VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
 
             DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
 
@@ -634,8 +634,8 @@ VkFormatFeatureFlags2KHR ValidationStateTracker::GetPotentialFormatFeatures(VkFo
             format_features |= format_properties.optimalTilingFeatures;
 
             if (IsExtEnabled(device_extensions.vk_ext_image_drm_format_modifier)) {
-                auto fmt_drm_props = vku::InitStruct<VkDrmFormatModifierPropertiesListEXT>();
-                auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_drm_props);
+                VkDrmFormatModifierPropertiesListEXT fmt_drm_props = vku::InitStructHelper();
+                VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_drm_props);
 
                 DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
 
@@ -1486,14 +1486,14 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
         // Can ingnore VkPhysicalDeviceIDProperties as it has no validation purpose
 
         if (dev_ext.vk_khr_multiview) {
-            auto multiview_props = vku::InitStruct<VkPhysicalDeviceMultiviewProperties>();
+            VkPhysicalDeviceMultiviewProperties multiview_props = vku::InitStructHelper();
             GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_multiview, &multiview_props);
             phys_dev_props_core11.maxMultiviewViewCount = multiview_props.maxMultiviewViewCount;
             phys_dev_props_core11.maxMultiviewInstanceIndex = multiview_props.maxMultiviewInstanceIndex;
         }
 
         if (dev_ext.vk_khr_maintenance3) {
-            auto maintenance3_props = vku::InitStruct<VkPhysicalDeviceMaintenance3Properties>();
+            VkPhysicalDeviceMaintenance3Properties maintenance3_props = vku::InitStructHelper();
             GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_maintenance3, &maintenance3_props);
             phys_dev_props_core11.maxPerSetDescriptors = maintenance3_props.maxPerSetDescriptors;
             phys_dev_props_core11.maxMemoryAllocationSize = maintenance3_props.maxMemoryAllocationSize;
@@ -1501,9 +1501,9 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
 
         // Some 1.1 properties were added to core without previous extensions
         if (api_version >= VK_API_VERSION_1_1) {
-            auto subgroup_prop = vku::InitStruct<VkPhysicalDeviceSubgroupProperties>();
-            auto protected_memory_prop = vku::InitStruct<VkPhysicalDeviceProtectedMemoryProperties>(&subgroup_prop);
-            auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&protected_memory_prop);
+            VkPhysicalDeviceSubgroupProperties subgroup_prop = vku::InitStructHelper();
+            VkPhysicalDeviceProtectedMemoryProperties protected_memory_prop = vku::InitStructHelper(&subgroup_prop);
+            VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&protected_memory_prop);
             instance_dispatch_table.GetPhysicalDeviceProperties2(physical_device, &prop2);
 
             phys_dev_props_core11.subgroupSize = subgroup_prop.subgroupSize;
@@ -1519,7 +1519,7 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
         // Can ingnore VkPhysicalDeviceDriverProperties as it has no validation purpose
 
         if (dev_ext.vk_ext_descriptor_indexing) {
-            auto descriptor_indexing_prop = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingProperties>();
+            VkPhysicalDeviceDescriptorIndexingProperties descriptor_indexing_prop = vku::InitStructHelper();
             GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_descriptor_indexing, &descriptor_indexing_prop);
             phys_dev_props_core12.maxUpdateAfterBindDescriptorsInAllPools =
                 descriptor_indexing_prop.maxUpdateAfterBindDescriptorsInAllPools;
@@ -1568,7 +1568,7 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
         }
 
         if (dev_ext.vk_khr_depth_stencil_resolve) {
-            auto depth_stencil_resolve_props = vku::InitStruct<VkPhysicalDeviceDepthStencilResolveProperties>();
+            VkPhysicalDeviceDepthStencilResolveProperties depth_stencil_resolve_props = vku::InitStructHelper();
             GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_depth_stencil_resolve, &depth_stencil_resolve_props);
             phys_dev_props_core12.supportedDepthResolveModes = depth_stencil_resolve_props.supportedDepthResolveModes;
             phys_dev_props_core12.supportedStencilResolveModes = depth_stencil_resolve_props.supportedStencilResolveModes;
@@ -1577,14 +1577,14 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
         }
 
         if (dev_ext.vk_khr_timeline_semaphore) {
-            auto timeline_semaphore_props = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreProperties>();
+            VkPhysicalDeviceTimelineSemaphoreProperties timeline_semaphore_props = vku::InitStructHelper();
             GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_timeline_semaphore, &timeline_semaphore_props);
             phys_dev_props_core12.maxTimelineSemaphoreValueDifference =
                 timeline_semaphore_props.maxTimelineSemaphoreValueDifference;
         }
 
         if (dev_ext.vk_ext_sampler_filter_minmax) {
-            auto sampler_filter_minmax_props = vku::InitStruct<VkPhysicalDeviceSamplerFilterMinmaxProperties>();
+            VkPhysicalDeviceSamplerFilterMinmaxProperties sampler_filter_minmax_props = vku::InitStructHelper();
             GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_ext_sampler_filter_minmax, &sampler_filter_minmax_props);
             phys_dev_props_core12.filterMinmaxSingleComponentFormats =
                 sampler_filter_minmax_props.filterMinmaxSingleComponentFormats;
@@ -1592,7 +1592,7 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
         }
 
         if (dev_ext.vk_khr_shader_float_controls) {
-            auto float_controls_props = vku::InitStruct<VkPhysicalDeviceFloatControlsProperties>();
+            VkPhysicalDeviceFloatControlsProperties float_controls_props = vku::InitStructHelper();
             GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_khr_shader_float_controls, &float_controls_props);
             phys_dev_props_core12.denormBehaviorIndependence = float_controls_props.denormBehaviorIndependence;
             phys_dev_props_core12.roundingModeIndependence = float_controls_props.roundingModeIndependence;
@@ -1681,8 +1681,8 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
 
     if (IsExtEnabled(dev_ext.vk_nv_cooperative_matrix)) {
         // Get the needed cooperative_matrix properties
-        auto cooperative_matrix_props = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixPropertiesNV>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&cooperative_matrix_props);
+        VkPhysicalDeviceCooperativeMatrixPropertiesNV cooperative_matrix_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&cooperative_matrix_props);
         instance_dispatch_table.GetPhysicalDeviceProperties2KHR(physical_device, &prop2);
         phys_dev_ext_props.cooperative_matrix_props = cooperative_matrix_props;
 
@@ -1697,8 +1697,8 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
 
     if (IsExtEnabled(dev_ext.vk_khr_cooperative_matrix)) {
         // Get the needed KHR cooperative_matrix properties
-        auto cooperative_matrix_props_khr = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixPropertiesKHR>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&cooperative_matrix_props_khr);
+        VkPhysicalDeviceCooperativeMatrixPropertiesKHR cooperative_matrix_props_khr = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&cooperative_matrix_props_khr);
         instance_dispatch_table.GetPhysicalDeviceProperties2KHR(physical_device, &prop2);
         phys_dev_ext_props.cooperative_matrix_props_khr = cooperative_matrix_props_khr;
 
@@ -1731,7 +1731,7 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
                 VkQueue queue = VK_NULL_HANDLE;
                 // vkGetDeviceQueue2() was added in vulkan 1.1, and there was never a KHR version of it.
                 if (api_version >= VK_API_VERSION_1_1 && queue_info.flags != 0) {
-                    auto get_info = vku::InitStruct<VkDeviceQueueInfo2>();
+                    VkDeviceQueueInfo2 get_info = vku::InitStructHelper();
                     get_info.flags = queue_info.flags;
                     get_info.queueFamilyIndex = queue_info.queue_family_index;
                     get_info.queueIndex = i;
@@ -3033,7 +3033,7 @@ void ValidationStateTracker::PostCallRecordCreateAccelerationStructureKHR(VkDevi
                                                                           const RecordObject &record_obj) {
     if (VK_SUCCESS != record_obj.result) return;
     auto buffer_state = Get<BUFFER_STATE>(pCreateInfo->buffer);
-    auto as_address_info = vku::InitStruct<VkAccelerationStructureDeviceAddressInfoKHR>();
+    VkAccelerationStructureDeviceAddressInfoKHR as_address_info = vku::InitStructHelper();
     as_address_info.accelerationStructure = *pAccelerationStructure;
     const VkDeviceAddress as_address = DispatchGetAccelerationStructureDeviceAddressKHR(device, &as_address_info);
     Add(CreateAccelerationStructureState(*pAccelerationStructure, pCreateInfo, std::move(buffer_state), as_address));
@@ -3966,7 +3966,7 @@ void ValidationStateTracker::UpdateBindImageMemoryState(const VkBindImageMemoryI
 
 VkBindImageMemoryInfo ValidationStateTracker::ConvertImageMemoryInfo(VkDevice device, VkImage image, VkDeviceMemory mem,
                                                                      VkDeviceSize memoryOffset) {
-    auto bind_info = vku::InitStruct<VkBindImageMemoryInfo>();
+    VkBindImageMemoryInfo bind_info = vku::InitStructHelper();
     bind_info.image = image;
     bind_info.memory = mem;
     bind_info.memoryOffset = memoryOffset;
@@ -4073,7 +4073,7 @@ void ValidationStateTracker::PostCallRecordGetMemoryWin32HandleKHR(VkDevice devi
     if (const auto memory_state = Get<DEVICE_MEMORY_STATE>(pGetWin32HandleInfo->memory)) {
         // For validation purposes we need to keep allocation size and memory type index.
         // There is no need to keep pNext chain.
-        auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+        VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
         alloc_info.allocationSize = memory_state->alloc_info.allocationSize;
         alloc_info.memoryTypeIndex = memory_state->alloc_info.memoryTypeIndex;
 
@@ -4092,7 +4092,7 @@ void ValidationStateTracker::PostCallRecordGetMemoryFdKHR(VkDevice device, const
     if (const auto memory_state = Get<DEVICE_MEMORY_STATE>(pGetFdInfo->memory)) {
         // For validation purposes we need to keep allocation size and memory type index.
         // There is no need to keep pNext chain.
-        auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+        VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
         alloc_info.allocationSize = memory_state->alloc_info.allocationSize;
         alloc_info.memoryTypeIndex = memory_state->alloc_info.memoryTypeIndex;
 
@@ -4479,7 +4479,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesK
                                                                                    const RecordObject &record_obj) {
     if (VK_SUCCESS != record_obj.result) return;
     auto surface_state = Get<SURFACE_STATE>(surface);
-    auto caps2 = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkSurfaceCapabilities2KHR caps2 = vku::InitStructHelper();
     caps2.surfaceCapabilities = *pSurfaceCapabilities;
     surface_state->SetCapabilities(physicalDevice, safe_VkSurfaceCapabilities2KHR(&caps2));
 }
@@ -4531,7 +4531,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
         pSurfaceCapabilities->supportedTransforms,     pSurfaceCapabilities->currentTransform,
         pSurfaceCapabilities->supportedCompositeAlpha, pSurfaceCapabilities->supportedUsageFlags,
     };
-    auto caps2 = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkSurfaceCapabilities2KHR caps2 = vku::InitStructHelper();
     caps2.surfaceCapabilities = caps;
     surface_state->SetCapabilities(physicalDevice, safe_VkSurfaceCapabilities2KHR(&caps2));
 }

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1650,10 +1650,10 @@ class ValidationStateTracker : public ValidationObject {
                 *ext_prop = vku::InitStructHelper();
             }
             if (api_version < VK_API_VERSION_1_1) {
-                auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(ext_prop);
+                VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(ext_prop);
                 DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
             } else {
-                auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(ext_prop);
+                VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(ext_prop);
                 DispatchGetPhysicalDeviceProperties2(gpu, &prop2);
             }
         }
@@ -1664,10 +1664,10 @@ class ValidationStateTracker : public ValidationObject {
         assert(ext_prop);
         *ext_prop = vku::InitStructHelper();
         if (api_version < VK_API_VERSION_1_1) {
-            auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(ext_prop);
+            VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(ext_prop);
             DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
         } else {
-            auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(ext_prop);
+            VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(ext_prop);
             DispatchGetPhysicalDeviceProperties2(gpu, &prop2);
         }
     }
@@ -1683,7 +1683,7 @@ class ValidationStateTracker : public ValidationObject {
     inline std::shared_ptr<SHADER_MODULE_STATE> GetShaderModuleStateFromIdentifier(
         const VkPipelineShaderStageModuleIdentifierCreateInfoEXT& shader_stage_id) const {
         if (shader_stage_id.pIdentifier) {
-            auto shader_id = vku::InitStruct<VkShaderModuleIdentifierEXT>();
+            VkShaderModuleIdentifierEXT shader_id = vku::InitStructHelper();
             shader_id.identifierSize = shader_stage_id.identifierSize;
             const uint32_t copy_size = std::min(VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT, shader_stage_id.identifierSize);
             std::copy(shader_stage_id.pIdentifier, shader_stage_id.pIdentifier + copy_size, shader_id.identifier);

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -260,94 +260,94 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
 
     if (IsExtEnabled(device_extensions.vk_nv_shading_rate_image)) {
         // Get the needed shading rate image limits
-        auto shading_rate_image_props = vku::InitStruct<VkPhysicalDeviceShadingRateImagePropertiesNV>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&shading_rate_image_props);
+        VkPhysicalDeviceShadingRateImagePropertiesNV shading_rate_image_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&shading_rate_image_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.shading_rate_image_props = shading_rate_image_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_nv_mesh_shader)) {
         // Get the needed mesh shader limits
-        auto mesh_shader_props = vku::InitStruct<VkPhysicalDeviceMeshShaderPropertiesNV>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&mesh_shader_props);
+        VkPhysicalDeviceMeshShaderPropertiesNV mesh_shader_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&mesh_shader_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.mesh_shader_props_nv = mesh_shader_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_ext_mesh_shader)) {
         // Get the needed mesh shader EXT limits
-        auto mesh_shader_props_ext = vku::InitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&mesh_shader_props_ext);
+        VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_props_ext = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&mesh_shader_props_ext);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.mesh_shader_props_ext = mesh_shader_props_ext;
     }
 
     if (IsExtEnabled(device_extensions.vk_nv_ray_tracing)) {
         // Get the needed ray tracing limits
-        auto ray_tracing_props = vku::InitStruct<VkPhysicalDeviceRayTracingPropertiesNV>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&ray_tracing_props);
+        VkPhysicalDeviceRayTracingPropertiesNV ray_tracing_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&ray_tracing_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.ray_tracing_props_nv = ray_tracing_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_khr_ray_tracing_pipeline)) {
         // Get the needed ray tracing limits
-        auto ray_tracing_props = vku::InitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&ray_tracing_props);
+        VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&ray_tracing_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.ray_tracing_props_khr = ray_tracing_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_khr_acceleration_structure)) {
         // Get the needed ray tracing acc structure limits
-        auto acc_structure_props = vku::InitStruct<VkPhysicalDeviceAccelerationStructurePropertiesKHR>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&acc_structure_props);
+        VkPhysicalDeviceAccelerationStructurePropertiesKHR acc_structure_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&acc_structure_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.acc_structure_props = acc_structure_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_ext_transform_feedback)) {
         // Get the needed transform feedback limits
-        auto transform_feedback_props = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&transform_feedback_props);
+        VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&transform_feedback_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.transform_feedback_props = transform_feedback_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_ext_vertex_attribute_divisor)) {
         // Get the needed vertex attribute divisor limits
-        auto vertex_attribute_divisor_props = vku::InitStruct<VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&vertex_attribute_divisor_props);
+        VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT vertex_attribute_divisor_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&vertex_attribute_divisor_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.vertex_attribute_divisor_props = vertex_attribute_divisor_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_ext_blend_operation_advanced)) {
         // Get the needed blend operation advanced properties
-        auto blend_operation_advanced_props = vku::InitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&blend_operation_advanced_props);
+        VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&blend_operation_advanced_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.blend_operation_advanced_props = blend_operation_advanced_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_khr_maintenance4)) {
         // Get the needed maintenance4 properties
-        auto maintance4_props = vku::InitStruct<VkPhysicalDeviceMaintenance4PropertiesKHR>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&maintance4_props);
+        VkPhysicalDeviceMaintenance4PropertiesKHR maintance4_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&maintance4_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.maintenance4_props = maintance4_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_khr_fragment_shading_rate)) {
-        auto fragment_shading_rate_props = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&fragment_shading_rate_props);
+        VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&fragment_shading_rate_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.fragment_shading_rate_props = fragment_shading_rate_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_khr_depth_stencil_resolve)) {
-        auto depth_stencil_resolve_props = vku::InitStruct<VkPhysicalDeviceDepthStencilResolveProperties>();
-        auto prop2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&depth_stencil_resolve_props);
+        VkPhysicalDeviceDepthStencilResolveProperties depth_stencil_resolve_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&depth_stencil_resolve_props);
         GetPhysicalDeviceProperties2(physicalDevice, prop2);
         phys_dev_ext_props.depth_stencil_resolve_props = depth_stencil_resolve_props;
     }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -4768,7 +4768,7 @@ bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const
 bool SyncValidator::PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                       VkSubpassContents contents, const ErrorObject &error_obj) const {
     bool skip = StateTracker::PreCallValidateCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, error_obj);
-    auto subpass_begin_info = vku::InitStruct<VkSubpassBeginInfo>();
+    VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
     subpass_begin_info.contents = contents;
     skip |= ValidateBeginRenderPass(commandBuffer, pRenderPassBegin, &subpass_begin_info, error_obj);
     return skip;
@@ -4811,7 +4811,7 @@ void SyncValidator::RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, cons
 void SyncValidator::PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                      VkSubpassContents contents, const RecordObject &record_obj) {
     StateTracker::PostCallRecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, record_obj);
-    auto subpass_begin_info = vku::InitStruct<VkSubpassBeginInfo>();
+    VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
     subpass_begin_info.contents = contents;
     RecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin, &subpass_begin_info, record_obj.location.function);
 }
@@ -4846,9 +4846,9 @@ bool SyncValidator::PreCallValidateCmdNextSubpass(VkCommandBuffer commandBuffer,
                                                   const ErrorObject &error_obj) const {
     bool skip = StateTracker::PreCallValidateCmdNextSubpass(commandBuffer, contents, error_obj);
     // Convert to a NextSubpass2
-    auto subpass_begin_info = vku::InitStruct<VkSubpassBeginInfo>();
+    VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
     subpass_begin_info.contents = contents;
-    auto subpass_end_info = vku::InitStruct<VkSubpassEndInfo>();
+    VkSubpassEndInfo subpass_end_info = vku::InitStructHelper();
     skip |= ValidateCmdNextSubpass(commandBuffer, &subpass_begin_info, &subpass_end_info, error_obj);
     return skip;
 }
@@ -4878,7 +4878,7 @@ void SyncValidator::RecordCmdNextSubpass(VkCommandBuffer commandBuffer, const Vk
 void SyncValidator::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
                                                  const RecordObject &record_obj) {
     StateTracker::PostCallRecordCmdNextSubpass(commandBuffer, contents, record_obj);
-    auto subpass_begin_info = vku::InitStruct<VkSubpassBeginInfo>();
+    VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
     subpass_begin_info.contents = contents;
     RecordCmdNextSubpass(commandBuffer, &subpass_begin_info, nullptr, record_obj.location.function);
 }
@@ -8625,20 +8625,20 @@ SignaledSemaphores::Signal::Signal(const std::shared_ptr<const SEMAPHORE_STATE> 
 FenceSyncState::FenceSyncState() : fence(), tag(kInvalidTag), queue_id(QueueSyncState::kQueueIdInvalid) {}
 
 VkSemaphoreSubmitInfo SubmitInfoConverter::BatchStore::WaitSemaphore(const VkSubmitInfo &info, uint32_t index) {
-    auto semaphore_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+    VkSemaphoreSubmitInfo semaphore_info = vku::InitStructHelper();
     semaphore_info.semaphore = info.pWaitSemaphores[index];
     semaphore_info.stageMask = info.pWaitDstStageMask[index];
     return semaphore_info;
 }
 VkCommandBufferSubmitInfo SubmitInfoConverter::BatchStore::CommandBuffer(const VkSubmitInfo &info, uint32_t index) {
-    auto cb_info = vku::InitStruct<VkCommandBufferSubmitInfo>();
+    VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = info.pCommandBuffers[index];
     return cb_info;
 }
 
 VkSemaphoreSubmitInfo SubmitInfoConverter::BatchStore::SignalSemaphore(const VkSubmitInfo &info, uint32_t index,
                                                                        VkQueueFlags queue_flags) {
-    auto semaphore_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+    VkSemaphoreSubmitInfo semaphore_info = vku::InitStructHelper();
     semaphore_info.semaphore = info.pSignalSemaphores[index];
     // Can't just use BOTTOM, because of how access expansion is done
     semaphore_info.stageMask =

--- a/layers/utils/convert_utils.cpp
+++ b/layers/utils/convert_utils.cpp
@@ -225,7 +225,7 @@ safe_VkRenderPassCreateInfo2 ConvertVkRenderPassCreateInfoToV2KHR(const VkRender
 
 safe_VkImageMemoryBarrier2 ConvertVkImageMemoryBarrierToV2(const VkImageMemoryBarrier& barrier, VkPipelineStageFlags2 srcStageMask,
                                                            VkPipelineStageFlags2 dstStageMask) {
-    auto barrier2 = vku::InitStruct<VkImageMemoryBarrier2>();
+    VkImageMemoryBarrier2 barrier2 = vku::InitStructHelper();
 
     // As of Vulkan 1.3.153, the VkImageMemoryBarrier2 supports the same pNext structs as VkImageMemoryBarrier
     // (VkExternalMemoryAcquireUnmodifiedEXT and VkSampleLocationsInfoEXT). It means we can copy entire pNext

--- a/layers/utils/ray_tracing_utils.cpp
+++ b/layers/utils/ray_tracing_utils.cpp
@@ -30,7 +30,7 @@ VkDeviceSize ComputeScratchSize(const VkDevice device, const VkAccelerationStruc
     for (uint32_t build_range_i = 0; build_range_i < build_info.geometryCount; build_range_i++) {
         primitive_counts[build_range_i] = range_infos[build_range_i].primitiveCount;
     }
-    auto size_info = vku::InitStruct<VkAccelerationStructureBuildSizesInfoKHR>();
+    VkAccelerationStructureBuildSizesInfoKHR size_info = vku::InitStructHelper();
     DispatchGetAccelerationStructureBuildSizesKHR(device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &build_info,
                                                   primitive_counts.data(), &size_info);
     switch (build_info.mode) {

--- a/layers/utils/vk_layer_utils.cpp
+++ b/layers/utils/vk_layer_utils.cpp
@@ -114,7 +114,7 @@ void layer_debug_messenger_actions(debug_report_data *report_data, const char *l
     // Flag as default if these settings are not from a vk_layer_settings.txt file
     const bool default_layer_callback = (debug_action & VK_DBG_LAYER_ACTION_DEFAULT) != 0;
 
-    auto dbg_create_info = vku::InitStruct<VkDebugUtilsMessengerCreateInfoEXT>();
+    VkDebugUtilsMessengerCreateInfoEXT dbg_create_info = vku::InitStructHelper();
     dbg_create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
     if (report_flags & kErrorBit) {
         dbg_create_info.messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -487,7 +487,7 @@ void DeviceMemory::unmap() const { vk::UnmapMemory(device(), handle()); }
 
 VkMemoryAllocateInfo DeviceMemory::get_resource_alloc_info(const Device &dev, const VkMemoryRequirements &reqs,
                                                            VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
-    auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>(alloc_info_pnext);
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(alloc_info_pnext);
     alloc_info.allocationSize = reqs.size;
     EXPECT(dev.phy().set_memory_type(reqs.memoryTypeBits, &alloc_info, mem_props));
     return alloc_info;
@@ -509,14 +509,14 @@ VkResult Fence::reset() {
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 VkResult Fence::export_handle(HANDLE &win32_handle, VkExternalFenceHandleTypeFlagBits handle_type) {
-    auto ghi = vku::InitStruct<VkFenceGetWin32HandleInfoKHR>();
+    VkFenceGetWin32HandleInfoKHR ghi = vku::InitStructHelper();
     ghi.fence = handle();
     ghi.handleType = handle_type;
     return vk::GetFenceWin32HandleKHR(device(), &ghi, &win32_handle);
 }
 
 VkResult Fence::import_handle(HANDLE win32_handle, VkExternalFenceHandleTypeFlagBits handle_type, VkFenceImportFlags flags) {
-    auto ifi = vku::InitStruct<VkImportFenceWin32HandleInfoKHR>();
+    VkImportFenceWin32HandleInfoKHR ifi = vku::InitStructHelper();
     ifi.fence = handle();
     ifi.handleType = handle_type;
     ifi.handle = win32_handle;
@@ -526,14 +526,14 @@ VkResult Fence::import_handle(HANDLE win32_handle, VkExternalFenceHandleTypeFlag
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 VkResult Fence::export_handle(int &fd_handle, VkExternalFenceHandleTypeFlagBits handle_type) {
-    auto gfi = vku::InitStruct<VkFenceGetFdInfoKHR>();
+    VkFenceGetFdInfoKHR gfi = vku::InitStructHelper();
     gfi.fence = handle();
     gfi.handleType = handle_type;
     return vk::GetFenceFdKHR(device(), &gfi, &fd_handle);
 }
 
 VkResult Fence::import_handle(int fd_handle, VkExternalFenceHandleTypeFlagBits handle_type, VkFenceImportFlags flags) {
-    auto ifi = vku::InitStruct<VkImportFenceFdInfoKHR>();
+    VkImportFenceFdInfoKHR ifi = vku::InitStructHelper();
     ifi.fence = handle();
     ifi.handleType = handle_type;
     ifi.fd = fd_handle;
@@ -550,7 +550,7 @@ void Semaphore::init(const Device &dev, const VkSemaphoreCreateInfo &info) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 VkResult Semaphore::export_handle(HANDLE &win32_handle, VkExternalSemaphoreHandleTypeFlagBits handle_type) {
     win32_handle = nullptr;
-    auto ghi = vku::InitStruct<VkSemaphoreGetWin32HandleInfoKHR>();
+    VkSemaphoreGetWin32HandleInfoKHR ghi = vku::InitStructHelper();
     ghi.semaphore = handle();
     ghi.handleType = handle_type;
     return vk::GetSemaphoreWin32HandleKHR(device(), &ghi, &win32_handle);
@@ -558,7 +558,7 @@ VkResult Semaphore::export_handle(HANDLE &win32_handle, VkExternalSemaphoreHandl
 
 VkResult Semaphore::import_handle(HANDLE win32_handle, VkExternalSemaphoreHandleTypeFlagBits handle_type,
                                   VkSemaphoreImportFlags flags) {
-    auto ihi = vku::InitStruct<VkImportSemaphoreWin32HandleInfoKHR>();
+    VkImportSemaphoreWin32HandleInfoKHR ihi = vku::InitStructHelper();
     ihi.semaphore = handle();
     ihi.handleType = handle_type;
     ihi.handle = win32_handle;
@@ -569,7 +569,7 @@ VkResult Semaphore::import_handle(HANDLE win32_handle, VkExternalSemaphoreHandle
 
 VkResult Semaphore::export_handle(int &fd_handle, VkExternalSemaphoreHandleTypeFlagBits handle_type) {
     fd_handle = -1;
-    auto ghi = vku::InitStruct<VkSemaphoreGetFdInfoKHR>();
+    VkSemaphoreGetFdInfoKHR ghi = vku::InitStructHelper();
     ghi.semaphore = handle();
     ghi.handleType = handle_type;
     return vk::GetSemaphoreFdKHR(device(), &ghi, &fd_handle);
@@ -577,7 +577,7 @@ VkResult Semaphore::export_handle(int &fd_handle, VkExternalSemaphoreHandleTypeF
 
 VkResult Semaphore::import_handle(int fd_handle, VkExternalSemaphoreHandleTypeFlagBits handle_type, VkSemaphoreImportFlags flags) {
     // Import opaque handle exported above
-    auto ihi = vku::InitStruct<VkImportSemaphoreFdInfoKHR>();
+    VkImportSemaphoreFdInfoKHR ihi = vku::InitStructHelper();
     ihi.semaphore = handle();
     ihi.handleType = handle_type;
     ihi.fd = fd_handle;
@@ -661,7 +661,7 @@ void Buffer::bind_memory(const DeviceMemory &mem, VkDeviceSize mem_offset) {
 }
 
 VkDeviceAddress Buffer::address(APIVersion vk_api_version /*= VK_API_VERSION_1_2*/) const {
-    auto bdai = vku::InitStruct<VkBufferDeviceAddressInfo>();
+    VkBufferDeviceAddressInfo bdai = vku::InitStructHelper();
     bdai.buffer = handle();
     if (vk_api_version < VK_API_VERSION_1_2) {
         const auto vkGetBufferDeviceAddressKHR =
@@ -863,7 +863,7 @@ vkt::Buffer AccelerationStructure::create_scratch_buffer(const Device &device, V
         if (buffer_device_address) create_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     }
 
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     void *pNext = nullptr;
     if (buffer_device_address) {
         alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
@@ -1164,7 +1164,7 @@ VkSamplerYcbcrConversionInfo SamplerYcbcrConversion::ConversionInfo() {
 
 // static
 VkSamplerYcbcrConversionCreateInfo SamplerYcbcrConversion::DefaultConversionInfo(VkFormat format) {
-    auto ycbcr_create_info = vku::InitStruct<VkSamplerYcbcrConversionCreateInfo>();
+    VkSamplerYcbcrConversionCreateInfo ycbcr_create_info = vku::InitStructHelper();
     ycbcr_create_info.format = format;
     ycbcr_create_info.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
     ycbcr_create_info.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL;

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1233,7 +1233,7 @@ struct GraphicsPipelineFromLibraries {
 
     GraphicsPipelineFromLibraries(const Device &dev, vvl::span<VkPipeline> libs, VkPipelineLayout layout)
         : GraphicsPipelineFromLibraries(libs) {
-        auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+        VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
         exe_pipe_ci.layout = layout;
         pipe.init(dev, exe_pipe_ci);
         pipe.initialized();

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -327,7 +327,7 @@ void ValidOwnershipTransfer(ErrorMonitor *monitor, VkCommandBufferObj *cb_from, 
 void ValidOwnershipTransferOp(ErrorMonitor *monitor, VkCommandBufferObj *cb, const VkBufferMemoryBarrier2KHR *buf_barrier,
                               const VkImageMemoryBarrier2KHR *img_barrier) {
     cb->begin();
-    auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dep_info = vku::InitStructHelper();
     dep_info.bufferMemoryBarrierCount = (buf_barrier) ? 1 : 0;
     dep_info.pBufferMemoryBarriers = buf_barrier;
     dep_info.imageMemoryBarrierCount = (img_barrier) ? 1 : 0;
@@ -399,8 +399,8 @@ VkFormat FindFormatWithoutFeatures2(VkPhysicalDevice gpu, VkImageTiling tiling, 
     const VkFormat first_vk_format = VK_FORMAT_R4G4_UNORM_PACK8;
     VkFormat return_format = VK_FORMAT_UNDEFINED;
     for (VkFormat format = first_vk_format; format < first_compressed_format; format = static_cast<VkFormat>(format + 1)) {
-        auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-        auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
         vk::GetPhysicalDeviceFormatProperties2(gpu, format, &fmt_props_2);
         auto features = (tiling == VK_IMAGE_TILING_LINEAR) ? fmt_props_3.linearTilingFeatures : fmt_props_3.optimalTilingFeatures;
         if ((features & undesired_features) == 0) {
@@ -416,9 +416,9 @@ bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkExternalSemaphoreHan
     constexpr auto export_import_flags =
         VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR | VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR;
 
-    auto info = vku::InitStruct<VkPhysicalDeviceExternalSemaphoreInfo>();
+    VkPhysicalDeviceExternalSemaphoreInfo info = vku::InitStructHelper();
     info.handleType = handle_type;
-    auto properties = vku::InitStruct<VkExternalSemaphoreProperties>();
+    VkExternalSemaphoreProperties properties = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu, &info, &properties);
     return (properties.externalSemaphoreFeatures & export_import_flags) == export_import_flags;
 }
@@ -825,8 +825,8 @@ bool VkLayerTest::IsDriver(VkDriverId driver_id) {
     if (VkRenderFramework::IgnoreDisableChecks()) {
         return false;
     } else {
-        auto driver_properties = vku::InitStruct<VkPhysicalDeviceDriverProperties>();
-        auto physical_device_properties2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&driver_properties);
+        VkPhysicalDeviceDriverProperties driver_properties = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 physical_device_properties2 = vku::InitStructHelper(&driver_properties);
         GetPhysicalDeviceProperties2(physical_device_properties2);
         return (driver_properties.driverID == driver_id);
     }
@@ -1423,7 +1423,7 @@ void Barrier2QueueFamilyTestHelper::operator()(const std::string &img_err, const
     buffer_barrier_.srcQueueFamilyIndex = src;
     buffer_barrier_.dstQueueFamilyIndex = dst;
 
-    auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dep_info = vku::InitStructHelper();
     dep_info.bufferMemoryBarrierCount = 1;
     dep_info.pBufferMemoryBarriers = &buffer_barrier_;
     dep_info.imageMemoryBarrierCount = 1;

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -182,13 +182,13 @@ class VkLayerTest : public VkLayerTestBase {
 
     template <typename Features>
     VkPhysicalDeviceFeatures2 GetPhysicalDeviceFeatures2(Features &feature_query) {
-        auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2>(&feature_query);
+        VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&feature_query);
         return GetPhysicalDeviceFeatures2(features2);
     }
 
     template <typename Properties>
     VkPhysicalDeviceProperties2 GetPhysicalDeviceProperties2(Properties &props_query) {
-        auto props2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&props_query);
+        VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&props_query);
         return GetPhysicalDeviceProperties2(props2);
     }
 

--- a/tests/framework/pipeline_helper.cpp
+++ b/tests/framework/pipeline_helper.cpp
@@ -504,7 +504,7 @@ void RayTracingPipelineHelper::InitKHRRayTracingPipelineInfo(VkPipelineCreateFla
 
 void RayTracingPipelineHelper::AddLibrary(const RayTracingPipelineHelper &library) {
     libraries_.emplace_back(library.pipeline_);
-    rp_library_ci_ = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    rp_library_ci_ = vku::InitStructHelper();
     rp_library_ci_.libraryCount = size32(libraries_);
     rp_library_ci_.pLibraries = libraries_.data();
     rp_ci_KHR_.pLibraryInfo = &rp_library_ci_;
@@ -532,9 +532,9 @@ void RayTracingPipelineHelper::InitLibraryInfoKHR(VkPipelineCreateFlags flags) {
     InitPipelineLayoutInfo();
     InitShaderInfoKHR();
     InitKHRRayTracingPipelineInfo(VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | flags);
-    auto ray_tracing_pipeline_props = vku::InitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
+    VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_pipeline_props = vku::InitStructHelper();
     layer_test_.GetPhysicalDeviceProperties2(ray_tracing_pipeline_props);
-    rp_i_ci_ = vku::InitStruct<VkRayTracingPipelineInterfaceCreateInfoKHR>();
+    rp_i_ci_ = vku::InitStructHelper();
     rp_i_ci_->maxPipelineRayPayloadSize = sizeof(float);  // Set according to payload defined in kRayGenShaderText
     rp_i_ci_->maxPipelineRayHitAttributeSize = ray_tracing_pipeline_props.maxRayHitAttributeSize;
     rp_ci_KHR_.pLibraryInterface = &rp_i_ci_.value();

--- a/tests/framework/ray_tracing_nv.cpp
+++ b/tests/framework/ray_tracing_nv.cpp
@@ -18,7 +18,7 @@ void GetSimpleGeometryForAccelerationStructureTests(const vkt::Device &device, v
                                                     VkGeometryNV *geometry, VkDeviceSize offset, bool buffer_device_address) {
     VkBufferUsageFlags usage =
         VK_BUFFER_USAGE_RAY_TRACING_BIT_NV | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR;
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     void *alloc_pnext = nullptr;
     if (buffer_device_address) {
         usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -133,7 +133,7 @@ GeometryKHR &GeometryKHR::SetInstanceDeviceAccelStructRef(const vkt::Device &dev
     auto vkGetAccelerationStructureDeviceAddressKHR = reinterpret_cast<PFN_vkGetAccelerationStructureDeviceAddressKHR>(
         vk::GetDeviceProcAddr(device.handle(), "vkGetAccelerationStructureDeviceAddressKHR"));
     assert(vkGetAccelerationStructureDeviceAddressKHR);
-    auto as_address_info = vku::InitStruct<VkAccelerationStructureDeviceAddressInfoKHR>();
+    VkAccelerationStructureDeviceAddressInfoKHR as_address_info = vku::InitStructHelper();
     as_address_info.accelerationStructure = bottom_level_as;
     VkDeviceAddress as_address = vkGetAccelerationStructureDeviceAddressKHR(device.handle(), &as_address_info);
     instance_.vk_instance = std::make_unique<VkAccelerationStructureInstanceKHR>();
@@ -142,7 +142,7 @@ GeometryKHR &GeometryKHR::SetInstanceDeviceAccelStructRef(const vkt::Device &dev
 
     // Create instance buffer. Do not copy instance_.vk_instance into it, for now no point in doing it for the test framework
     assert(!instance_.buffer.initialized());  // for now, do not handle already initialized buffer
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     instance_.buffer.init(
         device, sizeof(VkAccelerationStructureInstanceKHR),
@@ -238,9 +238,9 @@ void AccelerationStructureKHR::Build(const vkt::Device &device) {
 
     // Create a buffer to store acceleration structure
     if (!device_buffer_.initialized() && (buffer_usage_flags_ != 0)) {
-        auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+        VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
         alloc_flags.flags = buffer_memory_allocate_flags_;
-        auto ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo ci = vku::InitStructHelper();
         ci.size = vk_info_.size;
         ci.usage = buffer_usage_flags_;
         if (buffer_init_no_mem_) {
@@ -491,7 +491,7 @@ VkAccelerationStructureBuildSizesInfoKHR BuildGeometryInfoKHR::GetSizeInfo(VkDev
     }
 
     // Get VkAccelerationStructureBuildSizesInfoKHR using this->vk_info_
-    auto size_info = vku::InitStruct<VkAccelerationStructureBuildSizesInfoKHR>();
+    VkAccelerationStructureBuildSizesInfoKHR size_info = vku::InitStructHelper();
     vk::GetAccelerationStructureBuildSizesKHR(device, VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &vk_info_, &primitives_count,
                                               &size_info);
 
@@ -529,13 +529,13 @@ void BuildGeometryInfoKHR::BuildCommon(const vkt::Device &device, bool is_on_dev
         // Allocate device local scratch buffer
 
         // Get minAccelerationStructureScratchOffsetAlignment
-        auto as_props = vku::InitStruct<VkPhysicalDeviceAccelerationStructurePropertiesKHR>();
-        auto phys_dev_props = vku::InitStruct<VkPhysicalDeviceProperties2>(&as_props);
+        VkPhysicalDeviceAccelerationStructurePropertiesKHR as_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 phys_dev_props = vku::InitStructHelper(&as_props);
         vk::GetPhysicalDeviceProperties2(device.phy(), &phys_dev_props);
 
         assert(device_scratch_);  // So far null pointers are not supported
         if (!device_scratch_->initialized()) {
-            auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+            VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
             alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
 
             if (scratch_size > 0) {
@@ -632,7 +632,7 @@ GeometryKHR GeometrySimpleOnDeviceTriangleInfo(APIVersion vk_api_version, const 
     triangle_geometry.SetType(GeometryKHR::Type::Triangle);
 
     // Allocate vertex and index buffers
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     const VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
                                             VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR |
@@ -696,7 +696,7 @@ GeometryKHR GeometrySimpleOnDeviceAABBInfo(APIVersion vk_api_version, const vkt:
 
     const VkDeviceSize aabb_buffer_size = sizeof(aabbs[0]) * aabbs.size();
     vkt::Buffer aabb_buffer;
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     const VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
                                             VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR |

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -143,7 +143,7 @@ bool VkRenderFramework::DeviceExtensionSupported(const char *extension_name, con
 }
 
 VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
-    auto info = vku::InitStruct<VkInstanceCreateInfo>();
+    VkInstanceCreateInfo info = vku::InitStructHelper();
     info.pNext = m_errorMonitor->GetDebugCreateInfo();
 #if defined(VK_USE_PLATFORM_METAL_EXT)
     info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
@@ -306,8 +306,8 @@ void VkRenderFramework::InitFramework(void * /*unused compatibility parameter*/,
     m_errorMonitor->CreateCallback(instance_);
 
     if (print_driver_info && !driver_printed) {
-        auto driver_properties = vku::InitStruct<VkPhysicalDeviceDriverProperties>();
-        auto physical_device_properties2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&driver_properties);
+        VkPhysicalDeviceDriverProperties driver_properties = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 physical_device_properties2 = vku::InitStructHelper(&driver_properties);
         vk::GetPhysicalDeviceProperties2(gpu_, &physical_device_properties2);
         printf("Driver Name = %s\n", driver_properties.driverName);
         printf("Driver Info = %s\n", driver_properties.driverInfo);
@@ -636,7 +636,7 @@ bool VkRenderFramework::CreateSurface(SurfaceContext &surface_context, VkSurface
             surface_context.m_surface_window = XCreateSimpleWindow(
                 surface_context.m_surface_dpy, RootWindow(surface_context.m_surface_dpy, s), 0, 0, (int)m_width, (int)m_height, 1,
                 BlackPixel(surface_context.m_surface_dpy, s), WhitePixel(surface_context.m_surface_dpy, s));
-            auto surface_create_info = vku::InitStruct<VkXlibSurfaceCreateInfoKHR>();
+            VkXlibSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
             surface_create_info.dpy = surface_context.m_surface_dpy;
             surface_create_info.window = surface_context.m_surface_window;
             return VK_SUCCESS == vk::CreateXlibSurfaceKHR(instance(), &surface_create_info, nullptr, &surface);
@@ -649,7 +649,7 @@ bool VkRenderFramework::CreateSurface(SurfaceContext &surface_context, VkSurface
         surface_context.m_surface_xcb_conn = xcb_connect(nullptr, nullptr);
         if (surface_context.m_surface_xcb_conn) {
             xcb_window_t window = xcb_generate_id(surface_context.m_surface_xcb_conn);
-            auto surface_create_info = vku::InitStruct<VkXcbSurfaceCreateInfoKHR>();
+            VkXcbSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
             surface_create_info.connection = surface_context.m_surface_xcb_conn;
             surface_create_info.window = window;
             return VK_SUCCESS == vk::CreateXcbSurfaceKHR(instance(), &surface_create_info, nullptr, &surface);
@@ -1377,8 +1377,8 @@ void VkImageObj::InitNoLayout(const VkImageCreateInfo &create_info, VkMemoryProp
     VkImageTiling tiling = VK_IMAGE_TILING_OPTIMAL;
 
     if (m_device->IsEnabledExtension(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
-        auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-        auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
         vk::GetPhysicalDeviceFormatProperties2(m_device->phy().handle(), create_info.format, &fmt_props_2);
         linear_tiling_features = fmt_props_3.linearTilingFeatures;
         optimal_tiling_features = fmt_props_3.optimalTilingFeatures;
@@ -1451,8 +1451,8 @@ void VkImageObj::init(const VkImageCreateInfo *create_info) {
     VkFormatFeatureFlags2 optimal_tiling_features;
 
     if (m_device->IsEnabledExtension(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
-        auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-        auto fmt_props_2 = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
         vk::GetPhysicalDeviceFormatProperties2(m_device->phy().handle(), create_info->format, &fmt_props_2);
         linear_tiling_features = fmt_props_3.linearTilingFeatures;
         optimal_tiling_features = fmt_props_3.optimalTilingFeatures;

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -397,7 +397,7 @@ class VkImageObj : public vkt::Image {
     VkImage image() const { return handle(); }
 
     VkImageViewCreateInfo BasicViewCreatInfo(VkImageAspectFlags aspect_mask = VK_IMAGE_ASPECT_COLOR_BIT) const {
-        auto ci = vku::InitStruct<VkImageViewCreateInfo>();
+        VkImageViewCreateInfo ci = vku::InitStructHelper();
         ci.image = handle();
         ci.format = format();
         ci.viewType = VK_IMAGE_VIEW_TYPE_2D;

--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -932,7 +932,7 @@ class VideoContext {
     }
 
     void CreateStatusQueryPool(uint32_t query_count = 1) {
-        auto create_info = vku::InitStruct<VkQueryPoolCreateInfo>();
+        VkQueryPoolCreateInfo create_info = vku::InitStructHelper();
         create_info.pNext = config_.Profile();
         create_info.queryType = VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR;
         create_info.queryCount = query_count;
@@ -1080,9 +1080,9 @@ class VkVideoLayerTest : public VkLayerTest {
             GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
         }
 
-        auto prot_mem_features = vku::InitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
-        auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&prot_mem_features);
-        auto features = vku::InitStruct<VkPhysicalDeviceFeatures2>(&sync2_features);
+        VkPhysicalDeviceProtectedMemoryFeatures prot_mem_features = vku::InitStructHelper();
+        VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper(&prot_mem_features);
+        VkPhysicalDeviceFeatures2 features = vku::InitStructHelper(&sync2_features);
         vk::GetPhysicalDeviceFeatures2(gpu(), &features);
 
         if (!enable_protected_memory) {
@@ -1093,8 +1093,8 @@ class VkVideoLayerTest : public VkLayerTest {
             GTEST_SKIP() << "Test requires synchronization2.";
         }
 
-        auto prot_mem_props = vku::InitStruct<VkPhysicalDeviceProtectedMemoryProperties>();
-        auto props = vku::InitStruct<VkPhysicalDeviceProperties2>(&prot_mem_props);
+        VkPhysicalDeviceProtectedMemoryProperties prot_mem_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 props = vku::InitStructHelper(&prot_mem_props);
         vk::GetPhysicalDeviceProperties2(gpu(), &props);
 
         protected_memory_enabled_ = (prot_mem_features.protectedMemory == VK_TRUE);
@@ -1261,11 +1261,11 @@ class VkVideoLayerTest : public VkLayerTest {
     }
 
     bool GetCodecFormats(VideoConfig& config) {
-        auto video_profiles = vku::InitStruct<VkVideoProfileListInfoKHR>();
+        VkVideoProfileListInfoKHR video_profiles = vku::InitStructHelper();
         video_profiles.profileCount = 1;
         video_profiles.pProfiles = config.Profile();
 
-        auto info = vku::InitStruct<VkPhysicalDeviceVideoFormatInfoKHR>();
+        VkPhysicalDeviceVideoFormatInfoKHR info = vku::InitStructHelper();
         info.pNext = &video_profiles;
         uint32_t count = 0;
 

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -706,7 +706,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumSyncPrimitives) {
     m_errorMonitor->VerifyFound();
 
     constexpr int semaphore_warn_limit = 12;
-    const auto semaphore_ci = vku::InitStruct<VkSemaphoreCreateInfo>();
+    const VkSemaphoreCreateInfo semaphore_ci = vku::InitStructHelper();
     std::vector<vkt::Semaphore> test_semaphores(semaphore_warn_limit);
     for (int i = 0; i < semaphore_warn_limit - 1; ++i) {
         test_semaphores[i].init(*m_device, semaphore_ci);

--- a/tests/unit/android_hardware_buffer.cpp
+++ b/tests/unit/android_hardware_buffer.cpp
@@ -1432,10 +1432,10 @@ TEST_F(NegativeAndroidHardwareBuffer, DeviceImageMemoryReq) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto external_format = vku::InitStruct<VkExternalFormatANDROID>();
+    VkExternalFormatANDROID external_format = vku::InitStructHelper();
     external_format.externalFormat = 0;
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>(&external_format);
+    VkImageCreateInfo image_create_info = vku::InitStructHelper(&external_format);
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.arrayLayers = 1;
     image_create_info.extent = {64, 64, 1};
@@ -1446,10 +1446,10 @@ TEST_F(NegativeAndroidHardwareBuffer, DeviceImageMemoryReq) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    auto image_memory_req = vku::InitStruct<VkDeviceImageMemoryRequirements>();
+    VkDeviceImageMemoryRequirements image_memory_req = vku::InitStructHelper();
     image_memory_req.pCreateInfo = &image_create_info;
     image_memory_req.planeAspect = VK_IMAGE_ASPECT_COLOR_BIT;
-    auto out_memory_req = vku::InitStruct<VkMemoryRequirements2>();
+    VkMemoryRequirements2 out_memory_req = vku::InitStructHelper();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageMemoryRequirements-pNext-06996");
     vk::GetDeviceImageMemoryRequirementsKHR(device(), &image_memory_req, &out_memory_req);
     m_errorMonitor->VerifyFound();
@@ -1480,7 +1480,7 @@ TEST_F(NegativeAndroidHardwareBuffer, NullAHBProperties) {
     ahb_desc.stride = 1;
     AHardwareBuffer_allocate(&ahb_desc, &ahb);
 
-    auto ahb_props = vku::InitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = vku::InitStructHelper();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetAndroidHardwareBufferPropertiesANDROID-buffer-parameter");
     vk::GetAndroidHardwareBufferPropertiesANDROID(m_device->device(), nullptr, &ahb_props);
     m_errorMonitor->VerifyFound();
@@ -1517,15 +1517,15 @@ TEST_F(NegativeAndroidHardwareBuffer, NullAHBImport) {
     ext_buf_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
 
     vkt::Buffer buffer;
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>(&ext_buf_info);
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&ext_buf_info);
     buffer_create_info.size = 512;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer.init_no_mem(*m_device, buffer_create_info);
 
-    auto ahb_props = vku::InitStruct<VkAndroidHardwareBufferPropertiesANDROID>();
+    VkAndroidHardwareBufferPropertiesANDROID ahb_props = vku::InitStructHelper();
     vk::GetAndroidHardwareBufferPropertiesANDROID(m_device->device(), ahb, &ahb_props);
 
-    auto import_ahb_Info = vku::InitStruct<VkImportAndroidHardwareBufferInfoANDROID>();
+    VkImportAndroidHardwareBufferInfoANDROID import_ahb_Info = vku::InitStructHelper();
     import_ahb_Info.buffer = nullptr;  // invalid
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper(&import_ahb_Info);

--- a/tests/unit/android_hardware_buffer_positive.cpp
+++ b/tests/unit/android_hardware_buffer_positive.cpp
@@ -402,18 +402,18 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalImage) {
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     {
-        auto external_image_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
+        VkPhysicalDeviceExternalImageFormatInfo external_image_info = vku::InitStructHelper();
         external_image_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
-        auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_image_info);
+        VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_image_info);
         image_info.format = image_create_info.format;
         image_info.type = image_create_info.imageType;
         image_info.tiling = image_create_info.tiling;
         image_info.usage = image_create_info.usage;
         image_info.flags = image_create_info.flags;
 
-        auto ahb_usage = vku::InitStruct<VkAndroidHardwareBufferUsageANDROID>();
-        auto external_image_properties = vku::InitStruct<VkExternalImageFormatProperties>(&ahb_usage);
-        auto image_properties = vku::InitStruct<VkImageFormatProperties2>(&external_image_properties);
+        VkAndroidHardwareBufferUsageANDROID ahb_usage = vku::InitStructHelper();
+        VkExternalImageFormatProperties external_image_properties = vku::InitStructHelper(&ahb_usage);
+        VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_image_properties);
 
         if (vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties) != VK_SUCCESS) {
             AHardwareBuffer_release(ahb);
@@ -508,18 +508,18 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalCameraFormat) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     {
-        auto external_image_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
+        VkPhysicalDeviceExternalImageFormatInfo external_image_info = vku::InitStructHelper();
         external_image_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
-        auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_image_info);
+        VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_image_info);
         image_info.format = image_create_info.format;
         image_info.type = image_create_info.imageType;
         image_info.tiling = image_create_info.tiling;
         image_info.usage = image_create_info.usage;
         image_info.flags = image_create_info.flags;
 
-        auto ahb_usage = vku::InitStruct<VkAndroidHardwareBufferUsageANDROID>();
-        auto external_image_properties = vku::InitStruct<VkExternalImageFormatProperties>(&ahb_usage);
-        auto image_properties = vku::InitStruct<VkImageFormatProperties2>(&external_image_properties);
+        VkAndroidHardwareBufferUsageANDROID ahb_usage = vku::InitStructHelper();
+        VkExternalImageFormatProperties external_image_properties = vku::InitStructHelper(&ahb_usage);
+        VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_image_properties);
 
         if (vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties) != VK_SUCCESS) {
             AHardwareBuffer_release(ahb);

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -330,7 +330,7 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime64) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_atomic_int64_features = vku::InitStruct<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>();
+    VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT image_atomic_int64_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(image_atomic_int64_features);
     if (features2.features.shaderInt64 == VK_FALSE) {
         GTEST_SKIP() << "shaderInt64 feature not supported";
@@ -389,7 +389,7 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime32) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_atomic_int64_features = vku::InitStruct<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>();
+    VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT image_atomic_int64_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(image_atomic_int64_features);
     if (features2.features.shaderInt64 == VK_FALSE) {
         GTEST_SKIP() << "shaderInt64 feature not supported";
@@ -448,7 +448,7 @@ TEST_F(NegativeAtomic, ImageInt64DrawtimeSparse) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_atomic_int64_features = vku::InitStruct<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>();
+    VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT image_atomic_int64_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(image_atomic_int64_features);
     if (!features2.features.shaderInt64) {
         GTEST_SKIP() << "shaderInt64 feature not supported";
@@ -483,7 +483,7 @@ TEST_F(NegativeAtomic, ImageInt64DrawtimeSparse) {
     pipe.InitState();
     pipe.CreateComputePipeline();
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     buffer_ci.size = 1024;
     vkt::Buffer buffer(*m_device, buffer_ci);
@@ -527,8 +527,8 @@ TEST_F(NegativeAtomic, ImageInt64Mesh32) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto image_atomic_int64_features = vku::InitStruct<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(&mesh_shader_features);
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT image_atomic_int64_features = vku::InitStructHelper(&mesh_shader_features);
     auto features2 = GetPhysicalDeviceFeatures2(image_atomic_int64_features);
     if (features2.features.shaderInt64 == VK_FALSE) {
         GTEST_SKIP() << "shaderInt64 feature not supported";
@@ -865,8 +865,8 @@ TEST_F(NegativeAtomic, Float2) {
     }
 
     // Still check for proper 16-bit storage/float support for most tests
-    auto float16int8_features = vku::InitStruct<VkPhysicalDeviceShaderFloat16Int8Features>();
-    auto storage_16_bit_features = vku::InitStruct<VkPhysicalDevice16BitStorageFeatures>(&float16int8_features);
+    VkPhysicalDeviceShaderFloat16Int8Features float16int8_features = vku::InitStructHelper();
+    VkPhysicalDevice16BitStorageFeatures storage_16_bit_features = vku::InitStructHelper(&float16int8_features);
     auto features2 = GetPhysicalDeviceFeatures2(storage_16_bit_features);
 
     const bool support_16_bit =
@@ -1175,10 +1175,10 @@ TEST_F(NegativeAtomic, Float2WidthMismatch) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto features13 = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();  // need maintenance4
-    auto atomic_float2_features = vku::InitStruct<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(&features13);
-    auto float16int8_features = vku::InitStruct<VkPhysicalDeviceShaderFloat16Int8Features>(&atomic_float2_features);
-    auto storage_16_bit_features = vku::InitStruct<VkPhysicalDevice16BitStorageFeatures>(&float16int8_features);
+    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();  // need maintenance4
+    VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT atomic_float2_features = vku::InitStructHelper(&features13);
+    VkPhysicalDeviceShaderFloat16Int8Features float16int8_features = vku::InitStructHelper(&atomic_float2_features);
+    VkPhysicalDevice16BitStorageFeatures storage_16_bit_features = vku::InitStructHelper(&float16int8_features);
     GetPhysicalDeviceFeatures2(storage_16_bit_features);
     if (!float16int8_features.shaderFloat16 || !storage_16_bit_features.storageBuffer16BitAccess ||
         !atomic_float2_features.shaderBufferFloat16AtomicMinMax) {
@@ -1243,7 +1243,7 @@ TEST_F(NegativeAtomic, InvalidStorageOperation) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto atomic_float_features = vku::InitStruct<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>();
+    VkPhysicalDeviceShaderAtomicFloatFeaturesEXT atomic_float_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(atomic_float_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 

--- a/tests/unit/atomics_positive.cpp
+++ b/tests/unit/atomics_positive.cpp
@@ -25,7 +25,7 @@ TEST_F(PositiveAtomic, ImageInt64) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_atomic_int64_features = vku::InitStruct<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>();
+    VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT image_atomic_int64_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(image_atomic_int64_features);
     if (features2.features.shaderInt64 == VK_FALSE) {
         GTEST_SKIP() << "shaderInt64 feature not supported";
@@ -102,7 +102,7 @@ TEST_F(PositiveAtomic, ImageInt64DrawtimeSparse) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_atomic_int64_features = vku::InitStruct<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>();
+    VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT image_atomic_int64_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(image_atomic_int64_features);
     if (!features2.features.shaderInt64) {
         GTEST_SKIP() << "shaderInt64 feature not supported";
@@ -138,7 +138,7 @@ TEST_F(PositiveAtomic, ImageInt64DrawtimeSparse) {
     pipe.InitState();
     pipe.CreateComputePipeline();
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     buffer_ci.size = 1024;
     vkt::Buffer buffer(*m_device, buffer_ci);
@@ -181,7 +181,7 @@ TEST_F(PositiveAtomic, Float) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto atomic_float_features = vku::InitStruct<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>();
+    VkPhysicalDeviceShaderAtomicFloatFeaturesEXT atomic_float_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(atomic_float_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
@@ -438,10 +438,10 @@ TEST_F(PositiveAtomic, Float2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto atomic_float_features = vku::InitStruct<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>();
-    auto atomic_float2_features = vku::InitStruct<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(&atomic_float_features);
-    auto float16int8_features = vku::InitStruct<VkPhysicalDeviceShaderFloat16Int8Features>(&atomic_float2_features);
-    auto storage_16_bit_features = vku::InitStruct<VkPhysicalDevice16BitStorageFeatures>(&float16int8_features);
+    VkPhysicalDeviceShaderAtomicFloatFeaturesEXT atomic_float_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT atomic_float2_features = vku::InitStructHelper(&atomic_float_features);
+    VkPhysicalDeviceShaderFloat16Int8Features float16int8_features = vku::InitStructHelper(&atomic_float2_features);
+    VkPhysicalDevice16BitStorageFeatures storage_16_bit_features = vku::InitStructHelper(&float16int8_features);
     auto features2 = GetPhysicalDeviceFeatures2(storage_16_bit_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
@@ -716,7 +716,7 @@ TEST_F(PositiveAtomic, PhysicalPointer) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(features12);
     if (!features12.bufferDeviceAddress) {
         GTEST_SKIP() << "VkPhysicalDeviceVulkan12Features::bufferDeviceAddress not supported and is required";
@@ -796,7 +796,7 @@ TEST_F(PositiveAtomic, Int64) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto atomic_int64_features = vku::InitStruct<VkPhysicalDeviceShaderAtomicInt64Features>();
+    VkPhysicalDeviceShaderAtomicInt64Features atomic_int64_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(atomic_int64_features);
     if (features2.features.shaderInt64 == VK_FALSE) {
         GTEST_SKIP() << "shaderInt64 feature not supported";

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -1395,7 +1395,7 @@ TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollisio
     }
 
     // Create a device that enables descriptorBindingStorageBufferUpdateAfterBind
-    auto indexing_features = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(indexing_features);
 
     if (VK_FALSE == indexing_features.descriptorBindingStorageBufferUpdateAfterBind) {
@@ -1408,7 +1408,7 @@ TEST_F(VkBestPracticesLayerTest, ThreadUpdateDescriptorUpdateAfterBindNoCollisio
 
     std::array<VkDescriptorBindingFlagsEXT, 2> flags = {
         {VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT, VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT}};
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = (uint32_t)flags.size();
     flags_create_info.pBindingFlags = flags.data();
 
@@ -2209,7 +2209,7 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
     clear_range.layerCount = 1;
     clear_range.levelCount = 1;
 
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.srcAccessMask = 0;
     img_barrier.dstAccessMask = 0;
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -2262,7 +2262,7 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
                            nullptr, 0, nullptr, 1, &img_barrier);
 
     if (sync2) {
-        auto img_barrier2 = vku::InitStruct<VkImageMemoryBarrier2KHR>();
+        VkImageMemoryBarrier2KHR img_barrier2 = vku::InitStructHelper();
         img_barrier2.srcAccessMask = 0;
         img_barrier2.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
         img_barrier2.image = image.handle();
@@ -2272,7 +2272,7 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
         img_barrier2.subresourceRange.layerCount = 1;
         img_barrier2.subresourceRange.levelCount = 1;
 
-        auto dependency_info = vku::InitStruct<VkDependencyInfoKHR>();
+        VkDependencyInfoKHR dependency_info = vku::InitStructHelper();
         dependency_info.imageMemoryBarrierCount = 1;
         dependency_info.pImageMemoryBarriers = &img_barrier2;
 

--- a/tests/unit/best_practices_positive.cpp
+++ b/tests/unit/best_practices_positive.cpp
@@ -144,7 +144,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, DynStateIgnoreAttachments) {
         // Several drivers have been observed to crash on the legal null pAttachments - restrict to MockICD for now
         GTEST_SKIP() << "This test only runs on MockICD";
     }
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3ColorBlendEnable ||
         !extended_dynamic_state3_features.extendedDynamicState3ColorBlendEquation ||

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -398,13 +398,13 @@ TEST_F(NegativeBuffer, TexelBufferAlignment) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto texel_buffer_alignment_features = vku::InitStruct<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT>();
+    VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT texel_buffer_alignment_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(texel_buffer_alignment_features);
     if (texel_buffer_alignment_features.texelBufferAlignment != VK_TRUE) {
         GTEST_SKIP() << "texelBufferAlignment feature not supported";
     }
 
-    auto align_props = vku::InitStruct<VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT>();
+    VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT align_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(align_props);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &texel_buffer_alignment_features));
@@ -525,7 +525,7 @@ TEST_F(NegativeBuffer, IdxBufferAlignmentError) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     uint32_t const indices[] = {0};
-    auto buf_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buf_info = vku::InitStructHelper();
     buf_info.size = 1024;
     buf_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     buf_info.queueFamilyIndexCount = 1;
@@ -690,7 +690,7 @@ TEST_F(NegativeBuffer, IndexBuffer2Offset) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
@@ -730,7 +730,7 @@ TEST_F(NegativeBuffer, IndexBuffer2Size) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -765,19 +765,19 @@ TEST_F(NegativeBuffer, BufferUsageFlags2) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     vkt::Buffer buffer(*m_device, buffer_ci);
 
-    auto buffer_usage_flags = vku::InitStruct<VkBufferUsageFlags2CreateInfoKHR>();
+    VkBufferUsageFlags2CreateInfoKHR buffer_usage_flags = vku::InitStructHelper();
     buffer_usage_flags.usage = VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR | VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT_KHR;
 
-    auto buffer_view_ci = vku::InitStruct<VkBufferViewCreateInfo>(&buffer_usage_flags);
+    VkBufferViewCreateInfo buffer_view_ci = vku::InitStructHelper(&buffer_usage_flags);
     buffer_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     buffer_view_ci.range = VK_WHOLE_SIZE;
     buffer_view_ci.buffer = buffer.handle();
@@ -788,7 +788,7 @@ TEST_F(NegativeBuffer, BufferUsageFlagsUsage) {
     TEST_DESCRIPTION("Use bad buffer usage flag.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;
     buffer_ci.usage = 0;
     CreateBufferTest(*this, &buffer_ci, {"VUID-VkBufferCreateInfo-None-09206"});
@@ -808,19 +808,19 @@ TEST_F(NegativeBuffer, BufferUsageFlags2Subset) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
     vkt::Buffer buffer(*m_device, buffer_ci);
 
-    auto buffer_usage_flags = vku::InitStruct<VkBufferUsageFlags2CreateInfoKHR>();
+    VkBufferUsageFlags2CreateInfoKHR buffer_usage_flags = vku::InitStructHelper();
     buffer_usage_flags.usage = VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR;
 
-    auto buffer_view_ci = vku::InitStruct<VkBufferViewCreateInfo>(&buffer_usage_flags);
+    VkBufferViewCreateInfo buffer_view_ci = vku::InitStructHelper(&buffer_usage_flags);
     buffer_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     buffer_view_ci.range = VK_WHOLE_SIZE;
     buffer_view_ci.buffer = buffer.handle();
@@ -1053,14 +1053,14 @@ TEST_F(NegativeBuffer, MaxBufferSize) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto maintenance4_features = vku::InitStruct<VkPhysicalDeviceMaintenance4FeaturesKHR>();
+    VkPhysicalDeviceMaintenance4FeaturesKHR maintenance4_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance4_features);
     if (!maintenance4_features.maintenance4) {
         GTEST_SKIP() << "VkPhysicalDeviceMaintenance4FeaturesKHR::maintenance4 is required but not enabled.";
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance4_features));
 
-    auto maintenance4_properties = vku::InitStruct<VkPhysicalDeviceMaintenance4Properties>();
+    VkPhysicalDeviceMaintenance4Properties maintenance4_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(maintenance4_properties);
 
     const VkDeviceSize max_test_size = (1ull << 32);
@@ -1068,7 +1068,7 @@ TEST_F(NegativeBuffer, MaxBufferSize) {
         GTEST_SKIP() << "maxBufferSize too large to test";
     }
 
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = maintenance4_properties.maxBufferSize + 1;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-size-06409");

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -68,7 +68,7 @@ TEST_F(PositiveBuffer, TexelBufferAlignmentIn13) {
         GTEST_SKIP() << "Test requires support for VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT";
     }
 
-    auto props_1_3 = vku::InitStruct<VkPhysicalDeviceVulkan13Properties>();
+    VkPhysicalDeviceVulkan13Properties props_1_3 = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(props_1_3);
     if (props_1_3.uniformTexelBufferOffsetAlignmentBytes < 4 || !props_1_3.uniformTexelBufferOffsetSingleTexelAlignment) {
         GTEST_SKIP() << "need uniformTexelBufferOffsetAlignmentBytes to be more than 4 with "
@@ -102,12 +102,12 @@ TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressWorstCase) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto buffer_addr_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR buffer_addr_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(buffer_addr_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &buffer_addr_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // Allocate common buffer memory, all buffers will be bound to it so that they have the same starting address
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
     alloc_info.allocationSize = 100 * 4096 * 4096;
@@ -118,7 +118,7 @@ TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressWorstCase) {
     // for every range currently in the map.
     constexpr size_t N = 1400;
     std::vector<vkt::Buffer> buffers(N);
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
@@ -154,12 +154,12 @@ TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressGoodCase) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto buffer_addr_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR buffer_addr_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(buffer_addr_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &buffer_addr_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // Allocate common buffer memory, all buffers will be bound to it so that they have the same starting address
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
     alloc_info.allocationSize = 100 * 4096 * 4096;
@@ -169,7 +169,7 @@ TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressGoodCase) {
     // should be fast.
     constexpr size_t N = 1400;  // 100 * 4096;
     std::vector<vkt::Buffer> buffers(N);
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
@@ -194,7 +194,7 @@ TEST_F(PositiveBuffer, IndexBuffer2Size) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -223,19 +223,19 @@ TEST_F(PositiveBuffer, BufferViewUsageBasic) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
     vkt::Buffer buffer(*m_device, buffer_ci);
 
-    auto buffer_usage_flags = vku::InitStruct<VkBufferUsageFlags2CreateInfoKHR>();
+    VkBufferUsageFlags2CreateInfoKHR buffer_usage_flags = vku::InitStructHelper();
     buffer_usage_flags.usage = VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR;
 
-    auto buffer_view_ci = vku::InitStruct<VkBufferViewCreateInfo>(&buffer_usage_flags);
+    VkBufferViewCreateInfo buffer_view_ci = vku::InitStructHelper(&buffer_usage_flags);
     buffer_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     buffer_view_ci.range = VK_WHOLE_SIZE;
     buffer_view_ci.buffer = buffer.handle();
@@ -253,19 +253,19 @@ TEST_F(PositiveBuffer, BufferUsageFlags2Subset) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
     vkt::Buffer buffer(*m_device, buffer_ci);
 
-    auto buffer_usage_flags = vku::InitStruct<VkBufferUsageFlags2CreateInfoKHR>();
+    VkBufferUsageFlags2CreateInfoKHR buffer_usage_flags = vku::InitStructHelper();
     buffer_usage_flags.usage = VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR | VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT_KHR;
 
-    auto buffer_view_ci = vku::InitStruct<VkBufferViewCreateInfo>(&buffer_usage_flags);
+    VkBufferViewCreateInfo buffer_view_ci = vku::InitStructHelper(&buffer_usage_flags);
     buffer_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     buffer_view_ci.range = VK_WHOLE_SIZE;
     buffer_view_ci.buffer = buffer.handle();
@@ -283,14 +283,14 @@ TEST_F(PositiveBuffer, BufferUsageFlags2Ignore) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
-    auto buffer_usage_flags = vku::InitStruct<VkBufferUsageFlags2CreateInfoKHR>();
+    VkBufferUsageFlags2CreateInfoKHR buffer_usage_flags = vku::InitStructHelper();
     buffer_usage_flags.usage = VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR;
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>(&buffer_usage_flags);
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&buffer_usage_flags);
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT;
     CreateBufferTest(*this, &buffer_ci, {});
@@ -311,14 +311,14 @@ TEST_F(PositiveBuffer, BufferUsageFlags2Usage) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
-    auto buffer_usage_flags = vku::InitStruct<VkBufferUsageFlags2CreateInfoKHR>();
+    VkBufferUsageFlags2CreateInfoKHR buffer_usage_flags = vku::InitStructHelper();
     buffer_usage_flags.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>(&buffer_usage_flags);
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&buffer_usage_flags);
     buffer_ci.size = 32;
     buffer_ci.usage = 0;
     CreateBufferTest(*this, &buffer_ci, {});

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -204,7 +204,7 @@ TEST_F(NegativeCommand, Sync2SecondaryCommandbufferAsPrimary) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -215,10 +215,10 @@ TEST_F(NegativeCommand, Sync2SecondaryCommandbufferAsPrimary) {
     secondary.ClearAllBuffers(m_renderTargets, m_clear_color, nullptr, m_depth_clear_color, m_stencil_clear_color);
     secondary.end();
 
-    auto cb_info = vku::InitStruct<VkCommandBufferSubmitInfoKHR>();
+    VkCommandBufferSubmitInfoKHR cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = secondary.handle();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo2KHR>();
+    VkSubmitInfo2KHR submit_info = vku::InitStructHelper();
     submit_info.commandBufferInfoCount = 1;
     submit_info.pCommandBufferInfos = &cb_info;
 
@@ -269,7 +269,7 @@ TEST_F(NegativeCommand, Sync2CommandBufferTwoSubmits) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -285,10 +285,10 @@ TEST_F(NegativeCommand, Sync2CommandBufferTwoSubmits) {
 
     // Bypass framework since it does the waits automatically
     VkResult err = VK_SUCCESS;
-    auto cb_info = vku::InitStruct<VkCommandBufferSubmitInfoKHR>();
+    VkCommandBufferSubmitInfoKHR cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = m_commandBuffer->handle();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo2KHR>();
+    VkSubmitInfo2KHR submit_info = vku::InitStructHelper();
     submit_info.commandBufferInfoCount = 1;
     submit_info.pCommandBufferInfos = &cb_info;
 
@@ -855,7 +855,7 @@ TEST_F(NegativeCommand, MultiDrawDrawOutsideRenderPass) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>();
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(multi_draw_features);
     if (!multi_draw_features.multiDraw) {
         GTEST_SKIP() << "Test requires (unsupported) multiDraw";
@@ -1062,7 +1062,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipelineUpdateAfterBind
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto indexing_features = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(indexing_features);
     if (!indexing_features.descriptorBindingSampledImageUpdateAfterBind) {
         GTEST_SKIP() << "Test requires (unsupported)  descriptorBindingSampledImageUpdateAfterBind";
@@ -1087,7 +1087,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipelineUpdateAfterBind
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     VkDescriptorBindingFlagsEXT binding_flags = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT;
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = 1;
     flags_create_info.pBindingFlags = &binding_flags;
 
@@ -1122,7 +1122,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipelineUpdateAfterBind
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-viewType-07752");
@@ -3174,7 +3174,7 @@ TEST_F(NegativeCommand, CopyImageFormatSizeMismatch) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mp_features = vku::InitStruct<VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR>();
+    VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR mp_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(mp_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -4489,7 +4489,7 @@ TEST_F(NegativeCommand, ExecuteDiffertQueueFlagsSecondaryCB) {
     vkt::CommandPool command_pool_b(*m_device, pool_create_info);
     ASSERT_TRUE(command_pool_b.initialized());
 
-    auto command_buffer_allocate_info = vku::InitStruct<VkCommandBufferAllocateInfo>();
+    VkCommandBufferAllocateInfo command_buffer_allocate_info = vku::InitStructHelper();
     command_buffer_allocate_info.commandBufferCount = 1;
     command_buffer_allocate_info.commandPool = command_pool_a.handle();
     command_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -4500,12 +4500,12 @@ TEST_F(NegativeCommand, ExecuteDiffertQueueFlagsSecondaryCB) {
     command_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
     vkt::CommandBuffer command_buffer_secondary(*m_device, command_buffer_allocate_info);
 
-    auto cmdbuff_ii = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo cmdbuff_ii = vku::InitStructHelper();
     cmdbuff_ii.renderPass = m_renderPass;
     cmdbuff_ii.subpass = 0;
     cmdbuff_ii.framebuffer = m_framebuffer;
 
-    auto begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     begin_info.pInheritanceInfo = &cmdbuff_ii;
 
     // secondary
@@ -4697,10 +4697,10 @@ TEST_F(NegativeCommand, MultiDraw) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>();
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(multi_draw_features);
 
-    auto multi_draw_properties = vku::InitStruct<VkPhysicalDeviceMultiDrawPropertiesEXT>();
+    VkPhysicalDeviceMultiDrawPropertiesEXT multi_draw_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(multi_draw_properties);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &multi_draw_features));
@@ -4793,8 +4793,8 @@ TEST_F(NegativeCommand, MultiDrawMaintenance5) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>(&maintenance5_features);
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper(&maintenance5_features);
     GetPhysicalDeviceFeatures2(multi_draw_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &multi_draw_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -4842,8 +4842,8 @@ TEST_F(NegativeCommand, MultiDrawWholeSizeMaintenance5) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>(&maintenance5_features);
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper(&maintenance5_features);
     GetPhysicalDeviceFeatures2(multi_draw_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &multi_draw_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -4885,8 +4885,8 @@ TEST_F(NegativeCommand, MultiDrawMaintenance5Mixed) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>(&maintenance5_features);
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper(&maintenance5_features);
     GetPhysicalDeviceFeatures2(multi_draw_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &multi_draw_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -5311,7 +5311,7 @@ TEST_F(NegativeCommand, ExclusiveScissorNV) {
     }
 
     // Create a device that enables exclusive scissor but disables multiViewport
-    auto exclusive_scissor_features = vku::InitStruct<VkPhysicalDeviceExclusiveScissorFeaturesNV>();
+    VkPhysicalDeviceExclusiveScissorFeaturesNV exclusive_scissor_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(exclusive_scissor_features);
     features2.features.multiViewport = VK_FALSE;
 
@@ -5581,17 +5581,17 @@ TEST_F(NegativeCommand, FilterCubicSamplerInCmdDraw) {
     auto image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, format, usage, VK_IMAGE_TILING_OPTIMAL);
     VkImageViewType imageViewType = VK_IMAGE_VIEW_TYPE_2D;
 
-    auto imageview_format_info = vku::InitStruct<VkPhysicalDeviceImageViewImageFormatInfoEXT>();
+    VkPhysicalDeviceImageViewImageFormatInfoEXT imageview_format_info = vku::InitStructHelper();
     imageview_format_info.imageViewType = imageViewType;
-    auto image_format_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&imageview_format_info);
+    VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper(&imageview_format_info);
     image_format_info.type = image_ci.imageType;
     image_format_info.format = image_ci.format;
     image_format_info.tiling = image_ci.tiling;
     image_format_info.usage = image_ci.usage;
     image_format_info.flags = image_ci.flags;
 
-    auto filter_cubic_props = vku::InitStruct<VkFilterCubicImageViewImageFormatPropertiesEXT>();
-    auto image_format_properties = vku::InitStruct<VkImageFormatProperties2>(&filter_cubic_props);
+    VkFilterCubicImageViewImageFormatPropertiesEXT filter_cubic_props = vku::InitStructHelper();
+    VkImageFormatProperties2 image_format_properties = vku::InitStructHelper(&filter_cubic_props);
 
     vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
 
@@ -5603,13 +5603,13 @@ TEST_F(NegativeCommand, FilterCubicSamplerInCmdDraw) {
     image.Init(image_ci);
     VkImageView imageView = image.targetView(format, imageViewType);
 
-    auto sampler_ci = vku::InitStruct<VkSamplerCreateInfo>();
+    VkSamplerCreateInfo sampler_ci = vku::InitStructHelper();
     sampler_ci.minFilter = VK_FILTER_CUBIC_EXT;
     sampler_ci.magFilter = VK_FILTER_CUBIC_EXT;
     vkt::Sampler sampler(*m_device, sampler_ci);
     ASSERT_TRUE(sampler.initialized());
 
-    auto reduction_mode_ci = vku::InitStruct<VkSamplerReductionModeCreateInfo>();
+    VkSamplerReductionModeCreateInfo reduction_mode_ci = vku::InitStructHelper();
     reduction_mode_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MIN;
     sampler_ci.pNext = &reduction_mode_ci;
     vkt::Sampler sampler_reduction(*m_device, sampler_ci);
@@ -5692,7 +5692,7 @@ TEST_F(NegativeCommand, ImageFilterCubicSamplerInCmdDraw) {
     VkImageView imageView = image.targetView(format, VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0,
                                              VK_REMAINING_ARRAY_LAYERS, imageViewType);
 
-    auto sampler_ci = vku::InitStruct<VkSamplerCreateInfo>();
+    VkSamplerCreateInfo sampler_ci = vku::InitStructHelper();
     sampler_ci.minFilter = VK_FILTER_CUBIC_EXT;
     sampler_ci.magFilter = VK_FILTER_CUBIC_EXT;
     vkt::Sampler sampler(*m_device, sampler_ci);
@@ -6076,7 +6076,7 @@ TEST_F(NegativeCommand, ExecuteCommandsSubpassIndices) {
         0,                                     // dependencyFlags
     };
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.attachmentCount = 1;
     rpci.pAttachments = attach;
     rpci.subpassCount = 2;
@@ -6199,7 +6199,7 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     ASSERT_TRUE(image.initialized());
     vkt::Buffer dst_buffer(*m_device, 128 * 128, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     vkt::Buffer src_buffer(*m_device, 128 * 128, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
-    auto copy_region = vku::InitStruct<VkImageCopy2>();
+    VkImageCopy2 copy_region = vku::InitStructHelper();
     copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     copy_region.srcSubresource.layerCount = 1;
     copy_region.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -6208,7 +6208,7 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     copy_region.extent.width = 1;
     copy_region.extent.height = 1;
     copy_region.extent.depth = 1;
-    auto copy_image_info = vku::InitStruct<VkCopyImageInfo2>();
+    VkCopyImageInfo2 copy_image_info = vku::InitStructHelper();
     copy_image_info.srcImage = image.handle();
     copy_image_info.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;
     copy_image_info.dstImage = image.handle();
@@ -6219,10 +6219,10 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdCopyImage-aspect-06663");
     vk::CmdCopyImage2(m_commandBuffer->handle(), &copy_image_info);
     m_errorMonitor->VerifyFound();
-    auto copy_buffer = vku::InitStruct<VkBufferCopy2>();
+    VkBufferCopy2 copy_buffer = vku::InitStructHelper();
     copy_buffer.dstOffset = 4;
     copy_buffer.size = 4;
-    auto copy_buffer_info = vku::InitStruct<VkCopyBufferInfo2>();
+    VkCopyBufferInfo2 copy_buffer_info = vku::InitStructHelper();
     copy_buffer_info.srcBuffer = dst_buffer.handle();
     copy_buffer_info.dstBuffer = dst_buffer.handle();
     copy_buffer_info.regionCount = 1;
@@ -6230,7 +6230,7 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyBufferInfo2-srcBuffer-00118");
     vk::CmdCopyBuffer2(m_commandBuffer->handle(), &copy_buffer_info);
     m_errorMonitor->VerifyFound();
-    auto bic_region = vku::InitStruct<VkBufferImageCopy2>();
+    VkBufferImageCopy2 bic_region = vku::InitStructHelper();
     bic_region.bufferRowLength = 128;
     bic_region.bufferImageHeight = 128;
     bic_region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -6247,7 +6247,7 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyBufferToImageInfo2-dstImage-00177");
     vk::CmdCopyBufferToImage2(m_commandBuffer->handle(), &buffer_image_info);
     m_errorMonitor->VerifyFound();
-    auto image_buffer_info = vku::InitStruct<VkCopyImageToBufferInfo2>();
+    VkCopyImageToBufferInfo2 image_buffer_info = vku::InitStructHelper();
     image_buffer_info.dstBuffer = src_buffer.handle();
     image_buffer_info.srcImage = image.handle();
     image_buffer_info.srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
@@ -6256,7 +6256,7 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCopyImageToBufferInfo2-dstBuffer-00191");
     vk::CmdCopyImageToBuffer2(m_commandBuffer->handle(), &image_buffer_info);
     m_errorMonitor->VerifyFound();
-    auto blit_region = vku::InitStruct<VkImageBlit2>();
+    VkImageBlit2 blit_region = vku::InitStructHelper();
     blit_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     blit_region.srcSubresource.baseArrayLayer = 0;
     blit_region.srcSubresource.layerCount = 1;
@@ -6269,7 +6269,7 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     blit_region.srcOffsets[1] = {31, 31, 1};
     blit_region.dstOffsets[0] = {32, 32, 0};
     blit_region.dstOffsets[1] = {64, 64, 1};
-    auto blit_image_info = vku::InitStruct<VkBlitImageInfo2>();
+    VkBlitImageInfo2 blit_image_info = vku::InitStructHelper();
     blit_image_info.srcImage = image.handle();
     blit_image_info.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;
     blit_image_info.dstImage = image.handle();
@@ -6280,7 +6280,7 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBlitImageInfo2-dstImage-00224");
     vk::CmdBlitImage2(m_commandBuffer->handle(), &blit_image_info);
     m_errorMonitor->VerifyFound();
-    auto resolve_region = vku::InitStruct<VkImageResolve2>();
+    VkImageResolve2 resolve_region = vku::InitStructHelper();
     resolve_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     resolve_region.srcSubresource.mipLevel = 0;
     resolve_region.srcSubresource.baseArrayLayer = 0;
@@ -6298,7 +6298,7 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     resolve_region.extent.width = 1;
     resolve_region.extent.height = 1;
     resolve_region.extent.depth = 1;
-    auto resolve_image_info = vku::InitStruct<VkResolveImageInfo2>();
+    VkResolveImageInfo2 resolve_image_info = vku::InitStructHelper();
     resolve_image_info.srcImage = image.handle();
     resolve_image_info.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;
     resolve_image_info.dstImage = image2.handle();
@@ -6566,16 +6566,16 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
 
     vkt::RenderPass render_pass(*m_device, rp_ci);
 
-    auto depth_state_info = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo depth_state_info = vku::InitStructHelper();
     depth_state_info.depthTestEnable = VK_TRUE;
     depth_state_info.depthWriteEnable = VK_TRUE;
 
-    auto stencil_state_info = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo stencil_state_info = vku::InitStructHelper();
     stencil_state_info.front.failOp = VK_STENCIL_OP_ZERO;
     stencil_state_info.front.writeMask = 1;
     stencil_state_info.back.writeMask = 1;
 
-    auto stencil_disabled_state_info = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo stencil_disabled_state_info = vku::InitStructHelper();
     stencil_disabled_state_info.front.failOp = VK_STENCIL_OP_ZERO;
     stencil_disabled_state_info.front.writeMask = 1;
     stencil_disabled_state_info.back.writeMask = 0;
@@ -7120,7 +7120,7 @@ TEST_F(NegativeCommand, CmdClearAttachmentTests) {
         m_renderTargets[0]->width(), m_renderTargets[0]->height(), m_renderTargets[0]->create_info().mipLevels, 4,
         m_renderTargets[0]->format(), m_renderTargets[0]->usage(), VK_IMAGE_TILING_OPTIMAL);
     render_target.Init(render_target_ci, 0);
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = render_target.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     ivci.format = render_target_ci.format;
@@ -7141,7 +7141,7 @@ TEST_F(NegativeCommand, CmdClearAttachmentTests) {
     m_renderPassBeginInfo.framebuffer = framebuffer.handle();
 
     // Create secondary command buffer
-    auto secondary_cmd_buffer_alloc_info = vku::InitStruct<VkCommandBufferAllocateInfo>();
+    VkCommandBufferAllocateInfo secondary_cmd_buffer_alloc_info = vku::InitStructHelper();
     secondary_cmd_buffer_alloc_info.commandPool = m_commandPool->handle();
     secondary_cmd_buffer_alloc_info.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
     secondary_cmd_buffer_alloc_info.commandBufferCount = 1;

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -147,10 +147,10 @@ TEST_F(PositiveCommand, ClearAttachmentsCalledWithoutFbInSecondaryCB) {
 
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    auto hinfo = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo hinfo = vku::InitStructHelper();
     hinfo.renderPass = renderPass();
 
-    auto info = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo info = vku::InitStructHelper();
     info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     info.pInheritanceInfo = &hinfo;
 
@@ -440,7 +440,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithFeature) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     features12.drawIndirectCount = VK_TRUE;
     auto features2 = GetPhysicalDeviceFeatures2(features12);
     if (features12.drawIndirectCount != VK_TRUE) {
@@ -757,13 +757,13 @@ TEST_F(PositiveCommand, ThreadedCommandBuffersWithLabels) {
         vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_TRANSIENT_BIT);
 
         constexpr int command_buffers_per_pool = 4;
-        auto commands_allocate_info = vku::InitStruct<VkCommandBufferAllocateInfo>();
+        VkCommandBufferAllocateInfo commands_allocate_info = vku::InitStructHelper();
         commands_allocate_info.commandPool = pool.handle();
         commands_allocate_info.commandBufferCount = command_buffers_per_pool;
         commands_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-        const auto begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
+        const VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
 
-        auto label = vku::InitStruct<VkDebugUtilsLabelEXT>();
+        VkDebugUtilsLabelEXT label = vku::InitStructHelper();
         label.pLabelName = "Test label";
 
         constexpr int iteration_count = 1000;
@@ -924,7 +924,7 @@ TEST_F(PositiveCommand, DebugLabelPrimaryCommandBuffer) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     m_commandBuffer->begin();
 
-    auto label = vku::InitStruct<VkDebugUtilsLabelEXT>();
+    VkDebugUtilsLabelEXT label = vku::InitStructHelper();
     label.pLabelName = "test";
     vk::CmdBeginDebugUtilsLabelEXT(*m_commandBuffer, &label);
     vk::CmdEndDebugUtilsLabelEXT(*m_commandBuffer);
@@ -933,7 +933,7 @@ TEST_F(PositiveCommand, DebugLabelPrimaryCommandBuffer) {
 
     const std::array command_buffers = {m_commandBuffer->handle()};
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = size32(command_buffers);
     submit_info.pCommandBuffers = command_buffers.data();
 
@@ -956,7 +956,7 @@ TEST_F(PositiveCommand, DebugLabelPrimaryCommandBuffers) {
 
     // Start DebugLabel on 1 command buffer
     {
-        auto label = vku::InitStruct<VkDebugUtilsLabelEXT>();
+        VkDebugUtilsLabelEXT label = vku::InitStructHelper();
         label.pLabelName = "test";
         command_buffer_start.begin();
         vk::CmdBeginDebugUtilsLabelEXT(command_buffer_start.handle(), &label);
@@ -972,7 +972,7 @@ TEST_F(PositiveCommand, DebugLabelPrimaryCommandBuffers) {
 
     const std::array command_buffers = {command_buffer_start.handle(), command_buffer_end.handle()};
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = size32(command_buffers);
     submit_info.pCommandBuffers = command_buffers.data();
 
@@ -991,7 +991,7 @@ TEST_F(PositiveCommand, DebugLabelSecondaryCommandBuffer) {
     VkCommandBufferObj cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     cb.begin();
     {
-        auto label = vku::InitStruct<VkDebugUtilsLabelEXT>();
+        VkDebugUtilsLabelEXT label = vku::InitStructHelper();
         label.pLabelName = "test";
         vk::CmdBeginDebugUtilsLabelEXT(cb, &label);
         vk::CmdEndDebugUtilsLabelEXT(cb);
@@ -1012,7 +1012,7 @@ TEST_F(PositiveCommand, CopyImageRemainingLayersMaintenance5) {
         GTEST_SKIP() << "At least Vulkan 1.1 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
@@ -1068,7 +1068,7 @@ TEST_F(PositiveCommand, CopyImageTypeExtentMismatchMaintenance5) {
         GTEST_SKIP() << "At least Vulkan 1.1 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
@@ -1128,8 +1128,8 @@ TEST_F(PositiveCommand, MultiDrawMaintenance5) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>(&maintenance5_features);
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper(&maintenance5_features);
     GetPhysicalDeviceFeatures2(multi_draw_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &multi_draw_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -1179,8 +1179,8 @@ TEST_F(PositiveCommand, MultiDrawMaintenance5Mixed) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>(&maintenance5_features);
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper(&maintenance5_features);
     GetPhysicalDeviceFeatures2(multi_draw_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &multi_draw_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -37,7 +37,7 @@ TEST_F(NegativeDebugPrintf, BasicUsage) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>();
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multi_draw_features);
     if (!features2.features.vertexPipelineStoresAndAtomics || !features2.features.fragmentStoresAndAtomics) {
         GTEST_SKIP() << "Debug Printf test requires vertexPipelineStoresAndAtomics and fragmentStoresAndAtomics";
@@ -340,7 +340,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaders) {
     }
 
     // Create a device that enables mesh_shader
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
+    VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
@@ -408,8 +408,8 @@ TEST_F(NegativeDebugPrintf, GPL) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>();
-    auto gpl_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(&multi_draw_features);
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper();
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper(&multi_draw_features);
     auto features2 = GetPhysicalDeviceFeatures2(gpl_features);
     if (!gpl_features.graphicsPipelineLibrary) {
         GTEST_SKIP() << "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT::graphicsPipelineLibrary not supported";
@@ -746,7 +746,7 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
-    auto gpl_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>();
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(gpl_features);
     if (!gpl_features.graphicsPipelineLibrary) {
         GTEST_SKIP() << "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT::graphicsPipelineLibrary not supported";
@@ -825,7 +825,7 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
     vkt::GraphicsPipelineLibraryStage pre_raster_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
 
     VkDynamicState dyn_states[2] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
-    auto dyn_state = vku::InitStruct<VkPipelineDynamicStateCreateInfo>();
+    VkPipelineDynamicStateCreateInfo dyn_state = vku::InitStructHelper();
     dyn_state.dynamicStateCount = size(dyn_states);
     dyn_state.pDynamicStates = dyn_states;
     CreatePipelineHelper pre_raster(*this);
@@ -900,7 +900,7 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
-    auto gpl_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>();
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(gpl_features);
     if (!gpl_features.graphicsPipelineLibrary) {
         GTEST_SKIP() << "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT::graphicsPipelineLibrary not supported";
@@ -984,7 +984,7 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
     vkt::GraphicsPipelineLibraryStage pre_raster_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
 
     VkDynamicState dyn_states[2] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
-    auto dyn_state = vku::InitStruct<VkPipelineDynamicStateCreateInfo>();
+    VkPipelineDynamicStateCreateInfo dyn_state = vku::InitStructHelper();
     dyn_state.dynamicStateCount = size(dyn_states);
     dyn_state.pDynamicStates = dyn_states;
     CreatePipelineHelper pre_raster(*this);
@@ -1057,9 +1057,9 @@ TEST_F(NegativeDebugPrintf, BasicUsageShaderObjects) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto shader_object_features = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>(&shader_object_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderObjectFeaturesEXT shader_object_features = vku::InitStructHelper(&dynamic_rendering_features);
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper(&shader_object_features);
     auto features2 = GetPhysicalDeviceFeatures2(multi_draw_features);
     if (!features2.features.vertexPipelineStoresAndAtomics || !features2.features.fragmentStoresAndAtomics) {
         GTEST_SKIP() << "Debug Printf test requires vertexPipelineStoresAndAtomics and fragmentStoresAndAtomics";
@@ -1396,10 +1396,10 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaderObjects) {
     }
 
     // Create a device that enables mesh_shader
-    auto maintenance_4_features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>();
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>(&maintenance_4_features);
-    auto shader_object_features = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>(&shader_object_features);
+    VkPhysicalDeviceMaintenance4Features maintenance_4_features = vku::InitStructHelper();
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper(&maintenance_4_features);
+    VkPhysicalDeviceShaderObjectFeaturesEXT shader_object_features = vku::InitStructHelper(&dynamic_rendering_features);
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper(&shader_object_features);
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
 
     if (!mesh_shader_features.taskShader || !mesh_shader_features.meshShader) {

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -108,7 +108,7 @@ TEST_F(NegativeDescriptorBuffer, SetLayout) {
 
         VkPipelineLayout pipeline_layout;
         const std::array<VkDescriptorSetLayout, 2> set_layouts{dsl1.handle(), dsl2.handle()};
-        auto plci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+        VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
         plci.setLayoutCount = size32(set_layouts);
         plci.pSetLayouts = set_layouts.data();
 
@@ -140,13 +140,13 @@ TEST_F(NegativeDescriptorBuffer, SetLayout) {
 TEST_F(NegativeDescriptorBuffer, SetLayoutInlineUniformBlockEXT) {
     TEST_DESCRIPTION("Descriptor buffer set layout tests.");
     AddRequiredExtensions(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME);
-    auto inline_uniform_features = vku::InitStruct<VkPhysicalDeviceInlineUniformBlockFeaturesEXT>();
+    VkPhysicalDeviceInlineUniformBlockFeaturesEXT inline_uniform_features = vku::InitStructHelper();
     InitBasicDescriptorBuffer(&inline_uniform_features);
     if (::testing::Test::IsSkipped()) return;
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    auto inlineUniformProps = vku::InitStruct<VkPhysicalDeviceInlineUniformBlockPropertiesEXT>();
+    VkPhysicalDeviceInlineUniformBlockPropertiesEXT inlineUniformProps = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(inlineUniformProps);
 
     const VkDescriptorSetLayoutBinding binding{0, VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT,
@@ -163,7 +163,7 @@ TEST_F(NegativeDescriptorBuffer, SetLayoutInlineUniformBlockEXT) {
 TEST_F(NegativeDescriptorBuffer, SetLayoutMutableDescriptorEXT) {
     TEST_DESCRIPTION("Descriptor buffer set layout tests.");
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
-    auto mutable_descriptor_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_features = vku::InitStructHelper();
     InitBasicDescriptorBuffer(&mutable_descriptor_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -192,14 +192,14 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
-    auto acceleration_structure_features =
-        vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&buffer_device_address_features);
+    VkPhysicalDeviceBufferDeviceAddressFeatures buffer_device_address_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR acceleration_structure_features =
+        vku::InitStructHelper(&buffer_device_address_features);
     GetPhysicalDeviceFeatures2(acceleration_structure_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &acceleration_structure_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
@@ -210,7 +210,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
     const auto dslci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(nullptr, flags, 1U, &binding);
     vkt::DescriptorSetLayout dsl(*m_device, dslci);
 
-    auto plci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
     plci.setLayoutCount = 1;
     plci.pSetLayouts = &dsl.handle();
     vkt::PipelineLayout pipeline_layout(*m_device, plci);
@@ -233,7 +233,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
 
     {
         uint8_t buffer[128];
-        auto dgi = vku::InitStruct<VkDescriptorGetInfoEXT>();
+        VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
         dgi.type = VK_DESCRIPTOR_TYPE_SAMPLER;
         dgi.data.pSampler = &sampler.handle();
 
@@ -258,7 +258,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
 
         {
             uint32_t qfi = 0;
-            auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+            VkBufferCreateInfo buffCI = vku::InitStructHelper();
             buffCI.size = 4096;
             buffCI.flags = VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
             buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
@@ -283,7 +283,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         }
 
         {
-            auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+            VkImageCreateInfo image_create_info = vku::InitStructHelper();
             image_create_info.flags |= VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
             image_create_info.imageType = VK_IMAGE_TYPE_2D;
             image_create_info.extent.width = 128;
@@ -304,7 +304,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         }
 
         {
-            auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+            VkImageCreateInfo image_create_info = vku::InitStructHelper();
             image_create_info.imageType = VK_IMAGE_TYPE_2D;
             image_create_info.extent.width = 128;
             image_create_info.extent.height = 128;
@@ -317,7 +317,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
             image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
             vkt::Image temp_image(*m_device, image_create_info);
 
-            auto dsvci = vku::InitStruct<VkImageViewCreateInfo>();
+            VkImageViewCreateInfo dsvci = vku::InitStructHelper();
             dsvci.flags |= VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
             dsvci.image = temp_image.handle();
             dsvci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -335,7 +335,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
 
         if (IsExtensionsEnabled(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME)) {
             uint32_t qfi = 0;
-            auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+            VkBufferCreateInfo buffCI = vku::InitStructHelper();
             buffCI.size = 4096;
             buffCI.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
             buffCI.queueFamilyIndexCount = 1;
@@ -344,7 +344,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
             vkt::Buffer as_buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
             VkAccelerationStructureKHR as;
-            auto asci = vku::InitStruct<VkAccelerationStructureCreateInfoKHR>();
+            VkAccelerationStructureCreateInfoKHR asci = vku::InitStructHelper();
             asci.createFlags = VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
             asci.buffer = as_buffer.handle();
 
@@ -375,7 +375,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         uint8_t data[256];
 
         uint32_t qfi = 0;
-        auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo buffCI = vku::InitStructHelper();
         buffCI.size = 4096;
         buffCI.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
         buffCI.queueFamilyIndexCount = 1;
@@ -383,7 +383,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
 
         vkt::Buffer temp_buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
-        auto bcddi = vku::InitStruct<VkBufferCaptureDescriptorDataInfoEXT>();
+        VkBufferCaptureDescriptorDataInfoEXT bcddi = vku::InitStructHelper();
         bcddi.buffer = temp_buffer.handle();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetBufferOpaqueCaptureDescriptorDataEXT-None-08072");
@@ -395,7 +395,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
     {
         uint8_t data[256];
 
-        auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+        VkImageCreateInfo image_create_info = vku::InitStructHelper();
         image_create_info.imageType = VK_IMAGE_TYPE_2D;
         image_create_info.extent.width = 128;
         image_create_info.extent.height = 128;
@@ -410,7 +410,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         vkt::Image temp_image;
         temp_image.init(*m_device, image_create_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-        auto icddi = vku::InitStruct<VkImageCaptureDescriptorDataInfoEXT>();
+        VkImageCaptureDescriptorDataInfoEXT icddi = vku::InitStructHelper();
         icddi.image = temp_image.handle();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageOpaqueCaptureDescriptorDataEXT-None-08076");
@@ -422,7 +422,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
     {
         uint8_t data[256];
 
-        auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+        VkImageCreateInfo image_create_info = vku::InitStructHelper();
         image_create_info.imageType = VK_IMAGE_TYPE_2D;
         image_create_info.extent.width = 128;
         image_create_info.extent.height = 128;
@@ -436,7 +436,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         vkt::Image temp_image;
         temp_image.init(*m_device, image_create_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-        auto dsvci = vku::InitStruct<VkImageViewCreateInfo>();
+        VkImageViewCreateInfo dsvci = vku::InitStructHelper();
         // dsvci.flags |= VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
         dsvci.image = temp_image.handle();
         dsvci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -448,7 +448,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
 
         vkt::ImageView dsv(*m_device, dsvci);
 
-        auto icddi = vku::InitStruct<VkImageViewCaptureDescriptorDataInfoEXT>();
+        VkImageViewCaptureDescriptorDataInfoEXT icddi = vku::InitStructHelper();
         icddi.imageView = dsv.handle();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageViewOpaqueCaptureDescriptorDataEXT-None-08080");
@@ -460,7 +460,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
     {
         uint8_t data[256];
 
-        auto scddi = vku::InitStruct<VkSamplerCaptureDescriptorDataInfoEXT>();
+        VkSamplerCaptureDescriptorDataInfoEXT scddi = vku::InitStructHelper();
         scddi.sampler = sampler.handle();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetSamplerOpaqueCaptureDescriptorDataEXT-None-08084");
@@ -475,7 +475,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
 
         uint8_t data[256];
 
-        auto ascddi = vku::InitStruct<VkAccelerationStructureCaptureDescriptorDataInfoEXT>();
+        VkAccelerationStructureCaptureDescriptorDataInfoEXT ascddi = vku::InitStructHelper();
         ascddi.accelerationStructure = blas->handle();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT-None-08088");
@@ -487,18 +487,18 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
 
     {
         uint32_t qfi = 0;
-        auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo buffCI = vku::InitStructHelper();
         buffCI.size = 4096;
         buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
                        VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
         buffCI.queueFamilyIndexCount = 1;
         buffCI.pQueueFamilyIndices = &qfi;
 
-        auto allocate_flag_info = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+        VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
         allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
         vkt::Buffer d_buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
-        auto dbbi = vku::InitStruct<VkDescriptorBufferBindingInfoEXT>();
+        VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
         dbbi.address = d_buffer.address();
         dbbi.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
 
@@ -531,13 +531,13 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto descriptor_buffer_features = vku::InitStruct<VkPhysicalDeviceDescriptorBufferFeaturesEXT>();
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>(&descriptor_buffer_features);
+    VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptor_buffer_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeatures buffer_device_address_features = vku::InitStructHelper(&descriptor_buffer_features);
     GetPhysicalDeviceFeatures2(buffer_device_address_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &buffer_device_address_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     const bool testPushDescriptorsInBuffers =
@@ -546,7 +546,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
     m_commandBuffer->begin();
 
     uint32_t qfi = 0;
-    auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffCI = vku::InitStructHelper();
     buffCI.size = 4096;
     buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
                    VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
@@ -557,12 +557,12 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         buffCI.usage |= VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT;
     }
 
-    auto allocate_flag_info = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
     allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
     vkt::Buffer d_buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
     {
-        auto dbbi = vku::InitStruct<VkDescriptorBufferBindingInfoEXT>();
+        VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
         dbbi.address = d_buffer.address();
         dbbi.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
                      VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
@@ -591,7 +591,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         m_errorMonitor->VerifyFound();
 
         if (!testPushDescriptorsInBuffers) {
-            auto dbbpdbh = vku::InitStruct<VkDescriptorBufferBindingPushDescriptorBufferHandleEXT>();
+            VkDescriptorBufferBindingPushDescriptorBufferHandleEXT dbbpdbh = vku::InitStructHelper();
 
             dbbpdbh.buffer = d_buffer.handle();
 
@@ -609,7 +609,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
     vkt::Buffer d_buffer2(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
     if (descriptor_buffer_properties.descriptorBufferOffsetAlignment != 1) {
-        auto dbbi2 = vku::InitStruct<VkDescriptorBufferBindingInfoEXT>();
+        VkDescriptorBufferBindingInfoEXT dbbi2 = vku::InitStructHelper();
         dbbi2.address = d_buffer2.address() + 1;  // make alignment bad
         dbbi2.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
                       VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
@@ -623,7 +623,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         buffCI.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
         vkt::Buffer bufferA(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
-        auto dbbi2 = vku::InitStruct<VkDescriptorBufferBindingInfoEXT>();
+        VkDescriptorBufferBindingInfoEXT dbbi2 = vku::InitStructHelper();
         dbbi2.address = bufferA.address();
         dbbi2.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
@@ -667,7 +667,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         dsl2.init(*m_device, dslci2);
 
         const VkDescriptorSetLayout set_layouts[2] = {dsl1.handle(), dsl2.handle()};
-        auto plci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+        VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
         plci.setLayoutCount = 2;
         plci.pSetLayouts = set_layouts;
 
@@ -694,7 +694,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         buffCI.pQueueFamilyIndices = &qfi;
         vkt::Buffer bufferA(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
-        auto dbbi2 = vku::InitStruct<VkDescriptorBufferBindingInfoEXT>();
+        VkDescriptorBufferBindingInfoEXT dbbi2 = vku::InitStructHelper();
         dbbi2.address = bufferA.address();
         dbbi2.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
@@ -792,7 +792,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         vk::GetBufferMemoryRequirements(m_device->device(), large_buffer->handle(), &buffer_mem_reqs);
 
         // Allocate common buffer memory
-        auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+        VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
         alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
         VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
         alloc_info.allocationSize = buffer_mem_reqs.size;
@@ -809,7 +809,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
             // If it is mapped twice, the error below will not be thrown.
             const VkDeviceAddress common_address = large_buffer->address();
 
-            auto dbbi = vku::InitStruct<VkDescriptorBufferBindingInfoEXT>();
+            VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
             dbbi.address = common_address;
             dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
@@ -838,20 +838,20 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
 TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
     TEST_DESCRIPTION("Dispatch pipeline with descriptor set bound while descriptor buffer expected");
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
+    VkPhysicalDeviceBufferDeviceAddressFeatures buffer_device_address_features = vku::InitStructHelper();
     InitBasicDescriptorBuffer(&buffer_device_address_features);
     if (::testing::Test::IsSkipped()) return;
 
     const VkDescriptorSetLayoutBinding binding{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr};
 
-    auto dslci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo dslci = vku::InitStructHelper();
     dslci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
     dslci.bindingCount = 1;
     dslci.pBindings = &binding;
 
     vkt::DescriptorSetLayout dsl(*m_device, dslci);
 
-    auto plci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
     plci.setLayoutCount = 1;
     plci.pSetLayouts = &dsl.handle();
 
@@ -859,17 +859,17 @@ TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
     ASSERT_TRUE(pipeline_layout.initialized());
 
     uint32_t qfi = 0;
-    auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffCI = vku::InitStructHelper();
     buffCI.size = 4096;
     buffCI.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
     buffCI.queueFamilyIndexCount = 1;
     buffCI.pQueueFamilyIndices = &qfi;
 
-    auto allocate_flag_info = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
     allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
     vkt::Buffer buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
-    auto dbbi = vku::InitStruct<VkDescriptorBufferBindingInfoEXT>();
+    VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
     dbbi.address = buffer.address();
     dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
@@ -897,12 +897,12 @@ TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
 TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
     TEST_DESCRIPTION("Dispatch pipeline with descriptor buffer bound while of descriptor set expected");
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
+    VkPhysicalDeviceBufferDeviceAddressFeatures buffer_device_address_features = vku::InitStructHelper();
     InitBasicDescriptorBuffer(&buffer_device_address_features);
     if (::testing::Test::IsSkipped()) return;
 
     const VkDescriptorSetLayoutBinding binding{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr};
-    auto dslci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo dslci = vku::InitStructHelper();
     dslci.flags = 0;
     dslci.bindingCount = 1;
     dslci.pBindings = &binding;
@@ -913,7 +913,7 @@ TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.pPoolSizes = &ds_type_count;
@@ -924,7 +924,7 @@ TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
     std::unique_ptr<vkt::DescriptorSet> ds(pool.alloc_sets(*m_device, dsl));
     ASSERT_TRUE(ds);
 
-    auto plci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
     plci.setLayoutCount = 1;
     plci.pSetLayouts = &dsl.handle();
 
@@ -952,11 +952,11 @@ TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
 TEST_F(NegativeDescriptorBuffer, BindPoint) {
     TEST_DESCRIPTION("Descriptor buffer invalid bind point.");
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
+    VkPhysicalDeviceBufferDeviceAddressFeatures buffer_device_address_features = vku::InitStructHelper();
     InitBasicDescriptorBuffer(&buffer_device_address_features);
     if (::testing::Test::IsSkipped()) return;
 
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::PipelineLayout pipeline_layout;
@@ -979,7 +979,7 @@ TEST_F(NegativeDescriptorBuffer, BindPoint) {
         vkt::DescriptorSetLayout dsl2(*m_device, dslci2);
 
         const VkDescriptorSetLayout set_layouts[2] = {dsl1.handle(), dsl2.handle()};
-        auto plci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+        VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
         plci.setLayoutCount = 2;
         plci.pSetLayouts = set_layouts;
 
@@ -1013,10 +1013,10 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoBasic) {
     if (::testing::Test::IsSkipped()) return;
 
     uint8_t buffer[128];
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    auto dgi = vku::InitStruct<VkDescriptorGetInfoEXT>();
+    VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
     dgi.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorGetInfoEXT-type-08018");
@@ -1036,12 +1036,12 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoSampler) {
     if (::testing::Test::IsSkipped()) return;
 
     uint8_t buffer[128];
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
     const VkDescriptorImageInfo dii = {sampler.handle(), VK_NULL_HANDLE, VK_IMAGE_LAYOUT_GENERAL};
-    auto dgi = vku::InitStruct<VkDescriptorGetInfoEXT>();
+    VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
 
     dgi.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     dgi.data.pCombinedImageSampler = &dii;
@@ -1103,10 +1103,10 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAS) {
     if (::testing::Test::IsSkipped()) return;
 
     uint8_t buffer[128];
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    auto dgi = vku::InitStruct<VkDescriptorGetInfoEXT>();
+    VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
     dgi.type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
     dgi.data.accelerationStructure = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorDataEXT-type-08041");
@@ -1121,10 +1121,10 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoRtxNV) {
     if (::testing::Test::IsSkipped()) return;
 
     uint8_t buffer[128];
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    auto dgi = vku::InitStruct<VkDescriptorGetInfoEXT>();
+    VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
     dgi.type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV;
     dgi.data.accelerationStructure = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorDataEXT-type-08042");
@@ -1135,16 +1135,16 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoRtxNV) {
 TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAddressRange) {
     TEST_DESCRIPTION("Descriptor buffer vkDescriptorGetInfo() with VkDescriptorAddressInfoEXT.");
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
+    VkPhysicalDeviceBufferDeviceAddressFeatures buffer_device_address_features = vku::InitStructHelper();
     InitBasicDescriptorBuffer(&buffer_device_address_features);
     if (::testing::Test::IsSkipped()) return;
 
     uint8_t buffer[128];
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     uint32_t qfi = 0;
-    auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffCI = vku::InitStructHelper();
     buffCI.size = 4096;
     buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     buffCI.queueFamilyIndexCount = 1;
@@ -1153,8 +1153,8 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAddressRange) {
     vkt::Buffer d_buffer;
     d_buffer.init_no_mem(*m_device, buffCI);
 
-    auto dai = vku::InitStruct<VkDescriptorAddressInfoEXT>();
-    auto dgi = vku::InitStruct<VkDescriptorGetInfoEXT>();
+    VkDescriptorAddressInfoEXT dai = vku::InitStructHelper();
+    VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
     dgi.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     dgi.data.pUniformBuffer = &dai;
 
@@ -1169,7 +1169,7 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAddressRange) {
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(m_device->device(), d_buffer.handle(), &mem_reqs);
 
-    auto memflagsinfo = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo memflagsinfo = vku::InitStructHelper();
     memflagsinfo.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
     auto mem_alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, mem_reqs, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     mem_alloc_info.pNext = &memflagsinfo;
@@ -1244,7 +1244,7 @@ TEST_F(NegativeDescriptorBuffer, Various) {
     if (::testing::Test::IsSkipped()) return;
     const bool nv_ray_tracing = IsExtensionsEnabled(VK_NV_RAY_TRACING_EXTENSION_NAME);
 
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
@@ -1254,7 +1254,7 @@ TEST_F(NegativeDescriptorBuffer, Various) {
         VkDeviceAddress invalid_buffer = CastToHandle<VkDeviceAddress, uintptr_t>(0xbaadbeef);
 
         uint8_t buffer[128];
-        auto dgi = vku::InitStruct<VkDescriptorGetInfoEXT>();
+        VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
 
         const VkDescriptorImageInfo dii = {invalid_sampler, invalid_imageview, VK_IMAGE_LAYOUT_GENERAL};
 
@@ -1283,7 +1283,7 @@ TEST_F(NegativeDescriptorBuffer, Various) {
         vk::GetDescriptorEXT(m_device->device(), &dgi, descriptor_buffer_properties.storageImageDescriptorSize, &buffer);
         m_errorMonitor->VerifyFound();
 
-        auto dai = vku::InitStruct<VkDescriptorAddressInfoEXT>();
+        VkDescriptorAddressInfoEXT dai = vku::InitStructHelper();
         dai.address = invalid_buffer;
         dai.range = 64;
         dai.format = VK_FORMAT_R8_UINT;
@@ -1346,11 +1346,11 @@ TEST_F(NegativeDescriptorBuffer, Various) {
         }
     }
 
-    auto descriptor_buffer_features = vku::InitStruct<VkPhysicalDeviceDescriptorBufferFeaturesEXT>();
+    VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptor_buffer_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(descriptor_buffer_features);
     if (descriptor_buffer_features.descriptorBufferCaptureReplay) {
         uint32_t qfi = 0;
-        auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo buffCI = vku::InitStructHelper();
         buffCI.flags = VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
         buffCI.size = 4096;
         buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
@@ -1374,7 +1374,7 @@ TEST_F(NegativeDescriptorBuffer, Various) {
     }
 
     if (descriptor_buffer_features.descriptorBufferCaptureReplay) {
-        auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+        VkImageCreateInfo image_create_info = vku::InitStructHelper();
         image_create_info.flags = VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
         image_create_info.imageType = VK_IMAGE_TYPE_2D;
         image_create_info.extent.width = 128;
@@ -1423,20 +1423,20 @@ TEST_F(NegativeDescriptorBuffer, ExtensionCombination) {
     ASSERT_TRUE(q_props[0].queueCount > 0);
 
     const float q_priority[] = {1.0f};
-    auto queue_ci = vku::InitStruct<VkDeviceQueueCreateInfo>();
+    VkDeviceQueueCreateInfo queue_ci = vku::InitStructHelper();
     queue_ci.queueFamilyIndex = 0;
     queue_ci.queueCount = 1;
     queue_ci.pQueuePriorities = q_priority;
 
-    auto device_ci = vku::InitStruct<VkDeviceCreateInfo>();
+    VkDeviceCreateInfo device_ci = vku::InitStructHelper();
     device_ci.queueCreateInfoCount = 1;
     device_ci.pQueueCreateInfos = &queue_ci;
 
     device_ci.enabledExtensionCount = m_device_extension_names.size();
     device_ci.ppEnabledExtensionNames = m_device_extension_names.data();
 
-    auto dbf = vku::InitStruct<VkPhysicalDeviceDescriptorBufferFeaturesEXT>();
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&dbf);
+    VkPhysicalDeviceDescriptorBufferFeaturesEXT dbf = vku::InitStructHelper();
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&dbf);
     device_ci.pNext = &features2;
 
     dbf.descriptorBuffer = true;
@@ -1453,7 +1453,7 @@ TEST_F(NegativeDescriptorBuffer, SetBufferAddressSpaceLimits) {
     InitBasicDescriptorBuffer();
     if (::testing::Test::IsSkipped()) return;
 
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
     // After a few GB, can have memory issues running these tests
     // descriptorBufferAddressSpaceSize is always the largest of the 3 buffer address size limits
@@ -1462,7 +1462,7 @@ TEST_F(NegativeDescriptorBuffer, SetBufferAddressSpaceLimits) {
         GTEST_SKIP() << "descriptorBufferAddressSpaceSize are too large";
     }
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = descriptor_buffer_properties.descriptorBufferAddressSpaceSize + 1;
 
     buffer_ci.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
@@ -1483,14 +1483,14 @@ TEST_F(NegativeDescriptorBuffer, NullHandle) {
     InitBasicDescriptorBuffer();
     if (::testing::Test::IsSkipped()) return;
 
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     const auto invalid_sampler = CastToHandle<VkSampler, uintptr_t>(0x0);
     const auto invalid_imageview = CastToHandle<VkImageView, uintptr_t>(0x0);
 
     std::array<std::byte, 128> buffer = {};
-    auto dgi = vku::InitStruct<VkDescriptorGetInfoEXT>();
+    VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
 
     const VkDescriptorImageInfo dii = {invalid_sampler, invalid_imageview, VK_IMAGE_LAYOUT_GENERAL};
 
@@ -1506,14 +1506,14 @@ TEST_F(NegativeDescriptorBuffer, BufferUsage) {
     InitBasicDescriptorBuffer();
     if (::testing::Test::IsSkipped()) return;
 
-    auto descriptor_buffer_properties = vku::InitStruct<VkPhysicalDeviceDescriptorBufferPropertiesEXT>();
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     if (descriptor_buffer_properties.bufferlessPushDescriptors) {
         GTEST_SKIP() << "bufferlessPushDescriptors is supported";
     }
 
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = 64;
     buffer_create_info.usage = VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT;
 

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -22,7 +22,7 @@ void DescriptorBufferTest::InitBasicDescriptorBuffer(void* pNextFeatures) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto descriptor_buffer_features = vku::InitStruct<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(pNextFeatures);
+    VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptor_buffer_features = vku::InitStructHelper(pNextFeatures);
     GetPhysicalDeviceFeatures2(descriptor_buffer_features);
     if (!descriptor_buffer_features.descriptorBuffer) {
         GTEST_SKIP() << "Test requires (unsupported) descriptorBuffer , skipping.";
@@ -37,7 +37,7 @@ TEST_F(PositiveDescriptorBuffer, BasicUsage) {
     if (::testing::Test::IsSkipped()) return;
 
     // *descriptorBufferAddressSpaceSize properties are guaranteed to be 2^27
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
 
     {
@@ -60,18 +60,18 @@ TEST_F(PositiveDescriptorBuffer, BasicUsage) {
 TEST_F(PositiveDescriptorBuffer, BindBufferAndSetOffset) {
     TEST_DESCRIPTION("Bind descriptor buffer and set descriptor offset.");
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
+    VkPhysicalDeviceBufferDeviceAddressFeatures buffer_device_address_features = vku::InitStructHelper();
     InitBasicDescriptorBuffer(&buffer_device_address_features);
     if (::testing::Test::IsSkipped()) return;
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-    auto allocate_flag_info = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
     allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
     vkt::Buffer buffer(*m_device, buffer_ci, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
-    auto buffer_binding_info = vku::InitStruct<VkDescriptorBufferBindingInfoEXT>();
+    VkDescriptorBufferBindingInfoEXT buffer_binding_info = vku::InitStructHelper();
     buffer_binding_info.address = buffer.address();
     buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
 

--- a/tests/unit/descriptor_indexing.cpp
+++ b/tests/unit/descriptor_indexing.cpp
@@ -46,7 +46,7 @@ TEST_F(NegativeDescriptorIndexing, UpdateAfterBind) {
 
     VkDescriptorBindingFlagsEXT flags[3] = {0, VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT,
                                             VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT};
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = 3;
     flags_create_info.pBindingFlags = &flags[0];
 
@@ -56,7 +56,7 @@ TEST_F(NegativeDescriptorIndexing, UpdateAfterBind) {
         {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
         {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
     };
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(&flags_create_info);
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper(&flags_create_info);
     ds_layout_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT;
     ds_layout_ci.bindingCount = 3;
     ds_layout_ci.pBindings = &binding[0];
@@ -67,14 +67,14 @@ TEST_F(NegativeDescriptorIndexing, UpdateAfterBind) {
         {binding[1].descriptorType, binding[1].descriptorCount},
         {binding[2].descriptorType, binding[2].descriptorCount},
     };
-    auto dspci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo dspci = vku::InitStructHelper();
     dspci.flags = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT_EXT;
     dspci.poolSizeCount = 3;
     dspci.pPoolSizes = &pool_sizes[0];
     dspci.maxSets = 1;
     vkt::DescriptorPool pool(*m_device, dspci);
 
-    auto ds_alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo ds_alloc_info = vku::InitStructHelper();
     ds_alloc_info.descriptorPool = pool.handle();
     ds_alloc_info.descriptorSetCount = 1;
     ds_alloc_info.pSetLayouts = &ds_layout.handle();
@@ -83,7 +83,7 @@ TEST_F(NegativeDescriptorIndexing, UpdateAfterBind) {
     VkResult err = vk::AllocateDescriptorSets(m_device->handle(), &ds_alloc_info, &ds);
     ASSERT_VK_SUCCESS(err);
 
-    auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffCI = vku::InitStructHelper();
     buffCI.size = 1024;
     buffCI.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
@@ -105,7 +105,7 @@ TEST_F(NegativeDescriptorIndexing, UpdateAfterBind) {
     descriptor_write[1].dstBinding = 1;
     descriptor_write[1].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
 
-    auto pipeline_layout_ci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
     pipeline_layout_ci.setLayoutCount = 1;
     pipeline_layout_ci.pSetLayouts = &ds_layout.handle();
 
@@ -133,7 +133,7 @@ TEST_F(NegativeDescriptorIndexing, UpdateAfterBind) {
     // Make both bindings valid before binding to the command buffer
     vk::UpdateDescriptorSets(m_device->device(), 2, &descriptor_write[0], 0, NULL);
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
 
@@ -196,7 +196,7 @@ TEST_F(NegativeDescriptorIndexing, SetNonIdenticalWrite) {
     // not all identical VkDescriptorBindingFlags flags
     VkDescriptorBindingFlags flags[3] = {VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT, 0,
                                          VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT};
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfo>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfo flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = 3;
     flags_create_info.pBindingFlags = &flags[0];
 
@@ -205,28 +205,28 @@ TEST_F(NegativeDescriptorIndexing, SetNonIdenticalWrite) {
         {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
         {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
     };
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(&flags_create_info);
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper(&flags_create_info);
     ds_layout_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
     ds_layout_ci.bindingCount = 3;
     ds_layout_ci.pBindings = &binding[0];
     vkt::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
 
     VkDescriptorPoolSize pool_sizes = {VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 3};
-    auto dspci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo dspci = vku::InitStructHelper();
     dspci.flags = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT;
     dspci.poolSizeCount = 1;
     dspci.pPoolSizes = &pool_sizes;
     dspci.maxSets = 3;
     vkt::DescriptorPool pool(*m_device, dspci);
 
-    auto ds_alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo ds_alloc_info = vku::InitStructHelper();
     ds_alloc_info.descriptorPool = pool.handle();
     ds_alloc_info.descriptorSetCount = 1;
     ds_alloc_info.pSetLayouts = &ds_layout.handle();
     VkDescriptorSet ds = VK_NULL_HANDLE;
     ASSERT_VK_SUCCESS(vk::AllocateDescriptorSets(m_device->handle(), &ds_alloc_info, &ds));
 
-    auto buff_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buff_create_info = vku::InitStructHelper();
     buff_create_info.size = 1024;
     buff_create_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     vkt::Buffer buffer(*m_device, buff_create_info);
@@ -238,7 +238,7 @@ TEST_F(NegativeDescriptorIndexing, SetNonIdenticalWrite) {
     bufferInfo[1] = bufferInfo[0];
     bufferInfo[2] = bufferInfo[0];
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = ds;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
@@ -256,7 +256,7 @@ TEST_F(NegativeDescriptorIndexing, SetLayoutWithoutExtension) {
     TEST_DESCRIPTION("Create an update_after_bind set layout without loading the needed extension.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT;
 
     VkDescriptorSetLayout ds_layout = VK_NULL_HANDLE;
@@ -285,12 +285,12 @@ TEST_F(NegativeDescriptorIndexing, SetLayout) {
 
     std::array<VkDescriptorBindingFlagsEXT, 2> flags = {
         {VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT, VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT}};
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = size32(flags);
     flags_create_info.pBindingFlags = nullptr;
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(&flags_create_info);
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper(&flags_create_info);
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &binding;
 
@@ -329,13 +329,13 @@ TEST_F(NegativeDescriptorIndexing, SetLayout) {
         vkt::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
 
         VkDescriptorPoolSize pool_size = {binding.descriptorType, binding.descriptorCount};
-        auto dspci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+        VkDescriptorPoolCreateInfo dspci = vku::InitStructHelper();
         dspci.poolSizeCount = 1;
         dspci.pPoolSizes = &pool_size;
         dspci.maxSets = 1;
         vkt::DescriptorPool pool(*m_device, dspci);
 
-        auto ds_alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+        VkDescriptorSetAllocateInfo ds_alloc_info = vku::InitStructHelper();
         ds_alloc_info.descriptorPool = pool.handle();
         ds_alloc_info.descriptorSetCount = 1;
         ds_alloc_info.pSetLayouts = &ds_layout.handle();
@@ -349,7 +349,7 @@ TEST_F(NegativeDescriptorIndexing, SetLayout) {
 
     if (descriptor_indexing_features.descriptorBindingVariableDescriptorCount) {
         VkDescriptorPoolSize pool_size = {binding.descriptorType, 3};
-        auto dspci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+        VkDescriptorPoolCreateInfo dspci = vku::InitStructHelper();
         dspci.poolSizeCount = 1;
         dspci.pPoolSizes = &pool_size;
         dspci.maxSets = 2;
@@ -361,13 +361,13 @@ TEST_F(NegativeDescriptorIndexing, SetLayout) {
             flags[0] = VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT_EXT;
             vkt::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
 
-            auto count_alloc_info = vku::InitStruct<VkDescriptorSetVariableDescriptorCountAllocateInfoEXT>();
+            VkDescriptorSetVariableDescriptorCountAllocateInfoEXT count_alloc_info = vku::InitStructHelper();
             count_alloc_info.descriptorSetCount = 1;
             // Set variable count larger than what was in the descriptor binding
             uint32_t variable_count = 2;
             count_alloc_info.pDescriptorCounts = &variable_count;
 
-            auto ds_alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>(&count_alloc_info);
+            VkDescriptorSetAllocateInfo ds_alloc_info = vku::InitStructHelper(&count_alloc_info);
             ds_alloc_info.descriptorPool = pool.handle();
             ds_alloc_info.descriptorSetCount = 1;
             ds_alloc_info.pSetLayouts = &ds_layout.handle();
@@ -384,12 +384,12 @@ TEST_F(NegativeDescriptorIndexing, SetLayout) {
             binding.descriptorCount = 3;
             vkt::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
 
-            auto count_alloc_info = vku::InitStruct<VkDescriptorSetVariableDescriptorCountAllocateInfoEXT>();
+            VkDescriptorSetVariableDescriptorCountAllocateInfoEXT count_alloc_info = vku::InitStructHelper();
             count_alloc_info.descriptorSetCount = 1;
             uint32_t variable_count = 2;
             count_alloc_info.pDescriptorCounts = &variable_count;
 
-            auto ds_alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>(&count_alloc_info);
+            VkDescriptorSetAllocateInfo ds_alloc_info = vku::InitStructHelper(&count_alloc_info);
             ds_alloc_info.descriptorPool = pool.handle();
             ds_alloc_info.descriptorSetCount = 1;
             ds_alloc_info.pSetLayouts = &ds_layout.handle();
@@ -445,7 +445,7 @@ TEST_F(NegativeDescriptorIndexing, SetLayoutBindings) {
 
     VkDescriptorBindingFlags flags[2] = {VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT, 0};
 
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = 2;
     flags_create_info.pBindingFlags = flags;
 

--- a/tests/unit/descriptor_indexing_positive.cpp
+++ b/tests/unit/descriptor_indexing_positive.cpp
@@ -55,7 +55,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkDescriptorBindingFlagsEXT ds_binding_flags[2] = {};
-    auto layout_createinfo_binding_flags = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT layout_createinfo_binding_flags = vku::InitStructHelper();
     ds_binding_flags[0] = 0;
     // No Error
     ds_binding_flags[1] = VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT_EXT;
@@ -74,7 +74,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
                                        0, &layout_createinfo_binding_flags, 0);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
     uint32_t qfi = 0;
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = 32;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_create_info.queueFamilyIndexCount = 1;
@@ -87,7 +87,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     buffer_info[0].offset = 0;
     buffer_info[0].range = sizeof(uint32_t);
 
-    auto index_buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo index_buffer_create_info = vku::InitStructHelper();
     index_buffer_create_info.size = sizeof(uint32_t);
     index_buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     vkt::Buffer index_buffer(*m_device, index_buffer_create_info);
@@ -121,7 +121,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    auto begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     m_commandBuffer->begin(&begin_info);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
@@ -139,7 +139,7 @@ TEST_F(PositiveDescriptorIndexing, UpdateAfterBind) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    auto synchronization2 = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR synchronization2 = vku::InitStructHelper();
     InitBasicDescriptorIndexing(&synchronization2);
     if (::testing::Test::IsSkipped()) return;
 
@@ -151,7 +151,7 @@ TEST_F(PositiveDescriptorIndexing, UpdateAfterBind) {
     }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
@@ -163,7 +163,7 @@ TEST_F(PositiveDescriptorIndexing, UpdateAfterBind) {
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer1, &buffer_mem_reqs);
 
-    auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = buffer_mem_reqs.size;
 
     VkDeviceMemory memory1, memory2, memory3;
@@ -180,7 +180,7 @@ TEST_F(PositiveDescriptorIndexing, UpdateAfterBind) {
         {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
     };
     VkDescriptorBindingFlagsEXT flags[2] = {VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT, 0};
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = 2;
     flags_create_info.pBindingFlags = flags;
     OneOffDescriptorSet descriptor_set(m_device, binding_defs, VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT,
@@ -236,10 +236,10 @@ TEST_F(PositiveDescriptorIndexing, UpdateAfterBind) {
     buffer_info.buffer = buffer2;
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
 
-    auto cb_info = vku::InitStruct<VkCommandBufferSubmitInfoKHR>();
+    VkCommandBufferSubmitInfoKHR cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = m_commandBuffer->handle();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo2KHR>();
+    VkSubmitInfo2KHR submit_info = vku::InitStructHelper();
     submit_info.commandBufferInfoCount = 1;
     submit_info.pCommandBufferInfos = &cb_info;
 
@@ -259,7 +259,7 @@ TEST_F(PositiveDescriptorIndexing, PartiallyBoundDescriptors) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    auto synchronization2 = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR synchronization2 = vku::InitStructHelper();
     InitBasicDescriptorIndexing(&synchronization2);
     if (::testing::Test::IsSkipped()) return;
 
@@ -272,7 +272,7 @@ TEST_F(PositiveDescriptorIndexing, PartiallyBoundDescriptors) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
@@ -283,7 +283,7 @@ TEST_F(PositiveDescriptorIndexing, PartiallyBoundDescriptors) {
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer1, &buffer_mem_reqs);
 
-    auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = buffer_mem_reqs.size;
 
     VkDeviceMemory memory1, memory3;
@@ -298,7 +298,7 @@ TEST_F(PositiveDescriptorIndexing, PartiallyBoundDescriptors) {
         {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
     };
     VkDescriptorBindingFlagsEXT flags[2] = {VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT, 0};
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = 2;
     flags_create_info.pBindingFlags = flags;
     OneOffDescriptorSet descriptor_set(m_device, binding_defs, VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT,
@@ -352,10 +352,10 @@ TEST_F(PositiveDescriptorIndexing, PartiallyBoundDescriptors) {
 
     vk::DestroyBuffer(device(), buffer1, nullptr);
 
-    auto cb_info = vku::InitStruct<VkCommandBufferSubmitInfoKHR>();
+    VkCommandBufferSubmitInfoKHR cb_info = vku::InitStructHelper();
     cb_info.commandBuffer = m_commandBuffer->handle();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo2KHR>();
+    VkSubmitInfo2KHR submit_info = vku::InitStructHelper();
     submit_info.commandBufferInfoCount = 1;
     submit_info.pCommandBufferInfos = &cb_info;
 

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -29,7 +29,7 @@ TEST_F(NegativeDescriptors, DescriptorPoolConsistency) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.flags = 0;
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
@@ -64,7 +64,7 @@ TEST_F(NegativeDescriptors, AllocDescriptorFromEmptyPool) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
     ds_type_count.descriptorCount = 2;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.flags = 0;
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
@@ -84,7 +84,7 @@ TEST_F(NegativeDescriptors, AllocDescriptorFromEmptyPool) {
     // Try to allocate 2 sets when pool only has 1 set
     VkDescriptorSet descriptor_sets[2];
     VkDescriptorSetLayout set_layouts[2] = {ds_layout_samp.handle(), ds_layout_samp.handle()};
-    auto alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.descriptorSetCount = 2;
     alloc_info.descriptorPool = ds_pool.handle();
     alloc_info.pSetLayouts = set_layouts;
@@ -119,7 +119,7 @@ TEST_F(NegativeDescriptors, FreeDescriptorFromOneShotPool) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.flags = 0;
@@ -139,7 +139,7 @@ TEST_F(NegativeDescriptors, FreeDescriptorFromOneShotPool) {
     const vkt::DescriptorSetLayout ds_layout(*m_device, {dsl_binding});
 
     VkDescriptorSet descriptorSet;
-    auto alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.descriptorSetCount = 1;
     alloc_info.descriptorPool = ds_pool.handle();
     alloc_info.pSetLayouts = &ds_layout.handle();
@@ -213,7 +213,7 @@ TEST_F(NegativeDescriptors, DescriptorSetLayout) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-pSetLayouts-parameter");
     ASSERT_NO_FATAL_FAILURE(Init());
     VkPipelineLayout pipeline_layout;
-    auto plci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
     plci.setLayoutCount = 1;
     plci.pSetLayouts = &bad_layout;
     vk::CreatePipelineLayout(device(), &plci, NULL, &pipeline_layout);
@@ -245,7 +245,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetIntegrity) {
     OneOffDescriptorSet descriptor_set(m_device, bindings);
     ASSERT_TRUE(descriptor_set.Initialized());
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -258,7 +258,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetIntegrity) {
 
     // Create a buffer to update the descriptor with
     uint32_t qfi = 0;
-    auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffCI = vku::InitStructHelper();
     buffCI.size = 1024;
     buffCI.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffCI.queueFamilyIndexCount = 1;
@@ -362,7 +362,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetIdentitySwizzle) {
     ASSERT_TRUE(image_obj.initialized());
     VkImage image = image_obj.image();
 
-    auto image_view_ci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo image_view_ci = vku::InitStructHelper();
     image_view_ci.image = image;
     image_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -399,7 +399,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetConsecutiveUpdates) {
                                                  });
 
     uint32_t qfi = 0;
-    auto bci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo bci = vku::InitStructHelper();
     bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     bci.size = 2048;
     bci.queueFamilyIndexCount = 1;
@@ -423,7 +423,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetConsecutiveUpdates) {
         buffer_info[2].offset = 0;
         buffer_info[2].range = 1024;
 
-        auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_set.set_;  // descriptor_set;
         descriptor_write.dstBinding = 0;
         descriptor_write.descriptorCount = 3;
@@ -464,7 +464,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetConsecutiveUpdates) {
     // buffer2 just went out of scope and was destroyed
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkBuffer");
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -482,7 +482,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetBufferDestroyed) {
     {
         // Create a buffer to update the descriptor with
         uint32_t qfi = 0;
-        auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo buffCI = vku::InitStructHelper();
         buffCI.size = 1024;
         buffCI.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         buffCI.queueFamilyIndexCount = 1;
@@ -521,7 +521,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetBufferDestroyed) {
     // Destroy buffer should invalidate the cmd buffer, causing error on submit
 
     // Attempt to submit cmd buffer
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     // Invalid VkBuffer
@@ -541,7 +541,7 @@ TEST_F(NegativeDescriptors, DrawDescriptorSetBufferDestroyed) {
     {
         // Create a buffer to update the descriptor with
         uint32_t qfi = 0;
-        auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo buffCI = vku::InitStructHelper();
         buffCI.size = 1024;
         buffCI.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         buffCI.queueFamilyIndexCount = 1;
@@ -594,7 +594,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
@@ -613,7 +613,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
 
     VkResult err;
     VkDescriptorSet descriptorSet;
-    auto alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.descriptorSetCount = 1;
     alloc_info.descriptorPool = ds_pool.handle();
     alloc_info.pSetLayouts = &ds_layout.handle();
@@ -626,7 +626,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     const VkFormat tex_format = VK_FORMAT_B8G8R8A8_UNORM;
     const int32_t tex_width = 32;
     const int32_t tex_height = 32;
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = tex_format;
     image_create_info.extent.width = tex_width;
@@ -643,7 +643,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
 
     VkMemoryRequirements memory_reqs;
     bool pass;
-    auto memory_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = 0;
     memory_info.memoryTypeIndex = 0;
     vk::GetImageMemoryRequirements(m_device->device(), tmp_image.handle(), &memory_reqs);
@@ -659,7 +659,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     // Bind second image to memory right after first image
     image2.bind_memory(image_memory, aligned_size);
 
-    auto image_view_create_info = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo image_view_create_info = vku::InitStructHelper();
     image_view_create_info.image = tmp_image.handle();
     image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_create_info.format = tex_format;
@@ -685,7 +685,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     img_info.imageView = tmp_view.handle();
     img_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptorSet;
     descriptor_write.dstBinding = 0;
     descriptor_write.dstArrayElement = 0;
@@ -716,7 +716,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     m_commandBuffer->begin();
 
     // Transit image layout from VK_IMAGE_LAYOUT_UNDEFINED into VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
-    auto barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier barrier = vku::InitStructHelper();
     barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -739,7 +739,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     m_commandBuffer->Draw(1, 0, 0, 0);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     // This first submit should be successful
@@ -787,7 +787,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     img_info.sampler = sampler2.handle();
     vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
 
-    auto info = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo info = vku::InitStructHelper();
     info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkImage");
     m_commandBuffer->begin(&info);
@@ -872,7 +872,7 @@ TEST_F(NegativeDescriptors, DescriptorSetSamplerDestroyed) {
     image.Init(32, 32, 1, tex_format, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
-    auto image_view_create_info = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo image_view_create_info = vku::InitStructHelper();
     image_view_create_info.image = image.handle();
     image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_create_info.format = tex_format;
@@ -896,7 +896,7 @@ TEST_F(NegativeDescriptors, DescriptorSetSamplerDestroyed) {
     VkDescriptorImageInfo img_info1 = img_info;
     img_info1.sampler = sampler1.handle();
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.dstArrayElement = 0;
@@ -981,7 +981,7 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
     VkDescriptorImageInfo img_info = {};
     img_info.sampler = sampler.handle();
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptorSet;
     descriptor_write.dstBinding = 0;
     descriptor_write.dstArrayElement = 0;
@@ -999,7 +999,7 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
 
     VkCommandBufferObj cmd_buf(m_device, m_commandPool);
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &cmd_buf.handle();
 
@@ -1142,7 +1142,7 @@ TEST_F(NegativeDescriptors, DescriptorPoolInUseResetSignaled) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
     // Submit cmd buffer to put pool in-flight
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -1168,7 +1168,7 @@ TEST_F(NegativeDescriptors, DescriptorImageUpdateNoMemoryBound) {
     const VkFormat tex_format = VK_FORMAT_B8G8R8A8_UNORM;
     const int32_t tex_width = 32;
     const int32_t tex_height = 32;
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = tex_format;
     image_create_info.extent.width = tex_width;
@@ -1183,7 +1183,7 @@ TEST_F(NegativeDescriptors, DescriptorImageUpdateNoMemoryBound) {
     // Create with bound memory to avoid error at bind view time. We'll break binding before update.
     vkt::Image image(*m_device, image_create_info);
 
-    auto image_view_create_info = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo image_view_create_info = vku::InitStructHelper();
     image_view_create_info.image = image.handle();
     image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_create_info.format = tex_format;
@@ -1226,7 +1226,7 @@ TEST_F(NegativeDescriptors, DynamicOffsetCases) {
 
     // Create a buffer to update the descriptor with
     uint32_t qfi = 0;
-    auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffCI = vku::InitStructHelper();
     buffCI.size = 1024;
     buffCI.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffCI.queueFamilyIndexCount = 1;
@@ -1288,7 +1288,7 @@ TEST_F(NegativeDescriptors, DescriptorBufferUpdateNoMemoryBound) {
 
     // Create a buffer to update the descriptor with
     uint32_t qfi = 0;
-    auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffCI = vku::InitStructHelper();
     buffCI.size = 1024;
     buffCI.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffCI.queueFamilyIndexCount = 1;
@@ -1311,7 +1311,7 @@ TEST_F(NegativeDescriptors, DynamicDescriptorSet) {
 
     // Create a buffer to update the descriptor with
     uint32_t qfi = 0;
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = buffer_size;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_ci.queueFamilyIndexCount = 1;
@@ -1459,7 +1459,7 @@ TEST_F(NegativeDescriptors, DynamicOffsetWithNullBuffer) {
     buff_info[2].offset = 0;
     buff_info[2].range = 512;
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.dstArrayElement = 0;
@@ -1515,7 +1515,7 @@ TEST_F(NegativeDescriptors, UpdateDescriptorSetMismatchType) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     uint32_t qfi = 0;
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = m_device->props.limits.minUniformBufferOffsetAlignment;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_ci.queueFamilyIndexCount = 1;
@@ -1558,7 +1558,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
     ds_type_count[4].type = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
     ds_type_count[4].descriptorCount = 2;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.maxSets = 5;
     ds_pool_ci.poolSizeCount = NUM_DESCRIPTOR_TYPES;
     ds_pool_ci.pPoolSizes = ds_type_count;
@@ -1612,7 +1612,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
 
     static const uint32_t NUM_SETS = 4;
     VkDescriptorSet descriptorSet[NUM_SETS] = {};
-    auto alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.descriptorPool = ds_pool.handle();
     alloc_info.descriptorSetCount = ds_vk_layouts.size();
     alloc_info.pSetLayouts = ds_vk_layouts.data();
@@ -1638,7 +1638,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
 
     // Add buffer binding for UBO
     uint32_t qfi = 0;
-    auto bci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo bci = vku::InitStructHelper();
     bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     bci.size = 8;
     bci.queueFamilyIndexCount = 1;
@@ -1648,7 +1648,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
     buffer_info.buffer = buffer.handle();
     buffer_info.offset = 0;
     buffer_info.range = VK_WHOLE_SIZE;
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptorSet[0];
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -1809,7 +1809,7 @@ TEST_F(NegativeDescriptors, DSUsageBits) {
     img_info.imageView = image_view;
     img_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
     img_info.sampler = sampler.handle();
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
     descriptor_write.pTexelBufferView = &buffer_view;
@@ -1861,7 +1861,7 @@ TEST_F(NegativeDescriptors, DSUsageBitsFlags2) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
@@ -1872,15 +1872,15 @@ TEST_F(NegativeDescriptors, DSUsageBitsFlags2) {
         GTEST_SKIP() << "Device does not support VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT for this format";
     }
 
-    auto buffer_usage_flags = vku::InitStruct<VkBufferUsageFlags2CreateInfoKHR>();
+    VkBufferUsageFlags2CreateInfoKHR buffer_usage_flags = vku::InitStructHelper();
     buffer_usage_flags.usage = VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR;
 
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>(&buffer_usage_flags);
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&buffer_usage_flags);
     buffer_create_info.size = 1024;
     buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
     vkt::Buffer buffer(*m_device, buffer_create_info);
 
-    auto buff_view_ci = vku::InitStruct<VkBufferViewCreateInfo>();
+    VkBufferViewCreateInfo buff_view_ci = vku::InitStructHelper();
     buff_view_ci.buffer = buffer.handle();
     buff_view_ci.format = buffer_format;
     buff_view_ci.range = VK_WHOLE_SIZE;
@@ -1890,7 +1890,7 @@ TEST_F(NegativeDescriptors, DSUsageBitsFlags2) {
                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                  });
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -1940,7 +1940,7 @@ TEST_F(NegativeDescriptors, DSBufferLimit) {
                                                      });
 
         // Create a buffer to be used for invalid updates
-        auto bci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo bci = vku::InitStructHelper();
         bci.usage = test_case.buffer_usage;
         bci.size = test_case.max_range + test_case.min_align;  // Make buffer bigger than range limit
         bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
@@ -1956,7 +1956,7 @@ TEST_F(NegativeDescriptors, DSBufferLimit) {
         VkMemoryRequirements mem_reqs;
         vk::GetBufferMemoryRequirements(m_device->device(), buffer.handle(), &mem_reqs);
 
-        auto mem_alloc = vku::InitStruct<VkMemoryAllocateInfo>();
+        VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
         mem_alloc.allocationSize = mem_reqs.size;
         bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &mem_alloc, 0);
         if (!pass) {
@@ -1974,7 +1974,7 @@ TEST_F(NegativeDescriptors, DSBufferLimit) {
 
         VkDescriptorBufferInfo buff_info = {};
         buff_info.buffer = buffer.handle();
-        auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstBinding = 0;
         descriptor_write.descriptorCount = 1;
         descriptor_write.pTexelBufferView = nullptr;
@@ -2049,7 +2049,7 @@ TEST_F(NegativeDescriptors, DSUpdateOutOfBounds) {
     buff_info.offset = 0;
     buff_info.range = VK_WHOLE_SIZE;
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.dstArrayElement = 1; /* This index out of bounds for the update */
@@ -2236,7 +2236,7 @@ TEST_F(NegativeDescriptors, CopyDescriptorUpdate) {
     descriptor_set.WriteDescriptorImageInfo(1, VK_NULL_HANDLE, sampler.handle(), VK_DESCRIPTOR_TYPE_SAMPLER);
     descriptor_set.UpdateDescriptorSets();
     // Now perform a copy update that fails due to type mismatch
-    auto copy_ds_update = vku::InitStruct<VkCopyDescriptorSet>();
+    VkCopyDescriptorSet copy_ds_update = vku::InitStructHelper();
     copy_ds_update.srcSet = descriptor_set.set_;
     copy_ds_update.srcBinding = 1;  // Copy from SAMPLER binding
     copy_ds_update.dstSet = descriptor_set.set_;
@@ -2342,14 +2342,14 @@ TEST_F(NegativeDescriptors, UpdateDestroyDescriptorSetLayout) {
     info.buffer = buffer.handle();
     info.range = VK_WHOLE_SIZE;
 
-    auto write_descriptor = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet write_descriptor = vku::InitStructHelper();
     write_descriptor.dstSet = VK_NULL_HANDLE;  // must update this
     write_descriptor.dstBinding = 0;
     write_descriptor.descriptorCount = 1;
     write_descriptor.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     write_descriptor.pBufferInfo = &info;
 
-    auto copy_descriptor = vku::InitStruct<VkCopyDescriptorSet>();
+    VkCopyDescriptorSet copy_descriptor = vku::InitStructHelper();
     copy_descriptor.srcSet = VK_NULL_HANDLE;  // must update
     copy_descriptor.srcBinding = 0;
     copy_descriptor.dstSet = VK_NULL_HANDLE;  // must update
@@ -2492,7 +2492,7 @@ TEST_F(NegativeDescriptors, DuplicateDescriptorBinding) {
     dsl_binding[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
     dsl_binding[2].pImmutableSamplers = NULL;
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.bindingCount = NUM_BINDINGS;
     ds_layout_ci.pBindings = dsl_binding;
     VkDescriptorSetLayout ds_layout;
@@ -2524,20 +2524,20 @@ TEST_F(NegativeDescriptors, InlineUniformBlockEXT) {
     bool has_descriptor_indexing =
         IsExtensionsEnabled(VK_KHR_MAINTENANCE_3_EXTENSION_NAME) && IsExtensionsEnabled(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
 
-    auto descriptor_indexing_features = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT descriptor_indexing_features = vku::InitStructHelper();
     void *pNext = has_descriptor_indexing ? &descriptor_indexing_features : nullptr;
     // Create a device that enables inline_uniform_block
-    auto inline_uniform_block_features = vku::InitStruct<VkPhysicalDeviceInlineUniformBlockFeaturesEXT>(pNext);
+    VkPhysicalDeviceInlineUniformBlockFeaturesEXT inline_uniform_block_features = vku::InitStructHelper(pNext);
     auto features2 = GetPhysicalDeviceFeatures2(inline_uniform_block_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto inline_uniform_props = vku::InitStruct<VkPhysicalDeviceInlineUniformBlockPropertiesEXT>();
+    VkPhysicalDeviceInlineUniformBlockPropertiesEXT inline_uniform_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(inline_uniform_props);
 
     VkDescriptorSetLayoutBinding dslb = {};
     std::vector<VkDescriptorSetLayoutBinding> dslb_vec = {};
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
 
     // Test too many bindings
     dslb_vec.clear();
@@ -2570,7 +2570,7 @@ TEST_F(NegativeDescriptors, InlineUniformBlockEXT) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02215");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLayoutCreateInfo-descriptorType-02217");
 
-        auto pipeline_layout_ci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+        VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
         pipeline_layout_ci.setLayoutCount = 1;
         pipeline_layout_ci.pSetLayouts = &ds_layout.handle();
         VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
@@ -2596,7 +2596,7 @@ TEST_F(NegativeDescriptors, InlineUniformBlockEXT) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT;
     ds_type_count.descriptorCount = 33;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.flags = 0;
     ds_pool_ci.maxSets = 2;
     ds_pool_ci.poolSizeCount = 1;
@@ -2630,7 +2630,7 @@ TEST_F(NegativeDescriptors, InlineUniformBlockEXT) {
 
     VkDescriptorSet descriptor_sets[2];
     VkDescriptorSetLayout set_layouts[2] = {ds_layout.handle(), ds_layout.handle()};
-    auto alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.descriptorSetCount = 2;
     alloc_info.descriptorPool = pool.handle();
     alloc_info.pSetLayouts = set_layouts;
@@ -2638,7 +2638,7 @@ TEST_F(NegativeDescriptors, InlineUniformBlockEXT) {
     ASSERT_VK_SUCCESS(err);
 
     // Test invalid VkWriteDescriptorSet parameters (array element and size must be multiple of 4)
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_sets[0];
     descriptor_write.dstBinding = 0;
     descriptor_write.dstArrayElement = 0;
@@ -2646,7 +2646,7 @@ TEST_F(NegativeDescriptors, InlineUniformBlockEXT) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT;
 
     uint32_t dummyData[8] = {};
-    auto write_inline_uniform = vku::InitStruct<VkWriteDescriptorSetInlineUniformBlockEXT>();
+    VkWriteDescriptorSetInlineUniformBlockEXT write_inline_uniform = vku::InitStructHelper();
     write_inline_uniform.dataSize = 3;
     write_inline_uniform.pData = &dummyData[0];
     descriptor_write.pNext = &write_inline_uniform;
@@ -2674,7 +2674,7 @@ TEST_F(NegativeDescriptors, InlineUniformBlockEXT) {
     vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
 
     // Test invalid VkCopyDescriptorSet parameters (array element and size must be multiple of 4)
-    auto copy_ds_update = vku::InitStruct<VkCopyDescriptorSet>();
+    VkCopyDescriptorSet copy_ds_update = vku::InitStructHelper();
     copy_ds_update.srcSet = descriptor_sets[0];
     copy_ds_update.srcBinding = 0;
     copy_ds_update.srcArrayElement = 0;
@@ -2722,7 +2722,7 @@ TEST_F(NegativeDescriptors, InlineUniformBlockEXTFeature) {
     dslb.descriptorCount = 1;
     dslb.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.flags = 0;
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &dslb;
@@ -2751,7 +2751,7 @@ TEST_F(NegativeDescriptors, DstArrayElement) {
     image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     descriptor_set.image_infos.emplace_back(image_info);
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.dstArrayElement = 0;
@@ -2801,7 +2801,7 @@ TEST_F(NegativeDescriptors, DescriptorSetLayoutMisc) {
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
     dsl_binding.pImmutableSamplers = nullptr;
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &dsl_binding;
 
@@ -2832,7 +2832,7 @@ TEST_F(NegativeDescriptors, DescriptorSetLayoutStageFlags) {
     dsl_binding.stageFlags = 0xBADFFFFF;
     dsl_binding.pImmutableSamplers = nullptr;
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &dsl_binding;
 
@@ -2855,7 +2855,7 @@ TEST_F(NegativeDescriptors, DescriptorSetLayoutImmutableSamplers) {
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
     dsl_binding.pImmutableSamplers = badhandles;
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &dsl_binding;
 
@@ -2880,7 +2880,7 @@ TEST_F(NegativeDescriptors, DescriptorSetLayoutNullImmutableSamplers) {
     dsl_binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
     dsl_binding.pImmutableSamplers = null_samples;
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &dsl_binding;
 
@@ -2936,7 +2936,7 @@ TEST_F(NegativeDescriptors, NullDescriptorsEnabled) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto robustness2_features = vku::InitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
+    VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(robustness2_features);
 
     if (!robustness2_features.nullDescriptor) {
@@ -3031,7 +3031,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenAttachmentsAndDescript
     VkImageView view_input = image.targetView(format, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 1, 1);
     VkImageView attachments[] = {view_input, depth_view};
 
-    auto createView = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo createView = vku::InitStructHelper();
     createView.image = image.handle();
     createView.viewType = VK_IMAGE_VIEW_TYPE_2D;
     createView.format = format;
@@ -3131,7 +3131,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenAttachmentsAndDescript
                             {3, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {4, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
 
-    auto pipe_ds_state_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo pipe_ds_state_ci = vku::InitStructHelper();
     pipe_ds_state_ci.depthTestEnable = VK_TRUE;
     pipe_ds_state_ci.stencilTestEnable = VK_FALSE;
 
@@ -3180,7 +3180,7 @@ TEST_F(NegativeDescriptors, CreateDescriptorPoolFlags) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -3189,7 +3189,7 @@ TEST_F(NegativeDescriptors, CreateDescriptorPoolFlags) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT | VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT;
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
@@ -3215,7 +3215,7 @@ TEST_F(NegativeDescriptors, MissingMutableDescriptorTypeFeature) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT;
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
@@ -3241,7 +3241,7 @@ TEST_F(NegativeDescriptors, MutableDescriptorPoolsWithPartialOverlap) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
 
@@ -3267,11 +3267,11 @@ TEST_F(NegativeDescriptors, MutableDescriptorPoolsWithPartialOverlap) {
     lists[1].descriptorTypeCount = 2;
     lists[1].pDescriptorTypes = second_types;
 
-    auto mdtci = vku::InitStruct<VkMutableDescriptorTypeCreateInfoEXT>();
+    VkMutableDescriptorTypeCreateInfoEXT mdtci = vku::InitStructHelper();
     mdtci.mutableDescriptorTypeListCount = 2;
     mdtci.pMutableDescriptorTypeLists = lists;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>(&mdtci);
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper(&mdtci);
     ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT;
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 2;
@@ -3308,7 +3308,7 @@ TEST_F(NegativeDescriptors, CreateDescriptorPoolAllocateFlags) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -3317,7 +3317,7 @@ TEST_F(NegativeDescriptors, CreateDescriptorPoolAllocateFlags) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.flags = 0;
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
@@ -3337,7 +3337,7 @@ TEST_F(NegativeDescriptors, CreateDescriptorPoolAllocateFlags) {
 
     VkDescriptorSetLayout set_layout = ds_layout_samp.handle();
 
-    auto alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.descriptorSetCount = 1;
     alloc_info.descriptorPool = pool.handle();
     alloc_info.pSetLayouts = &set_layout;
@@ -3359,10 +3359,10 @@ TEST_F(NegativeDescriptors, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) 
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto inlineUniformProps = vku::InitStruct<VkPhysicalDeviceInlineUniformBlockPropertiesEXT>();
+    VkPhysicalDeviceInlineUniformBlockPropertiesEXT inlineUniformProps = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(inlineUniformProps);
 
-    auto extEnable = vku::InitStruct<VkPhysicalDeviceInlineUniformBlockFeaturesEXT>();
+    VkPhysicalDeviceInlineUniformBlockFeaturesEXT extEnable = vku::InitStructHelper();
     extEnable.inlineUniformBlock = VK_TRUE;
     extEnable.descriptorBindingInlineUniformBlockUpdateAfterBind = VK_FALSE;
 
@@ -3385,7 +3385,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) 
             layoutBinding[i].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
         }
 
-        auto layoutCreate = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+        VkDescriptorSetLayoutCreateInfo layoutCreate = vku::InitStructHelper();
         layoutCreate.bindingCount = 3;
         layoutCreate.pBindings = layoutBinding;
 
@@ -3401,7 +3401,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) 
 
     vkt::DescriptorPool descPool;
     {
-        auto descPoolInlineInfo = vku::InitStruct<VkDescriptorPoolInlineUniformBlockCreateInfoEXT>();
+        VkDescriptorPoolInlineUniformBlockCreateInfoEXT descPoolInlineInfo = vku::InitStructHelper();
         descPoolInlineInfo.maxInlineUniformBlockBindings = 2;
 
         VkDescriptorPoolSize poolSize[2];
@@ -3410,7 +3410,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) 
         poolSize[1].descriptorCount = 1;
         poolSize[1].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
 
-        auto poolCreate = vku::InitStruct<VkDescriptorPoolCreateInfo>(&descPoolInlineInfo);
+        VkDescriptorPoolCreateInfo poolCreate = vku::InitStructHelper(&descPoolInlineInfo);
         poolCreate.poolSizeCount = 2;
         poolCreate.pPoolSizes = poolSize;
         poolCreate.maxSets = 1;
@@ -3421,7 +3421,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) 
 
     VkDescriptorSet descSetHandle = VK_NULL_HANDLE;
     {
-        auto allocInfo = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+        VkDescriptorSetAllocateInfo allocInfo = vku::InitStructHelper();
         allocInfo.pSetLayouts = &descLayout.handle();
         allocInfo.descriptorSetCount = 1;
         allocInfo.descriptorPool = descPool.handle();
@@ -3434,11 +3434,11 @@ TEST_F(NegativeDescriptors, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) 
     }
     vkt::DescriptorSet descSet(*m_device, &descPool, descSetHandle);
 
-    auto writeInlineUbDesc = vku::InitStruct<VkWriteDescriptorSetInlineUniformBlockEXT>();
+    VkWriteDescriptorSetInlineUniformBlockEXT writeInlineUbDesc = vku::InitStructHelper();
     writeInlineUbDesc.dataSize = sizeof(inline_data);
     writeInlineUbDesc.pData = inline_data;
 
-    auto writeDesc = vku::InitStruct<VkWriteDescriptorSet>(&writeInlineUbDesc);
+    VkWriteDescriptorSet writeDesc = vku::InitStructHelper(&writeInlineUbDesc);
     writeDesc.descriptorCount = sizeof(inline_data);
     writeDesc.descriptorType = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT;
     writeDesc.dstBinding = 0;
@@ -3457,7 +3457,7 @@ TEST_F(NegativeDescriptors, WriteMutableDescriptorSet) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mutdesc_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutdesc_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutdesc_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutdesc_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -3466,7 +3466,7 @@ TEST_F(NegativeDescriptors, WriteMutableDescriptorSet) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_MUTABLE_EXT;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.pPoolSizes = &ds_type_count;
@@ -3489,18 +3489,18 @@ TEST_F(NegativeDescriptors, WriteMutableDescriptorSet) {
     list.descriptorTypeCount = 2;
     list.pDescriptorTypes = types;
 
-    auto mdtci = vku::InitStruct<VkMutableDescriptorTypeCreateInfoEXT>();
+    VkMutableDescriptorTypeCreateInfoEXT mdtci = vku::InitStructHelper();
     mdtci.mutableDescriptorTypeListCount = 1;
     mdtci.pMutableDescriptorTypeLists = &list;
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(&mdtci);
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper(&mdtci);
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &dsl_binding;
 
     vkt::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
     VkDescriptorSetLayout ds_layout_handle = ds_layout.handle();
 
-    auto allocate_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo allocate_info = vku::InitStructHelper();
     allocate_info.descriptorPool = pool.handle();
     allocate_info.descriptorSetCount = 1;
     allocate_info.pSetLayouts = &ds_layout_handle;
@@ -3509,7 +3509,7 @@ TEST_F(NegativeDescriptors, WriteMutableDescriptorSet) {
     VkResult err = vk::AllocateDescriptorSets(device(), &allocate_info, &descriptor_set);
     ASSERT_VK_SUCCESS(err);
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
@@ -3520,7 +3520,7 @@ TEST_F(NegativeDescriptors, WriteMutableDescriptorSet) {
     buffer_info.offset = 0;
     buffer_info.range = buffer_ci.size;
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -3547,7 +3547,7 @@ TEST_F(NegativeDescriptors, MutableDescriptors) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     VkDescriptorSetLayoutBinding dsl_binding = {};
@@ -3563,11 +3563,11 @@ TEST_F(NegativeDescriptors, MutableDescriptors) {
     mutable_descriptor_type_list.descriptorTypeCount = 1;
     mutable_descriptor_type_list.pDescriptorTypes = descriptor_types;
 
-    auto mutable_descriptor_type_ci = vku::InitStruct<VkMutableDescriptorTypeCreateInfoEXT>();
+    VkMutableDescriptorTypeCreateInfoEXT mutable_descriptor_type_ci = vku::InitStructHelper();
     mutable_descriptor_type_ci.mutableDescriptorTypeListCount = 1;
     mutable_descriptor_type_ci.pMutableDescriptorTypeLists = &mutable_descriptor_type_list;
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(&mutable_descriptor_type_ci);
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper(&mutable_descriptor_type_ci);
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &dsl_binding;
 
@@ -3621,7 +3621,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateTemplate) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
-    auto mutdesc_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutdesc_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutdesc_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutdesc_features));
 
@@ -3629,7 +3629,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateTemplate) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_MUTABLE_EXT;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.pPoolSizes = &ds_type_count;
@@ -3652,11 +3652,11 @@ TEST_F(NegativeDescriptors, DescriptorUpdateTemplate) {
     list.descriptorTypeCount = 2;
     list.pDescriptorTypes = types;
 
-    auto mdtci = vku::InitStruct<VkMutableDescriptorTypeCreateInfoEXT>();
+    VkMutableDescriptorTypeCreateInfoEXT mdtci = vku::InitStructHelper();
     mdtci.mutableDescriptorTypeListCount = 1;
     mdtci.pMutableDescriptorTypeLists = &list;
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(&mdtci);
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper(&mdtci);
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &dsl_binding;
 
@@ -3671,7 +3671,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateTemplate) {
     update_template_entry.offset = 0;
     update_template_entry.stride = 16;
 
-    auto update_template_ci = vku::InitStruct<VkDescriptorUpdateTemplateCreateInfo>();
+    VkDescriptorUpdateTemplateCreateInfo update_template_ci = vku::InitStructHelper();
     update_template_ci.descriptorUpdateEntryCount = 1;
     update_template_ci.pDescriptorUpdateEntries = &update_template_entry;
     update_template_ci.templateType = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET;
@@ -3693,14 +3693,14 @@ TEST_F(NegativeDescriptors, MutableDescriptorSetLayout) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_MUTABLE_EXT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &binding;
 
@@ -3718,7 +3718,7 @@ TEST_F(NegativeDescriptors, MutableDescriptorSetLayout) {
     list.descriptorTypeCount = 2;
     list.pDescriptorTypes = types;
 
-    auto mdtci = vku::InitStruct<VkMutableDescriptorTypeCreateInfoEXT>();
+    VkMutableDescriptorTypeCreateInfoEXT mdtci = vku::InitStructHelper();
     mdtci.mutableDescriptorTypeListCount = 1;
     mdtci.pMutableDescriptorTypeLists = &list;
 
@@ -3743,15 +3743,15 @@ TEST_F(NegativeDescriptors, MutableDescriptorSetLayoutMissingFeature) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     mutable_descriptor_type_features.mutableDescriptorType = VK_FALSE;
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&mutable_descriptor_type_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_HOST_ONLY_POOL_BIT_EXT;  // Invalid, feature is not enabled
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &binding;
@@ -3770,7 +3770,7 @@ TEST_F(NegativeDescriptors, MutableDescriptorSetLayoutMissingFeature) {
     list.descriptorTypeCount = 2;
     list.pDescriptorTypes = types;
 
-    auto mdtci = vku::InitStruct<VkMutableDescriptorTypeCreateInfoEXT>();
+    VkMutableDescriptorTypeCreateInfoEXT mdtci = vku::InitStructHelper();
     mdtci.mutableDescriptorTypeListCount = 1;
     mdtci.pMutableDescriptorTypeLists = &list;
 
@@ -3818,7 +3818,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -3826,7 +3826,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
 
     vkt::RenderPass render_pass(*m_device, rpci);
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = format;
     image_create_info.extent.width = width;
@@ -3842,7 +3842,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     VkImageObj image(m_device);
     image.init(&image_create_info);
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = format;
@@ -3857,7 +3857,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.width = width;
     fbci.height = height;
     fbci.layers = 1;
@@ -3867,7 +3867,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
 
     vkt::Framebuffer framebuffer(*m_device, fbci);
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer.handle();
     rpbi.renderPass = render_pass.handle();
     rpbi.renderArea.extent.width = width;
@@ -3911,7 +3911,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     image_info.sampler = sampler.handle();
     image_info.imageView = image_view.handle();
     image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -3961,7 +3961,7 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -3969,7 +3969,7 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
 
     vkt::RenderPass render_pass(*m_device, rpci);
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = format;
     image_create_info.extent.width = width;
@@ -3985,7 +3985,7 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
     VkImageObj image(m_device);
     image.init(&image_create_info);
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = format;
@@ -4000,7 +4000,7 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.width = width;
     fbci.height = height;
     fbci.layers = 1;
@@ -4010,7 +4010,7 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, fbci);
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer.handle();
     rpbi.renderPass = render_pass.handle();
     rpbi.renderArea.extent.width = width;
@@ -4053,7 +4053,7 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
     image_info.sampler = sampler.handle();
     image_info.imageView = image_view.handle();
     image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -4109,7 +4109,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -4117,7 +4117,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
 
     vkt::RenderPass render_pass(*m_device, rpci);
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = format;
     image_create_info.extent.width = width;
@@ -4133,7 +4133,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     VkImageObj image(m_device);
     image.init(&image_create_info);
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = format;
@@ -4148,7 +4148,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.width = width;
     fbci.height = height;
     fbci.layers = 1;
@@ -4158,7 +4158,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, fbci);
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer.handle();
     rpbi.renderPass = render_pass.handle();
     rpbi.renderArea.extent.width = width;
@@ -4213,7 +4213,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     image_info.sampler = sampler.handle();
     image_info.imageView = image_view.handle();
     image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set_storage_image.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -4247,7 +4247,7 @@ TEST_F(NegativeDescriptors, AllocatingVariableDescriptorSets) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto indexing_features = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(indexing_features);
     if (indexing_features.descriptorBindingVariableDescriptorCount == VK_FALSE) {
         GTEST_SKIP() << "descriptorBindingVariableDescriptorCount feature not supported";
@@ -4255,33 +4255,33 @@ TEST_F(NegativeDescriptors, AllocatingVariableDescriptorSets) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     VkDescriptorBindingFlagsEXT flags[2] = {0, VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT};
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = 2;
     flags_create_info.pBindingFlags = flags;
 
     VkDescriptorSetLayoutBinding bindings[2] = {
         {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
         {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, std::numeric_limits<uint32_t>::max() / 64, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(&flags_create_info);
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper(&flags_create_info);
     ds_layout_ci.bindingCount = 2;
     ds_layout_ci.pBindings = bindings;
     vkt::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
     VkDescriptorSetLayout ds_layout_handle = ds_layout.handle();
 
-    auto count_alloc_info = vku::InitStruct<VkDescriptorSetVariableDescriptorCountAllocateInfoEXT>();
+    VkDescriptorSetVariableDescriptorCountAllocateInfoEXT count_alloc_info = vku::InitStructHelper();
     count_alloc_info.descriptorSetCount = 1;
     uint32_t variable_count = 2;
     count_alloc_info.pDescriptorCounts = &variable_count;
 
     VkDescriptorPoolSize pool_sizes[2] = {{bindings[0].descriptorType, bindings[0].descriptorCount},
                                           {bindings[1].descriptorType, bindings[1].descriptorCount}};
-    auto dspci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo dspci = vku::InitStructHelper();
     dspci.poolSizeCount = 2;
     dspci.pPoolSizes = pool_sizes;
     dspci.maxSets = 1;
     vkt::DescriptorPool pool(*m_device, dspci);
 
-    auto ds_alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>(&count_alloc_info);
+    VkDescriptorSetAllocateInfo ds_alloc_info = vku::InitStructHelper(&count_alloc_info);
     ds_alloc_info.descriptorPool = pool.handle();
     ds_alloc_info.descriptorSetCount = 1;
     ds_alloc_info.pSetLayouts = &ds_layout_handle;
@@ -4299,7 +4299,7 @@ TEST_F(NegativeDescriptors, DescriptorSetLayoutBinding) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
 
@@ -4342,7 +4342,7 @@ TEST_F(NegativeDescriptors, BindingDescriptorSetFromHostOnlyPool) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mutdesc_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutdesc_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutdesc_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutdesc_features));
 
@@ -4394,7 +4394,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     {
@@ -4639,7 +4639,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         VkDescriptorImageInfo image_info = {};
         image_info.sampler = sampler.handle();
 
-        auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_sets[0];
         descriptor_write.dstBinding = 0;
         descriptor_write.dstArrayElement = 0;
@@ -4654,7 +4654,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         descriptor_write.pImageInfo = nullptr;
         vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
-        auto copy_set = vku::InitStruct<VkCopyDescriptorSet>();
+        VkCopyDescriptorSet copy_set = vku::InitStructHelper();
         copy_set.srcSet = descriptor_sets[0];
         copy_set.srcBinding = 0;
         copy_set.srcArrayElement = 0;
@@ -4688,7 +4688,7 @@ TEST_F(NegativeDescriptors, UpdatingMutableDescriptors) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
 
@@ -4846,8 +4846,8 @@ TEST_F(NegativeDescriptors, SampledImageDepthComparisonForFormat) {
 
     VkFormat format = VK_FORMAT_UNDEFINED;
     for (uint32_t fmt = VK_FORMAT_R4G4_UNORM_PACK8; fmt < VK_FORMAT_D16_UNORM; fmt++) {
-        auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-        auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
         vk::GetPhysicalDeviceFormatProperties2KHR(gpu(), (VkFormat)fmt, &fmt_props);
 

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -56,7 +56,7 @@ TEST_F(PositiveDescriptors, DeleteDescriptorSetLayoutsBeforeDescriptorSets) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
@@ -75,7 +75,7 @@ TEST_F(PositiveDescriptors, DeleteDescriptorSetLayoutsBeforeDescriptorSets) {
     {
         const vkt::DescriptorSetLayout ds_layout(*m_device, {dsl_binding});
 
-        auto alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+        VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
         alloc_info.descriptorSetCount = 1;
         alloc_info.descriptorPool = ds_pool_one.handle();
         alloc_info.pSetLayouts = &ds_layout.handle();
@@ -89,7 +89,7 @@ TEST_F(PositiveDescriptors, PoolSizeCountZero) {
     TEST_DESCRIPTION("Allow poolSizeCount to zero.");
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 0;
     vkt::DescriptorPool ds_pool_one(*m_device, ds_pool_ci);
@@ -128,7 +128,7 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
         image_info.imageView = view;
         image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-        auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_set.set_;
         descriptor_write.dstBinding = 0;
         descriptor_write.descriptorCount = 1;
@@ -150,7 +150,7 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
     // Buffer Case
     {
         uint32_t queue_family_index = 0;
-        auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
         buffer_create_info.size = 1024;
         buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         buffer_create_info.queueFamilyIndexCount = 1;
@@ -167,7 +167,7 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
         buffer_info.offset = 0;
         buffer_info.range = 1024;
 
-        auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_set.set_;
         descriptor_write.dstBinding = 0;
         descriptor_write.descriptorCount = 1;
@@ -189,7 +189,7 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
     // Texel Buffer Case
     {
         uint32_t queue_family_index = 0;
-        auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
         buffer_create_info.size = 1024;
         buffer_create_info.usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
         buffer_create_info.queueFamilyIndexCount = 1;
@@ -197,7 +197,7 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
 
         vkt::Buffer buffer(*m_device, buffer_create_info);
 
-        auto buff_view_ci = vku::InitStruct<VkBufferViewCreateInfo>();
+        VkBufferViewCreateInfo buff_view_ci = vku::InitStructHelper();
         buff_view_ci.buffer = buffer.handle();
         buff_view_ci.format = format_texel_case;
         buff_view_ci.range = VK_WHOLE_SIZE;
@@ -208,7 +208,7 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
                                                {0, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                            });
 
-        auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_set.set_;
         descriptor_write.dstBinding = 0;
         descriptor_write.descriptorCount = 1;
@@ -267,7 +267,7 @@ TEST_F(PositiveDescriptors, EmptyDescriptorUpdate) {
                                      });
 
     // Create a buffer to be used for update
-    auto buff_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buff_ci = vku::InitStructHelper();
     buff_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buff_ci.size = 256;
     buff_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
@@ -278,7 +278,7 @@ TEST_F(PositiveDescriptors, EmptyDescriptorUpdate) {
     buff_info.buffer = buffer.handle();
     buff_info.offset = 0;
     buff_info.range = VK_WHOLE_SIZE;
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstBinding = 2;
     descriptor_write.descriptorCount = 1;
     descriptor_write.pTexelBufferView = nullptr;
@@ -308,7 +308,7 @@ TEST_F(PositiveDescriptors, DynamicOffsetWithInactiveBinding) {
     // Create two buffers to update the descriptors with
     // The first will be 2k and used for bindings 0 & 1, the second is 1k for binding 2
     uint32_t qfi = 0;
-    auto buffCI = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffCI = vku::InitStructHelper();
     buffCI.size = 2048;
     buffCI.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffCI.queueFamilyIndexCount = 1;
@@ -332,7 +332,7 @@ TEST_F(PositiveDescriptors, DynamicOffsetWithInactiveBinding) {
     buff_info[2].offset = 0;
     buff_info[2].range = 512;
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = BINDING_COUNT;
@@ -383,7 +383,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
 
@@ -395,7 +395,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
     mutable_descriptor_type_lists[1].descriptorTypeCount = 0;
     mutable_descriptor_type_lists[1].pDescriptorTypes = nullptr;
 
-    auto mdtci = vku::InitStruct<VkMutableDescriptorTypeCreateInfoEXT>();
+    VkMutableDescriptorTypeCreateInfoEXT mdtci = vku::InitStructHelper();
     mdtci.mutableDescriptorTypeListCount = 2;
     mdtci.pMutableDescriptorTypeLists = mutable_descriptor_type_lists;
 
@@ -405,7 +405,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
     pool_sizes[1].type = VK_DESCRIPTOR_TYPE_MUTABLE_EXT;
     pool_sizes[1].descriptorCount = 2;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>(&mdtci);
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper(&mdtci);
     ds_pool_ci.maxSets = 2;
     ds_pool_ci.poolSizeCount = 2;
     ds_pool_ci.pPoolSizes = pool_sizes;
@@ -424,7 +424,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
     bindings[1].stageFlags = VK_SHADER_STAGE_ALL;
     bindings[1].pImmutableSamplers = nullptr;
 
-    auto create_info = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(&mdtci);
+    VkDescriptorSetLayoutCreateInfo create_info = vku::InitStructHelper(&mdtci);
     create_info.bindingCount = 2;
     create_info.pBindings = bindings;
 
@@ -433,7 +433,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
 
     VkDescriptorSetLayout layouts[2] = {set_layout_handle, set_layout_handle};
 
-    auto allocate_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo allocate_info = vku::InitStructHelper();
     allocate_info.descriptorPool = pool.handle();
     allocate_info.descriptorSetCount = 2;
     allocate_info.pSetLayouts = layouts;
@@ -441,7 +441,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
     VkDescriptorSet descriptor_sets[2];
     vk::AllocateDescriptorSets(device(), &allocate_info, descriptor_sets);
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
@@ -452,7 +452,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
     buffer_info.offset = 0;
     buffer_info.range = buffer_ci.size;
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_sets[0];
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -461,7 +461,7 @@ TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
 
     vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
-    auto copy_set = vku::InitStruct<VkCopyDescriptorSet>();
+    VkCopyDescriptorSet copy_set = vku::InitStructHelper();
     copy_set.srcSet = descriptor_sets[0];
     copy_set.srcBinding = 0;
     copy_set.dstSet = descriptor_sets[1];
@@ -483,9 +483,9 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
-    auto acc_struct_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&mutable_descriptor_type_features);
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&acc_struct_features);
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR acc_struct_features = vku::InitStructHelper(&mutable_descriptor_type_features);
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&acc_struct_features);
     GetPhysicalDeviceFeatures2(bda_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &bda_features));
 
@@ -495,7 +495,7 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
     mutable_descriptor_type_list.descriptorTypeCount = descriptor_types.size();
     mutable_descriptor_type_list.pDescriptorTypes = descriptor_types.data();
 
-    auto mdtci = vku::InitStruct<VkMutableDescriptorTypeCreateInfoEXT>();
+    VkMutableDescriptorTypeCreateInfoEXT mdtci = vku::InitStructHelper();
     mdtci.mutableDescriptorTypeListCount = 1;
     mdtci.pMutableDescriptorTypeLists = &mutable_descriptor_type_list;
 
@@ -505,7 +505,7 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
     pool_sizes[1].type = VK_DESCRIPTOR_TYPE_MUTABLE_EXT;
     pool_sizes[1].descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>(&mdtci);
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper(&mdtci);
     ds_pool_ci.maxSets = 2;
     ds_pool_ci.poolSizeCount = pool_sizes.size();
     ds_pool_ci.pPoolSizes = pool_sizes.data();
@@ -524,7 +524,7 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
     bindings[1].stageFlags = VK_SHADER_STAGE_ALL;
     bindings[1].pImmutableSamplers = nullptr;
 
-    auto create_info = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(&mdtci);
+    VkDescriptorSetLayoutCreateInfo create_info = vku::InitStructHelper(&mdtci);
     create_info.bindingCount = bindings.size();
     create_info.pBindings = bindings.data();
 
@@ -532,7 +532,7 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
 
     std::array<VkDescriptorSetLayout, 2> layouts = {set_layout.handle(), set_layout.handle()};
 
-    auto allocate_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo allocate_info = vku::InitStructHelper();
     allocate_info.descriptorPool = pool.handle();
     allocate_info.descriptorSetCount = layouts.size();
     allocate_info.pSetLayouts = layouts.data();
@@ -543,11 +543,11 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
     auto tlas = vkt::as::blueprint::AccelStructSimpleOnDeviceTopLevel(DeviceValidationVersion(), 4096);
     tlas->Build(*m_device);
 
-    auto blas_descriptor = vku::InitStruct<VkWriteDescriptorSetAccelerationStructureKHR>();
+    VkWriteDescriptorSetAccelerationStructureKHR blas_descriptor = vku::InitStructHelper();
     blas_descriptor.accelerationStructureCount = 1;
     blas_descriptor.pAccelerationStructures = &tlas->handle();
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_sets[0];
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = blas_descriptor.accelerationStructureCount;
@@ -556,7 +556,7 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
 
     vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
-    auto copy_set = vku::InitStruct<VkCopyDescriptorSet>();
+    VkCopyDescriptorSet copy_set = vku::InitStructHelper();
     copy_set.srcSet = descriptor_sets[0];
     copy_set.srcBinding = 0;
     copy_set.dstSet = descriptor_sets[1];
@@ -594,7 +594,7 @@ TEST_F(PositiveDescriptors, tImageViewAsDescriptorReadAndInputAttachment) {
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -602,7 +602,7 @@ TEST_F(PositiveDescriptors, tImageViewAsDescriptorReadAndInputAttachment) {
 
     vkt::RenderPass render_pass(*m_device, rpci);
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = format;
     image_create_info.extent.width = width;
@@ -618,7 +618,7 @@ TEST_F(PositiveDescriptors, tImageViewAsDescriptorReadAndInputAttachment) {
     VkImageObj image(m_device);
     image.init(&image_create_info);
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = format;
@@ -633,7 +633,7 @@ TEST_F(PositiveDescriptors, tImageViewAsDescriptorReadAndInputAttachment) {
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.width = width;
     fbci.height = height;
     fbci.layers = 1;
@@ -643,7 +643,7 @@ TEST_F(PositiveDescriptors, tImageViewAsDescriptorReadAndInputAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, fbci);
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer.handle();
     rpbi.renderPass = render_pass.handle();
     rpbi.renderArea.extent.width = width;
@@ -693,7 +693,7 @@ TEST_F(PositiveDescriptors, tImageViewAsDescriptorReadAndInputAttachment) {
     image_info.sampler = sampler.handle();
     image_info.imageView = image_view.handle();
     image_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -730,10 +730,10 @@ TEST_F(PositiveDescriptors, UpdateImageDescriptorSetThatHasImageViewUsage) {
     VkImageObj image(m_device);
     image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
 
-    auto image_view_usage_ci = vku::InitStruct<VkImageViewUsageCreateInfo>();
+    VkImageViewUsageCreateInfo image_view_usage_ci = vku::InitStructHelper();
     image_view_usage_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    auto image_view_ci = vku::InitStruct<VkImageViewCreateInfo>(&image_view_usage_ci);
+    VkImageViewCreateInfo image_view_ci = vku::InitStructHelper(&image_view_usage_ci);
     image_view_ci.image = image.handle();
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -769,7 +769,7 @@ TEST_F(PositiveDescriptors, MultipleThreadsUsingHostOnlyDescriptorSet) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mutable_descriptor = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor));
 
@@ -793,7 +793,7 @@ TEST_F(PositiveDescriptors, MultipleThreadsUsingHostOnlyDescriptorSet) {
         image_info.imageView = view1;
         image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-        auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_set.set_;
         descriptor_write.dstBinding = 0;
         descriptor_write.descriptorCount = 1;
@@ -807,7 +807,7 @@ TEST_F(PositiveDescriptors, MultipleThreadsUsingHostOnlyDescriptorSet) {
         image_info.imageView = view2;
         image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-        auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_set.set_;
         descriptor_write.dstBinding = 0;
         descriptor_write.dstArrayElement = 1;
@@ -872,7 +872,7 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
         subpass.inputAttachmentCount = 1;
         subpass.pInputAttachments = &attachment_reference;
 
-        auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+        VkRenderPassCreateInfo rpci = vku::InitStructHelper();
         rpci.attachmentCount = 1;
         rpci.pAttachments = &input_attachment;
         rpci.subpassCount = 1;
@@ -882,7 +882,7 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
         ASSERT_TRUE(render_pass.initialized());
     }
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.renderPass = render_pass.handle();
     fbci.attachmentCount = 1;
     fbci.pAttachments = &view_input;
@@ -946,7 +946,7 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
         // Create resources.
         //
         const VkDescriptorPoolSize pool_size = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 2};
-        auto descriptor_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+        VkDescriptorPoolCreateInfo descriptor_pool_ci = vku::InitStructHelper();
         descriptor_pool_ci.flags = 0;
         descriptor_pool_ci.maxSets = 2;
         descriptor_pool_ci.poolSizeCount = 1;
@@ -955,7 +955,7 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
 
         const VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT,
                                                       nullptr};
-        auto set_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+        VkDescriptorSetLayoutCreateInfo set_layout_ci = vku::InitStructHelper();
         set_layout_ci.flags = 0;
         set_layout_ci.bindingCount = 1;
         set_layout_ci.pBindings = &binding;
@@ -965,7 +965,7 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
         VkDescriptorSet set_B = VK_NULL_HANDLE;
         {
             const VkDescriptorSetLayout set_layouts[2] = {set_layout, set_layout};
-            auto set_alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+            VkDescriptorSetAllocateInfo set_alloc_info = vku::InitStructHelper();
             set_alloc_info.descriptorPool = pool;
             set_alloc_info.descriptorSetCount = 2;
             set_alloc_info.pSetLayouts = set_layouts;
@@ -975,14 +975,14 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
             set_B = sets[1];
         }
 
-        auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
         buffer_ci.size = 1024;
         buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         vkt::Buffer buffer(*m_device, buffer_ci, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
         VkShaderObj fs(this, kFragmentUniformGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        auto pipeline_layout_ci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+        VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
         pipeline_layout_ci.setLayoutCount = 1;
         pipeline_layout_ci.pSetLayouts = &set_layout.handle();
         vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
@@ -999,7 +999,7 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
             buffer_info.offset = 0;
             buffer_info.range = VK_WHOLE_SIZE;
 
-            auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+            VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
             descriptor_write.dstSet = set;
             descriptor_write.descriptorCount = 1;
             descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -1023,7 +1023,7 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
             vk::CmdDraw(cb, 0, 0, 0, 0);
             vk::CmdEndRenderPass(cb);
             cb.end();
-            auto submit_info = vku::InitStruct<VkSubmitInfo>();
+            VkSubmitInfo submit_info = vku::InitStructHelper();
             submit_info.commandBufferCount = 1;
             submit_info.pCommandBuffers = &cb.handle();
             ASSERT_VK_SUCCESS(vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE));
@@ -1042,7 +1042,7 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
             vk::CmdDraw(cb, 0, 0, 0, 0);
             vk::CmdEndRenderPass(cb);
             cb.end();
-            auto submit_info = vku::InitStruct<VkSubmitInfo>();
+            VkSubmitInfo submit_info = vku::InitStructHelper();
             submit_info.commandBufferCount = 1;
             submit_info.pCommandBuffers = &cb.handle();
             ASSERT_VK_SUCCESS(vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE));
@@ -1068,7 +1068,7 @@ TEST_F(PositiveDescriptors, DSUsageBitsFlags2) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 
@@ -1079,15 +1079,15 @@ TEST_F(PositiveDescriptors, DSUsageBitsFlags2) {
         GTEST_SKIP() << "Device does not support VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT for this format";
     }
 
-    auto buffer_usage_flags = vku::InitStruct<VkBufferUsageFlags2CreateInfoKHR>();
+    VkBufferUsageFlags2CreateInfoKHR buffer_usage_flags = vku::InitStructHelper();
     buffer_usage_flags.usage = VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT_KHR;
 
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>(&buffer_usage_flags);
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&buffer_usage_flags);
     buffer_create_info.size = 1024;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;  // would be wrong, but ignored
     vkt::Buffer buffer(*m_device, buffer_create_info);
 
-    auto buff_view_ci = vku::InitStruct<VkBufferViewCreateInfo>();
+    VkBufferViewCreateInfo buff_view_ci = vku::InitStructHelper();
     buff_view_ci.buffer = buffer.handle();
     buff_view_ci.format = buffer_format;
     buff_view_ci.range = VK_WHOLE_SIZE;
@@ -1097,7 +1097,7 @@ TEST_F(PositiveDescriptors, DSUsageBitsFlags2) {
                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                  });
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -26,12 +26,12 @@ TEST_F(NegativeDeviceQueue, FamilyIndex) {
     uint32_t queue_family_index = queue_family_count;
 
     float priority = 1.0f;
-    auto device_queue_ci = vku::InitStruct<VkDeviceQueueCreateInfo>();
+    VkDeviceQueueCreateInfo device_queue_ci = vku::InitStructHelper();
     device_queue_ci.queueFamilyIndex = queue_family_index;
     device_queue_ci.queueCount = 1;
     device_queue_ci.pQueuePriorities = &priority;
 
-    auto device_ci = vku::InitStruct<VkDeviceCreateInfo>();
+    VkDeviceCreateInfo device_ci = vku::InitStructHelper();
     device_ci.queueCreateInfoCount = 1;
     device_ci.pQueueCreateInfos = &device_queue_ci;
     device_ci.enabledLayerCount = 0;
@@ -228,7 +228,7 @@ TEST_F(NegativeDeviceQueue, MismatchedGlobalPriority) {
     device_queue_ci[1].queueCount = 1;
     device_queue_ci[1].pQueuePriorities = &priorities[1];
 
-    auto device_ci = vku::InitStruct<VkDeviceCreateInfo>();
+    VkDeviceCreateInfo device_ci = vku::InitStructHelper();
     device_ci.queueCreateInfoCount = 2;
     device_ci.pQueueCreateInfos = device_queue_ci;
     device_ci.enabledLayerCount = 0;
@@ -256,12 +256,12 @@ TEST_F(NegativeDeviceQueue, QueueCount) {
     std::vector<float> priorities(invalid_count);
     std::fill(priorities.begin(), priorities.end(), 0.0f);
 
-    auto device_queue_ci = vku::InitStruct<VkDeviceQueueCreateInfo>();
+    VkDeviceQueueCreateInfo device_queue_ci = vku::InitStructHelper();
     device_queue_ci.queueFamilyIndex = 0;
     device_queue_ci.queueCount = queue_props[0].queueCount + 1;
     device_queue_ci.pQueuePriorities = priorities.data();
 
-    auto device_ci = vku::InitStruct<VkDeviceCreateInfo>();
+    VkDeviceCreateInfo device_ci = vku::InitStructHelper();
     device_ci.queueCreateInfoCount = 1;
     device_ci.pQueueCreateInfos = &device_queue_ci;
     device_ci.enabledLayerCount = 0;
@@ -284,11 +284,11 @@ TEST_F(NegativeDeviceQueue, QueuePriorities) {
     std::vector<VkQueueFamilyProperties> queue_props(queue_family_count);
     vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_props.data());
 
-    auto device_queue_ci = vku::InitStruct<VkDeviceQueueCreateInfo>();
+    VkDeviceQueueCreateInfo device_queue_ci = vku::InitStructHelper();
     device_queue_ci.queueFamilyIndex = 0;
     device_queue_ci.queueCount = 1;
 
-    auto device_ci = vku::InitStruct<VkDeviceCreateInfo>();
+    VkDeviceCreateInfo device_ci = vku::InitStructHelper();
     device_ci.queueCreateInfoCount = 1;
     device_ci.pQueueCreateInfos = &device_queue_ci;
     device_ci.enabledLayerCount = 0;

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -40,8 +40,8 @@ void DynamicRenderingCommandBufferInheritanceRenderingInfoTest::Test(bool const 
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto linear_color_attachment = vku::InitStruct<VkPhysicalDeviceLinearColorAttachmentFeaturesNV>();
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceLinearColorAttachmentFeaturesNV linear_color_attachment = vku::InitStructHelper();
     if (IsExtensionsEnabled(VK_NV_LINEAR_COLOR_ATTACHMENT_EXTENSION_NAME)) {
         dynamic_rendering_features.pNext = &linear_color_attachment;
     }
@@ -57,26 +57,26 @@ void DynamicRenderingCommandBufferInheritanceRenderingInfoTest::Test(bool const 
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    auto multiview_props = vku::InitStruct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceMultiviewProperties multiview_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(multiview_props);
 
     VkFormat color_format = VK_FORMAT_D32_SFLOAT;
 
-    auto cmd_buffer_inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
+    VkCommandBufferInheritanceRenderingInfoKHR cmd_buffer_inheritance_rendering_info = vku::InitStructHelper();
     cmd_buffer_inheritance_rendering_info.colorAttachmentCount = 1;
     cmd_buffer_inheritance_rendering_info.pColorAttachmentFormats = &color_format;
     cmd_buffer_inheritance_rendering_info.depthAttachmentFormat = VK_FORMAT_R8G8B8_UNORM;
     cmd_buffer_inheritance_rendering_info.stencilAttachmentFormat = VK_FORMAT_R8G8B8_SNORM;
     cmd_buffer_inheritance_rendering_info.viewMask = 1 << multiview_props.maxMultiviewViewCount;
 
-    auto sample_count_info_amd = vku::InitStruct<VkAttachmentSampleCountInfoAMD>();
+    VkAttachmentSampleCountInfoAMD sample_count_info_amd = vku::InitStructHelper();
     sample_count_info_amd.pNext = &cmd_buffer_inheritance_rendering_info;
     sample_count_info_amd.colorAttachmentCount = 2;
 
-    auto cmd_buffer_inheritance_info = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo cmd_buffer_inheritance_info = vku::InitStructHelper();
     cmd_buffer_inheritance_info.pNext = &sample_count_info_amd;
 
-    auto cmd_buffer_allocate_info = vku::InitStruct<VkCommandBufferAllocateInfo>();
+    VkCommandBufferAllocateInfo cmd_buffer_allocate_info = vku::InitStructHelper();
     cmd_buffer_allocate_info.commandPool = m_commandPool->handle();
     cmd_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
     cmd_buffer_allocate_info.commandBufferCount = 0x1;
@@ -126,7 +126,7 @@ TEST_F(NegativeDynamicRendering, CommandDraw) {
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    auto ds_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
 
     VkPipelineObj pipe(m_device);
     pipe.AddShader(&vs);
@@ -138,14 +138,14 @@ TEST_F(NegativeDynamicRendering, CommandDraw) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.depthAttachmentFormat = depth_format;
     pipeline_rendering_info.stencilAttachmentFormat = depth_format;
 
-    auto multisample_state_create_info = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>();
+    VkPipelineMultisampleStateCreateInfo multisample_state_create_info = vku::InitStructHelper();
     multisample_state_create_info.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
 
-    auto create_info = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+    VkGraphicsPipelineCreateInfo create_info = vku::InitStructHelper();
     pipe.InitGraphicsPipelineCreateInfo(&create_info);
     create_info.pMultisampleState = &multisample_state_create_info;
     create_info.renderPass = VkRenderPass(0x1);
@@ -200,7 +200,7 @@ TEST_F(NegativeDynamicRendering, CommandDrawWithShaderTileImageRead) {
     TEST_DESCRIPTION("vkCmdDraw* with shader tile image read extension using dynamic Rendering Tests.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_EXT_SHADER_TILE_IMAGE_EXTENSION_NAME);
-    auto shader_tile_image_features = vku::InitStruct<VkPhysicalDeviceShaderTileImageFeaturesEXT>();
+    VkPhysicalDeviceShaderTileImageFeaturesEXT shader_tile_image_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&shader_tile_image_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -212,12 +212,12 @@ TEST_F(NegativeDynamicRendering, CommandDrawWithShaderTileImageRead) {
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     auto fs = VkShaderObj::CreateFromASM(this, kShaderTileImageDepthStencilReadSpv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    auto ds_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
     ds_state.depthWriteEnable = VK_TRUE;
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
     VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
     pipeline_rendering_info.depthAttachmentFormat = depth_format;
@@ -226,7 +226,7 @@ TEST_F(NegativeDynamicRendering, CommandDrawWithShaderTileImageRead) {
     VkDescriptorSetLayoutBinding dslb = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
 
-    auto ms_ci = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>();
+    VkPipelineMultisampleStateCreateInfo ms_ci = vku::InitStructHelper();
     ms_ci.sampleShadingEnable = VK_TRUE;
     ms_ci.minSampleShading = 1.0;
     ms_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
@@ -328,7 +328,7 @@ TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
         m_renderTargets[0]->width(), m_renderTargets[0]->height(), m_renderTargets[0]->create_info().mipLevels, 4,
         m_renderTargets[0]->format(), m_renderTargets[0]->usage(), VK_IMAGE_TILING_OPTIMAL);
     render_target.Init(render_target_ci, 0);
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = render_target.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     ivci.format = render_target_ci.format;
@@ -343,13 +343,13 @@ TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
     vkt::ImageView render_target_view(*m_device, ivci);
 
     // Create secondary command buffer
-    auto secondary_cmd_buffer_alloc_info = vku::InitStruct<VkCommandBufferAllocateInfo>();
+    VkCommandBufferAllocateInfo secondary_cmd_buffer_alloc_info = vku::InitStructHelper();
     secondary_cmd_buffer_alloc_info.commandPool = m_commandPool->handle();
     secondary_cmd_buffer_alloc_info.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
     secondary_cmd_buffer_alloc_info.commandBufferCount = 1;
 
     vkt::CommandBuffer secondary_cmd_buffer(*m_device, secondary_cmd_buffer_alloc_info);
-    auto inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
+    VkCommandBufferInheritanceRenderingInfoKHR inheritance_rendering_info = vku::InitStructHelper();
     inheritance_rendering_info.colorAttachmentCount = 1;
     inheritance_rendering_info.pColorAttachmentFormats = &render_target_ci.format;
     inheritance_rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
@@ -409,10 +409,10 @@ TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
 
     m_commandBuffer->begin();
 
-    auto color_attachment_info = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment_info = vku::InitStructHelper();
     color_attachment_info.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment_info.imageView = render_target_view.handle();
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR;
     begin_rendering_info.renderArea = clear_rect.rect;
     begin_rendering_info.layerCount = 2;
@@ -443,7 +443,7 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
     // Create color image
     const VkFormat color_format = VK_FORMAT_R32_SFLOAT;
     VkImageObj color_image(m_device);
-    auto imci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo imci = vku::InitStructHelper();
     imci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     imci.imageType = VK_IMAGE_TYPE_2D;
     imci.format = color_format;
@@ -496,16 +496,16 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
 
     // Dynamic rendering structs
     VkRect2D rect{{0, 0}, {32, 32}};
-    auto depth_attachment_info = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR depth_attachment_info = vku::InitStructHelper();
     depth_attachment_info.imageLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
     depth_attachment_info.imageView = depth_stencil_image_view.handle();
-    auto stencil_attachment_info = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR stencil_attachment_info = vku::InitStructHelper();
     stencil_attachment_info.imageLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
     stencil_attachment_info.imageView = depth_stencil_image_view.handle();
-    auto color_attachment_info = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment_info = vku::InitStructHelper();
     color_attachment_info.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment_info.imageView = color_image_view;
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
 
     begin_rendering_info.renderArea = rect;
     begin_rendering_info.layerCount = 1;
@@ -550,7 +550,7 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
     subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
     subpass_dependency.dependencyFlags = 0;
 
-    auto renderpass_ci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo renderpass_ci = vku::InitStructHelper();
     renderpass_ci.attachmentCount = static_cast<uint32_t>(attachments.size());
     renderpass_ci.pAttachments = attachments.data();
     renderpass_ci.subpassCount = static_cast<uint32_t>(subpass_descs.size());
@@ -561,7 +561,7 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
 
     std::array<VkImageView, 2> renderpass_image_views = {depth_stencil_image_view.handle(), color_image_view.handle()};
 
-    auto framebuffer_ci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
     framebuffer_ci.renderPass = renderpass.handle();
     framebuffer_ci.attachmentCount = 2;
     framebuffer_ci.pAttachments = renderpass_image_views.data();
@@ -569,7 +569,7 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
     framebuffer_ci.height = 32;
     framebuffer_ci.layers = 1;
 
-    auto renderpass_bi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo renderpass_bi = vku::InitStructHelper();
     renderpass_bi.renderPass = renderpass.handle();
     renderpass_bi.renderArea = rect;
     renderpass_bi.clearValueCount = 2;
@@ -741,7 +741,7 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
             std::unique_ptr<VkCommandBufferObj> secondary_cmd_buffer(
                 new VkCommandBufferObj(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY));
 
-            auto inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfo>();
+            VkCommandBufferInheritanceRenderingInfo inheritance_rendering_info = vku::InitStructHelper();
             const VkFormat color_format = VK_FORMAT_R32_SFLOAT;
             inheritance_rendering_info.colorAttachmentCount = begin_rendering_info.colorAttachmentCount;
             inheritance_rendering_info.pColorAttachmentFormats = &color_format;
@@ -835,25 +835,25 @@ TEST_F(NegativeDynamicRendering, GraphicsPipelineCreateInfo) {
 
     std::vector<VkPipelineColorBlendAttachmentState> color_blend_attachment_state(2);
 
-    auto color_blend_state_create_info = vku::InitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendStateCreateInfo color_blend_state_create_info = vku::InitStructHelper();
     color_blend_state_create_info.attachmentCount = 2;
     color_blend_state_create_info.pAttachments = color_blend_attachment_state.data();
 
     VkFormat color_format[2] = {VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_D32_SFLOAT_S8_UINT};
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 2;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format[0];
     pipeline_rendering_info.viewMask = 0x2;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_D32_SFLOAT_S8_UINT;
 
-    auto pipeline_tessellation_state_info = vku::InitStruct<VkPipelineTessellationStateCreateInfo>();
+    VkPipelineTessellationStateCreateInfo pipeline_tessellation_state_info = vku::InitStructHelper();
     pipeline_tessellation_state_info.patchControlPoints = 1;
 
-    auto pipeline_input_assembly_state_info = vku::InitStruct<VkPipelineInputAssemblyStateCreateInfo>();
+    VkPipelineInputAssemblyStateCreateInfo pipeline_input_assembly_state_info = vku::InitStructHelper();
     pipeline_input_assembly_state_info.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
 
-    auto create_info = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+    VkGraphicsPipelineCreateInfo create_info = vku::InitStructHelper();
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj gs(this, kGeometryMinimalGlsl, VK_SHADER_STAGE_GEOMETRY_BIT);
@@ -899,7 +899,7 @@ TEST_F(NegativeDynamicRendering, GraphicsPipelineCreateInfo) {
     m_errorMonitor->VerifyFound();
     color_format[0] = VK_FORMAT_R8G8B8A8_UNORM;
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     ds_ci.flags = VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS_BIT_ARM;
     color_blend_state_create_info.flags = VK_PIPELINE_COLOR_BLEND_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_BIT_ARM;
     create_info.pColorBlendState = &color_blend_state_create_info;
@@ -917,14 +917,14 @@ TEST_F(NegativeDynamicRendering, ColorAttachmentMismatch) {
     InitBasicDynamicRendering();
     if (::testing::Test::IsSkipped()) return;
 
-    auto color_blend_state_create_info = vku::InitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendStateCreateInfo color_blend_state_create_info = vku::InitStructHelper();
     color_blend_state_create_info.attachmentCount = 0;
     color_blend_state_create_info.pAttachments = nullptr;
 
     CreatePipelineHelper lib(*this);
 
     const VkFormat color_format = VK_FORMAT_UNDEFINED;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
@@ -953,7 +953,7 @@ TEST_F(NegativeDynamicRendering, ColorAttachmentMismatch) {
 
 TEST_F(NegativeDynamicRendering, MismatchingViewMask) {
     TEST_DESCRIPTION("Draw with Dynamic Rendering and a mismatching viewMask");
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&multiview_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -982,7 +982,7 @@ TEST_F(NegativeDynamicRendering, MismatchingViewMask) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkFormat color_formats = VK_FORMAT_UNDEFINED;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
     pipeline_rendering_info.viewMask = 1;
@@ -994,7 +994,7 @@ TEST_F(NegativeDynamicRendering, MismatchingViewMask) {
     pipe.SetViewport(m_viewports);
     pipe.SetScissor(m_scissors);
 
-    auto create_info = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+    VkGraphicsPipelineCreateInfo create_info = vku::InitStructHelper();
     pipe.InitGraphicsPipelineCreateInfo(&create_info);
     create_info.pNext = &pipeline_rendering_info;
 
@@ -1037,7 +1037,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats) {
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
 
     VkPipelineObj pipe1(m_device);
     pipe1.AddShader(&vs);
@@ -1050,13 +1050,13 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = color_formats;
 
-    auto create_info1 = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+    VkGraphicsPipelineCreateInfo create_info1 = vku::InitStructHelper();
     pipe1.InitGraphicsPipelineCreateInfo(&create_info1);
     create_info1.pNext = &pipeline_rendering_info;
 
     pipe1.CreateVKPipeline(pl.handle(), VK_NULL_HANDLE, &create_info1);
 
-    auto ds_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
 
     VkPipelineObj pipe2(m_device);
     pipe2.AddShader(&vs);
@@ -1069,7 +1069,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats) {
     pipeline_rendering_info.pColorAttachmentFormats = nullptr;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_D16_UNORM;
 
-    auto create_info2 = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+    VkGraphicsPipelineCreateInfo create_info2 = vku::InitStructHelper();
     pipe2.InitGraphicsPipelineCreateInfo(&create_info2);
     create_info2.pNext = &pipeline_rendering_info;
 
@@ -1110,7 +1110,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats) {
         pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
         pipeline_rendering_info.stencilAttachmentFormat = stencilFormat;
 
-        auto create_info3 = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+        VkGraphicsPipelineCreateInfo create_info3 = vku::InitStructHelper();
         pipe3.InitGraphicsPipelineCreateInfo(&create_info3);
         create_info3.pNext = &pipeline_rendering_info;
 
@@ -1126,15 +1126,15 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats) {
     VkImageView depthStencilImageView =
         depthStencilImage.targetView(depthStencilFormat, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = colorImageView;
 
-    auto depth_stencil_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR depth_stencil_attachment = vku::InitStructHelper();
     depth_stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     depth_stencil_attachment.imageView = depthStencilImageView;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
     m_commandBuffer->begin();
@@ -1203,7 +1203,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats2) {
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
 
     VkPipelineObj pipeline_color(m_device);
     pipeline_color.AddShader(&vs);
@@ -1216,13 +1216,13 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats2) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = color_formats;
 
-    auto create_info1 = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+    VkGraphicsPipelineCreateInfo create_info1 = vku::InitStructHelper();
     pipeline_color.InitGraphicsPipelineCreateInfo(&create_info1);
     create_info1.pNext = &pipeline_rendering_info;
 
     pipeline_color.CreateVKPipeline(pl.handle(), VK_NULL_HANDLE, &create_info1);
 
-    auto ds_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
 
     VkPipelineObj pipeline_depth(m_device);
     pipeline_depth.AddShader(&vs);
@@ -1235,7 +1235,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats2) {
     pipeline_rendering_info.pColorAttachmentFormats = nullptr;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_D16_UNORM;
 
-    auto create_info2 = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+    VkGraphicsPipelineCreateInfo create_info2 = vku::InitStructHelper();
     pipeline_depth.InitGraphicsPipelineCreateInfo(&create_info2);
     create_info2.pNext = &pipeline_rendering_info;
 
@@ -1254,7 +1254,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats2) {
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
     pipeline_rendering_info.stencilAttachmentFormat = depthStencilFormat;
 
-    auto create_info3 = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+    VkGraphicsPipelineCreateInfo create_info3 = vku::InitStructHelper();
     pipeline_stencil.InitGraphicsPipelineCreateInfo(&create_info3);
     create_info3.pNext = &pipeline_rendering_info;
 
@@ -1266,11 +1266,11 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats2) {
     VkImageObj depthStencilImage(m_device);
     depthStencilImage.Init(32, 32, 1, depthStencilFormat, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = VK_NULL_HANDLE;
 
-    auto depth_stencil_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR depth_stencil_attachment = vku::InitStructHelper();
     depth_stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     depth_stencil_attachment.imageView = VK_NULL_HANDLE;
 
@@ -1278,7 +1278,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats2) {
 
     {
         // Mismatching color formats
-        auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+        VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
         begin_rendering_info.layerCount = 1;
         begin_rendering_info.colorAttachmentCount = 1;
         begin_rendering_info.pColorAttachments = &color_attachment;
@@ -1293,7 +1293,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats2) {
 
     {
         // Mismatching depth format
-        auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+        VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
         begin_rendering_info.layerCount = 1;
         begin_rendering_info.pDepthAttachment = &depth_stencil_attachment;
         begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
@@ -1307,7 +1307,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats2) {
 
     {
         // Mismatching stencil format
-        auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+        VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
         begin_rendering_info.layerCount = 1;
         begin_rendering_info.pStencilAttachment = &depth_stencil_attachment;
         begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
@@ -1327,7 +1327,8 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats3Color) {
         "Draw with Dynamic Rendering with mismatching color attachment counts and depth/stencil formats where "
         "dynamicRenderingUnusedAttachments is enabled and neither format is VK_FORMAT_UNDEFINED");
     AddRequiredExtensions(VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME);
-    auto dynamic_rendering_unused_attachments_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT>();
+    VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT dynamic_rendering_unused_attachments_features =
+        vku::InitStructHelper();
     InitBasicDynamicRendering(&dynamic_rendering_unused_attachments_features);
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -1342,7 +1343,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats3Color) {
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
 
     VkFormat color_formats[] = {VK_FORMAT_B8G8R8A8_UNORM};
     pipeline_rendering_info.colorAttachmentCount = 1;
@@ -1360,11 +1361,11 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats3Color) {
     colorImage.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     VkImageView colorImageView = colorImage.targetView(VK_FORMAT_R8G8B8A8_UINT);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = colorImageView;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
     m_commandBuffer->begin();
@@ -1387,8 +1388,8 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats3DepthStencil) {
         "Draw with Dynamic Rendering with mismatching color attachment counts and depth/stencil formats where "
         "dynamicRenderingUnusedAttachments is enabled and neither format is VK_FORMAT_UNDEFINED");
     AddRequiredExtensions(VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME);
-    auto dynamic_rendering_unused_attachments_features =
-        vku::InitStruct<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT>();
+    VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT dynamic_rendering_unused_attachments_features =
+        vku::InitStructHelper();
     InitBasicDynamicRendering(&dynamic_rendering_unused_attachments_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -1402,7 +1403,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats3DepthStencil) {
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 0;
     pipeline_rendering_info.pColorAttachmentFormats = nullptr;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_D16_UNORM;
@@ -1411,7 +1412,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats3DepthStencil) {
     pipe1.InitState();
     pipe1.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe1.gp_ci_.layout = pl.handle();
-    pipe1.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    pipe1.ds_ci_ = vku::InitStructHelper();
     pipe1.gp_ci_.pNext = &pipeline_rendering_info;
     pipe1.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe1.gp_ci_.pColorBlendState = nullptr;
@@ -1447,7 +1448,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats3DepthStencil) {
         pipe2.InitState();
         pipe2.shader_stages_[1] = fs.GetStageCreateInfo();
         pipe2.gp_ci_.layout = pl.handle();
-        pipe2.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+        pipe2.ds_ci_ = vku::InitStructHelper();
         pipe2.gp_ci_.pNext = &pipeline_rendering_info;
         pipe2.gp_ci_.renderPass = VK_NULL_HANDLE;
         pipe2.gp_ci_.pColorBlendState = nullptr;
@@ -1459,11 +1460,11 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentFormats3DepthStencil) {
     VkImageView depthStencilImageView =
         depthStencilImage.targetView(depthStencilFormat, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
-    auto depth_stencil_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR depth_stencil_attachment = vku::InitStructHelper();
     depth_stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     depth_stencil_attachment.imageView = depthStencilImageView;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
     m_commandBuffer->begin();
@@ -1513,7 +1514,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentSamplesColor) {
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
 
     VkFormat color_formats[] = {VK_FORMAT_R8G8B8A8_UNORM};
     pipeline_rendering_info.colorAttachmentCount = 1;
@@ -1574,7 +1575,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentSamplesDepthStencil) {
 
     VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 0;
     pipeline_rendering_info.pColorAttachmentFormats = nullptr;
     pipeline_rendering_info.depthAttachmentFormat = depthStencilFormat;
@@ -1584,7 +1585,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentSamplesDepthStencil) {
     pipe1.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe1.gp_ci_.layout = pl.handle();
     pipe1.pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
-    pipe1.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    pipe1.ds_ci_ = vku::InitStructHelper();
     pipe1.gp_ci_.pColorBlendState = nullptr;
     pipe1.gp_ci_.pNext = &pipeline_rendering_info;
     pipe1.gp_ci_.renderPass = VK_NULL_HANDLE;
@@ -1599,7 +1600,7 @@ TEST_F(NegativeDynamicRendering, MistmatchingAttachmentSamplesDepthStencil) {
     pipe2.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe2.gp_ci_.layout = pl.handle();
     pipe2.pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
-    pipe2.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    pipe2.ds_ci_ = vku::InitStructHelper();
     pipe2.gp_ci_.pColorBlendState = nullptr;
     pipe2.gp_ci_.pNext = &pipeline_rendering_info;
     pipe2.gp_ci_.renderPass = VK_NULL_HANDLE;
@@ -1671,9 +1672,9 @@ TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesColor) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkSampleCountFlagBits counts[2] = {VK_SAMPLE_COUNT_2_BIT, VK_SAMPLE_COUNT_2_BIT};
-    auto samples_info = vku::InitStruct<VkAttachmentSampleCountInfoAMD>();
+    VkAttachmentSampleCountInfoAMD samples_info = vku::InitStructHelper();
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>(&samples_info);
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper(&samples_info);
 
     VkFormat color_formats[] = {VK_FORMAT_R8G8B8A8_UNORM};
     pipeline_rendering_info.colorAttachmentCount = 1;
@@ -1750,9 +1751,9 @@ TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesDepthStencil) 
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkSampleCountFlagBits counts[2] = {VK_SAMPLE_COUNT_2_BIT, VK_SAMPLE_COUNT_2_BIT};
-    auto samples_info = vku::InitStruct<VkAttachmentSampleCountInfoAMD>();
+    VkAttachmentSampleCountInfoAMD samples_info = vku::InitStructHelper();
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>(&samples_info);
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper(&samples_info);
 
     VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
 
@@ -1768,7 +1769,7 @@ TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesDepthStencil) 
     pipe1.InitState();
     pipe1.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe1.gp_ci_.layout = pl.handle();
-    pipe1.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    pipe1.ds_ci_ = vku::InitStructHelper();
     pipe1.gp_ci_.pColorBlendState = nullptr;
     pipe1.gp_ci_.pNext = &pipeline_rendering_info;
     pipe1.gp_ci_.renderPass = VK_NULL_HANDLE;
@@ -1782,7 +1783,7 @@ TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesDepthStencil) 
     pipe2.InitState();
     pipe2.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe2.gp_ci_.layout = pl.handle();
-    pipe2.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    pipe2.ds_ci_ = vku::InitStructHelper();
     pipe2.gp_ci_.pColorBlendState = nullptr;
     pipe2.gp_ci_.pNext = &pipeline_rendering_info;
     pipe2.gp_ci_.renderPass = VK_NULL_HANDLE;
@@ -1829,7 +1830,7 @@ TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesDepthStencil) 
 TEST_F(NegativeDynamicRendering, AttachmentInfo) {
     TEST_DESCRIPTION("AttachmentInfo Dynamic Rendering Tests.");
     AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
-    auto fdm_features = vku::InitStruct<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>();
+    VkPhysicalDeviceFragmentDensityMapFeaturesEXT fdm_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&fdm_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -1922,14 +1923,14 @@ TEST_F(NegativeDynamicRendering, BufferBeginInfoLegacy) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto cmd_buffer_inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
+    VkCommandBufferInheritanceRenderingInfoKHR cmd_buffer_inheritance_rendering_info = vku::InitStructHelper();
     cmd_buffer_inheritance_rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
-    auto cmd_buffer_inheritance_info = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo cmd_buffer_inheritance_info = vku::InitStructHelper();
     cmd_buffer_inheritance_info.pNext = &cmd_buffer_inheritance_rendering_info;
     cmd_buffer_inheritance_info.renderPass = VK_NULL_HANDLE;
 
-    auto cmd_buffer_allocate_info = vku::InitStruct<VkCommandBufferAllocateInfo>();
+    VkCommandBufferAllocateInfo cmd_buffer_allocate_info = vku::InitStructHelper();
     cmd_buffer_allocate_info.commandPool = m_commandPool->handle();
     cmd_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
     cmd_buffer_allocate_info.commandBufferCount = 0x1;
@@ -2023,7 +2024,7 @@ TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
     bool fragment_density = IsExtensionsEnabled(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
     bool shading_rate = IsExtensionsEnabled(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -2103,7 +2104,7 @@ TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
 
         const VkFormat color_format = VK_FORMAT_UNDEFINED;
 
-        auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+        VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
         pipeline_rendering_info.colorAttachmentCount = 1;
         pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
@@ -2138,7 +2139,7 @@ TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
 
         const VkFormat color_format = VK_FORMAT_UNDEFINED;
 
-        auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+        VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
         pipeline_rendering_info.colorAttachmentCount = 1;
         pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
@@ -2248,7 +2249,7 @@ TEST_F(NegativeDynamicRendering, InfoMismatchedSamples) {
 TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRate) {
     TEST_DESCRIPTION("Test BeginRenderingInfo with FragmentShadingRateAttachment.");
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&multiview_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -2256,7 +2257,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRate) {
         GTEST_SKIP() << "Test requires (unsupported) multiview";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -2266,7 +2267,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRate) {
         GTEST_SKIP() << "format doesn't support FRAGMENT_SHADING_RATE_ATTACHMENT_BIT";
     }
 
-    auto image_ci = vku::InitStruct<VkImageCreateInfo>(nullptr);
+    VkImageCreateInfo image_ci = vku::InitStructHelper(nullptr);
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_ci.extent.width = 32;
@@ -2289,7 +2290,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRate) {
     VkImageView image_view =
         image.targetView(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 2, VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
-    auto fragment_shading_rate = vku::InitStruct<VkRenderingFragmentShadingRateAttachmentInfoKHR>();
+    VkRenderingFragmentShadingRateAttachmentInfoKHR fragment_shading_rate = vku::InitStructHelper();
     fragment_shading_rate.imageView = image_view;
     fragment_shading_rate.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
     fragment_shading_rate.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
@@ -2335,7 +2336,7 @@ TEST_F(NegativeDynamicRendering, DeviceGroupRenderPassBeginInfo) {
     render_area.extent.width = 32;
     render_area.extent.height = 32;
 
-    auto device_group_render_pass_begin_info = vku::InitStruct<VkDeviceGroupRenderPassBeginInfo>();
+    VkDeviceGroupRenderPassBeginInfo device_group_render_pass_begin_info = vku::InitStructHelper();
     device_group_render_pass_begin_info.deviceRenderAreaCount = 1;
     device_group_render_pass_begin_info.pDeviceRenderAreas = &render_area;
 
@@ -2347,7 +2348,7 @@ TEST_F(NegativeDynamicRendering, DeviceGroupRenderPassBeginInfo) {
     color_attachment.imageView = colorImageView;
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>(&device_group_render_pass_begin_info);
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper(&device_group_render_pass_begin_info);
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
@@ -2381,7 +2382,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImage) {
         GTEST_SKIP() << "Skipping on AMD proprietary driver pending further investigation.";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     VkImageObj image(m_device);
@@ -2398,7 +2399,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImage) {
     invalid_image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     VkImageView invalid_image_view = invalid_image.targetView(VK_FORMAT_R8G8B8A8_UINT);
 
-    auto fragment_shading_rate = vku::InitStruct<VkRenderingFragmentShadingRateAttachmentInfoKHR>();
+    VkRenderingFragmentShadingRateAttachmentInfoKHR fragment_shading_rate = vku::InitStructHelper();
     fragment_shading_rate.imageView = invalid_image_view;
     fragment_shading_rate.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
     fragment_shading_rate.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
@@ -2500,7 +2501,7 @@ TEST_F(NegativeDynamicRendering, TestFragmentDensityMapRenderArea) {
     InitBasicDynamicRendering();
     if (::testing::Test::IsSkipped()) return;
 
-    auto fdm_props = vku::InitStruct<VkPhysicalDeviceFragmentDensityMapPropertiesEXT>();
+    VkPhysicalDeviceFragmentDensityMapPropertiesEXT fdm_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fdm_props);
 
     VkImageObj image(m_device);
@@ -2508,7 +2509,7 @@ TEST_F(NegativeDynamicRendering, TestFragmentDensityMapRenderArea) {
                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT);
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1);
 
-    auto fragment_density_map = vku::InitStruct<VkRenderingFragmentDensityMapAttachmentInfoEXT>();
+    VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map = vku::InitStructHelper();
     fragment_density_map.imageView = image_view;
     fragment_density_map.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
@@ -2565,7 +2566,7 @@ TEST_F(NegativeDynamicRendering, TestFragmentDensityMapRenderArea) {
     VkRect2D device_render_area = {};
     device_render_area.extent.width = 64 * fdm_props.maxFragmentDensityTexelSize.width;
     device_render_area.extent.height = 32 * fdm_props.maxFragmentDensityTexelSize.height;
-    auto device_group_render_pass_begin_info = vku::InitStruct<VkDeviceGroupRenderPassBeginInfo>();
+    VkDeviceGroupRenderPassBeginInfo device_group_render_pass_begin_info = vku::InitStructHelper();
     device_group_render_pass_begin_info.deviceRenderAreaCount = 1;
     device_group_render_pass_begin_info.pDeviceRenderAreas = &device_render_area;
     fragment_density_map.pNext = &device_group_render_pass_begin_info;
@@ -2600,7 +2601,7 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapRenderAreaWithoutDeviceGroupE
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(dynamic_rendering_features);
     if (dynamic_rendering_features.dynamicRendering == VK_FALSE) {
         GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
@@ -2608,7 +2609,7 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapRenderAreaWithoutDeviceGroupE
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto fdm_props = vku::InitStruct<VkPhysicalDeviceFragmentDensityMapPropertiesEXT>();
+    VkPhysicalDeviceFragmentDensityMapPropertiesEXT fdm_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fdm_props);
 
     VkImageObj image(m_device);
@@ -2616,7 +2617,7 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapRenderAreaWithoutDeviceGroupE
                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT);
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1);
 
-    auto fragment_density_map = vku::InitStruct<VkRenderingFragmentDensityMapAttachmentInfoEXT>();
+    VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map = vku::InitStructHelper();
     fragment_density_map.imageView = image_view;
     fragment_density_map.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
@@ -2644,7 +2645,7 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapRenderAreaWithoutDeviceGroupE
 TEST_F(NegativeDynamicRendering, BarrierShaderTileFeaturesNotEnabled) {
     TEST_DESCRIPTION("Test setting memory barrier without shader tile features enabled.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&sync2_features);
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -2658,13 +2659,13 @@ TEST_F(NegativeDynamicRendering, BarrierShaderTileFeaturesNotEnabled) {
 
     m_commandBuffer->BeginRendering(begin_rendering_info);
 
-    auto barrier2 = vku::InitStruct<VkMemoryBarrier2>();
+    VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
     barrier2.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
     barrier2.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
     barrier2.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
     barrier2.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
 
-    auto dependency_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dependency_info = vku::InitStructHelper();
     dependency_info.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &barrier2;
@@ -2672,7 +2673,7 @@ TEST_F(NegativeDynamicRendering, BarrierShaderTileFeaturesNotEnabled) {
     vk::CmdPipelineBarrier2(m_commandBuffer->handle(), &dependency_info);
     m_errorMonitor->VerifyFound();
 
-    auto barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier barrier = vku::InitStructHelper();
     barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
     barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
 
@@ -2698,8 +2699,8 @@ TEST_F(NegativeDynamicRendering, WithoutShaderTileImageAndBarrier) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto vk13features = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
-    auto shader_tile_image_features = vku::InitStruct<VkPhysicalDeviceShaderTileImageFeaturesEXT>();
+    VkPhysicalDeviceVulkan13Features vk13features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderTileImageFeaturesEXT shader_tile_image_features = vku::InitStructHelper();
     vk13features.pNext = &shader_tile_image_features;
 
     auto features2 = GetPhysicalDeviceFeatures2(vk13features);
@@ -2728,13 +2729,13 @@ TEST_F(NegativeDynamicRendering, WithoutShaderTileImageAndBarrier) {
 
     m_commandBuffer->BeginRendering(begin_rendering_info);
 
-    auto memory_barrier_2 = vku::InitStruct<VkMemoryBarrier2KHR>();
+    VkMemoryBarrier2KHR memory_barrier_2 = vku::InitStructHelper();
     memory_barrier_2.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
     memory_barrier_2.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
     memory_barrier_2.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
     memory_barrier_2.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
 
-    auto dependency_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dependency_info = vku::InitStructHelper();
     dependency_info.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &memory_barrier_2;
@@ -2747,7 +2748,7 @@ TEST_F(NegativeDynamicRendering, WithoutShaderTileImageAndBarrier) {
     vk::CmdPipelineBarrier2(m_commandBuffer->handle(), &dependency_info);
     m_errorMonitor->VerifyFound();
 
-    auto memory_barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier memory_barrier = vku::InitStructHelper();
     memory_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     memory_barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
 
@@ -2773,8 +2774,8 @@ TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto vk13features = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
-    auto shader_tile_image_features = vku::InitStruct<VkPhysicalDeviceShaderTileImageFeaturesEXT>();
+    VkPhysicalDeviceVulkan13Features vk13features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderTileImageFeaturesEXT shader_tile_image_features = vku::InitStructHelper();
     vk13features.pNext = &shader_tile_image_features;
 
     auto features2 = GetPhysicalDeviceFeatures2(vk13features);
@@ -2799,13 +2800,13 @@ TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
 
     m_commandBuffer->BeginRendering(begin_rendering_info);
 
-    auto memory_barrier_2 = vku::InitStruct<VkMemoryBarrier2KHR>();
+    VkMemoryBarrier2KHR memory_barrier_2 = vku::InitStructHelper();
     memory_barrier_2.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
     memory_barrier_2.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
     memory_barrier_2.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
     memory_barrier_2.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
 
-    auto dependency_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dependency_info = vku::InitStructHelper();
     dependency_info.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &memory_barrier_2;
@@ -2822,7 +2823,7 @@ TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
     vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
-    auto buf_barrier_2 = vku::InitStruct<VkBufferMemoryBarrier2KHR>();
+    VkBufferMemoryBarrier2KHR buf_barrier_2 = vku::InitStructHelper();
     buf_barrier_2.buffer = buffer.handle();
     buf_barrier_2.offset = 0;
     buf_barrier_2.size = VK_WHOLE_SIZE;
@@ -2899,7 +2900,7 @@ TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
                            VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
-    auto memory_barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier memory_barrier = vku::InitStructHelper();
     memory_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     memory_barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
 
@@ -2960,14 +2961,14 @@ TEST_F(NegativeDynamicRendering, InheritanceRenderingInfoStencilAttachmentFormat
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
 
-    auto cmd_buffer_inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
+    VkCommandBufferInheritanceRenderingInfoKHR cmd_buffer_inheritance_rendering_info = vku::InitStructHelper();
     cmd_buffer_inheritance_rendering_info.colorAttachmentCount = 1;
     cmd_buffer_inheritance_rendering_info.pColorAttachmentFormats = &color_format;
     cmd_buffer_inheritance_rendering_info.depthAttachmentFormat = depth_format;
     cmd_buffer_inheritance_rendering_info.stencilAttachmentFormat = depth_format;
     cmd_buffer_inheritance_rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
-    auto cmd_buffer_inheritance_info = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo cmd_buffer_inheritance_info = vku::InitStructHelper();
     cmd_buffer_inheritance_info.pNext = &cmd_buffer_inheritance_rendering_info;
     cmd_buffer_inheritance_info.renderPass = VK_NULL_HANDLE;
 
@@ -2975,7 +2976,7 @@ TEST_F(NegativeDynamicRendering, InheritanceRenderingInfoStencilAttachmentFormat
     cmd_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmd_buffer_begin_info.pInheritanceInfo = &cmd_buffer_inheritance_info;
 
-    auto cmd_buffer_allocate_info = vku::InitStruct<VkCommandBufferAllocateInfo>();
+    VkCommandBufferAllocateInfo cmd_buffer_allocate_info = vku::InitStructHelper();
     cmd_buffer_allocate_info.commandPool = m_commandPool->handle();
     cmd_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
     cmd_buffer_allocate_info.commandBufferCount = 1;
@@ -2996,11 +2997,11 @@ TEST_F(NegativeDynamicRendering, CreateGraphicsPipelineWithAttachmentSampleCount
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
 
-    auto sample_count_info_amd = vku::InitStruct<VkAttachmentSampleCountInfoNV>();
+    VkAttachmentSampleCountInfoNV sample_count_info_amd = vku::InitStructHelper();
     sample_count_info_amd.colorAttachmentCount = 1;
     sample_count_info_amd.depthStencilAttachmentSamples = static_cast<VkSampleCountFlagBits>(0x3);
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>(&sample_count_info_amd);
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper(&sample_count_info_amd);
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
@@ -3058,7 +3059,7 @@ TEST_F(NegativeDynamicRendering, AreaGreaterThanAttachmentExtent) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(dynamic_rendering_features);
     if (dynamic_rendering_features.dynamicRendering == VK_FALSE) {
         GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
@@ -3070,11 +3071,11 @@ TEST_F(NegativeDynamicRendering, AreaGreaterThanAttachmentExtent) {
     colorImage.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     VkImageView colorImageView = colorImage.targetView(VK_FORMAT_R8G8B8A8_UINT);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = colorImageView;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
@@ -3156,11 +3157,11 @@ TEST_F(NegativeDynamicRendering, DeviceGroupAreaGreaterThanAttachmentExtent) {
     colorImage.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     VkImageView colorImageView = colorImage.targetView(VK_FORMAT_R8G8B8A8_UINT);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = colorImageView;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
@@ -3246,7 +3247,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleRenderPass) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkSubpassDescription subpass = {};
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper();
     render_pass_ci.subpassCount = 1;
     render_pass_ci.pSubpasses = &subpass;
 
@@ -3255,7 +3256,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleRenderPass) {
     VkCommandBufferObj cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     VkCommandBuffer secondary_handle = cb.handle();
 
-    auto cmd_buffer_inheritance_info = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo cmd_buffer_inheritance_info = vku::InitStructHelper();
     cmd_buffer_inheritance_info.renderPass = render_pass.handle();
     VkCommandBufferBeginInfo cmd_buffer_begin_info = vku::InitStructHelper();
     cmd_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
@@ -3289,13 +3290,13 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
 
     VkSubpassDescription subpasses[2] = {};
 
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper();
     render_pass_ci.subpassCount = 2;
     render_pass_ci.pSubpasses = subpasses;
 
     vkt::RenderPass render_pass(*m_device, render_pass_ci);
 
-    auto framebuffer_ci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
     framebuffer_ci.renderPass = render_pass.handle();
     framebuffer_ci.width = 32;
     framebuffer_ci.height = 32;
@@ -3306,7 +3307,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
     VkCommandBufferObj cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     VkCommandBuffer secondary_handle = cb.handle();
 
-    auto cmd_buffer_inheritance_info = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo cmd_buffer_inheritance_info = vku::InitStructHelper();
     cmd_buffer_inheritance_info.renderPass = render_pass.handle();
     VkCommandBufferBeginInfo cmd_buffer_begin_info = vku::InitStructHelper();
     cmd_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
@@ -3315,7 +3316,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
     cb.begin(&cmd_buffer_begin_info);
     cb.end();
 
-    auto render_pass_begin_info = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
     render_pass_begin_info.renderPass = render_pass.handle();
     render_pass_begin_info.renderArea.extent = {32, 32};
     render_pass_begin_info.framebuffer = framebuffer.handle();
@@ -3348,7 +3349,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferContents) {
     VkCommandBufferObj cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     VkCommandBuffer secondary_handle = cb.handle();
 
-    auto cmd_buffer_inheritance_info = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo cmd_buffer_inheritance_info = vku::InitStructHelper();
     cmd_buffer_inheritance_info.renderPass = m_renderPass;
     VkCommandBufferBeginInfo cmd_buffer_begin_info = vku::InitStructHelper();
     cmd_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
@@ -3382,8 +3383,8 @@ TEST_F(NegativeDynamicRendering, ShaderLayerBuiltIn) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (dynamic_rendering_features.dynamicRendering == VK_FALSE) {
         GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
@@ -3415,7 +3416,7 @@ TEST_F(NegativeDynamicRendering, ShaderLayerBuiltIn) {
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
     pipeline_rendering_info.viewMask = 0x1;
@@ -3464,7 +3465,7 @@ TEST_F(NegativeDynamicRendering, InputAttachmentCapability) {
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
@@ -3486,7 +3487,7 @@ TEST_F(NegativeDynamicRendering, RenderingInfoColorAttachmentFormat) {
 
     VkFormat color_format = VK_FORMAT_MAX_ENUM;
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
@@ -3503,8 +3504,8 @@ TEST_F(NegativeDynamicRendering, RenderingInfoColorAttachmentFormat) {
 TEST_F(NegativeDynamicRendering, LibraryViewMask) {
     TEST_DESCRIPTION("Create pipeline with invalid view mask");
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
-    auto library_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(&multiview_features);
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT library_features = vku::InitStructHelper(&multiview_features);
     InitBasicDynamicRendering(&library_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -3519,12 +3520,12 @@ TEST_F(NegativeDynamicRendering, LibraryViewMask) {
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
     VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
-    auto color_blend_state_create_info = vku::InitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendStateCreateInfo color_blend_state_create_info = vku::InitStructHelper();
     color_blend_state_create_info.attachmentCount = 1;
     color_blend_state_create_info.pAttachments = &color_blend_attachment_state;
 
@@ -3536,7 +3537,7 @@ TEST_F(NegativeDynamicRendering, LibraryViewMask) {
     lib.CreateGraphicsPipeline();
 
     pipeline_rendering_info.viewMask = 0x1;
-    auto library_create_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>(&pipeline_rendering_info);
+    VkPipelineLibraryCreateInfoKHR library_create_info = vku::InitStructHelper(&pipeline_rendering_info);
     library_create_info.libraryCount = 1;
     library_create_info.pLibraries = &lib.pipeline_;
 
@@ -3562,12 +3563,12 @@ TEST_F(NegativeDynamicRendering, AttachmentSampleCount) {
 
     VkSampleCountFlagBits color_attachment_samples = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;
 
-    auto samples_info = vku::InitStruct<VkAttachmentSampleCountInfoAMD>();
+    VkAttachmentSampleCountInfoAMD samples_info = vku::InitStructHelper();
     samples_info.colorAttachmentCount = 1;
     samples_info.pColorAttachmentSamples = &color_attachment_samples;
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>(&samples_info);
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper(&samples_info);
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
@@ -3583,8 +3584,8 @@ TEST_F(NegativeDynamicRendering, AttachmentSampleCount) {
 TEST_F(NegativeDynamicRendering, LibrariesViewMask) {
     TEST_DESCRIPTION("Create pipeline with libaries that have incompatible view mask");
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
-    auto library_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(&multiview_features);
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT library_features = vku::InitStructHelper(&multiview_features);
     InitBasicDynamicRendering(&library_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -3599,12 +3600,12 @@ TEST_F(NegativeDynamicRendering, LibrariesViewMask) {
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
     VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
-    auto color_blend_state_create_info = vku::InitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendStateCreateInfo color_blend_state_create_info = vku::InitStructHelper();
     color_blend_state_create_info.attachmentCount = 1;
     color_blend_state_create_info.pAttachments = &color_blend_attachment_state;
 
@@ -3617,7 +3618,7 @@ TEST_F(NegativeDynamicRendering, LibrariesViewMask) {
 
     pipeline_rendering_info.viewMask = 0x1;
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
 
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -3631,12 +3632,12 @@ TEST_F(NegativeDynamicRendering, LibrariesViewMask) {
     lib2.CreateGraphicsPipeline();
 
     pipeline_rendering_info.viewMask = 0;
-    auto library_create_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR library_create_info = vku::InitStructHelper();
     library_create_info.libraryCount = 2;
     VkPipeline libraries[2] = {lib1.pipeline_, lib2.pipeline_};
     library_create_info.pLibraries = libraries;
 
-    auto pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&library_create_info);
+    VkGraphicsPipelineCreateInfo pipe_ci = vku::InitStructHelper(&library_create_info);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06627");
     vkt::Pipeline pipe(*m_device, pipe_ci);
     m_errorMonitor->VerifyFound();
@@ -3645,7 +3646,7 @@ TEST_F(NegativeDynamicRendering, LibrariesViewMask) {
 TEST_F(NegativeDynamicRendering, LibraryRenderPass) {
     TEST_DESCRIPTION("Create pipeline with invalid library render pass");
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
-    auto library_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>();
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT library_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&library_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -3657,12 +3658,12 @@ TEST_F(NegativeDynamicRendering, LibraryRenderPass) {
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
     VkPipelineColorBlendAttachmentState color_blend_attachment_state = {};
-    auto color_blend_state_create_info = vku::InitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendStateCreateInfo color_blend_state_create_info = vku::InitStructHelper();
     color_blend_state_create_info.attachmentCount = 1;
     color_blend_state_create_info.pAttachments = &color_blend_attachment_state;
 
@@ -3672,16 +3673,16 @@ TEST_F(NegativeDynamicRendering, LibraryRenderPass) {
     lib.InitState();
     lib.CreateGraphicsPipeline();
 
-    auto library_create_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>(&pipeline_rendering_info);
+    VkPipelineLibraryCreateInfoKHR library_create_info = vku::InitStructHelper(&pipeline_rendering_info);
     library_create_info.libraryCount = 1;
     library_create_info.pLibraries = &lib.pipeline_;
 
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
-    auto fs_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+    VkShaderModuleCreateInfo fs_ci = vku::InitStructHelper();
     fs_ci.codeSize = fs_spv.size() * sizeof(decltype(fs_spv)::value_type);
     fs_ci.pCode = fs_spv.data();
 
-    auto fs_stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&fs_ci);
+    VkPipelineShaderStageCreateInfo fs_stage_ci = vku::InitStructHelper(&fs_ci);
     fs_stage_ci.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     fs_stage_ci.module = VK_NULL_HANDLE;
     fs_stage_ci.pName = "main";
@@ -3700,7 +3701,7 @@ TEST_F(NegativeDynamicRendering, LibraryRenderPass) {
 TEST_F(NegativeDynamicRendering, PipelineMissingMultisampleState) {
     TEST_DESCRIPTION("Create pipeline with missing multisample state");
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
-    auto library_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>();
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT library_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&library_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -3736,7 +3737,7 @@ TEST_F(NegativeDynamicRendering, PipelineMissingMultisampleState) {
 TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachment) {
     TEST_DESCRIPTION("Use invalid VkRenderingFragmentDensityMapAttachmentInfoEXT");
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&multiview_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -3751,10 +3752,10 @@ TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachment) {
                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT, VK_IMAGE_TILING_LINEAR, 0);
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto rendering_fragment_density = vku::InitStruct<VkRenderingFragmentDensityMapAttachmentInfoEXT>();
+    VkRenderingFragmentDensityMapAttachmentInfoEXT rendering_fragment_density = vku::InitStructHelper();
     rendering_fragment_density.imageView = image_view;
     rendering_fragment_density.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>(&rendering_fragment_density);
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper(&rendering_fragment_density);
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
@@ -3799,10 +3800,10 @@ TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachmentUsage) {
     image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_LINEAR, 0);
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto rendering_fragment_density = vku::InitStruct<VkRenderingFragmentDensityMapAttachmentInfoEXT>();
+    VkRenderingFragmentDensityMapAttachmentInfoEXT rendering_fragment_density = vku::InitStructHelper();
     rendering_fragment_density.imageView = image_view;
     rendering_fragment_density.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>(&rendering_fragment_density);
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper(&rendering_fragment_density);
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
@@ -3835,10 +3836,10 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentCreateFlags) {
     image.Init(image_create_info);
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto rendering_fragment_density = vku::InitStruct<VkRenderingFragmentDensityMapAttachmentInfoEXT>();
+    VkRenderingFragmentDensityMapAttachmentInfoEXT rendering_fragment_density = vku::InitStructHelper();
     rendering_fragment_density.imageView = image_view;
     rendering_fragment_density.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>(&rendering_fragment_density);
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper(&rendering_fragment_density);
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
@@ -3852,7 +3853,7 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentCreateFlags) {
 TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentLayerCount) {
     TEST_DESCRIPTION("Use VkRenderingFragmentDensityMapAttachmentInfoEXT with invalid layer count");
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&multiview_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -3877,10 +3878,10 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentLayerCount) {
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0,
                                               VK_REMAINING_ARRAY_LAYERS, VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
-    auto rendering_fragment_density = vku::InitStruct<VkRenderingFragmentDensityMapAttachmentInfoEXT>();
+    VkRenderingFragmentDensityMapAttachmentInfoEXT rendering_fragment_density = vku::InitStructHelper();
     rendering_fragment_density.imageView = image_view;
     rendering_fragment_density.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>(&rendering_fragment_density);
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper(&rendering_fragment_density);
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.viewMask = 0x1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
@@ -3899,7 +3900,7 @@ TEST_F(NegativeDynamicRendering, PNextImageView) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&multiview_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -3909,7 +3910,7 @@ TEST_F(NegativeDynamicRendering, PNextImageView) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     VkImageObj image(m_device);
@@ -3918,15 +3919,15 @@ TEST_F(NegativeDynamicRendering, PNextImageView) {
                VK_IMAGE_TILING_LINEAR, 0);
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto rendering_fragment_shading_rate = vku::InitStruct<VkRenderingFragmentShadingRateAttachmentInfoKHR>();
+    VkRenderingFragmentShadingRateAttachmentInfoKHR rendering_fragment_shading_rate = vku::InitStructHelper();
     rendering_fragment_shading_rate.imageView = image_view;
     rendering_fragment_shading_rate.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
     rendering_fragment_shading_rate.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
-    auto rendering_fragment_density =
-        vku::InitStruct<VkRenderingFragmentDensityMapAttachmentInfoEXT>(&rendering_fragment_shading_rate);
+    VkRenderingFragmentDensityMapAttachmentInfoEXT rendering_fragment_density =
+        vku::InitStructHelper(&rendering_fragment_shading_rate);
     rendering_fragment_density.imageView = image_view;
     rendering_fragment_density.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>(&rendering_fragment_density);
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper(&rendering_fragment_density);
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.viewMask = 0x1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
@@ -3952,7 +3953,7 @@ TEST_F(NegativeDynamicRendering, RenderArea) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(dynamic_rendering_features);
     if (dynamic_rendering_features.dynamicRendering == VK_FALSE) {
         GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
@@ -3961,7 +3962,7 @@ TEST_F(NegativeDynamicRendering, RenderArea) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea.offset.x = -1;
     begin_rendering_info.renderArea.extent.width = 32;
@@ -4022,7 +4023,7 @@ TEST_F(NegativeDynamicRendering, RenderArea) {
 
 TEST_F(NegativeDynamicRendering, InfoViewMask) {
     TEST_DESCRIPTION("Use negative offset in RenderingInfo render area");
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&multiview_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -4032,14 +4033,14 @@ TEST_F(NegativeDynamicRendering, InfoViewMask) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto multiview_props = vku::InitStruct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceMultiviewProperties multiview_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(multiview_props);
 
     if (multiview_props.maxMultiviewViewCount == 32) {
         GTEST_SKIP() << "VUID is not testable as maxMultiviewViewCount is 32";
     }
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea.extent.width = 32;
     begin_rendering_info.renderArea.extent.height = 32;
@@ -4062,7 +4063,7 @@ TEST_F(NegativeDynamicRendering, ColorAttachmentFormat) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkFormat format = FindSupportedDepthStencilFormat(gpu());
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &format;
 
@@ -4653,7 +4654,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImageView) {
         GTEST_SKIP() << "Skipping on AMD proprietary driver pending further investigation.";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -4668,7 +4669,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImageView) {
     }
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto fragment_shading_rate = vku::InitStruct<VkRenderingFragmentShadingRateAttachmentInfoKHR>();
+    VkRenderingFragmentShadingRateAttachmentInfoKHR fragment_shading_rate = vku::InitStructHelper();
     fragment_shading_rate.imageView = image_view;
     fragment_shading_rate.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     fragment_shading_rate.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
@@ -4722,7 +4723,7 @@ TEST_F(NegativeDynamicRendering, RenderingInfoColorAttachment) {
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveImageView = resolve_image_view;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
@@ -4800,7 +4801,7 @@ TEST_F(NegativeDynamicRendering, RenderingInfoDepthAttachment) {
 
     VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
 
-    auto depth_stencil_resolve_properties = vku::InitStruct<VkPhysicalDeviceDepthStencilResolveProperties>();
+    VkPhysicalDeviceDepthStencilResolveProperties depth_stencil_resolve_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(depth_stencil_resolve_properties);
     bool has_depth_resolve_mode_average =
         (depth_stencil_resolve_properties.supportedDepthResolveModes & VK_RESOLVE_MODE_AVERAGE_BIT) != 0;
@@ -4844,15 +4845,15 @@ TEST_F(NegativeDynamicRendering, RenderingInfoDepthAttachment) {
     invalid_image.Init(image_create_info);
     VkImageView invalid_image_view = invalid_image.targetView(ds_format, VK_IMAGE_ASPECT_DEPTH_BIT);
 
-    auto depth_attachment = vku::InitStruct<VkRenderingAttachmentInfo>();
+    VkRenderingAttachmentInfo depth_attachment = vku::InitStructHelper();
     depth_attachment.imageView = depth_image_view;
     depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-    auto stencil_attachment = vku::InitStruct<VkRenderingAttachmentInfo>();
+    VkRenderingAttachmentInfo stencil_attachment = vku::InitStructHelper();
     stencil_attachment.imageView = stencil_image_view;
     stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.pDepthAttachment = &depth_attachment;
     begin_rendering_info.pStencilAttachment = &stencil_attachment;
@@ -5000,7 +5001,7 @@ TEST_F(NegativeDynamicRendering, RenderAreaNegativeOffset) {
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea.offset.x = -1;
     begin_rendering_info.renderArea.extent.width = 32;
@@ -5030,7 +5031,7 @@ TEST_F(NegativeDynamicRendering, ZeroRenderArea) {
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {64, 64}};
     begin_rendering_info.colorAttachmentCount = 1;
@@ -5061,7 +5062,7 @@ TEST_F(NegativeDynamicRendering, Pipeline) {
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
@@ -5099,8 +5100,8 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateAttachmentSize
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiviewFeaturesKHR multiview_features = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "Test requires (unsupported) multiview";
@@ -5109,7 +5110,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateAttachmentSize
         GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -5124,7 +5125,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateAttachmentSize
     }
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto fragment_shading_rate = vku::InitStruct<VkRenderingFragmentShadingRateAttachmentInfoKHR>();
+    VkRenderingFragmentShadingRateAttachmentInfoKHR fragment_shading_rate = vku::InitStructHelper();
     fragment_shading_rate.imageView = image_view;
     fragment_shading_rate.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
     fragment_shading_rate.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
@@ -5170,8 +5171,8 @@ TEST_F(NegativeDynamicRendering, FragmentShadingRateAttachmentSizeWithDeviceGrou
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiviewFeaturesKHR multiview_features = vku::InitStructHelper(&dynamic_rendering_features);
     VkPhysicalDeviceFeatures2 features2 = GetPhysicalDeviceFeatures2(multiview_features);
 
     if (multiview_features.multiview == VK_FALSE) {
@@ -5181,7 +5182,7 @@ TEST_F(NegativeDynamicRendering, FragmentShadingRateAttachmentSizeWithDeviceGrou
         GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -5196,7 +5197,7 @@ TEST_F(NegativeDynamicRendering, FragmentShadingRateAttachmentSizeWithDeviceGrou
     }
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto fragment_shading_rate = vku::InitStruct<VkRenderingFragmentShadingRateAttachmentInfoKHR>();
+    VkRenderingFragmentShadingRateAttachmentInfoKHR fragment_shading_rate = vku::InitStructHelper();
     fragment_shading_rate.imageView = image_view;
     fragment_shading_rate.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
     fragment_shading_rate.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
@@ -5236,7 +5237,7 @@ TEST_F(NegativeDynamicRendering, FragmentShadingRateAttachmentSizeWithDeviceGrou
     render_area.extent.width = 64 * fragment_shading_rate.shadingRateAttachmentTexelSize.width;
     render_area.extent.height = 32;
 
-    auto device_group_render_pass_begin_info = vku::InitStruct<VkDeviceGroupRenderPassBeginInfo>();
+    VkDeviceGroupRenderPassBeginInfo device_group_render_pass_begin_info = vku::InitStructHelper();
     device_group_render_pass_begin_info.deviceRenderAreaCount = 1;
     device_group_render_pass_begin_info.pDeviceRenderAreas = &render_area;
     fragment_shading_rate.pNext = &device_group_render_pass_begin_info;
@@ -5290,7 +5291,7 @@ TEST_F(NegativeDynamicRendering, SuspendingRenderPassInstance) {
     rendering_info.layerCount = 1;
     rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    auto cmd_begin = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cmd_begin = vku::InitStructHelper();
 
     cmd_buffer1.begin(&cmd_begin);
     cmd_buffer1.BeginRendering(suspend_rendering_info);
@@ -5346,7 +5347,7 @@ TEST_F(NegativeDynamicRendering, SuspendingRenderPassInstance) {
 TEST_F(NegativeDynamicRendering, SuspendingRenderPassInstanceQueueSubmit2) {
     TEST_DESCRIPTION("Test suspending render pass instance with QueueSubmit2.");
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    auto synchronization2 = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
+    VkPhysicalDeviceSynchronization2Features synchronization2 = vku::InitStructHelper();
     InitBasicDynamicRendering(&synchronization2);
     if (::testing::Test::IsSkipped()) return;
 
@@ -5369,7 +5370,7 @@ TEST_F(NegativeDynamicRendering, SuspendingRenderPassInstanceQueueSubmit2) {
     rendering_info.layerCount = 1;
     rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    auto cmd_begin = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cmd_begin = vku::InitStructHelper();
 
     cmd_buffer1.begin(&cmd_begin);
     cmd_buffer1.BeginRendering(suspend_rendering_info);
@@ -5441,14 +5442,14 @@ TEST_F(NegativeDynamicRendering, NullDepthStencilExecuteCommands) {
 
     VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
 
-    auto cbiri = vku::InitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
+    VkCommandBufferInheritanceRenderingInfoKHR cbiri = vku::InitStructHelper();
     // format is defined, although no image view provided in dynamic rendering
     cbiri.depthAttachmentFormat = depth_stencil_format;
     cbiri.stencilAttachmentFormat = depth_stencil_format;
     cbiri.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-    auto cbii = vku::InitStruct<VkCommandBufferInheritanceInfo>(&cbiri);
+    VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper(&cbiri);
 
-    auto cbbi = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     cbbi.pInheritanceInfo = &cbii;
     cbbi.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT | VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 
@@ -5458,11 +5459,11 @@ TEST_F(NegativeDynamicRendering, NullDepthStencilExecuteCommands) {
     VkImageView depth_stencil_view =
         depth_stencil.targetView(depth_stencil_format, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
-    auto rai = vku::InitStruct<VkRenderingAttachmentInfo>();
+    VkRenderingAttachmentInfo rai = vku::InitStructHelper();
     rai.imageView = depth_stencil_view;
     rai.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-    auto ri = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR ri = vku::InitStructHelper();
     ri.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR;
     ri.layerCount = 1;
     ri.pDepthAttachment = &rai;
@@ -5782,18 +5783,18 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingColorImageViewFor
     image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = imageView;
 
     constexpr std::array bad_color_formats = {VK_FORMAT_R8G8B8A8_UINT};
 
-    auto inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
+    VkCommandBufferInheritanceRenderingInfoKHR inheritance_rendering_info = vku::InitStructHelper();
     inheritance_rendering_info.colorAttachmentCount = bad_color_formats.size();
     inheritance_rendering_info.pColorAttachmentFormats = bad_color_formats.data();
     inheritance_rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR;
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
@@ -5802,9 +5803,9 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingColorImageViewFor
 
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    const auto cmdbuff_ii = vku::InitStruct<VkCommandBufferInheritanceInfo>(&inheritance_rendering_info);
+    const VkCommandBufferInheritanceInfo cmdbuff_ii = vku::InitStructHelper(&inheritance_rendering_info);
 
-    auto cmdbuff_bi = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cmdbuff_bi = vku::InitStructHelper();
     cmdbuff_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmdbuff_bi.pInheritanceInfo = &cmdbuff_ii;
 
@@ -5830,18 +5831,18 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithNullImageView) {
     InitBasicDynamicRendering();
     if (::testing::Test::IsSkipped()) return;
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = VK_NULL_HANDLE;
 
     constexpr std::array bad_color_formats = {VK_FORMAT_R8G8B8A8_UINT};
 
-    auto inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
+    VkCommandBufferInheritanceRenderingInfoKHR inheritance_rendering_info = vku::InitStructHelper();
     inheritance_rendering_info.colorAttachmentCount = bad_color_formats.size();
     inheritance_rendering_info.pColorAttachmentFormats = bad_color_formats.data();
     inheritance_rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR;
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
@@ -5850,9 +5851,9 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithNullImageView) {
 
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    const auto cmdbuff_ii = vku::InitStruct<VkCommandBufferInheritanceInfo>(&inheritance_rendering_info);
+    const VkCommandBufferInheritanceInfo cmdbuff_ii = vku::InitStructHelper(&inheritance_rendering_info);
 
-    auto cmdbuff_bi = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cmdbuff_bi = vku::InitStructHelper();
     cmdbuff_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmdbuff_bi.pInheritanceInfo = &cmdbuff_ii;
 
@@ -5936,7 +5937,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingViewMask) {
     TEST_DESCRIPTION(
         "Test CmdExecuteCommands inside a render pass begun with CmdBeginRendering that has mismatching viewMask format");
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    auto mv_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>();
+    VkPhysicalDeviceMultiviewFeaturesKHR mv_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&mv_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -6116,11 +6117,11 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewAttachme
     VkFormat color_formats = {VK_FORMAT_R8G8B8A8_UNORM};
 
     VkSampleCountFlagBits counts = {VK_SAMPLE_COUNT_2_BIT};
-    auto samples_info = vku::InitStruct<VkAttachmentSampleCountInfoAMD>();
+    VkAttachmentSampleCountInfoAMD samples_info = vku::InitStructHelper();
     samples_info.colorAttachmentCount = 1;
     samples_info.pColorAttachmentSamples = &counts;
 
-    auto inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfoKHR>(&samples_info);
+    VkCommandBufferInheritanceRenderingInfoKHR inheritance_rendering_info = vku::InitStructHelper(&samples_info);
     inheritance_rendering_info.colorAttachmentCount = 1;
     inheritance_rendering_info.pColorAttachmentFormats = &color_formats;
     inheritance_rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
@@ -6214,7 +6215,7 @@ TEST_F(NegativeDynamicRendering, InSecondaryCommandBuffers) {
 
     VkFormat format = VK_FORMAT_R32G32B32A32_UINT;
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &format;
 
@@ -6259,13 +6260,13 @@ TEST_F(NegativeDynamicRendering, CommandBufferInheritanceDepthFormat) {
         GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
 
-    auto inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
+    VkCommandBufferInheritanceRenderingInfoKHR inheritance_rendering_info = vku::InitStructHelper();
     inheritance_rendering_info.depthAttachmentFormat = stencil_format;
 
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    auto cmdbuf_ii = vku::InitStruct<VkCommandBufferInheritanceInfo>(&inheritance_rendering_info);
-    auto cmdbuf_bi = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferInheritanceInfo cmdbuf_ii = vku::InitStructHelper(&inheritance_rendering_info);
+    VkCommandBufferBeginInfo cmdbuf_bi = vku::InitStructHelper();
     cmdbuf_bi.pInheritanceInfo = &cmdbuf_ii;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferInheritanceRenderingInfo-depthAttachmentFormat-06540");
@@ -6290,7 +6291,7 @@ TEST_F(NegativeDynamicRendering, DeviceGroupRenderArea) {
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>(&device_group_render_pass_begin_info);
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper(&device_group_render_pass_begin_info);
     begin_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR;
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.colorAttachmentCount = 1;
@@ -6338,7 +6339,7 @@ TEST_F(NegativeDynamicRendering, MaxFramebufferLayers) {
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = m_device->props.limits.maxFramebufferLayers + 1;
     begin_rendering_info.renderArea = {{0, 0}, {64, 64}};
     begin_rendering_info.colorAttachmentCount = 1;
@@ -6474,7 +6475,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingDisabled) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
@@ -6523,13 +6524,13 @@ TEST_F(NegativeDynamicRendering, PipelineRenderingParameters) {
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
 
-    auto create_info = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+    VkGraphicsPipelineCreateInfo create_info = vku::InitStructHelper();
     pipe.InitGraphicsPipelineCreateInfo(&create_info);
     create_info.pNext = &pipeline_rendering_info;
 
-    auto depth_stencil_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo depth_stencil_state = vku::InitStructHelper();
     create_info.pDepthStencilState = &depth_stencil_state;
 
     VkFormat depth_format = VK_FORMAT_X8_D24_UNORM_PACK32;
@@ -6601,7 +6602,7 @@ TEST_F(NegativeDynamicRendering, PipelineRenderingParameters) {
 
 TEST_F(NegativeDynamicRendering, PipelineRenderingViewMaskParameter) {
     TEST_DESCRIPTION("Test pipeline rendering viewmask maximum index");
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&multiview_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -6622,13 +6623,13 @@ TEST_F(NegativeDynamicRendering, PipelineRenderingViewMaskParameter) {
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
 
     VkFormat color_formats = {VK_FORMAT_R8G8B8A8_UNORM};
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
-    auto multiview_props = vku::InitStruct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceMultiviewProperties multiview_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(multiview_props);
 
     if (multiview_props.maxMultiviewViewCount == 32) {
@@ -6667,7 +6668,7 @@ TEST_F(NegativeDynamicRendering, CreateGraphicsPipeline) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
-    auto rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR rendering_info = vku::InitStructHelper();
     rendering_info.colorAttachmentCount = 1;
     rendering_info.pColorAttachmentFormats = &color_format;
 
@@ -6712,7 +6713,7 @@ TEST_F(NegativeDynamicRendering, CreateGraphicsPipelineNoInfo) {
 TEST_F(NegativeDynamicRendering, DynamicColorBlendAttchment) {
     TEST_DESCRIPTION("Test all color blend attachments are dynamically set at draw time with Dynamic Rendering.");
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&extended_dynamic_state3_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -6721,7 +6722,7 @@ TEST_F(NegativeDynamicRendering, DynamicColorBlendAttchment) {
     }
 
     VkFormat color_formats = VK_FORMAT_UNDEFINED;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
@@ -6766,7 +6767,7 @@ TEST_F(NegativeDynamicRendering, BeginTwice) {
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {64, 64}};
     begin_rendering_info.colorAttachmentCount = 1;
@@ -6789,7 +6790,7 @@ TEST_F(NegativeDynamicRendering, EndTwice) {
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {64, 64}};
     begin_rendering_info.colorAttachmentCount = 1;

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -26,7 +26,7 @@ void DynamicRenderingTest::InitBasicDynamicRendering(void* pNextFeatures) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(pNextFeatures);
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper(pNextFeatures);
     GetPhysicalDeviceFeatures2(dynamic_rendering_features);
     if (!dynamic_rendering_features.dynamicRendering) {
         GTEST_SKIP() << "Test requires (unsupported) dynamicRendering , skipping.";
@@ -43,7 +43,7 @@ TEST_F(PositiveDynamicRendering, BasicUsage) {
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {64, 64}};
     begin_rendering_info.colorAttachmentCount = 1;
@@ -67,7 +67,7 @@ TEST_F(PositiveDynamicRendering, Draw) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkFormat color_formats = VK_FORMAT_UNDEFINED;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
@@ -109,7 +109,7 @@ TEST_F(PositiveDynamicRendering, DrawMultiBind) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkFormat color_formats = VK_FORMAT_UNDEFINED;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
     pipeline_rendering_info.depthAttachmentFormat = depth_format;
@@ -118,7 +118,7 @@ TEST_F(PositiveDynamicRendering, DrawMultiBind) {
     pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
-    pipe.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    pipe.ds_ci_ = vku::InitStructHelper();
     pipe.gp_ci_.pNext = &pipeline_rendering_info;
     pipe.CreateGraphicsPipeline();
 
@@ -155,7 +155,7 @@ TEST_F(PositiveDynamicRendering, DrawMultiBind) {
 TEST_F(PositiveDynamicRendering, BeginQuery) {
     TEST_DESCRIPTION("Test calling vkCmdBeginQuery with a dynamic render pass.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&sync2_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -187,7 +187,7 @@ TEST_F(PositiveDynamicRendering, PipeWithDiscard) {
     InitBasicDynamicRendering();
     if (::testing::Test::IsSkipped()) return;
 
-    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     ds_ci.depthTestEnable = VK_TRUE;
     ds_ci.depthWriteEnable = VK_TRUE;
 
@@ -196,7 +196,7 @@ TEST_F(PositiveDynamicRendering, PipeWithDiscard) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkFormat color_formats = {VK_FORMAT_R8G8B8A8_UNORM};
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_D16_UNORM;  // D16_UNORM has guaranteed support
@@ -220,7 +220,7 @@ TEST_F(PositiveDynamicRendering, UseStencilAttachmentWithIntegerFormatAndDepthSt
         GTEST_SKIP() << "VK_FORMAT_S8_UINT format not supported";
     }
 
-    auto depth_stencil_resolve_properties = vku::InitStruct<VkPhysicalDeviceDepthStencilResolveProperties>();
+    VkPhysicalDeviceDepthStencilResolveProperties depth_stencil_resolve_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(depth_stencil_resolve_properties);
     if ((depth_stencil_resolve_properties.supportedStencilResolveModes & VK_RESOLVE_MODE_AVERAGE_BIT) == 0) {
         GTEST_SKIP() << "VK_RESOLVE_MODE_AVERAGE_BIT not supported for VK_FORMAT_S8_UINT";
@@ -299,7 +299,7 @@ TEST_F(PositiveDynamicRendering, FragmentDensityMapSubsampledBit) {
     begin_rendering_info.pColorAttachments = &color_attachment;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    auto fragment_density_map = vku::InitStruct<VkRenderingFragmentDensityMapAttachmentInfoEXT>();
+    VkRenderingFragmentDensityMapAttachmentInfoEXT fragment_density_map = vku::InitStructHelper();
     fragment_density_map.imageView = fdm_image_view;
     fragment_density_map.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
     begin_rendering_info.pNext = &fragment_density_map;
@@ -320,7 +320,7 @@ TEST_F(PositiveDynamicRendering, SuspendResumeDraw) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkFormat color_formats = VK_FORMAT_UNDEFINED;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
@@ -328,7 +328,7 @@ TEST_F(PositiveDynamicRendering, SuspendResumeDraw) {
     pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
-    pipe.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    pipe.ds_ci_ = vku::InitStructHelper();
     pipe.gp_ci_.pNext = &pipeline_rendering_info;
     pipe.CreateGraphicsPipeline();
 
@@ -369,7 +369,7 @@ TEST_F(PositiveDynamicRendering, SuspendResumeDraw) {
     cb2.end();
 
     std::array<VkCommandBuffer, 3> cbs = {m_commandBuffer->handle(), cb1.handle(), cb2.handle()};
-    auto submit = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit = vku::InitStructHelper();
     submit.commandBufferCount = static_cast<uint32_t>(cbs.size());
     submit.pCommandBuffers = cbs.data();
     vk::QueueSubmit(m_device->m_queue, 1, &submit, VK_NULL_HANDLE);
@@ -398,7 +398,7 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipeline) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
-    auto rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR rendering_info = vku::InitStructHelper();
     rendering_info.colorAttachmentCount = 1;
     rendering_info.pColorAttachmentFormats = &color_format;
 
@@ -486,7 +486,7 @@ TEST_F(PositiveDynamicRendering, CommandDrawWithShaderTileImageRead) {
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_EXT_SHADER_TILE_IMAGE_EXTENSION_NAME);
-    auto shader_tile_image_features = vku::InitStruct<VkPhysicalDeviceShaderTileImageFeaturesEXT>();
+    VkPhysicalDeviceShaderTileImageFeaturesEXT shader_tile_image_features = vku::InitStructHelper();
     InitBasicDynamicRendering(&shader_tile_image_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -499,12 +499,12 @@ TEST_F(PositiveDynamicRendering, CommandDrawWithShaderTileImageRead) {
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     auto fs = VkShaderObj::CreateFromASM(this, kShaderTileImageDepthStencilReadSpv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    auto ds_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
     ds_state.depthWriteEnable = VK_TRUE;
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
     VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
     pipeline_rendering_info.depthAttachmentFormat = depth_format;
@@ -513,7 +513,7 @@ TEST_F(PositiveDynamicRendering, CommandDrawWithShaderTileImageRead) {
     VkDescriptorSetLayoutBinding dslb = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
 
-    auto ms_ci = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>();
+    VkPipelineMultisampleStateCreateInfo ms_ci = vku::InitStructHelper();
     ms_ci.sampleShadingEnable = VK_TRUE;
     ms_ci.minSampleShading = 1.0;
     ms_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
@@ -619,7 +619,7 @@ TEST_F(PositiveDynamicRendering, DualSourceBlending) {
     cb_attachments.alphaBlendOp = VK_BLEND_OP_ADD;
 
     VkFormat color_formats = VK_FORMAT_UNDEFINED;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
@@ -657,18 +657,18 @@ TEST_F(PositiveDynamicRendering, ExecuteCommandsWithNullImageView) {
     InitBasicDynamicRendering();
     if (::testing::Test::IsSkipped()) return;
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = VK_NULL_HANDLE;
 
     constexpr std::array bad_color_formats = {VK_FORMAT_UNDEFINED};
 
-    auto inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfoKHR>();
+    VkCommandBufferInheritanceRenderingInfoKHR inheritance_rendering_info = vku::InitStructHelper();
     inheritance_rendering_info.colorAttachmentCount = bad_color_formats.size();
     inheritance_rendering_info.pColorAttachmentFormats = bad_color_formats.data();
     inheritance_rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR;
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
@@ -677,9 +677,9 @@ TEST_F(PositiveDynamicRendering, ExecuteCommandsWithNullImageView) {
 
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    const auto cmdbuff_ii = vku::InitStruct<VkCommandBufferInheritanceInfo>(&inheritance_rendering_info);
+    const VkCommandBufferInheritanceInfo cmdbuff_ii = vku::InitStructHelper(&inheritance_rendering_info);
 
-    auto cmdbuff_bi = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cmdbuff_bi = vku::InitStructHelper();
     cmdbuff_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmdbuff_bi.pInheritanceInfo = &cmdbuff_ii;
 
@@ -708,7 +708,7 @@ TEST_F(PositiveDynamicRendering, SuspendPrimaryResumeInSecondary) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkFormat color_formats = {VK_FORMAT_UNDEFINED};
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
@@ -752,7 +752,7 @@ TEST_F(PositiveDynamicRendering, SuspendPrimaryResumeInSecondary) {
     m_commandBuffer->end();
 
     // Submit
-    auto submit = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit = vku::InitStructHelper();
     submit.commandBufferCount = 1;
     submit.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit, VK_NULL_HANDLE);
@@ -780,7 +780,7 @@ TEST_F(PositiveDynamicRendering, SuspendSecondaryResumeInPrimary) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     VkFormat color_formats = {VK_FORMAT_UNDEFINED};
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
@@ -834,7 +834,7 @@ TEST_F(PositiveDynamicRendering, SuspendSecondaryResumeInPrimary) {
 
     // Submit
     std::array<VkCommandBuffer, 2> cbs = {m_commandBuffer->handle(), cb.handle()};
-    auto submit = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit = vku::InitStructHelper();
     submit.commandBufferCount = static_cast<uint32_t>(cbs.size());
     submit.pCommandBuffers = cbs.data();
     vk::QueueSubmit(m_device->m_queue, 1, &submit, VK_NULL_HANDLE);
@@ -846,8 +846,8 @@ TEST_F(PositiveDynamicRendering, WithShaderTileImageAndBarrier) {
     TEST_DESCRIPTION("Test setting memory barrier with shader tile image features are enabled.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_EXT_SHADER_TILE_IMAGE_EXTENSION_NAME);
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
-    auto shader_tile_image_features = vku::InitStruct<VkPhysicalDeviceShaderTileImageFeaturesEXT>(&sync2_features);
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderTileImageFeaturesEXT shader_tile_image_features = vku::InitStructHelper(&sync2_features);
     InitBasicDynamicRendering(&shader_tile_image_features);
     if (::testing::Test::IsSkipped()) return;
     if (!shader_tile_image_features.shaderTileImageColorReadAccess && !shader_tile_image_features.shaderTileImageDepthReadAccess &&
@@ -864,13 +864,13 @@ TEST_F(PositiveDynamicRendering, WithShaderTileImageAndBarrier) {
     begin_rendering_info.renderArea = clear_rect.rect;
     begin_rendering_info.layerCount = 1;
 
-    auto memory_barrier_2 = vku::InitStruct<VkMemoryBarrier2KHR>();
+    VkMemoryBarrier2KHR memory_barrier_2 = vku::InitStructHelper();
     memory_barrier_2.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
     memory_barrier_2.srcAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
     memory_barrier_2.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
     memory_barrier_2.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT;
 
-    auto dependency_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dependency_info = vku::InitStructHelper();
     dependency_info.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &memory_barrier_2;
@@ -883,7 +883,7 @@ TEST_F(PositiveDynamicRendering, WithShaderTileImageAndBarrier) {
     vk::CmdPipelineBarrier2(m_commandBuffer->handle(), &dependency_info);
     m_commandBuffer->EndRendering();
 
-    auto memory_barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier memory_barrier = vku::InitStructHelper();
     memory_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     memory_barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
     m_commandBuffer->BeginRendering(begin_rendering_info);
@@ -913,7 +913,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
 
     VkPipelineObj pipeline_color(m_device);
     pipeline_color.AddShader(&vs);
@@ -927,13 +927,13 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
     pipeline_rendering_info.pColorAttachmentFormats = color_formats;
 
     {
-        auto pipeline_create_info = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+        VkGraphicsPipelineCreateInfo pipeline_create_info = vku::InitStructHelper();
         pipeline_color.InitGraphicsPipelineCreateInfo(&pipeline_create_info);
         pipeline_create_info.pNext = &pipeline_rendering_info;
 
         pipeline_color.CreateVKPipeline(pl.handle(), VK_NULL_HANDLE, &pipeline_create_info);
     }
-    auto ds_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
 
     VkPipelineObj pipeline_depth(m_device);
     pipeline_depth.AddShader(&vs);
@@ -947,7 +947,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
 
     {
-        auto pipeline_create_info = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+        VkGraphicsPipelineCreateInfo pipeline_create_info = vku::InitStructHelper();
         pipeline_depth.InitGraphicsPipelineCreateInfo(&pipeline_create_info);
         pipeline_create_info.pNext = &pipeline_rendering_info;
 
@@ -966,7 +966,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
     pipeline_rendering_info.stencilAttachmentFormat = VK_FORMAT_UNDEFINED;
 
     {
-        auto pipeline_create_info = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+        VkGraphicsPipelineCreateInfo pipeline_create_info = vku::InitStructHelper();
         pipeline_stencil.InitGraphicsPipelineCreateInfo(&pipeline_create_info);
         pipeline_create_info.pNext = &pipeline_rendering_info;
 
@@ -980,11 +980,11 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
     const VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
     depthStencilImage.Init(32, 32, 1, depthStencilFormat, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = VK_NULL_HANDLE;
 
-    auto depth_stencil_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR depth_stencil_attachment = vku::InitStructHelper();
     depth_stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     depth_stencil_attachment.imageView = VK_NULL_HANDLE;
 
@@ -992,7 +992,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
 
     {
         // Mismatching color formats
-        auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+        VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
         begin_rendering_info.layerCount = 1;
         begin_rendering_info.colorAttachmentCount = 1;
         begin_rendering_info.pColorAttachments = &color_attachment;
@@ -1005,7 +1005,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
 
     {
         // Mismatching depth format
-        auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+        VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
         begin_rendering_info.layerCount = 1;
         begin_rendering_info.pDepthAttachment = &depth_stencil_attachment;
         begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
@@ -1017,7 +1017,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
 
     {
         // Mismatching stencil format
-        auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+        VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
         begin_rendering_info.layerCount = 1;
         begin_rendering_info.pStencilAttachment = &depth_stencil_attachment;
         begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
@@ -1033,7 +1033,8 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
 TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     TEST_DESCRIPTION("Draw with Dynamic Rendering with dynamicRenderingUnusedAttachments enabled and matching formats");
     AddRequiredExtensions(VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME);
-    auto dynamic_rendering_unused_attachments_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT>();
+    VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT dynamic_rendering_unused_attachments_features =
+        vku::InitStructHelper();
     InitBasicDynamicRendering(&dynamic_rendering_unused_attachments_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -1053,7 +1054,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
 
     VkPipelineObj pipeline_color(m_device);
     pipeline_color.AddShader(&vs);
@@ -1067,13 +1068,13 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     pipeline_rendering_info.pColorAttachmentFormats = color_formats;
 
     {
-        auto pipeline_create_info = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+        VkGraphicsPipelineCreateInfo pipeline_create_info = vku::InitStructHelper();
         pipeline_color.InitGraphicsPipelineCreateInfo(&pipeline_create_info);
         pipeline_create_info.pNext = &pipeline_rendering_info;
 
         pipeline_color.CreateVKPipeline(pl.handle(), VK_NULL_HANDLE, &pipeline_create_info);
     }
-    auto ds_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
 
     VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
 
@@ -1089,7 +1090,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     pipeline_rendering_info.depthAttachmentFormat = depthStencilFormat;
 
     {
-        auto pipeline_create_info = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+        VkGraphicsPipelineCreateInfo pipeline_create_info = vku::InitStructHelper();
         pipeline_depth.InitGraphicsPipelineCreateInfo(&pipeline_create_info);
         pipeline_create_info.pNext = &pipeline_rendering_info;
 
@@ -1108,7 +1109,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     pipeline_rendering_info.stencilAttachmentFormat = depthStencilFormat;
 
     {
-        auto pipeline_create_info = vku::InitStruct<VkGraphicsPipelineCreateInfo>();
+        VkGraphicsPipelineCreateInfo pipeline_create_info = vku::InitStructHelper();
         pipeline_stencil.InitGraphicsPipelineCreateInfo(&pipeline_create_info);
         pipeline_create_info.pNext = &pipeline_rendering_info;
 
@@ -1121,11 +1122,11 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     VkImageObj depthStencilImage(m_device);
     depthStencilImage.Init(32, 32, 1, depthStencilFormat, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = VK_NULL_HANDLE;
 
-    auto depth_stencil_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR depth_stencil_attachment = vku::InitStructHelper();
     depth_stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     depth_stencil_attachment.imageView = VK_NULL_HANDLE;
 
@@ -1133,7 +1134,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
 
     {
         // Null color image view
-        auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+        VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
         begin_rendering_info.layerCount = 1;
         begin_rendering_info.colorAttachmentCount = 1;
         begin_rendering_info.pColorAttachments = &color_attachment;
@@ -1154,7 +1155,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
 
     {
         // Null depth image view
-        auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+        VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
         begin_rendering_info.layerCount = 1;
         begin_rendering_info.pDepthAttachment = &depth_stencil_attachment;
         begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
@@ -1174,7 +1175,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
 
     {
         // Null stencil image view
-        auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+        VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
         begin_rendering_info.layerCount = 1;
         begin_rendering_info.pStencilAttachment = &depth_stencil_attachment;
         begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
@@ -1202,16 +1203,16 @@ TEST_F(PositiveDynamicRendering, ExecuteCommandsFlags) {
 
     constexpr VkFormat color_formats = {VK_FORMAT_UNDEFINED};  // undefined because no image view will be used
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfo>();
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto inheritance_rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfo>();
+    VkCommandBufferInheritanceRenderingInfo inheritance_rendering_info = vku::InitStructHelper();
     inheritance_rendering_info.colorAttachmentCount = 1;
     inheritance_rendering_info.pColorAttachmentFormats = &color_formats;
     inheritance_rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     inheritance_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT;
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
@@ -1220,12 +1221,12 @@ TEST_F(PositiveDynamicRendering, ExecuteCommandsFlags) {
 
     VkCommandBufferObj secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    auto cb_inheritance_info = vku::InitStruct<VkCommandBufferInheritanceInfo>(&inheritance_rendering_info);
+    VkCommandBufferInheritanceInfo cb_inheritance_info = vku::InitStructHelper(&inheritance_rendering_info);
     cb_inheritance_info.renderPass = VK_NULL_HANDLE;
     cb_inheritance_info.subpass = 0;
     cb_inheritance_info.framebuffer = VK_NULL_HANDLE;
 
-    auto cb_begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cb_begin_info = vku::InitStructHelper();
     cb_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cb_begin_info.pInheritanceInfo = &cb_inheritance_info;
     secondary.begin(&cb_begin_info);

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -48,7 +48,7 @@ TEST_F(NegativeDynamicState, LineStippleNotBound) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto line_rasterization_features = vku::InitStruct<VkPhysicalDeviceLineRasterizationFeaturesEXT>();
+    VkPhysicalDeviceLineRasterizationFeaturesEXT line_rasterization_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(line_rasterization_features);
     if (!line_rasterization_features.stippledBresenhamLines || !line_rasterization_features.bresenhamLines) {
         GTEST_SKIP() << "Stipple Bresenham lines not supported";
@@ -262,7 +262,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -347,7 +347,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorPipeline) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -403,7 +403,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateDuplicate) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -448,7 +448,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateBindVertexBuffers) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -526,7 +526,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateBindVertexBuffersWholeSize) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
 
@@ -549,7 +549,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorDraw) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -624,7 +624,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateSetViewportScissor) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -736,7 +736,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateEnabledNoMultiview) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -781,9 +781,9 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Disabled) {
     }
 
     // Add first extension to catch bugs where layers check from wrong feature bit
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
-    auto extended_dynamic_state2_features =
-        vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(&extended_dynamic_state_features);
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features =
+        vku::InitStructHelper(&extended_dynamic_state_features);
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state2_features);
     if (!extended_dynamic_state2_features.extendedDynamicState2) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState2, skipping";
@@ -834,7 +834,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state2_features);
     if (!extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState2LogicOp, skipping";
@@ -875,7 +875,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state2_features);
     if (!extended_dynamic_state2_features.extendedDynamicState2LogicOp) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState2LogicOp, skipping";
@@ -915,7 +915,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Enabled) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state2_features);
     if (!extended_dynamic_state2_features.extendedDynamicState2) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState2, skipping";
@@ -979,7 +979,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsEnabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state2_features);
     if (!extended_dynamic_state2_features.extendedDynamicState2PatchControlPoints) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState2PatchControlPoints, skipping";
@@ -1038,7 +1038,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpEnabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state2_features);
     if (!extended_dynamic_state2_features.extendedDynamicState2LogicOp) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState2LogicOp, skipping";
@@ -1563,7 +1563,7 @@ TEST_F(NegativeDynamicState, DrawNotSetTessellationDomainOrigin) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3TessellationDomainOrigin) {
         GTEST_SKIP() << "extendedDynamicState3TessellationDomainOrigin not supported";
@@ -1575,9 +1575,9 @@ TEST_F(NegativeDynamicState, DrawNotSetTessellationDomainOrigin) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_TESSELLATION_DOMAIN_ORIGIN_EXT);
-    auto tess_domain_ci = vku::InitStruct<VkPipelineTessellationDomainOriginStateCreateInfo>();
+    VkPipelineTessellationDomainOriginStateCreateInfo tess_domain_ci = vku::InitStructHelper();
     tess_domain_ci.domainOrigin = VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT;
-    auto tess_ci = vku::InitStruct<VkPipelineTessellationStateCreateInfo>(&tess_domain_ci);
+    VkPipelineTessellationStateCreateInfo tess_ci = vku::InitStructHelper(&tess_domain_ci);
     pipe.gp_ci_.pTessellationState = &tess_ci;
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
@@ -1602,7 +1602,7 @@ TEST_F(NegativeDynamicState, DrawNotSetDepthClampEnable) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3DepthClampEnable) {
         GTEST_SKIP() << "extendedDynamicState3DepthClampEnable not supported";
@@ -1639,7 +1639,7 @@ TEST_F(NegativeDynamicState, DrawNotSetPolygonMode) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3PolygonMode) {
         GTEST_SKIP() << "extendedDynamicState3PolygonMode not supported";
@@ -1684,7 +1684,7 @@ TEST_F(NegativeDynamicState, DrawNotSetAlphaToOneEnable) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3AlphaToOneEnable) {
         GTEST_SKIP() << "extendedDynamicState3AlphaToOneEnable not supported";
@@ -1720,7 +1720,7 @@ TEST_F(NegativeDynamicState, DrawNotSetLogicOpEnable) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3LogicOpEnable) {
         GTEST_SKIP() << "extendedDynamicState3LogicOpEnable not supported";
@@ -1758,7 +1758,7 @@ TEST_F(NegativeDynamicState, DrawNotSetColorBlendEquation) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3ColorBlendEquation) {
         GTEST_SKIP() << "extendedDynamicState3ColorBlendEquation not supported";
@@ -1802,9 +1802,9 @@ TEST_F(NegativeDynamicState, DrawNotSetRasterizationStream) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto transform_feedback_features = vku::InitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
-    auto extended_dynamic_state3_features =
-        vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(&transform_feedback_features);
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT transform_feedback_features = vku::InitStructHelper();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features =
+        vku::InitStructHelper(&transform_feedback_features);
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3RasterizationStream) {
         GTEST_SKIP() << "extendedDynamicState3RasterizationStream not supported";
@@ -1813,7 +1813,7 @@ TEST_F(NegativeDynamicState, DrawNotSetRasterizationStream) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state3_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto transform_feedback_props = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transform_feedback_props);
 
     m_commandBuffer->begin();
@@ -1849,7 +1849,7 @@ TEST_F(NegativeDynamicState, DrawNotSetExtraPrimitiveOverestimationSize) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3ExtraPrimitiveOverestimationSize) {
         GTEST_SKIP() << "extendedDynamicState3ExtraPrimitiveOverestimationSize not supported";
@@ -1887,7 +1887,7 @@ TEST_F(NegativeDynamicState, DrawNotSetColorBlendAdvanced) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3ColorBlendAdvanced) {
         GTEST_SKIP() << "extendedDynamicState3ColorBlendAdvanced not supported";
@@ -1895,7 +1895,7 @@ TEST_F(NegativeDynamicState, DrawNotSetColorBlendAdvanced) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state3_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto blend_operation_advanced = vku::InitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
+    VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(blend_operation_advanced);
 
     m_commandBuffer->begin();
@@ -1936,7 +1936,7 @@ TEST_F(NegativeDynamicState, DrawNotSetProvokingVertexMode) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3ProvokingVertexMode) {
         GTEST_SKIP() << "extendedDynamicState3ProvokingVertexMode not supported";
@@ -1973,7 +1973,7 @@ TEST_F(NegativeDynamicState, DrawNotSetLineRasterizationMode) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3LineRasterizationMode) {
         GTEST_SKIP() << "extendedDynamicState3LineRasterizationMode not supported";
@@ -2015,8 +2015,9 @@ TEST_F(NegativeDynamicState, DrawNotSetLineStippleEnable) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto line_raster_features = vku::InitStruct<VkPhysicalDeviceLineRasterizationFeaturesEXT>();
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(&line_raster_features);
+    VkPhysicalDeviceLineRasterizationFeaturesEXT line_raster_features = vku::InitStructHelper();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features =
+        vku::InitStructHelper(&line_raster_features);
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3LineStippleEnable) {
         GTEST_SKIP() << "dynamic state 3 features not supported";
@@ -2052,7 +2053,7 @@ TEST_F(NegativeDynamicState, DrawNotSetColorWriteMask) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3ColorWriteMask) {
         GTEST_SKIP() << "extendedDynamicState3ColorWriteMask not supported";
@@ -2113,7 +2114,7 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto vertex_input_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT vertex_input_dynamic_state_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(vertex_input_dynamic_state_features);
     if (!vertex_input_dynamic_state_features.vertexInputDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) vertexInputDynamicState, skipping";
@@ -2314,9 +2315,9 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateDivisor) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto vertex_attribute_divisor_features = vku::InitStruct<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT>();
-    auto vertex_input_dynamic_state_features =
-        vku::InitStruct<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(&vertex_attribute_divisor_features);
+    VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vertex_attribute_divisor_features = vku::InitStructHelper();
+    VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT vertex_input_dynamic_state_features =
+        vku::InitStructHelper(&vertex_attribute_divisor_features);
     auto features2 = GetPhysicalDeviceFeatures2(vertex_input_dynamic_state_features);
     if (!vertex_attribute_divisor_features.vertexAttributeInstanceRateDivisor) {
         GTEST_SKIP() << "Test requires (unsupported) vertexAttributeInstanceRateDivisor, skipping";
@@ -2325,7 +2326,7 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateDivisor) {
         GTEST_SKIP() << "Test requires (unsupported) vertexInputDynamicState, skipping";
     }
 
-    auto vertex_attribute_divisor_properties = vku::InitStruct<VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
+    VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT vertex_attribute_divisor_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(vertex_attribute_divisor_properties);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
@@ -2365,7 +2366,7 @@ TEST_F(NegativeDynamicState, RasterizationSamples) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3RasterizationSamples) {
         GTEST_SKIP() << "extendedDynamicState3RasterizationSamples not supported";
@@ -2374,7 +2375,7 @@ TEST_F(NegativeDynamicState, RasterizationSamples) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state3_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto ms_state_ci = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>();
+    VkPipelineMultisampleStateCreateInfo ms_state_ci = vku::InitStructHelper();
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;  // is ignored since dynamic
 
     CreatePipelineHelper pipe(*this);
@@ -2412,7 +2413,7 @@ TEST_F(NegativeDynamicState, ColorBlendAttchment) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
 
     if (!extended_dynamic_state3_features.extendedDynamicState3ColorBlendEnable) {
@@ -2469,8 +2470,9 @@ void NegativeDynamicState::InitLineRasterizationFeatureDisabled() {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto line_raster_features = vku::InitStruct<VkPhysicalDeviceLineRasterizationFeaturesEXT>();
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(&line_raster_features);
+    VkPhysicalDeviceLineRasterizationFeaturesEXT line_raster_features = vku::InitStructHelper();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features =
+        vku::InitStructHelper(&line_raster_features);
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3LineRasterizationMode ||
         !extended_dynamic_state3_features.extendedDynamicState3LineStippleEnable) {
@@ -2634,7 +2636,7 @@ TEST_F(NegativeDynamicState, DISABLED_MaxFragmentDualSrcAttachmentsDynamicBlendE
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
 
     if (features2.features.dualSrcBlend == VK_FALSE) {
@@ -2741,7 +2743,7 @@ TEST_F(NegativeDynamicState, ColorWriteNotSet) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto color_write_enable_features = vku::InitStruct<VkPhysicalDeviceColorWriteEnableFeaturesEXT>();
+    VkPhysicalDeviceColorWriteEnableFeaturesEXT color_write_enable_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(color_write_enable_features);
 
     if (color_write_enable_features.colorWriteEnable == VK_FALSE) {
@@ -2883,7 +2885,7 @@ TEST_F(NegativeDynamicState, DiscardRectanglesNotSet) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto discard_rect_ci = vku::InitStruct<VkPipelineDiscardRectangleStateCreateInfoEXT>();
+    VkPipelineDiscardRectangleStateCreateInfoEXT discard_rect_ci = vku::InitStructHelper();
     discard_rect_ci.discardRectangleMode = VK_DISCARD_RECTANGLE_MODE_INCLUSIVE_EXT;
     discard_rect_ci.discardRectangleCount = 4;
 
@@ -2925,7 +2927,7 @@ TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferResetBitmask) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto discard_rect_ci = vku::InitStruct<VkPipelineDiscardRectangleStateCreateInfoEXT>();
+    VkPipelineDiscardRectangleStateCreateInfoEXT discard_rect_ci = vku::InitStructHelper();
     discard_rect_ci.discardRectangleMode = VK_DISCARD_RECTANGLE_MODE_INCLUSIVE_EXT;
     discard_rect_ci.discardRectangleCount = 1;
 
@@ -2987,7 +2989,7 @@ TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferReset) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto sample_locations_props = vku::InitStruct<VkPhysicalDeviceSampleLocationsPropertiesEXT>();
+    VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(sample_locations_props);
 
     if ((sample_locations_props.sampleLocationSampleCounts & VK_SAMPLE_COUNT_1_BIT) == 0) {
@@ -3000,7 +3002,7 @@ TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferReset) {
     pipe.CreateGraphicsPipeline();
 
     VkSampleLocationEXT sample_location = {0.5f, 0.5f};
-    auto sample_locations_info = vku::InitStruct<VkSampleLocationsInfoEXT>();
+    VkSampleLocationsInfoEXT sample_locations_info = vku::InitStructHelper();
     sample_locations_info.sampleLocationsPerPixel = VK_SAMPLE_COUNT_1_BIT;
     sample_locations_info.sampleLocationGridSize = {1u, 1u};
     sample_locations_info.sampleLocationsCount = 1;
@@ -3051,7 +3053,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitViewport());
 
-    auto sample_locations_props = vku::InitStruct<VkPhysicalDeviceSampleLocationsPropertiesEXT>();
+    VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(sample_locations_props);
 
     if ((sample_locations_props.sampleLocationSampleCounts & VK_SAMPLE_COUNT_1_BIT) == 0) {
@@ -3060,7 +3062,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
 
     const bool support_64_sample_count = ((sample_locations_props.sampleLocationSampleCounts & VK_SAMPLE_COUNT_64_BIT) != 0);
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.extent.width = 128;
     image_create_info.extent.height = 128;
@@ -3118,7 +3120,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
         vku::InitStruct<VkFramebufferCreateInfo>(nullptr, 0u, m_renderPass, 2u, m_framebuffer_attachments.data(), 128u, 128u, 1u);
     vk::CreateFramebuffer(m_device->handle(), &m_framebuffer_info, nullptr, &m_framebuffer);
 
-    auto multisample_prop = vku::InitStruct<VkMultisamplePropertiesEXT>();
+    VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
     vk::GetPhysicalDeviceMultisamplePropertiesEXT(gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
     // 1 from VK_SAMPLE_COUNT_1_BIT
     const uint32_t valid_count =
@@ -3129,23 +3131,23 @@ TEST_F(NegativeDynamicState, SampleLocations) {
     }
 
     std::vector<VkSampleLocationEXT> sample_location(valid_count, {0.5, 0.5});
-    auto sample_locations_info = vku::InitStruct<VkSampleLocationsInfoEXT>();
+    VkSampleLocationsInfoEXT sample_locations_info = vku::InitStructHelper();
     sample_locations_info.sampleLocationsPerPixel = VK_SAMPLE_COUNT_1_BIT;
     sample_locations_info.sampleLocationGridSize = multisample_prop.maxSampleLocationGridSize;
     sample_locations_info.sampleLocationsCount = valid_count;
     sample_locations_info.pSampleLocations = sample_location.data();
 
-    auto sample_location_state = vku::InitStruct<VkPipelineSampleLocationsStateCreateInfoEXT>();
+    VkPipelineSampleLocationsStateCreateInfoEXT sample_location_state = vku::InitStructHelper();
     sample_location_state.sampleLocationsEnable = VK_TRUE;
     sample_location_state.sampleLocationsInfo = sample_locations_info;
 
-    auto pipe_ms_state_ci = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>(&sample_location_state);
+    VkPipelineMultisampleStateCreateInfo pipe_ms_state_ci = vku::InitStructHelper(&sample_location_state);
     pipe_ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     pipe_ms_state_ci.sampleShadingEnable = 0;
     pipe_ms_state_ci.minSampleShading = 1.0;
     pipe_ms_state_ci.pSampleMask = NULL;
 
-    auto pipe_ds_state_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo pipe_ds_state_ci = vku::InitStructHelper();
     pipe_ds_state_ci.depthTestEnable = VK_TRUE;
     pipe_ds_state_ci.stencilTestEnable = VK_FALSE;
 
@@ -3452,7 +3454,7 @@ TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTOffsets) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto discard_rectangle_properties = vku::InitStruct<VkPhysicalDeviceDiscardRectanglePropertiesEXT>();
+    VkPhysicalDeviceDiscardRectanglePropertiesEXT discard_rectangle_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(discard_rectangle_properties);
 
     if (discard_rectangle_properties.maxDiscardRectangles == 0) {
@@ -3520,7 +3522,7 @@ TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTRectangleCount) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto discard_rectangle_properties = vku::InitStruct<VkPhysicalDeviceDiscardRectanglePropertiesEXT>();
+    VkPhysicalDeviceDiscardRectanglePropertiesEXT discard_rectangle_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(discard_rectangle_properties);
 
     VkRect2D discard_rectangles = {};
@@ -3760,7 +3762,7 @@ TEST_F(NegativeDynamicState, PipelineColorBlendStateCreateInfoArrayDynamic) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3ColorBlendEnable ||
         !extended_dynamic_state3_features.extendedDynamicState3ColorBlendEquation) {
@@ -3823,7 +3825,7 @@ void NegativeDynamicState::ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -3951,7 +3953,7 @@ TEST_F(NegativeDynamicState, DepthBoundsTestEnableState) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
 
@@ -3988,7 +3990,7 @@ TEST_F(NegativeDynamicState, ViewportStateIgnored) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -4398,7 +4400,7 @@ TEST_F(NegativeDynamicState, DrawNotSetSampleLocations) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto sample_locations_props = vku::InitStruct<VkPhysicalDeviceSampleLocationsPropertiesEXT>();
+    VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(sample_locations_props);
 
     if ((sample_locations_props.sampleLocationSampleCounts & VK_SAMPLE_COUNT_1_BIT) == 0) {
@@ -4420,7 +4422,7 @@ TEST_F(NegativeDynamicState, DrawNotSetSampleLocations) {
 
     VkSampleLocationEXT sample_location = {0.5f, 0.5f};
 
-    auto sample_locations_info = vku::InitStruct<VkSampleLocationsInfoEXT>();
+    VkSampleLocationsInfoEXT sample_locations_info = vku::InitStructHelper();
     sample_locations_info.sampleLocationsPerPixel = VK_SAMPLE_COUNT_1_BIT;
     sample_locations_info.sampleLocationGridSize = {1u, 1u};
     sample_locations_info.sampleLocationsCount = 1;
@@ -4500,7 +4502,7 @@ TEST_F(NegativeDynamicState, DrawNotSetAttachmentFeedbackLoopEnable) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto feedback_loop_dynamic_features = vku::InitStruct<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT feedback_loop_dynamic_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(feedback_loop_dynamic_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &feedback_loop_dynamic_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -4558,9 +4560,9 @@ TEST_F(NegativeDynamicState, AttachmentFeedbackLoopEnableAspectMask) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto feedback_loop_dynamic_features = vku::InitStruct<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT>();
-    auto feedback_loop_features =
-        vku::InitStruct<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>(&feedback_loop_dynamic_features);
+    VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT feedback_loop_dynamic_features = vku::InitStructHelper();
+    VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT feedback_loop_features =
+        vku::InitStructHelper(&feedback_loop_dynamic_features);
     GetPhysicalDeviceFeatures2(feedback_loop_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &feedback_loop_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -4591,9 +4593,9 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
-    auto depth_bias_control_features =
-        vku::InitStruct<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(&extended_dynamic_state2_features);
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
+    VkPhysicalDeviceDepthBiasControlFeaturesEXT depth_bias_control_features =
+        vku::InitStructHelper(&extended_dynamic_state2_features);
     auto features2 = GetPhysicalDeviceFeatures2(depth_bias_control_features);
     features2.features.depthBiasClamp = VK_FALSE;
 
@@ -4610,7 +4612,7 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
 
     vk::CmdSetDepthBiasEnableEXT(m_commandBuffer->handle(), VK_TRUE);
 
-    auto depth_bias_info = vku::InitStruct<VkDepthBiasInfoEXT>();
+    VkDepthBiasInfoEXT depth_bias_info = vku::InitStructHelper();
     depth_bias_info.depthBiasConstantFactor = 1.0f;
     depth_bias_info.depthBiasClamp = 1.0f;
     depth_bias_info.depthBiasSlopeFactor = 1.0f;
@@ -4637,9 +4639,9 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasControlFeaturesDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
-    auto depth_bias_control_features =
-        vku::InitStruct<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(&extended_dynamic_state2_features);
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
+    VkPhysicalDeviceDepthBiasControlFeaturesEXT depth_bias_control_features =
+        vku::InitStructHelper(&extended_dynamic_state2_features);
     auto features2 = GetPhysicalDeviceFeatures2(depth_bias_control_features);
     features2.features.depthBiasClamp = VK_FALSE;
     depth_bias_control_features.leastRepresentableValueForceUnormRepresentation = VK_FALSE;
@@ -4664,13 +4666,13 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasControlFeaturesDisabled) {
 
     vk::CmdSetDepthBiasEnableEXT(m_commandBuffer->handle(), VK_TRUE);
 
-    auto depth_bias_info = vku::InitStruct<VkDepthBiasInfoEXT>();
+    VkDepthBiasInfoEXT depth_bias_info = vku::InitStructHelper();
     depth_bias_info.depthBiasConstantFactor = 1.0f;
     depth_bias_info.depthBiasClamp = 0.0f;
     depth_bias_info.depthBiasSlopeFactor = 1.0f;
     vk::CmdSetDepthBias2EXT(m_commandBuffer->handle(), &depth_bias_info);
 
-    auto depth_bias_representation = vku::InitStruct<VkDepthBiasRepresentationInfoEXT>();
+    VkDepthBiasRepresentationInfoEXT depth_bias_representation = vku::InitStructHelper();
     depth_bias_representation.depthBiasRepresentation = VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORCE_UNORM_EXT;
     depth_bias_representation.depthBiasExact = VK_TRUE;
     depth_bias_info.pNext = &depth_bias_representation;
@@ -4703,7 +4705,7 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasControlFeaturesDisabled) {
 TEST_F(NegativeDynamicState, AlphaToCoverageOutputNoAlpha) {
     TEST_DESCRIPTION("Dynamically set alphaToCoverageEnabled to true and not have component set.");
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     InitBasicExtendedDynamicState3(extended_dynamic_state_features);
     if (::testing::Test::IsSkipped()) return;
     if (!extended_dynamic_state_features.extendedDynamicState3AlphaToCoverageEnable) {
@@ -4720,7 +4722,7 @@ TEST_F(NegativeDynamicState, AlphaToCoverageOutputNoAlpha) {
     )glsl";
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    auto ms_state_ci = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>();
+    VkPipelineMultisampleStateCreateInfo ms_state_ci = vku::InitStructHelper();
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_FALSE;  // should be ignored
 
@@ -4746,7 +4748,7 @@ TEST_F(NegativeDynamicState, ShadingRateImageEnableNotSet) {
     TEST_DESCRIPTION("Create pipeline with VK_DYNAMIC_STATE_SHADING_RATE_IMAGE_ENABLE_NV but dont set the dynamic state.");
 
     AddRequiredExtensions(VK_NV_SHADING_RATE_IMAGE_EXTENSION_NAME);
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     InitBasicExtendedDynamicState3(extended_dynamic_state_features);
     if (::testing::Test::IsSkipped()) return;
     if (!extended_dynamic_state_features.extendedDynamicState3ShadingRateImageEnable) {
@@ -4774,7 +4776,7 @@ TEST_F(NegativeDynamicState, CoverageReductionModeNotSet) {
     TEST_DESCRIPTION("Create pipeline with VK_DYNAMIC_STATE_COVERAGE_REDUCTION_MODE_NV but dont set the dynamic state.");
 
     AddRequiredExtensions(VK_NV_COVERAGE_REDUCTION_MODE_EXTENSION_NAME);
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     InitBasicExtendedDynamicState3(extended_dynamic_state_features);
     if (::testing::Test::IsSkipped()) return;
     if (!extended_dynamic_state_features.extendedDynamicState3CoverageReductionMode) {
@@ -4811,7 +4813,7 @@ TEST_F(NegativeDynamicState, DrawNotSetExclusiveScissor) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto exclusiveScissorFeatures = vku::InitStruct<VkPhysicalDeviceExclusiveScissorFeaturesNV>();
+    VkPhysicalDeviceExclusiveScissorFeaturesNV exclusiveScissorFeatures = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(exclusiveScissorFeatures);
     if (exclusiveScissorFeatures.exclusiveScissor == VK_FALSE) {
         GTEST_SKIP() << "exclusiveScissor not supported.";
@@ -4880,7 +4882,7 @@ TEST_F(NegativeDynamicState, MultisampleStateIgnored) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3RasterizationSamples) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState3RasterizationSamples";
@@ -4908,7 +4910,7 @@ TEST_F(NegativeDynamicState, MultisampleStateIgnored) {
 
 TEST_F(NegativeDynamicState, MultisampleStateIgnoredAlphaToOne) {
     TEST_DESCRIPTION("Ignore null pMultisampleState with alphaToOne enabled");
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     InitBasicExtendedDynamicState3(extended_dynamic_state3_features);
     if (::testing::Test::IsSkipped()) return;
     if (!extended_dynamic_state3_features.extendedDynamicState3RasterizationSamples) {
@@ -4944,16 +4946,16 @@ TEST_F(NegativeDynamicState, InputAssemblyStateIgnored) {
     TEST_DESCRIPTION("Ignore null pInputAssemblyState");
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
-    auto extended_dynamic_state2_features =
-        vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(&extended_dynamic_state_features);
-    auto extended_dynamic_state3_features =
-        vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(&extended_dynamic_state2_features);
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features =
+        vku::InitStructHelper(&extended_dynamic_state_features);
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features =
+        vku::InitStructHelper(&extended_dynamic_state2_features);
     InitBasicExtendedDynamicState3(extended_dynamic_state3_features);
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto dynamic_state_3_props = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3PropertiesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3PropertiesEXT dynamic_state_3_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(dynamic_state_3_props);
     if (dynamic_state_3_props.dynamicPrimitiveTopologyUnrestricted) {
         GTEST_SKIP() << "dynamicPrimitiveTopologyUnrestricted is VK_TRUE";
@@ -4971,7 +4973,7 @@ TEST_F(NegativeDynamicState, InputAssemblyStateIgnored) {
 
 TEST_F(NegativeDynamicState, ColorBlendStateIgnored) {
     TEST_DESCRIPTION("Ignore null pColorBlendState");
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     InitBasicExtendedDynamicState3(extended_dynamic_state3_features);
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -5018,7 +5020,7 @@ TEST_F(NegativeDynamicState, VertexInputLocationMissing) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto vertex_input_dsf = vku::InitStruct<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT vertex_input_dsf = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(vertex_input_dsf);
     if (!vertex_input_dsf.vertexInputDynamicState) {
         GTEST_SKIP() << "vertexInputDynamicState not supported";
@@ -5054,12 +5056,12 @@ TEST_F(NegativeDynamicState, VertexInputLocationMissing) {
     VkDeviceSize offset = 0u;
     vk::CmdBindVertexBuffers(m_commandBuffer->handle(), 0u, 1u, &buffer.handle(), &offset);
 
-    auto vertexInputBindingDescription = vku::InitStruct<VkVertexInputBindingDescription2EXT>();
+    VkVertexInputBindingDescription2EXT vertexInputBindingDescription = vku::InitStructHelper();
     vertexInputBindingDescription.binding = 0u;
     vertexInputBindingDescription.stride = sizeof(float) * 4;
     vertexInputBindingDescription.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
     vertexInputBindingDescription.divisor = 1u;
-    auto vertexAttributeDescription = vku::InitStruct<VkVertexInputAttributeDescription2EXT>();
+    VkVertexInputAttributeDescription2EXT vertexAttributeDescription = vku::InitStructHelper();
     vertexAttributeDescription.location = 0u;
     vertexAttributeDescription.binding = 0u;
     vertexAttributeDescription.format = VK_FORMAT_R32G32B32A32_SFLOAT;
@@ -5082,9 +5084,9 @@ TEST_F(NegativeDynamicState, MissingCmdSetVertexInput) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
-    auto vertex_input_dynamic_state_features =
-        vku::InitStruct<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(&extended_dynamic_state_features);
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
+    VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT vertex_input_dynamic_state_features =
+        vku::InitStructHelper(&extended_dynamic_state_features);
     GetPhysicalDeviceFeatures2(vertex_input_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -5125,7 +5127,7 @@ TEST_F(NegativeDynamicState, MissingCmdBindVertexBuffers2) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -22,7 +22,7 @@ void DynamicStateTest::InitBasicExtendedDynamicState() {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -83,7 +83,7 @@ TEST_F(PositiveDynamicState, ViewportWithCountNoMultiViewport) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -115,7 +115,7 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXT) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto vertex_input_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT vertex_input_dynamic_state_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(vertex_input_dynamic_state_features);
     if (!vertex_input_dynamic_state_features.vertexInputDynamicState) {
         GTEST_SKIP() << "Feature vertexInputDynamicState is not supported.";
@@ -127,7 +127,7 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXT) {
     // Fill with bad data as should be ignored with dynamic state
     VkVertexInputBindingDescription input_binding = {5, 7, VK_VERTEX_INPUT_RATE_VERTEX};
     VkVertexInputAttributeDescription input_attrib = {5, 7, VK_FORMAT_UNDEFINED, 9};
-    auto vi_ci = vku::InitStruct<VkPipelineVertexInputStateCreateInfo>();
+    VkPipelineVertexInputStateCreateInfo vi_ci = vku::InitStructHelper();
     vi_ci.pVertexBindingDescriptions = &input_binding;
     vi_ci.vertexBindingDescriptionCount = 1;
     vi_ci.pVertexAttributeDescriptions = &input_attrib;
@@ -178,8 +178,9 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXTStride) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto extdyn_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
-    auto vertex_input_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(&extdyn_features);
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extdyn_features = vku::InitStructHelper();
+    VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT vertex_input_dynamic_state_features =
+        vku::InitStructHelper(&extdyn_features);
     auto features2 = GetPhysicalDeviceFeatures2(vertex_input_dynamic_state_features);
 
     if (!vertex_input_dynamic_state_features.vertexInputDynamicState) {
@@ -236,8 +237,8 @@ TEST_F(PositiveDynamicState, ExtendedDynamicStateBindVertexBuffersMaintenance5) 
         GTEST_SKIP() << "At least Vulkan 1.1 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(&maintenance5_features);
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper(&maintenance5_features);
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
 
@@ -262,7 +263,7 @@ TEST_F(PositiveDynamicState, DiscardRectanglesWithDynamicState) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // pass in struct, but don't set the dynamic state in the pipeline
-    auto discard_rect_ci = vku::InitStruct<VkPipelineDiscardRectangleStateCreateInfoEXT>();
+    VkPipelineDiscardRectangleStateCreateInfoEXT discard_rect_ci = vku::InitStructHelper();
     discard_rect_ci.discardRectangleMode = VK_DISCARD_RECTANGLE_MODE_INCLUSIVE_EXT;
     discard_rect_ci.discardRectangleCount = 4;
     std::vector<VkRect2D> discard_rectangles(4);
@@ -292,7 +293,7 @@ TEST_F(PositiveDynamicState, DynamicColorWriteNoColorAttachments) {
     }
 
     // Extension enabed as a dependency of VK_EXT_color_write_enable
-    auto color_write_features = vku::InitStruct<VkPhysicalDeviceColorWriteEnableFeaturesEXT>();
+    VkPhysicalDeviceColorWriteEnableFeaturesEXT color_write_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(color_write_features);
     if (!color_write_features.colorWriteEnable) {
         GTEST_SKIP() << "colorWriteEnable feature not supported";
@@ -371,7 +372,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesPipelineDepthWriteEnable) {
     auto ds_view = ds_image.targetView(m_depth_stencil_fmt, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(1, &ds_view));
 
-    auto ds_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
     ds_state.depthWriteEnable = VK_TRUE;
 
     CreatePipelineHelper pipe(*this);
@@ -405,7 +406,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesDynamicDepthWriteEnable) {
     auto ds_view = ds_image.targetView(m_depth_stencil_fmt, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(1, &ds_view));
 
-    auto ds_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT);
@@ -437,7 +438,7 @@ TEST_F(PositiveDynamicState, DynamicStateDoublePipelineBind) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state2_features);
     if (!extended_dynamic_state2_features.extendedDynamicState2) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState2, skipping";
@@ -505,9 +506,9 @@ TEST_F(PositiveDynamicState, AttachmentFeedbackLoopEnable) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto feedback_loop_dynamic_features = vku::InitStruct<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT>();
-    auto feedback_loop_features =
-        vku::InitStruct<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>(&feedback_loop_dynamic_features);
+    VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT feedback_loop_dynamic_features = vku::InitStructHelper();
+    VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT feedback_loop_features =
+        vku::InitStructHelper(&feedback_loop_dynamic_features);
     GetPhysicalDeviceFeatures2(feedback_loop_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &feedback_loop_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -542,9 +543,9 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampEnabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
-    auto depth_bias_control_features =
-        vku::InitStruct<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(&extended_dynamic_state2_features);
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
+    VkPhysicalDeviceDepthBiasControlFeaturesEXT depth_bias_control_features =
+        vku::InitStructHelper(&extended_dynamic_state2_features);
     auto features2 = GetPhysicalDeviceFeatures2(depth_bias_control_features);
 
     if (!extended_dynamic_state2_features.extendedDynamicState2) {
@@ -564,7 +565,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampEnabled) {
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
-    auto raster_state = vku::InitStruct<VkPipelineRasterizationStateCreateInfo>();
+    VkPipelineRasterizationStateCreateInfo raster_state = vku::InitStructHelper();
     raster_state.depthBiasEnable = VK_TRUE;
     pipe.rs_state_ci_ = raster_state;
     pipe.CreateGraphicsPipeline();
@@ -573,7 +574,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampEnabled) {
 
     vk::CmdSetDepthBiasEnableEXT(m_commandBuffer->handle(), VK_TRUE);
 
-    auto depth_bias_info = vku::InitStruct<VkDepthBiasInfoEXT>();
+    VkDepthBiasInfoEXT depth_bias_info = vku::InitStructHelper();
     depth_bias_info.depthBiasConstantFactor = 1.0f;
     depth_bias_info.depthBiasClamp = 1.0f;
     depth_bias_info.depthBiasSlopeFactor = 1.0f;
@@ -602,9 +603,9 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
-    auto depth_bias_control_features =
-        vku::InitStruct<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(&extended_dynamic_state2_features);
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
+    VkPhysicalDeviceDepthBiasControlFeaturesEXT depth_bias_control_features =
+        vku::InitStructHelper(&extended_dynamic_state2_features);
     auto features2 = GetPhysicalDeviceFeatures2(depth_bias_control_features);
 
     if (!extended_dynamic_state2_features.extendedDynamicState2) {
@@ -624,7 +625,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
-    auto raster_state = vku::InitStruct<VkPipelineRasterizationStateCreateInfo>();
+    VkPipelineRasterizationStateCreateInfo raster_state = vku::InitStructHelper();
     raster_state.depthBiasEnable = VK_TRUE;
     pipe.rs_state_ci_ = raster_state;
     pipe.CreateGraphicsPipeline();
@@ -633,7 +634,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
 
     vk::CmdSetDepthBiasEnableEXT(m_commandBuffer->handle(), VK_TRUE);
 
-    auto depth_bias_info = vku::InitStruct<VkDepthBiasInfoEXT>();
+    VkDepthBiasInfoEXT depth_bias_info = vku::InitStructHelper();
     depth_bias_info.depthBiasConstantFactor = 1.0f;
     depth_bias_info.depthBiasClamp = 0.0f;  // depthBiasClamp feature is disabled, so depth_bias_info.depthBiasClamp must be 0
     depth_bias_info.depthBiasSlopeFactor = 1.0f;
@@ -665,9 +666,9 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentatio
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
-    auto depth_bias_control_features =
-        vku::InitStruct<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(&extended_dynamic_state2_features);
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
+    VkPhysicalDeviceDepthBiasControlFeaturesEXT depth_bias_control_features =
+        vku::InitStructHelper(&extended_dynamic_state2_features);
     auto features2 = GetPhysicalDeviceFeatures2(depth_bias_control_features);
 
     if (!extended_dynamic_state2_features.extendedDynamicState2) {
@@ -694,7 +695,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentatio
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
-    auto raster_state = vku::InitStruct<VkPipelineRasterizationStateCreateInfo>();
+    VkPipelineRasterizationStateCreateInfo raster_state = vku::InitStructHelper();
     raster_state.depthBiasEnable = VK_TRUE;
     pipe.rs_state_ci_ = raster_state;
     pipe.CreateGraphicsPipeline();
@@ -702,7 +703,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentatio
 
     vk::CmdSetDepthBiasEnableEXT(m_commandBuffer->handle(), VK_TRUE);
 
-    auto depth_bias_info = vku::InitStruct<VkDepthBiasInfoEXT>();
+    VkDepthBiasInfoEXT depth_bias_info = vku::InitStructHelper();
     depth_bias_info.depthBiasConstantFactor = 1.0f;
     depth_bias_info.depthBiasClamp = 1.0f;
     depth_bias_info.depthBiasSlopeFactor = 1.0f;
@@ -712,7 +713,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentatio
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     // Without correct state tracking, VUID-vkCmdDraw-None-07834 would be thrown here and in the follow-up calls
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
-    auto depth_bias_representation = vku::InitStruct<VkDepthBiasRepresentationInfoEXT>();
+    VkDepthBiasRepresentationInfoEXT depth_bias_representation = vku::InitStructHelper();
     depth_bias_representation.depthBiasRepresentation = VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORCE_UNORM_EXT;
     depth_bias_representation.depthBiasExact = VK_TRUE;
     depth_bias_info.pNext = &depth_bias_representation;
@@ -732,7 +733,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentatio
 TEST_F(PositiveDynamicState, AlphaToCoverageSetFalse) {
     TEST_DESCRIPTION("Dynamically set alphaToCoverageEnabled to false so its not checked.");
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     InitBasicExtendedDynamicState3(extended_dynamic_state_features);
     if (::testing::Test::IsSkipped()) return;
     if (!extended_dynamic_state_features.extendedDynamicState3AlphaToCoverageEnable) {
@@ -749,7 +750,7 @@ TEST_F(PositiveDynamicState, AlphaToCoverageSetFalse) {
     )glsl";
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    auto ms_state_ci = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>();
+    VkPipelineMultisampleStateCreateInfo ms_state_ci = vku::InitStructHelper();
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;  // should be ignored
 
@@ -772,7 +773,7 @@ TEST_F(PositiveDynamicState, AlphaToCoverageSetFalse) {
 TEST_F(PositiveDynamicState, AlphaToCoverageSetTrue) {
     TEST_DESCRIPTION("Dynamically set alphaToCoverageEnabled to true, but have component set.");
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     InitBasicExtendedDynamicState3(extended_dynamic_state_features);
     if (::testing::Test::IsSkipped()) return;
     if (!extended_dynamic_state_features.extendedDynamicState3AlphaToCoverageEnable) {
@@ -802,7 +803,7 @@ TEST_F(PositiveDynamicState, MultisampleStateIgnored) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
     if (!extended_dynamic_state3_features.extendedDynamicState3RasterizationSamples) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState3RasterizationSamples";
@@ -831,7 +832,7 @@ TEST_F(PositiveDynamicState, MultisampleStateIgnored) {
 
 TEST_F(PositiveDynamicState, MultisampleStateIgnoredAlphaToOne) {
     TEST_DESCRIPTION("Ignore null pMultisampleState with alphaToOne enabled");
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     InitBasicExtendedDynamicState3(extended_dynamic_state3_features);
     if (::testing::Test::IsSkipped()) return;
     if (!extended_dynamic_state3_features.extendedDynamicState3RasterizationSamples) {
@@ -865,16 +866,16 @@ TEST_F(PositiveDynamicState, InputAssemblyStateIgnored) {
     TEST_DESCRIPTION("Ignore null pInputAssemblyState");
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
-    auto extended_dynamic_state2_features =
-        vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(&extended_dynamic_state_features);
-    auto extended_dynamic_state3_features =
-        vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(&extended_dynamic_state2_features);
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features =
+        vku::InitStructHelper(&extended_dynamic_state_features);
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features =
+        vku::InitStructHelper(&extended_dynamic_state2_features);
     InitBasicExtendedDynamicState3(extended_dynamic_state3_features);
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto dynamic_state_3_props = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3PropertiesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3PropertiesEXT dynamic_state_3_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(dynamic_state_3_props);
     if (!dynamic_state_3_props.dynamicPrimitiveTopologyUnrestricted) {
         GTEST_SKIP() << "dynamicPrimitiveTopologyUnrestricted is VK_FALSE";
@@ -896,7 +897,7 @@ TEST_F(PositiveDynamicState, ViewportStateIgnored) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -913,9 +914,9 @@ TEST_F(PositiveDynamicState, ViewportStateIgnored) {
 TEST_F(PositiveDynamicState, ColorBlendStateIgnored) {
     TEST_DESCRIPTION("Ignore null pColorBlendState");
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
-    auto extended_dynamic_state3_features =
-        vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(&extended_dynamic_state2_features);
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features =
+        vku::InitStructHelper(&extended_dynamic_state2_features);
     InitBasicExtendedDynamicState3(extended_dynamic_state3_features);
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -958,7 +959,7 @@ TEST_F(PositiveDynamicState, DepthBoundsTestEnableState) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
 

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -28,9 +28,9 @@ TEST_F(NegativeExternalMemorySync, CreateBufferIncompatibleHandleTypes) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // Try all flags first. It's unlikely all of them are compatible.
-    auto external_memory_info = vku::InitStruct<VkExternalMemoryBufferCreateInfo>();
+    VkExternalMemoryBufferCreateInfo external_memory_info = vku::InitStructHelper();
     external_memory_info.handleTypes = AllVkExternalMemoryHandleTypeFlagBits;
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>(&external_memory_info);
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&external_memory_info);
     buffer_create_info.size = 1024;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-pNext-00920");
@@ -40,10 +40,10 @@ TEST_F(NegativeExternalMemorySync, CreateBufferIncompatibleHandleTypes) {
     VkExternalMemoryHandleTypeFlags any_compatible_group = 0;
     IterateFlags<VkExternalMemoryHandleTypeFlagBits>(
         AllVkExternalMemoryHandleTypeFlagBits, [&](VkExternalMemoryHandleTypeFlagBits flag) {
-            auto external_buffer_info = vku::InitStruct<VkPhysicalDeviceExternalBufferInfo>();
+            VkPhysicalDeviceExternalBufferInfo external_buffer_info = vku::InitStructHelper();
             external_buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
             external_buffer_info.handleType = flag;
-            auto external_buffer_properties = vku::InitStruct<VkExternalBufferProperties>();
+            VkExternalBufferProperties external_buffer_properties = vku::InitStructHelper();
             vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &external_buffer_info, &external_buffer_properties);
             const auto external_features = external_buffer_properties.externalMemoryProperties.externalMemoryFeatures;
             if (external_features & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT) {
@@ -70,9 +70,9 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // Try all flags first. It's unlikely all of them are compatible.
-    auto external_memory_info = vku::InitStruct<VkExternalMemoryImageCreateInfo>();
+    VkExternalMemoryImageCreateInfo external_memory_info = vku::InitStructHelper();
     external_memory_info.handleTypes = AllVkExternalMemoryHandleTypeFlagBits;
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>(&external_memory_info);
+    VkImageCreateInfo image_create_info = vku::InitStructHelper(&external_memory_info);
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_create_info.extent.width = 32;
@@ -90,8 +90,8 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
     VkExternalMemoryHandleTypeFlags supported_handle_types = 0;
     VkExternalMemoryHandleTypeFlags any_compatible_group = 0;
 
-    auto external_image_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
-    auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_image_info);
+    VkPhysicalDeviceExternalImageFormatInfo external_image_info = vku::InitStructHelper();
+    VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_image_info);
     image_info.format = image_create_info.format;
     image_info.type = image_create_info.imageType;
     image_info.tiling = image_create_info.tiling;
@@ -101,8 +101,8 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
     IterateFlags<VkExternalMemoryHandleTypeFlagBits>(
         AllVkExternalMemoryHandleTypeFlagBits, [&](VkExternalMemoryHandleTypeFlagBits flag) {
             external_image_info.handleType = flag;
-            auto external_image_properties = vku::InitStruct<VkExternalImageFormatProperties>();
-            auto image_properties = vku::InitStruct<VkImageFormatProperties2>(&external_image_properties);
+            VkExternalImageFormatProperties external_image_properties = vku::InitStructHelper();
+            VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_image_properties);
             VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
             const auto external_features = external_image_properties.externalMemoryProperties.externalMemoryFeatures;
             if (result == VK_SUCCESS && (external_features & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT)) {
@@ -128,8 +128,8 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypesNV) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto external_memory_info = vku::InitStruct<VkExternalMemoryImageCreateInfoNV>();
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>(&external_memory_info);
+    VkExternalMemoryImageCreateInfoNV external_memory_info = vku::InitStructHelper();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper(&external_memory_info);
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_create_info.extent.width = 32;
@@ -176,8 +176,8 @@ TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // Create export image
-    auto external_image_info = vku::InitStruct<VkExternalMemoryImageCreateInfo>();
-    auto image_info = vku::InitStruct<VkImageCreateInfo>(&external_image_info);
+    VkExternalMemoryImageCreateInfo external_image_info = vku::InitStructHelper();
+    VkImageCreateInfo image_info = vku::InitStructHelper(&external_image_info);
     image_info.imageType = VK_IMAGE_TYPE_2D;
     image_info.arrayLayers = 1;
     image_info.extent = {64, 64, 1};
@@ -202,7 +202,7 @@ TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
     vkt::Image image(*m_device, image_info, vkt::NoMemT{});
 
     // Create export memory with a different handle type
-    auto dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+    VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.image = image;
     const bool dedicated_allocation = HandleTypeNeedsDedicatedAllocation(image_info, handle_type2);
     auto export_memory_info = vku::InitStruct<VkExportMemoryAllocateInfo>(dedicated_allocation ? &dedicated_info : nullptr);
@@ -214,7 +214,7 @@ TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
     m_errorMonitor->VerifyFound();
 
     // vkBindImageMemory2
-    auto bind_image_info = vku::InitStruct<VkBindImageMemoryInfo>();
+    VkBindImageMemoryInfo bind_image_info = vku::InitStructHelper();
     bind_image_info.image = image.handle();
     bind_image_info.memory = image.memory();  // re-use memory object from the previous check
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryInfo-memory-02728");
@@ -231,7 +231,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithUnsupportedHandleType) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto external_buffer_info = vku::InitStruct<VkExternalMemoryBufferCreateInfo>();
+    VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     const auto buffer_info = vkt::Buffer::create_info(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
     const auto exportable_types = FindSupportedExternalMemoryHandleTypes(buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
@@ -251,7 +251,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithUnsupportedHandleType) {
             dedicated_allocation = true;
         }
     });
-    auto dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+    VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.buffer = buffer;
 
     // Create memory object with unsupported handle type
@@ -281,7 +281,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithIncompatibleHandleTypes) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto external_buffer_info = vku::InitStruct<VkExternalMemoryBufferCreateInfo>();
+    VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     const auto buffer_info = vkt::Buffer::create_info(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
     const auto exportable_types = FindSupportedExternalMemoryHandleTypes(buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
@@ -302,7 +302,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithIncompatibleHandleTypes) {
             dedicated_allocation = true;
         }
     });
-    auto dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+    VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.buffer = buffer;
 
     // Create memory object with incompatible handle types
@@ -322,8 +322,8 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithUnsupportedHandleType) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto external_image_info = vku::InitStruct<VkExternalMemoryImageCreateInfo>();
-    auto image_info = vku::InitStruct<VkImageCreateInfo>(&external_image_info);
+    VkExternalMemoryImageCreateInfo external_image_info = vku::InitStructHelper();
+    VkImageCreateInfo image_info = vku::InitStructHelper(&external_image_info);
     image_info.imageType = VK_IMAGE_TYPE_2D;
     image_info.arrayLayers = 1;
     image_info.extent = {64, 64, 1};
@@ -352,7 +352,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithUnsupportedHandleType) {
 
     // Create memory object which additionally includes unsupported handle type
     const auto not_supported_type = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(~exportable_types);
-    auto dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+    VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.image = image;
     const bool dedicated_allocation = HandleTypeNeedsDedicatedAllocation(image_info, handle_type);
     auto export_memory_info = vku::InitStruct<VkExportMemoryAllocateInfo>(dedicated_allocation ? &dedicated_info : nullptr);
@@ -373,8 +373,8 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithIncompatibleHandleTypes) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // Create export image
-    auto external_image_info = vku::InitStruct<VkExternalMemoryImageCreateInfo>();
-    auto image_info = vku::InitStruct<VkImageCreateInfo>(&external_image_info);
+    VkExternalMemoryImageCreateInfo external_image_info = vku::InitStructHelper();
+    VkImageCreateInfo image_info = vku::InitStructHelper(&external_image_info);
     image_info.imageType = VK_IMAGE_TYPE_2D;
     image_info.arrayLayers = 1;
     image_info.extent = {64, 64, 1};
@@ -407,7 +407,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithIncompatibleHandleTypes) {
             dedicated_allocation = true;
         }
     });
-    auto dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+    VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.image = image;
 
     // Create memory object with incompatible handle types
@@ -429,8 +429,8 @@ TEST_F(NegativeExternalMemorySync, ExportBufferHandleType) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // Create export buffer
-    auto external_info = vku::InitStruct<VkExternalMemoryBufferCreateInfo>();
-    auto buffer_info = vku::InitStruct<VkBufferCreateInfo>(&external_info);
+    VkExternalMemoryBufferCreateInfo external_info = vku::InitStructHelper();
+    VkBufferCreateInfo buffer_info = vku::InitStructHelper(&external_info);
     buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buffer_info.size = 4096;
 
@@ -449,7 +449,7 @@ TEST_F(NegativeExternalMemorySync, ExportBufferHandleType) {
 
     // Check if dedicated allocation is required
     const bool dedicated_allocation = HandleTypeNeedsDedicatedAllocation(buffer_info, handle_type2);
-    auto dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+    VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.buffer = buffer;
 
     // Create export memory with a different handle type
@@ -465,7 +465,7 @@ TEST_F(NegativeExternalMemorySync, ExportBufferHandleType) {
     vk::BindBufferMemory(device(), buffer.handle(), memory.handle(), 0);
     m_errorMonitor->VerifyFound();
 
-    auto bind_buffer_info = vku::InitStruct<VkBindBufferMemoryInfo>();
+    VkBindBufferMemoryInfo bind_buffer_info = vku::InitStructHelper();
     bind_buffer_info.buffer = buffer.handle();
     bind_buffer_info.memory = memory.handle();
 
@@ -496,18 +496,18 @@ TEST_F(NegativeExternalMemorySync, TimelineSemaphore) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     // Check for external semaphore import and export capability
     {
-        auto sti = vku::InitStruct<VkSemaphoreTypeCreateInfo>();
+        VkSemaphoreTypeCreateInfo sti = vku::InitStructHelper();
         sti.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-        auto esi = vku::InitStruct<VkPhysicalDeviceExternalSemaphoreInfoKHR>(&sti);
+        VkPhysicalDeviceExternalSemaphoreInfoKHR esi = vku::InitStructHelper(&sti);
         esi.handleType = handle_type;
 
-        auto esp = vku::InitStruct<VkExternalSemaphorePropertiesKHR>();
+        VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
 
         vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
@@ -520,11 +520,11 @@ TEST_F(NegativeExternalMemorySync, TimelineSemaphore) {
     VkResult err;
 
     // Create a semaphore to export payload from
-    auto esci = vku::InitStruct<VkExportSemaphoreCreateInfoKHR>();
+    VkExportSemaphoreCreateInfoKHR esci = vku::InitStructHelper();
     esci.handleTypes = handle_type;
-    auto stci = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>(&esci);
+    VkSemaphoreTypeCreateInfoKHR stci = vku::InitStructHelper(&esci);
     stci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
-    auto sci = vku::InitStruct<VkSemaphoreCreateInfo>(&stci);
+    VkSemaphoreCreateInfo sci = vku::InitStructHelper(&stci);
 
     vkt::Semaphore export_semaphore(*m_device, sci);
 
@@ -558,15 +558,15 @@ TEST_F(NegativeExternalMemorySync, SyncFdSemaphore) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // Check for external semaphore import and export capability
-    auto esi = vku::InitStruct<VkPhysicalDeviceExternalSemaphoreInfoKHR>();
+    VkPhysicalDeviceExternalSemaphoreInfoKHR esi = vku::InitStructHelper();
     esi.handleType = handle_type;
 
-    auto esp = vku::InitStruct<VkExternalSemaphorePropertiesKHR>();
+    VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
 
     vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
@@ -583,14 +583,14 @@ TEST_F(NegativeExternalMemorySync, SyncFdSemaphore) {
 
     // create a timeline semaphore.
     // Note that adding a sync fd VkExportSemaphoreCreateInfo will cause creation to fail.
-    auto stci = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>();
+    VkSemaphoreTypeCreateInfoKHR stci = vku::InitStructHelper();
     stci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-    auto sci = vku::InitStruct<VkSemaphoreCreateInfo>(&stci);
+    VkSemaphoreCreateInfo sci = vku::InitStructHelper(&stci);
 
     vkt::Semaphore timeline_sem(*m_device, sci);
 
     // binary semaphore works fine.
-    auto esci = vku::InitStruct<VkExportSemaphoreCreateInfo>();
+    VkExportSemaphoreCreateInfo esci = vku::InitStructHelper();
     esci.handleTypes = handle_type;
     stci.pNext = &esci;
 
@@ -613,7 +613,7 @@ TEST_F(NegativeExternalMemorySync, SyncFdSemaphore) {
     binary_sem.export_handle(fd_handle, handle_type);
     m_errorMonitor->VerifyFound();
 
-    auto si = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo si = vku::InitStructHelper();
     si.signalSemaphoreCount = 1;
     si.pSignalSemaphores = &binary_sem.handle();
 
@@ -654,9 +654,9 @@ TEST_F(NegativeExternalMemorySync, TemporaryFence) {
     }
 
     // Check for external fence import and export capability
-    auto efi = vku::InitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
+    VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
-    auto efp = vku::InitStruct<VkExternalFencePropertiesKHR>();
+    VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -667,9 +667,9 @@ TEST_F(NegativeExternalMemorySync, TemporaryFence) {
     VkResult err;
 
     // Create a fence to export payload from
-    auto efci = vku::InitStruct<VkExportFenceCreateInfoKHR>();
+    VkExportFenceCreateInfoKHR efci = vku::InitStructHelper();
     efci.handleTypes = handle_type;
-    auto fci = vku::InitStruct<VkFenceCreateInfo>(&efci);
+    VkFenceCreateInfo fci = vku::InitStructHelper(&efci);
     vkt::Fence export_fence(*m_device, fci);
 
     // Create a fence to import payload into
@@ -732,9 +732,9 @@ TEST_F(NegativeExternalMemorySync, Fence) {
     }
 
     // Check for external fence import and export capability
-    auto efi = vku::InitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
+    VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
-    auto efp = vku::InitStruct<VkExternalFencePropertiesKHR>();
+    VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -743,9 +743,9 @@ TEST_F(NegativeExternalMemorySync, Fence) {
     }
 
     // Create a fence to export payload from
-    auto efci = vku::InitStruct<VkExportFenceCreateInfoKHR>();
+    VkExportFenceCreateInfoKHR efci = vku::InitStructHelper();
     efci.handleTypes = handle_type;
-    auto fci = vku::InitStruct<VkFenceCreateInfo>(&efci);
+    VkFenceCreateInfo fci = vku::InitStructHelper(&efci);
     vkt::Fence export_fence(*m_device, fci);
 
     // Create a fence to import payload into
@@ -774,7 +774,7 @@ TEST_F(NegativeExternalMemorySync, Fence) {
     import_fence.import_handle(ext_handle, bad_type);
     m_errorMonitor->VerifyFound();
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-    auto ifi = vku::InitStruct<VkImportFenceWin32HandleInfoKHR>();
+    VkImportFenceWin32HandleInfoKHR ifi = vku::InitStructHelper();
     ifi.fence = import_fence.handle();
     ifi.handleType = handle_type;
     ifi.handle = ext_handle;
@@ -809,9 +809,9 @@ TEST_F(NegativeExternalMemorySync, SyncFdFence) {
     }
 
     // Check for external fence import and export capability
-    auto efi = vku::InitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
+    VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
-    auto efp = vku::InitStruct<VkExternalFencePropertiesKHR>();
+    VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -820,9 +820,9 @@ TEST_F(NegativeExternalMemorySync, SyncFdFence) {
     }
 
     // Create a fence to export payload from
-    auto efci = vku::InitStruct<VkExportFenceCreateInfoKHR>();
+    VkExportFenceCreateInfoKHR efci = vku::InitStructHelper();
     efci.handleTypes = handle_type;
-    auto fci = vku::InitStruct<VkFenceCreateInfo>(&efci);
+    VkFenceCreateInfo fci = vku::InitStructHelper(&efci);
     vkt::Fence export_fence(*m_device, fci);
 
     // Create a fence to import payload into
@@ -871,10 +871,10 @@ TEST_F(NegativeExternalMemorySync, TemporarySemaphore) {
     }
 
     // Check for external semaphore import and export capability
-    auto esi = vku::InitStruct<VkPhysicalDeviceExternalSemaphoreInfoKHR>();
+    VkPhysicalDeviceExternalSemaphoreInfoKHR esi = vku::InitStructHelper();
     esi.handleType = handle_type;
 
-    auto esp = vku::InitStruct<VkExternalSemaphorePropertiesKHR>();
+    VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
 
     vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
@@ -886,9 +886,9 @@ TEST_F(NegativeExternalMemorySync, TemporarySemaphore) {
     VkResult err;
 
     // Create a semaphore to export payload from
-    auto esci = vku::InitStruct<VkExportSemaphoreCreateInfoKHR>();
+    VkExportSemaphoreCreateInfoKHR esci = vku::InitStructHelper();
     esci.handleTypes = handle_type;
-    auto sci = vku::InitStruct<VkSemaphoreCreateInfo>(&esci);
+    VkSemaphoreCreateInfo sci = vku::InitStructHelper(&esci);
 
     vkt::Semaphore export_semaphore(*m_device, sci);
 
@@ -972,10 +972,10 @@ TEST_F(NegativeExternalMemorySync, Semaphore) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     // Check for external semaphore import and export capability
-    auto esi = vku::InitStruct<VkPhysicalDeviceExternalSemaphoreInfoKHR>();
+    VkPhysicalDeviceExternalSemaphoreInfoKHR esi = vku::InitStructHelper();
     esi.handleType = handle_type;
 
-    auto esp = vku::InitStruct<VkExternalSemaphorePropertiesKHR>();
+    VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
 
     vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
@@ -984,9 +984,9 @@ TEST_F(NegativeExternalMemorySync, Semaphore) {
         GTEST_SKIP() << "External semaphore does not support importing and exporting, skipping test";
     }
     // Create a semaphore to export payload from
-    auto esci = vku::InitStruct<VkExportSemaphoreCreateInfoKHR>();
+    VkExportSemaphoreCreateInfoKHR esci = vku::InitStructHelper();
     esci.handleTypes = handle_type;
-    auto sci = vku::InitStruct<VkSemaphoreCreateInfo>(&esci);
+    VkSemaphoreCreateInfo sci = vku::InitStructHelper(&esci);
 
     vkt::Semaphore export_semaphore(*m_device, sci);
 
@@ -1041,11 +1041,11 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
 
     // Check for import/export capability
     // export used to feed memory to test import
-    auto ebi = vku::InitStruct<VkPhysicalDeviceExternalBufferInfo>();
+    VkPhysicalDeviceExternalBufferInfo ebi = vku::InitStructHelper();
     ebi.handleType = handle_type;
     ebi.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
-    auto ebp = vku::InitStruct<VkExternalBufferPropertiesKHR>();
+    VkExternalBufferPropertiesKHR ebp = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &ebi, &ebp);
     if (!(ebp.externalMemoryProperties.compatibleHandleTypes & handle_type) ||
         !(ebp.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1061,7 +1061,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     constexpr VkDeviceSize buffer_size = 1024;
 
     // Create export and import buffers
-    auto external_buffer_info = vku::InitStruct<VkExternalMemoryBufferCreateInfo>();
+    VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     external_buffer_info.handleTypes = handle_type;
 
     auto buffer_info = vkt::Buffer::create_info(buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
@@ -1090,13 +1090,13 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     auto alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer_export_reqs, mem_flags);
 
     // Add export allocation info to pNext chain
-    auto export_info = vku::InitStruct<VkExportMemoryAllocateInfoKHR>();
+    VkExportMemoryAllocateInfoKHR export_info = vku::InitStructHelper();
     export_info.handleTypes = handle_type;
 
     alloc_info.pNext = &export_info;
 
     // Add dedicated allocation info to pNext chain if required
-    auto dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+    VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.buffer = buffer_export.handle();
 
     if (buffer_dedicated_allocation) {
@@ -1110,7 +1110,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     // Bind exported memory
     buffer_export.bind_memory(memory_buffer_export, 0);
 
-    auto external_image_info = vku::InitStruct<VkExternalMemoryImageCreateInfoKHR>();
+    VkExternalMemoryImageCreateInfoKHR external_image_info = vku::InitStructHelper();
     external_image_info.handleTypes = handle_type;
 
     VkImageCreateInfo image_info = vku::InitStructHelper(&external_image_info);
@@ -1126,7 +1126,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     vkt::Image image_export(*m_device, image_info, vkt::no_mem);
 
     const bool image_dedicated_allocation = HandleTypeNeedsDedicatedAllocation(image_info, handle_type);
-    auto image_dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+    VkMemoryDedicatedAllocateInfo image_dedicated_info = vku::InitStructHelper();
     image_dedicated_info.image = image_export;
 
     auto export_memory_info =
@@ -1160,11 +1160,11 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
                                                           handle_type, handle_image};
 #else
     // Export memory to fd
-    auto mgfi_buffer = vku::InitStruct<VkMemoryGetFdInfoKHR>();
+    VkMemoryGetFdInfoKHR mgfi_buffer = vku::InitStructHelper();
     mgfi_buffer.handleType = handle_type;
     mgfi_buffer.memory = memory_buffer_export.handle();
 
-    auto mgfi_image = vku::InitStruct<VkMemoryGetFdInfoKHR>();
+    VkMemoryGetFdInfoKHR mgfi_image = vku::InitStructHelper();
     mgfi_image.handleType = handle_type;
     mgfi_image.memory = image_export.memory().handle();
 
@@ -1173,11 +1173,11 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     ASSERT_VK_SUCCESS(vk::GetMemoryFdKHR(m_device->device(), &mgfi_buffer, &fd_buffer));
     ASSERT_VK_SUCCESS(vk::GetMemoryFdKHR(m_device->device(), &mgfi_image, &fd_image));
 
-    auto import_info_buffer = vku::InitStruct<VkImportMemoryFdInfoKHR>();
+    VkImportMemoryFdInfoKHR import_info_buffer = vku::InitStructHelper();
     import_info_buffer.handleType = handle_type;
     import_info_buffer.fd = fd_buffer;
 
-    auto import_info_image = vku::InitStruct<VkImportMemoryFdInfoKHR>();
+    VkImportMemoryFdInfoKHR import_info_image = vku::InitStructHelper();
     import_info_image.handleType = handle_type;
     import_info_image.fd = fd_image;
 #endif
@@ -1248,10 +1248,10 @@ TEST_F(NegativeExternalMemorySync, FenceExportWithUnsupportedHandleType) {
     }
     // Fence export with unsupported handle type
     const auto unsupported_type = LeastSignificantFlag<VkExternalFenceHandleTypeFlagBits>(~exportable_types);
-    auto export_info = vku::InitStruct<VkExportFenceCreateInfo>();
+    VkExportFenceCreateInfo export_info = vku::InitStructHelper();
     export_info.handleTypes = unsupported_type;
 
-    const auto create_info = vku::InitStruct<VkFenceCreateInfo>(&export_info);
+    const VkFenceCreateInfo create_info = vku::InitStructHelper(&export_info);
     VkFence fence = VK_NULL_HANDLE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportFenceCreateInfo-handleTypes-01446");
     vk::CreateFence(m_device->device(), &create_info, nullptr, &fence);
@@ -1278,10 +1278,10 @@ TEST_F(NegativeExternalMemorySync, FenceExportWithIncompatibleHandleType) {
     }
 
     // Fence export with incompatible handle types
-    auto export_info = vku::InitStruct<VkExportFenceCreateInfo>();
+    VkExportFenceCreateInfo export_info = vku::InitStructHelper();
     export_info.handleTypes = exportable_types;
 
-    const auto create_info = vku::InitStruct<VkFenceCreateInfo>(&export_info);
+    const VkFenceCreateInfo create_info = vku::InitStructHelper(&export_info);
     VkFence fence = VK_NULL_HANDLE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportFenceCreateInfo-handleTypes-01446");
     vk::CreateFence(m_device->device(), &create_info, nullptr, &fence);
@@ -1306,10 +1306,10 @@ TEST_F(NegativeExternalMemorySync, SemaphoreExportWithUnsupportedHandleType) {
     }
     // Semaphore export with unsupported handle type
     const auto unsupported_type = LeastSignificantFlag<VkExternalSemaphoreHandleTypeFlagBits>(~exportable_types);
-    auto export_info = vku::InitStruct<VkExportSemaphoreCreateInfo>();
+    VkExportSemaphoreCreateInfo export_info = vku::InitStructHelper();
     export_info.handleTypes = unsupported_type;
 
-    const auto create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&export_info);
+    const VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&export_info);
     VkSemaphore semaphore = VK_NULL_HANDLE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportSemaphoreCreateInfo-handleTypes-01124");
     vk::CreateSemaphore(m_device->device(), &create_info, nullptr, &semaphore);
@@ -1336,10 +1336,10 @@ TEST_F(NegativeExternalMemorySync, SemaphoreExportWithIncompatibleHandleType) {
     }
 
     // Semaphore export with incompatible handle types
-    auto export_info = vku::InitStruct<VkExportSemaphoreCreateInfo>();
+    VkExportSemaphoreCreateInfo export_info = vku::InitStructHelper();
     export_info.handleTypes = exportable_types;
 
-    const auto create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&export_info);
+    const VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&export_info);
     VkSemaphore semaphore = VK_NULL_HANDLE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportSemaphoreCreateInfo-handleTypes-01124");
     vk::CreateSemaphore(m_device->device(), &create_info, nullptr, &semaphore);
@@ -1358,8 +1358,8 @@ TEST_F(NegativeExternalMemorySync, MemoryAndMemoryNV) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto external_mem_nv = vku::InitStruct<VkExternalMemoryImageCreateInfoNV>();
-    auto external_mem = vku::InitStruct<VkExternalMemoryImageCreateInfo>(&external_mem_nv);
+    VkExternalMemoryImageCreateInfoNV external_mem_nv = vku::InitStructHelper();
+    VkExternalMemoryImageCreateInfo external_mem = vku::InitStructHelper(&external_mem_nv);
     VkImageCreateInfo ici = vku::InitStructHelper(&external_mem);
     ici.imageType = VK_IMAGE_TYPE_2D;
     ici.arrayLayers = 1;
@@ -1409,7 +1409,7 @@ TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
         CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-01443");
     }
     if (IsExtensionsEnabled(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME)) {
-        auto external_mem_nv = vku::InitStruct<VkExternalMemoryImageCreateInfoNV>();
+        VkExternalMemoryImageCreateInfoNV external_mem_nv = vku::InitStructHelper();
         const auto supported_types_nv = FindSupportedExternalMemoryHandleTypesNV(ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_NV);
         if (supported_types_nv) {
             external_mem_nv.handleTypes = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBitsNV>(supported_types_nv);
@@ -1433,10 +1433,10 @@ TEST_F(NegativeExternalMemorySync, D3D12FenceSubmitInfo) {
     // VkD3D12FenceSubmitInfoKHR::waitSemaphoreValuesCount == 1 is different from VkSubmitInfo::waitSemaphoreCount == 0
     {
         const uint64_t waitSemaphoreValues = 0;
-        auto d3d12_fence_submit_info = vku::InitStruct<VkD3D12FenceSubmitInfoKHR>();
+        VkD3D12FenceSubmitInfoKHR d3d12_fence_submit_info = vku::InitStructHelper();
         d3d12_fence_submit_info.waitSemaphoreValuesCount = 1;
         d3d12_fence_submit_info.pWaitSemaphoreValues = &waitSemaphoreValues;
-        const auto submit_info = vku::InitStruct<VkSubmitInfo>(&d3d12_fence_submit_info);
+        const VkSubmitInfo submit_info = vku::InitStructHelper(&d3d12_fence_submit_info);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkD3D12FenceSubmitInfoKHR-waitSemaphoreValuesCount-00079");
         vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -1444,8 +1444,8 @@ TEST_F(NegativeExternalMemorySync, D3D12FenceSubmitInfo) {
     }
     // VkD3D12FenceSubmitInfoKHR::signalSemaphoreCount == 0 is different from VkSubmitInfo::signalSemaphoreCount == 1
     {
-        auto d3d12_fence_submit_info = vku::InitStruct<VkD3D12FenceSubmitInfoKHR>();
-        auto submit_info = vku::InitStruct<VkSubmitInfo>(&d3d12_fence_submit_info);
+        VkD3D12FenceSubmitInfoKHR d3d12_fence_submit_info = vku::InitStructHelper();
+        VkSubmitInfo submit_info = vku::InitStructHelper(&d3d12_fence_submit_info);
         submit_info.signalSemaphoreCount = 1;
         submit_info.pSignalSemaphores = &semaphore.handle();
 
@@ -1472,13 +1472,13 @@ TEST_F(NegativeExternalMemorySync, GetMemoryFdHandle) {
 
     // Allocate memory without VkExportMemoryAllocateInfo in the pNext chain
     {
-        auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+        VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
         alloc_info.allocationSize = 32;
         alloc_info.memoryTypeIndex = 0;
         vkt::DeviceMemory memory;
         memory.init(*m_device, alloc_info);
 
-        auto get_handle_info = vku::InitStruct<VkMemoryGetFdInfoKHR>();
+        VkMemoryGetFdInfoKHR get_handle_info = vku::InitStructHelper();
         get_handle_info.memory = memory;
         get_handle_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
@@ -1488,16 +1488,16 @@ TEST_F(NegativeExternalMemorySync, GetMemoryFdHandle) {
     }
     // VkExportMemoryAllocateInfo::handleTypes does not include requested handle type
     {
-        auto export_info = vku::InitStruct<VkExportMemoryAllocateInfo>();
+        VkExportMemoryAllocateInfo export_info = vku::InitStructHelper();
         export_info.handleTypes = 0;
 
-        auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>(&export_info);
+        VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&export_info);
         alloc_info.allocationSize = 1024;
         alloc_info.memoryTypeIndex = 0;
         vkt::DeviceMemory memory;
         memory.init(*m_device, alloc_info);
 
-        auto get_handle_info = vku::InitStruct<VkMemoryGetFdInfoKHR>();
+        VkMemoryGetFdInfoKHR get_handle_info = vku::InitStructHelper();
         get_handle_info.memory = memory;
         get_handle_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
@@ -1507,16 +1507,16 @@ TEST_F(NegativeExternalMemorySync, GetMemoryFdHandle) {
     }
     // Request handle of the wrong type
     {
-        auto export_info = vku::InitStruct<VkExportMemoryAllocateInfo>();
+        VkExportMemoryAllocateInfo export_info = vku::InitStructHelper();
         export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
 
-        auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>(&export_info);
+        VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&export_info);
         alloc_info.allocationSize = 1024;
         alloc_info.memoryTypeIndex = 0;
 
         vkt::DeviceMemory memory;
         memory.init(*m_device, alloc_info);
-        auto get_handle_info = vku::InitStruct<VkMemoryGetFdInfoKHR>();
+        VkMemoryGetFdInfoKHR get_handle_info = vku::InitStructHelper();
         get_handle_info.memory = memory;
         get_handle_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
 
@@ -1544,10 +1544,10 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromFdHandle) {
     {
         constexpr auto required_features =
             VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_KHR | VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT_KHR;
-        auto external_info = vku::InitStruct<VkPhysicalDeviceExternalBufferInfo>();
+        VkPhysicalDeviceExternalBufferInfo external_info = vku::InitStructHelper();
         external_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
         external_info.handleType = handle_type;
-        auto external_properties = vku::InitStruct<VkExternalBufferProperties>();
+        VkExternalBufferProperties external_properties = vku::InitStructHelper();
         vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &external_info, &external_properties);
         external_features = external_properties.externalMemoryProperties.externalMemoryFeatures;
         if ((external_features & required_features) != required_features) {
@@ -1557,7 +1557,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromFdHandle) {
 
     vkt::Buffer buffer;
     {
-        auto external_info = vku::InitStruct<VkExternalMemoryBufferCreateInfo>();
+        VkExternalMemoryBufferCreateInfo external_info = vku::InitStructHelper();
         external_info.handleTypes = handle_type;
         auto create_info = vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
         create_info.pNext = &external_info;
@@ -1569,7 +1569,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromFdHandle) {
     uint32_t payload_memory_type = 0;
     {
         const bool dedicated_allocation = (external_features & VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT) != 0;
-        auto dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+        VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
         dedicated_info.buffer = buffer;
         auto export_info = vku::InitStruct<VkExportMemoryAllocateInfo>(dedicated_allocation ? &dedicated_info : nullptr);
         export_info.handleTypes = handle_type;
@@ -1582,15 +1582,15 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromFdHandle) {
 
     int fd = -1;
     {
-        auto get_handle_info = vku::InitStruct<VkMemoryGetFdInfoKHR>();
+        VkMemoryGetFdInfoKHR get_handle_info = vku::InitStructHelper();
         get_handle_info.memory = memory;
         get_handle_info.handleType = handle_type;
         ASSERT_VK_SUCCESS(vk::GetMemoryFdKHR(*m_device, &get_handle_info, &fd));
     }
-    auto import_info = vku::InitStruct<VkImportMemoryFdInfoKHR>();
+    VkImportMemoryFdInfoKHR import_info = vku::InitStructHelper();
     import_info.handleType = handle_type;
     import_info.fd = fd;
-    auto alloc_info_with_import = vku::InitStruct<VkMemoryAllocateInfo>(&import_info);
+    VkMemoryAllocateInfo alloc_info_with_import = vku::InitStructHelper(&import_info);
     VkDeviceMemory imported_memory = VK_NULL_HANDLE;
 
     // allocationSize != payload's allocationSize
@@ -1638,15 +1638,15 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
     {
         constexpr auto required_features =
             VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_KHR | VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT_KHR;
-        auto external_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
+        VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
         external_info.handleType = handle_type;
-        auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_info);
+        VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_info);
         image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
         image_info.type = VK_IMAGE_TYPE_2D;
         image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
         image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-        auto external_properties = vku::InitStruct<VkExternalImageFormatProperties>();
-        auto image_properties = vku::InitStruct<VkImageFormatProperties2>(&external_properties);
+        VkExternalImageFormatProperties external_properties = vku::InitStructHelper();
+        VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_properties);
         const VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
         external_features = external_properties.externalMemoryProperties.externalMemoryFeatures;
         if (result != VK_SUCCESS || (external_features & required_features) != required_features) {
@@ -1656,7 +1656,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
 
     VkImageObj image(m_device);
     {
-        auto external_info = vku::InitStruct<VkExternalMemoryImageCreateInfo>();
+        VkExternalMemoryImageCreateInfo external_info = vku::InitStructHelper();
         external_info.handleTypes = handle_type;
         auto create_info = VkImageObj::create_info();
         create_info.pNext = &external_info;
@@ -1672,7 +1672,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
     uint32_t payload_memory_type = 0;
     {
         const bool dedicated_allocation = (external_features & VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT) != 0;
-        auto dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+        VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
         dedicated_info.image = image;
         auto export_info = vku::InitStruct<VkExportMemoryAllocateInfo>(dedicated_allocation ? &dedicated_info : nullptr);
         export_info.handleTypes = handle_type;
@@ -1685,15 +1685,15 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
 
     HANDLE handle = NULL;
     {
-        auto get_handle_info = vku::InitStruct<VkMemoryGetWin32HandleInfoKHR>();
+        VkMemoryGetWin32HandleInfoKHR get_handle_info = vku::InitStructHelper();
         get_handle_info.memory = memory;
         get_handle_info.handleType = handle_type;
         ASSERT_VK_SUCCESS(vk::GetMemoryWin32HandleKHR(*m_device, &get_handle_info, &handle));
     }
-    auto import_info = vku::InitStruct<VkImportMemoryWin32HandleInfoKHR>();
+    VkImportMemoryWin32HandleInfoKHR import_info = vku::InitStructHelper();
     import_info.handleType = handle_type;
     import_info.handle = handle;
-    auto alloc_info_with_import = vku::InitStruct<VkMemoryAllocateInfo>(&import_info);
+    VkMemoryAllocateInfo alloc_info_with_import = vku::InitStructHelper(&import_info);
     VkDeviceMemory imported_memory = VK_NULL_HANDLE;
 
     // allocationSize != payload's allocationSize
@@ -1729,7 +1729,7 @@ TEST_F(NegativeExternalMemorySync, BufferDedicatedAllocation) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto external_buffer_info = vku::InitStruct<VkExternalMemoryBufferCreateInfo>();
+    VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     const auto buffer_info = vkt::Buffer::create_info(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
     const auto exportable_dedicated_types = FindSupportedExternalMemoryHandleTypes(
         buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
@@ -1738,7 +1738,7 @@ TEST_F(NegativeExternalMemorySync, BufferDedicatedAllocation) {
     }
     const auto handle_type = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(exportable_dedicated_types);
 
-    auto export_memory_info = vku::InitStruct<VkExportMemoryAllocateInfo>();
+    VkExportMemoryAllocateInfo export_memory_info = vku::InitStructHelper();
     export_memory_info.handleTypes = handle_type;
     external_buffer_info.handleTypes = handle_type;
 
@@ -1757,8 +1757,8 @@ TEST_F(NegativeExternalMemorySync, ImageDedicatedAllocation) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto external_image_info = vku::InitStruct<VkExternalMemoryImageCreateInfo>();
-    auto image_info = vku::InitStruct<VkImageCreateInfo>(&external_image_info);
+    VkExternalMemoryImageCreateInfo external_image_info = vku::InitStructHelper();
+    VkImageCreateInfo image_info = vku::InitStructHelper(&external_image_info);
     image_info.imageType = VK_IMAGE_TYPE_2D;
     image_info.arrayLayers = 1;
     image_info.extent = {64, 64, 1};
@@ -1779,7 +1779,7 @@ TEST_F(NegativeExternalMemorySync, ImageDedicatedAllocation) {
     }
     const auto handle_type = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(exportable_dedicated_types);
 
-    auto export_memory_info = vku::InitStruct<VkExportMemoryAllocateInfo>();
+    VkExportMemoryAllocateInfo export_memory_info = vku::InitStructHelper();
     export_memory_info.handleTypes = handle_type;
     external_image_info.handleTypes = handle_type;
 
@@ -1809,7 +1809,7 @@ TEST_F(NegativeExternalMemorySync, Win32MemoryHandleProperties) {
 
     const HANDLE handle_that_passes_validation = (HANDLE)0x12345678;
 
-    auto properties = vku::InitStruct<VkMemoryWin32HandlePropertiesKHR>();
+    VkMemoryWin32HandlePropertiesKHR properties = vku::InitStructHelper();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetMemoryWin32HandlePropertiesKHR-handle-00665");
     vk::GetMemoryWin32HandlePropertiesKHR(*m_device, handle_type, invalid_win32_handle, &properties);
@@ -1840,7 +1840,7 @@ TEST_F(NegativeExternalMemorySync, FdMemoryHandleProperties) {
     constexpr int invalid_fd_handle = -1;
     constexpr int valid_fd_handle = 0;
 
-    auto properties = vku::InitStruct<VkMemoryFdPropertiesKHR>();
+    VkMemoryFdPropertiesKHR properties = vku::InitStructHelper();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetMemoryFdPropertiesKHR-fd-00673");
     vk::GetMemoryFdPropertiesKHR(*m_device, handle_type, invalid_fd_handle, &properties);

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -17,44 +17,44 @@
 
 VkExternalMemoryHandleTypeFlags ExternalMemorySyncTest::GetCompatibleHandleTypes(const VkBufferCreateInfo &buffer_create_info,
                                                                                  VkExternalMemoryHandleTypeFlagBits handle_type) {
-    auto external_info = vku::InitStruct<VkPhysicalDeviceExternalBufferInfo>();
+    VkPhysicalDeviceExternalBufferInfo external_info = vku::InitStructHelper();
     external_info.flags = buffer_create_info.flags;
     external_info.usage = buffer_create_info.usage;
     external_info.handleType = handle_type;
-    auto external_buffer_properties = vku::InitStruct<VkExternalBufferProperties>();
+    VkExternalBufferProperties external_buffer_properties = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &external_info, &external_buffer_properties);
     return external_buffer_properties.externalMemoryProperties.compatibleHandleTypes;
 }
 
 VkExternalMemoryHandleTypeFlags ExternalMemorySyncTest::GetCompatibleHandleTypes(const VkImageCreateInfo &image_create_info,
                                                                                  VkExternalMemoryHandleTypeFlagBits handle_type) {
-    auto external_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
+    VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
     external_info.handleType = handle_type;
-    auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_info);
+    VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_info);
     image_info.format = image_create_info.format;
     image_info.type = image_create_info.imageType;
     image_info.tiling = image_create_info.tiling;
     image_info.usage = image_create_info.usage;
     image_info.flags = image_create_info.flags;
-    auto external_properties = vku::InitStruct<VkExternalImageFormatProperties>();
-    auto image_properties = vku::InitStruct<VkImageFormatProperties2>(&external_properties);
+    VkExternalImageFormatProperties external_properties = vku::InitStructHelper();
+    VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_properties);
     if (vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties) != VK_SUCCESS) return 0;
     return external_properties.externalMemoryProperties.compatibleHandleTypes;
 }
 
 VkExternalFenceHandleTypeFlags ExternalMemorySyncTest::GetCompatibleHandleTypes(VkExternalFenceHandleTypeFlagBits handle_type) {
-    auto external_info = vku::InitStruct<VkPhysicalDeviceExternalFenceInfo>();
+    VkPhysicalDeviceExternalFenceInfo external_info = vku::InitStructHelper();
     external_info.handleType = handle_type;
-    auto external_properties = vku::InitStruct<VkExternalFenceProperties>();
+    VkExternalFenceProperties external_properties = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalFenceProperties(gpu(), &external_info, &external_properties);
     return external_properties.compatibleHandleTypes;
 }
 
 VkExternalSemaphoreHandleTypeFlags ExternalMemorySyncTest::GetCompatibleHandleTypes(
     VkExternalSemaphoreHandleTypeFlagBits handle_type) {
-    auto external_info = vku::InitStruct<VkPhysicalDeviceExternalSemaphoreInfo>();
+    VkPhysicalDeviceExternalSemaphoreInfo external_info = vku::InitStructHelper();
     external_info.handleType = handle_type;
-    auto external_properties = vku::InitStruct<VkExternalSemaphoreProperties>();
+    VkExternalSemaphoreProperties external_properties = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu(), &external_info, &external_properties);
     return external_properties.compatibleHandleTypes;
 }
@@ -64,9 +64,9 @@ VkExternalFenceHandleTypeFlags ExternalMemorySyncTest::FindSupportedExternalFenc
     VkExternalFenceHandleTypeFlags supported_types = 0;
     IterateFlags<VkExternalFenceHandleTypeFlagBits>(
         AllVkExternalFenceHandleTypeFlagBits, [&](VkExternalFenceHandleTypeFlagBits flag) {
-            auto external_info = vku::InitStruct<VkPhysicalDeviceExternalFenceInfo>();
+            VkPhysicalDeviceExternalFenceInfo external_info = vku::InitStructHelper();
             external_info.handleType = flag;
-            auto external_properties = vku::InitStruct<VkExternalFenceProperties>();
+            VkExternalFenceProperties external_properties = vku::InitStructHelper();
             vk::GetPhysicalDeviceExternalFenceProperties(gpu(), &external_info, &external_properties);
             if ((external_properties.externalFenceFeatures & requested_features) == requested_features) {
                 supported_types |= flag;
@@ -80,9 +80,9 @@ VkExternalSemaphoreHandleTypeFlags ExternalMemorySyncTest::FindSupportedExternal
     VkExternalSemaphoreHandleTypeFlags supported_types = 0;
     IterateFlags<VkExternalSemaphoreHandleTypeFlagBits>(
         AllVkExternalSemaphoreHandleTypeFlagBits, [&](VkExternalSemaphoreHandleTypeFlagBits flag) {
-            auto external_info = vku::InitStruct<VkPhysicalDeviceExternalSemaphoreInfo>();
+            VkPhysicalDeviceExternalSemaphoreInfo external_info = vku::InitStructHelper();
             external_info.handleType = flag;
-            auto external_properties = vku::InitStruct<VkExternalSemaphoreProperties>();
+            VkExternalSemaphoreProperties external_properties = vku::InitStructHelper();
             vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu(), &external_info, &external_properties);
             if ((external_properties.externalSemaphoreFeatures & requested_features) == requested_features) {
                 supported_types |= flag;
@@ -93,7 +93,7 @@ VkExternalSemaphoreHandleTypeFlags ExternalMemorySyncTest::FindSupportedExternal
 
 VkExternalMemoryHandleTypeFlags ExternalMemorySyncTest::FindSupportedExternalMemoryHandleTypes(
     const VkBufferCreateInfo &buffer_create_info, VkExternalMemoryFeatureFlags requested_features) {
-    auto external_info = vku::InitStruct<VkPhysicalDeviceExternalBufferInfo>();
+    VkPhysicalDeviceExternalBufferInfo external_info = vku::InitStructHelper();
     external_info.flags = buffer_create_info.flags;
     external_info.usage = buffer_create_info.usage;
 
@@ -101,7 +101,7 @@ VkExternalMemoryHandleTypeFlags ExternalMemorySyncTest::FindSupportedExternalMem
     IterateFlags<VkExternalMemoryHandleTypeFlagBits>(
         AllVkExternalMemoryHandleTypeFlagBits, [&](VkExternalMemoryHandleTypeFlagBits flag) {
             external_info.handleType = flag;
-            auto external_properties = vku::InitStruct<VkExternalBufferProperties>();
+            VkExternalBufferProperties external_properties = vku::InitStructHelper();
             vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &external_info, &external_properties);
             const auto external_features = external_properties.externalMemoryProperties.externalMemoryFeatures;
             if ((external_features & requested_features) == requested_features) {
@@ -113,8 +113,8 @@ VkExternalMemoryHandleTypeFlags ExternalMemorySyncTest::FindSupportedExternalMem
 
 VkExternalMemoryHandleTypeFlags ExternalMemorySyncTest::FindSupportedExternalMemoryHandleTypes(
     const VkImageCreateInfo &image_create_info, VkExternalMemoryFeatureFlags requested_features) {
-    auto external_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
-    auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_info);
+    VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
+    VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_info);
     image_info.format = image_create_info.format;
     image_info.type = image_create_info.imageType;
     image_info.tiling = image_create_info.tiling;
@@ -125,8 +125,8 @@ VkExternalMemoryHandleTypeFlags ExternalMemorySyncTest::FindSupportedExternalMem
     IterateFlags<VkExternalMemoryHandleTypeFlagBits>(
         AllVkExternalMemoryHandleTypeFlagBits, [&](VkExternalMemoryHandleTypeFlagBits flag) {
             external_info.handleType = flag;
-            auto external_properties = vku::InitStruct<VkExternalImageFormatProperties>();
-            auto image_properties = vku::InitStruct<VkImageFormatProperties2>(&external_properties);
+            VkExternalImageFormatProperties external_properties = vku::InitStructHelper();
+            VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_properties);
             VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
             const auto external_features = external_properties.externalMemoryProperties.externalMemoryFeatures;
             if (result == VK_SUCCESS && (external_features & requested_features) == requested_features) {
@@ -155,12 +155,12 @@ VkExternalMemoryHandleTypeFlagsNV ExternalMemorySyncTest::FindSupportedExternalM
 
 bool ExternalMemorySyncTest::HandleTypeNeedsDedicatedAllocation(const VkBufferCreateInfo &buffer_create_info,
                                                                 VkExternalMemoryHandleTypeFlagBits handle_type) {
-    auto external_info = vku::InitStruct<VkPhysicalDeviceExternalBufferInfo>();
+    VkPhysicalDeviceExternalBufferInfo external_info = vku::InitStructHelper();
     external_info.flags = buffer_create_info.flags;
     external_info.usage = buffer_create_info.usage;
     external_info.handleType = handle_type;
 
-    auto external_properties = vku::InitStruct<VkExternalBufferProperties>();
+    VkExternalBufferProperties external_properties = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &external_info, &external_properties);
 
     const auto external_features = external_properties.externalMemoryProperties.externalMemoryFeatures;
@@ -169,17 +169,17 @@ bool ExternalMemorySyncTest::HandleTypeNeedsDedicatedAllocation(const VkBufferCr
 
 bool ExternalMemorySyncTest::HandleTypeNeedsDedicatedAllocation(const VkImageCreateInfo &image_create_info,
                                                                 VkExternalMemoryHandleTypeFlagBits handle_type) {
-    auto external_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>();
+    VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
     external_info.handleType = handle_type;
-    auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_info);
+    VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_info);
     image_info.format = image_create_info.format;
     image_info.type = image_create_info.imageType;
     image_info.tiling = image_create_info.tiling;
     image_info.usage = image_create_info.usage;
     image_info.flags = image_create_info.flags;
 
-    auto external_properties = vku::InitStruct<VkExternalImageFormatProperties>();
-    auto image_properties = vku::InitStruct<VkImageFormatProperties2>(&external_properties);
+    VkExternalImageFormatProperties external_properties = vku::InitStructHelper();
+    VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_properties);
     VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
     if (result != VK_SUCCESS) return false;
 
@@ -200,16 +200,16 @@ TEST_F(PositiveExternalMemorySync, GetMemoryFdHandle) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto export_info = vku::InitStruct<VkExportMemoryAllocateInfo>();
+    VkExportMemoryAllocateInfo export_info = vku::InitStructHelper();
     export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
-    auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>(&export_info);
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&export_info);
     alloc_info.allocationSize = 1024;
     alloc_info.memoryTypeIndex = 0;
 
     vkt::DeviceMemory memory;
     memory.init(*m_device, alloc_info);
-    auto get_handle_info = vku::InitStruct<VkMemoryGetFdInfoKHR>();
+    VkMemoryGetFdInfoKHR get_handle_info = vku::InitStructHelper();
     get_handle_info.memory = memory;
     get_handle_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
@@ -351,7 +351,7 @@ TEST_F(PositiveExternalMemorySync, BufferDedicatedAllocation) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto external_buffer_info = vku::InitStruct<VkExternalMemoryBufferCreateInfo>();
+    VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     const auto buffer_info = vkt::Buffer::create_info(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
     const auto exportable_types = FindSupportedExternalMemoryHandleTypes(buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
@@ -368,10 +368,10 @@ TEST_F(PositiveExternalMemorySync, BufferDedicatedAllocation) {
     external_buffer_info.handleTypes = handle_type;
     vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
-    auto dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfo>();
+    VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.buffer = buffer;
 
-    auto export_memory_info = vku::InitStruct<VkExportMemoryAllocateInfo>(&dedicated_info);
+    VkExportMemoryAllocateInfo export_memory_info = vku::InitStructHelper(&dedicated_info);
     export_memory_info.handleTypes = handle_type;
 
     buffer.allocate_and_bind_memory(*m_device, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &export_memory_info);

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -215,7 +215,7 @@ TEST_F(NegativeFragmentShadingRate, CombinerOpsLimit) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     if (fsr_properties.fragmentShadingRateNonTrivialCombinerOps) {
@@ -268,15 +268,15 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveFragmentShadingRateWriteMultiViewpo
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     if (fsr_properties.primitiveFragmentShadingRateWithMultipleViewports) {
         GTEST_SKIP() << "Test requires primitiveFragmentShadingRateWithMultipleViewports to be unsupported.";
     }
 
-    auto eds_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(&eds_features);
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT eds_features = vku::InitStructHelper();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper(&eds_features);
     auto features2 = GetPhysicalDeviceFeatures2(fsr_features);
 
     if (!fsr_features.primitiveFragmentShadingRate) {
@@ -423,8 +423,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapLayerCount) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
-    auto fdm_features = vku::InitStruct<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(&multiview_features);
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
+    VkPhysicalDeviceFragmentDensityMapFeaturesEXT fdm_features = vku::InitStructHelper(&multiview_features);
     auto features2 = GetPhysicalDeviceFeatures2(fdm_features);
 
     if (fdm_features.fragmentDensityMap != VK_TRUE) {
@@ -435,7 +435,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapLayerCount) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -446,10 +446,10 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapLayerCount) {
     auto rpfdmi = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>(nullptr, ref);
 
     // Create a renderPass with viewMask 0
-    auto subpass = vku::InitStruct<VkSubpassDescription2>();
+    VkSubpassDescription2 subpass = vku::InitStructHelper();
     subpass.viewMask = 0;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>(&rpfdmi);
+    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper(&rpfdmi);
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -463,7 +463,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapLayerCount) {
     VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0, 2,
                                              VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
-    auto fb_info = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
     fb_info.renderPass = rp.handle();
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = &imageView;
@@ -514,7 +514,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapEnabled) {
     features2 = vku::InitStructHelper(&density_map2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto density_map2_properties = vku::InitStruct<VkPhysicalDeviceFragmentDensityMap2PropertiesEXT>();
+    VkPhysicalDeviceFragmentDensityMap2PropertiesEXT density_map2_properties = vku::InitStructHelper();
     auto properties2 = GetPhysicalDeviceProperties2(density_map2_properties);
 
     // Test sampler parameters
@@ -934,10 +934,10 @@ TEST_F(NegativeFragmentShadingRate, FramebufferUsage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(fsr_features);
     if (fsr_features.attachmentFragmentShadingRate != VK_TRUE) {
         GTEST_SKIP() << "VkPhysicalDeviceFragmentShadingRateFeaturesKHR::attachmentFragmentShadingRate not supported.";
@@ -945,24 +945,24 @@ TEST_F(NegativeFragmentShadingRate, FramebufferUsage) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto attach = vku::InitStruct<VkAttachmentReference2KHR>();
+    VkAttachmentReference2KHR attach = vku::InitStructHelper();
     attach.layout = VK_IMAGE_LAYOUT_GENERAL;
     attach.attachment = 0;
 
-    auto fsr_attachment = vku::InitStruct<VkFragmentShadingRateAttachmentInfoKHR>();
+    VkFragmentShadingRateAttachmentInfoKHR fsr_attachment = vku::InitStructHelper();
     fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
     fsr_attachment.pFragmentShadingRateAttachment = &attach;
 
     // Create a renderPass with a single fsr attachment
-    auto subpass = vku::InitStruct<VkSubpassDescription2KHR>(&fsr_attachment);
+    VkSubpassDescription2KHR subpass = vku::InitStructHelper(&fsr_attachment);
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8_UINT;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo2KHR>();
+    VkRenderPassCreateInfo2KHR rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -975,7 +975,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferUsage) {
     image.InitNoLayout(1, 1, 1, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView imageView = image.targetView(VK_FORMAT_R8_UINT);
 
-    auto fb_info = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
     fb_info.renderPass = rp.handle();
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = &imageView;
@@ -1004,11 +1004,11 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
                         "investigation.";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiviewFeaturesKHR multiview_features = vku::InitStructHelper();
     if (IsExtensionsEnabled(VK_KHR_MULTIVIEW_EXTENSION_NAME)) {
         fsr_features.pNext = &multiview_features;
     }
@@ -1024,24 +1024,24 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto attach = vku::InitStruct<VkAttachmentReference2>();
+    VkAttachmentReference2 attach = vku::InitStructHelper();
     attach.layout = VK_IMAGE_LAYOUT_GENERAL;
     attach.attachment = 0;
 
-    auto fsr_attachment = vku::InitStruct<VkFragmentShadingRateAttachmentInfoKHR>();
+    VkFragmentShadingRateAttachmentInfoKHR fsr_attachment = vku::InitStructHelper();
     fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
     fsr_attachment.pFragmentShadingRateAttachment = &attach;
 
     // Create a renderPass with a single fsr attachment
-    auto subpass = vku::InitStruct<VkSubpassDescription2>(&fsr_attachment);
+    VkSubpassDescription2 subpass = vku::InitStructHelper(&fsr_attachment);
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8_UINT;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -1059,7 +1059,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     const auto imageView = image.targetView(image_view_ci);
 
-    auto fb_info = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
     fb_info.renderPass = rp.handle();
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = &imageView;
@@ -1114,7 +1114,7 @@ TEST_F(NegativeFragmentShadingRate, Attachments) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(fsr_features);
 
     if (fsr_features.attachmentFragmentShadingRate != VK_TRUE) {
@@ -1123,27 +1123,27 @@ TEST_F(NegativeFragmentShadingRate, Attachments) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
-    auto attach = vku::InitStruct<VkAttachmentReference2>();
+    VkAttachmentReference2 attach = vku::InitStructHelper();
     attach.layout = VK_IMAGE_LAYOUT_GENERAL;
     attach.attachment = 0;
 
-    auto fsr_attachment = vku::InitStruct<VkFragmentShadingRateAttachmentInfoKHR>();
+    VkFragmentShadingRateAttachmentInfoKHR fsr_attachment = vku::InitStructHelper();
     fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
     fsr_attachment.pFragmentShadingRateAttachment = &attach;
 
     // Create a renderPass with a single fsr attachment
-    auto subpass = vku::InitStruct<VkSubpassDescription2>(&fsr_attachment);
+    VkSubpassDescription2 subpass = vku::InitStructHelper(&fsr_attachment);
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8_UINT;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -1250,11 +1250,11 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     // Create a render pass without a Fragment Shading Rate attachment
-    auto col_attach = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 col_attach = vku::InitStructHelper();
     col_attach.format = VK_FORMAT_R8G8B8A8_UNORM;
     col_attach.samples = VK_SAMPLE_COUNT_1_BIT;
     col_attach.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -1295,7 +1295,7 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
 
     VkSubpassDescription2 fsr_subpass_2 = vku::InitStructHelper(&fsr_attachment_2);
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -1457,7 +1457,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(fsr_features);
 
     if (fsr_features.attachmentFragmentShadingRate != VK_TRUE) {
@@ -1502,7 +1502,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
     // Create a view with the fragment shading rate attachment usage, but that doesn't support it
     CreateImageViewTest(*this, &createinfo, "VUID-VkImageViewCreateInfo-usage-04550");
 
-    auto fsrProperties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsrProperties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsrProperties);
 
     if (!fsrProperties.layeredShadingRateAttachments) {
@@ -1619,7 +1619,7 @@ TEST_F(NegativeFragmentShadingRate, PipelineCombinerOpsLimit) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     if (fsr_properties.fragmentShadingRateNonTrivialCombinerOps) {
@@ -1902,7 +1902,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapAttachmentCount) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto fdm_features = vku::InitStruct<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>();
+    VkPhysicalDeviceFragmentDensityMapFeaturesEXT fdm_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(fdm_features);
     if (fdm_features.fragmentDensityMap != VK_TRUE) {
         GTEST_SKIP() << "requires fragmentDensityMap feature";
@@ -1910,7 +1910,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapAttachmentCount) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -1919,14 +1919,14 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapAttachmentCount) {
     VkAttachmentReference ref = {};
     ref.attachment = 1;
     ref.layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
-    auto rpfdmi = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>();
+    VkRenderPassFragmentDensityMapCreateInfoEXT rpfdmi = vku::InitStructHelper();
     rpfdmi.fragmentDensityMapAttachment = ref;
 
     // Create a renderPass with viewMask 0
-    auto subpass = vku::InitStruct<VkSubpassDescription2>();
+    VkSubpassDescription2 subpass = vku::InitStructHelper();
     subpass.viewMask = 0;
 
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo2>(&rpfdmi);
+    VkRenderPassCreateInfo2 render_pass_ci = vku::InitStructHelper(&rpfdmi);
     render_pass_ci.subpassCount = 1;
     render_pass_ci.pSubpasses = &subpass;
     render_pass_ci.attachmentCount = 1;
@@ -1948,7 +1948,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "multiview feature not supported";
@@ -2025,7 +2025,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
                                                         size32(preserve), preserve.data());
 
     // Create a renderPass with a single color attachment for fragment density map
-    auto fragment_density_map_create_info = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>();
+    VkRenderPassFragmentDensityMapCreateInfoEXT fragment_density_map_create_info = vku::InitStructHelper();
     fragment_density_map_create_info.fragmentDensityMapAttachment.layout = VK_IMAGE_LAYOUT_GENERAL;
 
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>(&fragment_density_map_create_info, 0u, size32(attachments),
@@ -2038,7 +2038,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
     subpass.viewMask = 0x3u;
     rp2[1].init(*m_device, rpci, true);
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8_UNORM;
     image_create_info.extent.width = 16;
@@ -2095,7 +2095,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
 
     // Create view attachment
     VkImageView iv[7];
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = fdm_image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     ivci.format = VK_FORMAT_R8G8_UNORM;
@@ -2144,7 +2144,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
     ASSERT_TRUE(iv6.initialized());
     iv[6] = iv6.handle();
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.flags = 0;
     fbci.width = 16;
     fbci.height = 16;
@@ -2165,13 +2165,13 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
         vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp2[1].handle(), fb2.handle(), VkRect2D{{0, 0}, {16u, 16u}}, 0u, nullptr);
 
     if (rp2Supported) {
-        auto offsetting = vku::InitStruct<VkSubpassFragmentDensityMapOffsetEndInfoQCOM>();
-        auto subpassEndInfo = vku::InitStruct<VkSubpassEndInfoKHR>(&offsetting);
+        VkSubpassFragmentDensityMapOffsetEndInfoQCOM offsetting = vku::InitStructHelper();
+        VkSubpassEndInfoKHR subpassEndInfo = vku::InitStructHelper(&offsetting);
         VkOffset2D m_vOffsets[2];
         offsetting.pFragmentDensityOffsets = m_vOffsets;
         offsetting.fragmentDensityOffsetCount = 2;
 
-        auto fdm_offset_properties = vku::InitStruct<VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM>();
+        VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM fdm_offset_properties = vku::InitStructHelper();
         GetPhysicalDeviceProperties2(fdm_offset_properties);
 
         m_vOffsets[0].x = 1;
@@ -2275,7 +2275,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
     }
 
     // Create a device that enables shading_rate_image but disables multiViewport
-    auto shading_rate_image_features = vku::InitStruct<VkPhysicalDeviceShadingRateImageFeaturesNV>();
+    VkPhysicalDeviceShadingRateImageFeaturesNV shading_rate_image_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(shading_rate_image_features);
     if (!shading_rate_image_features.shadingRateImage) {
         GTEST_SKIP() << "shadingRateImage not supported";
@@ -2552,7 +2552,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNVViewportCount) {
     }
 
     // Create a device that enables shading_rate_image but disables multiViewport
-    auto shading_rate_image_features = vku::InitStruct<VkPhysicalDeviceShadingRateImageFeaturesNV>();
+    VkPhysicalDeviceShadingRateImageFeaturesNV shading_rate_image_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(shading_rate_image_features);
     if (!shading_rate_image_features.shadingRateImage) {
         GTEST_SKIP() << "shadingRateImage not supported";
@@ -2624,11 +2624,11 @@ TEST_F(NegativeFragmentShadingRate, StageUsage) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
     sync2_features.synchronization2 = VK_TRUE;  // sync2 extension guarantees feature support
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
 
-    auto query_pool_create_info = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo query_pool_create_info = vku::InitStructHelper();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
     const vkt::QueryPool query_pool(*m_device, query_pool_create_info);
@@ -2659,11 +2659,11 @@ TEST_F(NegativeFragmentShadingRate, StageUsageNV) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
     sync2_features.synchronization2 = VK_TRUE;  // sync2 extension guarantees feature support
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
 
-    auto query_pool_create_info = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo query_pool_create_info = vku::InitStructHelper();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
     const vkt::QueryPool query_pool(*m_device, query_pool_create_info);
@@ -2693,7 +2693,7 @@ TEST_F(NegativeFragmentShadingRate, ImageMaxLimitsQCOM) {
     }
 
     const VkPhysicalDeviceLimits &dev_limits = m_device->props.limits;
-    auto image_ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.flags = 0;
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.format = VK_FORMAT_R8G8_UNORM;

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -23,16 +23,16 @@ TEST_F(PositiveFragmentShadingRate, StageInVariousAPIs) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto shading_rate_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR shading_rate_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(shading_rate_features);
     if (shading_rate_features.attachmentFragmentShadingRate == VK_FALSE) {
         GTEST_SKIP() << "Test requires (unsupported) attachmentFragmentShadingRate";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>(&shading_rate_features);
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper(&shading_rate_features);
     sync2_features.synchronization2 = VK_TRUE;  // sync2 extension guarantees feature support
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
 
-    auto query_pool_create_info = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo query_pool_create_info = vku::InitStructHelper();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 1;
     const vkt::QueryPool query_pool(*m_device, query_pool_create_info);
@@ -55,7 +55,7 @@ TEST_F(PositiveFragmentShadingRate, StageWithPipelineBarrier) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(fsr_features);
     if (fsr_features.attachmentFragmentShadingRate == VK_FALSE) {
         GTEST_SKIP() << "Test requires (unsupported) attachmentFragmentShadingRate";
@@ -77,7 +77,7 @@ TEST_F(PositiveFragmentShadingRate, StageWithPipelineBarrier) {
                VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
-    auto imageMemoryBarrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
     imageMemoryBarrier.srcAccessMask = VK_ACCESS_NONE;
     imageMemoryBarrier.dstAccessMask = VK_ACCESS_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR;
     imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -111,8 +111,8 @@ TEST_F(PositiveFragmentShadingRate, Attachments) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>(&fsr_features);
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper(&fsr_features);
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "multiview feature not supported";
@@ -127,7 +127,7 @@ TEST_F(PositiveFragmentShadingRate, Attachments) {
     attach.layout = VK_IMAGE_LAYOUT_GENERAL;
     attach.attachment = 0;
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
     VkFragmentShadingRateAttachmentInfoKHR fsr_attachment = vku::InitStructHelper();
@@ -137,13 +137,13 @@ TEST_F(PositiveFragmentShadingRate, Attachments) {
     VkSubpassDescription2 subpass = vku::InitStructHelper(&fsr_attachment);
     subpass.viewMask = 0x2;
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8_UINT;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;

--- a/tests/unit/geometry_tessellation_positive.cpp
+++ b/tests/unit/geometry_tessellation_positive.cpp
@@ -30,7 +30,7 @@ TEST_F(PositiveGeometryTessellation, PointSizeGeomShaderDontWriteMaintenance5) {
         GTEST_SKIP() << "At least Vulkan 1.1 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -39,7 +39,7 @@ bool VkGpuAssistedLayerTest::CanEnableGpuAV() {
         printf("At least Vulkan version 1.1 is required for GPU-AV\n");
         return false;
     }
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2>();
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features2);
     if (!features2.features.fragmentStoresAndAtomics || !features2.features.vertexPipelineStoresAndAtomics) {
         printf("fragmentStoresAndAtomics and vertexPipelineStoresAndAtomics are required for GPU-AV\n");
@@ -72,10 +72,10 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
         GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
-    auto maintenance4_features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>();
+    VkPhysicalDeviceMaintenance4Features maintenance4_features = vku::InitStructHelper();
     maintenance4_features.maintenance4 = true;
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&maintenance4_features);
-    auto indexing_features = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&maintenance4_features);
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
     if (descriptor_indexing) {
         maintenance4_features.pNext = &indexing_features;
         GetPhysicalDeviceFeatures2(features2);
@@ -536,7 +536,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuRobustBufferOOB) {
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
-    auto pipeline_robustness_features = vku::InitStruct<VkPhysicalDevicePipelineRobustnessFeaturesEXT>();
+    VkPhysicalDevicePipelineRobustnessFeaturesEXT pipeline_robustness_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(pipeline_robustness_features);
     features2.features.robustBufferAccess = VK_FALSE;
     if (!pipeline_robustness_features.pipelineRobustness) {
@@ -570,7 +570,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuRobustBufferOOB) {
     )glsl";
 
     VkShaderObj vs(this, vertshader, VK_SHADER_STAGE_VERTEX_BIT);
-    auto pipeline_robustness_ci = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+    VkPipelineRobustnessCreateInfoEXT pipeline_robustness_ci = vku::InitStructHelper();
     VkPipelineObj robust_pipe(m_device);
     robust_pipe.AddShader(&vs);
     robust_pipe.AddDefaultColorAttachment();
@@ -624,7 +624,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOB) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
 
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>();
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper();
     const bool multi_draw = IsExtensionsEnabled(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
     auto robustness2_features = vku::InitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>(multi_draw ? &multi_draw_features : nullptr);
     auto features2 = GetPhysicalDeviceFeatures2(robustness2_features);
@@ -823,11 +823,11 @@ void VkGpuAssistedLayerTest::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDe
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
     dynamic_rendering_features.dynamicRendering = VK_TRUE;
-    auto shader_object_features = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
+    VkPhysicalDeviceShaderObjectFeaturesEXT shader_object_features = vku::InitStructHelper(&dynamic_rendering_features);
     shader_object_features.shaderObject = VK_TRUE;
-    auto features = vku::InitStruct<VkPhysicalDeviceFeatures2>();  // Make sure robust buffer access is not enabled
+    VkPhysicalDeviceFeatures2 features = vku::InitStructHelper();  // Make sure robust buffer access is not enabled
     if (shader_objects) {
         features.pNext = &shader_object_features;
     }
@@ -1048,7 +1048,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     VkResult err;
     const bool mesh_shader_supported = IsExtensionsEnabled(VK_NV_MESH_SHADER_EXTENSION_NAME);
 
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
+    VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = vku::InitStructHelper();
     auto bda_features =
         vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(mesh_shader_supported ? &mesh_shader_features : nullptr);
 
@@ -1065,7 +1065,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
 
     // Make a uniform buffer to be passed to the shader that contains the pointer and write count
     uint32_t qfi = 0;
-    auto bci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo bci = vku::InitStructHelper();
     bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     bci.size = 12;  // 64 bit pointer + int
     bci.queueFamilyIndexCount = 1;
@@ -1077,7 +1077,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     // Make another buffer to write to
     bci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
     bci.size = 64;  // Buffer should be 16*4 = 64 bytes
-    auto allocate_flag_info = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
     allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
     vkt::Buffer buffer1(*m_device, bci, mem_props, &allocate_flag_info);
 
@@ -1087,12 +1087,12 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     VkViewport viewport = m_viewports[0];
     VkRect2D scissors = m_scissors[0];
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
 
-    auto begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
-    auto hinfo = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    VkCommandBufferInheritanceInfo hinfo = vku::InitStructHelper();
     begin_info.pInheritanceInfo = &hinfo;
 
     struct TestCase {
@@ -1111,7 +1111,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
         push_constant_ranges.offset = 0;
         push_constant_ranges.size = 2 * sizeof(VkDeviceAddress);
 
-        auto plci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+        VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
         plci = vku::InitStructHelper();
         plci.pushConstantRangeCount = 1;
         plci.pPushConstantRanges = &push_constant_ranges;
@@ -1181,7 +1181,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
         buffer_test_buffer_info.offset = 0;
         buffer_test_buffer_info.range = sizeof(uint32_t);
 
-        auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_set.set_;
         descriptor_write.dstBinding = 0;
         descriptor_write.descriptorCount = 1;
@@ -1252,7 +1252,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
         push_constant_ranges[0].offset = 0;
         push_constant_ranges[0].size = 2 * sizeof(VkDeviceAddress);
 
-        auto plci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+        VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
         plci.pushConstantRangeCount = push_constant_range_count;
         plci.pPushConstantRanges = push_constant_ranges;
         plci.setLayoutCount = 0;
@@ -1444,9 +1444,9 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndexedIndirectCountDeviceLimitSubmit2) {
     props.limits.maxDrawIndirectCount = 1;
     fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
 
-    auto features_13 = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
-    auto features_12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>(&features_13);
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2>(&features_12);
+    VkPhysicalDeviceVulkan13Features features_13 = vku::InitStructHelper();
+    VkPhysicalDeviceVulkan12Features features_12 = vku::InitStructHelper(&features_13);
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&features_12);
     GetPhysicalDeviceFeatures2(features2);
     if (!features_12.drawIndirectCount) {
         GTEST_SKIP() << "drawIndirectCount not supported";
@@ -1665,7 +1665,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2>();
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features2);
     features2.features.drawIndirectFirstInstance = VK_FALSE;
 
@@ -1775,13 +1775,13 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
-    auto indexing_features = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
-    auto inline_uniform_block_features = vku::InitStruct<VkPhysicalDeviceInlineUniformBlockFeaturesEXT>(&indexing_features);
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
+    VkPhysicalDeviceInlineUniformBlockFeaturesEXT inline_uniform_block_features = vku::InitStructHelper(&indexing_features);
     auto features2 = GetPhysicalDeviceFeatures2(inline_uniform_block_features);
     if (!indexing_features.descriptorBindingPartiallyBound || !inline_uniform_block_features.inlineUniformBlock) {
         GTEST_SKIP() << "Not all features supported";
     }
-    auto inline_uniform_props = vku::InitStruct<VkPhysicalDeviceInlineUniformBlockPropertiesEXT>();
+    VkPhysicalDeviceInlineUniformBlockPropertiesEXT inline_uniform_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(inline_uniform_props);
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
@@ -2255,8 +2255,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPL) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
 
-    auto robustness2_features = vku::InitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
-    auto gpl_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(&robustness2_features);
+    VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features = vku::InitStructHelper();
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper(&robustness2_features);
     auto features2 = GetPhysicalDeviceFeatures2(gpl_features);
     if (!robustness2_features.nullDescriptor) {
         GTEST_SKIP() << "nullDescriptor feature not supported";
@@ -2436,8 +2436,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPLIndependentSets) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto robustness2_features = vku::InitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
-    auto gpl_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(&robustness2_features);
+    VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features = vku::InitStructHelper();
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper(&robustness2_features);
     auto features2 = GetPhysicalDeviceFeatures2(gpl_features);
     if (!robustness2_features.nullDescriptor) {
         GTEST_SKIP() << "nullDescriptor feature not supported";
@@ -2523,7 +2523,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPLIndependentSets) {
     ASSERT_VK_SUCCESS(vi.CreateGraphicsPipeline(false));
 
     VkDynamicState dyn_states[2] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
-    auto dyn_state = vku::InitStruct<VkPipelineDynamicStateCreateInfo>();
+    VkPipelineDynamicStateCreateInfo dyn_state = vku::InitStructHelper();
     dyn_state.dynamicStateCount = size(dyn_states);
     dyn_state.pDynamicStates = dyn_states;
     CreatePipelineHelper pre_raster(*this);

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -71,7 +71,7 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOBindDescriptor) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_0.layout_});
     ASSERT_TRUE(pipeline_layout.initialized());
 
-    auto pipeline_info = vku::InitStruct<VkComputePipelineCreateInfo>();
+    VkComputePipelineCreateInfo pipeline_info = vku::InitStructHelper();
     pipeline_info.flags = 0;
     pipeline_info.layout = pipeline_layout.handle();
     pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
@@ -82,7 +82,7 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOBindDescriptor) {
     vk::CreateComputePipelines(device(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr, &pipeline);
 
     vkt::Buffer buffer_0;
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     buffer_ci.size = 262144;
     buffer_0.init(*m_device, buffer_ci);
@@ -114,7 +114,7 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOBindDescriptor) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
 
@@ -177,7 +177,7 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOPushDescriptor) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_0.layout_});
     ASSERT_TRUE(pipeline_layout.initialized());
 
-    auto pipeline_info = vku::InitStruct<VkComputePipelineCreateInfo>();
+    VkComputePipelineCreateInfo pipeline_info = vku::InitStructHelper();
     pipeline_info.flags = 0;
     pipeline_info.layout = pipeline_layout.handle();
     pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
@@ -188,7 +188,7 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOPushDescriptor) {
     vk::CreateComputePipelines(device(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr, &pipeline);
 
     vkt::Buffer buffer_0;
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     buffer_ci.size = 262144;
     buffer_0.init(*m_device, buffer_ci);
@@ -218,7 +218,7 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOPushDescriptor) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
 
@@ -249,7 +249,7 @@ TEST_F(PositiveGpuAssistedLayer, GpuBufferDeviceAddress) {
     if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
         GTEST_SKIP() << "This test should not be run on the AMD proprietary driver.";
     }
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper();
     VkPhysicalDeviceFeatures2KHR features2 = GetPhysicalDeviceFeatures2(bda_features);
     if (!features2.features.shaderInt64) {
         GTEST_SKIP() << "shaderInt64 is not supported";
@@ -262,7 +262,7 @@ TEST_F(PositiveGpuAssistedLayer, GpuBufferDeviceAddress) {
 
     // Make a uniform buffer to be passed to the shader that contains the pointer and write count
     uint32_t qfi = 0;
-    auto bci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo bci = vku::InitStructHelper();
     bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     bci.size = 12;  // 64 bit pointer + int
     bci.queueFamilyIndexCount = 1;
@@ -271,12 +271,12 @@ TEST_F(PositiveGpuAssistedLayer, GpuBufferDeviceAddress) {
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     buffer0.init(*m_device, bci, mem_props);
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
 
-    auto begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
-    auto hinfo = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    VkCommandBufferInheritanceInfo hinfo = vku::InitStructHelper();
     begin_info.pInheritanceInfo = &hinfo;
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -287,7 +287,7 @@ TEST_F(PositiveGpuAssistedLayer, GpuBufferDeviceAddress) {
     buffer_test_buffer_info.offset = 0;
     buffer_test_buffer_info.range = sizeof(uint32_t);
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -333,7 +333,7 @@ TEST_F(PositiveGpuAssistedLayer, GpuBufferDeviceAddress) {
     // Make another buffer to write to
     bci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
     bci.size = 64;  // Buffer should be 16*4 = 64 bytes
-    auto allocate_flag_info = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
     allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
     vkt::Buffer buffer1(*m_device, bci, mem_props, &allocate_flag_info);
 
@@ -359,22 +359,22 @@ TEST_F(PositiveGpuAssistedLayer, GetCounterFromSignaledSemaphoreAfterSubmit) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>(&sync2_features);
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper(&sync2_features);
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
-    auto semaphore_type_info = vku::InitStruct<VkSemaphoreTypeCreateInfo>();
+    VkSemaphoreTypeCreateInfo semaphore_type_info = vku::InitStructHelper();
     semaphore_type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-    const auto create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_info);
+    const VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&semaphore_type_info);
     vkt::Semaphore semaphore(*m_device, create_info);
 
-    auto signal_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+    VkSemaphoreSubmitInfo signal_info = vku::InitStructHelper();
     signal_info.semaphore = semaphore;
     signal_info.value = 1;
     signal_info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo2>();
+    VkSubmitInfo2 submit_info = vku::InitStructHelper();
     submit_info.signalSemaphoreInfoCount = 1;
     submit_info.pSignalSemaphoreInfos = &signal_info;
     ASSERT_VK_SUCCESS(vk::QueueSubmit2(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE));
@@ -398,7 +398,7 @@ TEST_F(PositiveGpuAssistedLayer, MutableBuffer) {
     if (IsPlatform(kShieldTVb)) {
         GTEST_SKIP() << "This test should not run on Shield TV";
     }
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -439,7 +439,7 @@ TEST_F(PositiveGpuAssistedLayer, MutableBuffer) {
     lists[1].descriptorTypeCount = 2;
     lists[1].pDescriptorTypes = desc_types;
 
-    auto mdtci = vku::InitStruct<VkMutableDescriptorTypeCreateInfoEXT>();
+    VkMutableDescriptorTypeCreateInfoEXT mdtci = vku::InitStructHelper();
     mdtci.mutableDescriptorTypeListCount = 3;
     mdtci.pMutableDescriptorTypeLists = lists;
 
@@ -453,7 +453,7 @@ TEST_F(PositiveGpuAssistedLayer, MutableBuffer) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_0.layout_});
     ASSERT_TRUE(pipeline_layout.initialized());
 
-    auto pipeline_info = vku::InitStruct<VkComputePipelineCreateInfo>();
+    VkComputePipelineCreateInfo pipeline_info = vku::InitStructHelper();
     pipeline_info.flags = 0;
     pipeline_info.layout = pipeline_layout.handle();
     pipeline_info.basePipelineHandle = VK_NULL_HANDLE;
@@ -464,14 +464,14 @@ TEST_F(PositiveGpuAssistedLayer, MutableBuffer) {
     vk::CreateComputePipelines(device(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr, &pipeline);
 
     vkt::Buffer buffer_0;
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     buffer_ci.size = 262144;
     buffer_0.init(*m_device, buffer_ci);
     vkt::Buffer buffer_1;
     buffer_1.init(*m_device, buffer_ci);
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set_0.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.dstArrayElement = 0;
@@ -482,7 +482,7 @@ TEST_F(PositiveGpuAssistedLayer, MutableBuffer) {
 
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
 
-    auto descriptor_copy = vku::InitStruct<VkCopyDescriptorSet>();
+    VkCopyDescriptorSet descriptor_copy = vku::InitStructHelper();
     // copy the storage descriptor to the first mutable descriptor
     descriptor_copy.srcSet = descriptor_set_0.set_;
     descriptor_copy.srcBinding = 0;
@@ -507,7 +507,7 @@ TEST_F(PositiveGpuAssistedLayer, MutableBuffer) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
 

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -27,7 +27,7 @@ TEST_F(NegativeGraphicsLibrary, DSLs) {
     dsl_binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
     dsl_binding.pImmutableSamplers = nullptr;
 
-    auto dsl_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo dsl_ci = vku::InitStructHelper();
     dsl_ci.bindingCount = 1;
     dsl_ci.pBindings = &dsl_binding;
 
@@ -63,7 +63,7 @@ TEST_F(NegativeGraphicsLibrary, GPLDSLs) {
     dsl_binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
     dsl_binding.pImmutableSamplers = nullptr;
 
-    auto dsl_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo dsl_ci = vku::InitStructHelper();
     dsl_ci.bindingCount = 1;
     dsl_ci.pBindings = &dsl_binding;
 
@@ -109,12 +109,12 @@ TEST_F(NegativeGraphicsLibrary, IndependentSetsLinkOnly) {
         pre_raster_lib.pipeline_,
         frag_shader_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06615");
-    auto lib_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -140,7 +140,7 @@ TEST_F(NegativeGraphicsLibrary, IndependentSetsLinkCreate) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+        VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
         link_info.libraryCount = 1;
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
@@ -220,7 +220,7 @@ TEST_F(NegativeGraphicsLibrary, MissingDSState) {
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&dynamic_rendering_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -248,7 +248,7 @@ TEST_F(NegativeGraphicsLibrary, MissingDSStateWithFragOutputState) {
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&dynamic_rendering_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -258,7 +258,7 @@ TEST_F(NegativeGraphicsLibrary, MissingDSStateWithFragOutputState) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfo>();
+    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
     pipeline_rendering_info.depthAttachmentFormat = depth_format;
@@ -304,7 +304,7 @@ TEST_F(NegativeGraphicsLibrary, MissingDSStateWithFragOutputState) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+        VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
         link_info.pNext = &pipeline_rendering_info;
         link_info.libraryCount = 2;
         link_info.pLibraries = libraries;
@@ -328,8 +328,9 @@ TEST_F(NegativeGraphicsLibrary, DepthStencilStateIgnored) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(&extended_dynamic_state_features);
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features =
+        vku::InitStructHelper(&extended_dynamic_state_features);
     InitBasicGraphicsLibrary(&dynamic_rendering_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -359,7 +360,7 @@ TEST_F(NegativeGraphicsLibrary, MissingColorBlendState) {
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&dynamic_rendering_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -368,12 +369,12 @@ TEST_F(NegativeGraphicsLibrary, MissingColorBlendState) {
     }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfo>();
+    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
 
     CreatePipelineHelper pre_raster_lib(*this);
     {
@@ -512,7 +513,7 @@ TEST_F(NegativeGraphicsLibrary, LinkOptimization) {
     VkPipeline libraries[1] = {
         vertex_input_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
@@ -582,7 +583,7 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsNullInCreate) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+        VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
         link_info.libraryCount = 1;
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
@@ -631,7 +632,7 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsNullInLink) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+        VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
         link_info.libraryCount = 1;
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
@@ -688,11 +689,11 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsLinkOnly) {
         pre_raster_lib.pipeline_,
         frag_shader_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto lib_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06758");
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
@@ -751,7 +752,7 @@ TEST_F(NegativeGraphicsLibrary, ImmutableSamplersIncompatibleDSL) {
 
     const std::array<VkDescriptorSet, 3> desc_sets = {ds.set_, VK_NULL_HANDLE, ds2.set_};
 
-    auto ub_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo ub_ci = vku::InitStructHelper();
     ub_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     ub_ci.size = 1024;
     vkt::Buffer uniform_buffer(*m_device, ub_ci);
@@ -801,11 +802,11 @@ TEST_F(NegativeGraphicsLibrary, ImmutableSamplersIncompatibleDSL) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pipeline_layout_null.handle();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -831,22 +832,22 @@ TEST_F(NegativeGraphicsLibrary, PreRasterWithFS) {
 
     // Create and add a vertex shader to silence 06896
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
-    auto vs_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+    VkShaderModuleCreateInfo vs_ci = vku::InitStructHelper();
     vs_ci.codeSize = vs_spv.size() * sizeof(decltype(vs_spv)::value_type);
     vs_ci.pCode = vs_spv.data();
 
-    auto vs_stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&vs_ci);
+    VkPipelineShaderStageCreateInfo vs_stage_ci = vku::InitStructHelper(&vs_ci);
     vs_stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
     vs_stage_ci.module = VK_NULL_HANDLE;
     vs_stage_ci.pName = "main";
     stages.emplace_back(vs_stage_ci);
 
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
-    auto fs_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+    VkShaderModuleCreateInfo fs_ci = vku::InitStructHelper();
     fs_ci.codeSize = fs_spv.size() * sizeof(decltype(fs_spv)::value_type);
     fs_ci.pCode = fs_spv.data();
 
-    auto fs_stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&fs_ci);
+    VkPipelineShaderStageCreateInfo fs_stage_ci = vku::InitStructHelper(&fs_ci);
     // The library is not created with fragment shader state, and therefore cannot have a fragment shader
     fs_stage_ci.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     fs_stage_ci.module = VK_NULL_HANDLE;
@@ -872,22 +873,22 @@ TEST_F(NegativeGraphicsLibrary, FragmentStateWithPreRaster) {
     std::vector<VkPipelineShaderStageCreateInfo> stages;
 
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
-    auto fs_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+    VkShaderModuleCreateInfo fs_ci = vku::InitStructHelper();
     fs_ci.codeSize = fs_spv.size() * sizeof(decltype(fs_spv)::value_type);
     fs_ci.pCode = fs_spv.data();
 
-    auto fs_stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&fs_ci);
+    VkPipelineShaderStageCreateInfo fs_stage_ci = vku::InitStructHelper(&fs_ci);
     fs_stage_ci.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     fs_stage_ci.module = VK_NULL_HANDLE;
     fs_stage_ci.pName = "main";
     stages.emplace_back(fs_stage_ci);
 
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
-    auto vs_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+    VkShaderModuleCreateInfo vs_ci = vku::InitStructHelper();
     vs_ci.codeSize = vs_spv.size() * sizeof(decltype(vs_spv)::value_type);
     vs_ci.pCode = vs_spv.data();
 
-    auto vs_stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&vs_ci);
+    VkPipelineShaderStageCreateInfo vs_stage_ci = vku::InitStructHelper(&vs_ci);
     // VK_SHADER_STAGE_VERTEX_BIT is a pre-raster shader stage, but the library will be created with only fragment shader state
     vs_stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
     vs_stage_ci.module = VK_NULL_HANDLE;
@@ -930,7 +931,7 @@ TEST_F(NegativeGraphicsLibrary, DescriptorBufferLibrary) {
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
-    auto db_features = vku::InitStruct<VkPhysicalDeviceDescriptorBufferFeaturesEXT>();
+    VkPhysicalDeviceDescriptorBufferFeaturesEXT db_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&db_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -979,11 +980,11 @@ TEST_F(NegativeGraphicsLibrary, DescriptorBufferLibrary) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = layout;
     VkPipeline pipeline;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-08096");
@@ -1117,7 +1118,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
     const auto tes_spv = GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, tes_src);
     vkt::GraphicsPipelineLibraryStage tes_stage(tes_spv, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT);
 
-    auto iasci = vku::InitStruct<VkPipelineInputAssemblyStateCreateInfo>();
+    VkPipelineInputAssemblyStateCreateInfo iasci = vku::InitStructHelper();
     iasci.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
 
     VkPipelineTessellationStateCreateInfo tsci{VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO, nullptr, 0, 3};
@@ -1152,7 +1153,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
         fs_lib.pipeline_,
         fo_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = static_cast<uint32_t>(libs.size());
     link_info.pLibraries = libs.data();
 
@@ -1194,7 +1195,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
 
         libs[0] = vi_patch_lib.pipeline_;
         libs[1] = pre_raster_lib.pipeline_;
-        auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+        VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
         exe_pipe_ci.layout = fs_lib.gp_ci_.layout;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-topology-08889");
         vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
@@ -1271,7 +1272,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
 
         libs[0] = vi_lib.pipeline_;
         libs[1] = pre_raster_lib.pipeline_;
-        auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+        VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
         exe_pipe_ci.layout = fs_lib.gp_ci_.layout;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-08888");
         vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
@@ -1283,7 +1284,7 @@ TEST_F(NegativeGraphicsLibrary, PipelineExecutableProperties) {
     TEST_DESCRIPTION("VK_KHR_pipeline_executable_properties with GPL");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME);
-    auto executable_features = vku::InitStruct<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR>();
+    VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR executable_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&executable_features);
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -1303,11 +1304,11 @@ TEST_F(NegativeGraphicsLibrary, PipelineExecutableProperties) {
             vertex_input_lib.pipeline_,
             frag_out_lib.pipeline_,
         };
-        auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+        VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
         link_info.libraryCount = size(libraries);
         link_info.pLibraries = libraries;
 
-        auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+        VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06646");
         vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
         m_errorMonitor->VerifyFound();
@@ -1319,7 +1320,7 @@ TEST_F(NegativeGraphicsLibrary, PipelineExecutableProperties) {
         vertex_input_lib.InitState();
         vertex_input_lib.CreateGraphicsPipeline(false);
 
-        auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+        VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
         link_info.libraryCount = 1;
         link_info.pLibraries = &vertex_input_lib.pipeline_;
 
@@ -1340,7 +1341,7 @@ TEST_F(NegativeGraphicsLibrary, PipelineExecutableProperties) {
             VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR;
         vertex_input_lib.CreateGraphicsPipeline(false);
 
-        auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+        VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
         link_info.libraryCount = 1;
         link_info.pLibraries = &vertex_input_lib.pipeline_;
 
@@ -1382,7 +1383,7 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
     const std::array<VkDescriptorSet, 3> desc_sets_null = {ds.set_, VK_NULL_HANDLE, ds2.set_};
     const std::array<VkDescriptorSet, 3> desc_sets_empty = {ds.set_, ds_empty.set_, ds2.set_};
 
-    auto ub_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo ub_ci = vku::InitStructHelper();
     ub_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     ub_ci.size = 1024;
     vkt::Buffer uniform_buffer(*m_device, ub_ci);
@@ -1435,11 +1436,11 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = libraries.size();
     link_info.pLibraries = libraries.data();
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pipeline_layout.handle();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -1490,9 +1491,9 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
 
     SetTargetApiVersion(VK_API_VERSION_1_3);  // Pipeline cache control needed
     AddRequiredExtensions(VK_EXT_SHADER_MODULE_IDENTIFIER_EXTENSION_NAME);
-    auto pipeline_cache_control_features = vku::InitStruct<VkPhysicalDevicePipelineCreationCacheControlFeatures>();
-    auto shader_module_id_features =
-        vku::InitStruct<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(&pipeline_cache_control_features);
+    VkPhysicalDevicePipelineCreationCacheControlFeatures pipeline_cache_control_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT shader_module_id_features =
+        vku::InitStructHelper(&pipeline_cache_control_features);
     InitBasicGraphicsLibrary(&shader_module_id_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -1504,14 +1505,14 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto sm_id_create_info = vku::InitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
-    auto vs_ci = vku::InitStruct<VkShaderModuleCreateInfo>(&sm_id_create_info);
+    VkShaderModuleCreateInfo vs_ci = vku::InitStructHelper(&sm_id_create_info);
     vs_ci.codeSize = vs_spv.size() * sizeof(decltype(vs_spv)::value_type);
     vs_ci.pCode = vs_spv.data();
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&vs_ci);
+    VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper(&vs_ci);
     stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
     stage_ci.module = VK_NULL_HANDLE;
     stage_ci.pName = "main";
@@ -1540,7 +1541,7 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    auto get_identifier = vku::InitStruct<VkShaderModuleIdentifierEXT>();
+    VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
     vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
@@ -1582,11 +1583,11 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
     }
     // Now use it in a gpl
     VkPipeline libraries[1] = {pipe2.pipeline_};
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo pipe_ci = vku::InitStructHelper(&link_info);
     // no VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-06855");
     vkt::Pipeline exe_pipe(*m_device, pipe_ci);
@@ -1606,12 +1607,12 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifierFeatures) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto pipeline_cache_control_features = vku::InitStruct<VkPhysicalDevicePipelineCreationCacheControlFeatures>();
+    VkPhysicalDevicePipelineCreationCacheControlFeatures pipeline_cache_control_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(pipeline_cache_control_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>();
+    VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper();
     stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
     stage_ci.module = VK_NULL_HANDLE;
     stage_ci.pName = "main";
@@ -1626,7 +1627,7 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifierFeatures) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    auto sm_id_create_info = vku::InitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
     sm_id_create_info.identifierSize = 4;
     stage_ci.pNext = &sm_id_create_info;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageModuleIdentifierCreateInfoEXT-pNext-06850");
@@ -1634,12 +1635,12 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifierFeatures) {
     m_errorMonitor->VerifyFound();
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
-    auto get_identifier = vku::InitStruct<VkShaderModuleIdentifierEXT>();
+    VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetShaderModuleIdentifierEXT-shaderModuleIdentifier-06884");
     vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
     m_errorMonitor->VerifyFound();
 
-    auto sm_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+    VkShaderModuleCreateInfo sm_ci = vku::InitStructHelper();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetShaderModuleCreateInfoIdentifierEXT-shaderModuleIdentifier-06885");
     uint32_t code = 0;
     sm_ci.codeSize = 4;
@@ -1690,11 +1691,11 @@ TEST_F(NegativeGraphicsLibrary, Layouts) {
         frag_shader_lib.pipeline_,
         fo_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto lib_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-None-07826");
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
@@ -1757,11 +1758,11 @@ TEST_F(NegativeGraphicsLibrary, IncompatibleLayouts) {
         frag_shader_lib.pipeline_,
         fo_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_ci = vku::InitStructHelper(&link_info);
     exe_ci.layout = pipeline_layout_exe.handle();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkGraphicsPipelineCreateInfo-layout-07827");  // incompatible with pre-raster state
@@ -1800,11 +1801,11 @@ TEST_F(NegativeGraphicsLibrary, NullLibrary) {
         VK_NULL_HANDLE,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parameter");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
@@ -1841,11 +1842,11 @@ TEST_F(NegativeGraphicsLibrary, BadLibrary) {
         bad_pipeline,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parameter");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
@@ -1899,7 +1900,7 @@ TEST_F(NegativeGraphicsLibrary, DynamicPrimitiveTopolgyIngoreState) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
@@ -1908,7 +1909,7 @@ TEST_F(NegativeGraphicsLibrary, DynamicPrimitiveTopolgyIngoreState) {
     dynamic_create_info.pDynamicStates = dynamic_states;
     dynamic_create_info.dynamicStateCount = 1;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
     exe_pipe_ci.pDynamicState = &dynamic_create_info;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -22,7 +22,7 @@ void GraphicsLibraryTest::InitBasicGraphicsLibrary(void *pNextFeatures) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto gpl_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(pNextFeatures);
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper(pNextFeatures);
     GetPhysicalDeviceFeatures2(gpl_features);
     if (!gpl_features.graphicsPipelineLibrary) {
         GTEST_SKIP() << "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT::graphicsPipelineLibrary not supported";
@@ -163,11 +163,11 @@ TEST_F(PositiveGraphicsLibrary, ExeLibrary) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -198,7 +198,7 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
 
     const std::array<VkDescriptorSet, 3> desc_sets = {ds.set_, VK_NULL_HANDLE, ds2.set_};
 
-    auto ub_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo ub_ci = vku::InitStructHelper();
     ub_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     ub_ci.size = 1024;
     vkt::Buffer uniform_buffer(*m_device, ub_ci);
@@ -249,11 +249,11 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pipeline_layout_null.handle();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -323,7 +323,7 @@ TEST_F(PositiveGraphicsLibrary, VertexAttributeDivisorInstanceRateZero) {
     VkVertexInputBindingDivisorDescriptionEXT divisor_description = {};
     divisor_description.binding = 0;
     divisor_description.divisor = 0;
-    auto divisor_state_create_info = vku::InitStruct<VkPipelineVertexInputDivisorStateCreateInfoEXT>();
+    VkPipelineVertexInputDivisorStateCreateInfoEXT divisor_state_create_info = vku::InitStructHelper();
     divisor_state_create_info.vertexBindingDivisorCount = 1;
     divisor_state_create_info.pVertexBindingDivisors = &divisor_description;
     VkVertexInputBindingDescription vertex_input_binding_description = {divisor_description.binding, 12,
@@ -353,7 +353,7 @@ TEST_F(PositiveGraphicsLibrary, NotAttachmentDynamicBlendEnable) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
-    auto extended_dynamic_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&extended_dynamic_state3_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -396,7 +396,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyAllState) {
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
 
-    auto ia_state = vku::InitStruct<VkPipelineInputAssemblyStateCreateInfo>();
+    VkPipelineInputAssemblyStateCreateInfo ia_state = vku::InitStructHelper();
     ia_state.primitiveRestartEnable = false;
     ia_state.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
 
@@ -446,11 +446,11 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyAllState) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.pInputAssemblyState = &ia_state;
     exe_pipe_ci.pDynamicState = &dynamic_create_info;
     exe_pipe_ci.layout = layout;
@@ -486,7 +486,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateAndLinked) {
     VkRenderPass render_pass = VK_NULL_HANDLE;
     uint32_t subpass = 0;
 
-    auto ia_state = vku::InitStruct<VkPipelineInputAssemblyStateCreateInfo>();
+    VkPipelineInputAssemblyStateCreateInfo ia_state = vku::InitStructHelper();
     ia_state.primitiveRestartEnable = false;
     ia_state.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
 
@@ -536,11 +536,11 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateAndLinked) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.pInputAssemblyState = &ia_state;
     exe_pipe_ci.pDynamicState = &dynamic_create_info;
     exe_pipe_ci.layout = layout;
@@ -571,7 +571,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateOnly) {
     VkRenderPass render_pass = VK_NULL_HANDLE;
     uint32_t subpass = 0;
 
-    auto ia_state = vku::InitStruct<VkPipelineInputAssemblyStateCreateInfo>();
+    VkPipelineInputAssemblyStateCreateInfo ia_state = vku::InitStructHelper();
     ia_state.primitiveRestartEnable = false;
     ia_state.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
 
@@ -621,11 +621,11 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateOnly) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = layout;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -646,7 +646,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentOutput) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
 
-    auto dyn_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT dyn_state3_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&dyn_state3_features);
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -702,11 +702,11 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentOutput) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = layout;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -727,7 +727,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentShader) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
 
-    auto dyn_state3_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT dyn_state3_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&dyn_state3_features);
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -783,11 +783,11 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentShader) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = layout;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -870,11 +870,11 @@ TEST_F(PositiveGraphicsLibrary, LinkingInputAttachment) {
         frag_shader_lib.pipeline_,
         frag_out_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = layout;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -898,7 +898,7 @@ TEST_F(PositiveGraphicsLibrary, TessellationWithoutPreRasterization) {
     VkPipelineShaderStageCreateInfo stages[2];
 
     const auto tcs_spv = GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, kTessellationControlMinimalGlsl);
-    auto tcs_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+    VkShaderModuleCreateInfo tcs_ci = vku::InitStructHelper();
     tcs_ci.codeSize = tcs_spv.size() * sizeof(decltype(tcs_spv)::value_type);
     tcs_ci.pCode = tcs_spv.data();
     stages[0] = vku::InitStructHelper(&tcs_ci);
@@ -907,7 +907,7 @@ TEST_F(PositiveGraphicsLibrary, TessellationWithoutPreRasterization) {
     stages[0].pName = "main";
 
     const auto tes_spv = GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, kTessellationEvalMinimalGlsl);
-    auto tes_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+    VkShaderModuleCreateInfo tes_ci = vku::InitStructHelper();
     tes_ci.codeSize = tes_spv.size() * sizeof(decltype(tes_spv)::value_type);
     tes_ci.pCode = tes_spv.data();
     stages[1] = vku::InitStructHelper(&tes_ci);
@@ -924,7 +924,7 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
     TEST_DESCRIPTION("Check ignored pointers with dynamics rendering and GPL");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&dynamic_rendering_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -944,7 +944,7 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
 
     // Create an executable pipeline with rasterization disabled
     // Pass rendering info with null pointers that should be ignored
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfo>();
+    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 2;  // <- bad data that should be ignored
 
     CreatePipelineHelper fs_lib(*this);
@@ -955,7 +955,7 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
         stencil.depthFailOp = VK_STENCIL_OP_KEEP;
         stencil.compareOp = VK_COMPARE_OP_NEVER;
 
-        auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+        VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
         ds_ci.depthTestEnable = VK_FALSE;
         ds_ci.depthWriteEnable = VK_TRUE;
         ds_ci.depthCompareOp = VK_COMPARE_OP_NEVER;
@@ -988,11 +988,11 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
         vi_lib.pipeline_, pr_lib.pipeline_, fs_lib.pipeline_,
         // fragment output not needed due to rasterization being disabled
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size32(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pr_lib.gp_ci_.layout;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -1002,7 +1002,7 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
     TEST_DESCRIPTION("Check ignored pointers with dynamics rendering and GPL");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&dynamic_rendering_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -1029,7 +1029,7 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
         stencil.depthFailOp = VK_STENCIL_OP_KEEP;
         stencil.compareOp = VK_COMPARE_OP_NEVER;
 
-        auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+        VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
         ds_ci.depthTestEnable = VK_FALSE;
         ds_ci.depthWriteEnable = VK_TRUE;
         ds_ci.depthCompareOp = VK_COMPARE_OP_NEVER;
@@ -1057,7 +1057,7 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
     pr_lib.CreateGraphicsPipeline();
 
     VkFormat color_formats = VK_FORMAT_UNDEFINED;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfo>();
+    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
     pipeline_rendering_info.depthAttachmentFormat = m_depth_stencil_fmt;
@@ -1075,23 +1075,23 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
         fs_lib.pipeline_,
         fo_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size32(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pr_lib.gp_ci_.layout;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto depth_attachment = vku::InitStruct<VkRenderingAttachmentInfo>();
+    VkRenderingAttachmentInfo depth_attachment = vku::InitStructHelper();
     depth_attachment.imageView = *m_depthStencil->BindInfo();
     depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
     begin_rendering_info.layerCount = 1;
@@ -1110,7 +1110,7 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
     TEST_DESCRIPTION("Create a GPL with depth state");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
-    auto dyn_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT dyn_state2_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&dyn_state2_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -1130,7 +1130,7 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
         stencil.depthFailOp = VK_STENCIL_OP_KEEP;
         stencil.compareOp = VK_COMPARE_OP_NEVER;
 
-        auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+        VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
         ds_ci.depthTestEnable = VK_FALSE;
         ds_ci.depthWriteEnable = VK_TRUE;
         ds_ci.depthCompareOp = VK_COMPARE_OP_NEVER;
@@ -1176,11 +1176,11 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
             fs_lib.pipeline_,
             fo_lib.pipeline_,
         };
-        auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+        VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
         link_info.libraryCount = size32(libraries);
         link_info.pLibraries = libraries;
 
-        auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+        VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
         exe_pipe_ci.layout = pr_lib.gp_ci_.layout;
         vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
         ASSERT_TRUE(exe_pipe.initialized());
@@ -1206,11 +1206,11 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
         fs_lib.pipeline_,
         fo_lib.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size32(libraries);
     link_info.pLibraries = libraries;
 
-    auto exe_pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pr_lib.gp_ci_.layout;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -1220,7 +1220,7 @@ TEST_F(PositiveGraphicsLibrary, FOIgnoredDynamicRendering) {
     TEST_DESCRIPTION("Check ignored pointers with dynamics rendering and no fragment output state");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
     InitBasicGraphicsLibrary(&dynamic_rendering_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -1234,10 +1234,10 @@ TEST_F(PositiveGraphicsLibrary, FOIgnoredDynamicRendering) {
 
     // Create an executable pipeline with rasterization disabled
     // Pass rendering info with null pointers that should be ignored
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfo>();
+    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 2;  // <- bad data that should be ignored
 
-    auto lib_info = vku::InitStruct<VkGraphicsPipelineLibraryCreateInfoEXT>(&pipeline_rendering_info);
+    VkGraphicsPipelineLibraryCreateInfoEXT lib_info = vku::InitStructHelper(&pipeline_rendering_info);
     lib_info.flags =
         VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT | VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT;
 
@@ -1247,7 +1247,7 @@ TEST_F(PositiveGraphicsLibrary, FOIgnoredDynamicRendering) {
     stencil.depthFailOp = VK_STENCIL_OP_KEEP;
     stencil.compareOp = VK_COMPARE_OP_NEVER;
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     ds_ci.depthTestEnable = VK_FALSE;
     ds_ci.depthWriteEnable = VK_TRUE;
     ds_ci.depthCompareOp = VK_COMPARE_OP_NEVER;
@@ -1291,10 +1291,10 @@ TEST_F(PositiveGraphicsLibrary, ShaderModuleIdentifier) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto gpl_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>();
-    auto pipeline_cache_control_features = vku::InitStruct<VkPhysicalDevicePipelineCreationCacheControlFeatures>(&gpl_features);
-    auto shader_module_id_features =
-        vku::InitStruct<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(&pipeline_cache_control_features);
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper();
+    VkPhysicalDevicePipelineCreationCacheControlFeatures pipeline_cache_control_features = vku::InitStructHelper(&gpl_features);
+    VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT shader_module_id_features =
+        vku::InitStructHelper(&pipeline_cache_control_features);
     GetPhysicalDeviceFeatures2(shader_module_id_features);
 
     if (!gpl_features.graphicsPipelineLibrary) {
@@ -1311,14 +1311,14 @@ TEST_F(PositiveGraphicsLibrary, ShaderModuleIdentifier) {
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     ASSERT_TRUE(vs.initialized());
 
-    auto vs_identifier = vku::InitStruct<VkShaderModuleIdentifierEXT>();
+    VkShaderModuleIdentifierEXT vs_identifier = vku::InitStructHelper();
     vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &vs_identifier);
 
-    auto sm_id_create_info = vku::InitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
     sm_id_create_info.identifierSize = vs_identifier.identifierSize;
     sm_id_create_info.pIdentifier = vs_identifier.identifier;
 
-    auto stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&sm_id_create_info);
+    VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper(&sm_id_create_info);
     stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
     stage_ci.module = VK_NULL_HANDLE;
     stage_ci.pName = "main";
@@ -1331,17 +1331,17 @@ TEST_F(PositiveGraphicsLibrary, ShaderModuleIdentifier) {
 
     // Create a fragment shader library with FS referencing an identifier queried from VkShaderModuleCreateInfo
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
-    auto fs_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+    VkShaderModuleCreateInfo fs_ci = vku::InitStructHelper();
     fs_ci.codeSize = fs_spv.size() * sizeof(decltype(fs_spv)::value_type);
     fs_ci.pCode = fs_spv.data();
 
-    auto fs_identifier = vku::InitStruct<VkShaderModuleIdentifierEXT>();
+    VkShaderModuleIdentifierEXT fs_identifier = vku::InitStructHelper();
     vk::GetShaderModuleCreateInfoIdentifierEXT(device(), &fs_ci, &fs_identifier);
 
     sm_id_create_info.identifierSize = fs_identifier.identifierSize;
     sm_id_create_info.pIdentifier = fs_identifier.identifier;
 
-    auto fs_stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&sm_id_create_info);
+    VkPipelineShaderStageCreateInfo fs_stage_ci = vku::InitStructHelper(&sm_id_create_info);
     fs_stage_ci.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     fs_stage_ci.module = VK_NULL_HANDLE;
     fs_stage_ci.pName = "main";
@@ -1368,11 +1368,11 @@ TEST_F(PositiveGraphicsLibrary, ShaderModuleIdentifier) {
         fs_pipe.pipeline_,
         fo_pipe.pipeline_,
     };
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    auto pipe_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+    VkGraphicsPipelineCreateInfo pipe_ci = vku::InitStructHelper(&link_info);
     pipe_ci.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
     pipe_ci.layout = pipe.gp_ci_.layout;
     vkt::Pipeline exe_pipe(*m_device, pipe_ci);
@@ -1385,8 +1385,9 @@ TEST_F(PositiveGraphicsLibrary, DepthStencilStateIgnored) {
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(&extended_dynamic_state_features);
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features =
+        vku::InitStructHelper(&extended_dynamic_state_features);
     InitBasicGraphicsLibrary(&dynamic_rendering_features);
     if (::testing::Test::IsSkipped()) return;
 
@@ -1417,10 +1418,11 @@ TEST_F(PositiveGraphicsLibrary, ColorBlendStateIgnored) {
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
-    auto extended_dynamic_state2_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>();
-    auto extended_dynamic_state3_features =
-        vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(&extended_dynamic_state2_features);
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>(&extended_dynamic_state3_features);
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2_features = vku::InitStructHelper();
+    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features =
+        vku::InitStructHelper(&extended_dynamic_state2_features);
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features =
+        vku::InitStructHelper(&extended_dynamic_state3_features);
     InitBasicGraphicsLibrary(&dynamic_rendering_features);
     if (::testing::Test::IsSkipped()) return;
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -1438,12 +1440,12 @@ TEST_F(PositiveGraphicsLibrary, ColorBlendStateIgnored) {
         GTEST_SKIP() << "extendedDynamicState3ColorWriteMask not supported";
     }
 
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfo>();
+    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+    VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
 
     CreatePipelineHelper pre_raster_lib(*this);
     {

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -35,7 +35,7 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToFromMemory) {
 
     std::vector<uint8_t> pixels(width * height * 4);
 
-    auto region_to_image = vku::InitStruct<VkMemoryToImageCopyEXT>();
+    VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
     region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     region_to_image.imageSubresource.layerCount = 1;
@@ -43,14 +43,14 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToFromMemory) {
     region_to_image.imageExtent.height = height;
     region_to_image.imageExtent.depth = 1;
 
-    auto copy_to_image = vku::InitStruct<VkCopyMemoryToImageInfoEXT>();
+    VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.flags = 0;
     copy_to_image.dstImage = image;
     copy_to_image.dstImageLayout = VK_IMAGE_LAYOUT_GENERAL;
     copy_to_image.regionCount = 1;
     copy_to_image.pRegions = &region_to_image;
 
-    auto region_from_image = vku::InitStruct<VkImageToMemoryCopyEXT>();
+    VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
     region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     region_from_image.imageSubresource.layerCount = 1;
@@ -58,7 +58,7 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToFromMemory) {
     region_from_image.imageExtent.height = height;
     region_from_image.imageExtent.depth = 1;
 
-    auto copy_from_image = vku::InitStruct<VkCopyImageToMemoryInfoEXT>();
+    VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.flags = 0;
     copy_from_image.srcImage = image;
     copy_from_image.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -489,7 +489,7 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToFromMemory) {
         vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
         m_errorMonitor->VerifyFound();
 
-        auto stencil_usage_ci = vku::InitStruct<VkImageStencilUsageCreateInfo>();
+        VkImageStencilUsageCreateInfo stencil_usage_ci = vku::InitStructHelper();
         stencil_usage_ci.stencilUsage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
         image_ci.pNext = &stencil_usage_ci;
         VkImageObj image_separate_stencil(m_device);
@@ -676,11 +676,11 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToImage) {
 
     VkImageFormatProperties img_prop = {};
     VkImageLayout layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    auto image_copy_2 = vku::InitStruct<VkImageCopy2>();
+    VkImageCopy2 image_copy_2 = vku::InitStructHelper();
     image_copy_2.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.extent = {width, height, 1};
-    auto copy_image_to_image = vku::InitStruct<VkCopyImageToImageInfoEXT>();
+    VkCopyImageToImageInfoEXT copy_image_to_image = vku::InitStructHelper();
     copy_image_to_image.regionCount = 1;
     copy_image_to_image.pRegions = &image_copy_2;
     copy_image_to_image.srcImageLayout = layout;
@@ -747,7 +747,7 @@ TEST_F(NegativeHostImageCopy, HostCopyImageToImage) {
         m_errorMonitor->VerifyFound();
 
         // Seperate stencil, no VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT
-        auto stencil_usage_ci = vku::InitStruct<VkImageStencilUsageCreateInfo>();
+        VkImageStencilUsageCreateInfo stencil_usage_ci = vku::InitStructHelper();
         stencil_usage_ci.stencilUsage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
         image_ci.pNext = &stencil_usage_ci;
         VkImageObj image_separate_stencil1(m_device);
@@ -1207,7 +1207,7 @@ TEST_F(NegativeHostImageCopy, HostTransitionImageLayout) {
     range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     range.layerCount = 1;
     range.levelCount = 1;
-    auto transition_info = vku::InitStruct<VkHostImageLayoutTransitionInfoEXT>();
+    VkHostImageLayoutTransitionInfoEXT transition_info = vku::InitStructHelper();
     transition_info.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     transition_info.newLayout = VK_IMAGE_LAYOUT_GENERAL;
     transition_info.subresourceRange = range;
@@ -1428,7 +1428,7 @@ TEST_F(NegativeHostImageCopy, Features) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto host_copy_features = vku::InitStruct<VkPhysicalDeviceHostImageCopyFeaturesEXT>();
+    VkPhysicalDeviceHostImageCopyFeaturesEXT host_copy_features = vku::InitStructHelper();
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_copy_features));
     auto image_ci = VkImageObj::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT,
                                                   VK_IMAGE_TILING_OPTIMAL);
@@ -1442,7 +1442,7 @@ TEST_F(NegativeHostImageCopy, Features) {
     image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
     std::vector<uint8_t> pixels(32 * 32 * 4);
-    auto region_to_image = vku::InitStruct<VkMemoryToImageCopyEXT>();
+    VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
     region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     region_to_image.imageSubresource.layerCount = 1;
@@ -1450,7 +1450,7 @@ TEST_F(NegativeHostImageCopy, Features) {
     region_to_image.imageExtent.height = 32;
     region_to_image.imageExtent.depth = 1;
 
-    auto copy_to_image = vku::InitStruct<VkCopyMemoryToImageInfoEXT>();
+    VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.flags = 0;
     copy_to_image.dstImage = image;
     copy_to_image.dstImageLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -1460,7 +1460,7 @@ TEST_F(NegativeHostImageCopy, Features) {
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
 
-    auto region_from_image = vku::InitStruct<VkImageToMemoryCopyEXT>();
+    VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
     region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     region_from_image.imageSubresource.layerCount = 1;
@@ -1468,7 +1468,7 @@ TEST_F(NegativeHostImageCopy, Features) {
     region_from_image.imageExtent.height = 32;
     region_from_image.imageExtent.depth = 1;
 
-    auto copy_from_image = vku::InitStruct<VkCopyImageToMemoryInfoEXT>();
+    VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.flags = 0;
     copy_from_image.srcImage = image;
     copy_from_image.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -1483,11 +1483,11 @@ TEST_F(NegativeHostImageCopy, Features) {
     image2.Init(image_ci);
     image2.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
-    auto image_copy_2 = vku::InitStruct<VkImageCopy2>();
+    VkImageCopy2 image_copy_2 = vku::InitStructHelper();
     image_copy_2.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.extent = {32, 32, 1};
-    auto copy_image_to_image = vku::InitStruct<VkCopyImageToImageInfoEXT>();
+    VkCopyImageToImageInfoEXT copy_image_to_image = vku::InitStructHelper();
     copy_image_to_image.regionCount = 1;
     copy_image_to_image.pRegions = &image_copy_2;
     copy_image_to_image.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -1523,7 +1523,7 @@ TEST_F(NegativeHostImageCopy, ImageMemoryOverlap) {
     imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     imageSubresource.layerCount = 1;
 
-    auto region = vku::InitStruct<VkImageToMemoryCopyEXT>();
+    VkImageToMemoryCopyEXT region = vku::InitStructHelper();
     region.pHostPointer = data;
     region.memoryRowLength = 0;
     region.memoryImageHeight = 0;
@@ -1531,7 +1531,7 @@ TEST_F(NegativeHostImageCopy, ImageMemoryOverlap) {
     region.imageOffset = {0, 0, 0};
     region.imageExtent = {32, 32, 1};
     const uint32_t copy_size = (32 * 32 * 4) / 8;  // 64 bit pointer
-    auto copy_image_to_memory = vku::InitStruct<VkCopyImageToMemoryInfoEXT>();
+    VkCopyImageToMemoryInfoEXT copy_image_to_memory = vku::InitStructHelper();
     copy_image_to_memory.srcImage = image.handle();
     copy_image_to_memory.srcImageLayout = layout;
     copy_image_to_memory.regionCount = 1;
@@ -1556,7 +1556,7 @@ TEST_F(NegativeHostImageCopy, ImageMemoryOverlap) {
     vk::CopyImageToMemoryEXT(*m_device, &copy_image_to_memory);
     m_errorMonitor->VerifyFound();
 
-    auto region2 = vku::InitStruct<VkMemoryToImageCopyEXT>();
+    VkMemoryToImageCopyEXT region2 = vku::InitStructHelper();
     region2.pHostPointer = data;
     region2.memoryRowLength = 0;
     region2.memoryImageHeight = 0;
@@ -1564,7 +1564,7 @@ TEST_F(NegativeHostImageCopy, ImageMemoryOverlap) {
     region2.imageOffset = {0, 0, 0};
     region2.imageExtent = {32, 32, 1};
 
-    auto copy_memory_to_image = vku::InitStruct<VkCopyMemoryToImageInfoEXT>();
+    VkCopyMemoryToImageInfoEXT copy_memory_to_image = vku::InitStructHelper();
     copy_memory_to_image.dstImage = image.handle();
     copy_memory_to_image.dstImageLayout = layout;
     copy_memory_to_image.regionCount = 1;
@@ -1606,7 +1606,7 @@ TEST_F(NegativeHostImageCopy, ImageMemorySparseUnbound) {
     imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     imageSubresource.layerCount = 1;
 
-    auto region = vku::InitStruct<VkImageToMemoryCopyEXT>();
+    VkImageToMemoryCopyEXT region = vku::InitStructHelper();
     region.pHostPointer = data.data();
     region.memoryRowLength = 0;
     region.memoryImageHeight = 0;
@@ -1614,7 +1614,7 @@ TEST_F(NegativeHostImageCopy, ImageMemorySparseUnbound) {
     region.imageOffset = {0, 0, 0};
     region.imageExtent = {width, height, 1};
 
-    auto copy_image_to_memory = vku::InitStruct<VkCopyImageToMemoryInfoEXT>();
+    VkCopyImageToMemoryInfoEXT copy_image_to_memory = vku::InitStructHelper();
     copy_image_to_memory.srcImage = image.handle();
     copy_image_to_memory.srcImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     copy_image_to_memory.regionCount = 1;
@@ -1626,7 +1626,7 @@ TEST_F(NegativeHostImageCopy, ImageMemorySparseUnbound) {
     vk::CopyImageToMemoryEXT(*m_device, &copy_image_to_memory);
     m_errorMonitor->VerifyFound();
 
-    auto region2 = vku::InitStruct<VkMemoryToImageCopyEXT>();
+    VkMemoryToImageCopyEXT region2 = vku::InitStructHelper();
     region2.pHostPointer = data.data();
     region2.memoryRowLength = 0;
     region2.memoryImageHeight = 0;
@@ -1634,7 +1634,7 @@ TEST_F(NegativeHostImageCopy, ImageMemorySparseUnbound) {
     region2.imageOffset = {0, 0, 0};
     region2.imageExtent = {width, height, 1};
 
-    auto copy_memory_to_image = vku::InitStruct<VkCopyMemoryToImageInfoEXT>();
+    VkCopyMemoryToImageInfoEXT copy_memory_to_image = vku::InitStructHelper();
     copy_memory_to_image.dstImage = image.handle();
     copy_memory_to_image.dstImageLayout = VK_IMAGE_LAYOUT_GENERAL;
     copy_memory_to_image.regionCount = 1;
@@ -1651,11 +1651,11 @@ TEST_F(NegativeHostImageCopy, ImageMemorySparseUnbound) {
     // so check for both src and dst in one call
     image2.init_no_mem(*m_device, image_ci);
 
-    auto image_copy = vku::InitStruct<VkImageCopy2>();
+    VkImageCopy2 image_copy = vku::InitStructHelper();
     image_copy.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy.extent = {32, 32, 1};
-    auto copy_image_to_image = vku::InitStruct<VkCopyImageToImageInfoEXT>();
+    VkCopyImageToImageInfoEXT copy_image_to_image = vku::InitStructHelper();
     copy_image_to_image.regionCount = 1;
     copy_image_to_image.pRegions = &image_copy;
     copy_image_to_image.srcImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -32,8 +32,8 @@ void HostImageCopyTest::InitHostImageCopyTest(const VkImageCreateInfo &image_ci)
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto separate_depth_stencil_layouts_features = vku::InitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR>();
-    auto host_copy_features = vku::InitStruct<VkPhysicalDeviceHostImageCopyFeaturesEXT>(&separate_depth_stencil_layouts_features);
+    VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR separate_depth_stencil_layouts_features = vku::InitStructHelper();
+    VkPhysicalDeviceHostImageCopyFeaturesEXT host_copy_features = vku::InitStructHelper(&separate_depth_stencil_layouts_features);
     GetPhysicalDeviceFeatures2(host_copy_features);
     if (!host_copy_features.hostImageCopy) {
         GTEST_SKIP() << "Test requires (unsupported) hostImageCopy";
@@ -57,7 +57,7 @@ void HostImageCopyTest::InitHostImageCopyTest(const VkImageCreateInfo &image_ci)
         GTEST_SKIP() << "Required formats/features not supported";
     }
 
-    auto host_image_copy_props = vku::InitStruct<VkPhysicalDeviceHostImageCopyPropertiesEXT>();
+    VkPhysicalDeviceHostImageCopyPropertiesEXT host_image_copy_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(host_image_copy_props);
     copy_src_layouts.resize(host_image_copy_props.copySrcLayoutCount);
     copy_dst_layouts.resize(host_image_copy_props.copyDstLayoutCount);
@@ -103,7 +103,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
         channel = static_cast<uint8_t>((r & 0xffu) | ((r >> 8) & 0xff) | ((r >> 16) & 0xff) | (r >> 24));
     }
 
-    auto region_to_image = vku::InitStruct<VkMemoryToImageCopyEXT>();
+    VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
     region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     region_to_image.imageSubresource.layerCount = 1;
@@ -111,7 +111,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     region_to_image.imageExtent.height = height;
     region_to_image.imageExtent.depth = 1;
 
-    auto copy_to_image = vku::InitStruct<VkCopyMemoryToImageInfoEXT>();
+    VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.flags = 0;
     copy_to_image.dstImage = image;
     copy_to_image.dstImageLayout = layout;
@@ -124,7 +124,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     // Copy back to host memory
     std::vector<uint8_t> welcome_back(width * height * 4);
 
-    auto region_from_image = vku::InitStruct<VkImageToMemoryCopyEXT>();
+    VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = welcome_back.data();
     region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     region_from_image.imageSubresource.layerCount = 1;
@@ -132,7 +132,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     region_from_image.imageExtent.height = height;
     region_from_image.imageExtent.depth = 1;
 
-    auto copy_from_image = vku::InitStruct<VkCopyImageToMemoryInfoEXT>();
+    VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.flags = 0;
     copy_from_image.srcImage = image;
     copy_from_image.srcImageLayout = layout;
@@ -148,11 +148,11 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     image2.Init(image_ci);
     image2.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, layout);
 
-    auto image_copy_2 = vku::InitStruct<VkImageCopy2>();
+    VkImageCopy2 image_copy_2 = vku::InitStructHelper();
     image_copy_2.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.extent = {width, height, 1};
-    auto copy_image_to_image = vku::InitStruct<VkCopyImageToImageInfoEXT>();
+    VkCopyImageToImageInfoEXT copy_image_to_image = vku::InitStructHelper();
     copy_image_to_image.regionCount = 1;
     copy_image_to_image.pRegions = &image_copy_2;
     copy_image_to_image.srcImageLayout = layout;
@@ -173,7 +173,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     ASSERT_EQ(pixels, after_image_copy);
 
     // Do a layout transition, then use the image in new layout
-    auto transition_info = vku::InitStruct<VkHostImageLayoutTransitionInfoEXT>();
+    VkHostImageLayoutTransitionInfoEXT transition_info = vku::InitStructHelper();
     transition_info.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     transition_info.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
     transition_info.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -194,16 +194,16 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     m_commandBuffer->QueueCommandBuffer(true);
 
     // Get memory size of tiled image
-    auto subresource = vku::InitStruct<VkImageSubresource2KHR>();
+    VkImageSubresource2KHR subresource = vku::InitStructHelper();
     subresource.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    auto host_copy_size = vku::InitStruct<VkSubresourceHostMemcpySizeEXT>();
-    auto subresource_layout = vku::InitStruct<VkSubresourceLayout2KHR>(&host_copy_size);
+    VkSubresourceHostMemcpySizeEXT host_copy_size = vku::InitStructHelper();
+    VkSubresourceLayout2KHR subresource_layout = vku::InitStructHelper(&host_copy_size);
     vk::GetImageSubresourceLayout2EXT(*m_device, image, &subresource, &subresource_layout);
     ASSERT_NE(host_copy_size.size, 0);
 
-    auto perf_data = vku::InitStruct<VkHostImageCopyDevicePerformanceQueryEXT>();
-    auto image_format_properties = vku::InitStruct<VkImageFormatProperties2>(&perf_data);
-    auto image_format_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>();
+    VkHostImageCopyDevicePerformanceQueryEXT perf_data = vku::InitStructHelper();
+    VkImageFormatProperties2 image_format_properties = vku::InitStructHelper(&perf_data);
+    VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper();
     image_format_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_format_info.type = VK_IMAGE_TYPE_2D;
     image_format_info.tiling = VK_IMAGE_TILING_OPTIMAL;
@@ -239,7 +239,7 @@ TEST_F(PositiveHostImageCopy, CopyImageToMemoryMipLevel) {
     imageSubresource.baseArrayLayer = 0u;
     imageSubresource.layerCount = 1u;
 
-    auto region = vku::InitStruct<VkImageToMemoryCopyEXT>();
+    VkImageToMemoryCopyEXT region = vku::InitStructHelper();
     region.pHostPointer = data.data();
     region.memoryRowLength = 0u;
     region.memoryImageHeight = 0u;
@@ -247,7 +247,7 @@ TEST_F(PositiveHostImageCopy, CopyImageToMemoryMipLevel) {
     region.imageOffset = {0u, 0u, 0u};
     region.imageExtent = {4u, 4u, 1u};
 
-    auto copyImageToMemory = vku::InitStruct<VkCopyImageToMemoryInfoEXT>();
+    VkCopyImageToMemoryInfoEXT copyImageToMemory = vku::InitStructHelper();
     copyImageToMemory.flags = VK_HOST_IMAGE_COPY_MEMCPY_EXT;
     copyImageToMemory.srcImage = image.handle();
     copyImageToMemory.srcImageLayout = layout;

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -1384,7 +1384,7 @@ TEST_F(NegativeImage, ImageLayout) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -2536,7 +2536,7 @@ TEST_F(NegativeImage, UndefinedFormat) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_UNDEFINED;
     image_create_info.extent.width = 32;
@@ -3594,7 +3594,7 @@ TEST_F(NegativeImage, CornerSampledImageNV) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto corner_sampled_image_features = vku::InitStruct<VkPhysicalDeviceCornerSampledImageFeaturesNV>();
+    VkPhysicalDeviceCornerSampledImageFeaturesNV corner_sampled_image_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(corner_sampled_image_features);
     if (corner_sampled_image_features.cornerSampledImage != VK_TRUE) {
         GTEST_SKIP() << "cornerSampledImage feature not supported";
@@ -3789,7 +3789,7 @@ TEST_F(NegativeImage, AstcDecodeMode) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto astc_decode_features = vku::InitStruct<VkPhysicalDeviceASTCDecodeFeaturesEXT>();
+    VkPhysicalDeviceASTCDecodeFeaturesEXT astc_decode_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(astc_decode_features);
     if (!features2.features.textureCompressionASTC_LDR) {
         GTEST_SKIP() << "textureCompressionASTC_LDR feature not supported";
@@ -3962,7 +3962,7 @@ TEST_F(NegativeImage, ImageViewMissingYcbcrConversion) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features11 = vku::InitStruct<VkPhysicalDeviceVulkan11Features>();
+    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(features11);
     if (features11.samplerYcbcrConversion != VK_TRUE) {
         printf("samplerYcbcrConversion not supported, skipping test\n");
@@ -4322,7 +4322,7 @@ TEST_F(NegativeImage, ImageSplitInstanceBindRegionCountWithDeviceGroup) {
     std::vector<VkPhysicalDeviceGroupProperties> physical_device_group(physical_device_group_count,
                                                                        {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, physical_device_group.data());
-    auto create_device_pnext = vku::InitStruct<VkDeviceGroupDeviceCreateInfo>();
+    VkDeviceGroupDeviceCreateInfo create_device_pnext = vku::InitStructHelper();
     create_device_pnext.physicalDeviceCount = 0;
     create_device_pnext.pPhysicalDevices = nullptr;
     for (const auto &dg : physical_device_group) {
@@ -4401,7 +4401,7 @@ TEST_F(NegativeImage, BlockTexelViewLevelOrLayerCount) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.flags = VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
@@ -4469,7 +4469,7 @@ TEST_F(NegativeImage, BindIMageMemoryDeviceGroupInfo) {
     std::vector<VkPhysicalDeviceGroupProperties> physical_device_group(physical_device_group_count,
                                                                        {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, physical_device_group.data());
-    auto create_device_pnext = vku::InitStruct<VkDeviceGroupDeviceCreateInfo>();
+    VkDeviceGroupDeviceCreateInfo create_device_pnext = vku::InitStructHelper();
     create_device_pnext.physicalDeviceCount = 0;
     create_device_pnext.pPhysicalDevices = nullptr;
     for (const auto &dg : physical_device_group) {
@@ -4553,7 +4553,7 @@ TEST_F(NegativeImage, BlockTexelViewType) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.flags = VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_3D;
     image_create_info.format = VK_FORMAT_BC1_RGBA_SRGB_BLOCK;
@@ -4602,7 +4602,7 @@ TEST_F(NegativeImage, BlockTexelViewFormat) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.flags = VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_BC1_RGBA_SRGB_BLOCK;  // 64-bit block size
@@ -4655,7 +4655,7 @@ TEST_F(NegativeImage, ImageSubresourceRangeAspectMask) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features11 = vku::InitStruct<VkPhysicalDeviceVulkan11Features>();
+    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(features11);
     if (features11.samplerYcbcrConversion != VK_TRUE) {
         printf("samplerYcbcrConversion not supported, skipping test\n");
@@ -4724,7 +4724,7 @@ TEST_F(NegativeImage, CreateImageSharingModeConcurrentQueueFamilies) {
     AddOptionalExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    auto ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_2D;
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     ci.extent.width = 64;
@@ -4844,7 +4844,7 @@ TEST_F(NegativeImage, Image2DViewOf3D) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_2D_view_of_3D_features = vku::InitStruct<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT>();
+    VkPhysicalDeviceImage2DViewOf3DFeaturesEXT image_2D_view_of_3D_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(image_2D_view_of_3D_features);
     if (!image_2D_view_of_3D_features.image2DViewOf3D) {
         GTEST_SKIP() << "Test requires unsupported image2DViewOf3D feature";
@@ -4923,7 +4923,7 @@ TEST_F(NegativeImage, Image2DViewOf3DFeature) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_2D_view_of_3D_features = vku::InitStruct<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT>();
+    VkPhysicalDeviceImage2DViewOf3DFeaturesEXT image_2D_view_of_3D_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(image_2D_view_of_3D_features);
     image_2D_view_of_3D_features.image2DViewOf3D = VK_FALSE;
     image_2D_view_of_3D_features.sampler2DViewOf3D = VK_FALSE;
@@ -4979,7 +4979,7 @@ TEST_F(NegativeImage, ImageViewMinLod) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto image_view_min_lod_features = vku::InitStruct<VkPhysicalDeviceImageViewMinLodFeaturesEXT>();
+    VkPhysicalDeviceImageViewMinLodFeaturesEXT image_view_min_lod_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(image_view_min_lod_features);
     if (image_view_min_lod_features.minLod == VK_FALSE) {
         GTEST_SKIP() << "Test requires unsupported minLod feature";
@@ -5013,7 +5013,7 @@ TEST_F(NegativeImage, ImageViewMinLod) {
     ivci.subresourceRange.baseArrayLayer = 0;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    auto ivml = vku::InitStruct<VkImageViewMinLodCreateInfoEXT>();
+    VkImageViewMinLodCreateInfoEXT ivml = vku::InitStructHelper();
     ivml.minLod = 4.0;
     ivci.pNext = &ivml;
 
@@ -5047,7 +5047,7 @@ TEST_F(NegativeImage, ImageViewMinLodFeature) {
     ivci.subresourceRange.baseArrayLayer = 0;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    auto ivml = vku::InitStruct<VkImageViewMinLodCreateInfoEXT>();
+    VkImageViewMinLodCreateInfoEXT ivml = vku::InitStructHelper();
     ivml.minLod = 1.0;
     ivci.pNext = &ivml;
 
@@ -5092,10 +5092,10 @@ TEST_F(NegativeImage, ImageCopyMissingUsage) {
     }
 
     auto format = FindSupportedDepthStencilFormat(gpu());
-    auto stencil_usage_ci = vku::InitStruct<VkImageStencilUsageCreateInfo>();
+    VkImageStencilUsageCreateInfo stencil_usage_ci = vku::InitStructHelper();
     stencil_usage_ci.stencilUsage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    auto image_ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.format = format;
     image_ci.extent.width = 32;
@@ -5187,7 +5187,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_compression_control = vku::InitStruct<VkPhysicalDeviceImageCompressionControlFeaturesEXT>();
+    VkPhysicalDeviceImageCompressionControlFeaturesEXT image_compression_control = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(image_compression_control);
     if (!image_compression_control.imageCompressionControl) {
         GTEST_SKIP() << "Test requires (unsupported) imageCompressionControl, skipping.";
@@ -5196,7 +5196,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
     // A bit set flag bit
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &image_compression_control));
     {
-        auto compression_control = vku::InitStruct<VkImageCompressionControlEXT>();  // specify the desired compression settings
+        VkImageCompressionControlEXT compression_control = vku::InitStructHelper();  // specify the desired compression settings
         compression_control.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_DEFAULT_EXT | VK_IMAGE_COMPRESSION_DISABLED_EXT;
 
         auto image_create_info = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
@@ -5208,7 +5208,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
 
     // Explicit Fixed Rate
     {
-        auto compression_control = vku::InitStruct<VkImageCompressionControlEXT>();  // specify the desired compression settings
+        VkImageCompressionControlEXT compression_control = vku::InitStructHelper();  // specify the desired compression settings
         compression_control.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_EXPLICIT_EXT;
         compression_control.pFixedRateFlags = nullptr;
 
@@ -5221,7 +5221,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
 
     // Image creation lambda
     const auto create_compressed_image = [&](VkFormat format, VkImageTiling imageTiling, VkImageObj &image) -> bool {
-        auto compression_control = vku::InitStruct<VkImageCompressionControlEXT>();  // specify the desired compression settings
+        VkImageCompressionControlEXT compression_control = vku::InitStructHelper();  // specify the desired compression settings
         compression_control.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_DEFAULT_EXT;
 
         auto image_create_info =
@@ -5400,8 +5400,8 @@ TEST_F(NegativeImage, GetImageSubresourceLayout2Maintenance5) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
-    auto multi_draw_features = vku::InitStruct<VkPhysicalDeviceMultiDrawFeaturesEXT>(&maintenance5_features);
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultiDrawFeaturesEXT multi_draw_features = vku::InitStructHelper(&maintenance5_features);
     GetPhysicalDeviceFeatures2(multi_draw_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &multi_draw_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -5413,9 +5413,9 @@ TEST_F(NegativeImage, GetImageSubresourceLayout2Maintenance5) {
 
     // Exceed MipmapLevel
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-mipLevel-01716");
-    auto subresource = vku::InitStruct<VkImageSubresource2KHR>();
+    VkImageSubresource2KHR subresource = vku::InitStructHelper();
     subresource.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 1, 0};
-    auto layout = vku::InitStruct<VkSubresourceLayout2KHR>();
+    VkSubresourceLayout2KHR layout = vku::InitStructHelper();
     vk::GetImageSubresourceLayout2KHR(m_device->handle(), image.handle(), &subresource, &layout);
     m_errorMonitor->VerifyFound();
 
@@ -5459,7 +5459,7 @@ TEST_F(NegativeImage, AttachmentFeedbackLoopLayoutFeature) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -5474,14 +5474,14 @@ TEST_F(NegativeImage, AttachmentFeedbackLoopLayoutFeature) {
     m_errorMonitor->VerifyFound();
 
     m_commandBuffer->begin();
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier2KHR>();
+    VkImageMemoryBarrier2KHR img_barrier = vku::InitStructHelper();
     img_barrier.image = image.handle();
     img_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     img_barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     img_barrier.dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     img_barrier.newLayout = VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT;
 
-    auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dep_info = vku::InitStructHelper();
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &img_barrier;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageMemoryBarrier2-attachmentFeedbackLoopLayout-07313");
@@ -5571,7 +5571,7 @@ TEST_F(NegativeImage, SlicedDeviceFeature) {
     InitState();
 
     VkImageObj image(m_device);
-    auto ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_3D;
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     ci.extent = {32, 32, 8};
@@ -5585,11 +5585,11 @@ TEST_F(NegativeImage, SlicedDeviceFeature) {
     image.init(&ci);
     ASSERT_TRUE(image.initialized());
 
-    auto sliced_info = vku::InitStruct<VkImageViewSlicedCreateInfoEXT>();
+    VkImageViewSlicedCreateInfoEXT sliced_info = vku::InitStructHelper();
     sliced_info.sliceCount = VK_REMAINING_3D_SLICES_EXT;
     sliced_info.sliceOffset = 0;
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>(&sliced_info);
+    VkImageViewCreateInfo ivci = vku::InitStructHelper(&sliced_info);
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_3D;
     ivci.format = ci.format;
@@ -5619,7 +5619,7 @@ TEST_F(NegativeImage, SlicedImageType) {
     }
 
     {
-        auto slice_feature = vku::InitStruct<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT>();
+        VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT slice_feature = vku::InitStructHelper();
         GetPhysicalDeviceFeatures2(slice_feature);
         if (slice_feature.imageSlicedViewOf3D == VK_FALSE) {
             GTEST_SKIP() << "Test requires (unsupported) imageSlicedViewOf3D";
@@ -5628,7 +5628,7 @@ TEST_F(NegativeImage, SlicedImageType) {
     }
 
     VkImageObj image(m_device);
-    auto ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_2D;  // imageType should be VK_IMAGE_TYPE_3D
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     ci.extent = {32, 32, 1};
@@ -5642,11 +5642,11 @@ TEST_F(NegativeImage, SlicedImageType) {
     image.init(&ci);
     ASSERT_TRUE(image.initialized());
 
-    auto sliced_info = vku::InitStruct<VkImageViewSlicedCreateInfoEXT>();
+    VkImageViewSlicedCreateInfoEXT sliced_info = vku::InitStructHelper();
     sliced_info.sliceCount = VK_REMAINING_3D_SLICES_EXT;
     sliced_info.sliceOffset = 0;
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>(&sliced_info);
+    VkImageViewCreateInfo ivci = vku::InitStructHelper(&sliced_info);
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;  // viewType should be VK_IMAGE_VIEW_TYPE_3D
     ivci.format = ci.format;
@@ -5677,7 +5677,7 @@ TEST_F(NegativeImage, SlicedMipLevel) {
     }
 
     {
-        auto slice_feature = vku::InitStruct<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT>();
+        VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT slice_feature = vku::InitStructHelper();
         GetPhysicalDeviceFeatures2(slice_feature);
         if (slice_feature.imageSlicedViewOf3D == VK_FALSE) {
             GTEST_SKIP() << "Test requires (unsupported) imageSlicedViewOf3D";
@@ -5686,7 +5686,7 @@ TEST_F(NegativeImage, SlicedMipLevel) {
     }
 
     VkImageObj image(m_device);
-    auto ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_3D;
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     ci.extent = {32, 32, 8};
@@ -5700,11 +5700,11 @@ TEST_F(NegativeImage, SlicedMipLevel) {
     image.init(&ci);
     ASSERT_TRUE(image.initialized());
 
-    auto sliced_info = vku::InitStruct<VkImageViewSlicedCreateInfoEXT>();
+    VkImageViewSlicedCreateInfoEXT sliced_info = vku::InitStructHelper();
     sliced_info.sliceCount = VK_REMAINING_3D_SLICES_EXT;
     sliced_info.sliceOffset = 0;
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>(&sliced_info);
+    VkImageViewCreateInfo ivci = vku::InitStructHelper(&sliced_info);
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_3D;
     ivci.format = ci.format;
@@ -5770,7 +5770,7 @@ TEST_F(NegativeImage, SlicedUsage) {
     }
 
     {
-        auto slice_feature = vku::InitStruct<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT>();
+        VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT slice_feature = vku::InitStructHelper();
         GetPhysicalDeviceFeatures2(slice_feature);
         if (slice_feature.imageSlicedViewOf3D == VK_FALSE) {
             GTEST_SKIP() << "Test requires (unsupported) imageSlicedViewOf3D";
@@ -5779,7 +5779,7 @@ TEST_F(NegativeImage, SlicedUsage) {
     }
 
     VkImageObj image(m_device);
-    auto ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_3D;
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     ci.extent = {32, 32, 8};
@@ -5793,9 +5793,9 @@ TEST_F(NegativeImage, SlicedUsage) {
     image.init(&ci);
     ASSERT_TRUE(image.initialized());
 
-    auto sliced_info = vku::InitStruct<VkImageViewSlicedCreateInfoEXT>();
+    VkImageViewSlicedCreateInfoEXT sliced_info = vku::InitStructHelper();
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>(&sliced_info);
+    VkImageViewCreateInfo ivci = vku::InitStructHelper(&sliced_info);
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_3D;
     ivci.format = ci.format;
@@ -5873,7 +5873,7 @@ TEST_F(NegativeImage, ImageViewTextureSampleWeighted) {
         GTEST_SKIP() << "Vulkan >= 1.1 required";
     }
 
-    auto image_proc_features = vku::InitStruct<VkPhysicalDeviceImageProcessingFeaturesQCOM>();
+    VkPhysicalDeviceImageProcessingFeaturesQCOM image_proc_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(image_proc_features);
 
     if (image_proc_features.textureSampleWeighted == VK_FALSE) {
@@ -5881,12 +5881,12 @@ TEST_F(NegativeImage, ImageViewTextureSampleWeighted) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &image_proc_features));
 
-    auto image_proc_properties = vku::InitStruct<VkPhysicalDeviceImageProcessingPropertiesQCOM>();
+    VkPhysicalDeviceImageProcessingPropertiesQCOM image_proc_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(image_proc_properties);
 
     // check the format feature flags
-    auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-    auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+    VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+    VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
     vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8_UNORM, &fmt_props);
     if ((fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM) == 0) {
         GTEST_SKIP() << "Required VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM bit not supported for R8_UNORM";
@@ -5966,14 +5966,14 @@ TEST_F(NegativeImage, ImageViewTextureSampleWeighted) {
     const VkComponentMapping identity = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
                                          VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY};
 
-    auto ivswci = vku::InitStruct<VkImageViewSampleWeightCreateInfoQCOM>();
+    VkImageViewSampleWeightCreateInfoQCOM ivswci = vku::InitStructHelper();
     ivswci.filterCenter.x = 32;
     ivswci.filterCenter.y = 32;
     ivswci.filterSize.height = 64;
     ivswci.filterSize.width = 64;
     ivswci.numPhases = 64;  // 8 vert * 8 horiz
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.pNext = &ivswci;
     ivci.image = weight_image2D.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;

--- a/tests/unit/image_drm.cpp
+++ b/tests/unit/image_drm.cpp
@@ -22,7 +22,7 @@ TEST_F(NegativeImageDrm, Basic) {
         GTEST_SKIP() << "No valid Format Modifier found";
     }
 
-    auto image_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_info = vku::InitStructHelper();
     image_info.imageType = VK_IMAGE_TYPE_2D;
     image_info.arrayLayers = 1;
     image_info.extent = {64, 64, 1};
@@ -33,13 +33,13 @@ TEST_F(NegativeImageDrm, Basic) {
     image_info.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    auto image_format_prop = vku::InitStruct<VkImageFormatProperties2>();
-    auto image_format_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>();
+    VkImageFormatProperties2 image_format_prop = vku::InitStructHelper();
+    VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper();
     image_format_info.format = image_info.format;
     image_format_info.tiling = image_info.tiling;
     image_format_info.type = image_info.imageType;
     image_format_info.usage = image_info.usage;
-    auto drm_format_mod_info = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+    VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_mod_info = vku::InitStructHelper();
     drm_format_mod_info.drmFormatModifier = mods[0];
     drm_format_mod_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     drm_format_mod_info.queueFamilyIndexCount = 0;
@@ -56,11 +56,11 @@ TEST_F(NegativeImageDrm, Basic) {
 
     VkSubresourceLayout fake_plane_layout = {0, 0, 0, 0, 0};
 
-    auto drm_format_mod_list = vku::InitStruct<VkImageDrmFormatModifierListCreateInfoEXT>();
+    VkImageDrmFormatModifierListCreateInfoEXT drm_format_mod_list = vku::InitStructHelper();
     drm_format_mod_list.drmFormatModifierCount = mods.size();
     drm_format_mod_list.pDrmFormatModifiers = mods.data();
 
-    auto drm_format_mod_explicit = vku::InitStruct<VkImageDrmFormatModifierExplicitCreateInfoEXT>();
+    VkImageDrmFormatModifierExplicitCreateInfoEXT drm_format_mod_explicit = vku::InitStructHelper();
     drm_format_mod_explicit.drmFormatModifierPlaneCount = 1;
     drm_format_mod_explicit.pPlaneLayouts = &fake_plane_layout;
 
@@ -80,7 +80,7 @@ TEST_F(NegativeImageDrm, Basic) {
     // reset dummy plane layout
     memset(&fake_plane_layout, 0, sizeof(fake_plane_layout));
 
-    auto drm_format_modifier = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+    VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
     drm_format_modifier.drmFormatModifier = mods[1];
     image_format_info.pNext = &drm_format_modifier;
     VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &image_format_info, &image_format_prop);
@@ -113,16 +113,16 @@ TEST_F(NegativeImageDrm, ImageFormatInfo) {
     InitBasicImageDrm();
     if (::testing::Test::IsSkipped()) return;
 
-    auto image_drm_format_modifier = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+    VkPhysicalDeviceImageDrmFormatModifierInfoEXT image_drm_format_modifier = vku::InitStructHelper();
 
-    auto image_format_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&image_drm_format_modifier);
+    VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper(&image_drm_format_modifier);
     image_format_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_format_info.type = VK_IMAGE_TYPE_2D;
     image_format_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_format_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_format_info.flags = 0;
 
-    auto image_format_properties = vku::InitStruct<VkImageFormatProperties2>();
+    VkImageFormatProperties2 image_format_properties = vku::InitStructHelper();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249");
     vk::GetPhysicalDeviceImageFormatProperties2KHR(gpu(), &image_format_info, &image_format_properties);
     m_errorMonitor->VerifyFound();
@@ -133,7 +133,7 @@ TEST_F(NegativeImageDrm, ImageFormatInfo) {
     vk::GetPhysicalDeviceImageFormatProperties2KHR(gpu(), &image_format_info, &image_format_properties);
     m_errorMonitor->VerifyFound();
 
-    auto format_list = vku::InitStruct<VkImageFormatListCreateInfo>(&image_drm_format_modifier);
+    VkImageFormatListCreateInfo format_list = vku::InitStructHelper(&image_drm_format_modifier);
     format_list.viewFormatCount = 0;  // Invalid
     image_format_info.pNext = &format_list;
     image_format_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
@@ -153,10 +153,10 @@ TEST_F(NegativeImageDrm, GetImageSubresourceLayoutPlane) {
         GTEST_SKIP() << "No valid Format Modifier found";
     }
 
-    auto list_create_info = vku::InitStruct<VkImageDrmFormatModifierListCreateInfoEXT>();
+    VkImageDrmFormatModifierListCreateInfoEXT list_create_info = vku::InitStructHelper();
     list_create_info.drmFormatModifierCount = mods.size();
     list_create_info.pDrmFormatModifiers = mods.data();
-    auto create_info = vku::InitStruct<VkImageCreateInfo>(&list_create_info);
+    VkImageCreateInfo create_info = vku::InitStructHelper(&list_create_info);
     create_info.imageType = VK_IMAGE_TYPE_2D;
     create_info.format = format;
     create_info.extent.width = 64;
@@ -169,16 +169,16 @@ TEST_F(NegativeImageDrm, GetImageSubresourceLayoutPlane) {
     create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     for (uint64_t mod : mods) {
-        auto drm_format_modifier = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+        VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
         drm_format_modifier.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         drm_format_modifier.drmFormatModifier = mod;
-        auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&drm_format_modifier);
+        VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&drm_format_modifier);
         image_info.format = format;
         image_info.type = create_info.imageType;
         image_info.tiling = create_info.tiling;
         image_info.usage = create_info.usage;
         image_info.flags = create_info.flags;
-        auto image_properties = vku::InitStruct<VkImageFormatProperties2>();
+        VkImageFormatProperties2 image_properties = vku::InitStructHelper();
         if (vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties) != VK_SUCCESS) {
             // Works with Mesa, Pixel 7 doesn't support this combo
             GTEST_SKIP() << "Required formats/features not supported";
@@ -208,11 +208,11 @@ TEST_F(NegativeImageDrm, DeviceImageMemoryRequirements) {
     if (::testing::Test::IsSkipped()) return;
 
     VkSubresourceLayout planeLayout = {0, 0, 0, 0, 0};
-    auto drm_format_modifier_create_info = vku::InitStruct<VkImageDrmFormatModifierExplicitCreateInfoEXT>();
+    VkImageDrmFormatModifierExplicitCreateInfoEXT drm_format_modifier_create_info = vku::InitStructHelper();
     drm_format_modifier_create_info.drmFormatModifierPlaneCount = 1;
     drm_format_modifier_create_info.pPlaneLayouts = &planeLayout;
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>(&drm_format_modifier_create_info);
+    VkImageCreateInfo image_create_info = vku::InitStructHelper(&drm_format_modifier_create_info);
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_create_info.extent = {32, 32, 1};
@@ -222,11 +222,11 @@ TEST_F(NegativeImageDrm, DeviceImageMemoryRequirements) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.arrayLayers = 1;
 
-    auto device_image_memory_requirements = vku::InitStruct<VkDeviceImageMemoryRequirementsKHR>();
+    VkDeviceImageMemoryRequirementsKHR device_image_memory_requirements = vku::InitStructHelper();
     device_image_memory_requirements.pCreateInfo = &image_create_info;
     device_image_memory_requirements.planeAspect = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    auto memory_requirements = vku::InitStruct<VkMemoryRequirements2>();
+    VkMemoryRequirements2 memory_requirements = vku::InitStructHelper();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageMemoryRequirements-pCreateInfo-06776");
     vk::GetDeviceImageMemoryRequirementsKHR(device(), &device_image_memory_requirements, &memory_requirements);
@@ -272,11 +272,11 @@ TEST_F(NegativeImageDrm, MutableFormat) {
         GTEST_SKIP() << "No valid Format Modifier found";
     }
 
-    auto mod_list = vku::InitStruct<VkImageDrmFormatModifierListCreateInfoEXT>();
+    VkImageDrmFormatModifierListCreateInfoEXT mod_list = vku::InitStructHelper();
     mod_list.pDrmFormatModifiers = mods.data();
     mod_list.drmFormatModifierCount = mods.size();
 
-    auto image_info = vku::InitStruct<VkImageCreateInfo>(&mod_list);
+    VkImageCreateInfo image_info = vku::InitStructHelper(&mod_list);
     image_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_info.imageType = VK_IMAGE_TYPE_2D;
     image_info.arrayLayers = 1;
@@ -289,7 +289,7 @@ TEST_F(NegativeImageDrm, MutableFormat) {
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     CreateImageTest(*this, &image_info, "VUID-VkImageCreateInfo-tiling-02353");
 
-    auto format_list = vku::InitStruct<VkImageFormatListCreateInfo>();
+    VkImageFormatListCreateInfo format_list = vku::InitStructHelper();
     format_list.viewFormatCount = 0;
     mod_list.pNext = &format_list;
     CreateImageTest(*this, &image_info, "VUID-VkImageCreateInfo-tiling-02353");
@@ -301,17 +301,17 @@ TEST_F(NegativeImageDrm, CompressionControl) {
     InitBasicImageDrm();
     if (::testing::Test::IsSkipped()) return;
 
-    auto compression_control = vku::InitStruct<VkImageCompressionControlEXT>();
+    VkImageCompressionControlEXT compression_control = vku::InitStructHelper();
     compression_control.flags = VK_IMAGE_COMPRESSION_DEFAULT_EXT;
     compression_control.compressionControlPlaneCount = 1;
     compression_control.pFixedRateFlags = nullptr;
 
     VkSubresourceLayout fake_plane_layout = {0, 0, 0, 0, 0};
-    auto drm_format_mod_explicit = vku::InitStruct<VkImageDrmFormatModifierExplicitCreateInfoEXT>(&compression_control);
+    VkImageDrmFormatModifierExplicitCreateInfoEXT drm_format_mod_explicit = vku::InitStructHelper(&compression_control);
     drm_format_mod_explicit.drmFormatModifierPlaneCount = 1;
     drm_format_mod_explicit.pPlaneLayouts = &fake_plane_layout;
 
-    auto image_info = vku::InitStruct<VkImageCreateInfo>(&drm_format_mod_explicit);
+    VkImageCreateInfo image_info = vku::InitStructHelper(&drm_format_mod_explicit);
     image_info.imageType = VK_IMAGE_TYPE_2D;
     image_info.arrayLayers = 1;
     image_info.extent = {64, 64, 1};
@@ -329,7 +329,7 @@ TEST_F(NegativeImageDrm, GetImageDrmFormatModifierProperties) {
     InitBasicImageDrm();
     if (::testing::Test::IsSkipped()) return;
 
-    auto image_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_info = vku::InitStructHelper();
     image_info.imageType = VK_IMAGE_TYPE_2D;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_info.extent = {128, 128, 1};
@@ -342,7 +342,7 @@ TEST_F(NegativeImageDrm, GetImageDrmFormatModifierProperties) {
     image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     vkt::Image image(*m_device, image_info);
 
-    auto props = vku::InitStruct<VkImageDrmFormatModifierPropertiesEXT>();
+    VkImageDrmFormatModifierPropertiesEXT props = vku::InitStructHelper();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageDrmFormatModifierPropertiesEXT-image-02272");
     vk::GetImageDrmFormatModifierPropertiesEXT(device(), image.handle(), &props);
     m_errorMonitor->VerifyFound();
@@ -359,21 +359,21 @@ TEST_F(NegativeImageDrm, PhysicalDeviceImageDrmFormatModifierInfo) {
     InitBasicImageDrm();
     if (::testing::Test::IsSkipped()) return;
 
-    auto drm_format_modifier = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+    VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
     drm_format_modifier.sharingMode = VK_SHARING_MODE_CONCURRENT;
     drm_format_modifier.queueFamilyIndexCount = 0;
 
-    auto external_image_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>(&drm_format_modifier);
+    VkPhysicalDeviceExternalImageFormatInfo external_image_info = vku::InitStructHelper(&drm_format_modifier);
     external_image_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
-    auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_image_info);
+    VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_image_info);
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_info.type = VK_IMAGE_TYPE_2D;
     image_info.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
     image_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_info.flags = 0;
 
-    auto image_properties = vku::InitStruct<VkImageFormatProperties2>();
+    VkImageFormatProperties2 image_properties = vku::InitStructHelper();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceImageDrmFormatModifierInfoEXT-sharingMode-02315");
     vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
@@ -399,22 +399,22 @@ TEST_F(NegativeImageDrm, PhysicalDeviceImageDrmFormatModifierInfoQuery) {
     }
     uint32_t queue_family_indices[2] = {0, 1};
 
-    auto drm_format_modifier = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+    VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
     drm_format_modifier.sharingMode = VK_SHARING_MODE_CONCURRENT;
     drm_format_modifier.queueFamilyIndexCount = 2;
     drm_format_modifier.pQueueFamilyIndices = queue_family_indices;
 
-    auto external_image_info = vku::InitStruct<VkPhysicalDeviceExternalImageFormatInfo>(&drm_format_modifier);
+    VkPhysicalDeviceExternalImageFormatInfo external_image_info = vku::InitStructHelper(&drm_format_modifier);
     external_image_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
-    auto image_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>(&external_image_info);
+    VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_image_info);
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_info.type = VK_IMAGE_TYPE_2D;
     image_info.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
     image_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_info.flags = 0;
 
-    auto image_properties = vku::InitStruct<VkImageFormatProperties2>();
+    VkImageFormatProperties2 image_properties = vku::InitStructHelper();
 
     // Count too large
     queue_family_indices[0] = queue_family_property_count + 1;

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -19,7 +19,7 @@
 
 // A reasonable well supported default VkImageCreateInfo for image creation
 VkImageCreateInfo ImageTest::DefaultImageInfo() {
-    auto ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo ci = vku::InitStructHelper();
     ci.flags = 0;                          // assumably any is supported
     ci.imageType = VK_IMAGE_TYPE_2D;       // any is supported
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;  // has mandatory support for all usages
@@ -119,7 +119,7 @@ TEST_F(PositiveImage, UncompressedToCompressedImageCopy) {
                      comp_10x10b_40x40t_image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     // The next copy swaps source and dest s.t. we need an execution barrier on for the prior source and an access barrier for
     // prior dest
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     image_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
     image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -558,7 +558,7 @@ TEST_F(PositiveImage, ImagelessLayoutTracking) {
     vkt::RenderPass renderPass(*m_device, renderPassCreateInfo);
 
     // Create an image to use in an imageless framebuffer.  Bind swapchain memory to it.
-    auto image_swapchain_create_info = vku::InitStruct<VkImageSwapchainCreateInfoKHR>();
+    VkImageSwapchainCreateInfoKHR image_swapchain_create_info = vku::InitStructHelper();
     image_swapchain_create_info.swapchain = m_swapchain;
     VkImageCreateInfo imageCreateInfo = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                                          &image_swapchain_create_info,
@@ -579,18 +579,18 @@ TEST_F(PositiveImage, ImagelessLayoutTracking) {
     VkImageObj image(m_device);
     image.init_no_mem(*m_device, imageCreateInfo);
 
-    auto bind_devicegroup_info = vku::InitStruct<VkBindImageMemoryDeviceGroupInfo>();
+    VkBindImageMemoryDeviceGroupInfo bind_devicegroup_info = vku::InitStructHelper();
     bind_devicegroup_info.deviceIndexCount = 1;
     std::array<uint32_t, 2> deviceIndices = {{0}};
     bind_devicegroup_info.pDeviceIndices = deviceIndices.data();
     bind_devicegroup_info.splitInstanceBindRegionCount = 0;
     bind_devicegroup_info.pSplitInstanceBindRegions = nullptr;
 
-    auto bind_swapchain_info = vku::InitStruct<VkBindImageMemorySwapchainInfoKHR>(&bind_devicegroup_info);
+    VkBindImageMemorySwapchainInfoKHR bind_swapchain_info = vku::InitStructHelper(&bind_devicegroup_info);
     bind_swapchain_info.swapchain = m_swapchain;
     bind_swapchain_info.imageIndex = 0;
 
-    auto bind_info = vku::InitStruct<VkBindImageMemoryInfo>(&bind_swapchain_info);
+    VkBindImageMemoryInfo bind_info = vku::InitStructHelper(&bind_swapchain_info);
     bind_info.image = image.image();
     bind_info.memory = VK_NULL_HANDLE;
     bind_info.memoryOffset = 0;
@@ -665,7 +665,7 @@ TEST_F(PositiveImage, ExtendedUsageWithDifferentFormatViews) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.flags =
         VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_EXTENDED_USAGE_BIT | VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
     image_ci.imageType = VK_IMAGE_TYPE_2D;
@@ -698,7 +698,7 @@ TEST_F(PositiveImage, ExtendedUsageWithDifferentFormatViews) {
     ASSERT_TRUE(image.handle() != VK_NULL_HANDLE);
 
     // Since the format is compatible with all image's usage, there's no need to restrict usage
-    auto iv_ci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo iv_ci = vku::InitStructHelper();
     iv_ci.image = image.handle();
     iv_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     iv_ci.format = VK_FORMAT_R32G32B32A32_UINT;
@@ -735,7 +735,7 @@ TEST_F(PositiveImage, ImageCompressionControl) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_compression_control = vku::InitStruct<VkPhysicalDeviceImageCompressionControlFeaturesEXT>();
+    VkPhysicalDeviceImageCompressionControlFeaturesEXT image_compression_control = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(image_compression_control);
     if (!image_compression_control.imageCompressionControl) {
         GTEST_SKIP() << "Test requires (unsupported) imageCompressionControl, skipping";
@@ -744,14 +744,14 @@ TEST_F(PositiveImage, ImageCompressionControl) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &image_compression_control));
 
     // Query possible image format with vkGetPhysicalDeviceImageFormatProperties2KHR
-    auto image_format_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>();
+    VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper();
     image_format_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_format_info.tiling = VK_IMAGE_TILING_LINEAR;
     image_format_info.type = VK_IMAGE_TYPE_2D;
     image_format_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
-    auto compression_properties = vku::InitStruct<VkImageCompressionPropertiesEXT>();
-    auto image_format_properties = vku::InitStruct<VkImageFormatProperties2>(&compression_properties);
+    VkImageCompressionPropertiesEXT compression_properties = vku::InitStructHelper();
+    VkImageFormatProperties2 image_format_properties = vku::InitStructHelper(&compression_properties);
 
     vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
 
@@ -763,7 +763,7 @@ TEST_F(PositiveImage, ImageCompressionControl) {
 
     // Create with disabled image compression
     {
-        auto compressionControl = vku::InitStruct<VkImageCompressionControlEXT>();
+        VkImageCompressionControlEXT compressionControl = vku::InitStructHelper();
         compressionControl.flags = VK_IMAGE_COMPRESSION_DISABLED_EXT;
         image_ci.pNext = &compressionControl;
 
@@ -772,7 +772,7 @@ TEST_F(PositiveImage, ImageCompressionControl) {
 
     // Create with default image compression, without fixed rate
     {
-        auto compressionControl = vku::InitStruct<VkImageCompressionControlEXT>();
+        VkImageCompressionControlEXT compressionControl = vku::InitStructHelper();
         compressionControl.flags = VK_IMAGE_COMPRESSION_DEFAULT_EXT;
         image_ci.pNext = &compressionControl;
 
@@ -781,7 +781,7 @@ TEST_F(PositiveImage, ImageCompressionControl) {
 
     // Create with fixed rate compression image
     {
-        auto compressionControl = vku::InitStruct<VkImageCompressionControlEXT>();
+        VkImageCompressionControlEXT compressionControl = vku::InitStructHelper();
         compressionControl.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_DEFAULT_EXT;
         image_ci.pNext = &compressionControl;
 
@@ -802,7 +802,7 @@ TEST_F(PositiveImage, ImageCompressionControl) {
         ASSERT_TRUE(supported_compression_fixed_rate != VK_IMAGE_COMPRESSION_FIXED_RATE_NONE_EXT);
 
         VkImageCompressionFixedRateFlagsEXT fixedRageFlags = supported_compression_fixed_rate;
-        auto compressionControl = vku::InitStruct<VkImageCompressionControlEXT>();
+        VkImageCompressionControlEXT compressionControl = vku::InitStructHelper();
         compressionControl.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_EXPLICIT_EXT;
         compressionControl.pFixedRateFlags = &fixedRageFlags;
         compressionControl.compressionControlPlaneCount = 1;
@@ -818,7 +818,7 @@ TEST_F(PositiveImage, Create3DImageView) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     VkImageObj image(m_device);
-    auto ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_3D;
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     ci.extent = {32, 32, 8};
@@ -832,7 +832,7 @@ TEST_F(PositiveImage, Create3DImageView) {
     image.init(&ci);
     ASSERT_TRUE(image.initialized());
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_3D;
     ivci.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -859,7 +859,7 @@ TEST_F(PositiveImage, SlicedCreateInfo) {
     }
 
     {
-        auto slice_feature = vku::InitStruct<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT>();
+        VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT slice_feature = vku::InitStructHelper();
         GetPhysicalDeviceFeatures2(slice_feature);
         if (slice_feature.imageSlicedViewOf3D == VK_FALSE) {
             GTEST_SKIP() << "Test requires (unsupported) imageSlicedViewOf3D";
@@ -868,7 +868,7 @@ TEST_F(PositiveImage, SlicedCreateInfo) {
     }
 
     VkImageObj image(m_device);
-    auto ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_3D;
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     ci.extent = {32, 32, 8};
@@ -882,9 +882,9 @@ TEST_F(PositiveImage, SlicedCreateInfo) {
     image.init(&ci);
     ASSERT_TRUE(image.initialized());
 
-    auto sliced_info = vku::InitStruct<VkImageViewSlicedCreateInfoEXT>();
+    VkImageViewSlicedCreateInfoEXT sliced_info = vku::InitStructHelper();
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>(&sliced_info);
+    VkImageViewCreateInfo ivci = vku::InitStructHelper(&sliced_info);
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_3D;
     ivci.format = ci.format;
@@ -1012,7 +1012,7 @@ TEST_F(PositiveImage, CopyImageSubresource) {
     vk::CmdClearColorImage(cb, image.handle(), dst_layout, &clear_color, 1, &src_range);
     m_commandBuffer->end();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
 
@@ -1078,7 +1078,7 @@ TEST_F(PositiveImage, DescriptorSubresourceLayout) {
     VkImageSubresourceRange view_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 3, 1};
     VkImageSubresourceRange first_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     VkImageSubresourceRange full_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 5};
-    auto image_view_create_info = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo image_view_create_info = vku::InitStructHelper();
     image_view_create_info.image = image.handle();
     image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_create_info.format = format;
@@ -1129,7 +1129,7 @@ TEST_F(PositiveImage, DescriptorSubresourceLayout) {
 
         for (TestType test_type : test_list) {
             auto init_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-            auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+            VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
 
             cmd_buf.begin();
             image_barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
@@ -1210,7 +1210,7 @@ TEST_F(VkPositiveLayerTest, ImageDescriptor3D2DSubresourceLayout) {
     static const uint32_t kWidth = 128;
     static const uint32_t kHeight = 128;
 
-    auto image_ci_3d = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_ci_3d = vku::InitStructHelper();
     image_ci_3d.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
     image_ci_3d.imageType = VK_IMAGE_TYPE_3D;
     image_ci_3d.format = format;
@@ -1239,7 +1239,7 @@ TEST_F(VkPositiveLayerTest, ImageDescriptor3D2DSubresourceLayout) {
     //    to the entire subresource referenced which is the entire mip level in this case.
     VkImageSubresourceRange full_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     vkt::ImageView view_2d, other_view;
-    auto image_view_create_info = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo image_view_create_info = vku::InitStructHelper();
     image_view_create_info.image = image_3d.handle();
     image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_create_info.format = format;
@@ -1336,7 +1336,7 @@ TEST_F(VkPositiveLayerTest, ImageDescriptor3D2DSubresourceLayout) {
         vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
 
         for (TestType test_type : test_list) {
-            auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+            VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
 
             VkFramebufferCreateInfo fbci = {
                 VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.handle(), 1, &view->handle(), kWidth, kHeight, 1};

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -27,7 +27,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     }
     bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
-    auto imageless_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
+    VkPhysicalDeviceImagelessFramebufferFeaturesKHR imageless_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(imageless_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -47,7 +47,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     VkSubpassDescription subpassDescription = {};
     subpassDescription.colorAttachmentCount = 1;
     subpassDescription.pColorAttachments = &attachmentReference;
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpassDescription;
     rpci.attachmentCount = 1;
@@ -422,8 +422,8 @@ TEST_F(NegativeImagelessFramebuffer, BasicUsage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto mv_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>();
-    auto imageless_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
+    VkPhysicalDeviceMultiviewFeaturesKHR mv_features = vku::InitStructHelper();
+    VkPhysicalDeviceImagelessFramebufferFeaturesKHR imageless_features = vku::InitStructHelper();
     if (IsExtensionsEnabled(VK_KHR_MULTIVIEW_EXTENSION_NAME)) {
         imageless_features.pNext = &mv_features;
     }
@@ -536,7 +536,7 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImageUsageMismatch) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto imageless_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
+    VkPhysicalDeviceImagelessFramebufferFeaturesKHR imageless_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(imageless_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -681,8 +681,8 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentMultiviewImageLayerCountMismatch)
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto mv_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>();
-    auto imageless_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>(&mv_features);
+    VkPhysicalDeviceMultiviewFeaturesKHR mv_features = vku::InitStructHelper();
+    VkPhysicalDeviceImagelessFramebufferFeaturesKHR imageless_features = vku::InitStructHelper(&mv_features);
     GetPhysicalDeviceFeatures2(imageless_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -833,8 +833,8 @@ TEST_F(NegativeImagelessFramebuffer, DepthStencilResolveAttachment) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto mv_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>();
-    auto imageless_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>(&mv_features);
+    VkPhysicalDeviceMultiviewFeaturesKHR mv_features = vku::InitStructHelper();
+    VkPhysicalDeviceImagelessFramebufferFeaturesKHR imageless_features = vku::InitStructHelper(&mv_features);
     GetPhysicalDeviceFeatures2(imageless_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -944,11 +944,11 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateUsage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
-    auto if_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeatures>();
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(&if_features);
+    VkPhysicalDeviceImagelessFramebufferFeatures if_features = vku::InitStructHelper();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper(&if_features);
     auto features2 = GetPhysicalDeviceFeatures2(fsr_features);
 
     if (fsr_features.attachmentFragmentShadingRate != VK_TRUE) {
@@ -968,7 +968,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateUsage) {
     // Create a renderPass with a single fsr attachment
     VkSubpassDescription2 subpass = vku::InitStructHelper(&fsr_attachment);
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8_UINT;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -1022,15 +1022,15 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensions) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
-    auto mv_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>();
-    auto if_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeatures>();
+    VkPhysicalDeviceMultiviewFeaturesKHR mv_features = vku::InitStructHelper();
+    VkPhysicalDeviceImagelessFramebufferFeatures if_features = vku::InitStructHelper();
     if (IsExtensionsEnabled(VK_KHR_MULTIVIEW_EXTENSION_NAME)) {
         if_features.pNext = &mv_features;
     }
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(&if_features);
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper(&if_features);
     auto features2 = GetPhysicalDeviceFeatures2(fsr_features);
 
     if (fsr_features.attachmentFragmentShadingRate != VK_TRUE) {
@@ -1050,7 +1050,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensions) {
     // Create a renderPass with a single fsr attachment
     VkSubpassDescription2 subpass = vku::InitStructHelper(&fsr_attachment);
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8_UINT;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -1137,7 +1137,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     }
     bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
-    auto imageless_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
+    VkPhysicalDeviceImagelessFramebufferFeaturesKHR imageless_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(imageless_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     uint32_t attachmentWidth = 512;
@@ -1252,10 +1252,10 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImagePNext) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // random invalid struct for a framebuffer pNext change
-    auto invalid_struct = vku::InitStruct<VkCommandPoolCreateInfo>();
+    VkCommandPoolCreateInfo invalid_struct = vku::InitStructHelper();
 
     VkFormat attachment_format = VK_FORMAT_R8G8B8A8_UNORM;
-    auto fb_fdm = vku::InitStruct<VkFramebufferAttachmentImageInfo>(&invalid_struct);
+    VkFramebufferAttachmentImageInfo fb_fdm = vku::InitStructHelper(&invalid_struct);
     fb_fdm.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     fb_fdm.width = 64;
     fb_fdm.height = 64;
@@ -1263,11 +1263,11 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImagePNext) {
     fb_fdm.viewFormatCount = 1;
     fb_fdm.pViewFormats = &attachment_format;
 
-    auto fb_aci_fdm = vku::InitStruct<VkFramebufferAttachmentsCreateInfo>();
+    VkFramebufferAttachmentsCreateInfo fb_aci_fdm = vku::InitStructHelper();
     fb_aci_fdm.attachmentImageInfoCount = 1;
     fb_aci_fdm.pAttachmentImageInfos = &fb_fdm;
 
-    auto framebufferCreateInfo = vku::InitStruct<VkFramebufferCreateInfo>(&fb_aci_fdm);
+    VkFramebufferCreateInfo framebufferCreateInfo = vku::InitStructHelper(&fb_aci_fdm);
     framebufferCreateInfo.width = 64;
     framebufferCreateInfo.height = 64;
     framebufferCreateInfo.layers = 1;

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -20,7 +20,7 @@ TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto imageless_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
+    VkPhysicalDeviceImagelessFramebufferFeaturesKHR imageless_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(imageless_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -40,24 +40,24 @@ TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
     VkSubpassDescription subpass = {};
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &attachment_reference;
-    auto rp_ci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper();
     rp_ci.subpassCount = 1;
     rp_ci.pSubpasses = &subpass;
     rp_ci.attachmentCount = 1;
     rp_ci.pAttachments = &attachment_description;
     vkt::RenderPass render_pass(*m_device, rp_ci);
 
-    auto fb_attachment_image_info = vku::InitStruct<VkFramebufferAttachmentImageInfoKHR>();
+    VkFramebufferAttachmentImageInfoKHR fb_attachment_image_info = vku::InitStructHelper();
     fb_attachment_image_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     fb_attachment_image_info.width = attachment_width;
     fb_attachment_image_info.height = attachment_height;
     fb_attachment_image_info.layerCount = 1;
     fb_attachment_image_info.viewFormatCount = 1;
     fb_attachment_image_info.pViewFormats = &format;
-    auto fb_attachment_ci = vku::InitStruct<VkFramebufferAttachmentsCreateInfoKHR>();
+    VkFramebufferAttachmentsCreateInfoKHR fb_attachment_ci = vku::InitStructHelper();
     fb_attachment_ci.attachmentImageInfoCount = 1;
     fb_attachment_ci.pAttachmentImageInfos = &fb_attachment_image_info;
-    auto fb_ci = vku::InitStruct<VkFramebufferCreateInfo>(&fb_attachment_ci);
+    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper(&fb_attachment_ci);
     fb_ci.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR;
     fb_ci.width = attachment_width;
     fb_ci.height = attachment_height;
@@ -84,7 +84,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto imageless_framebuffer = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeatures>();
+    VkPhysicalDeviceImagelessFramebufferFeatures imageless_framebuffer = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(imageless_framebuffer);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_framebuffer));
 
@@ -106,7 +106,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     attachment.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
     attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rp_ci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper();
     rp_ci.subpassCount = 1;
     rp_ci.pSubpasses = &subpass;
     rp_ci.attachmentCount = 1;
@@ -115,7 +115,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     vkt::RenderPass render_pass;
     render_pass.init(*m_device, rp_ci);
 
-    auto image_ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
     image_ci.imageType = VK_IMAGE_TYPE_3D;
     image_ci.format = format;
@@ -132,7 +132,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     image.Init(image_ci);
     VkImageView imageView = image.targetView(format, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 4, VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
-    auto framebuffer_attachment_image_info = vku::InitStruct<VkFramebufferAttachmentImageInfo>();
+    VkFramebufferAttachmentImageInfo framebuffer_attachment_image_info = vku::InitStructHelper();
     framebuffer_attachment_image_info.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
     framebuffer_attachment_image_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     framebuffer_attachment_image_info.width = 32;
@@ -141,11 +141,11 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     framebuffer_attachment_image_info.viewFormatCount = 1;
     framebuffer_attachment_image_info.pViewFormats = &format;
 
-    auto framebuffer_attachments = vku::InitStruct<VkFramebufferAttachmentsCreateInfo>();
+    VkFramebufferAttachmentsCreateInfo framebuffer_attachments = vku::InitStructHelper();
     framebuffer_attachments.attachmentImageInfoCount = 1;
     framebuffer_attachments.pAttachmentImageInfos = &framebuffer_attachment_image_info;
 
-    auto framebuffer_ci = vku::InitStruct<VkFramebufferCreateInfo>(&framebuffer_attachments);
+    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper(&framebuffer_attachments);
     framebuffer_ci.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
     framebuffer_ci.renderPass = render_pass.handle();
     framebuffer_ci.attachmentCount = 1;
@@ -159,11 +159,11 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     VkClearValue clear_value = {};
     clear_value.color = {{0u, 0u, 0u, 0u}};
 
-    auto render_pass_attachment_bi = vku::InitStruct<VkRenderPassAttachmentBeginInfo>();
+    VkRenderPassAttachmentBeginInfo render_pass_attachment_bi = vku::InitStructHelper();
     render_pass_attachment_bi.attachmentCount = 1;
     render_pass_attachment_bi.pAttachments = &imageView;
 
-    auto render_pass_bi = vku::InitStruct<VkRenderPassBeginInfo>(&render_pass_attachment_bi);
+    VkRenderPassBeginInfo render_pass_bi = vku::InitStructHelper(&render_pass_attachment_bi);
     render_pass_bi.renderPass = render_pass.handle();
     render_pass_bi.framebuffer = framebuffer.handle();
     render_pass_bi.renderArea.extent = {1, 1};

--- a/tests/unit/layer_utils_positive.cpp
+++ b/tests/unit/layer_utils_positive.cpp
@@ -21,7 +21,7 @@ class PositiveLayerUtils : public VkPositiveLayerTest {};
 TEST_F(PositiveLayerUtils, GetEffectiveExtent) {
     TEST_DESCRIPTION("Test unlikely GetEffectiveExtent edge cases");
 
-    auto ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo ci = vku::InitStructHelper();
     VkExtent3D extent = {};
 
     // Return zero extent if mip level doesn't exist

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -404,7 +404,7 @@ TEST_F(NegativeMemory, QueryMemoryCommitmentWithoutLazyProperty) {
     image.init_no_mem(*m_device, image_ci);
 
     const auto mem_reqs = image.memory_requirements();
-    auto image_alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
     image_alloc_info.allocationSize = mem_reqs.size;
 
     // the last argument is the "forbid" argument for set_memory_type, disallowing
@@ -500,7 +500,7 @@ TEST_F(NegativeMemory, BindMemory) {
 
     if (IsExtensionsEnabled(VK_AMD_DEVICE_COHERENT_MEMORY_EXTENSION_NAME) &&
         IsExtensionsEnabled(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME)) {
-        auto coherent_mem_features = vku::InitStruct<VkPhysicalDeviceCoherentMemoryFeaturesAMD>();
+        VkPhysicalDeviceCoherentMemoryFeaturesAMD coherent_mem_features = vku::InitStructHelper();
         GetPhysicalDeviceFeatures2(coherent_mem_features);
         ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &coherent_mem_features));
     } else {
@@ -1467,7 +1467,7 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     vkt::Buffer buffer;
     buffer.init_no_mem(*m_device, buffer_info);
     auto buffer_alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer.memory_requirements(), mem_flags);
-    auto buffer_dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfoKHR>();
+    VkMemoryDedicatedAllocateInfoKHR buffer_dedicated_info = vku::InitStructHelper();
     buffer_dedicated_info.buffer = buffer.handle();
     buffer_alloc_info.pNext = &buffer_dedicated_info;
     vkt::DeviceMemory dedicated_buffer_memory;
@@ -1503,7 +1503,7 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     image.init_no_mem(*m_device, image_info);
     wrong_image.init_no_mem(*m_device, image_info);
 
-    auto image_dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfoKHR>();
+    VkMemoryDedicatedAllocateInfoKHR image_dedicated_info = vku::InitStructHelper();
     image_dedicated_info.image = image.handle();
     auto image_alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, image.memory_requirements(), mem_flags);
     image_alloc_info.pNext = &image_dedicated_info;
@@ -1537,7 +1537,7 @@ TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto aliasing_features = vku::InitStruct<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>();
+    VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV aliasing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(aliasing_features);
     if (aliasing_features.dedicatedAllocationImageAliasing != VK_TRUE) {
         GTEST_SKIP() << "dedicatedAllocationImageAliasing feature not supported";
@@ -1560,7 +1560,7 @@ TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
     identical_image.init_no_mem(*m_device, image_info);
     post_delete_image.init_no_mem(*m_device, image_info);
 
-    auto image_dedicated_info = vku::InitStruct<VkMemoryDedicatedAllocateInfoKHR>();
+    VkMemoryDedicatedAllocateInfoKHR image_dedicated_info = vku::InitStructHelper();
     image_dedicated_info.image = image->handle();
     auto image_alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, image->memory_requirements(), mem_flags);
     image_alloc_info.pNext = &image_dedicated_info;
@@ -1619,7 +1619,7 @@ TEST_F(NegativeMemory, BufferDeviceAddressEXT) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferAddressFeaturesEXT>();
+    VkPhysicalDeviceBufferAddressFeaturesEXT buffer_device_address_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(buffer_device_address_features);
     buffer_device_address_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
 
@@ -1673,7 +1673,7 @@ TEST_F(NegativeMemory, BufferDeviceAddressEXTDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferAddressFeaturesEXT>();
+    VkPhysicalDeviceBufferAddressFeaturesEXT buffer_device_address_features = vku::InitStructHelper();
     buffer_device_address_features.bufferDeviceAddress = VK_FALSE;
     buffer_device_address_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
 
@@ -1708,7 +1708,7 @@ TEST_F(NegativeMemory, BufferDeviceAddressKHR) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR buffer_device_address_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(buffer_device_address_features);
     buffer_device_address_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
 
@@ -1789,7 +1789,7 @@ TEST_F(NegativeMemory, BufferDeviceAddressKHRDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto buffer_device_address_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR buffer_device_address_features = vku::InitStructHelper();
     buffer_device_address_features.bufferDeviceAddress = VK_FALSE;
     buffer_device_address_features.bufferDeviceAddressCaptureReplay = VK_FALSE;
 
@@ -1902,7 +1902,7 @@ TEST_F(NegativeMemory, DeviceCoherentMemoryDisabledAMD) {
         GTEST_SKIP() << "Test not supported by MockICD, does not support the necessary memory type";
     }
 
-    auto coherent_memory_features_amd = vku::InitStruct<VkPhysicalDeviceCoherentMemoryFeaturesAMD>();
+    VkPhysicalDeviceCoherentMemoryFeaturesAMD coherent_memory_features_amd = vku::InitStructHelper();
     coherent_memory_features_amd.deviceCoherentMemory = VK_FALSE;
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &coherent_memory_features_amd));
@@ -2201,16 +2201,16 @@ TEST_F(NegativeMemory, MemoryAllocatepNextChain) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkDeviceMemory mem;
-    auto mem_alloc = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
     mem_alloc.memoryTypeIndex = 0;
     mem_alloc.allocationSize = 4;
 
     // pNext chain includes both VkExportMemoryAllocateInfo and VkExportMemoryAllocateInfoNV
     {
-        auto export_memory_info_nv = vku::InitStruct<VkExportMemoryAllocateInfoNV>();
+        VkExportMemoryAllocateInfoNV export_memory_info_nv = vku::InitStructHelper();
         export_memory_info_nv.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_NV;
 
-        auto export_memory_info = vku::InitStruct<VkExportMemoryAllocateInfo>(&export_memory_info_nv);
+        VkExportMemoryAllocateInfo export_memory_info = vku::InitStructHelper(&export_memory_info_nv);
         export_memory_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-00640");
@@ -2221,11 +2221,11 @@ TEST_F(NegativeMemory, MemoryAllocatepNextChain) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     // pNext chain includes both VkExportMemoryAllocateInfo and VkExportMemoryWin32HandleInfoNV
     {
-        auto export_memory_info_win32_nv = vku::InitStruct<VkExportMemoryWin32HandleInfoNV>();
+        VkExportMemoryWin32HandleInfoNV export_memory_info_win32_nv = vku::InitStructHelper();
         export_memory_info_win32_nv.pAttributes = nullptr;
         export_memory_info_win32_nv.dwAccess = 0;
 
-        auto export_memory_info = vku::InitStruct<VkExportMemoryAllocateInfo>(&export_memory_info_win32_nv);
+        VkExportMemoryAllocateInfo export_memory_info = vku::InitStructHelper(&export_memory_info_win32_nv);
         export_memory_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-00640");
@@ -2235,10 +2235,10 @@ TEST_F(NegativeMemory, MemoryAllocatepNextChain) {
     }
     // pNext chain includes both VkImportMemoryWin32HandleInfoKHR and VkImportMemoryWin32HandleInfoNV
     {
-        auto import_memory_info_win32_khr = vku::InitStruct<VkImportMemoryWin32HandleInfoKHR>();
+        VkImportMemoryWin32HandleInfoKHR import_memory_info_win32_khr = vku::InitStructHelper();
         import_memory_info_win32_khr.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
 
-        auto import_memory_info_win32_nv = vku::InitStruct<VkImportMemoryWin32HandleInfoNV>(&import_memory_info_win32_khr);
+        VkImportMemoryWin32HandleInfoNV import_memory_info_win32_nv = vku::InitStructHelper(&import_memory_info_win32_khr);
         import_memory_info_win32_nv.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_NV;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-00641");
@@ -2262,10 +2262,10 @@ TEST_F(NegativeMemory, DeviceImageMemoryRequirementsSwapchain) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_swapchain_create_info = vku::InitStruct<VkImageSwapchainCreateInfoKHR>();
+    VkImageSwapchainCreateInfoKHR image_swapchain_create_info = vku::InitStructHelper();
     image_swapchain_create_info.swapchain = m_swapchain;
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>(&image_swapchain_create_info);
+    VkImageCreateInfo image_create_info = vku::InitStructHelper(&image_swapchain_create_info);
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_create_info.extent = {32, 32, 1};
@@ -2275,7 +2275,7 @@ TEST_F(NegativeMemory, DeviceImageMemoryRequirementsSwapchain) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.arrayLayers = 1;
 
-    auto device_image_memory_requirements = vku::InitStruct<VkDeviceImageMemoryRequirementsKHR>();
+    VkDeviceImageMemoryRequirementsKHR device_image_memory_requirements = vku::InitStructHelper();
     device_image_memory_requirements.pCreateInfo = &image_create_info;
     device_image_memory_requirements.planeAspect = VK_IMAGE_ASPECT_COLOR_BIT;
 
@@ -2306,7 +2306,7 @@ TEST_F(NegativeMemory, DeviceImageMemoryRequirementsDisjoint) {
         GTEST_SKIP() << "Test requires disjoint support extensions";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
     image_create_info.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
@@ -2317,7 +2317,7 @@ TEST_F(NegativeMemory, DeviceImageMemoryRequirementsDisjoint) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.arrayLayers = 1;
 
-    auto device_image_memory_requirements = vku::InitStruct<VkDeviceImageMemoryRequirementsKHR>();
+    VkDeviceImageMemoryRequirementsKHR device_image_memory_requirements = vku::InitStructHelper();
     device_image_memory_requirements.pCreateInfo = &image_create_info;
     device_image_memory_requirements.planeAspect = VK_IMAGE_ASPECT_NONE_KHR;
 
@@ -2355,7 +2355,7 @@ TEST_F(NegativeMemory, BindBufferMemoryDeviceGroup) {
     std::vector<VkPhysicalDeviceGroupProperties> physical_device_group(physical_device_group_count,
                                                                        {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, physical_device_group.data());
-    auto create_device_pnext = vku::InitStruct<VkDeviceGroupDeviceCreateInfo>();
+    VkDeviceGroupDeviceCreateInfo create_device_pnext = vku::InitStructHelper();
     create_device_pnext.physicalDeviceCount = 0;
     create_device_pnext.pPhysicalDevices = nullptr;
     for (const auto &dg : physical_device_group) {

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -346,7 +346,7 @@ TEST_F(PositiveMemory, BindImageMemoryMultiThreaded) {
         GTEST_SKIP() << "This test can crash drivers with threading issues";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
     image_create_info.extent.width = 32;
@@ -371,7 +371,7 @@ TEST_F(PositiveMemory, BindImageMemoryMultiThreaded) {
 
             vk::GetImageMemoryRequirements(m_device->device(), image, &mem_reqs);
 
-            auto mem_alloc = vku::InitStruct<VkMemoryAllocateInfo>();
+            VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
             mem_alloc.memoryTypeIndex = 0;
             mem_alloc.allocationSize = mem_reqs.size;
             const bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &mem_alloc, 0);
@@ -412,7 +412,7 @@ TEST_F(PositiveMemory, DeviceBufferMemoryRequirements) {
     }
 
     uint32_t queue_family_index = 0;
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = 1024;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_create_info.queueFamilyIndexCount = 1;
@@ -422,12 +422,12 @@ TEST_F(PositiveMemory, DeviceBufferMemoryRequirements) {
     buffer.init_no_mem(*m_device, buffer_create_info);
     ASSERT_TRUE(buffer.initialized());
 
-    auto info = vku::InitStruct<VkDeviceBufferMemoryRequirements>();
+    VkDeviceBufferMemoryRequirements info = vku::InitStructHelper();
     info.pCreateInfo = &buffer_create_info;
-    auto memory_reqs2 = vku::InitStruct<VkMemoryRequirements2>();
+    VkMemoryRequirements2 memory_reqs2 = vku::InitStructHelper();
     vk::GetDeviceBufferMemoryRequirements(m_device->device(), &info, &memory_reqs2);
 
-    auto memory_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = memory_reqs2.memoryRequirements.size;
 
     const bool pass = m_device->phy().set_memory_type(memory_reqs2.memoryRequirements.memoryTypeBits, &memory_info, 0);
@@ -450,7 +450,7 @@ TEST_F(PositiveMemory, DeviceImageMemoryRequirements) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
     image_create_info.extent.width = 32;
@@ -467,12 +467,12 @@ TEST_F(PositiveMemory, DeviceImageMemoryRequirements) {
     image.init_no_mem(*m_device, image_create_info);
     ASSERT_TRUE(image.initialized());
 
-    auto info = vku::InitStruct<VkDeviceImageMemoryRequirements>();
+    VkDeviceImageMemoryRequirements info = vku::InitStructHelper();
     info.pCreateInfo = &image_create_info;
-    auto mem_reqs = vku::InitStruct<VkMemoryRequirements2>();
+    VkMemoryRequirements2 mem_reqs = vku::InitStructHelper();
     vk::GetDeviceImageMemoryRequirements(m_device->device(), &info, &mem_reqs);
 
-    auto mem_alloc = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
     mem_alloc.memoryTypeIndex = 0;
     mem_alloc.allocationSize = mem_reqs.memoryRequirements.size;
     const bool pass = m_device->phy().set_memory_type(mem_reqs.memoryRequirements.memoryTypeBits, &mem_alloc, 0);

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -31,12 +31,12 @@ TEST_F(NegativeMesh, BasicUsage) {
     }
 
     // Create a device that enables mesh_shader
-    auto vertex_input_dynamic_state = vku::InitStruct<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>();
-    auto extended_dynamic_state2 = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(&vertex_input_dynamic_state);
-    auto maintenance4 = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&extended_dynamic_state2);
-    auto multiview_feature = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>(&maintenance4);
-    auto xfb_feature = vku::InitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(&multiview_feature);
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>(&xfb_feature);
+    VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT vertex_input_dynamic_state = vku::InitStructHelper();
+    VkPhysicalDeviceExtendedDynamicState2FeaturesEXT extended_dynamic_state2 = vku::InitStructHelper(&vertex_input_dynamic_state);
+    VkPhysicalDeviceMaintenance4Features maintenance4 = vku::InitStructHelper(&extended_dynamic_state2);
+    VkPhysicalDeviceMultiviewFeatures multiview_feature = vku::InitStructHelper(&maintenance4);
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT xfb_feature = vku::InitStructHelper(&multiview_feature);
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper(&xfb_feature);
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
     mesh_shader_features.multiviewMeshShader = VK_FALSE;
     features2.features.multiDrawIndirect = VK_FALSE;
@@ -230,7 +230,7 @@ TEST_F(NegativeMesh, BasicUsage) {
         }
 
         // viewMask without enabling multiviewMeshShader feature
-        auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+        VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
         pipeline_rendering_info.viewMask = 0x2;
 
         const auto break_vp5 = [&](CreatePipelineHelper &helper) {
@@ -252,8 +252,8 @@ TEST_F(NegativeMesh, ExtensionDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto maintenance4 = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>();
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>(&maintenance4);
+    VkPhysicalDeviceMaintenance4Features maintenance4 = vku::InitStructHelper();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper(&maintenance4);
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (mesh_shader_features.meshShader != VK_TRUE) {
         GTEST_SKIP() << "Mesh shader feature not supported";
@@ -365,8 +365,8 @@ TEST_F(NegativeMesh, RuntimeSpirv) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto maintenance4 = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>();
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>(&maintenance4);
+    VkPhysicalDeviceMaintenance4Features maintenance4 = vku::InitStructHelper();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper(&maintenance4);
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (mesh_shader_features.meshShader != VK_TRUE) {
         GTEST_SKIP() << "Mesh shader feature not supported";
@@ -544,7 +544,7 @@ TEST_F(NegativeMesh, RuntimeSpirvNV) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
+    VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (mesh_shader_features.meshShader != VK_TRUE) {
         GTEST_SKIP() << "Mesh shader feature not supported";
@@ -607,7 +607,7 @@ TEST_F(NegativeMesh, BasicUsageNV) {
     }
 
     // Create a device that enables mesh_shader
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
+    VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
     features2.features.multiDrawIndirect = VK_FALSE;
 
@@ -709,7 +709,7 @@ TEST_F(NegativeMesh, ExtensionDisabledNV) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
+    VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (mesh_shader_features.meshShader != VK_TRUE) {
         GTEST_SKIP() << "Mesh shader feature not supported";
@@ -876,8 +876,8 @@ TEST_F(NegativeMesh, DrawCmds) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto maintenance4 = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>();
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>(&maintenance4);
+    VkPhysicalDeviceMaintenance4Features maintenance4 = vku::InitStructHelper();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper(&maintenance4);
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (mesh_shader_features.meshShader != VK_TRUE) {
         GTEST_SKIP() << "Mesh shader feature not supported";
@@ -1026,8 +1026,8 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto maintenance4 = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>();
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>(&maintenance4);
+    VkPhysicalDeviceMaintenance4Features maintenance4 = vku::InitStructHelper();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper(&maintenance4);
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (mesh_shader_features.meshShader != VK_TRUE) {
         GTEST_SKIP() << "Mesh shader feature not supported";
@@ -1159,7 +1159,7 @@ TEST_F(NegativeMesh, DrawCmdsNV) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
+    VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (mesh_shader_features.meshShader != VK_TRUE) {
         GTEST_SKIP() << "Mesh shader feature not supported";

--- a/tests/unit/mesh_positive.cpp
+++ b/tests/unit/mesh_positive.cpp
@@ -24,7 +24,7 @@ TEST_F(PositiveMesh, BasicUsage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (mesh_shader_features.meshShader == VK_FALSE) {
         GTEST_SKIP() << "Mesh shader feature not supported";
@@ -78,7 +78,7 @@ TEST_F(PositiveMesh, MeshShaderOnly) {
     }
 
     // Create a device that enables mesh_shader
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
+    VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     if (mesh_shader_features.meshShader != VK_TRUE) {
@@ -132,7 +132,7 @@ TEST_F(PositiveMesh, PointSize) {
     }
 
     // Create a device that enables mesh_shader
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
+    VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(mesh_shader_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     if (mesh_shader_features.meshShader != VK_TRUE) {

--- a/tests/unit/multi_device.cpp
+++ b/tests/unit/multi_device.cpp
@@ -17,7 +17,7 @@ TEST_F(MultiDeviceTest, CommonParentFillBuffer) {
     auto features = m_device->phy().features();
     m_second_device = new VkDeviceObj(0, gpu_, m_device_extension_names, &features, nullptr);
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buffer_ci.queueFamilyIndexCount = 0;
@@ -42,7 +42,7 @@ TEST_F(MultiDeviceTest, CommonParentBindBuffer) {
     auto features = m_device->phy().features();
     m_second_device = new VkDeviceObj(0, gpu_, m_device_extension_names, &features, nullptr);
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buffer_ci.queueFamilyIndexCount = 0;
@@ -142,14 +142,14 @@ TEST_F(MultiDeviceTest, CommonParentBindPipeline) {
     auto features = m_device->phy().features();
     m_second_device = new VkDeviceObj(0, gpu_, m_device_extension_names, &features, nullptr);
 
-    auto pipeline_layout_ci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
     pipeline_layout_ci.setLayoutCount = 0;
     vkt::PipelineLayout pipeline_layout(*m_second_device, pipeline_layout_ci);
 
     VkShaderObj cs(this, kMinimalShaderGlsl, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL_TRY);
     cs.InitFromGLSLTry(false, m_second_device);
 
-    auto pipeline_ci = vku::InitStruct<VkComputePipelineCreateInfo>();
+    VkComputePipelineCreateInfo pipeline_ci = vku::InitStructHelper();
     pipeline_ci.layout = pipeline_layout.handle();
     pipeline_ci.stage = cs.GetStageCreateInfo();
     vkt::Pipeline pipeline(*m_second_device, pipeline_ci);

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -30,14 +30,14 @@ TEST_F(NegativeMultiview, MaxInstanceIndex) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     multiview_features.multiview = VK_TRUE;
     VkPhysicalDeviceFeatures2 pd_features2 = vku::InitStructHelper(&multiview_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto multiview_props = vku::InitStruct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceMultiviewProperties multiview_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(multiview_props);
     if (multiview_props.maxMultiviewInstanceIndex == std::numeric_limits<uint32_t>::max()) {
         GTEST_SKIP() << "maxMultiviewInstanceIndex is uint32_t max";
@@ -67,7 +67,7 @@ TEST_F(NegativeMultiview, ClearColorAttachments) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (!multiview_features.multiview) {
         GTEST_SKIP() << "VkPhysicalDeviceMultiviewFeatures::multiview not supported";
@@ -181,7 +181,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "Device does not support multiview.";
@@ -209,7 +209,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
     for (unsigned i = 0; i < multiview_count; ++i) {
         viewMasks[i] = 1u << i;
     }
-    auto renderPassMultiviewCreateInfo = vku::InitStruct<VkRenderPassMultiviewCreateInfo>();
+    VkRenderPassMultiviewCreateInfo renderPassMultiviewCreateInfo = vku::InitStructHelper();
     renderPassMultiviewCreateInfo.subpassCount = multiview_count;
     renderPassMultiviewCreateInfo.pViewMasks = viewMasks;
 
@@ -247,7 +247,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
 
     vk::CreateRenderPass(m_device->handle(), &m_renderPass_info, nullptr, &m_renderPass);
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_create_info.extent.width = m_width;
@@ -266,7 +266,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
     VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_REMAINING_MIP_LEVELS, 0,
                                              VK_REMAINING_ARRAY_LAYERS, VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
-    auto framebufferCreateInfo = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo framebufferCreateInfo = vku::InitStructHelper();
     framebufferCreateInfo.width = m_width;
     framebufferCreateInfo.height = m_height;
     framebufferCreateInfo.layers = 1;
@@ -378,7 +378,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         VkShaderObj const fs(this, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
 
         VkPushConstantRange push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, 36};
-        auto pipeline_layout_info = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+        VkPipelineLayoutCreateInfo pipeline_layout_info = vku::InitStructHelper();
         pipeline_layout_info.pushConstantRangeCount = 1;
         pipeline_layout_info.pPushConstantRanges = &push_constant_range;
 
@@ -433,7 +433,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
     {
         OneOffDescriptorSet descriptor_set{m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}}};
 
-        auto bci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo bci = vku::InitStructHelper();
         bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         bci.size = 8;
         vkt::Buffer buffer(*m_device, bci);
@@ -441,7 +441,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         buffer_info.buffer = buffer.handle();
         buffer_info.offset = 0;
         buffer_info.range = VK_WHOLE_SIZE;
-        auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
         descriptor_write.dstSet = descriptor_set.set_;
         descriptor_write.dstBinding = 0;
         descriptor_write.descriptorCount = 1;
@@ -449,7 +449,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         descriptor_write.pBufferInfo = &buffer_info;
         vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, NULL);
 
-        auto pipeline_layout_info = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+        VkPipelineLayoutCreateInfo pipeline_layout_info = vku::InitStructHelper();
         pipeline_layout_info.setLayoutCount = 1;
         pipeline_layout_info.pSetLayouts = &descriptor_set.layout_.handle();
 
@@ -664,8 +664,8 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto mv_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeaturesKHR>();
-    auto tf_features = vku::InitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(&mv_features);
+    VkPhysicalDeviceMultiviewFeaturesKHR mv_features = vku::InitStructHelper();
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT tf_features = vku::InitStructHelper(&mv_features);
     auto pd_features = GetPhysicalDeviceFeatures2(tf_features);
 
     if (!tf_features.transformFeedback) {
@@ -770,7 +770,7 @@ TEST_F(NegativeMultiview, Features) {
     std::vector<const char *> device_extensions;
     device_extensions.push_back(VK_KHR_MULTIVIEW_EXTENSION_NAME);
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
 
     // Set false to trigger VUs
@@ -819,7 +819,7 @@ TEST_F(NegativeMultiview, RenderPassCreateOverlappingCorrelationMasks) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "multiview feature not supported";
@@ -860,7 +860,7 @@ TEST_F(NegativeMultiview, RenderPassViewMasksNotEnough) {
     AddOptionalExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "multiview feature not supported";
@@ -920,7 +920,7 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (!features2.features.multiViewport) {
         GTEST_SKIP() << "multiViewport feature is not supported, skipping test.\n";
@@ -952,33 +952,33 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
     subpass.pColorAttachments = &color_att;
 
     uint32_t viewMasks[] = {0x3u};
-    auto rpmvci = vku::InitStruct<VkRenderPassMultiviewCreateInfo>();
+    VkRenderPassMultiviewCreateInfo rpmvci = vku::InitStructHelper();
     rpmvci.subpassCount = 1;
     rpmvci.pViewMasks = viewMasks;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpmvci);
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper(&rpmvci);
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attach;
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
 
     // Set up VkRenderPassCreateInfo2 struct used with VK_VERSION_1_2
-    auto color_att2 = vku::InitStruct<VkAttachmentReference2>();
+    VkAttachmentReference2 color_att2 = vku::InitStructHelper();
     color_att2.layout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto attach2 = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach2 = vku::InitStructHelper();
     attach2.samples = VK_SAMPLE_COUNT_1_BIT;
     attach2.format = VK_FORMAT_B8G8R8A8_UNORM;
     attach2.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     attach2.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto subpass2 = vku::InitStruct<VkSubpassDescription2>();
+    VkSubpassDescription2 subpass2 = vku::InitStructHelper();
     subpass2.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     subpass2.viewMask = 0x3u;
     subpass2.colorAttachmentCount = 1;
     subpass2.pColorAttachments = &color_att2;
 
-    auto rpci2 = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 rpci2 = vku::InitStructHelper();
     rpci2.attachmentCount = 1;
     rpci2.pAttachments = &attach2;
     rpci2.subpassCount = 1;
@@ -1015,7 +1015,7 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
     image.Init(ici2d);
     ASSERT_TRUE(image.initialized());
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     ivci.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -1025,7 +1025,7 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
     vkt::ImageView iv(*m_device, ivci);
 
     // Create framebuffers for rp[0] and rp2[0]
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.renderPass = rp[0].handle();
     fbci.attachmentCount = 1;
     fbci.pAttachments = &iv.handle();
@@ -1040,7 +1040,7 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
         fb2.init(*m_device, fbci);
     }
 
-    auto rp_begin = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rp_begin = vku::InitStructHelper();
     rp_begin.renderPass = rp[0].handle();
     rp_begin.framebuffer = fb.handle();
     rp_begin.renderArea = {{0, 0}, {128, 128}};
@@ -1073,10 +1073,10 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
         pipe2_2.CreateGraphicsPipeline();
     }
 
-    auto cbii = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = rp[0].handle();
     cbii.subpass = 0;
-    auto cbbi = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     cbbi.pInheritanceInfo = &cbii;
 
     // Begin rp[0] for VK_VERSION_1_0 test cases
@@ -1145,7 +1145,7 @@ TEST_F(NegativeMultiview, RenderPassViewMasksZero) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto render_pass_multiview_props = vku::InitStruct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceMultiviewProperties render_pass_multiview_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(render_pass_multiview_props);
     if (render_pass_multiview_props.maxMultiviewViewCount < 2) {
         GTEST_SKIP() << "maxMultiviewViewCount lower than required";
@@ -1175,7 +1175,7 @@ TEST_F(NegativeMultiview, RenderPassViewOffsets) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto render_pass_multiview_props = vku::InitStruct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceMultiviewProperties render_pass_multiview_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(render_pass_multiview_props);
     if (render_pass_multiview_props.maxMultiviewViewCount < 2) {
         GTEST_SKIP() << "maxMultiviewViewCount lower than required";
@@ -1211,7 +1211,7 @@ TEST_F(NegativeMultiview, RenderPassViewMasksLimit) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto render_pass_multiview_props = vku::InitStruct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceMultiviewProperties render_pass_multiview_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(render_pass_multiview_props);
 
     if (render_pass_multiview_props.maxMultiviewViewCount >= 32) {
@@ -1348,8 +1348,8 @@ TEST_F(NegativeMultiview, DynamicRenderingMaxMultiviewInstanceIndex) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
-    auto features11 = vku::InitStruct<VkPhysicalDeviceVulkan11Features>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper(&dynamic_rendering_features);
     GetPhysicalDeviceFeatures2(features11);
     if (!features11.multiview) {
         GTEST_SKIP() << "multiview not supported.";

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -141,7 +141,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
         GTEST_SKIP() << "Test requires sparseBinding";
     }
 
-    auto general_queue_ci = vku::InitStruct<VkDeviceQueueCreateInfo>();
+    VkDeviceQueueCreateInfo general_queue_ci = vku::InitStructHelper();
     general_queue_ci.queueCount = 1;
     general_queue_ci.pQueuePriorities = &defaultQueuePriority;
     {
@@ -153,7 +153,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
         general_queue_ci.queueFamilyIndex = familyIndex.value();
     }
 
-    auto transfer_queue_ci = vku::InitStruct<VkDeviceQueueCreateInfo>();
+    VkDeviceQueueCreateInfo transfer_queue_ci = vku::InitStructHelper();
     transfer_queue_ci.queueCount = 1;
     transfer_queue_ci.pQueuePriorities = &defaultQueuePriority;
     {
@@ -265,9 +265,9 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto rt_pipeline_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto as_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&rt_pipeline_features);
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&as_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR rt_pipeline_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR as_features = vku::InitStructHelper(&rt_pipeline_features);
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&as_features);
     GetPhysicalDeviceFeatures2(bda_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &bda_features));
 
@@ -564,7 +564,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_SwitchTessGeometryMesh)
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(dynamic_rendering_features);
     if (!dynamic_rendering_features.dynamicRendering) {
         GTEST_SKIP() << "This test requires dynamicRendering";
@@ -712,7 +712,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_ZcullDirection)
                                              "UNASSIGNED-BestPractices-Zcull-LessGreaterRatio");
     };
 
-    auto depth_stencil_state_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo depth_stencil_state_ci = vku::InitStructHelper();
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -69,7 +69,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferBufferDestroyed) {
 TEST_F(NegativeObjectLifetime, CmdBarrierBufferDestroyed) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    auto buf_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buf_info = vku::InitStructHelper();
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buf_info.size = 256;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
@@ -80,7 +80,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierBufferDestroyed) {
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(m_device->device(), buffer.handle(), &mem_reqs);
 
-    auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_reqs.size;
 
     bool pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, 0);
@@ -92,7 +92,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierBufferDestroyed) {
     ASSERT_VK_SUCCESS(vk::BindBufferMemory(m_device->device(), buffer.handle(), buffer_mem.handle(), 0));
 
     m_commandBuffer->begin();
-    auto buf_barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+    VkBufferMemoryBarrier buf_barrier = vku::InitStructHelper();
     buf_barrier.buffer = buffer.handle();
     buf_barrier.offset = 0;
     buf_barrier.size = VK_WHOLE_SIZE;
@@ -101,7 +101,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierBufferDestroyed) {
                            NULL, 1, &buf_barrier, 0, NULL);
     m_commandBuffer->end();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -127,7 +127,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierImageDestroyed) {
 
     vk::GetImageMemoryRequirements(device(), image.handle(), &mem_reqs);
 
-    auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_reqs.size;
     bool pass = false;
     pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, 0);
@@ -139,7 +139,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierImageDestroyed) {
     ASSERT_VK_SUCCESS(err);
 
     m_commandBuffer->begin();
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.image = image.handle();
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     img_barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -149,7 +149,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierImageDestroyed) {
                            NULL, 0, NULL, 1, &img_barrier);
     m_commandBuffer->end();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -168,7 +168,7 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierBufferDestroyed) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -201,14 +201,14 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierBufferDestroyed) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkDeviceMemory");
     m_commandBuffer->begin();
-    auto buf_barrier = vku::InitStruct<VkBufferMemoryBarrier2KHR>();
+    VkBufferMemoryBarrier2KHR buf_barrier = vku::InitStructHelper();
     buf_barrier.buffer = buffer;
     buf_barrier.offset = 0;
     buf_barrier.size = VK_WHOLE_SIZE;
     buf_barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     buf_barrier.dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 
-    auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dep_info = vku::InitStructHelper();
     dep_info.bufferMemoryBarrierCount = 1;
     dep_info.pBufferMemoryBarriers = &buf_barrier;
 
@@ -220,7 +220,7 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierBufferDestroyed) {
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkDeviceMemory");
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -238,7 +238,7 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierImageDestroyed) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -254,7 +254,7 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierImageDestroyed) {
 
     vk::GetImageMemoryRequirements(device(), image, &mem_reqs);
 
-    auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_reqs.size;
     bool pass = false;
     pass = m_device->phy().set_memory_type(mem_reqs.memoryTypeBits, &alloc_info, 0);
@@ -268,13 +268,13 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierImageDestroyed) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkDeviceMemory");
     m_commandBuffer->begin();
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier2KHR>();
+    VkImageMemoryBarrier2KHR img_barrier = vku::InitStructHelper();
     img_barrier.image = image;
     img_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     img_barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     img_barrier.dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 
-    auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dep_info = vku::InitStructHelper();
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &img_barrier;
 
@@ -286,7 +286,7 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierImageDestroyed) {
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidCommandBuffer-VkDeviceMemory");
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -1157,9 +1157,9 @@ TEST_F(NegativeObjectLifetime, ImportFdSemaphoreInUse) {
     }
 
     // Create semaphore and export its fd handle
-    auto export_info = vku::InitStruct<VkExportSemaphoreCreateInfo>();
+    VkExportSemaphoreCreateInfo export_info = vku::InitStructHelper();
     export_info.handleTypes = handle_type;
-    auto create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&export_info);
+    VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&export_info);
     vkt::Semaphore export_semaphore(*m_device, create_info);
     int fd = -1;
     ASSERT_VK_SUCCESS(export_semaphore.export_handle(fd, handle_type));
@@ -1198,9 +1198,9 @@ TEST_F(NegativeObjectLifetime, ImportWin32SemaphoreInUse) {
     }
 
     // Create semaphore and export its Win32 handle
-    auto export_info = vku::InitStruct<VkExportSemaphoreCreateInfo>();
+    VkExportSemaphoreCreateInfo export_info = vku::InitStructHelper();
     export_info.handleTypes = handle_type;
-    auto create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&export_info);
+    VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&export_info);
     vkt::Semaphore export_semaphore(*m_device, create_info);
     HANDLE handle = NULL;
     ASSERT_VK_SUCCESS(export_semaphore.export_handle(handle, handle_type));

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -318,9 +318,9 @@ TEST_F(VkPositiveLayerTest, ModifyPnext) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto shading = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV>();
+    VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV shading = vku::InitStructHelper();
     shading.maxFragmentShadingRateInvocationCount = static_cast<VkSampleCountFlagBits>(0);
-    auto props = vku::InitStruct<VkPhysicalDeviceProperties2>(&shading);
+    VkPhysicalDeviceProperties2 props = vku::InitStructHelper(&shading);
 
     vk::GetPhysicalDeviceProperties2(gpu(), &props);
 }
@@ -335,7 +335,7 @@ TEST_F(VkPositiveLayerTest, HostQueryResetSuccess) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto host_query_reset_features = vku::InitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
+    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_query_reset_features));
 
@@ -428,7 +428,7 @@ TEST_F(VkPositiveLayerTest, Vulkan12Features) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
+    VkPhysicalDeviceBufferDeviceAddressFeatures bda_features = vku::InitStructHelper();
     VkPhysicalDeviceFeatures2 features2 = GetPhysicalDeviceFeatures2(bda_features);
     if (!bda_features.bufferDeviceAddress) {
         GTEST_SKIP() << "Buffer Device Address feature not supported, skipping test";
@@ -603,10 +603,10 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
 
     // Initialize framework
     {
-        auto queue_info = vku::InitStruct<VkExportMetalObjectCreateInfoEXT>();
+        VkExportMetalObjectCreateInfoEXT queue_info = vku::InitStructHelper();
         queue_info.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_COMMAND_QUEUE_BIT_EXT;
 
-        auto metal_info = vku::InitStruct<VkExportMetalObjectCreateInfoEXT>();
+        VkExportMetalObjectCreateInfoEXT metal_info = vku::InitStructHelper();
         metal_info.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_DEVICE_BIT_EXT;
         metal_info.pNext = &queue_info;
 
@@ -615,7 +615,7 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
             GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
         }
 
-        auto portability_features = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+        VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_features = vku::InitStructHelper();
         auto features2 = GetPhysicalDeviceFeatures2(portability_features);
 
         ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
@@ -627,10 +627,10 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
     {
         const VkQueue queue = m_device->m_queue;
 
-        auto queueInfo = vku::InitStruct<VkExportMetalCommandQueueInfoEXT>();
+        VkExportMetalCommandQueueInfoEXT queueInfo = vku::InitStructHelper();
         queueInfo.queue = queue;
-        auto deviceInfo = vku::InitStruct<VkExportMetalDeviceInfoEXT>(&queueInfo);
-        auto objectsInfo = vku::InitStruct<VkExportMetalObjectsInfoEXT>(&deviceInfo);
+        VkExportMetalDeviceInfoEXT deviceInfo = vku::InitStructHelper(&queueInfo);
+        VkExportMetalObjectsInfoEXT objectsInfo = vku::InitStructHelper(&deviceInfo);
 
         // This tests both device, queue, and pNext chaining
         vk::ExportMetalObjectsEXT(device, &objectsInfo);
@@ -641,7 +641,7 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
 
     // Get Metal Buffer
     {
-        auto metalBufferCreateInfo = vku::InitStruct<VkExportMetalObjectCreateInfoEXT>();
+        VkExportMetalObjectCreateInfoEXT metalBufferCreateInfo = vku::InitStructHelper();
         metalBufferCreateInfo.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT;
 
         VkMemoryAllocateInfo mem_info = vku::InitStructHelper();
@@ -652,9 +652,9 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
         const VkResult err = vk::AllocateMemory(device, &mem_info, NULL, &memory);
         ASSERT_VK_SUCCESS(err);
 
-        auto bufferInfo = vku::InitStruct<VkExportMetalBufferInfoEXT>();
+        VkExportMetalBufferInfoEXT bufferInfo = vku::InitStructHelper();
         bufferInfo.memory = memory;
-        auto objectsInfo = vku::InitStruct<VkExportMetalObjectsInfoEXT>(&bufferInfo);
+        VkExportMetalObjectsInfoEXT objectsInfo = vku::InitStructHelper(&bufferInfo);
 
         vk::ExportMetalObjectsEXT(device, &objectsInfo);
 
@@ -665,9 +665,9 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
 
     // Get Metal Texture and Metal IOSurfaceRef
     {
-        auto metalSurfaceInfo = vku::InitStruct<VkExportMetalObjectCreateInfoEXT>();
+        VkExportMetalObjectCreateInfoEXT metalSurfaceInfo = vku::InitStructHelper();
         metalSurfaceInfo.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_IOSURFACE_BIT_EXT;
-        auto metalTextureCreateInfo = vku::InitStruct<VkExportMetalObjectCreateInfoEXT>(&metalSurfaceInfo);
+        VkExportMetalObjectCreateInfoEXT metalTextureCreateInfo = vku::InitStructHelper(&metalSurfaceInfo);
         metalTextureCreateInfo.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT;
 
         // Image contents don't matter
@@ -684,12 +684,12 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
         image.Init(ici);
         ASSERT_TRUE(image.initialized());
 
-        auto surfaceInfo = vku::InitStruct<VkExportMetalIOSurfaceInfoEXT>();
+        VkExportMetalIOSurfaceInfoEXT surfaceInfo = vku::InitStructHelper();
         surfaceInfo.image = image.handle();
-        auto textureInfo = vku::InitStruct<VkExportMetalTextureInfoEXT>(&surfaceInfo);
+        VkExportMetalTextureInfoEXT textureInfo = vku::InitStructHelper(&surfaceInfo);
         textureInfo.image = image.handle();
         textureInfo.plane = VK_IMAGE_ASPECT_PLANE_0_BIT;  // Image is not multi-planar
-        auto objectsInfo = vku::InitStruct<VkExportMetalObjectsInfoEXT>(&textureInfo);
+        VkExportMetalObjectsInfoEXT objectsInfo = vku::InitStructHelper(&textureInfo);
 
         // This tests both texture, surface, and pNext chaining
         vk::ExportMetalObjectsEXT(device, &objectsInfo);
@@ -700,16 +700,16 @@ TEST_F(VkPositiveLayerTest, ExportMetalObjects) {
 
     // Get Metal Shared Event
     {
-        auto metalEventCreateInfo = vku::InitStruct<VkExportMetalObjectCreateInfoEXT>();
+        VkExportMetalObjectCreateInfoEXT metalEventCreateInfo = vku::InitStructHelper();
         metalEventCreateInfo.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT;
 
-        auto eventCreateInfo = vku::InitStruct<VkEventCreateInfo>(&metalEventCreateInfo);
+        VkEventCreateInfo eventCreateInfo = vku::InitStructHelper(&metalEventCreateInfo);
         vkt::Event event(*m_device, eventCreateInfo);
         ASSERT_TRUE(event.initialized());
 
-        auto eventInfo = vku::InitStruct<VkExportMetalSharedEventInfoEXT>();
+        VkExportMetalSharedEventInfoEXT eventInfo = vku::InitStructHelper();
         eventInfo.event = event.handle();
-        auto objectsInfo = vku::InitStruct<VkExportMetalObjectsInfoEXT>(&eventInfo);
+        VkExportMetalObjectsInfoEXT objectsInfo = vku::InitStructHelper(&eventInfo);
 
         vk::ExportMetalObjectsEXT(device, &objectsInfo);
 
@@ -797,8 +797,8 @@ TEST_F(VkPositiveLayerTest, FormatProperties3FromProfiles) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-    auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+    VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+    VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
     vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8_UNORM, &fmt_props);
     vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
 }
@@ -833,7 +833,7 @@ TEST_F(VkPositiveLayerTest, UseInteractionApi) {
         GetDeviceProcAddr<PFN_vkGetDeviceGroupPresentCapabilitiesKHR>("vkGetDeviceGroupPresentCapabilitiesKHR");
     ASSERT_NE(vkGetDeviceGroupPresentCapabilitiesKHR, nullptr);
 
-    auto device_group_present_caps = vku::InitStruct<VkDeviceGroupPresentCapabilitiesKHR>();
+    VkDeviceGroupPresentCapabilitiesKHR device_group_present_caps = vku::InitStructHelper();
     vkGetDeviceGroupPresentCapabilitiesKHR(m_device->device(), &device_group_present_caps);
 }
 
@@ -852,7 +852,7 @@ TEST_F(VkPositiveLayerTest, ExtensionExpressions) {
         GTEST_SKIP() << "Vulkan 1.1 required";
     }
 
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(fsr_features);
     if (!fsr_features.pipelineFragmentShadingRate) {
         GTEST_SKIP() << "VkPhysicalDeviceFragmentShadingRateFeaturesKHR::pipelineFragmentShadingRate not supported";
@@ -877,8 +877,8 @@ TEST_F(VkPositiveLayerTest, AllowedDuplicateStype) {
     ici.enabledLayerCount = instance_layers_.size();
     ici.ppEnabledLayerNames = instance_layers_.data();
 
-    auto dbgUtils0 = vku::InitStruct<VkDebugUtilsMessengerCreateInfoEXT>();
-    auto dbgUtils1 = vku::InitStruct<VkDebugUtilsMessengerCreateInfoEXT>(&dbgUtils0);
+    VkDebugUtilsMessengerCreateInfoEXT dbgUtils0 = vku::InitStructHelper();
+    VkDebugUtilsMessengerCreateInfoEXT dbgUtils1 = vku::InitStructHelper(&dbgUtils0);
     ici.pNext = &dbgUtils1;
 
     ASSERT_VK_SUCCESS(vk::CreateInstance(&ici, nullptr, &instance));
@@ -925,7 +925,7 @@ TEST_F(VkPositiveLayerTest, CustomSafePNextCopy) {
     // whose members must be partially ignored depending on the graphics sub-state present.
 
     VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
-    auto pri = vku::InitStruct<VkPipelineRenderingCreateInfo>();
+    VkPipelineRenderingCreateInfo pri = vku::InitStructHelper();
     pri.colorAttachmentCount = 1;
     pri.pColorAttachmentFormats = &format;
 
@@ -943,7 +943,7 @@ TEST_F(VkPositiveLayerTest, CustomSafePNextCopy) {
     };
 
     {
-        auto gpci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&pri);
+        VkGraphicsPipelineCreateInfo gpci = vku::InitStructHelper(&pri);
         safe_VkGraphicsPipelineCreateInfo safe_gpci(&gpci, false, false, &copy_state);
 
         auto safe_pri = reinterpret_cast<const safe_VkPipelineRenderingCreateInfo *>(safe_gpci.pNext);
@@ -958,8 +958,8 @@ TEST_F(VkPositiveLayerTest, CustomSafePNextCopy) {
 
     // Ensure PNextCopyState::init is also applied when there is more than one element in the pNext chain
     {
-        auto gpl_info = vku::InitStruct<VkGraphicsPipelineLibraryCreateInfoEXT>(&pri);
-        auto gpci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&gpl_info);
+        VkGraphicsPipelineLibraryCreateInfoEXT gpl_info = vku::InitStructHelper(&pri);
+        VkGraphicsPipelineCreateInfo gpci = vku::InitStructHelper(&gpl_info);
 
         safe_VkGraphicsPipelineCreateInfo safe_gpci(&gpci, false, false, &copy_state);
 
@@ -980,7 +980,7 @@ TEST_F(VkPositiveLayerTest, CustomSafePNextCopy) {
         pri.pColorAttachmentFormats = &format;
 
         ignore_default_construction = false;
-        auto gpci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&pri);
+        VkGraphicsPipelineCreateInfo gpci = vku::InitStructHelper(&pri);
         safe_VkGraphicsPipelineCreateInfo safe_gpci(&gpci, false, false, &copy_state);
 
         auto safe_pri = reinterpret_cast<const safe_VkPipelineRenderingCreateInfo *>(safe_gpci.pNext);
@@ -1000,7 +1000,7 @@ TEST_F(VkPositiveLayerTest, FreeCommandBuffersNull) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
-    auto command_buffer_allocate_info = vku::InitStruct<VkCommandBufferAllocateInfo>();
+    VkCommandBufferAllocateInfo command_buffer_allocate_info = vku::InitStructHelper();
     command_buffer_allocate_info.commandPool = m_commandPool->handle();
     command_buffer_allocate_info.commandBufferCount = 1;
     command_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -1017,7 +1017,7 @@ TEST_F(VkPositiveLayerTest, FreeDescriptorSetsNull) {
 
     VkDescriptorPoolSize ds_type_count = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1};
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
@@ -1030,7 +1030,7 @@ TEST_F(VkPositiveLayerTest, FreeDescriptorSetsNull) {
     const vkt::DescriptorSetLayout ds_layout(*m_device, {dsl_binding});
 
     VkDescriptorSet descriptor_sets[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
-    auto alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.descriptorSetCount = 1;
     alloc_info.descriptorPool = ds_pool.handle();
     alloc_info.pSetLayouts = &ds_layout.handle();

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -62,8 +62,8 @@ TEST_F(VkLayerTest, UnsupportedPnextApiVersion) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    auto phys_dev_props_2 = vku::InitStruct<VkPhysicalDeviceProperties2>();
-    auto bad_version_1_1_struct = vku::InitStruct<VkPhysicalDeviceVulkan12Properties>();
+    VkPhysicalDeviceProperties2 phys_dev_props_2 = vku::InitStructHelper();
+    VkPhysicalDeviceVulkan12Properties bad_version_1_1_struct = vku::InitStructHelper();
     phys_dev_props_2.pNext = &bad_version_1_1_struct;
 
     // VkPhysDevVulkan12Props was introduced in 1.2, so try adding it to a 1.1 pNext chain
@@ -75,7 +75,7 @@ TEST_F(VkLayerTest, UnsupportedPnextApiVersion) {
 
     // 1.1 context, VK_KHR_depth_stencil_resolve is NOT enabled, but using its struct is valid
     if (DeviceExtensionSupported(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME)) {
-        auto unenabled_device_ext_struct = vku::InitStruct<VkPhysicalDeviceDepthStencilResolveProperties>();
+        VkPhysicalDeviceDepthStencilResolveProperties unenabled_device_ext_struct = vku::InitStructHelper();
         phys_dev_props_2.pNext = &unenabled_device_ext_struct;
         if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
             vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
@@ -103,7 +103,7 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto private_data_features = vku::InitStruct<VkPhysicalDevicePrivateDataFeaturesEXT>();
+    VkPhysicalDevicePrivateDataFeaturesEXT private_data_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(private_data_features);
     if (private_data_features.privateData == VK_FALSE) {
         GTEST_SKIP() << "privateData feature is not supported";
@@ -341,7 +341,7 @@ TEST_F(VkLayerTest, DuplicateMessageLimit) {
     // Create an invalid pNext structure to trigger the stateless validation warning
     VkBaseOutStructure bogus_struct{};
     bogus_struct.sType = static_cast<VkStructureType>(0x33333333);
-    auto properties2 = vku::InitStruct<VkPhysicalDeviceProperties2KHR>(&bogus_struct);
+    VkPhysicalDeviceProperties2KHR properties2 = vku::InitStructHelper(&bogus_struct);
 
     // Should get the first three errors just fine
     m_errorMonitor->SetDesiredFailureMsg((kErrorBit), "VUID-VkPhysicalDeviceProperties2-pNext-pNext");
@@ -515,7 +515,7 @@ TEST_F(VkLayerTest, LayerInfoMessages) {
 
     VkInstance local_instance;
 
-    auto callback_create_info = vku::InitStruct<VkDebugUtilsMessengerCreateInfoEXT>();
+    VkDebugUtilsMessengerCreateInfoEXT callback_create_info = vku::InitStructHelper();
     callback_create_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
     callback_create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
     callback_create_info.pfnUserCallback = DebugUtilsCallback;
@@ -748,7 +748,7 @@ TEST_F(VkLayerTest, PnextOnlyStructValidation) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     // Create a device passing in a bad PdevFeatures2 value
-    auto indexing_features = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(indexing_features);
     // Set one of the features values to an invalid boolean value
     indexing_features.descriptorBindingUniformBufferUpdateAfterBind = 800;
@@ -909,7 +909,7 @@ TEST_F(VkLayerTest, DebugUtilsNameTest) {
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
-    auto callback_create_info = vku::InitStruct<VkDebugUtilsMessengerCreateInfoEXT>();
+    VkDebugUtilsMessengerCreateInfoEXT callback_create_info = vku::InitStructHelper();
     callback_create_info.messageSeverity =
         VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
     callback_create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
@@ -1004,7 +1004,7 @@ TEST_F(VkLayerTest, DebugUtilsNameTest) {
     const VkRect2D scissor = {{-1, 0}, {16, 16}};
     const VkRect2D scissors[] = {scissor, scissor};
 
-    auto command_label = vku::InitStruct<VkDebugUtilsLabelEXT>();
+    VkDebugUtilsLabelEXT command_label = vku::InitStructHelper();
     command_label.pLabelName = "Command Label 0123";
     command_label.color[0] = 0.;
     command_label.color[1] = 1.;
@@ -1054,7 +1054,7 @@ TEST_F(VkLayerTest, DebugUtilsParameterFlags) {
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
-    auto callback_create_info = vku::InitStruct<VkDebugUtilsMessengerCreateInfoEXT>();
+    VkDebugUtilsMessengerCreateInfoEXT callback_create_info = vku::InitStructHelper();
     callback_create_info.messageSeverity = 0;
     callback_create_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
     callback_create_info.pfnUserCallback = DebugUtilsCallback;
@@ -1104,8 +1104,8 @@ TEST_F(VkLayerTest, InvalidStructPNext) {
     // Need to pick a function that has no allowed pNext structure types.
     // Expected to trigger an error with StatelessValidation::ValidateStructPnext
     VkCommandPool pool = VK_NULL_HANDLE;
-    auto pool_ci = vku::InitStruct<VkCommandPoolCreateInfo>();
-    auto app_info = vku::InitStruct<VkApplicationInfo>();
+    VkCommandPoolCreateInfo pool_ci = vku::InitStructHelper();
+    VkApplicationInfo app_info = vku::InitStructHelper();
     pool_ci.pNext = &app_info;
     vk::CreateCommandPool(device(), &pool_ci, NULL, &pool);
     m_errorMonitor->VerifyFound();
@@ -1278,7 +1278,7 @@ TEST_F(VkLayerTest, LeakABuffer) {
     VkDevice leaky_device;
     ASSERT_VK_SUCCESS(vk::CreateDevice(gpu(), &device_ci, nullptr, &leaky_device));
 
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
     buffer_create_info.size = 1;
@@ -1617,7 +1617,7 @@ TEST_F(VkLayerTest, FeaturesVariablePointer) {
     device_extensions.push_back(VK_KHR_STORAGE_BUFFER_STORAGE_CLASS_EXTENSION_NAME);
 
     // Create a device that enables variablePointers but not variablePointersStorageBuffer
-    auto variable_features = vku::InitStruct<VkPhysicalDeviceVariablePointersFeatures>();
+    VkPhysicalDeviceVariablePointersFeatures variable_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(variable_features);
     if (variable_features.variablePointers == VK_FALSE) {
         GTEST_SKIP() << "variablePointer feature not supported";
@@ -1901,7 +1901,7 @@ TEST_F(VkLayerTest, FreeDescriptorSetsNull) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     VkDescriptorPoolSize ds_type_count = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1};
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
@@ -2495,7 +2495,7 @@ TEST_F(VkLayerTest, ZeroBitmask) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSemaphoreCreateInfo-flags-zerobitmask");
-    auto semaphore_ci = vku::InitStruct<VkSemaphoreCreateInfo>();
+    VkSemaphoreCreateInfo semaphore_ci = vku::InitStructHelper();
     semaphore_ci.flags = 1;
     VkSemaphore semaphore = VK_NULL_HANDLE;
     vk::CreateSemaphore(m_device->device(), &semaphore_ci, nullptr, &semaphore);
@@ -2538,18 +2538,18 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     const bool ycbcr_conversion_extension = IsExtensionsEnabled(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
-    auto portability_features = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_features);
 
     if (ycbcr_conversion_extension) {
-        auto ycbcr_features = vku::InitStruct<VkPhysicalDeviceSamplerYcbcrConversionFeatures>();
+        VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcr_features = vku::InitStructHelper();
         ycbcr_features.samplerYcbcrConversion = VK_TRUE;
         portability_features.pNext = &ycbcr_features;
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto metal_object_create_info = vku::InitStruct<VkExportMetalObjectCreateInfoEXT>();
+    VkExportMetalObjectCreateInfoEXT metal_object_create_info = vku::InitStructHelper();
     auto instance_ci = GetInstanceCreateInfo();
     metal_object_create_info.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT;
     metal_object_create_info.pNext = instance_ci.pNext;
@@ -2561,7 +2561,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     m_errorMonitor->VerifyFound();
     metal_object_create_info.pNext = nullptr;
 
-    auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.pNext = &metal_object_create_info;
     alloc_info.allocationSize = 1024;
     VkDeviceMemory memory;
@@ -2583,7 +2583,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     ici.pNext = &metal_object_create_info;
     CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-06783");
 
-    auto import_metal_texture_info = vku::InitStruct<VkImportMetalTextureInfoEXT>();
+    VkImportMetalTextureInfoEXT import_metal_texture_info = vku::InitStructHelper();
     import_metal_texture_info.plane = VK_IMAGE_ASPECT_COLOR_BIT;
     ici.pNext = &import_metal_texture_info;
     ici.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
@@ -2625,7 +2625,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     ivci.pNext = &metal_object_create_info;
     CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-pNext-06787");
 
-    auto sem_info = vku::InitStruct<VkSemaphoreCreateInfo>();
+    VkSemaphoreCreateInfo sem_info = vku::InitStructHelper();
     sem_info.pNext = &metal_object_create_info;
     VkSemaphore semaphore;
     metal_object_create_info.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT;
@@ -2633,7 +2633,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     vk::CreateSemaphore(device(), &sem_info, NULL, &semaphore);
     m_errorMonitor->VerifyFound();
 
-    auto event_info = vku::InitStruct<VkEventCreateInfo>();
+    VkEventCreateInfo event_info = vku::InitStructHelper();
     if (portability_features.events) {
         event_info.pNext = &metal_object_create_info;
         VkEvent event;
@@ -2642,9 +2642,9 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
         m_errorMonitor->VerifyFound();
     }
 
-    auto export_metal_objects_info = vku::InitStruct<VkExportMetalObjectsInfoEXT>();
-    auto metal_device_info = vku::InitStruct<VkExportMetalDeviceInfoEXT>();
-    auto metal_command_queue_info = vku::InitStruct<VkExportMetalCommandQueueInfoEXT>();
+    VkExportMetalObjectsInfoEXT export_metal_objects_info = vku::InitStructHelper();
+    VkExportMetalDeviceInfoEXT metal_device_info = vku::InitStructHelper();
+    VkExportMetalCommandQueueInfoEXT metal_command_queue_info = vku::InitStructHelper();
     metal_command_queue_info.queue = m_device->m_queue;
     export_metal_objects_info.pNext = &metal_device_info;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportMetalObjectsInfoEXT-pNext-06791");
@@ -2659,7 +2659,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     alloc_info.pNext = nullptr;
     VkResult err = vk::AllocateMemory(device(), &alloc_info, nullptr, &memory);
     ASSERT_VK_SUCCESS(err);
-    auto metal_buffer_info = vku::InitStruct<VkExportMetalBufferInfoEXT>();
+    VkExportMetalBufferInfoEXT metal_buffer_info = vku::InitStructHelper();
     metal_buffer_info.memory = memory;
     export_metal_objects_info.pNext = &metal_buffer_info;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportMetalObjectsInfoEXT-pNext-06793");
@@ -2667,7 +2667,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     m_errorMonitor->VerifyFound();
     vk::FreeMemory(device(), memory, nullptr);
 
-    auto export_metal_object_create_info = vku::InitStruct<VkExportMetalObjectCreateInfoEXT>();
+    VkExportMetalObjectCreateInfoEXT export_metal_object_create_info = vku::InitStructHelper();
     export_metal_object_create_info.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT;
     ici.pNext = &export_metal_object_create_info;
     VkImageObj export_image_obj(m_device);
@@ -2675,7 +2675,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     vkt::BufferView export_buffer_view;
     buff_view_ci.pNext = &export_metal_object_create_info;
     export_buffer_view.init(*m_device, buff_view_ci);
-    auto metal_texture_info = vku::InitStruct<VkExportMetalTextureInfoEXT>();
+    VkExportMetalTextureInfoEXT metal_texture_info = vku::InitStructHelper();
     metal_texture_info.bufferView = export_buffer_view.handle();
     metal_texture_info.image = export_image_obj.handle();
     metal_texture_info.plane = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -2740,7 +2740,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     vk::ExportMetalObjectsEXT(m_device->handle(), &export_metal_objects_info);
     m_errorMonitor->VerifyFound();
 
-    auto metal_iosurface_info = vku::InitStruct<VkExportMetalIOSurfaceInfoEXT>();
+    VkExportMetalIOSurfaceInfoEXT metal_iosurface_info = vku::InitStructHelper();
     metal_iosurface_info.image = image_obj.handle();
     export_metal_objects_info.pNext = &metal_iosurface_info;
     // metal_iosurface_info.image not created with struct in pNext
@@ -2748,7 +2748,7 @@ TEST_F(VkLayerTest, ExportMetalObjects) {
     vk::ExportMetalObjectsEXT(m_device->handle(), &export_metal_objects_info);
     m_errorMonitor->VerifyFound();
 
-    auto metal_shared_event_info = vku::InitStruct<VkExportMetalSharedEventInfoEXT>();
+    VkExportMetalSharedEventInfoEXT metal_shared_event_info = vku::InitStructHelper();
     export_metal_objects_info.pNext = &metal_shared_event_info;
     // metal_shared_event_info event and semaphore both VK_NULL_HANDLE
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkExportMetalObjectsInfoEXT-pNext-06804");

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -67,7 +67,7 @@ TEST_F(NegativePipeline, BasicCompute) {
     pipe.InitState();
     pipe.CreateComputePipeline();
 
-    auto bci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo bci = vku::InitStructHelper();
     bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     bci.size = 1024;
     vkt::Buffer buffer(*m_device, bci);
@@ -282,7 +282,7 @@ TEST_F(NegativePipeline, BadPipelineObject) {
         GTEST_SKIP() << "Test requires at least Vulkan 1.2";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);
     bool has_khr_indirect = IsExtensionsEnabled(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
     if (has_khr_indirect && !features12.drawIndirectCount) {
@@ -486,12 +486,12 @@ TEST_F(NegativePipeline, SamplePNextUnknown) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto sample_locations = vku::InitStruct<VkPipelineSampleLocationsStateCreateInfoEXT>();
+    VkPipelineSampleLocationsStateCreateInfoEXT sample_locations = vku::InitStructHelper();
     sample_locations.sampleLocationsInfo = vku::InitStructHelper();
     auto good_chain = [&sample_locations](CreatePipelineHelper &helper) { helper.pipe_ms_state_ci_.pNext = &sample_locations; };
     CreatePipelineHelper::OneshotTest(*this, good_chain, kErrorBit);
 
-    auto instance_ci = vku::InitStruct<VkInstanceCreateInfo>();
+    VkInstanceCreateInfo instance_ci = vku::InitStructHelper();
     auto bad_chain = [&instance_ci](CreatePipelineHelper &helper) { helper.pipe_ms_state_ci_.pNext = &instance_ci; };
     CreatePipelineHelper::OneshotTest(*this, bad_chain, kErrorBit, "VUID-VkPipelineMultisampleStateCreateInfo-pNext-pNext");
 }
@@ -503,7 +503,7 @@ TEST_F(NegativePipeline, DISABLED_SamplePNextDisabled) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto sample_locations = vku::InitStruct<VkPipelineSampleLocationsStateCreateInfoEXT>();
+    VkPipelineSampleLocationsStateCreateInfoEXT sample_locations = vku::InitStructHelper();
     sample_locations.sampleLocationsInfo = vku::InitStructHelper();
     auto bad_chain = [&sample_locations](CreatePipelineHelper &helper) { helper.pipe_ms_state_ci_.pNext = &sample_locations; };
     CreatePipelineHelper::OneshotTest(*this, bad_chain, kErrorBit, "VUID-VkPipelineMultisampleStateCreateInfo-pNext-pNext");
@@ -547,7 +547,7 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     ASSERT_TRUE(renderpass.initialized());
 
     auto render_target_view = m_renderTargets[0]->targetView(m_renderTargets[0]->format());
-    auto framebuffer_info = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo framebuffer_info = vku::InitStructHelper();
     framebuffer_info.renderPass = renderpass;
     framebuffer_info.width = m_renderTargets[0]->width();
     framebuffer_info.height = m_renderTargets[0]->height();
@@ -579,7 +579,7 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     pipeline_1.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderpass.handle());
     pipeline_2.CreateVKPipeline(descriptorSet.GetPipelineLayout(), renderpass.handle());
 
-    auto rpbinfo = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
     rpbinfo.renderPass = renderpass.handle();
     rpbinfo.framebuffer = framebuffer;
     rpbinfo.renderArea.extent.width = framebuffer_info.width;
@@ -761,7 +761,7 @@ TEST_F(NegativePipeline, RasterizerDiscardWithFragmentShader) {
         1.0f};
 
     VkPipelineLayout pipeline_layout;
-    auto pipeline_layout_create_info = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo pipeline_layout_create_info = vku::InitStructHelper();
     VkResult err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_create_info, nullptr, &pipeline_layout);
     ASSERT_VK_SUCCESS(err);
 
@@ -828,7 +828,7 @@ TEST_F(NegativePipeline, CreateGraphicsPipelineWithBadBasePointer) {
         1.0f};
 
     VkPipelineLayout pipeline_layout;
-    auto pipeline_layout_create_info = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo pipeline_layout_create_info = vku::InitStructHelper();
     VkResult err = vk::CreatePipelineLayout(m_device->device(), &pipeline_layout_create_info, nullptr, &pipeline_layout);
     ASSERT_VK_SUCCESS(err);
 
@@ -883,7 +883,7 @@ TEST_F(NegativePipeline, PipelineCreationCacheControl) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto cache_control_features = vku::InitStruct<VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT>();
+    VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT cache_control_features = vku::InitStructHelper();
     cache_control_features.pipelineCreationCacheControl = VK_FALSE;  // Tests all assume feature is off
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &cache_control_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -1280,8 +1280,8 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesNV) {
         rpi.pSubpasses = &sp;
         vkt::RenderPass rp(*m_device, rpi);
 
-        auto ds = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
-        auto cmi = vku::InitStruct<VkPipelineCoverageModulationStateCreateInfoNV>();
+        VkPipelineDepthStencilStateCreateInfo ds = vku::InitStructHelper();
+        VkPipelineCoverageModulationStateCreateInfoNV cmi = vku::InitStructHelper();
 
         // Create a dummy modulation table that can be used for the positive
         // coverageModulationTableCount test.
@@ -1639,7 +1639,7 @@ TEST_F(NegativePipeline, ViewportSwizzleNV) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto vp_swizzle_state = vku::InitStruct<VkPipelineViewportSwizzleStateCreateInfoNV>();
+    VkPipelineViewportSwizzleStateCreateInfoNV vp_swizzle_state = vku::InitStructHelper();
 
     // Test invalid VkViewportSwizzleNV
     {
@@ -1706,7 +1706,7 @@ TEST_F(NegativePipeline, CreationFeedbackCount) {
         GTEST_SKIP() << "Driver data writeback check not supported by MockICD";
     }
 
-    auto feedback_info = vku::InitStruct<VkPipelineCreationFeedbackCreateInfoEXT>();
+    VkPipelineCreationFeedbackCreateInfoEXT feedback_info = vku::InitStructHelper();
     VkPipelineCreationFeedbackEXT feedbacks[3] = {};
     // Set flags to known value that the driver has to overwrite
     feedbacks[0].flags = VK_PIPELINE_CREATION_FEEDBACK_FLAG_BITS_MAX_ENUM;
@@ -1765,7 +1765,7 @@ TEST_F(NegativePipeline, LineRasterization) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto line_rasterization_features = vku::InitStruct<VkPhysicalDeviceLineRasterizationFeaturesEXT>();
+    VkPhysicalDeviceLineRasterizationFeaturesEXT line_rasterization_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(line_rasterization_features);
 
     line_rasterization_features.rectangularLines = VK_FALSE;
@@ -2496,7 +2496,7 @@ TEST_F(NegativePipeline, DiscardRectangle) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto discard_rectangle_properties = vku::InitStruct<VkPhysicalDeviceDiscardRectanglePropertiesEXT>();
+    VkPhysicalDeviceDiscardRectanglePropertiesEXT discard_rectangle_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(discard_rectangle_properties);
 
     uint32_t count = discard_rectangle_properties.maxDiscardRectangles + 1;
@@ -2555,7 +2555,7 @@ TEST_F(VkLayerTest, ValidateVariableSampleLocations) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto sample_locations = vku::InitStruct<VkPhysicalDeviceSampleLocationsPropertiesEXT>();
+    VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(sample_locations);
 
     if (sample_locations.variableSampleLocations) {
@@ -2611,7 +2611,7 @@ TEST_F(VkLayerTest, ValidateVariableSampleLocations) {
     vkt::Framebuffer framebuffer(*m_device, framebuffer_info);
     ASSERT_TRUE(framebuffer.initialized());
 
-    auto multisample_prop = vku::InitStruct<VkMultisamplePropertiesEXT>();
+    VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
     vk::GetPhysicalDeviceMultisamplePropertiesEXT(gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
     const uint32_t valid_count =
         multisample_prop.maxSampleLocationGridSize.width * multisample_prop.maxSampleLocationGridSize.height;
@@ -2633,7 +2633,7 @@ TEST_F(VkLayerTest, ValidateVariableSampleLocations) {
     sample_locations_state.sampleLocationsEnable = VK_TRUE;
     sample_locations_state.sampleLocationsInfo = sample_locations_info;
 
-    auto multi_sample_state = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>(&sample_locations_state);
+    VkPipelineMultisampleStateCreateInfo multi_sample_state = vku::InitStructHelper(&sample_locations_state);
     multi_sample_state.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     multi_sample_state.sampleShadingEnable = VK_FALSE;
     multi_sample_state.minSampleShading = 1.0;
@@ -2713,7 +2713,7 @@ TEST_F(NegativePipeline, RasterizationConservativeStateCreateInfo) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto conservative_rasterization_props = vku::InitStruct<VkPhysicalDeviceConservativeRasterizationPropertiesEXT>();
+    VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_rasterization_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(conservative_rasterization_props);
 
     VkPipelineRasterizationConservativeStateCreateInfoEXT conservative_state =
@@ -2777,7 +2777,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessWithoutFeature) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto rasterization_order_features = vku::InitStruct<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM>();
+    VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM rasterization_order_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(rasterization_order_features);
 
     rasterization_order_features.rasterizationOrderColorAttachmentAccess = 0;
@@ -2786,9 +2786,9 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessWithoutFeature) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &rasterization_order_features));
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     VkPipelineColorBlendAttachmentState cb_as = {};
-    auto cb_ci = vku::InitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendStateCreateInfo cb_ci = vku::InitStructHelper();
     cb_ci.attachmentCount = 1;
     cb_ci.pAttachments = &cb_as;
 
@@ -2877,7 +2877,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessNoSubpassFlags) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto rasterization_order_features = vku::InitStruct<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM>();
+    VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM rasterization_order_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(rasterization_order_features);
 
     if (!rasterization_order_features.rasterizationOrderColorAttachmentAccess &&
@@ -2888,9 +2888,9 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessNoSubpassFlags) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &rasterization_order_features));
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     VkPipelineColorBlendAttachmentState cb_as = {};
-    auto cb_ci = vku::InitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendStateCreateInfo cb_ci = vku::InitStructHelper();
     cb_ci.attachmentCount = 1;
     cb_ci.pAttachments = &cb_as;
     VkRenderPass render_pass_handle = VK_NULL_HANDLE;
@@ -3048,7 +3048,7 @@ TEST_F(NegativePipeline, MismatchedRenderPassAndPipelineAttachments) {
     pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
-    pipe.cb_ci_ = vku::InitStruct<VkPipelineColorBlendStateCreateInfo>();
+    pipe.cb_ci_ = vku::InitStructHelper();
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -3098,8 +3098,8 @@ TEST_F(NegativePipeline, ShaderTileImageDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
-    auto shader_tile_image_features = vku::InitStruct<VkPhysicalDeviceShaderTileImageFeaturesEXT>();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderTileImageFeaturesEXT shader_tile_image_features = vku::InitStructHelper();
     dynamic_rendering_features.pNext = &shader_tile_image_features;
     auto features2 = GetPhysicalDeviceFeatures2(dynamic_rendering_features);
     if (!dynamic_rendering_features.dynamicRendering) {
@@ -3120,7 +3120,7 @@ TEST_F(NegativePipeline, ShaderTileImageDisabled) {
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
     VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
     pipeline_rendering_info.depthAttachmentFormat = depth_format;
@@ -3179,8 +3179,8 @@ TEST_F(NegativePipeline, ShaderTileImage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
-    auto shader_tile_image_features = vku::InitStruct<VkPhysicalDeviceShaderTileImageFeaturesEXT>();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderTileImageFeaturesEXT shader_tile_image_features = vku::InitStructHelper();
     dynamic_rendering_features.pNext = &shader_tile_image_features;
     auto features2 = GetPhysicalDeviceFeatures2(dynamic_rendering_features);
     if (!dynamic_rendering_features.dynamicRendering) {
@@ -3197,13 +3197,13 @@ TEST_F(NegativePipeline, ShaderTileImage) {
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
     VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
     pipeline_rendering_info.depthAttachmentFormat = depth_format;
     pipeline_rendering_info.stencilAttachmentFormat = depth_format;
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
 
     if (shader_tile_image_features.shaderTileImageDepthReadAccess) {
         auto fs = VkShaderObj::CreateFromASM(this, kShaderTileImageDepthReadSpv, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -3281,7 +3281,7 @@ TEST_F(NegativePipeline, ShaderTileImage) {
                                           "VUID-VkGraphicsPipelineCreateInfo-renderPass-08710");
 
         // sampleShading enable and minSampleShading not equal to 1.0
-        auto ms_ci = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>();
+        VkPipelineMultisampleStateCreateInfo ms_ci = vku::InitStructHelper();
         ms_ci.sampleShadingEnable = VK_TRUE;
         ms_ci.minSampleShading = 0;
         ms_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
@@ -3313,7 +3313,7 @@ TEST_F(NegativePipeline, RasterStateWithDepthBiasRepresentationInfo) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto depth_bias_control_features = vku::InitStruct<VkPhysicalDeviceDepthBiasControlFeaturesEXT>();
+    VkPhysicalDeviceDepthBiasControlFeaturesEXT depth_bias_control_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(depth_bias_control_features);
 
     if (!depth_bias_control_features.depthBiasControl) {
@@ -3334,12 +3334,12 @@ TEST_F(NegativePipeline, RasterStateWithDepthBiasRepresentationInfo) {
         CreatePipelineHelper pipe(*this);
         pipe.InitState();
         pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
-        const auto raster_state = vku::InitStruct<VkPipelineRasterizationStateCreateInfo>(&depth_bias_representation);
+        const VkPipelineRasterizationStateCreateInfo raster_state = vku::InitStructHelper(&depth_bias_representation);
         pipe.rs_state_ci_ = raster_state;
         pipe.CreateGraphicsPipeline();
     };
 
-    auto depth_bias_representation = vku::InitStruct<VkDepthBiasRepresentationInfoEXT>();
+    VkDepthBiasRepresentationInfoEXT depth_bias_representation = vku::InitStructHelper();
     depth_bias_representation.depthBiasRepresentation = VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORCE_UNORM_EXT;
     depth_bias_representation.depthBiasExact = VK_TRUE;
     m_errorMonitor->SetDesiredFailureMsg(

--- a/tests/unit/pipeline_advanced_blend.cpp
+++ b/tests/unit/pipeline_advanced_blend.cpp
@@ -28,7 +28,7 @@ TEST_F(NegativePipelineAdvancedBlend, BlendOps) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto blend_operation_advanced = vku::InitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
+    VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(blend_operation_advanced);
 
     if (!blend_operation_advanced.advancedBlendAllOperations) {
@@ -87,7 +87,7 @@ TEST_F(NegativePipelineAdvancedBlend, MaxBlendAttachment) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto blend_operation_advanced_props = vku::InitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
+    VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(blend_operation_advanced_props);
     if (blend_operation_advanced_props.advancedBlendMaxColorAttachments > 2) {
         GTEST_SKIP() << "advancedBlendMaxColorAttachments is too high";
@@ -124,7 +124,7 @@ TEST_F(NegativePipelineAdvancedBlend, Properties) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto blend_operation_advanced_props = vku::InitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
+    VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(blend_operation_advanced_props);
 
     if (blend_operation_advanced_props.advancedBlendCorrelatedOverlap &&
@@ -133,7 +133,7 @@ TEST_F(NegativePipelineAdvancedBlend, Properties) {
         GTEST_SKIP() << "All VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT properties are enabled; nothing to test";
     }
 
-    auto color_blend_advanced = vku::InitStruct<VkPipelineColorBlendAdvancedStateCreateInfoEXT>();
+    VkPipelineColorBlendAdvancedStateCreateInfoEXT color_blend_advanced = vku::InitStructHelper();
     color_blend_advanced.blendOverlap = VK_BLEND_OVERLAP_DISJOINT_EXT;
     color_blend_advanced.dstPremultiplied = VK_FALSE;
     color_blend_advanced.srcPremultiplied = VK_FALSE;
@@ -170,7 +170,7 @@ TEST_F(VkLayerTest, PipelineInvalidAdvancedBlend) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto blend_operation_advanced = vku::InitStruct<VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
+    VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(blend_operation_advanced);
 
     if (blend_operation_advanced.advancedBlendAllOperations) {

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -55,7 +55,7 @@ TEST_F(NegativePipelineLayout, ExcessSubsampledPerStageDescriptors) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto density_map2_properties = vku::InitStruct<VkPhysicalDeviceFragmentDensityMap2PropertiesEXT>();
+    VkPhysicalDeviceFragmentDensityMap2PropertiesEXT density_map2_properties = vku::InitStructHelper();
     auto properties2 = GetPhysicalDeviceProperties2(density_map2_properties);
 
     ASSERT_NO_FATAL_FAILURE(InitState());
@@ -1034,7 +1034,7 @@ TEST_F(NegativePipelineLayout, SetLayoutFlags) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mut_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mut_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mut_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mut_features));
 

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -83,7 +83,7 @@ TEST_F(PositivePipeline, FragmentShadingRate) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
     VkPhysicalDeviceFeatures2 features2 = GetPhysicalDeviceFeatures2(fsr_features);
     if (fsr_features.pipelineFragmentShadingRate == VK_FALSE || fsr_features.primitiveFragmentShadingRate == VK_FALSE) {
         GTEST_SKIP() << "Test requires (unsupported) pipelineFragmentShadingRate and primitiveFragmentShadingRate";
@@ -885,7 +885,7 @@ TEST_F(PositivePipeline, ConditionalRendering) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto cond_rendering_feature = vku::InitStruct<VkPhysicalDeviceConditionalRenderingFeaturesEXT>();
+    VkPhysicalDeviceConditionalRenderingFeaturesEXT cond_rendering_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(cond_rendering_feature);
     if (cond_rendering_feature.conditionalRendering == VK_FALSE) {
         GTEST_SKIP() << "conditionalRendering feature not supported";
@@ -964,8 +964,8 @@ TEST_F(PositivePipeline, ShaderTileImage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
-    auto shader_tile_image_features = vku::InitStruct<VkPhysicalDeviceShaderTileImageFeaturesEXT>();
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderTileImageFeaturesEXT shader_tile_image_features = vku::InitStructHelper();
     dynamic_rendering_features.pNext = &shader_tile_image_features;
     auto features2 = GetPhysicalDeviceFeatures2(dynamic_rendering_features);
     if (!dynamic_rendering_features.dynamicRendering) {
@@ -982,13 +982,13 @@ TEST_F(PositivePipeline, ShaderTileImage) {
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
     VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
-    auto pipeline_rendering_info = vku::InitStruct<VkPipelineRenderingCreateInfoKHR>();
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
     pipeline_rendering_info.depthAttachmentFormat = depth_format;
     pipeline_rendering_info.stencilAttachmentFormat = depth_format;
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
 
     if (shader_tile_image_features.shaderTileImageDepthReadAccess) {
@@ -1032,7 +1032,7 @@ TEST_F(PositivePipeline, ShaderTileImage) {
     if (shader_tile_image_features.shaderTileImageColorReadAccess) {
         auto fs = VkShaderObj::CreateFromASM(this, kShaderTileImageColorReadSpv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        auto ms_ci = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>();
+        VkPipelineMultisampleStateCreateInfo ms_ci = vku::InitStructHelper();
         ms_ci.sampleShadingEnable = VK_TRUE;
         ms_ci.minSampleShading = 1.0;
         ms_ci.rasterizationSamples = VK_SAMPLE_COUNT_4_BIT;
@@ -1060,7 +1060,7 @@ TEST_F(VkPositiveLayerTest, TestPervertexNVShaderAttributes) {
     VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV fragment_shader_barycentric_features =
         vku::InitStructHelper();
     fragment_shader_barycentric_features.fragmentShaderBarycentric = VK_TRUE;
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&fragment_shader_barycentric_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&fragment_shader_barycentric_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -1139,8 +1139,8 @@ TEST_F(PositivePipeline, MutableStorageImageFormatWriteForFormat) {
         GTEST_SKIP() << "Failed to load device profile layer.";
     }
 
-    auto fmt_props_3 = vku::InitStruct<VkFormatProperties3>();
-    auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+    VkFormatProperties3 fmt_props_3 = vku::InitStructHelper();
+    VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
     fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(gpu(), image_format, &fmt_props);
     fmt_props.formatProperties.optimalTilingFeatures =
@@ -1214,7 +1214,7 @@ TEST_F(PositivePipeline, MutableStorageImageFormatWriteForFormat) {
         GTEST_SKIP() << "Device will not be able to initialize buffer view skipped";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = image_format;
@@ -1277,7 +1277,7 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineRasterizationOrderAttachmentAcces
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto rasterization_order_features = vku::InitStruct<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM>();
+    VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM rasterization_order_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(rasterization_order_features);
 
     if (!rasterization_order_features.rasterizationOrderColorAttachmentAccess &&
@@ -1288,9 +1288,9 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineRasterizationOrderAttachmentAcces
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &rasterization_order_features));
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     VkPipelineColorBlendAttachmentState cb_as = {};
-    auto cb_ci = vku::InitStruct<VkPipelineColorBlendStateCreateInfo>();
+    VkPipelineColorBlendStateCreateInfo cb_ci = vku::InitStructHelper();
     cb_ci.attachmentCount = 1;
     cb_ci.pAttachments = &cb_as;
     VkRenderPass render_pass_handle = VK_NULL_HANDLE;
@@ -1408,7 +1408,7 @@ TEST_F(PositivePipeline, DualBlendShader) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2>();
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features2);
 
     if (features2.features.dualSrcBlend == VK_FALSE) {
@@ -1475,7 +1475,7 @@ TEST_F(PositivePipeline, DISABLED_CreationFeedbackCount0) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto feedback_info = vku::InitStruct<VkPipelineCreationFeedbackCreateInfoEXT>();
+    VkPipelineCreationFeedbackCreateInfoEXT feedback_info = vku::InitStructHelper();
     VkPipelineCreationFeedbackEXT feedbacks[1] = {};
     // Set flags to known value that the driver has to overwrite
     feedbacks[0].flags = VK_PIPELINE_CREATION_FEEDBACK_FLAG_BITS_MAX_ENUM;
@@ -1500,22 +1500,22 @@ TEST_F(PositivePipeline, ShaderModuleIdentifier) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto shader_cache_control_features = vku::InitStruct<VkPhysicalDevicePipelineCreationCacheControlFeatures>();
-    auto shader_module_id_features =
-        vku::InitStruct<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(&shader_cache_control_features);
+    VkPhysicalDevicePipelineCreationCacheControlFeatures shader_cache_control_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT shader_module_id_features =
+        vku::InitStructHelper(&shader_cache_control_features);
     auto features2 = GetPhysicalDeviceFeatures2(shader_module_id_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-    auto sm_id_create_info = vku::InitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto get_identifier = vku::InitStruct<VkShaderModuleIdentifierEXT>();
+    VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
     vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
 
-    auto stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&sm_id_create_info);
+    VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper(&sm_id_create_info);
     stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
     stage_ci.module = VK_NULL_HANDLE;
     stage_ci.pName = "main";
@@ -1553,7 +1553,7 @@ TEST_F(PositivePipeline, ViewportSwizzleNV) {
     // Test case where VkPipelineViewportSwizzleStateCreateInfoNV::viewportCount is EQUAL TO viewportCount set in
     // VkPipelineViewportStateCreateInfo
     {
-        auto vp_swizzle_state = vku::InitStruct<VkPipelineViewportSwizzleStateCreateInfoNV>();
+        VkPipelineViewportSwizzleStateCreateInfoNV vp_swizzle_state = vku::InitStructHelper();
         vp_swizzle_state.viewportCount = size32(viewports);
         vp_swizzle_state.pViewportSwizzles = swizzle.data();
 
@@ -1572,7 +1572,7 @@ TEST_F(PositivePipeline, ViewportSwizzleNV) {
     // Test case where VkPipelineViewportSwizzleStateCreateInfoNV::viewportCount is GREATER THAN viewportCount set in
     // VkPipelineViewportStateCreateInfo
     {
-        auto vp_swizzle_state = vku::InitStruct<VkPipelineViewportSwizzleStateCreateInfoNV>();
+        VkPipelineViewportSwizzleStateCreateInfoNV vp_swizzle_state = vku::InitStructHelper();
         vp_swizzle_state.viewportCount = size32(viewports);
         vp_swizzle_state.pViewportSwizzles = swizzle.data();
 
@@ -1599,7 +1599,7 @@ TEST_F(PositivePipeline, RasterStateWithDepthBiasRepresentationInfo) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto depth_bias_control_features = vku::InitStruct<VkPhysicalDeviceDepthBiasControlFeaturesEXT>();
+    VkPhysicalDeviceDepthBiasControlFeaturesEXT depth_bias_control_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(depth_bias_control_features);
     features2.features.depthBiasClamp =
         VK_FALSE;  // Make sure validation of VkDepthBiasRepresentationInfoEXT in VkPipelineRasterizationStateCreateInfo does not
@@ -1635,13 +1635,13 @@ TEST_F(PositivePipeline, RasterStateWithDepthBiasRepresentationInfo) {
         pipe.AddShader(&fs);
 
         pipe.MakeDynamic(VK_DYNAMIC_STATE_DEPTH_BIAS);
-        const auto raster_state = vku::InitStruct<VkPipelineRasterizationStateCreateInfo>(&depth_bias_representation);
+        const VkPipelineRasterizationStateCreateInfo raster_state = vku::InitStructHelper(&depth_bias_representation);
         pipe.SetRasterization(&raster_state);
 
         pipe.CreateVKPipeline(pl.handle(), m_renderPass);
     };
 
-    auto depth_bias_representation = vku::InitStruct<VkDepthBiasRepresentationInfoEXT>();
+    VkDepthBiasRepresentationInfoEXT depth_bias_representation = vku::InitStructHelper();
     depth_bias_representation.depthBiasRepresentation = VK_DEPTH_BIAS_REPRESENTATION_LEAST_REPRESENTABLE_VALUE_FORCE_UNORM_EXT;
     depth_bias_representation.depthBiasExact = VK_TRUE;
     create_pipe_with_depth_bias_representation(depth_bias_representation);

--- a/tests/unit/pipeline_topology.cpp
+++ b/tests/unit/pipeline_topology.cpp
@@ -94,7 +94,7 @@ TEST_F(NegativePipelineTopology, PointSizeNonDynamicAndRestricted) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto dynamic_state_3_props = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3PropertiesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3PropertiesEXT dynamic_state_3_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(dynamic_state_3_props);
     if (dynamic_state_3_props.dynamicPrimitiveTopologyUnrestricted) {
         GTEST_SKIP() << "dynamicPrimitiveTopologyUnrestricted is VK_TRUE";
@@ -122,7 +122,7 @@ TEST_F(NegativePipelineTopology, PointSizeNonDynamicAndUnrestricted) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto dynamic_state_3_props = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3PropertiesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3PropertiesEXT dynamic_state_3_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(dynamic_state_3_props);
     if (!dynamic_state_3_props.dynamicPrimitiveTopologyUnrestricted) {
         GTEST_SKIP() << "dynamicPrimitiveTopologyUnrestricted is VK_FALSE";
@@ -148,7 +148,7 @@ TEST_F(NegativePipelineTopology, PointSizeDynamicAndRestricted) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -157,7 +157,7 @@ TEST_F(NegativePipelineTopology, PointSizeDynamicAndRestricted) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto dynamic_state_3_props = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3PropertiesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3PropertiesEXT dynamic_state_3_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(dynamic_state_3_props);
     if (dynamic_state_3_props.dynamicPrimitiveTopologyUnrestricted) {
         GTEST_SKIP() << "dynamicPrimitiveTopologyUnrestricted is VK_TRUE";
@@ -166,7 +166,7 @@ TEST_F(NegativePipelineTopology, PointSizeDynamicAndRestricted) {
     VkShaderObj vs(this, NoPointSizeVertShader, VK_SHADER_STAGE_VERTEX_BIT);
 
     const VkDynamicState dyn_state = VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY;
-    auto dyn_state_ci = vku::InitStruct<VkPipelineDynamicStateCreateInfo>();
+    VkPipelineDynamicStateCreateInfo dyn_state_ci = vku::InitStructHelper();
     dyn_state_ci.dynamicStateCount = 1;
     dyn_state_ci.pDynamicStates = &dyn_state;
 
@@ -246,7 +246,7 @@ TEST_F(NegativePipelineTopology, PrimitiveTopologyListRestart) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto ptl_restart_features = vku::InitStruct<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>();
+    VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT ptl_restart_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(ptl_restart_features);
 
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -189,7 +189,7 @@ TEST_F(PositivePipelineTopology, PointSizeStructMemeberWritten) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " required but not supported";
     }
-    auto maint4features = vku::InitStruct<VkPhysicalDeviceMaintenance4FeaturesKHR>();
+    VkPhysicalDeviceMaintenance4FeaturesKHR maint4features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maint4features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maint4features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -495,7 +495,7 @@ TEST_F(PositivePipelineTopology, LineTopologyClasses) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
 
     if (!extended_dynamic_state_features.extendedDynamicState) {
@@ -545,7 +545,7 @@ TEST_F(PositivePipelineTopology, PointSizeDynamicAndUnestricted) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto extended_dynamic_state_features = vku::InitStruct<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceExtendedDynamicStateFeaturesEXT extended_dynamic_state_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(extended_dynamic_state_features);
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
@@ -554,7 +554,7 @@ TEST_F(PositivePipelineTopology, PointSizeDynamicAndUnestricted) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &extended_dynamic_state_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto dynamic_state_3_props = vku::InitStruct<VkPhysicalDeviceExtendedDynamicState3PropertiesEXT>();
+    VkPhysicalDeviceExtendedDynamicState3PropertiesEXT dynamic_state_3_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(dynamic_state_3_props);
     if (!dynamic_state_3_props.dynamicPrimitiveTopologyUnrestricted) {
         GTEST_SKIP() << "dynamicPrimitiveTopologyUnrestricted is VK_TRUE";
@@ -569,7 +569,7 @@ TEST_F(PositivePipelineTopology, PointSizeDynamicAndUnestricted) {
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
     const VkDynamicState dyn_state = VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY;
-    auto dyn_state_ci = vku::InitStruct<VkPipelineDynamicStateCreateInfo>();
+    VkPipelineDynamicStateCreateInfo dyn_state_ci = vku::InitStructHelper();
     dyn_state_ci.dynamicStateCount = 1;
     dyn_state_ci.pDynamicStates = &dyn_state;
 
@@ -595,7 +595,7 @@ TEST_F(PositivePipelineTopology, PointSizeMaintenance5) {
         GTEST_SKIP() << "At least Vulkan 1.1 is required";
     }
 
-    auto maintenance5_features = vku::InitStruct<VkPhysicalDeviceMaintenance5FeaturesKHR>();
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance5_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance5_features));
 

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -60,7 +60,7 @@ TEST_F(NegativePortabilitySubset, Event) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     portability_feature.events = VK_FALSE;  // Make sure events are disabled
 
@@ -81,7 +81,7 @@ TEST_F(NegativePortabilitySubset, Image) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     // Make sure image features are disabled via portability extension
     portability_feature.imageView2DOn3DImage = VK_FALSE;
@@ -122,7 +122,7 @@ TEST_F(NegativePortabilitySubset, ImageViewFormatSwizzle) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(portability_feature);
     portability_feature.imageViewFormatSwizzle = VK_FALSE;
 
@@ -176,7 +176,7 @@ TEST_F(NegativePortabilitySubset, ImageViewFormatReinterpretationComponentCount)
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     portability_feature.imageViewFormatReinterpretation = VK_FALSE;
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &portability_feature));
@@ -223,7 +223,7 @@ TEST_F(NegativePortabilitySubset, Sampler) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     // Make sure image features are disabled via portability extension
     portability_feature.samplerMipLodBias = VK_FALSE;
@@ -243,7 +243,7 @@ TEST_F(NegativePortabilitySubset, TriangleFans) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     // Make sure image features are disabled via portability extension
     portability_feature.triangleFans = VK_FALSE;
@@ -273,12 +273,12 @@ TEST_F(NegativePortabilitySubset, VertexInputStride) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
     // Get the current vertex stride to ensure we pass an incorrect value when creating the graphics pipeline
-    auto portability_properties = vku::InitStruct<VkPhysicalDevicePortabilitySubsetPropertiesKHR>();
+    VkPhysicalDevicePortabilitySubsetPropertiesKHR portability_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(portability_properties);
 
     ASSERT_TRUE(portability_properties.minVertexInputBindingStrideAlignment > 0);
@@ -314,7 +314,7 @@ TEST_F(NegativePortabilitySubset, VertexAttributes) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     // Make sure image features are disabled via portability extension
     portability_feature.vertexAttributeAccessBeyondStride = VK_FALSE;
@@ -356,7 +356,7 @@ TEST_F(NegativePortabilitySubset, RasterizationState) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     // Make sure point polygons are disabled
     portability_feature.pointPolygons = VK_FALSE;
@@ -404,7 +404,7 @@ TEST_F(NegativePortabilitySubset, DepthStencilState) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     portability_feature.separateStencilMaskRef = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
@@ -413,7 +413,7 @@ TEST_F(NegativePortabilitySubset, DepthStencilState) {
     m_depthStencil->Init(m_device, m_width, m_height, m_depth_stencil_fmt);
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget(m_depthStencil->BindInfo()));
 
-    auto depth_stencil_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo depth_stencil_ci = vku::InitStructHelper();
     depth_stencil_ci.stencilTestEnable = VK_TRUE;
     depth_stencil_ci.front.reference = 1;
     depth_stencil_ci.back.reference = depth_stencil_ci.front.reference + 1;
@@ -445,7 +445,7 @@ TEST_F(NegativePortabilitySubset, ColorBlendAttachmentState) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     portability_feature.constantAlphaColorBlendFactors = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
@@ -488,7 +488,7 @@ TEST_F(VkPortabilitySubsetTest, UpdateDescriptorSets) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     // Make sure image features are disabled via portability extension
     portability_feature.mutableComparisonSamplers = VK_FALSE;
@@ -537,7 +537,7 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto portability_feature = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+    VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_feature = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(portability_feature);
     portability_feature.tessellationIsolines = VK_FALSE;                    // Make sure IsoLines are disabled
     portability_feature.tessellationPointMode = VK_FALSE;                   // Make sure PointMode is disabled

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -30,7 +30,7 @@ TEST_F(NegativeProtectedMemory, Queue) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto protected_features = vku::InitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
+    VkPhysicalDeviceProtectedMemoryFeatures protected_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(protected_features);
 
     if (protected_features.protectedMemory == VK_FALSE) {
@@ -171,7 +171,7 @@ TEST_F(NegativeProtectedMemory, Memory) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto protected_memory_features = vku::InitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
+    VkPhysicalDeviceProtectedMemoryFeatures protected_memory_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(protected_memory_features);
 
     if (protected_memory_features.protectedMemory == VK_FALSE) {
@@ -322,7 +322,7 @@ TEST_F(NegativeProtectedMemory, UniqueQueueDeviceCreationBothProtected) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto protected_features = vku::InitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
+    VkPhysicalDeviceProtectedMemoryFeatures protected_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(protected_features);
 
     if (protected_features.protectedMemory == VK_FALSE) {
@@ -530,11 +530,11 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     const bool pipeline_libraries = IsExtensionsEnabled(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
-    auto gpl_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>();
-    auto protected_memory_features = vku::InitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper();
+    VkPhysicalDeviceProtectedMemoryFeatures protected_memory_features = vku::InitStructHelper();
     if (pipeline_libraries) protected_memory_features.pNext = &gpl_features;
-    auto pipeline_protected_access_features =
-        vku::InitStruct<VkPhysicalDevicePipelineProtectedAccessFeaturesEXT>(&protected_memory_features);
+    VkPhysicalDevicePipelineProtectedAccessFeaturesEXT pipeline_protected_access_features =
+        vku::InitStructHelper(&protected_memory_features);
     auto features2 = GetPhysicalDeviceFeatures2(pipeline_protected_access_features);
     pipeline_protected_access_features.pipelineProtectedAccess = VK_TRUE;
 
@@ -578,11 +578,11 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
     if (pipeline_libraries) {
         CreatePipelineHelper pre_raster_lib(*this);
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
-        auto vs_ci = vku::InitStruct<VkShaderModuleCreateInfo>();
+        VkShaderModuleCreateInfo vs_ci = vku::InitStructHelper();
         vs_ci.codeSize = vs_spv.size() * sizeof(decltype(vs_spv)::value_type);
         vs_ci.pCode = vs_spv.data();
 
-        auto stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&vs_ci);
+        VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper(&vs_ci);
         stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
         stage_ci.module = VK_NULL_HANDLE;
         stage_ci.pName = "main";
@@ -595,12 +595,12 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
         VkPipeline libraries[1] = {
             pre_raster_lib.pipeline_,
         };
-        auto link_info = vku::InitStruct<VkPipelineLibraryCreateInfoKHR>();
+        VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
         link_info.libraryCount = size(libraries);
         link_info.pLibraries = libraries;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLibraryCreateInfoKHR-pipeline-07404");
-        auto lib_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+        VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
         lib_ci.flags = VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT;
         vkt::Pipeline lib(*m_device, lib_ci);
         m_errorMonitor->VerifyFound();
@@ -617,7 +617,7 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
         protected_pre_raster_lib.gp_ci_.flags = VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT;
         ASSERT_VK_SUCCESS(protected_pre_raster_lib.CreateGraphicsPipeline());
         libraries[0] = protected_pre_raster_lib.pipeline_;
-        auto protected_lib_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+        VkGraphicsPipelineCreateInfo protected_lib_ci = vku::InitStructHelper(&link_info);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLibraryCreateInfoKHR-pipeline-07407");
         lib_ci.flags = 0;
         vkt::Pipeline lib3(*m_device, protected_lib_ci);
@@ -630,7 +630,7 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
         unprotected_pre_raster_lib.gp_ci_.flags = VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT;
         ASSERT_VK_SUCCESS(unprotected_pre_raster_lib.CreateGraphicsPipeline());
         libraries[0] = unprotected_pre_raster_lib.pipeline_;
-        auto unprotected_lib_ci = vku::InitStruct<VkGraphicsPipelineCreateInfo>(&link_info);
+        VkGraphicsPipelineCreateInfo unprotected_lib_ci = vku::InitStructHelper(&link_info);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineLibraryCreateInfoKHR-pipeline-07405");
         vkt::Pipeline lib4(*m_device, unprotected_lib_ci);
         m_errorMonitor->VerifyFound();
@@ -694,7 +694,7 @@ TEST_F(NegativeProtectedMemory, UnprotectedCommands) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto protected_memory_features = vku::InitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
+    VkPhysicalDeviceProtectedMemoryFeatures protected_memory_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(protected_memory_features);
 
     if (protected_memory_features.protectedMemory == VK_FALSE) {
@@ -774,14 +774,14 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto protected_memory_features = vku::InitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
+    VkPhysicalDeviceProtectedMemoryFeatures protected_memory_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(protected_memory_features);
 
     if (protected_memory_features.protectedMemory == VK_FALSE) {
         GTEST_SKIP() << "protectedMemory feature not supported";
     };
 
-    auto protected_memory_properties = vku::InitStruct<VkPhysicalDeviceProtectedMemoryProperties>();
+    VkPhysicalDeviceProtectedMemoryProperties protected_memory_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(protected_memory_properties);
 
     // Turns m_commandBuffer into a unprotected command buffer without passing in a VkCommandPoolCreateFlags

--- a/tests/unit/protected_memory_positive.cpp
+++ b/tests/unit/protected_memory_positive.cpp
@@ -36,7 +36,7 @@ TEST_F(PositiveProtectedMemory, MixProtectedQueue) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto protected_features = vku::InitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
+    VkPhysicalDeviceProtectedMemoryFeatures protected_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(protected_features);
     if (protected_features.protectedMemory == VK_FALSE) {
         GTEST_SKIP() << "test requires protectedMemory";

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -37,7 +37,7 @@ TEST_F(NegativePushDescriptor, DSBufferInfo) {
     OneOffDescriptorSet descriptor_set(m_device, ds_bindings);
 
     // Create a buffer to be used for invalid updates
-    auto buff_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buff_ci = vku::InitStructHelper();
     buff_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buff_ci.size = m_device->props.limits.minUniformBufferOffsetAlignment;
     buff_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
@@ -45,7 +45,7 @@ TEST_F(NegativePushDescriptor, DSBufferInfo) {
 
     VkDescriptorBufferInfo buff_info = {};
     buff_info.buffer = buffer.handle();
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
     descriptor_write.pTexelBufferView = nullptr;
@@ -72,7 +72,7 @@ TEST_F(NegativePushDescriptor, DSBufferInfo) {
     update_template_entry.offset = offsetof(SimpleTemplateData, buff_info);
     update_template_entry.stride = sizeof(SimpleTemplateData);
 
-    auto update_template_ci = vku::InitStruct<VkDescriptorUpdateTemplateCreateInfoKHR>();
+    VkDescriptorUpdateTemplateCreateInfoKHR update_template_ci = vku::InitStructHelper();
     update_template_ci.descriptorUpdateEntryCount = 1;
     update_template_ci.pDescriptorUpdateEntries = &update_template_entry;
     update_template_ci.templateType = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET;
@@ -89,7 +89,7 @@ TEST_F(NegativePushDescriptor, DSBufferInfo) {
     pipeline_layout.reset(new vkt::PipelineLayout(*m_device, {push_dsl.get()}));
     ASSERT_TRUE(push_dsl->initialized());
 
-    auto push_template_ci = vku::InitStruct<VkDescriptorUpdateTemplateCreateInfoKHR>();
+    VkDescriptorUpdateTemplateCreateInfoKHR push_template_ci = vku::InitStructHelper();
     push_template_ci.descriptorUpdateEntryCount = 1;
     push_template_ci.pDescriptorUpdateEntries = &update_template_entry;
     push_template_ci.templateType = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR;
@@ -157,20 +157,20 @@ TEST_F(NegativePushDescriptor, DestroyDescriptorSetLayout) {
 
     VkDescriptorSetLayoutBinding ds_binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
     VkDescriptorSetLayout ds_layout = VK_NULL_HANDLE;
-    auto dsl_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo dsl_ci = vku::InitStructHelper();
     dsl_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR;
     dsl_ci.bindingCount = 1;
     dsl_ci.pBindings = &ds_binding;
     vk::CreateDescriptorSetLayout(m_device->device(), &dsl_ci, nullptr, &ds_layout);
 
-    auto pipeline_layout_ci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
     pipeline_layout_ci.setLayoutCount = 1;
     pipeline_layout_ci.pSetLayouts = &ds_layout;
     pipeline_layout_ci.pushConstantRangeCount = 0;
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
     VkDescriptorBufferInfo buffer_info = {buffer.handle(), 0, 32};
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
     descriptor_write.pTexelBufferView = nullptr;
@@ -200,20 +200,20 @@ TEST_F(NegativePushDescriptor, TemplateDestroyDescriptorSetLayout) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     vkt::Buffer buffer(*m_device, buffer_ci);
 
     VkDescriptorSetLayoutBinding ds_binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
     VkDescriptorSetLayout ds_layout = VK_NULL_HANDLE;
-    auto dsl_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo dsl_ci = vku::InitStructHelper();
     dsl_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR;
     dsl_ci.bindingCount = 1;
     dsl_ci.pBindings = &ds_binding;
     vk::CreateDescriptorSetLayout(m_device->device(), &dsl_ci, nullptr, &ds_layout);
 
-    auto pipeline_layout_ci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
     pipeline_layout_ci.setLayoutCount = 1;
     pipeline_layout_ci.pSetLayouts = &ds_layout;
     pipeline_layout_ci.pushConstantRangeCount = 0;
@@ -232,7 +232,7 @@ TEST_F(NegativePushDescriptor, TemplateDestroyDescriptorSetLayout) {
     update_template_entry.offset = offsetof(SimpleTemplateData, buff_info);
     update_template_entry.stride = sizeof(SimpleTemplateData);
 
-    auto update_template_ci = vku::InitStruct<VkDescriptorUpdateTemplateCreateInfoKHR>();
+    VkDescriptorUpdateTemplateCreateInfoKHR update_template_ci = vku::InitStructHelper();
     update_template_ci.descriptorUpdateEntryCount = 1;
     update_template_ci.pDescriptorUpdateEntries = &update_template_entry;
     update_template_ci.templateType = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR;
@@ -306,7 +306,7 @@ TEST_F(NegativePushDescriptor, ImageLayout) {
     img_info.sampler = sampler.handle();
     img_info.imageView = image_view;
     img_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = 0;
     descriptor_write.descriptorCount = 1;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
@@ -351,7 +351,7 @@ TEST_F(NegativePushDescriptor, SetLayoutWithoutExtension) {
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR;
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &binding;
@@ -374,20 +374,20 @@ TEST_F(NegativePushDescriptor, AllocateSet) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR;
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &binding;
     vkt::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
 
     VkDescriptorPoolSize pool_size = {binding.descriptorType, binding.descriptorCount};
-    auto dspci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo dspci = vku::InitStructHelper();
     dspci.poolSizeCount = 1;
     dspci.pPoolSizes = &pool_size;
     dspci.maxSets = 1;
     vkt::DescriptorPool pool(*m_device, dspci);
 
-    auto ds_alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo ds_alloc_info = vku::InitStructHelper();
     ds_alloc_info.descriptorPool = pool.handle();
     ds_alloc_info.descriptorSetCount = 1;
     ds_alloc_info.pSetLayouts = &ds_layout.handle();
@@ -428,7 +428,7 @@ TEST_F(NegativePushDescriptor, CreateDescriptorUpdateTemplate) {
 
     constexpr uint64_t badhandle = 0xcadecade;
     VkDescriptorUpdateTemplateEntry entries = {0, 0, 1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 0, sizeof(VkBuffer)};
-    auto create_info = vku::InitStruct<VkDescriptorUpdateTemplateCreateInfo>();
+    VkDescriptorUpdateTemplateCreateInfo create_info = vku::InitStructHelper();
     create_info.flags = 0;
     create_info.descriptorUpdateEntryCount = 1;
     create_info.pDescriptorUpdateEntries = &entries;
@@ -510,12 +510,12 @@ TEST_F(NegativePushDescriptor, SetLayout) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     // Get the push descriptor limits
-    auto push_descriptor_prop = vku::InitStruct<VkPhysicalDevicePushDescriptorPropertiesKHR>();
+    VkPhysicalDevicePushDescriptorPropertiesKHR push_descriptor_prop = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(push_descriptor_prop);
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR;
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &binding;
@@ -555,14 +555,14 @@ TEST_F(NegativePushDescriptor, SetLayoutMutableDescriptor) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto mutable_descriptor_type_features = vku::InitStruct<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>();
+    VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &mutable_descriptor_type_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_MUTABLE_EXT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
 
-    auto ds_layout_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &binding;
 
@@ -580,7 +580,7 @@ TEST_F(NegativePushDescriptor, SetLayoutMutableDescriptor) {
     list.descriptorTypeCount = 2;
     list.pDescriptorTypes = types;
 
-    auto mdtci = vku::InitStruct<VkMutableDescriptorTypeCreateInfoEXT>();
+    VkMutableDescriptorTypeCreateInfoEXT mdtci = vku::InitStructHelper();
     mdtci.mutableDescriptorTypeListCount = 1;
     mdtci.pMutableDescriptorTypeLists = &list;
 
@@ -644,7 +644,7 @@ TEST_F(NegativePushDescriptor, DescriptorUpdateTemplateEntryWithInlineUniformBlo
     update_template_entry.offset = offsetof(SimpleTemplateData, buff_info);
     update_template_entry.stride = sizeof(SimpleTemplateData);
 
-    auto update_template_ci = vku::InitStruct<VkDescriptorUpdateTemplateCreateInfoKHR>();
+    VkDescriptorUpdateTemplateCreateInfoKHR update_template_ci = vku::InitStructHelper();
     update_template_ci.descriptorUpdateEntryCount = 1;
     update_template_ci.pDescriptorUpdateEntries = &update_template_entry;
     update_template_ci.templateType = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET;

--- a/tests/unit/push_descriptor_positive.cpp
+++ b/tests/unit/push_descriptor_positive.cpp
@@ -53,7 +53,7 @@ TEST_F(PositivePushDescriptor, NullDstSet) {
     buff_info.buffer = vbo.handle();
     buff_info.offset = 0;
     buff_info.range = data_size;
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstBinding = 2;
     descriptor_write.descriptorCount = 1;
     descriptor_write.pTexelBufferView = nullptr;
@@ -330,7 +330,7 @@ TEST_F(PositivePushDescriptor, ImmutableSampler) {
     img_info.imageView = imageView;
     img_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
     descriptor_write.pTexelBufferView = nullptr;
@@ -356,7 +356,7 @@ TEST_F(PositivePushDescriptor, TemplateBasic) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     vkt::Buffer buffer(*m_device, buffer_ci);
@@ -381,7 +381,7 @@ TEST_F(PositivePushDescriptor, TemplateBasic) {
     update_template_entry.offset = offsetof(SimpleTemplateData, buff_info);
     update_template_entry.stride = sizeof(SimpleTemplateData);
 
-    auto update_template_ci = vku::InitStruct<VkDescriptorUpdateTemplateCreateInfoKHR>();
+    VkDescriptorUpdateTemplateCreateInfoKHR update_template_ci = vku::InitStructHelper();
     update_template_ci.descriptorUpdateEntryCount = 1;
     update_template_ci.pDescriptorUpdateEntries = &update_template_entry;
     update_template_ci.templateType = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS_KHR;
@@ -416,13 +416,13 @@ TEST_F(PositivePushDescriptor, WriteDescriptorSetNotAllocated) {
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     VkDescriptorSetLayoutBinding ds_binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
-    auto dsl_ci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>();
+    VkDescriptorSetLayoutCreateInfo dsl_ci = vku::InitStructHelper();
     dsl_ci.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR;
     dsl_ci.bindingCount = 1;
     dsl_ci.pBindings = &ds_binding;
     vkt::DescriptorSetLayout ds_layout(*m_device, dsl_ci);
 
-    auto pipeline_layout_ci = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
     pipeline_layout_ci.setLayoutCount = 1;
     pipeline_layout_ci.pSetLayouts = &ds_layout.handle();
     pipeline_layout_ci.pushConstantRangeCount = 0;
@@ -433,7 +433,7 @@ TEST_F(PositivePushDescriptor, WriteDescriptorSetNotAllocated) {
     VkDescriptorSet bad_set = CastFromUint64<VkDescriptorSet>(0xcadecade);
 
     VkDescriptorBufferInfo buffer_info = {buffer.handle(), 0, 32};
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = bad_set;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -26,7 +26,7 @@ TEST_F(NegativeQuery, PerformanceCreation) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto performance_features = vku::InitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
+    VkPhysicalDevicePerformanceQueryFeaturesKHR performance_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(performance_features);
     if (!performance_features.performanceCounterQueryPools) {
         GTEST_SKIP() << "Performance query pools are not supported.";
@@ -107,7 +107,7 @@ TEST_F(NegativeQuery, PerformanceCounterCommandbufferScope) {
     AddRequiredExtensions(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    auto performance_features = vku::InitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
+    VkPhysicalDevicePerformanceQueryFeaturesKHR performance_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(performance_features);
     if (!performance_features.performanceCounterQueryPools) {
         GTEST_SKIP() << "Performance query pools are not supported.";
@@ -276,7 +276,7 @@ TEST_F(NegativeQuery, PerformanceCounterRenderPassScope) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    auto performance_features = vku::InitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
+    VkPhysicalDevicePerformanceQueryFeaturesKHR performance_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(performance_features);
     if (!performance_features.performanceCounterQueryPools) {
         GTEST_SKIP() << "Performance query pools are not supported.";
@@ -379,7 +379,7 @@ TEST_F(NegativeQuery, PerformanceReleaseProfileLockBeforeSubmit) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    auto performance_features = vku::InitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>();
+    VkPhysicalDevicePerformanceQueryFeaturesKHR performance_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(performance_features);
     if (!performance_features.performanceCounterQueryPools) {
         GTEST_SKIP() << "Performance query pools are not supported.";
@@ -538,8 +538,8 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    auto host_query_reset_features = vku::InitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
-    auto performance_features = vku::InitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>(&host_query_reset_features);
+    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features = vku::InitStructHelper();
+    VkPhysicalDevicePerformanceQueryFeaturesKHR performance_features = vku::InitStructHelper(&host_query_reset_features);
     GetPhysicalDeviceFeatures2(performance_features);
     if (!performance_features.performanceCounterQueryPools) {
         GTEST_SKIP() << "Performance query pools are not supported.";
@@ -548,7 +548,7 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
         GTEST_SKIP() << "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR doesn't match up with profile queues";
     }
 
-    auto perf_query_props = vku::InitStruct<VkPhysicalDevicePerformanceQueryPropertiesKHR>();
+    VkPhysicalDevicePerformanceQueryPropertiesKHR perf_query_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(perf_query_props);
 
     VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
@@ -802,8 +802,8 @@ TEST_F(NegativeQuery, PerformanceResetAndBegin) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    auto host_query_reset_features = vku::InitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
-    auto performance_features = vku::InitStruct<VkPhysicalDevicePerformanceQueryFeaturesKHR>(&host_query_reset_features);
+    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features = vku::InitStructHelper();
+    VkPhysicalDevicePerformanceQueryFeaturesKHR performance_features = vku::InitStructHelper(&host_query_reset_features);
     GetPhysicalDeviceFeatures2(performance_features);
     if (!performance_features.performanceCounterQueryPools) {
         GTEST_SKIP() << "Performance query pools are not supported.";
@@ -956,7 +956,7 @@ TEST_F(NegativeQuery, HostResetFirstQuery) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto host_query_reset_features = vku::InitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
+    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_query_reset_features));
 
@@ -981,7 +981,7 @@ TEST_F(NegativeQuery, HostyResetBadRange) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto host_query_reset_features = vku::InitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
+    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_query_reset_features));
 
@@ -1007,7 +1007,7 @@ TEST_F(NegativeQuery, HostyResetQueryPool) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto host_query_reset_features = vku::InitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
+    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_query_reset_features));
 
@@ -1037,7 +1037,7 @@ TEST_F(NegativeQuery, HostyResetDevice) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto host_query_reset_features = vku::InitStruct<VkPhysicalDeviceHostQueryResetFeaturesEXT>();
+    VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(host_query_reset_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &host_query_reset_features));
 
@@ -1398,7 +1398,7 @@ TEST_F(NegativeQuery, PerformanceQueryIntel) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto performance_api_info_intel = vku::InitStruct<VkInitializePerformanceApiInfoINTEL>();
+    VkInitializePerformanceApiInfoINTEL performance_api_info_intel = vku::InitStructHelper();
     vk::InitializePerformanceApiINTEL(m_device->device(), &performance_api_info_intel);
 
     vkt::Buffer buffer(*m_device, 128, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
@@ -1465,7 +1465,7 @@ TEST_F(NegativeQuery, WriteTimeStamp) {
     bool sync2 = IsExtensionsEnabled(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     VkPhysicalDeviceSynchronization2FeaturesKHR synchronization2 = vku::InitStructHelper();
     synchronization2.synchronization2 = VK_TRUE;
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>();
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper();
     if (sync2) {
         features2.pNext = &synchronization2;
     }
@@ -1499,7 +1499,7 @@ TEST_F(NegativeQuery, CmdEndQueryIndexedEXTIndex) {
 
     InitState();
 
-    auto transform_feedback_properties = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transform_feedback_properties);
     if (transform_feedback_properties.maxTransformFeedbackStreams < 1) {
         GTEST_SKIP() << "maxTransformFeedbackStreams < 1";
@@ -1551,7 +1551,7 @@ TEST_F(NegativeQuery, CmdEndQueryIndexedEXTPrimitiveGenerated) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto primitives_generated_features = vku::InitStruct<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>();
+    VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT primitives_generated_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(primitives_generated_features);
     if (primitives_generated_features.primitivesGeneratedQuery == VK_FALSE) {
         GTEST_SKIP() << "primitivesGeneratedQuery feature is not supported.";
@@ -1559,7 +1559,7 @@ TEST_F(NegativeQuery, CmdEndQueryIndexedEXTPrimitiveGenerated) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto transform_feedback_properties = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transform_feedback_properties);
 
     VkQueryPoolCreateInfo qpci = vku::InitStructHelper();
@@ -1615,7 +1615,7 @@ TEST_F(NegativeQuery, TransformFeedbackStream) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto transform_feedback_props = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transform_feedback_props);
     if (transform_feedback_props.transformFeedbackQueries) {
         GTEST_SKIP() << "Transform feedback queries are supported";
@@ -1706,7 +1706,7 @@ TEST_F(NegativeQuery, DestroyActiveQueryPool) {
     VkQueryPool query_pool;
     vk::CreateQueryPool(device(), &query_pool_create_info, nullptr, &query_pool);
 
-    auto cmd_begin = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cmd_begin = vku::InitStructHelper();
     cmd_begin.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
     m_commandBuffer->begin(&cmd_begin);
     vk::CmdResetQueryPool(m_commandBuffer->handle(), query_pool, 0, 1);
@@ -1746,7 +1746,7 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features_1_1 = vku::InitStruct<VkPhysicalDeviceVulkan11Features>();
+    VkPhysicalDeviceVulkan11Features features_1_1 = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(features_1_1);
     if (!features_1_1.multiview) {
         GTEST_SKIP() << "Test requires VkPhysicalDeviceVulkan11Features::multiview feature.";
@@ -1772,13 +1772,13 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
 
     uint32_t viewMasks[] = {0x3u};
     uint32_t correlationMasks[] = {0x1u};
-    auto rpmv_ci = vku::InitStruct<VkRenderPassMultiviewCreateInfo>();
+    VkRenderPassMultiviewCreateInfo rpmv_ci = vku::InitStructHelper();
     rpmv_ci.subpassCount = 1;
     rpmv_ci.pViewMasks = viewMasks;
     rpmv_ci.correlationMaskCount = 1;
     rpmv_ci.pCorrelationMasks = correlationMasks;
 
-    auto rp_ci = vku::InitStruct<VkRenderPassCreateInfo>(&rpmv_ci);
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&rpmv_ci);
     rp_ci.attachmentCount = 1;
     rp_ci.pAttachments = &attach;
     rp_ci.subpassCount = 1;
@@ -1814,7 +1814,7 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
 
     VkImageView image_view_handle = image_view.handle();
 
-    auto fb_ci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
     fb_ci.renderPass = render_pass.handle();
     fb_ci.attachmentCount = 1;
     fb_ci.pAttachments = &image_view_handle;
@@ -1830,7 +1830,7 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
 
     vkt::QueryPool query_pool(*m_device, qpci);
 
-    auto rp_begin = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rp_begin = vku::InitStructHelper();
     rp_begin.renderPass = render_pass.handle();
     rp_begin.framebuffer = framebuffer.handle();
     rp_begin.renderArea.extent = {64, 64};
@@ -1934,7 +1934,7 @@ TEST_F(NegativeQuery, PrimitivesGenerated) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto primitives_generated_features = vku::InitStruct<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>();
+    VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT primitives_generated_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(primitives_generated_features);
     if (primitives_generated_features.primitivesGeneratedQuery == VK_FALSE) {
         GTEST_SKIP() << "primitivesGeneratedQuery feature is not supported";
@@ -1942,7 +1942,7 @@ TEST_F(NegativeQuery, PrimitivesGenerated) {
     primitives_generated_features.primitivesGeneratedQueryWithNonZeroStreams = VK_FALSE;
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
-    auto transform_feedback_properties = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transform_feedback_properties);
 
     const std::optional<uint32_t> compute_queue_family_index =
@@ -1998,7 +1998,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedFeature) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto primitives_generated_features = vku::InitStruct<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>();
+    VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT primitives_generated_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(primitives_generated_features);
     if (primitives_generated_features.primitivesGeneratedQuery == VK_FALSE) {
         GTEST_SKIP() << "primitivesGeneratedQuery feature is not supported";
@@ -2030,7 +2030,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedDiscardEnabled) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto primitives_generated_features = vku::InitStruct<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>();
+    VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT primitives_generated_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(primitives_generated_features);
     if (primitives_generated_features.primitivesGeneratedQuery == VK_FALSE) {
         GTEST_SKIP() << "primitivesGeneratedQuery feature is not supported";
@@ -2039,7 +2039,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedDiscardEnabled) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto rs_ci = vku::InitStruct<VkPipelineRasterizationStateCreateInfo>();
+    VkPipelineRasterizationStateCreateInfo rs_ci = vku::InitStructHelper();
     rs_ci.lineWidth = 1.0f;
     rs_ci.rasterizerDiscardEnable = VK_TRUE;
 
@@ -2050,7 +2050,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedDiscardEnabled) {
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
-    auto query_pool_ci = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo query_pool_ci = vku::InitStructHelper();
     query_pool_ci.queryCount = 1;
     query_pool_ci.queryType = VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT;
 
@@ -2085,15 +2085,15 @@ TEST_F(NegativeQuery, PrimitivesGeneratedStreams) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto xfb_props = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT xfb_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(xfb_props);
     if (!xfb_props.transformFeedbackRasterizationStreamSelect) {
         GTEST_SKIP() << "VkPhysicalDeviceTransformFeedbackFeaturesEXT::transformFeedbackRasterizationStreamSelect is VK_FALSE";
     }
 
-    auto transform_feedback_features = vku::InitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
-    auto primitives_generated_features =
-        vku::InitStruct<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>(&transform_feedback_features);
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT transform_feedback_features = vku::InitStructHelper();
+    VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT primitives_generated_features =
+        vku::InitStructHelper(&transform_feedback_features);
     auto features2 = GetPhysicalDeviceFeatures2(primitives_generated_features);
     if (primitives_generated_features.primitivesGeneratedQuery == VK_FALSE) {
         GTEST_SKIP() << "primitivesGeneratedQuery feature is not supported.";
@@ -2108,7 +2108,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedStreams) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto rasterization_streams = vku::InitStruct<VkPipelineRasterizationStateStreamCreateInfoEXT>();
+    VkPipelineRasterizationStateStreamCreateInfoEXT rasterization_streams = vku::InitStructHelper();
     rasterization_streams.rasterizationStream = 1;
 
     CreatePipelineHelper pipe(*this);
@@ -2116,7 +2116,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedStreams) {
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
-    auto query_pool_ci = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo query_pool_ci = vku::InitStructHelper();
     query_pool_ci.queryCount = 1;
     query_pool_ci.queryType = VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT;
 
@@ -2225,7 +2225,7 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
     }
     const bool indexed_queries = DeviceExtensionSupported(gpu(), nullptr, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "multiview feature not supported";
@@ -2254,7 +2254,7 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
 
     uint32_t viewMasks[2] = {0x1u, 0x3u};
     uint32_t correlationMasks[] = {0x1u};
-    auto rpmv_ci = vku::InitStruct<VkRenderPassMultiviewCreateInfo>();
+    VkRenderPassMultiviewCreateInfo rpmv_ci = vku::InitStructHelper();
     rpmv_ci.subpassCount = 2;
     rpmv_ci.pViewMasks = viewMasks;
     rpmv_ci.correlationMaskCount = 1;
@@ -2268,7 +2268,7 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
     dependency.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
 
-    auto rp_ci = vku::InitStruct<VkRenderPassCreateInfo>(&rpmv_ci);
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper(&rpmv_ci);
     rp_ci.attachmentCount = 1;
     rp_ci.pAttachments = &attach;
     rp_ci.subpassCount = 2;
@@ -2306,7 +2306,7 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
 
     VkImageView image_view_handle = image_view.handle();
 
-    auto fb_ci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
     fb_ci.renderPass = render_pass.handle();
     fb_ci.attachmentCount = 1;
     fb_ci.pAttachments = &image_view_handle;
@@ -2322,7 +2322,7 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
 
     vkt::QueryPool query_pool(*m_device, qpci);
 
-    auto rp_begin = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rp_begin = vku::InitStructHelper();
     rp_begin.renderPass = render_pass.handle();
     rp_begin.framebuffer = framebuffer.handle();
     rp_begin.renderArea.extent = {64, 64};
@@ -2410,7 +2410,7 @@ TEST_F(NegativeQuery, WriteTimestampWithoutQueryPool) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto synchronization2 = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
+    VkPhysicalDeviceSynchronization2Features synchronization2 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(synchronization2);
     if (synchronization2.synchronization2 == VK_FALSE) {
         GTEST_SKIP() << "synchronization2 feature is not available";
@@ -2459,7 +2459,7 @@ TEST_F(NegativeQuery, CmdEndQueryWithoutQueryPool) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     VkQueryPool bad_query_pool = CastFromUint64<VkQueryPool>(0xFFFFEEEE);
-    auto query_pool_create_info = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo query_pool_create_info = vku::InitStructHelper();
     query_pool_create_info.queryType = VK_QUERY_TYPE_OCCLUSION;
     query_pool_create_info.queryCount = 1;
     vkt::QueryPool query_pool(*m_device, query_pool_create_info);
@@ -2480,7 +2480,7 @@ TEST_F(NegativeQuery, CmdCopyQueryPoolResultsWithoutQueryPool) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     VkQueryPool bad_query_pool = CastFromUint64<VkQueryPool>(0xFFFFEEEE);
-    auto query_pool_create_info = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo query_pool_create_info = vku::InitStructHelper();
     query_pool_create_info.queryType = VK_QUERY_TYPE_OCCLUSION;
     query_pool_create_info.queryCount = 1;
     vkt::QueryPool query_pool(*m_device, query_pool_create_info);
@@ -2489,7 +2489,7 @@ TEST_F(NegativeQuery, CmdCopyQueryPoolResultsWithoutQueryPool) {
     vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 0, 0);
     vk::CmdEndQuery(m_commandBuffer->handle(), query_pool.handle(), 0);
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 1024;
     buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     vkt::Buffer buffer(*m_device, buffer_ci);
@@ -2600,7 +2600,7 @@ TEST_F(NegativeQuery, CmdExecuteCommandsActiveQueries) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto primitives_generated_features = vku::InitStruct<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>();
+    VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT primitives_generated_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(primitives_generated_features);
     if (primitives_generated_features.primitivesGeneratedQuery == VK_FALSE) {
         GTEST_SKIP() << "primitivesGeneratedQuery feature is not supported.";

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -384,7 +384,7 @@ TEST_F(PositiveQuery, WriteTimestampNoneAndAll) {
     }
     VkPhysicalDeviceSynchronization2FeaturesKHR synchronization2 = vku::InitStructHelper();
     synchronization2.synchronization2 = VK_TRUE;
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>();
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper();
     features2.pNext = &synchronization2;
     InitState(nullptr, &features2);
     if (synchronization2.synchronization2 != VK_TRUE) {

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -43,7 +43,7 @@ void RayTracingTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
     }
 
     VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper();
-    auto indexing_features = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
     if (descriptor_indexing) {
         features2 = GetPhysicalDeviceFeatures2(indexing_features);
         if (!indexing_features.runtimeDescriptorArray || !indexing_features.descriptorBindingPartiallyBound ||
@@ -61,8 +61,8 @@ void RayTracingTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
         (PFN_vkGetPhysicalDeviceProperties2KHR)vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR");
     ASSERT_TRUE(vkGetPhysicalDeviceProperties2KHR != nullptr);
 
-    auto ray_tracing_properties = vku::InitStruct<VkPhysicalDeviceRayTracingPropertiesNV>();
-    auto properties2 = vku::InitStruct<VkPhysicalDeviceProperties2KHR>(&ray_tracing_properties);
+    VkPhysicalDeviceRayTracingPropertiesNV ray_tracing_properties = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2KHR properties2 = vku::InitStructHelper(&ray_tracing_properties);
     vkGetPhysicalDeviceProperties2KHR(gpu(), &properties2);
     if (ray_tracing_properties.maxTriangleCount == 0) {
         GTEST_SKIP() << "Did not find required ray tracing properties";
@@ -1018,15 +1018,15 @@ TEST_F(NegativeRayTracing, BarrierAccessAccelerationStructure) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    auto mem_barrier = vku::InitStruct<VkMemoryBarrier2>();
+    VkMemoryBarrier2 mem_barrier = vku::InitStructHelper();
     mem_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
     mem_barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
 
-    auto dependency_info = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
 
@@ -1072,17 +1072,17 @@ TEST_F(NegativeRayTracing, BarrierSync2AccessAccelerationStructureRayQueryDisabl
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    auto mem_barrier = vku::InitStruct<VkMemoryBarrier2>();
+    VkMemoryBarrier2 mem_barrier = vku::InitStructHelper();
     mem_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
     mem_barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
 
     vkt::Buffer buffer(*m_device, 32);
 
-    auto buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier2>();
+    VkBufferMemoryBarrier2 buffer_barrier = vku::InitStructHelper();
     buffer_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
     buffer_barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
     buffer_barrier.buffer = buffer.handle();
@@ -1092,13 +1092,13 @@ TEST_F(NegativeRayTracing, BarrierSync2AccessAccelerationStructureRayQueryDisabl
     image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier2>();
+    VkImageMemoryBarrier2 image_barrier = vku::InitStructHelper();
     image_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
     image_barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
     image_barrier.image = image.handle();
     image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    auto dependency_info = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
     dependency_info.bufferMemoryBarrierCount = 1;
@@ -1149,12 +1149,12 @@ TEST_F(NegativeRayTracing, BarrierSync1AccessAccelerationStructureRayQueryDisabl
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto memory_barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier memory_barrier = vku::InitStructHelper();
     memory_barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     memory_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
 
     vkt::Buffer buffer(*m_device, 32);
-    auto buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+    VkBufferMemoryBarrier buffer_barrier = vku::InitStructHelper();
     buffer_barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     buffer_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     buffer_barrier.buffer = buffer.handle();
@@ -1163,7 +1163,7 @@ TEST_F(NegativeRayTracing, BarrierSync1AccessAccelerationStructureRayQueryDisabl
     VkImageObj image(m_device);
     image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     image_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     image_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -1206,12 +1206,12 @@ TEST_F(NegativeRayTracing, EventSync1AccessAccelerationStructureRayQueryDisabled
 
     const vkt::Event event(*m_device);
 
-    auto memory_barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier memory_barrier = vku::InitStructHelper();
     memory_barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     memory_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
 
     vkt::Buffer buffer(*m_device, 32);
-    auto buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+    VkBufferMemoryBarrier buffer_barrier = vku::InitStructHelper();
     buffer_barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     buffer_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     buffer_barrier.buffer = buffer.handle();
@@ -1220,7 +1220,7 @@ TEST_F(NegativeRayTracing, EventSync1AccessAccelerationStructureRayQueryDisabled
     VkImageObj image(m_device);
     image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     image_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     image_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -1269,7 +1269,7 @@ TEST_F(NegativeRayTracing, DescriptorBindingUpdateAfterBindWithAccelerationStruc
 
     VkDescriptorBindingFlags flags = VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT;
 
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = 1;
     flags_create_info.pBindingFlags = &flags;
 
@@ -1296,11 +1296,11 @@ TEST_F(NegativeRayTracing, AccelerationStructureBindings) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto accel_struct_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto ray_tracing_pipeline_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(&accel_struct_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_struct_features = vku::InitStructHelper();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_pipeline_features = vku::InitStructHelper(&accel_struct_features);
     GetPhysicalDeviceFeatures2(ray_tracing_pipeline_features);
 
-    auto accel_struct_props = vku::InitStruct<VkPhysicalDeviceAccelerationStructurePropertiesKHR>();
+    VkPhysicalDeviceAccelerationStructurePropertiesKHR accel_struct_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(accel_struct_props);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_pipeline_features));
@@ -1578,8 +1578,8 @@ TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto as_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&as_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR as_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&as_features);
     GetPhysicalDeviceFeatures2(bda_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &bda_features));
 
@@ -1590,7 +1590,7 @@ TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure) {
     auto valid_blas = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(DeviceValidationVersion(), 4096);
     valid_blas->Build(*m_device);
 
-    auto copy_info = vku::InitStruct<VkCopyAccelerationStructureInfoKHR>();
+    VkCopyAccelerationStructureInfoKHR copy_info = vku::InitStructHelper();
     copy_info.src = blas_no_mem->handle();
     copy_info.dst = valid_blas->handle();
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR;
@@ -1621,8 +1621,8 @@ TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&bda_features);
+    VkPhysicalDeviceBufferDeviceAddressFeatures bda_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper(&bda_features);
     auto features2 = GetPhysicalDeviceFeatures2(accel_features);
 
     if (accel_features.accelerationStructureHostCommands == VK_FALSE) {
@@ -1633,7 +1633,7 @@ TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
 
     // Init a non host visible buffer
     vkt::Buffer buffer;
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     buffer.init_no_mem(*m_device, buffer_ci);
@@ -1658,7 +1658,7 @@ TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
     blas_host_mem->SetDeviceBufferMemoryPropertyFlags(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     blas_host_mem->Build(*m_device);
 
-    auto copy_info = vku::InitStruct<VkCopyAccelerationStructureInfoKHR>();
+    VkCopyAccelerationStructureInfoKHR copy_info = vku::InitStructHelper();
     copy_info.src = blas_no_mem->handle();
     copy_info.dst = blas->handle();
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR;
@@ -1699,10 +1699,10 @@ TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate CmdCopyMemoryToAccelerationStructureKHR with dst buffer not bound to memory");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_tracing_features);
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&bda_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper(&ray_tracing_features);
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -1715,7 +1715,7 @@ TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructureKHR) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     vkt::Buffer src_buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
@@ -1760,8 +1760,8 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructureKHR) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto acc_structure_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_tracing_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR acc_structure_features = vku::InitStructHelper(&ray_tracing_features);
     auto features2 = GetPhysicalDeviceFeatures2(acc_structure_features);
     if (acc_structure_features.accelerationStructureHostCommands == VK_FALSE) {
         GTEST_SKIP() << "accelerationStructureHostCommands feature not supported";
@@ -1771,7 +1771,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructureKHR) {
 
     // Init a non host visible buffer
     vkt::Buffer non_host_visible_buffer;
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     non_host_visible_buffer.init_no_mem(*m_device, buffer_ci);
@@ -1821,8 +1821,8 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructureMemory) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>();
-    auto as_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_query_features);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR as_features = vku::InitStructHelper(&ray_query_features);
     GetPhysicalDeviceFeatures2(as_features);
 
     if (as_features.accelerationStructureHostCommands == VK_FALSE) {
@@ -1833,7 +1833,7 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructureMemory) {
 
     // Init a non host visible buffer
     vkt::Buffer non_host_visible_buffer;
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     non_host_visible_buffer.init_no_mem(*m_device, buffer_ci);
@@ -1876,7 +1876,7 @@ TEST_F(NegativeRayTracing, CopyMemoryToAsBuffer) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(accel_features);
     if (accel_features.accelerationStructureHostCommands == VK_FALSE) {
         GTEST_SKIP() << "accelerationStructureHostCommands feature is not supported";
@@ -1886,7 +1886,7 @@ TEST_F(NegativeRayTracing, CopyMemoryToAsBuffer) {
 
     // Init a non host visible buffer
     vkt::Buffer non_host_visible_buffer;
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     non_host_visible_buffer.init_no_mem(*m_device, buffer_ci);
@@ -1907,7 +1907,7 @@ TEST_F(NegativeRayTracing, CopyMemoryToAsBuffer) {
     VkDeviceOrHostAddressConstKHR output_data;
     output_data.hostAddress = reinterpret_cast<void *>(output);
 
-    auto info = vku::InitStruct<VkCopyMemoryToAccelerationStructureInfoKHR>();
+    VkCopyMemoryToAccelerationStructureInfoKHR info = vku::InitStructHelper();
     info.dst = blas->handle();
     info.src = output_data;
     info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR;
@@ -1930,11 +1930,11 @@ TEST_F(NegativeRayTracing, CreateAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate acceleration structure creation.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&ray_tracing_features);
-    auto acc_struct_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_query_features);
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&acc_struct_features);
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&bda_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&ray_tracing_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR acc_struct_features = vku::InitStructHelper(&ray_query_features);
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&acc_struct_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -1942,7 +1942,7 @@ TEST_F(NegativeRayTracing, CreateAccelerationStructureKHR) {
 
     VkAccelerationStructureKHR as;
     VkAccelerationStructureCreateInfoKHR as_create_info = vku::InitStructHelper();
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     vkt::Buffer buffer(*m_device, 4096,
                        VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
@@ -2020,9 +2020,9 @@ TEST_F(NegativeRayTracing, CreateAccelerationStructureKHRReplayFeature) {
     TEST_DESCRIPTION("Validate acceleration structure creation replay feature.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    auto acc_struct_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&acc_struct_features);
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&bda_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR acc_struct_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&acc_struct_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -2030,7 +2030,7 @@ TEST_F(NegativeRayTracing, CreateAccelerationStructureKHRReplayFeature) {
     acc_struct_features.accelerationStructureCaptureReplay = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     vkt::Buffer buffer(*m_device, 4096,
                        VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
@@ -2060,10 +2060,10 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper();
     bda_features.bufferDeviceAddress = VK_TRUE;
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(&bda_features);
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_tracing_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper(&bda_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_tracing_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -2129,14 +2129,14 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &mem_reqs);
 
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
     alloc_info.allocationSize = 4096;
     vkt::DeviceMemory mem(*m_device, alloc_info);
     vk::BindBufferMemory(device(), buffer.handle(), mem.handle(), 0);
 
-    auto ray_tracing_properties = vku::InitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
+    VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_properties);
 
     const VkDeviceAddress device_address = buffer.address();
@@ -2260,9 +2260,9 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirectKHR) {
     TEST_DESCRIPTION("Validate vkCmdTraceRaysIndirectKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&ray_tracing_features);
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&bda_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&ray_tracing_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -2276,11 +2276,11 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirectKHR) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     buf_info.size = 4096;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    auto allocate_flag_info = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
     allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
     vkt::Buffer buffer(*m_device, buf_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
 
-    auto ray_tracing_properties = vku::InitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
+    VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_properties);
 
     const VkDeviceAddress device_address = buffer.address(DeviceValidationVersion());
@@ -2356,9 +2356,9 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRFeatureDisabled) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
-    // auto maintenance1_features = vku::InitStruct<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&bda_features);
+    // VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR maintenance1_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper();
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -2374,7 +2374,7 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRFeatureDisabled) {
     buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     buffer_info.size = 4096;
     buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    auto allocate_flag_info = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
     allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
     vkt::Buffer buffer(*m_device, buffer_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
 
@@ -2397,9 +2397,9 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRAddress) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
-    auto maintenance1_features = vku::InitStruct<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&maintenance1_features);
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&bda_features);
+    VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR maintenance1_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&maintenance1_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -2419,7 +2419,7 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRAddress) {
     buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     buffer_info.size = 4096;
     buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    auto allocate_flag_info = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
     allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
     vkt::Buffer buffer(*m_device, buffer_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
 
@@ -2444,7 +2444,7 @@ TEST_F(NegativeRayTracing, AccelerationStructureVersionInfoKHR) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(ray_tracing_features);
     if (ray_tracing_features.rayTracingPipeline == VK_FALSE) {
         GTEST_SKIP() << "rayTracing not supported";
@@ -2477,15 +2477,15 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
 
     AddOptionalExtensions(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME);
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
     ray_query_features.rayQuery = VK_TRUE;
     accel_features.accelerationStructureIndirectBuild = VK_TRUE;
     accel_features.accelerationStructureHostCommands = VK_TRUE;
     bda_features.bufferDeviceAddress = VK_TRUE;
 
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_query_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -2493,7 +2493,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
 
     const bool index_type_uint8 = IsExtensionsEnabled(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME);
 
-    auto acc_struct_properties = vku::InitStruct<VkPhysicalDeviceAccelerationStructurePropertiesKHR>();
+    VkPhysicalDeviceAccelerationStructurePropertiesKHR acc_struct_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(acc_struct_properties);
 
     // Command buffer not in recording mode
@@ -2739,7 +2739,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     }
     // Buffer is missing VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR usage flag
     {
-        auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+        VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
         alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
         vkt::Buffer bad_usage_buffer(*m_device, 1024,
                                      VK_BUFFER_USAGE_RAY_TRACING_BIT_NV | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
@@ -2752,7 +2752,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     }
     // Scratch data buffer is missing VK_BUFFER_USAGE_STORAGE_BUFFER_BIT usage flag
     {
-        auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+        VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
         alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
         auto bad_scratch = std::make_shared<vkt::Buffer>(*m_device, 4096, VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
                                                          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
@@ -2765,7 +2765,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     }
     // Scratch data buffer is 0
     {
-        auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+        VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
         alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
         // no VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT => scratch address will be set to 0
         auto bad_scratch = std::make_shared<vkt::Buffer>(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
@@ -2786,14 +2786,14 @@ TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
         "Validate acceleration structure building when source/destination acceleration structures and scratch buffers overlap.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
     accel_features.accelerationStructure = VK_TRUE;
     bda_features.bufferDeviceAddress = VK_TRUE;
     ray_query_features.rayQuery = VK_TRUE;
 
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_query_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -2803,7 +2803,7 @@ TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
     constexpr size_t build_info_count = 3;
 
     // All buffers used to back source/destination acceleration struct and scratch will be bound to this memory chunk
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
     alloc_info.allocationSize = 8192;
@@ -2811,7 +2811,7 @@ TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
 
     // Test overlapping scratch buffers
     {
-        auto scratch_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo scratch_buffer_ci = vku::InitStructHelper();
         scratch_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         scratch_buffer_ci.size = 4096;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
@@ -2842,7 +2842,7 @@ TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
 
     // Test overlapping destination acceleration structures
     {
-        auto dst_blas_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo dst_blas_buffer_ci = vku::InitStructHelper();
         dst_blas_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         dst_blas_buffer_ci.size = 4096;
         dst_blas_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
@@ -2873,13 +2873,13 @@ TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
 
     // Test overlapping destination acceleration structure and scratch buffer
     {
-        auto dst_blas_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo dst_blas_buffer_ci = vku::InitStructHelper();
         dst_blas_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         dst_blas_buffer_ci.size = 4096;
         dst_blas_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
                                    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR |
                                    VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-        auto scratch_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo scratch_buffer_ci = vku::InitStructHelper();
         scratch_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         scratch_buffer_ci.size = 4096;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
@@ -2923,7 +2923,7 @@ TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
 
     // Test overlapping source acceleration structure and destination acceleration structures
     {
-        auto blas_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo blas_buffer_ci = vku::InitStructHelper();
         blas_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         blas_buffer_ci.size = 4096;
         blas_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
@@ -2976,12 +2976,12 @@ TEST_F(NegativeRayTracing, DISABLED_AccelerationStructuresOverlappingMemory) {
 
     // Test overlapping source acceleration structure and scratch buffer
     {
-        auto blas_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo blas_buffer_ci = vku::InitStructHelper();
         blas_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         blas_buffer_ci.size = 4096;
         blas_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
                                VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-        auto scratch_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo scratch_buffer_ci = vku::InitStructHelper();
         scratch_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         scratch_buffer_ci.size = 4096;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
@@ -3041,10 +3041,10 @@ TEST_F(NegativeRayTracing, ObjInUseCmdBuildAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate acceleration structure building tracks the objects used.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_tracing_features);
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&bda_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper(&ray_tracing_features);
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -3084,21 +3084,21 @@ TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&ray_tracing_features);
-    auto acc_struct_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_query_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&ray_tracing_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR acc_struct_features = vku::InitStructHelper(&ray_query_features);
     GetPhysicalDeviceFeatures2(acc_struct_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &acc_struct_features));
 
     constexpr VkDeviceSize buffer_size = 4096;
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = buffer_size;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     vkt::Buffer buffer;
     buffer.init_no_mem(*m_device, buffer_ci);
 
-    auto as_create_info = vku::InitStruct<VkAccelerationStructureCreateInfoKHR>();
+    VkAccelerationStructureCreateInfoKHR as_create_info = vku::InitStructHelper();
     as_create_info.pNext = NULL;
     as_create_info.buffer = buffer.handle();
     as_create_info.createFlags = 0;
@@ -3114,7 +3114,7 @@ TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
     int8_t output[buffer_size + alignment_padding];
     VkDeviceOrHostAddressKHR output_data;
     output_data.hostAddress = reinterpret_cast<void *>(((intptr_t)output + alignment_padding) & ~alignment_padding);
-    auto copy_info = vku::InitStruct<VkCopyAccelerationStructureToMemoryInfoKHR>();
+    VkCopyAccelerationStructureToMemoryInfoKHR copy_info = vku::InitStructHelper();
     copy_info.src = as;
     copy_info.dst = output_data;
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR;
@@ -3138,9 +3138,9 @@ TEST_F(NegativeRayTracing, UpdateAccelerationStructureKHR) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto buffer_address_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&ray_tracing_features);
-    auto acc_structure_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&buffer_address_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR buffer_address_features = vku::InitStructHelper(&ray_tracing_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR acc_structure_features = vku::InitStructHelper(&buffer_address_features);
     GetPhysicalDeviceFeatures2(acc_structure_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &acc_structure_features));
 
@@ -3172,10 +3172,10 @@ TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
         "as long as valid buffers are correctly removed from the internal buffer device addresses to buffers mapping.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(&accel_features);
-    auto buffer_addr_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&ray_tracing_features);
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&buffer_addr_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR buffer_addr_features = vku::InitStructHelper(&ray_tracing_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&buffer_addr_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -3185,7 +3185,7 @@ TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // Allocate common buffer memory
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
     alloc_info.allocationSize = 4096;
@@ -3200,7 +3200,7 @@ TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
     const VkBufferUsageFlags bad_buffer_usage =
         VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     buffer_ci.size = 4096;
     buffer_ci.usage = good_buffer_usage;
@@ -3268,9 +3268,9 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresProperties) {
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_RAY_QUERY_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "Test requires at least Vulkan 1.1";
@@ -3361,10 +3361,10 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1) {
     AddRequiredExtensions(VK_KHR_RAY_QUERY_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
 
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
-    auto ray_tracing_maintenance1 = vku::InitStruct<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(&ray_query_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
+    VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR ray_tracing_maintenance1 = vku::InitStructHelper(&ray_query_features);
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
@@ -3508,7 +3508,7 @@ TEST_F(NegativeRayTracingNV, AccelerationStructureBindings) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto ray_tracing_props = vku::InitStruct<VkPhysicalDeviceRayTracingPropertiesNV>();
+    VkPhysicalDeviceRayTracingPropertiesNV ray_tracing_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_props);
 
     ASSERT_NO_FATAL_FAILURE(InitState());

--- a/tests/unit/ray_tracing_pipeline.cpp
+++ b/tests/unit/ray_tracing_pipeline.cpp
@@ -25,7 +25,7 @@ TEST_F(NegativeRayTracingPipeline, BasicUsage) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(ray_tracing_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
     const vkt::PipelineLayout empty_pipeline_layout(*m_device, {});
@@ -184,7 +184,7 @@ TEST_F(NegativeRayTracingPipeline, ShaderGroupsKHR) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(ray_tracing_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
 
@@ -679,7 +679,7 @@ TEST_F(NegativeRayTracingPipeline, LibraryFlags) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(ray_tracing_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
 
@@ -789,7 +789,7 @@ TEST_F(NegativeRayTracingPipeline, LibraryFlags) {
     }
 
     if (ray_tracing_features.rayTracingPipelineShaderGroupHandleCaptureReplay) {
-        auto ray_tracing_properties = vku::InitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
+        VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_properties = vku::InitStructHelper();
         GetPhysicalDeviceProperties2(ray_tracing_properties);
         std::vector<uint8_t> handle_buffer;
         handle_buffer.resize(ray_tracing_properties.shaderGroupHandleCaptureReplaySize);
@@ -807,9 +807,9 @@ TEST_F(NegativeRayTracingPipeline, GetCaptureReplayShaderGroupHandlesKHR) {
     TEST_DESCRIPTION("Validate vkGetRayTracingCaptureReplayShaderGroupHandlesKHR.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
-    auto rt_pipeline_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR rt_pipeline_features = vku::InitStructHelper();
     rt_pipeline_features.rayTracingPipelineShaderGroupHandleCaptureReplay = VK_TRUE;
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&rt_pipeline_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&rt_pipeline_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -818,7 +818,7 @@ TEST_F(NegativeRayTracingPipeline, GetCaptureReplayShaderGroupHandlesKHR) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     features2 = GetPhysicalDeviceFeatures2(ray_tracing_features);
     if (ray_tracing_features.rayTracingPipelineShaderGroupHandleCaptureReplay == VK_FALSE) {
         GTEST_SKIP() << "rayTracingShaderGroupHandleCaptureReplay not enabled";
@@ -849,7 +849,7 @@ TEST_F(NegativeRayTracingPipeline, GetCaptureReplayShaderGroupHandlesKHR) {
     m_errorMonitor->VerifyFound();
 
     // dataSize must be at least VkPhysicalDeviceRayTracingPropertiesKHR::shaderGroupHandleCaptureReplaySize
-    auto ray_tracing_properties = vku::InitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
+    VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_properties);
     // Check only when the reported size is
     if (ray_tracing_properties.shaderGroupHandleCaptureReplaySize > 0) {
@@ -878,8 +878,8 @@ TEST_F(NegativeRayTracingPipeline, DeferredOp) {
         "Test that objects created with deferred operations are recorded once the operation has successfully completed.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_tracing_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_tracing_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -1023,7 +1023,7 @@ TEST_F(NegativeRayTracingPipeline, MaxResources) {
         GTEST_SKIP() << "Failed to load device profile layer.";
     }
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(ray_tracing_features);
     if (!ray_tracing_features.rayTraversalPrimitiveCulling) {
         GTEST_SKIP() << "Feature rayTraversalPrimitiveCulling is not supported.";
@@ -1051,7 +1051,7 @@ TEST_F(NegativeRayTracingPipeline, MaxResources) {
     stage_create_info.module = rgen_shader.handle();
     stage_create_info.pName = "main";
 
-    auto shader_group = vku::InitStruct<VkRayTracingShaderGroupCreateInfoKHR>();
+    VkRayTracingShaderGroupCreateInfoKHR shader_group = vku::InitStructHelper();
     shader_group.type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR;
     shader_group.generalShader = 0;
     shader_group.closestHitShader = VK_SHADER_UNUSED_KHR;
@@ -1083,7 +1083,7 @@ TEST_F(NegativeRayTracingPipeline, PipelineFlags) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(ray_tracing_features);
     if (!ray_tracing_features.rayTraversalPrimitiveCulling) {
         GTEST_SKIP() << "Feature rayTraversalPrimitiveCulling is not supported.";
@@ -1098,7 +1098,7 @@ TEST_F(NegativeRayTracingPipeline, PipelineFlags) {
     stage_create_info.module = rgen_shader.handle();
     stage_create_info.pName = "main";
 
-    auto shader_group = vku::InitStruct<VkRayTracingShaderGroupCreateInfoKHR>();
+    VkRayTracingShaderGroupCreateInfoKHR shader_group = vku::InitStructHelper();
     shader_group.type = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_NV;
     shader_group.generalShader = 0;
     shader_group.closestHitShader = VK_SHADER_UNUSED_KHR;
@@ -1154,9 +1154,9 @@ TEST_F(NegativeRayTracingPipeline, LibraryGroupHandlesEXT) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
-    auto pipeline_library_group_handles_features =
-        vku::InitStruct<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT>(&ray_tracing_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
+    VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT pipeline_library_group_handles_features =
+        vku::InitStructHelper(&ray_tracing_features);
     GetPhysicalDeviceFeatures2(pipeline_library_group_handles_features);
     if (!ray_tracing_features.rayTracingPipelineShaderGroupHandleCaptureReplay) {
         GTEST_SKIP() << "rayTracingShaderGroupHandleCaptureReplay not enabled";
@@ -1182,7 +1182,7 @@ TEST_F(NegativeRayTracingPipeline, LibraryGroupHandlesEXT) {
     interface_ci.maxPipelineRayHitAttributeSize = 4;
     interface_ci.maxPipelineRayPayloadSize = 4;
 
-    auto ray_tracing_properties = vku::InitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
+    VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_properties);
 
     const auto vkGetRayTracingShaderGroupHandlesKHR =
@@ -1222,7 +1222,7 @@ TEST_F(NegativeRayTracingPipelineNV, BasicUsage) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto pipleline_features = vku::InitStruct<VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT>();
+    VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT pipleline_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(pipleline_features);
     // Set this to true as it is a required feature
     pipleline_features.pipelineCreationCacheControl = VK_TRUE;
@@ -1828,7 +1828,7 @@ TEST_F(NegativeRayTracingPipelineNV, StageCreationFeedbackCount) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto rtnv_props = vku::InitStruct<VkPhysicalDeviceRayTracingPropertiesNV>();
+    VkPhysicalDeviceRayTracingPropertiesNV rtnv_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(rtnv_props);
 
     if (rtnv_props.maxDescriptorSetAccelerationStructures < 1) {
@@ -1837,7 +1837,7 @@ TEST_F(NegativeRayTracingPipelineNV, StageCreationFeedbackCount) {
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto feedback_info = vku::InitStruct<VkPipelineCreationFeedbackCreateInfoEXT>();
+    VkPipelineCreationFeedbackCreateInfoEXT feedback_info = vku::InitStructHelper();
     VkPipelineCreationFeedbackEXT feedbacks[4] = {};
 
     feedback_info.pPipelineCreationFeedback = &feedbacks[0];

--- a/tests/unit/ray_tracing_pipeline_positive.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive.cpp
@@ -23,7 +23,7 @@ TEST_F(PositiveRayTracingPipeline, ShaderGroupsKHR) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(ray_tracing_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
 
@@ -122,8 +122,8 @@ TEST_F(PositiveRayTracingPipeline, CacheControl) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto features13 = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(&features13);
+    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper(&features13);
     GetPhysicalDeviceFeatures2(ray_tracing_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ray_tracing_features));
 
@@ -170,7 +170,7 @@ TEST_F(PositiveRayTracingPipelineNV, BasicUsage) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
 
-    auto rtnv_props = vku::InitStruct<VkPhysicalDeviceRayTracingPropertiesNV>();
+    VkPhysicalDeviceRayTracingPropertiesNV rtnv_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(rtnv_props);
     if (rtnv_props.maxDescriptorSetAccelerationStructures < 1) {
         GTEST_SKIP() << "VkPhysicalDeviceRayTracingPropertiesNV::maxDescriptorSetAccelerationStructures < 1";
@@ -188,13 +188,13 @@ TEST_F(PositiveRayTracingPipeline, GetCaptureReplayShaderGroupHandlesKHR) {
         "pipeline created using pipeline libraries, the total shader group count is computed using info from the libraries.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
-    auto rt_pipeline_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>();
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR rt_pipeline_features = vku::InitStructHelper();
     rt_pipeline_features.rayTracingPipelineShaderGroupHandleCaptureReplay = VK_TRUE;
-    auto gpl_features = vku::InitStruct<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(&rt_pipeline_features);
+    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper(&rt_pipeline_features);
     gpl_features.graphicsPipelineLibrary = VK_TRUE;
-    auto pipeline_group_handle_features = vku::InitStruct<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT>(&gpl_features);
+    VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT pipeline_group_handle_features = vku::InitStructHelper(&gpl_features);
     pipeline_group_handle_features.pipelineLibraryGroupHandles = VK_TRUE;
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&pipeline_group_handle_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&pipeline_group_handle_features);
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_PIPELINE_LIBRARY_GROUP_HANDLES_EXTENSION_NAME);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
@@ -230,7 +230,7 @@ TEST_F(PositiveRayTracingPipeline, GetCaptureReplayShaderGroupHandlesKHR) {
     rt_pipe.InitState();
     ASSERT_VK_SUCCESS(rt_pipe.CreateKHRRayTracingPipeline());
 
-    VkBufferCreateInfo buf_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buf_info = vku::InitStructHelper();
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buf_info.size = 4096;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
@@ -239,13 +239,13 @@ TEST_F(PositiveRayTracingPipeline, GetCaptureReplayShaderGroupHandlesKHR) {
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &mem_reqs);
 
-    VkMemoryAllocateInfo alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = 4096;
     vkt::DeviceMemory mem(*m_device, alloc_info);
     vk::BindBufferMemory(device(), buffer.handle(), mem.handle(), 0);
 
     // dataSize must be at least groupCount * VkPhysicalDeviceRayTracingPropertiesKHR::shaderGroupHandleCaptureReplaySize
-    auto ray_tracing_properties = vku::InitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
+    VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_properties);
     vk::GetRayTracingCaptureReplayShaderGroupHandlesKHR(m_device->handle(), rt_pipe.pipeline_, 0, 3,
                                                         3 * ray_tracing_properties.shaderGroupHandleCaptureReplaySize, &buffer);

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -71,14 +71,14 @@ TEST_F(PositiveRayTracing, GetAccelerationStructureBuildSizes) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto accel_struct_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_struct_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(accel_struct_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &accel_struct_features));
 
-    auto build_info = vku::InitStruct<VkAccelerationStructureBuildGeometryInfoKHR>();
+    VkAccelerationStructureBuildGeometryInfoKHR build_info = vku::InitStructHelper();
     build_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
     uint32_t max_primitives_count;
-    auto build_sizes_info = vku::InitStruct<VkAccelerationStructureBuildSizesInfoKHR>();
+    VkAccelerationStructureBuildSizesInfoKHR build_sizes_info = vku::InitStructHelper();
     vk::GetAccelerationStructureBuildSizesKHR(device(), VK_ACCELERATION_STRUCTURE_BUILD_TYPE_HOST_OR_DEVICE_KHR, &build_info,
                                               &max_primitives_count, &build_sizes_info);
 }
@@ -98,9 +98,9 @@ TEST_F(PositiveRayTracing, AccelerationStructureReference) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeatures>();
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
-    auto acc_structure_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_query_features);
+    VkPhysicalDeviceBufferDeviceAddressFeatures bda_features = vku::InitStructHelper();
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR acc_structure_features = vku::InitStructHelper(&ray_query_features);
     GetPhysicalDeviceFeatures2(acc_structure_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &acc_structure_features));
 
@@ -131,8 +131,8 @@ TEST_F(PositiveRayTracing, HostAccelerationStructureReference) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>();
-    auto acc_structure_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(&ray_query_features);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper();
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR acc_structure_features = vku::InitStructHelper(&ray_query_features);
     GetPhysicalDeviceFeatures2(acc_structure_features);
 
     if (acc_structure_features.accelerationStructureHostCommands == VK_FALSE) {
@@ -157,10 +157,10 @@ TEST_F(PositiveRayTracing, StridedDeviceAddressRegion) {
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper();
     bda_features.bufferDeviceAddress = VK_TRUE;
-    auto ray_tracing_features = vku::InitStruct<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(&bda_features);
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_tracing_features);
+    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper(&bda_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_tracing_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -226,14 +226,14 @@ TEST_F(PositiveRayTracing, StridedDeviceAddressRegion) {
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &mem_reqs);
 
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
     alloc_info.allocationSize = 4096;
     vkt::DeviceMemory mem(*m_device, alloc_info);
     vk::BindBufferMemory(device(), buffer.handle(), mem.handle(), 0);
 
-    auto ray_tracing_properties = vku::InitStruct<VkPhysicalDeviceRayTracingPipelinePropertiesKHR>();
+    VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_properties);
 
     const VkDeviceAddress device_address = buffer.address();
@@ -290,18 +290,18 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto ray_query_feature = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>();
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&ray_query_feature);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_feature = vku::InitStructHelper();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper(&ray_query_feature);
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    auto mem_barrier = vku::InitStruct<VkMemoryBarrier2>();
+    VkMemoryBarrier2 mem_barrier = vku::InitStructHelper();
     mem_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
     mem_barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
 
     vkt::Buffer buffer(*m_device, 32);
 
-    auto buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier2>();
+    VkBufferMemoryBarrier2 buffer_barrier = vku::InitStructHelper();
     buffer_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
     buffer_barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
     buffer_barrier.buffer = buffer.handle();
@@ -311,13 +311,13 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier2>();
+    VkImageMemoryBarrier2 image_barrier = vku::InitStructHelper();
     image_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
     image_barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
     image_barrier.image = image.handle();
     image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    auto dependency_info = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
     dependency_info.bufferMemoryBarrierCount = 1;
@@ -362,18 +362,18 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto ray_query_feature = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>();
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&ray_query_feature);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_feature = vku::InitStructHelper();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper(&ray_query_feature);
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    auto mem_barrier = vku::InitStruct<VkMemoryBarrier2>();
+    VkMemoryBarrier2 mem_barrier = vku::InitStructHelper();
     mem_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
     mem_barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
 
     vkt::Buffer buffer(*m_device, 32);
 
-    auto buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier2>();
+    VkBufferMemoryBarrier2 buffer_barrier = vku::InitStructHelper();
     buffer_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
     buffer_barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
     buffer_barrier.buffer = buffer.handle();
@@ -383,13 +383,13 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier2>();
+    VkImageMemoryBarrier2 image_barrier = vku::InitStructHelper();
     image_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
     image_barrier.dstStageMask = VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
     image_barrier.image = image.handle();
     image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    auto dependency_info = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
     dependency_info.bufferMemoryBarrierCount = 1;
@@ -424,7 +424,7 @@ TEST_F(PositiveRayTracing, BarrierSync1NoCrash) {
     // This stage can not be used with ACCELERATION_STRUCTURE_READ access when ray query is disabled, but VVL also should not crash.
     constexpr VkPipelineStageFlags invalid_src_stage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 
-    auto barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier barrier = vku::InitStructHelper();
     barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
 
     m_errorMonitor->SetUnexpectedError("VUID-vkCmdPipelineBarrier-srcAccessMask-06257");
@@ -437,14 +437,14 @@ TEST_F(PositiveRayTracing, BuildAccelerationStructuresList) {
     TEST_DESCRIPTION("Build a list of destination acceleration structures, then do an update build on that same list");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
     accel_features.accelerationStructure = VK_TRUE;
     bda_features.bufferDeviceAddress = VK_TRUE;
     ray_query_features.rayQuery = VK_TRUE;
 
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_query_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -478,14 +478,14 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
         "overlap.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
     accel_features.accelerationStructure = VK_TRUE;
     bda_features.bufferDeviceAddress = VK_TRUE;
     ray_query_features.rayQuery = VK_TRUE;
 
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_query_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -504,7 +504,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
 
     constexpr size_t build_info_count = 3;
 
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
     alloc_info.allocationSize = 8192 * build_info_count;
@@ -513,7 +513,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
     // Test using non overlapping memory chunks from the same buffer in multiple builds
     // The scratch buffer is used in multiple builds but bound at different offsets, so no validation error should be issued
     {
-        auto scratch_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo scratch_buffer_ci = vku::InitStructHelper();
         scratch_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         scratch_buffer_ci.size = 8192 * build_info_count;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
@@ -540,14 +540,14 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
     TEST_DESCRIPTION("Repro https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6461");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
     accel_features.accelerationStructure = VK_TRUE;
     bda_features.bufferDeviceAddress = VK_TRUE;
     ray_query_features.rayQuery = VK_TRUE;
 
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_query_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -565,7 +565,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // Allocate a memory chunk that will be used as backing memory for scratch buffer
-    auto alloc_flags = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
     alloc_info.allocationSize = 8192;
@@ -592,7 +592,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         // Nothing to wait for, resources used in frame 0 will be released in frame 2
 
         // Create scratch buffer
-        auto scratch_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo scratch_buffer_ci = vku::InitStructHelper();
         scratch_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         scratch_buffer_ci.size = 8192;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
@@ -610,7 +610,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         vkt::as::BuildAccelerationStructuresKHR(*m_device, cmd_buffer_frame_0.handle(), build_infos_frame_0);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
-        auto barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+        VkBufferMemoryBarrier barrier = vku::InitStructHelper();
         barrier.buffer = scratch_buffer_frame_0->handle();
         barrier.size = scratch_buffer_ci.size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
@@ -622,7 +622,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
 
         // Submit command buffer
         VkCommandBuffer cmd_buffer_handle = cmd_buffer_frame_0.handle();
-        auto submit_info = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &cmd_buffer_handle;
         vk::QueueSubmit(m_device->GetDefaultQueue()->handle(), 1, &submit_info, fence_frame_0);
@@ -633,7 +633,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         // Still nothing to wait for
 
         // Create scratch buffer
-        auto scratch_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo scratch_buffer_ci = vku::InitStructHelper();
         scratch_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         scratch_buffer_ci.size = 8192;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
@@ -651,7 +651,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         vkt::as::BuildAccelerationStructuresKHR(*m_device, cmd_buffer_frame_1.handle(), build_infos_frame_1);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
-        auto barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+        VkBufferMemoryBarrier barrier = vku::InitStructHelper();
         barrier.buffer = scratch_buffer_frame_1->handle();
         barrier.size = scratch_buffer_ci.size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
@@ -663,7 +663,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
 
         // Submit command buffer
         VkCommandBuffer cmd_buffer_handle = cmd_buffer_frame_1.handle();
-        auto submit_info = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &cmd_buffer_handle;
         vk::QueueSubmit(m_device->GetDefaultQueue()->handle(), 1, &submit_info, fence_frame_1);
@@ -689,7 +689,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         build_infos_frame_0.clear();       // scratch_buffer_frame_0 will be destroyed in this call
 
         // Create scratch buffer
-        auto scratch_buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo scratch_buffer_ci = vku::InitStructHelper();
         scratch_buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         scratch_buffer_ci.size = 8192;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
@@ -707,7 +707,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         vkt::as::BuildAccelerationStructuresKHR(*m_device, cmd_buffer_frame_2.handle(), build_infos_frame_2);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
-        auto barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+        VkBufferMemoryBarrier barrier = vku::InitStructHelper();
         barrier.buffer = scratch_buffer_frame_2->handle();
         barrier.size = scratch_buffer_ci.size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
@@ -719,7 +719,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
 
         // Submit command buffer
         VkCommandBuffer cmd_buffer_handle = cmd_buffer_frame_2.handle();
-        auto submit_info = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &cmd_buffer_handle;
         vk::QueueSubmit(m_device->GetDefaultQueue()->handle(), 1, &submit_info, fence_frame_2);
@@ -735,14 +735,14 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         "This time, each scratch buffer has its own memory");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    auto accel_features = vku::InitStruct<VkPhysicalDeviceAccelerationStructureFeaturesKHR>();
-    auto bda_features = vku::InitStruct<VkPhysicalDeviceBufferDeviceAddressFeaturesKHR>(&accel_features);
-    auto ray_query_features = vku::InitStruct<VkPhysicalDeviceRayQueryFeaturesKHR>(&bda_features);
+    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
+    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
+    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
     accel_features.accelerationStructure = VK_TRUE;
     bda_features.bufferDeviceAddress = VK_TRUE;
     ray_query_features.rayQuery = VK_TRUE;
 
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&ray_query_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
@@ -783,7 +783,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         vkt::as::BuildAccelerationStructuresKHR(*m_device, cmd_buffer_frame_0.handle(), build_infos_frame_0);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
-        auto barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+        VkBufferMemoryBarrier barrier = vku::InitStructHelper();
         barrier.buffer = build_infos_frame_0[0].GetScratchBuffer()->handle();
         barrier.size = build_infos_frame_0[0].GetScratchBuffer()->create_info().size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
@@ -795,7 +795,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
 
         // Submit command buffer
         VkCommandBuffer cmd_buffer_handle = cmd_buffer_frame_0.handle();
-        auto submit_info = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &cmd_buffer_handle;
         vk::QueueSubmit(m_device->GetDefaultQueue()->handle(), 1, &submit_info, fence_frame_0);
@@ -812,7 +812,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         vkt::as::BuildAccelerationStructuresKHR(*m_device, cmd_buffer_frame_1.handle(), build_infos_frame_1);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
-        auto barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+        VkBufferMemoryBarrier barrier = vku::InitStructHelper();
         barrier.buffer = build_infos_frame_1[0].GetScratchBuffer()->handle();
         barrier.size = build_infos_frame_1[0].GetScratchBuffer()->create_info().size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
@@ -824,7 +824,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
 
         // Submit command buffer
         VkCommandBuffer cmd_buffer_handle = cmd_buffer_frame_1.handle();
-        auto submit_info = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &cmd_buffer_handle;
         vk::QueueSubmit(m_device->GetDefaultQueue()->handle(), 1, &submit_info, fence_frame_1);
@@ -843,7 +843,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         vkt::as::BuildAccelerationStructuresKHR(*m_device, cmd_buffer_frame_2.handle(), build_infos_frame_2);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
-        auto barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+        VkBufferMemoryBarrier barrier = vku::InitStructHelper();
         barrier.buffer = build_infos_frame_2[0].GetScratchBuffer()->handle();
         barrier.size = build_infos_frame_2[0].GetScratchBuffer()->create_info().size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
@@ -855,7 +855,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
 
         // Submit command buffer
         VkCommandBuffer cmd_buffer_handle = cmd_buffer_frame_2.handle();
-        auto submit_info = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &cmd_buffer_handle;
         vk::QueueSubmit(m_device->GetDefaultQueue()->handle(), 1, &submit_info, fence_frame_2);

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -507,7 +507,7 @@ TEST_F(PositiveRenderPass, ImagelessFramebufferNonZeroBaseMip) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto pd_imageless_fb_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>();
+    VkPhysicalDeviceImagelessFramebufferFeaturesKHR pd_imageless_fb_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(pd_imageless_fb_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_imageless_fb_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -537,7 +537,7 @@ TEST_F(PositiveRenderPass, ImagelessFramebufferNonZeroBaseMip) {
     rp_ci.pAttachments = &attachment_desc;
     vkt::RenderPass rp(*m_device, rp_ci);
 
-    auto fb_attachment_image_info = vku::InitStruct<VkFramebufferAttachmentImageInfoKHR>();
+    VkFramebufferAttachmentImageInfoKHR fb_attachment_image_info = vku::InitStructHelper();
     fb_attachment_image_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     fb_attachment_image_info.width = width;
     fb_attachment_image_info.height = height;
@@ -547,11 +547,11 @@ TEST_F(PositiveRenderPass, ImagelessFramebufferNonZeroBaseMip) {
     fb_attachment_image_info.height = 1;
     fb_attachment_image_info.width = width >> base_mip;
 
-    auto fb_attachments_ci = vku::InitStruct<VkFramebufferAttachmentsCreateInfoKHR>();
+    VkFramebufferAttachmentsCreateInfoKHR fb_attachments_ci = vku::InitStructHelper();
     fb_attachments_ci.attachmentImageInfoCount = 1;
     fb_attachments_ci.pAttachmentImageInfos = &fb_attachment_image_info;
 
-    auto fb_ci = vku::InitStruct<VkFramebufferCreateInfo>(&fb_attachments_ci);
+    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper(&fb_attachments_ci);
     fb_ci.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR;
     fb_ci.width = width >> base_mip;
     fb_ci.height = height;
@@ -562,7 +562,7 @@ TEST_F(PositiveRenderPass, ImagelessFramebufferNonZeroBaseMip) {
     vkt::Framebuffer fb(*m_device, fb_ci);
     ASSERT_TRUE(fb.initialized());
 
-    auto image_ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_ci.extent.width = width;
     image_ci.extent.height = 1;
@@ -577,7 +577,7 @@ TEST_F(PositiveRenderPass, ImagelessFramebufferNonZeroBaseMip) {
     image_object.init(&image_ci);
     VkImage image = image_object.image();
 
-    auto image_view_ci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo image_view_ci = vku::InitStructHelper();
     image_view_ci.image = image;
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_1D_ARRAY;
     image_view_ci.format = formats[0];
@@ -588,10 +588,10 @@ TEST_F(PositiveRenderPass, ImagelessFramebufferNonZeroBaseMip) {
     vkt::ImageView image_view_obj(*m_device, image_view_ci);
     VkImageView image_view = image_view_obj.handle();
 
-    auto rp_attachment_begin_info = vku::InitStruct<VkRenderPassAttachmentBeginInfoKHR>();
+    VkRenderPassAttachmentBeginInfoKHR rp_attachment_begin_info = vku::InitStructHelper();
     rp_attachment_begin_info.attachmentCount = 1;
     rp_attachment_begin_info.pAttachments = &image_view;
-    auto rp_begin_info = vku::InitStruct<VkRenderPassBeginInfo>(&rp_attachment_begin_info);
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper(&rp_attachment_begin_info);
     rp_begin_info.renderPass = rp.handle();
     rp_begin_info.renderArea.extent.width = width >> base_mip;
     rp_begin_info.renderArea.extent.height = height;
@@ -832,7 +832,7 @@ TEST_F(PositiveRenderPass, ViewMasks) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto vulkan_11_features = vku::InitStruct<VkPhysicalDeviceVulkan11Features>();
+    VkPhysicalDeviceVulkan11Features vulkan_11_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(vulkan_11_features);
     if (vulkan_11_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "multiview feature not supported, skipping test.";
@@ -840,7 +840,7 @@ TEST_F(PositiveRenderPass, ViewMasks) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
@@ -849,7 +849,7 @@ TEST_F(PositiveRenderPass, ViewMasks) {
     VkSubpassDescription2 subpass = vku::InitStructHelper();
     subpass.viewMask = 0x1;
 
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 render_pass_ci = vku::InitStructHelper();
     render_pass_ci.subpassCount = 1;
     render_pass_ci.pSubpasses = &subpass;
     render_pass_ci.attachmentCount = 1;
@@ -873,7 +873,7 @@ TEST_F(PositiveRenderPass, BeginWithViewMasks) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto vulkan_11_features = vku::InitStruct<VkPhysicalDeviceVulkan11Features>();
+    VkPhysicalDeviceVulkan11Features vulkan_11_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(vulkan_11_features);
     if (vulkan_11_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "multiview feature not supported, skipping test.";
@@ -881,7 +881,7 @@ TEST_F(PositiveRenderPass, BeginWithViewMasks) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
@@ -891,7 +891,7 @@ TEST_F(PositiveRenderPass, BeginWithViewMasks) {
     subpasses[0].viewMask = 0x1;
     subpasses[1].viewMask = 0x1;
 
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 render_pass_ci = vku::InitStructHelper();
     render_pass_ci.subpassCount = subpasses.size();
     render_pass_ci.pSubpasses = subpasses.data();
     render_pass_ci.attachmentCount = 1;
@@ -904,7 +904,7 @@ TEST_F(PositiveRenderPass, BeginWithViewMasks) {
     image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -914,7 +914,7 @@ TEST_F(PositiveRenderPass, BeginWithViewMasks) {
 
     vkt::ImageView view(*m_device, ivci);
 
-    auto fci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fci = vku::InitStructHelper();
     fci.renderPass = render_pass.handle();
     fci.attachmentCount = 1;
     fci.pAttachments = &view.handle();
@@ -923,7 +923,7 @@ TEST_F(PositiveRenderPass, BeginWithViewMasks) {
     fci.layers = 1;
     vkt::Framebuffer fb(*m_device, fci);
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.renderPass = render_pass.handle();
     rpbi.framebuffer = fb.handle();
     rpbi.renderArea = {{0, 0}, {32, 32}};
@@ -987,7 +987,7 @@ TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto vulkan_12_features = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features vulkan_12_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(vulkan_12_features);
     if (vulkan_12_features.separateDepthStencilLayouts == VK_FALSE) {
         GTEST_SKIP() << "separateDepthStencilLayouts feature not supported, skipping test.";
@@ -1006,27 +1006,27 @@ TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
     VkImageView ds_view = ds_image.targetView(ds_format, VK_IMAGE_ASPECT_DEPTH_BIT);
 
     // Create depth stencil attachment
-    auto attachment_desc_stencil_layout = vku::InitStruct<VkAttachmentDescriptionStencilLayoutKHR>();
+    VkAttachmentDescriptionStencilLayoutKHR attachment_desc_stencil_layout = vku::InitStructHelper();
     attachment_desc_stencil_layout.stencilInitialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attachment_desc_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-    auto ds_attachment_desc = vku::InitStruct<VkAttachmentDescription2>(&attachment_desc_stencil_layout);
+    VkAttachmentDescription2 ds_attachment_desc = vku::InitStructHelper(&attachment_desc_stencil_layout);
     ds_attachment_desc.format = ds_format;
     ds_attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     ds_attachment_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     ds_attachment_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
     ds_attachment_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     ds_attachment_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    auto attachment_ref_stencil_layout = vku::InitStruct<VkAttachmentReferenceStencilLayoutKHR>();
+    VkAttachmentReferenceStencilLayoutKHR attachment_ref_stencil_layout = vku::InitStructHelper();
     attachment_ref_stencil_layout.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-    auto ds_attachment_ref = vku::InitStruct<VkAttachmentReference2>(&attachment_ref_stencil_layout);
+    VkAttachmentReference2 ds_attachment_ref = vku::InitStructHelper(&attachment_ref_stencil_layout);
     ds_attachment_ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
 
     // Create render pass
-    auto subpass = vku::InitStruct<VkSubpassDescription2>();
+    VkSubpassDescription2 subpass = vku::InitStructHelper();
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     subpass.pDepthStencilAttachment = &ds_attachment_ref;
 
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 render_pass_ci = vku::InitStructHelper();
     render_pass_ci.subpassCount = 1;
     render_pass_ci.pSubpasses = &subpass;
     render_pass_ci.attachmentCount = 1;
@@ -1035,7 +1035,7 @@ TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
     vkt::RenderPass render_pass(*m_device, render_pass_ci);
 
     // Create framebuffer
-    auto fci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fci = vku::InitStructHelper();
     fci.renderPass = render_pass.handle();
     fci.attachmentCount = 1;
     fci.pAttachments = &ds_view;
@@ -1044,13 +1044,13 @@ TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
     fci.layers = 1;
     vkt::Framebuffer fb(*m_device, fci);
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.renderPass = render_pass.handle();
     rpbi.framebuffer = fb.handle();
     rpbi.renderArea = {{0, 0}, {fci.width, fci.height}};
 
     // Use helper to create graphics pipeline
-    auto ds_state = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
     // One stencil op is not OP_KEEP, both write mask are not 0
     ds_state.front.failOp = VK_STENCIL_OP_ZERO;
     ds_state.front.writeMask = 0x1;
@@ -1081,7 +1081,7 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto vulkan_11_features = vku::InitStruct<VkPhysicalDeviceVulkan11Features>();
+    VkPhysicalDeviceVulkan11Features vulkan_11_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(vulkan_11_features);
 
     if (vulkan_11_features.multiview == VK_FALSE) {
@@ -1106,7 +1106,7 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
 
     uint32_t viewMasks[] = {0x3u};
     uint32_t correlationMasks[] = {0x1u};
-    auto rpmvci = vku::InitStruct<VkRenderPassMultiviewCreateInfo>();
+    VkRenderPassMultiviewCreateInfo rpmvci = vku::InitStructHelper();
     rpmvci.subpassCount = 1;
     rpmvci.pViewMasks = viewMasks;
     rpmvci.correlationMaskCount = 1;
@@ -1120,7 +1120,7 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
 
     vkt::RenderPass rp(*m_device, rpci);
 
-    auto image_ci = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_ci.extent.width = 32;
     image_ci.extent.height = 32;
@@ -1306,7 +1306,7 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
     constexpr unsigned depth_count = 2u;
 
     // 3D image with 2 depths
-    auto image_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_info = vku::InitStructHelper();
     image_info.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
     image_info.imageType = VK_IMAGE_TYPE_3D;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1323,7 +1323,7 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
     image_3d.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
     // 2D image views to be used as color attchments for framebuffer
-    auto view_info = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo view_info = vku::InitStructHelper();
     view_info.image = image_3d.handle();
     view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
     view_info.format = image_info.format;
@@ -1359,7 +1359,7 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
         attach_desc[i].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     }
 
-    auto rp_info = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rp_info = vku::InitStructHelper();
     rp_info.subpassCount = depth_count;
     rp_info.pSubpasses = subpasses;
     rp_info.attachmentCount = depth_count;
@@ -1367,7 +1367,7 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
 
     vkt::RenderPass renderpass(*m_device, rp_info);
 
-    auto fb_info = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
     fb_info.renderPass = renderpass.handle();
     fb_info.attachmentCount = depth_count;
     fb_info.pAttachments = views;
@@ -1377,7 +1377,7 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
 
     vkt::Framebuffer framebuffer(*m_device, fb_info);
 
-    auto rp_begin_info = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
     rp_begin_info.renderPass = renderpass.handle();
     rp_begin_info.framebuffer = framebuffer.handle();
     rp_begin_info.renderArea = {{0, 0}, {image_info.extent.width, image_info.extent.height}};
@@ -1404,7 +1404,7 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     }
 
     if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
-        auto portability_subset_features = vku::InitStruct<VkPhysicalDevicePortabilitySubsetFeaturesKHR>();
+        VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_subset_features = vku::InitStructHelper();
         GetPhysicalDeviceFeatures2(portability_subset_features);
         if (!portability_subset_features.imageView2DOn3DImage) {
             GTEST_SKIP() << "imageView2DOn3DImage not supported, skipping test";
@@ -1414,7 +1414,7 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     constexpr unsigned image_depth = 2u;
 
     // 3D image
-    auto image_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_info = vku::InitStructHelper();
     image_info.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
     image_info.imageType = VK_IMAGE_TYPE_3D;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1431,7 +1431,7 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     image_3d.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
     // 2D image views for each slice of the 3D image
-    auto view_info = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo view_info = vku::InitStructHelper();
     view_info.image = image_3d.handle();
     view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
     view_info.format = image_info.format;
@@ -1462,14 +1462,14 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     attach_desc_1.initialLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     attach_desc_1.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto rp_info = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rp_info = vku::InitStructHelper();
     rp_info.subpassCount = 1;
     rp_info.pSubpasses = &subpass_1;
     rp_info.attachmentCount = 1;
     rp_info.pAttachments = &attach_desc_1;
     vkt::RenderPass renderpass_1(*m_device, rp_info);
 
-    auto fb_info = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
     fb_info.renderPass = renderpass_1.handle();
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = &views[0];
@@ -1478,7 +1478,7 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     fb_info.layers = 1;
     vkt::Framebuffer framebuffer_1(*m_device, fb_info);
 
-    auto rp_begin_info_1 = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rp_begin_info_1 = vku::InitStructHelper();
     rp_begin_info_1.renderPass = renderpass_1.handle();
     rp_begin_info_1.framebuffer = framebuffer_1.handle();
     rp_begin_info_1.renderArea = {{0, 0}, {image_info.extent.width, image_info.extent.height}};
@@ -1501,14 +1501,14 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     attach_desc_2.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     attach_desc_2.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto rp_info_2 = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rp_info_2 = vku::InitStructHelper();
     rp_info_2.subpassCount = 1;
     rp_info_2.pSubpasses = &subpass_2;
     rp_info_2.attachmentCount = 1;
     rp_info_2.pAttachments = &attach_desc_2;
 
     vkt::RenderPass renderpass_2(*m_device, rp_info_2);
-    auto fb_info_2 = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_info_2 = vku::InitStructHelper();
     fb_info_2.renderPass = renderpass_2;
     fb_info_2.attachmentCount = 1;
     fb_info_2.pAttachments = &views[1];
@@ -1517,7 +1517,7 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     fb_info_2.layers = 1;
     vkt::Framebuffer framebuffer_2(*m_device, fb_info_2);
 
-    auto rp_begin_info_2 = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rp_begin_info_2 = vku::InitStructHelper();
     rp_begin_info_2.renderPass = renderpass_2;
     rp_begin_info_2.framebuffer = framebuffer_2;
     rp_begin_info_2.renderArea = rp_begin_info_1.renderArea;
@@ -1605,7 +1605,7 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
         GTEST_SKIP() << VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME << " not supported";
     }
 
-    auto separate_features = vku::InitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
+    VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures separate_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(separate_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &separate_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 

--- a/tests/unit/renderpass.cpp
+++ b/tests/unit/renderpass.cpp
@@ -142,7 +142,7 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayout) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto separate_depth_stencil_layouts_features = vku::InitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
+    VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures separate_depth_stencil_layouts_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
     separate_depth_stencil_layouts_features.separateDepthStencilLayouts = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
@@ -163,7 +163,7 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayout) {
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &attach_ref;
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attach_desc;
     rpci.subpassCount = 1;
@@ -264,7 +264,7 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayout) {
             attach_desc.format = depth_stencil_format;
             attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
 
-            auto attachment_description_stencil_layout = vku::InitStruct<VkAttachmentDescriptionStencilLayoutKHR>();
+            VkAttachmentDescriptionStencilLayoutKHR attachment_description_stencil_layout = vku::InitStructHelper();
             attachment_description_stencil_layout.stencilInitialLayout = VK_IMAGE_LAYOUT_GENERAL;
             attachment_description_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_GENERAL;
             safe_VkRenderPassCreateInfo2 rpci2 = ConvertVkRenderPassCreateInfoToV2KHR(rpci);
@@ -800,7 +800,7 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto separate_depth_stencil_layouts_features = vku::InitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
+    VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures separate_depth_stencil_layouts_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &separate_depth_stencil_layouts_features));
 
@@ -867,7 +867,7 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
         rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
 
         // Set a valid VkAttachmentReferenceStencilLayout since the feature bit is set
-        auto attachment_reference_stencil_layout = vku::InitStruct<VkAttachmentReferenceStencilLayout>();
+        VkAttachmentReferenceStencilLayout attachment_reference_stencil_layout = vku::InitStructHelper();
         attachment_reference_stencil_layout.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR;
         rpci2.pSubpasses[0].pDepthStencilAttachment->pNext = &attachment_reference_stencil_layout;
 
@@ -928,7 +928,7 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
 
         attachment_reference_stencil_layout.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
 
-        auto attachment_description_stencil_layout = vku::InitStruct<VkAttachmentDescriptionStencilLayoutKHR>();
+        VkAttachmentDescriptionStencilLayoutKHR attachment_description_stencil_layout = vku::InitStructHelper();
         attachment_description_stencil_layout.stencilInitialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
         attachment_description_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
 
@@ -1064,7 +1064,7 @@ TEST_F(NegativeRenderPass, MixedAttachmentSamplesAMD) {
     subpass.pColorAttachments = &color_ref;
     subpass.pDepthStencilAttachment = &depth_ref;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.attachmentCount = attachments.size();
     rpci.pAttachments = attachments.data();
     rpci.subpassCount = 1;
@@ -1168,7 +1168,7 @@ TEST_F(NegativeRenderPass, BeginIncompatibleFramebuffer) {
     image.Init(128, 128, 1, VK_FORMAT_D16_UNORM, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
     ASSERT_TRUE(image.initialized());
 
-    auto dsvci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo dsvci = vku::InitStructHelper();
     dsvci.image = image.handle();
     dsvci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     dsvci.format = VK_FORMAT_D16_UNORM;
@@ -1229,7 +1229,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
     }
 
     if (feedback_loop_layout) {
-        auto attachment_feedback_loop_layout_features = vku::InitStruct<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>();
+        VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT attachment_feedback_loop_layout_features = vku::InitStructHelper();
         auto features2 = GetPhysicalDeviceFeatures2(attachment_feedback_loop_layout_features);
         attachment_feedback_loop_layout_features.attachmentFeedbackLoopLayout = true;
         ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -1243,7 +1243,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
     iai.InitNoLayout(128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
     ASSERT_TRUE(iai.initialized());
 
-    auto iavci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo iavci = vku::InitStructHelper();
     iavci.image = iai.handle();
     iavci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     iavci.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1268,7 +1268,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
     cai.InitNoLayout(128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
     ASSERT_TRUE(cai.initialized());
 
-    auto cavci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo cavci = vku::InitStructHelper();
     cavci.image = cai.handle();
     cavci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     cavci.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1407,7 +1407,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported, skipping test.";
     }
 
-    auto separate_depth_stencil_layouts_features = vku::InitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
+    VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures separate_depth_stencil_layouts_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
     ASSERT_NO_FATAL_FAILURE(
         InitState(nullptr, &separate_depth_stencil_layouts_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -1428,37 +1428,37 @@ TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
             input_image.targetView(depth_stencil_format, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0, 1, 0, 1);
 
         // Create the render pass attachment...
-        auto stencil_layout = vku::InitStruct<VkAttachmentDescriptionStencilLayout>();
+        VkAttachmentDescriptionStencilLayout stencil_layout = vku::InitStructHelper();
         stencil_layout.stencilInitialLayout = stencil_initial_layout;
         stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_GENERAL;
-        auto depth_stencil_attachment_desc = vku::InitStruct<VkAttachmentDescription2>(&stencil_layout);
+        VkAttachmentDescription2 depth_stencil_attachment_desc = vku::InitStructHelper(&stencil_layout);
         depth_stencil_attachment_desc.format = depth_stencil_format;
         depth_stencil_attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
         depth_stencil_attachment_desc.initialLayout = depth_initial_layout;  // This will trigger errors
         depth_stencil_attachment_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         // ... and a reference to it...
-        auto stencil_ref = vku::InitStruct<VkAttachmentReferenceStencilLayoutKHR>();
+        VkAttachmentReferenceStencilLayoutKHR stencil_ref = vku::InitStructHelper();
         stencil_ref.stencilLayout = VK_IMAGE_LAYOUT_GENERAL;
-        auto input_attachment_ref = vku::InitStruct<VkAttachmentReference2>(&stencil_ref);
+        VkAttachmentReference2 input_attachment_ref = vku::InitStructHelper(&stencil_ref);
         input_attachment_ref.attachment = 0;
         input_attachment_ref.layout = VK_IMAGE_LAYOUT_GENERAL;
         input_attachment_ref.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
 
         // ... which is used in the one subpass.
-        auto subpass_desc = vku::InitStruct<VkSubpassDescription2>();
+        VkSubpassDescription2 subpass_desc = vku::InitStructHelper();
         subpass_desc.inputAttachmentCount = 1;
         subpass_desc.pInputAttachments = &input_attachment_ref;
 
         // Create render pass and framebuffer
-        auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>();
+        VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
         rpci.attachmentCount = 1;
         rpci.pAttachments = &depth_stencil_attachment_desc;
         rpci.subpassCount = 1;
         rpci.pSubpasses = &subpass_desc;
         vkt::RenderPass rp(*m_device, rpci);
 
-        auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+        VkFramebufferCreateInfo fbci = vku::InitStructHelper();
         fbci.renderPass = rp;
         fbci.attachmentCount = 1;
         fbci.pAttachments = &input_view;
@@ -1469,7 +1469,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
         vkt::Framebuffer fb(*m_device, fbci);
 
         // Begin render pass and trigger errors
-        auto rp_begin = vku::InitStruct<VkRenderPassBeginInfo>();
+        VkRenderPassBeginInfo rp_begin = vku::InitStructHelper();
         rp_begin.renderPass = rp;
         rp_begin.framebuffer = fb;
         rp_begin.renderArea.extent = {fbci.width, fbci.height};
@@ -1492,7 +1492,7 @@ TEST_F(NegativeRenderPass, BeginStencilFormat) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto separate_depth_stencil_layouts_features = vku::InitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>();
+    VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures separate_depth_stencil_layouts_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &separate_depth_stencil_layouts_features));
 
@@ -1514,24 +1514,24 @@ TEST_F(NegativeRenderPass, BeginStencilFormat) {
         ASSERT_TRUE(depth_stencil_image.initialized());
 
         // Create the render pass attachment...
-        auto depth_stencil_attachment_desc = vku::InitStruct<VkAttachmentDescription2>();
+        VkAttachmentDescription2 depth_stencil_attachment_desc = vku::InitStructHelper();
         depth_stencil_attachment_desc.format = depth_stencil_format;
         depth_stencil_attachment_desc.samples = VK_SAMPLE_COUNT_1_BIT;
         depth_stencil_attachment_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;  // This will trigger errors
         depth_stencil_attachment_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         // ... and a reference to it...
-        auto depth_stencil_attachment_ref = vku::InitStruct<VkAttachmentReference2>();
+        VkAttachmentReference2 depth_stencil_attachment_ref = vku::InitStructHelper();
         depth_stencil_attachment_ref.attachment = 0;
         depth_stencil_attachment_ref.layout = depth_stencil_attachment_ref_layout;
         depth_stencil_attachment_ref.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
 
         // ... which is used in the one subpass.
-        auto subpass_desc = vku::InitStruct<VkSubpassDescription2>();
+        VkSubpassDescription2 subpass_desc = vku::InitStructHelper();
         subpass_desc.pDepthStencilAttachment = &depth_stencil_attachment_ref;
 
         // Create render pass
-        auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>();
+        VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
         rpci.attachmentCount = 1;
         rpci.pAttachments = &depth_stencil_attachment_desc;
         rpci.subpassCount = 1;
@@ -1570,7 +1570,7 @@ TEST_F(NegativeRenderPass, BeginClearOpMismatch) {
     VkSubpassDescription subpass = {};
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &attach;
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -1583,7 +1583,7 @@ TEST_F(NegativeRenderPass, BeginClearOpMismatch) {
     rpci.pAttachments = &attach_desc;
     vkt::RenderPass rp(*m_device, rpci);
 
-    auto rp_begin = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rp_begin = vku::InitStructHelper();
     rp_begin.renderPass = renderPass();
     rp_begin.framebuffer = framebuffer();
     rp_begin.renderArea.extent = {1, 1};
@@ -1605,7 +1605,7 @@ TEST_F(NegativeRenderPass, BeginSampleLocationsIndicesEXT) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    auto sample_locations_props = vku::InitStruct<VkPhysicalDeviceSampleLocationsPropertiesEXT>();
+    VkPhysicalDeviceSampleLocationsPropertiesEXT sample_locations_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(sample_locations_props);
 
     if ((sample_locations_props.sampleLocationSampleCounts & VK_SAMPLE_COUNT_1_BIT) == 0) {
@@ -1618,7 +1618,7 @@ TEST_F(NegativeRenderPass, BeginSampleLocationsIndicesEXT) {
     image.Init(128, 128, 1, VK_FORMAT_D16_UNORM, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
     ASSERT_TRUE(image.initialized());
 
-    auto dsvci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo dsvci = vku::InitStructHelper();
     dsvci.image = image.handle();
     dsvci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     dsvci.format = VK_FORMAT_D16_UNORM;
@@ -1688,7 +1688,7 @@ TEST_F(NegativeRenderPass, DestroyWhileInUse) {
     VkSubpassDescription subpass = {};
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &attach;
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -1701,7 +1701,7 @@ TEST_F(NegativeRenderPass, DestroyWhileInUse) {
     vkt::RenderPass rp(*m_device, rpci);
 
     m_commandBuffer->begin();
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = m_framebuffer;
     rpbi.renderPass = rp.handle();
     rpbi.renderArea.extent = {1, 1};
@@ -1709,7 +1709,7 @@ TEST_F(NegativeRenderPass, DestroyWhileInUse) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -1758,20 +1758,20 @@ TEST_F(NegativeRenderPass, FramebufferDepthStencilResolveAttachment) {
     attachmentDescriptions[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attachmentDescriptions[1].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto depthStencilAttachmentReference = vku::InitStruct<VkAttachmentReference2>();
+    VkAttachmentReference2 depthStencilAttachmentReference = vku::InitStructHelper();
     depthStencilAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
     depthStencilAttachmentReference.attachment = 0;
-    auto depthStencilResolveAttachmentReference = vku::InitStruct<VkAttachmentReference2>();
+    VkAttachmentReference2 depthStencilResolveAttachmentReference = vku::InitStructHelper();
     depthStencilResolveAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
     depthStencilResolveAttachmentReference.attachment = 1;
-    auto subpassDescriptionDepthStencilResolve = vku::InitStruct<VkSubpassDescriptionDepthStencilResolveKHR>();
+    VkSubpassDescriptionDepthStencilResolveKHR subpassDescriptionDepthStencilResolve = vku::InitStructHelper();
     subpassDescriptionDepthStencilResolve.pDepthStencilResolveAttachment = &depthStencilResolveAttachmentReference;
     subpassDescriptionDepthStencilResolve.depthResolveMode = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR;
     subpassDescriptionDepthStencilResolve.stencilResolveMode = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR;
-    auto subpassDescription = vku::InitStruct<VkSubpassDescription2>(&subpassDescriptionDepthStencilResolve);
+    VkSubpassDescription2 subpassDescription = vku::InitStructHelper(&subpassDescriptionDepthStencilResolve);
     subpassDescription.pDepthStencilAttachment = &depthStencilAttachmentReference;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
     rpci.attachmentCount = 2;
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpassDescription;
@@ -1781,7 +1781,7 @@ TEST_F(NegativeRenderPass, FramebufferDepthStencilResolveAttachment) {
 
     // Depth resolve attachment, mismatched image usage
     // Try creating Framebuffer with images, but with invalid image create usage flags
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = attachmentFormat;
     image_create_info.extent.width = attachmentWidth;
@@ -1808,7 +1808,7 @@ TEST_F(NegativeRenderPass, FramebufferDepthStencilResolveAttachment) {
     image_views[0] = ds_image.targetView(attachmentFormat, VK_IMAGE_ASPECT_DEPTH_BIT);
     image_views[1] = ds_resolve_image.targetView(image_create_info.format, VK_IMAGE_ASPECT_COLOR_BIT);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.width = attachmentWidth;
     fbci.height = attachmentHeight;
     fbci.layers = 1;
@@ -1862,7 +1862,7 @@ TEST_F(NegativeRenderPass, FramebufferIncompatible) {
     auto fci = vku::InitStruct<VkFramebufferCreateInfo>(nullptr, 0u, rp.handle(), 1u, &view.handle(), 32u, 32u, 1u);
     vkt::Framebuffer fb(*m_device, fci);
 
-    auto cbai = vku::InitStruct<VkCommandBufferAllocateInfo>();
+    VkCommandBufferAllocateInfo cbai = vku::InitStructHelper();
     cbai.commandPool = m_commandPool->handle();
     cbai.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
     cbai.commandBufferCount = 1;
@@ -1870,8 +1870,8 @@ TEST_F(NegativeRenderPass, FramebufferIncompatible) {
     VkCommandBuffer sec_cb;
     auto err = vk::AllocateCommandBuffers(m_device->device(), &cbai, &sec_cb);
     ASSERT_VK_SUCCESS(err);
-    auto cbbi = vku::InitStruct<VkCommandBufferBeginInfo>();
-    auto cbii = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
+    VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = renderPass();
     cbii.framebuffer = fb.handle();
     cbbi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
@@ -1879,7 +1879,7 @@ TEST_F(NegativeRenderPass, FramebufferIncompatible) {
     vk::BeginCommandBuffer(sec_cb, &cbbi);
     vk::EndCommandBuffer(sec_cb);
 
-    auto cbbi2 = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cbbi2 = vku::InitStructHelper();
     vk::BeginCommandBuffer(m_commandBuffer->handle(), &cbbi2);
     vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
 
@@ -1934,7 +1934,7 @@ TEST_F(NegativeRenderPass, Framebuffer) {
                      << VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME << " are supported.";
     }
 
-    auto fdm_features = vku::InitStruct<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>();
+    VkPhysicalDeviceFragmentDensityMapFeaturesEXT fdm_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(fdm_features);
     if (!fdm_features.fragmentDensityMap) {
         GTEST_SKIP() << "fragmentDensityMap not supported.";
@@ -1951,7 +1951,7 @@ TEST_F(NegativeRenderPass, Framebuffer) {
     attach.layout = VK_IMAGE_LAYOUT_GENERAL;
     VkSubpassDescription subpass = {};
     subpass.pColorAttachments = &attach;
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -1966,7 +1966,7 @@ TEST_F(NegativeRenderPass, Framebuffer) {
     ivs[0] = m_renderTargets[0]->targetView(VK_FORMAT_B8G8R8A8_UNORM);
     ivs[1] = m_renderTargets[0]->targetView(VK_FORMAT_B8G8R8A8_UNORM);
 
-    auto fb_info = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
     fb_info.pAttachments = ivs;
     fb_info.width = 100;
     fb_info.height = 100;
@@ -2002,7 +2002,7 @@ TEST_F(NegativeRenderPass, Framebuffer) {
     }
 
     {
-        auto image_ci = vku::InitStruct<VkImageCreateInfo>();
+        VkImageCreateInfo image_ci = vku::InitStructHelper();
         image_ci.imageType = VK_IMAGE_TYPE_3D;
         image_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
         image_ci.extent.width = 256;
@@ -2061,7 +2061,7 @@ TEST_F(NegativeRenderPass, Framebuffer) {
         ASSERT_TRUE(image.initialized());
 
         // Create a image view with two mip levels.
-        auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+        VkImageViewCreateInfo ivci = vku::InitStructHelper();
         ivci.image = image.handle();
         ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
         ivci.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -2122,10 +2122,10 @@ TEST_F(NegativeRenderPass, Framebuffer) {
         attach_desc_fragment_density_map.format = attachment_format;
         attach_desc_fragment_density_map.samples = VK_SAMPLE_COUNT_1_BIT;
         attach_desc_fragment_density_map.finalLayout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
-        auto fragment_density_map_create_info = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>();
+        VkRenderPassFragmentDensityMapCreateInfoEXT fragment_density_map_create_info = vku::InitStructHelper();
         fragment_density_map_create_info.fragmentDensityMapAttachment.layout = VK_IMAGE_LAYOUT_GENERAL;
         VkSubpassDescription subpass_fragment_density_map = {};
-        auto rpci_fragment_density_map = vku::InitStruct<VkRenderPassCreateInfo>(&fragment_density_map_create_info);
+        VkRenderPassCreateInfo rpci_fragment_density_map = vku::InitStructHelper(&fragment_density_map_create_info);
         rpci_fragment_density_map.subpassCount = 1;
         rpci_fragment_density_map.pSubpasses = &subpass_fragment_density_map;
         rpci_fragment_density_map.attachmentCount = 1;
@@ -2133,7 +2133,7 @@ TEST_F(NegativeRenderPass, Framebuffer) {
         vkt::RenderPass rp_fragment_density_map(*m_device, rpci_fragment_density_map);
 
         // Create view attachment
-        auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+        VkImageViewCreateInfo ivci = vku::InitStructHelper();
         ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
         ivci.format = attachment_format;
         ivci.flags = 0;
@@ -2142,18 +2142,18 @@ TEST_F(NegativeRenderPass, Framebuffer) {
         ivci.subresourceRange.levelCount = 1;
         ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-        auto fb_fdm = vku::InitStruct<VkFramebufferAttachmentImageInfoKHR>();
+        VkFramebufferAttachmentImageInfoKHR fb_fdm = vku::InitStructHelper();
         fb_fdm.usage = VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT;
         fb_fdm.width = frame_width;
         fb_fdm.height = frame_height;
         fb_fdm.layerCount = 1;
         fb_fdm.viewFormatCount = 1;
         fb_fdm.pViewFormats = &attachment_format;
-        auto fb_aci_fdm = vku::InitStruct<VkFramebufferAttachmentsCreateInfoKHR>();
+        VkFramebufferAttachmentsCreateInfoKHR fb_aci_fdm = vku::InitStructHelper();
         fb_aci_fdm.attachmentImageInfoCount = 1;
         fb_aci_fdm.pAttachmentImageInfos = &fb_fdm;
 
-        auto fbci = vku::InitStruct<VkFramebufferCreateInfo>(&fb_aci_fdm);
+        VkFramebufferCreateInfo fbci = vku::InitStructHelper(&fb_aci_fdm);
         fbci.flags = 0;
         fbci.width = frame_width;
         fbci.height = frame_height;
@@ -2203,7 +2203,7 @@ TEST_F(NegativeRenderPass, Framebuffer) {
         ASSERT_TRUE(image.initialized());
 
         // Create view attachment with non-identity swizzle
-        auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+        VkImageViewCreateInfo ivci = vku::InitStructHelper();
         ivci.image = image.handle();
         ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
         ivci.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -2263,7 +2263,7 @@ TEST_F(NegativeRenderPass, Framebuffer) {
             image.Init(128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
             ASSERT_TRUE(image.initialized());
 
-            auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+            VkImageViewCreateInfo ivci = vku::InitStructHelper();
             ivci.image = image.handle();
             ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
             ivci.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -2352,7 +2352,7 @@ TEST_F(NegativeRenderPass, FramebufferAttachmentPointers) {
     std::array attachment_refs = {attachment_ref, attachment_ref};
     VkSubpassDescription subpass = {};
     subpass.pColorAttachments = attachment_refs.data();
-    auto rp_ci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper();
     rp_ci.subpassCount = 1;
     rp_ci.pSubpasses = &subpass;
     rp_ci.attachmentCount = 2;
@@ -2365,7 +2365,7 @@ TEST_F(NegativeRenderPass, FramebufferAttachmentPointers) {
     rp_ci.pAttachments = attachment_descs.data();
     vkt::RenderPass render_pass(*m_device, rp_ci);
 
-    auto fb_ci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
     fb_ci.width = 100;
     fb_ci.height = 100;
     fb_ci.layers = 1;
@@ -2430,7 +2430,7 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPass) {
     VkSubpassDescription subpass = {};
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &color_att;
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -2449,10 +2449,10 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPass) {
     pipe.gp_ci_.renderPass = rp.handle();
     pipe.CreateGraphicsPipeline();
 
-    auto cbii = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = rp.handle();
     cbii.subpass = 0;
-    auto cbbi = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     cbbi.pInheritanceInfo = &cbii;
     vk::BeginCommandBuffer(m_commandBuffer->handle(), &cbbi);
     vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
@@ -2504,10 +2504,10 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPassFragmentDen
     ref.attachment = 0;
     ref.layout = VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT;
 
-    auto rpfdmi = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>();
+    VkRenderPassFragmentDensityMapCreateInfoEXT rpfdmi = vku::InitStructHelper();
     rpfdmi.fragmentDensityMapAttachment = ref;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpfdmi);
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper(&rpfdmi);
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attach;
     rpci.subpassCount = 1;
@@ -2530,7 +2530,7 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPassFragmentDen
     VkImageView iv = image.targetView(VK_FORMAT_B8G8R8A8_UNORM);
 
     // Create a framebuffer with rp1
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.renderPass = rp1.handle();
     fbci.attachmentCount = 1;
     fbci.pAttachments = &iv;
@@ -2541,7 +2541,7 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPassFragmentDen
     vkt::Framebuffer fb(*m_device, fbci);
     ASSERT_TRUE(fb.initialized());
 
-    auto rp_begin = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rp_begin = vku::InitStructHelper();
     rp_begin.renderPass = rp1.handle();
     rp_begin.framebuffer = fb.handle();
     rp_begin.renderArea = {{0, 0}, {128, 128}};
@@ -2553,10 +2553,10 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPassFragmentDen
     pipe.CreateGraphicsPipeline();
 
     // Begin renderpass and bind to pipeline
-    auto cbii = vku::InitStruct<VkCommandBufferInheritanceInfo>();
+    VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = rp1.handle();
     cbii.subpass = 0;
-    auto cbbi = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     cbbi.pInheritanceInfo = &cbii;
     vk::BeginCommandBuffer(m_commandBuffer->handle(), &cbbi);
     vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
@@ -2582,7 +2582,7 @@ TEST_F(NegativeRenderPass, MissingAttachment) {
     attach.layout = VK_IMAGE_LAYOUT_GENERAL;
     VkSubpassDescription subpass = {};
     subpass.pColorAttachments = &attach;
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -2595,7 +2595,7 @@ TEST_F(NegativeRenderPass, MissingAttachment) {
     vkt::RenderPass rp(*m_device, rpci);
     ASSERT_TRUE(rp.initialized());
 
-    auto createView = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo createView = vku::InitStructHelper();
     createView.image = m_renderTargets[0]->handle();
     createView.viewType = VK_IMAGE_VIEW_TYPE_2D;
     createView.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -2608,7 +2608,7 @@ TEST_F(NegativeRenderPass, MissingAttachment) {
 
     vkt::ImageView iv(*m_device, createView);
 
-    auto fb_info = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
     fb_info.renderPass = rp.handle();
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = &iv.handle();
@@ -2623,7 +2623,7 @@ TEST_F(NegativeRenderPass, MissingAttachment) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassBeginInfo-framebuffer-parameter");
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.renderPass = rp.handle();
     rpbi.framebuffer = fb.handle();
     rpbi.renderArea = {{0, 0}, {32, 32}};
@@ -2654,7 +2654,7 @@ void RenderPassCreatePotentialFormatFeaturesTest::Test(bool const useLinearColor
     }
 
     if (useLinearColorAttachment) {
-        auto linear_color_attachment = vku::InitStruct<VkPhysicalDeviceLinearColorAttachmentFeaturesNV>();
+        VkPhysicalDeviceLinearColorAttachmentFeaturesNV linear_color_attachment = vku::InitStructHelper();
         VkPhysicalDeviceFeatures2 features2 = GetPhysicalDeviceFeatures2(linear_color_attachment);
         if (useLinearColorAttachment && !linear_color_attachment.linearColorAttachment) {
             GTEST_SKIP() << "Test requires linearColorAttachment";
@@ -2809,7 +2809,7 @@ TEST_F(NegativeRenderPass, DepthStencilResolveMode) {
         GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
 
-    auto ds_resolve_props = vku::InitStruct<VkPhysicalDeviceDepthStencilResolveProperties>();
+    VkPhysicalDeviceDepthStencilResolveProperties ds_resolve_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ds_resolve_props);
 
     VkRenderPass renderPass;
@@ -2828,18 +2828,18 @@ TEST_F(NegativeRenderPass, DepthStencilResolveMode) {
     attachmentDescriptions[1].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     attachmentDescriptions[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 
-    auto depthStencilAttachmentReference = vku::InitStruct<VkAttachmentReference2KHR>();
+    VkAttachmentReference2KHR depthStencilAttachmentReference = vku::InitStructHelper();
     depthStencilAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
     depthStencilAttachmentReference.attachment = 0;
-    auto depthStencilResolveAttachmentReference = vku::InitStruct<VkAttachmentReference2KHR>();
+    VkAttachmentReference2KHR depthStencilResolveAttachmentReference = vku::InitStructHelper();
     depthStencilResolveAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
     depthStencilResolveAttachmentReference.attachment = 1;
-    auto subpassDescriptionDSR = vku::InitStruct<VkSubpassDescriptionDepthStencilResolveKHR>();
+    VkSubpassDescriptionDepthStencilResolveKHR subpassDescriptionDSR = vku::InitStructHelper();
     subpassDescriptionDSR.pDepthStencilResolveAttachment = &depthStencilResolveAttachmentReference;
-    auto subpassDescription = vku::InitStruct<VkSubpassDescription2KHR>(&subpassDescriptionDSR);
+    VkSubpassDescription2KHR subpassDescription = vku::InitStructHelper(&subpassDescriptionDSR);
     subpassDescription.pDepthStencilAttachment = &depthStencilAttachmentReference;
 
-    auto renderPassCreateInfo = vku::InitStruct<VkRenderPassCreateInfo2KHR>();
+    VkRenderPassCreateInfo2KHR renderPassCreateInfo = vku::InitStructHelper();
     renderPassCreateInfo.attachmentCount = 2;
     renderPassCreateInfo.subpassCount = 1;
     renderPassCreateInfo.pSubpasses = &subpassDescription;
@@ -2968,7 +2968,7 @@ TEST_F(NegativeRenderPass, RenderArea) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto rpbinfo = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
     rpbinfo.renderPass = m_renderPass;
     rpbinfo.framebuffer = m_framebuffer;
     rpbinfo.renderArea.extent.width = m_framebuffer_info.width;
@@ -3026,12 +3026,12 @@ TEST_F(NegativeRenderPass, DeviceGroupRenderArea) {
     renderArea.extent.width = 64;
     renderArea.extent.height = 64;
 
-    auto device_group_render_pass_begin_info = vku::InitStruct<VkDeviceGroupRenderPassBeginInfo>();
+    VkDeviceGroupRenderPassBeginInfo device_group_render_pass_begin_info = vku::InitStructHelper();
     device_group_render_pass_begin_info.deviceMask = 0x1;
     device_group_render_pass_begin_info.deviceRenderAreaCount = 1;
     device_group_render_pass_begin_info.pDeviceRenderAreas = &renderArea;
 
-    auto rpbinfo = vku::InitStruct<VkRenderPassBeginInfo>(&device_group_render_pass_begin_info);
+    VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper(&device_group_render_pass_begin_info);
     rpbinfo.renderPass = m_renderPass;
     rpbinfo.framebuffer = m_framebuffer;
     rpbinfo.renderArea.extent.width = m_framebuffer_info.width;
@@ -3105,23 +3105,23 @@ TEST_F(NegativeRenderPass, DepthStencilResolveAttachmentFormat) {
     attachmentDescriptions[1].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     attachmentDescriptions[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 
-    auto depthStencilAttachmentReference = vku::InitStruct<VkAttachmentReference2KHR>();
+    VkAttachmentReference2KHR depthStencilAttachmentReference = vku::InitStructHelper();
     depthStencilAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
     depthStencilAttachmentReference.attachment = 1;
 
-    auto depthStencilResolveAttachmentReference = vku::InitStruct<VkAttachmentReference2KHR>();
+    VkAttachmentReference2KHR depthStencilResolveAttachmentReference = vku::InitStructHelper();
     depthStencilResolveAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
     depthStencilResolveAttachmentReference.attachment = 0;
 
-    auto subpassDescriptionDepthStencilResolve = vku::InitStruct<VkSubpassDescriptionDepthStencilResolveKHR>();
+    VkSubpassDescriptionDepthStencilResolveKHR subpassDescriptionDepthStencilResolve = vku::InitStructHelper();
     subpassDescriptionDepthStencilResolve.pDepthStencilResolveAttachment = &depthStencilResolveAttachmentReference;
     subpassDescriptionDepthStencilResolve.depthResolveMode = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT;
     subpassDescriptionDepthStencilResolve.stencilResolveMode = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT;
 
-    auto subpassDescription = vku::InitStruct<VkSubpassDescription2>(&subpassDescriptionDepthStencilResolve);
+    VkSubpassDescription2 subpassDescription = vku::InitStructHelper(&subpassDescriptionDepthStencilResolve);
     subpassDescription.pDepthStencilAttachment = &depthStencilAttachmentReference;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpassDescription;
     rpci.attachmentCount = 2;
@@ -3159,7 +3159,7 @@ TEST_F(NegativeRenderPass, RenderPassAttachmentFormat) {
 
     VkSubpassDescription subpass = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 0, nullptr, nullptr, nullptr, 0, nullptr};
 
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper();
     render_pass_ci.attachmentCount = 1;
     render_pass_ci.pAttachments = &attach_desc;
     render_pass_ci.subpassCount = 1;
@@ -3170,15 +3170,15 @@ TEST_F(NegativeRenderPass, RenderPassAttachmentFormat) {
     vk::CreateRenderPass(device(), &render_pass_ci, nullptr, &render_pass);
     m_errorMonitor->VerifyFound();
 
-    auto attach_desc_2 = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc_2 = vku::InitStructHelper();
     attach_desc_2.format = VK_FORMAT_UNDEFINED;
     attach_desc_2.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc_2.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
     attach_desc_2.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto subpass_2 = vku::InitStruct<VkSubpassDescription2>();
+    VkSubpassDescription2 subpass_2 = vku::InitStructHelper();
 
-    auto render_pass_ci_2 = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 render_pass_ci_2 = vku::InitStructHelper();
     render_pass_ci_2.attachmentCount = 1;
     render_pass_ci_2.pAttachments = &attach_desc_2;
     render_pass_ci_2.subpassCount = 1;
@@ -3216,7 +3216,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -3224,7 +3224,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
 
     vkt::RenderPass render_pass(*m_device, rpci);
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = format;
     image_create_info.extent.width = width;
@@ -3240,7 +3240,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     VkImageObj image(m_device);
     image.init(&image_create_info);
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = format;
@@ -3255,7 +3255,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.width = width;
     fbci.height = height;
     fbci.layers = 1;
@@ -3265,7 +3265,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, fbci);
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer.handle();
     rpbi.renderPass = render_pass.handle();
     rpbi.renderArea.extent.width = width;
@@ -3293,7 +3293,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     VkRect2D rect = {};
     m_scissors.push_back(rect);
     pipe.SetScissor(m_scissors);
-    auto pipe_ds_state_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo pipe_ds_state_ci = vku::InitStructHelper();
     pipe_ds_state_ci.depthTestEnable = VK_TRUE;
     pipe_ds_state_ci.stencilTestEnable = VK_FALSE;
     pipe.SetDepthStencil(&pipe_ds_state_ci);
@@ -3317,7 +3317,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     image_info.sampler = sampler.handle();
     image_info.imageView = image_view.handle();
     image_info.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -3353,10 +3353,10 @@ TEST_F(NegativeRenderPass, ColorAttachmentImageViewUsage) {
     image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
                VK_IMAGE_TILING_OPTIMAL, 0);
 
-    auto image_view_usage = vku::InitStruct<VkImageViewUsageCreateInfo>();
+    VkImageViewUsageCreateInfo image_view_usage = vku::InitStructHelper();
     image_view_usage.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
-    auto image_view_ci = vku::InitStruct<VkImageViewCreateInfo>(&image_view_usage);
+    VkImageViewCreateInfo image_view_ci = vku::InitStructHelper(&image_view_usage);
     image_view_ci.image = image.handle();
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -3375,7 +3375,7 @@ TEST_F(NegativeRenderPass, ColorAttachmentImageViewUsage) {
     image_info.imageView = image_view.handle();
     image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-    auto descriptor_write = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
     descriptor_write.descriptorCount = 1;
@@ -3407,16 +3407,16 @@ TEST_F(NegativeRenderPass, StencilLoadOp) {
         GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = stencil_format;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
     attach_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
 
-    auto subpass = vku::InitStruct<VkSubpassDescription2>();
+    VkSubpassDescription2 subpass = vku::InitStructHelper();
 
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 render_pass_ci = vku::InitStructHelper();
     render_pass_ci.subpassCount = 1;
     render_pass_ci.pSubpasses = &subpass;
     render_pass_ci.attachmentCount = 1;
@@ -3429,7 +3429,7 @@ TEST_F(NegativeRenderPass, StencilLoadOp) {
 
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto attach_desc_stencil_layout = vku::InitStruct<VkAttachmentDescriptionStencilLayout>();
+    VkAttachmentDescriptionStencilLayout attach_desc_stencil_layout = vku::InitStructHelper();
     attach_desc_stencil_layout.stencilInitialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_GENERAL;
     attach_desc.pNext = &attach_desc_stencil_layout;
@@ -3454,16 +3454,16 @@ TEST_F(NegativeRenderPass, ViewMask) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto subpass = vku::InitStruct<VkSubpassDescription2>();
+    VkSubpassDescription2 subpass = vku::InitStructHelper();
     subpass.viewMask = 0x1;
 
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 render_pass_ci = vku::InitStructHelper();
     render_pass_ci.subpassCount = 1;
     render_pass_ci.pSubpasses = &subpass;
     render_pass_ci.attachmentCount = 1;
@@ -3493,8 +3493,8 @@ TEST_F(NegativeRenderPass, AllViewMasksZero) {
     dependency.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
     dependency.dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
-    auto render_pass_multiview_ci = vku::InitStruct<VkRenderPassMultiviewCreateInfo>();
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo>(&render_pass_multiview_ci);
+    VkRenderPassMultiviewCreateInfo render_pass_multiview_ci = vku::InitStructHelper();
+    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper(&render_pass_multiview_ci);
     render_pass_ci.subpassCount = 1;
     render_pass_ci.pSubpasses = &subpass_description;
     render_pass_ci.dependencyCount = 1;
@@ -3541,7 +3541,7 @@ TEST_F(NegativeRenderPass, AttachmentUndefinedLayout) {
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -3575,37 +3575,38 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeaturesKHR>();
-    auto ms_render_to_single_sampled_features =
-        vku::InitStruct<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT>(&dynamic_rendering_features);
-    auto imageless_features = vku::InitStruct<VkPhysicalDeviceImagelessFramebufferFeaturesKHR>(&ms_render_to_single_sampled_features);
+    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT ms_render_to_single_sampled_features =
+        vku::InitStructHelper(&dynamic_rendering_features);
+    VkPhysicalDeviceImagelessFramebufferFeaturesKHR imageless_features =
+        vku::InitStructHelper(&ms_render_to_single_sampled_features);
     GetPhysicalDeviceFeatures2(imageless_features);
 
     bool imageless_fb_supported = IsExtensionsEnabled(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
 
-    auto vulkan_12_features = vku::InitStruct<VkPhysicalDeviceVulkan12Properties>();
+    VkPhysicalDeviceVulkan12Properties vulkan_12_features = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(vulkan_12_features);
 
     ms_render_to_single_sampled_features.multisampledRenderToSingleSampled = true;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &imageless_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto attachmentRef = vku::InitStruct<VkAttachmentReference2>();
+    VkAttachmentReference2 attachmentRef = vku::InitStructHelper();
     attachmentRef.layout = VK_IMAGE_LAYOUT_GENERAL;
     attachmentRef.attachment = 0;
-    auto depthRef = vku::InitStruct<VkAttachmentReference2>();
+    VkAttachmentReference2 depthRef = vku::InitStructHelper();
     depthRef.layout = VK_IMAGE_LAYOUT_GENERAL;
     depthRef.attachment = 1;
 
-    auto ms_render_to_ss = vku::InitStruct<VkMultisampledRenderToSingleSampledInfoEXT>();
+    VkMultisampledRenderToSingleSampledInfoEXT ms_render_to_ss = vku::InitStructHelper();
     ms_render_to_ss.multisampledRenderToSingleSampledEnable = VK_TRUE;
     ms_render_to_ss.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
 
-    auto subpass = vku::InitStruct<VkSubpassDescription2>(&ms_render_to_ss);
+    VkSubpassDescription2 subpass = vku::InitStructHelper(&ms_render_to_ss);
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &attachmentRef;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 2;
@@ -3640,7 +3641,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     vk::CreateRenderPass2(device(), &rpci, nullptr, &rp);
     m_errorMonitor->VerifyFound();
 
-    auto depth_stencil_resolve = vku::InitStruct<VkSubpassDescriptionDepthStencilResolve>();
+    VkSubpassDescriptionDepthStencilResolve depth_stencil_resolve = vku::InitStructHelper();
     ms_render_to_ss.pNext = &depth_stencil_resolve;
     // VkSubpassDescriptionDepthStencilResolve depthResolveMode and stencilResolveMode both VK_RESOLVE_MODE_NONE
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSubpassDescriptionDepthStencilResolve-pNext-06873");
@@ -3729,7 +3730,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     // Create a usable renderpass
     vkt::RenderPass test_rp(*m_device, rpci);
 
-    auto ms_state = vku::InitStruct<VkPipelineMultisampleStateCreateInfo>();
+    VkPipelineMultisampleStateCreateInfo ms_state = vku::InitStructHelper();
     ms_state.flags = 0;
     ms_state.rasterizationSamples = VK_SAMPLE_COUNT_4_BIT;
     ms_state.sampleShadingEnable = VK_FALSE;
@@ -3752,11 +3753,11 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     pipe_helper.pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
     pipe_helper.CreateGraphicsPipeline();
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfoKHR>();
+    VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     ms_render_to_ss.rasterizationSamples = VK_SAMPLE_COUNT_4_BIT;
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfoKHR>(&ms_render_to_ss);
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper(&ms_render_to_ss);
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
@@ -3770,8 +3771,8 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     m_commandBuffer->EndRendering();
     m_commandBuffer->end();
 
-    auto image_format_prop = vku::InitStruct<VkImageFormatProperties2>();
-    auto image_format_info = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>();
+    VkImageFormatProperties2 image_format_prop = vku::InitStructHelper();
+    VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper();
     image_format_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_format_info.type = VK_IMAGE_TYPE_2D;
     image_format_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -3782,7 +3783,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
                         "Skipping remainder of the test";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.flags = 0;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -3944,7 +3945,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
 
         if (imageless_fb_supported) {
             VkFormat framebufferAttachmentFormats[1] = {unsampleable_format};
-            auto framebufferAttachmentImageInfo = vku::InitStruct<VkFramebufferAttachmentImageInfoKHR>();
+            VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfo = vku::InitStructHelper();
             framebufferAttachmentImageInfo.flags = image_create_info.flags;
             framebufferAttachmentImageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
             framebufferAttachmentImageInfo.width = 64;
@@ -3952,7 +3953,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
             framebufferAttachmentImageInfo.layerCount = 1;
             framebufferAttachmentImageInfo.viewFormatCount = 1;
             framebufferAttachmentImageInfo.pViewFormats = framebufferAttachmentFormats;
-            auto framebufferAttachmentsCreateInfo = vku::InitStruct<VkFramebufferAttachmentsCreateInfoKHR>();
+            VkFramebufferAttachmentsCreateInfoKHR framebufferAttachmentsCreateInfo = vku::InitStructHelper();
             framebufferAttachmentsCreateInfo.attachmentImageInfoCount = 1;
             framebufferAttachmentsCreateInfo.pAttachmentImageInfos = &framebufferAttachmentImageInfo;
             rpci.attachmentCount = 1;
@@ -3965,10 +3966,10 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
             imageless_fbci.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR;
             vkt::Framebuffer imageless_fb(*m_device, imageless_fbci);
 
-            auto renderPassAttachmentBeginInfo = vku::InitStruct<VkRenderPassAttachmentBeginInfo>();
+            VkRenderPassAttachmentBeginInfo renderPassAttachmentBeginInfo = vku::InitStructHelper();
             renderPassAttachmentBeginInfo.attachmentCount = 1;
             renderPassAttachmentBeginInfo.pAttachments = &unsampleable_image_view.handle();
-            auto renderPassBeginInfo = vku::InitStruct<VkRenderPassBeginInfo>(&renderPassAttachmentBeginInfo);
+            VkRenderPassBeginInfo renderPassBeginInfo = vku::InitStructHelper(&renderPassAttachmentBeginInfo);
             renderPassBeginInfo.renderPass = imageless_rp.handle();
             renderPassBeginInfo.renderArea.extent.width = 64;
             renderPassBeginInfo.renderArea.extent.height = 64;
@@ -4007,7 +4008,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     m_errorMonitor->VerifyFound();
 
     vkt::QueueCreateInfoArray queue_info(m_device->queue_props);
-    auto device_create_info = vku::InitStruct<VkDeviceCreateInfo>();
+    VkDeviceCreateInfo device_create_info = vku::InitStructHelper();
     device_create_info.queueCreateInfoCount = queue_info.size();
     device_create_info.pQueueCreateInfos = queue_info.data();
     device_create_info.pEnabledFeatures = nullptr;
@@ -4038,7 +4039,7 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionUndefinedFormat) {
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &color_attach;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -4109,7 +4110,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass) {
     image.InitNoLayout(width, height, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto fb_ci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
     fb_ci.renderPass = render_pass1.handle();
     fb_ci.attachmentCount = 1;
     fb_ci.pAttachments = &imageView;
@@ -4154,7 +4155,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "multiview feature not supported";
@@ -4217,7 +4218,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass2) {
     image.InitNoLayout(width, height, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto fb_ci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
     fb_ci.renderPass = render_pass1.handle();
     fb_ci.attachmentCount = 1;
     fb_ci.pAttachments = &imageView;
@@ -4428,7 +4429,7 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSynchronization2) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
 
@@ -4499,7 +4500,7 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSeparateDepthStencil) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto separate_depth_stencil_layouts_features = vku::InitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR>();
+    VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR separate_depth_stencil_layouts_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &separate_depth_stencil_layouts_features));
 
@@ -4599,14 +4600,14 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSeparateDepthStencil) {
         vk::GetPhysicalDeviceImageFormatProperties(gpu_, depth_stencil_attachment.format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                                                    VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, 0u, &imageFormatProperties);
     if (rp2_supported && res == VK_SUCCESS) {
-        auto rpci2 = vku::InitStruct<VkRenderPassCreateInfo2KHR>();
+        VkRenderPassCreateInfo2KHR rpci2 = vku::InitStructHelper();
         rpci2.attachmentCount = 1;
         rpci2.pAttachments = &depth_stencil_attachment;
-        auto stencil_ref = vku::InitStruct<VkAttachmentReferenceStencilLayoutKHR>();
+        VkAttachmentReferenceStencilLayoutKHR stencil_ref = vku::InitStructHelper();
         stencil_ref.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL_KHR;
-        auto depth_stencil_ref = vku::InitStruct<VkAttachmentReference2KHR>(&stencil_ref);
+        VkAttachmentReference2KHR depth_stencil_ref = vku::InitStructHelper(&stencil_ref);
         depth_stencil_ref.attachment = 0;
-        auto subpass2 = vku::InitStruct<VkSubpassDescription2KHR>();
+        VkSubpassDescription2KHR subpass2 = vku::InitStructHelper();
         subpass2.pDepthStencilAttachment = &depth_stencil_ref;
         rpci2.subpassCount = 1;
         rpci2.pSubpasses = &subpass2;

--- a/tests/unit/robustness.cpp
+++ b/tests/unit/robustness.cpp
@@ -31,7 +31,7 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabled) {
     {
         CreateComputePipelineHelper pipe(*this);
         pipe.InitState();
-        auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+        VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.storageBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
         pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
@@ -43,7 +43,7 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabled) {
     {
         CreateComputePipelineHelper pipe(*this);
         pipe.InitState();
-        auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+        VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.uniformBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
         pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
@@ -55,7 +55,7 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabled) {
     {
         CreateComputePipelineHelper pipe(*this);
         pipe.InitState();
-        auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+        VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.vertexInputs = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
         pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
@@ -67,7 +67,7 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabled) {
     {
         CreateComputePipelineHelper pipe(*this);
         pipe.InitState();
-        auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+        VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.images = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT;
         pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
@@ -96,7 +96,7 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabledShaderStage) {
     pipe.InitState();
     pipe.LateBindPipelineInfo();
 
-    auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+    VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
     pipeline_robustness_info.storageBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
     pipe.cp_ci_.stage.pNext = &pipeline_robustness_info;
 
@@ -119,9 +119,9 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabledShaderStageWithIdentifier) 
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto shader_cache_control_features = vku::InitStruct<VkPhysicalDevicePipelineCreationCacheControlFeatures>();
-    auto shader_module_id_features =
-        vku::InitStruct<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(&shader_cache_control_features);
+    VkPhysicalDevicePipelineCreationCacheControlFeatures shader_cache_control_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT shader_module_id_features =
+        vku::InitStructHelper(&shader_cache_control_features);
     GetPhysicalDeviceFeatures2(shader_module_id_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &shader_module_id_features));
 
@@ -130,15 +130,15 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabledShaderStageWithIdentifier) 
     pipe.InitState();
     pipe.LateBindPipelineInfo();
 
-    auto sm_id_create_info = vku::InitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
     VkShaderObj cs(this, kMinimalShaderGlsl, VK_SHADER_STAGE_COMPUTE_BIT);
 
-    auto get_identifier = vku::InitStruct<VkShaderModuleIdentifierEXT>();
+    VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
     vk::GetShaderModuleIdentifierEXT(device(), cs.handle(), &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
 
-    auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>(&sm_id_create_info);
+    VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper(&sm_id_create_info);
     pipeline_robustness_info.storageBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
     pipe.cp_ci_.stage.module = VK_NULL_HANDLE;
     pipe.cp_ci_.stage.pNext = &pipeline_robustness_info;
@@ -167,7 +167,7 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustBufferAccess2Unsuppo
     }
 
     if (IsExtensionsEnabled(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)) {
-        auto robustness2_features = vku::InitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
+        VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features = vku::InitStructHelper();
         GetPhysicalDeviceFeatures2(robustness2_features);
 
         if (robustness2_features.robustBufferAccess2) {
@@ -175,7 +175,7 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustBufferAccess2Unsuppo
         }
     }
 
-    auto pipeline_robustness_features = vku::InitStruct<VkPhysicalDevicePipelineRobustnessFeaturesEXT>();
+    VkPhysicalDevicePipelineRobustnessFeaturesEXT pipeline_robustness_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(pipeline_robustness_features);
 
     if (!pipeline_robustness_features.pipelineRobustness) {
@@ -187,7 +187,7 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustBufferAccess2Unsuppo
     {
         CreateComputePipelineHelper pipe(*this);
         pipe.InitState();
-        auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+        VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.storageBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
         pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
@@ -199,7 +199,7 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustBufferAccess2Unsuppo
     {
         CreateComputePipelineHelper pipe(*this);
         pipe.InitState();
-        auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+        VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.uniformBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
         pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
@@ -211,7 +211,7 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustBufferAccess2Unsuppo
     {
         CreateComputePipelineHelper pipe(*this);
         pipe.InitState();
-        auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+        VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.vertexInputs = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
         pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
@@ -239,7 +239,7 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustImageAccess2Unsuppor
     }
 
     if (IsExtensionsEnabled(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME)) {
-        auto robustness2_features = vku::InitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
+        VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features = vku::InitStructHelper();
         GetPhysicalDeviceFeatures2(robustness2_features);
 
         if (robustness2_features.robustImageAccess2) {
@@ -247,7 +247,7 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustImageAccess2Unsuppor
         }
     }
 
-    auto pipeline_robustness_features = vku::InitStruct<VkPhysicalDevicePipelineRobustnessFeaturesEXT>();
+    VkPhysicalDevicePipelineRobustnessFeaturesEXT pipeline_robustness_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(pipeline_robustness_features);
 
     if (!pipeline_robustness_features.pipelineRobustness) {
@@ -258,7 +258,7 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustImageAccess2Unsuppor
 
     CreateComputePipelineHelper pipe(*this);
     pipe.InitState();
-    auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+    VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
     pipeline_robustness_info.images = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT;
     pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
@@ -279,7 +279,7 @@ TEST_F(NegativeRobustness, PipelineRobustnessRobustImageAccessNotExposed) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto pipeline_robustness_features = vku::InitStruct<VkPhysicalDevicePipelineRobustnessFeaturesEXT>();
+    VkPhysicalDevicePipelineRobustnessFeaturesEXT pipeline_robustness_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(pipeline_robustness_features);
     if (!pipeline_robustness_features.pipelineRobustness) {
         GTEST_SKIP() << "pipelineRobustness is not supported";
@@ -291,7 +291,7 @@ TEST_F(NegativeRobustness, PipelineRobustnessRobustImageAccessNotExposed) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.InitState();
-    auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+    VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
     pipeline_robustness_info.images = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT;
     pipe.cp_ci_.pNext = &pipeline_robustness_info;
 

--- a/tests/unit/robustness_positive.cpp
+++ b/tests/unit/robustness_positive.cpp
@@ -24,7 +24,7 @@ TEST_F(PositiveRobustness, WriteDescriptorSetAccelerationStructureNVNullDescript
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto robustness2_features = vku::InitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
+    VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(robustness2_features);
     if (robustness2_features.nullDescriptor != VK_TRUE) {
         GTEST_SKIP() << "nullDescriptor feature not supported";
@@ -61,7 +61,7 @@ TEST_F(PositiveRobustness, BindVertexBuffers2EXTNullDescriptors) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto robustness2_features = vku::InitStruct<VkPhysicalDeviceRobustness2FeaturesEXT>();
+    VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(robustness2_features);
     if (!robustness2_features.nullDescriptor) {
         GTEST_SKIP() << "nullDescriptor feature not supported";
@@ -106,7 +106,7 @@ TEST_F(PositiveRobustness, PipelineRobustnessRobustImageAccessExposed) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto pipeline_robustness_features = vku::InitStruct<VkPhysicalDevicePipelineRobustnessFeaturesEXT>();
+    VkPhysicalDevicePipelineRobustnessFeaturesEXT pipeline_robustness_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(pipeline_robustness_features);
     if (!pipeline_robustness_features.pipelineRobustness) {
         GTEST_SKIP() << "pipelineRobustness is not supported";
@@ -115,7 +115,7 @@ TEST_F(PositiveRobustness, PipelineRobustnessRobustImageAccessExposed) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.InitState();
-    auto pipeline_robustness_info = vku::InitStruct<VkPipelineRobustnessCreateInfoEXT>();
+    VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
     pipeline_robustness_info.images = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT;
     pipe.cp_ci_.pNext = &pipeline_robustness_info;
     pipe.CreateComputePipeline();

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -529,7 +529,7 @@ TEST_F(NegativeSampler, MultiplaneImageSamplerConversionMismatch) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features11 = vku::InitStruct<VkPhysicalDeviceVulkan11Features>();
+    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(features11);
     if (features11.samplerYcbcrConversion != VK_TRUE) {
         GTEST_SKIP() << "SamplerYcbcrConversion not supported";
@@ -742,7 +742,7 @@ TEST_F(NegativeSampler, CustomBorderColor) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto border_color_features = vku::InitStruct<VkPhysicalDeviceCustomBorderColorFeaturesEXT>();
+    VkPhysicalDeviceCustomBorderColorFeaturesEXT border_color_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(border_color_features);
     if (border_color_features.customBorderColors != VK_TRUE) {
         GTEST_SKIP() << "customBorderColors feature not supported";
@@ -778,7 +778,7 @@ TEST_F(NegativeSampler, CustomBorderColor) {
     vk::CreateDescriptorSetLayout(m_device->device(), &ds_layout_ci, NULL, &ds_layout);
     m_errorMonitor->VerifyFound();
 
-    auto custom_properties = vku::InitStruct<VkPhysicalDeviceCustomBorderColorPropertiesEXT>();
+    VkPhysicalDeviceCustomBorderColorPropertiesEXT custom_properties = vku::InitStructHelper();
     auto prop2 = GetPhysicalDeviceProperties2(custom_properties);
 
     if ((custom_properties.maxCustomBorderColorSamplers <= 0xFFFF) &&
@@ -808,7 +808,7 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefined) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto border_color_features = vku::InitStruct<VkPhysicalDeviceCustomBorderColorFeaturesEXT>();
+    VkPhysicalDeviceCustomBorderColorFeaturesEXT border_color_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(border_color_features);
     if (!border_color_features.customBorderColors || !border_color_features.customBorderColorWithoutFormat) {
         GTEST_SKIP() << "Custom border color feature not supported";
@@ -889,8 +889,8 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesCombinedSampler) {
     // Verify that it is allowed on this implementation if
     // VK_KHR_format_feature_flags2 is available.
     if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
-        auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-        auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
         vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
 
@@ -989,8 +989,8 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSampler) {
     // Verify that it is allowed on this implementation if
     // VK_KHR_format_feature_flags2 is available.
     if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
-        auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-        auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
         vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
 
@@ -1341,7 +1341,7 @@ TEST_F(NegativeSampler, ReductionModeFeature) {
         GTEST_SKIP() << "Test requires at least Vulkan 1.2";
     }
 
-    auto sampler_reduction_mode_ci = vku::InitStruct<VkSamplerReductionModeCreateInfo>();
+    VkSamplerReductionModeCreateInfo sampler_reduction_mode_ci = vku::InitStructHelper();
     sampler_reduction_mode_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MIN;
 
     auto sampler_ci = SafeSaneSamplerCreateInfo();
@@ -1379,7 +1379,7 @@ TEST_F(NegativeSampler, NonSeamlessCubeMapNotEnabled) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto non_seamless_cube_map_features = vku::InitStruct<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT>();
+    VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT non_seamless_cube_map_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(non_seamless_cube_map_features);
     non_seamless_cube_map_features.nonSeamlessCubeMap = false;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
@@ -1440,7 +1440,7 @@ TEST_F(NegativeSampler, CustomBorderColorsFeature) {
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.borderColor = VK_BORDER_COLOR_FLOAT_CUSTOM_EXT;
 
-    auto custom_color_cinfo = vku::InitStruct<VkSamplerCustomBorderColorCreateInfoEXT>();
+    VkSamplerCustomBorderColorCreateInfoEXT custom_color_cinfo = vku::InitStructHelper();
     custom_color_cinfo.format = VK_FORMAT_R32_SFLOAT;
     sampler_info.pNext = &custom_color_cinfo;
 

--- a/tests/unit/sampler_positive.cpp
+++ b/tests/unit/sampler_positive.cpp
@@ -66,7 +66,7 @@ TEST_F(PositiveSampler, SamplerMirrorClampToEdgeWithFeature) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     features12.samplerMirrorClampToEdge = VK_TRUE;
     auto features2 = GetPhysicalDeviceFeatures2(features12);
     if (features12.samplerMirrorClampToEdge != VK_TRUE) {

--- a/tests/unit/shader_compute.cpp
+++ b/tests/unit/shader_compute.cpp
@@ -86,7 +86,7 @@ TEST_F(NegativeShaderCompute, SharedMemoryOverLimitWorkgroupMemoryExplicitLayout
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto explicit_layout_features = vku::InitStruct<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>();
+    VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR explicit_layout_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(explicit_layout_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
@@ -334,7 +334,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeId) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto features13 = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
+    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features13));
 
@@ -378,7 +378,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantDefault) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto features13 = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
+    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features13));
 
@@ -427,7 +427,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantSet) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto features13 = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
+    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features13));
 
@@ -487,7 +487,7 @@ TEST_F(NegativeShaderCompute, WorkgroupMemoryExplicitLayout) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto float16int8_features = vku::InitStruct<VkPhysicalDeviceShaderFloat16Int8Features>();
+    VkPhysicalDeviceShaderFloat16Int8Features float16int8_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(float16int8_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
@@ -662,8 +662,8 @@ TEST_F(NegativeShaderCompute, ZeroInitializeWorkgroupMemory) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     bool zero_initialize_workgroup_memory = AreRequiredExtensionsEnabled();
 
-    auto zero_initialize_work_group_memory_features = vku::InitStruct<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR>();
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&zero_initialize_work_group_memory_features);
+    VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR zero_initialize_work_group_memory_features = vku::InitStructHelper();
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&zero_initialize_work_group_memory_features);
     if (zero_initialize_workgroup_memory) {
         features2.pNext = &zero_initialize_work_group_memory_features;
     }

--- a/tests/unit/shader_compute_positive.cpp
+++ b/tests/unit/shader_compute_positive.cpp
@@ -118,7 +118,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizeLocalSizeId) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto features13 = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
+    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features13));
 
@@ -157,7 +157,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizeLocalSizeIdSpecConstant) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto features13 = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
+    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features13));
 
@@ -218,7 +218,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizePrecedenceOverLocalSizeId) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto features13 = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
+    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features13));
 
@@ -326,7 +326,7 @@ TEST_F(PositiveShaderCompute, ZeroInitializeWorkgroupMemoryFeature) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " required but not supported";
     }
 
-    auto zero_initialize_work_group_memory_features = vku::InitStruct<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR>();
+    VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeaturesKHR zero_initialize_work_group_memory_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(zero_initialize_work_group_memory_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &zero_initialize_work_group_memory_features));

--- a/tests/unit/shader_cooperative_matrix.cpp
+++ b/tests/unit/shader_cooperative_matrix.cpp
@@ -31,9 +31,9 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRSpecInfo) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto cooperative_matrix_features = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
-    auto memory_model_features = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features = vku::InitStructHelper(&float16_features);
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR memory_model_features = vku::InitStructHelper(&cooperative_matrix_features);
     GetPhysicalDeviceFeatures2(memory_model_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
@@ -100,11 +100,11 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRUnsupportedStage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto cooperative_matrix_features = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>();
-    auto memory_model_features = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
+    VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features = vku::InitStructHelper();
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR memory_model_features = vku::InitStructHelper(&cooperative_matrix_features);
     GetPhysicalDeviceFeatures2(memory_model_features);
 
-    auto props = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixPropertiesKHR>();
+    VkPhysicalDeviceCooperativeMatrixPropertiesKHR props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(props);
 
     if ((props.cooperativeMatrixSupportedStages & VK_SHADER_STAGE_VERTEX_BIT) != 0) {
@@ -166,9 +166,9 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRParametersMatchProperties) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto cooperative_matrix_features = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
-    auto memory_model_features = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features = vku::InitStructHelper(&float16_features);
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR memory_model_features = vku::InitStructHelper(&cooperative_matrix_features);
     GetPhysicalDeviceFeatures2(memory_model_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
@@ -213,9 +213,9 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRDimXMultipleSubgroupSize) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto cooperative_matrix_features = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
-    auto memory_model_features = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features = vku::InitStructHelper(&float16_features);
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR memory_model_features = vku::InitStructHelper(&cooperative_matrix_features);
     GetPhysicalDeviceFeatures2(memory_model_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
@@ -285,9 +285,9 @@ TEST_F(NegativeShaderCooperativeMatrix, KHRSameScope) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto cooperative_matrix_features = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
-    auto memory_model_features = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features = vku::InitStructHelper(&float16_features);
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR memory_model_features = vku::InitStructHelper(&cooperative_matrix_features);
     GetPhysicalDeviceFeatures2(memory_model_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
@@ -368,9 +368,9 @@ TEST_F(NegativeShaderCooperativeMatrix, DISABLED_MatchSizeWithProperties) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto cooperative_matrix_features = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
-    auto memory_model_features = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features = vku::InitStructHelper(&float16_features);
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR memory_model_features = vku::InitStructHelper(&cooperative_matrix_features);
     GetPhysicalDeviceFeatures2(memory_model_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
@@ -493,9 +493,9 @@ TEST_F(NegativeShaderCooperativeMatrix, DISABLED_KHRSignedCheck) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto cooperative_matrix_features = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
-    auto memory_model_features = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features = vku::InitStructHelper(&float16_features);
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR memory_model_features = vku::InitStructHelper(&cooperative_matrix_features);
     GetPhysicalDeviceFeatures2(memory_model_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 

--- a/tests/unit/shader_cooperative_matrix_positive.cpp
+++ b/tests/unit/shader_cooperative_matrix_positive.cpp
@@ -58,9 +58,9 @@ TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixNV) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto cooperative_matrix_features = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesNV>(&float16_features);
-    auto memory_model_features = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDeviceCooperativeMatrixFeaturesNV cooperative_matrix_features = vku::InitStructHelper(&float16_features);
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR memory_model_features = vku::InitStructHelper(&cooperative_matrix_features);
     GetPhysicalDeviceFeatures2(memory_model_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
@@ -129,10 +129,10 @@ TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixKHR) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto storage16_features = vku::InitStruct<VkPhysicalDevice16BitStorageFeatures>(&float16_features);
-    auto cooperative_matrix_features = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&storage16_features);
-    auto memory_model_features = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDevice16BitStorageFeatures storage16_features = vku::InitStructHelper(&float16_features);
+    VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features = vku::InitStructHelper(&storage16_features);
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR memory_model_features = vku::InitStructHelper(&cooperative_matrix_features);
     GetPhysicalDeviceFeatures2(memory_model_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &memory_model_features));
 
@@ -144,7 +144,7 @@ TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixKHR) {
     }
     vk::GetPhysicalDeviceCooperativeMatrixPropertiesKHR(gpu(), &props_count, props.data());
 
-    auto subgroup_prop = vku::InitStruct<VkCooperativeMatrixPropertiesKHR>();
+    VkCooperativeMatrixPropertiesKHR subgroup_prop = vku::InitStructHelper();
     bool found_scope_subgroup = false;
     for (const auto &prop : props) {
         if (prop.scope == VK_SCOPE_SUBGROUP_KHR) {

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -227,11 +227,11 @@ TEST_F(PositiveShaderInterface, UboStd430Layout) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto uniform_buffer_standard_layout_features = vku::InitStruct<VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR>(NULL);
+    VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR uniform_buffer_standard_layout_features = vku::InitStructHelper(NULL);
     uniform_buffer_standard_layout_features.uniformBufferStandardLayout = VK_TRUE;
     GetPhysicalDeviceFeatures2(uniform_buffer_standard_layout_features);
 
-    auto set_features2 = vku::InitStruct<VkPhysicalDeviceFeatures2>(&uniform_buffer_standard_layout_features);
+    VkPhysicalDeviceFeatures2 set_features2 = vku::InitStructHelper(&uniform_buffer_standard_layout_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &set_features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -281,9 +281,9 @@ TEST_F(PositiveShaderInterface, ScalarBlockLayout) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto scalar_block_features = vku::InitStruct<VkPhysicalDeviceScalarBlockLayoutFeaturesEXT>(NULL);
+    VkPhysicalDeviceScalarBlockLayoutFeaturesEXT scalar_block_features = vku::InitStructHelper(NULL);
     GetPhysicalDeviceFeatures2(scalar_block_features);
-    auto set_features2 = vku::InitStruct<VkPhysicalDeviceFeatures2>(&scalar_block_features);
+    VkPhysicalDeviceFeatures2 set_features2 = vku::InitStructHelper(&scalar_block_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &set_features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -360,7 +360,7 @@ TEST_F(PositiveShaderInterface, RelaxedTypeMatch) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " required but not supported";
     }
-    auto maintenance_4_features = vku::InitStruct<VkPhysicalDeviceMaintenance4FeaturesKHR>();
+    VkPhysicalDeviceMaintenance4FeaturesKHR maintenance_4_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(maintenance_4_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &maintenance_4_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -595,7 +595,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features12));
 
@@ -628,7 +628,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
                                                      0,
                                                      nullptr};
 
-    auto renderPassInfo = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo renderPassInfo = vku::InitStructHelper();
     renderPassInfo.attachmentCount = 1;
     renderPassInfo.pAttachments = &inputAttachmentDescription;
     renderPassInfo.subpassCount = 1;
@@ -750,7 +750,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentDepthStencil) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features12));
 
@@ -777,7 +777,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentDepthStencil) {
                                                      0,
                                                      nullptr};
 
-    auto renderPassInfo = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo renderPassInfo = vku::InitStructHelper();
     renderPassInfo.attachmentCount = 2;
     renderPassInfo.pAttachments = inputAttachmentDescriptions;
     renderPassInfo.subpassCount = 1;
@@ -948,7 +948,7 @@ TEST_F(VkPositiveLayerTest, TestShaderInputOutputMatch) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateGraphicsPipeline();
 
-    auto ub_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo ub_ci = vku::InitStructHelper();
     ub_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     ub_ci.size = 1024;
     vkt::Buffer uniform_buffer(*m_device, ub_ci);
@@ -1430,7 +1430,7 @@ TEST_F(PositiveShaderInterface, PhysicalStorageBufferGlslang3) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);
     if (VK_TRUE != features12.bufferDeviceAddress) {
         GTEST_SKIP() << "bufferDeviceAddress not supported and is required";
@@ -1476,7 +1476,7 @@ TEST_F(PositiveShaderInterface, PhysicalStorageBufferGlslang6) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);
     if (VK_TRUE != features12.bufferDeviceAddress) {
         GTEST_SKIP() << "bufferDeviceAddress not supported and is required";
@@ -1514,7 +1514,7 @@ TEST_F(PositiveShaderInterface, PhysicalStorageBuffer) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);
     if (VK_TRUE != features12.bufferDeviceAddress) {
         GTEST_SKIP() << "bufferDeviceAddress not supported and is required";

--- a/tests/unit/shader_limits.cpp
+++ b/tests/unit/shader_limits.cpp
@@ -266,7 +266,7 @@ TEST_F(NegativeShaderLimits, DISABLED_MaxFragmentDualSrcAttachments) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2>();
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features2);
 
     if (features2.features.dualSrcBlend == VK_FALSE) {

--- a/tests/unit/shader_limits_positive.cpp
+++ b/tests/unit/shader_limits_positive.cpp
@@ -34,7 +34,7 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryWorkgroupMemoryExplicitLayout) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto explicit_layout_features = vku::InitStruct<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>();
+    VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR explicit_layout_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(explicit_layout_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
@@ -86,7 +86,7 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryWorkgroupMemoryExplicitLayoutSpe
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto explicit_layout_features = vku::InitStruct<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>();
+    VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR explicit_layout_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(explicit_layout_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &explicit_layout_features));
 
@@ -203,7 +203,7 @@ TEST_F(PositiveShaderLimits, MeshSharedMemoryAtLimit) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (!mesh_shader_features.meshShader) {
         GTEST_SKIP() << "Mesh shader not supported";
@@ -215,7 +215,7 @@ TEST_F(PositiveShaderLimits, MeshSharedMemoryAtLimit) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
     }
 
-    auto mesh_shader_properties = vku::InitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
@@ -250,7 +250,7 @@ TEST_F(PositiveShaderLimits, TaskSharedMemoryAtLimit) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (!mesh_shader_features.meshShader || !mesh_shader_features.taskShader) {
         GTEST_SKIP() << "Mesh and Task shader not supported";
@@ -262,7 +262,7 @@ TEST_F(PositiveShaderLimits, TaskSharedMemoryAtLimit) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
     }
 
-    auto mesh_shader_properties = vku::InitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;

--- a/tests/unit/shader_mesh.cpp
+++ b/tests/unit/shader_mesh.cpp
@@ -21,7 +21,7 @@ TEST_F(NegativeShaderMesh, SharedMemoryOverLimit) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (!mesh_shader_features.meshShader) {
         GTEST_SKIP() << "Mesh shader not supported";
@@ -33,7 +33,7 @@ TEST_F(NegativeShaderMesh, SharedMemoryOverLimit) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
     }
 
-    auto mesh_shader_properties = vku::InitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
@@ -71,8 +71,8 @@ TEST_F(NegativeShaderMesh, SharedMemoryOverLimitWorkgroupMemoryExplicitLayout) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto explicit_layout_features = vku::InitStruct<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>();
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>(&explicit_layout_features);
+    VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR explicit_layout_features = vku::InitStructHelper();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper(&explicit_layout_features);
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (!mesh_shader_features.meshShader) {
         GTEST_SKIP() << "Mesh shader not supported";
@@ -86,7 +86,7 @@ TEST_F(NegativeShaderMesh, SharedMemoryOverLimitWorkgroupMemoryExplicitLayout) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
     }
 
-    auto mesh_shader_properties = vku::InitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
@@ -134,7 +134,7 @@ TEST_F(NegativeShaderMesh, SharedMemorySpecConstantDefault) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (!mesh_shader_features.meshShader) {
         GTEST_SKIP() << "Mesh shader not supported";
@@ -146,7 +146,7 @@ TEST_F(NegativeShaderMesh, SharedMemorySpecConstantDefault) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
     }
 
-    auto mesh_shader_properties = vku::InitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
@@ -185,7 +185,7 @@ TEST_F(NegativeShaderMesh, SharedMemorySpecConstantSet) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (!mesh_shader_features.meshShader) {
         GTEST_SKIP() << "Mesh shader not supported";
@@ -197,7 +197,7 @@ TEST_F(NegativeShaderMesh, SharedMemorySpecConstantSet) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
     }
 
-    auto mesh_shader_properties = vku::InitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
@@ -249,7 +249,7 @@ TEST_F(NegativeShaderMesh, TaskSharedMemoryOverLimit) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mesh_shader_features);
     if (!mesh_shader_features.meshShader || !mesh_shader_features.taskShader) {
         GTEST_SKIP() << "Mesh and Task shader not supported";
@@ -261,7 +261,7 @@ TEST_F(NegativeShaderMesh, TaskSharedMemoryOverLimit) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required.";
     }
 
-    auto mesh_shader_properties = vku::InitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxTaskSharedMemorySize;

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -21,7 +21,7 @@ TEST_F(NegativeShaderObject, SpirvCodeSize) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]) - 2u;
@@ -44,7 +44,7 @@ TEST_F(NegativeShaderObject, LinkedComputeShader) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, kMinimalShaderGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.flags = VK_SHADER_CREATE_LINK_STAGE_BIT_EXT;
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -66,7 +66,7 @@ TEST_F(NegativeShaderObject, InvalidFlags) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.flags = VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT;
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -101,7 +101,7 @@ TEST_F(NegativeShaderObject, InvalidMeshShaderExtFlags) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderCreateInfoEXT-flags-08414");
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&meshShaderFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.taskShader == VK_FALSE) {
@@ -110,7 +110,7 @@ TEST_F(NegativeShaderObject, InvalidMeshShaderExtFlags) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.flags = VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT;
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -134,7 +134,7 @@ TEST_F(NegativeShaderObject, VertexNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.nextStage = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -158,7 +158,7 @@ TEST_F(NegativeShaderObject, TessellationControlNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, kTessellationControlMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
     createInfo.nextStage = VK_SHADER_STAGE_GEOMETRY_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -182,7 +182,7 @@ TEST_F(NegativeShaderObject, TessellationEvaluationNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, kTessellationEvalMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
     createInfo.nextStage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -206,7 +206,7 @@ TEST_F(NegativeShaderObject, GeometryNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_GEOMETRY_BIT, kGeometryMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
     createInfo.nextStage = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -230,7 +230,7 @@ TEST_F(NegativeShaderObject, FragmentNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.nextStage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -250,7 +250,7 @@ TEST_F(NegativeShaderObject, TaskNextStage) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderCreateInfoEXT-nextStage-08435");
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&meshShaderFeatures, VK_API_VERSION_1_2);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.taskShader == VK_FALSE) {
@@ -259,7 +259,7 @@ TEST_F(NegativeShaderObject, TaskNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_TASK_BIT_EXT, kTaskMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_TASK_BIT_EXT;
     createInfo.nextStage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -279,7 +279,7 @@ TEST_F(NegativeShaderObject, MeshNextStage) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderCreateInfoEXT-nextStage-08436");
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&meshShaderFeatures, VK_API_VERSION_1_2);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
@@ -288,7 +288,7 @@ TEST_F(NegativeShaderObject, MeshNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_MESH_BIT_EXT, kMeshMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_MESH_BIT_EXT;
     createInfo.nextStage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -308,7 +308,7 @@ TEST_F(NegativeShaderObject, TaskNVNextStage) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderCreateInfoEXT-nextStage-08435");
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&meshShaderFeatures, VK_API_VERSION_1_2);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.taskShader == VK_FALSE) {
@@ -317,7 +317,7 @@ TEST_F(NegativeShaderObject, TaskNVNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_TASK_BIT_NV, kTaskMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_TASK_BIT_NV;
     createInfo.nextStage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -337,7 +337,7 @@ TEST_F(NegativeShaderObject, MeshNVNextStage) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderCreateInfoEXT-nextStage-08436");
 
     AddRequiredExtensions(VK_NV_MESH_SHADER_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesNV>();
+    VkPhysicalDeviceMeshShaderFeaturesNV meshShaderFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&meshShaderFeatures, VK_API_VERSION_1_2);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
@@ -346,7 +346,7 @@ TEST_F(NegativeShaderObject, MeshNVNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_MESH_BIT_NV, kMeshMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_MESH_BIT_NV;
     createInfo.nextStage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -372,7 +372,7 @@ TEST_F(NegativeShaderObject, BinaryCodeAlignment) {
 
     auto ptr = reinterpret_cast<std::uintptr_t>(spv.data()) + sizeof(uint8_t);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_BINARY_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -397,7 +397,7 @@ TEST_F(NegativeShaderObject, SpirvCodeAlignment) {
 
     auto ptr = reinterpret_cast<std::uintptr_t>(spv.data()) + sizeof(uint8_t);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -420,7 +420,7 @@ TEST_F(NegativeShaderObject, InvalidStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_SUBPASS_SHADING_BIT_HUAWEI;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -447,8 +447,8 @@ TEST_F(NegativeShaderObject, BindVertexAndTaskShaders) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features, VK_API_VERSION_1_3);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.taskShader == VK_FALSE) {
@@ -461,14 +461,14 @@ TEST_F(NegativeShaderObject, BindVertexAndTaskShaders) {
     const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     const auto task_spv = GLSLToSPV(VK_SHADER_STAGE_TASK_BIT_EXT, kTaskMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto vertCreateInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT vertCreateInfo = vku::InitStructHelper();
     vertCreateInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     vertCreateInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     vertCreateInfo.codeSize = vert_spv.size() * sizeof(vert_spv[0]);
     vertCreateInfo.pCode = vert_spv.data();
     vertCreateInfo.pName = "main";
 
-    auto taskCreateInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT taskCreateInfo = vku::InitStructHelper();
     taskCreateInfo.stage = VK_SHADER_STAGE_TASK_BIT_EXT;
     taskCreateInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     taskCreateInfo.codeSize = task_spv.size() * sizeof(task_spv[0]);
@@ -500,8 +500,8 @@ TEST_F(NegativeShaderObject, BindVertexAndMeshShaders) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features, VK_API_VERSION_1_2);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
@@ -514,14 +514,14 @@ TEST_F(NegativeShaderObject, BindVertexAndMeshShaders) {
     const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     const auto mesh_spv = GLSLToSPV(VK_SHADER_STAGE_MESH_BIT_EXT, kMeshMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto vertCreateInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT vertCreateInfo = vku::InitStructHelper();
     vertCreateInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     vertCreateInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     vertCreateInfo.codeSize = vert_spv.size() * sizeof(vert_spv[0]);
     vertCreateInfo.pCode = vert_spv.data();
     vertCreateInfo.pName = "main";
 
-    auto meshCreateInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT meshCreateInfo = vku::InitStructHelper();
     meshCreateInfo.stage = VK_SHADER_STAGE_MESH_BIT_EXT;
     meshCreateInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     meshCreateInfo.codeSize = mesh_spv.size() * sizeof(mesh_spv[0]);
@@ -556,7 +556,7 @@ TEST_F(NegativeShaderObject, CreateShadersWithoutEnabledFeatures) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>();
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
     features2.features.tessellationShader = VK_FALSE;
     features2.features.geometryShader = VK_FALSE;
@@ -571,7 +571,7 @@ TEST_F(NegativeShaderObject, CreateShadersWithoutEnabledFeatures) {
 
         const auto spv = GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, kTessellationControlMinimalGlsl);
 
-        auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+        VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
         createInfo.stage = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
         createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
         createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -589,7 +589,7 @@ TEST_F(NegativeShaderObject, CreateShadersWithoutEnabledFeatures) {
 
         const auto spv = GLSLToSPV(VK_SHADER_STAGE_GEOMETRY_BIT, kGeometryMinimalGlsl);
 
-        auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+        VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
         createInfo.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
         createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
         createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -613,8 +613,8 @@ TEST_F(NegativeShaderObject, CreateMeshShadersWithoutEnabledFeatures) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&shaderObjectFeatures);
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&shaderObjectFeatures);
     GetPhysicalDeviceFeatures2(maintenance4Features);
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
@@ -635,7 +635,7 @@ TEST_F(NegativeShaderObject, CreateMeshShadersWithoutEnabledFeatures) {
 
         const auto spv = GLSLToSPV(VK_SHADER_STAGE_TASK_BIT_EXT, kTaskMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-        auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+        VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
         createInfo.stage = VK_SHADER_STAGE_TASK_BIT_EXT;
         createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
         createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -652,7 +652,7 @@ TEST_F(NegativeShaderObject, CreateMeshShadersWithoutEnabledFeatures) {
 
         const auto spv = GLSLToSPV(VK_SHADER_STAGE_MESH_BIT_EXT, kMeshMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-        auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+        VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
         createInfo.stage = VK_SHADER_STAGE_MESH_BIT_EXT;
         createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
         createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -681,7 +681,7 @@ TEST_F(NegativeShaderObject, ComputeShaderNotSupportedByCommandPool) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, kMinimalShaderGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -717,7 +717,7 @@ TEST_F(NegativeShaderObject, GraphicsShadersNotSupportedByCommandPool) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -744,8 +744,8 @@ TEST_F(NegativeShaderObject, GraphicsMeshShadersNotSupportedByCommandPool) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features, VK_API_VERSION_1_2);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
@@ -763,7 +763,7 @@ TEST_F(NegativeShaderObject, GraphicsMeshShadersNotSupportedByCommandPool) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_MESH_BIT_EXT, kMeshMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_MESH_BIT_EXT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -793,7 +793,7 @@ TEST_F(NegativeShaderObject, NonUniqueShadersBind) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -830,7 +830,7 @@ TEST_F(NegativeShaderObject, InvalidShaderStageBind) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -862,7 +862,7 @@ TEST_F(NegativeShaderObject, GetShaderBinaryDataInvalidPointer) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -942,7 +942,7 @@ TEST_F(NegativeShaderObject, DrawWithoutBindingMeshShadersWhenEnabled) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08689");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08690");
 
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     InitBasicShaderObject(&meshShaderFeatures);
     if (::testing::Test::IsSkipped()) return;
@@ -978,7 +978,7 @@ TEST_F(NegativeShaderObject, InvalidShaderCreateInfoFlags) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.flags = VK_SHADER_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_EXT;
     createInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -1007,7 +1007,7 @@ TEST_F(NegativeShaderObject, LinkSingleStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.flags = VK_SHADER_CREATE_LINK_STAGE_BIT_EXT;
     createInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -1061,8 +1061,8 @@ TEST_F(NegativeShaderObject, MissingLinkStageBitMesh) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
@@ -1103,8 +1103,8 @@ TEST_F(NegativeShaderObject, LinkedVertexAndMeshStages) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
@@ -1146,8 +1146,8 @@ TEST_F(NegativeShaderObject, LinkedTaskAndMeshNoTaskShaders) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.taskShader == VK_FALSE) {
@@ -1324,8 +1324,8 @@ TEST_F(NegativeShaderObject, UnsupportedNextStage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
     if (!shaderObjectFeatures.shaderObject) {
         GTEST_SKIP() << "Test requires (unsupported) shaderObject , skipping.";
@@ -1338,7 +1338,7 @@ TEST_F(NegativeShaderObject, UnsupportedNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.nextStage = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -1367,7 +1367,7 @@ TEST_F(NegativeShaderObject, InvalidTessellationControlNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, kTessellationControlMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
     createInfo.nextStage = VK_SHADER_STAGE_GEOMETRY_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -1391,7 +1391,7 @@ TEST_F(NegativeShaderObject, InvalidTessellationEvaluationNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, kTessellationEvalMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
     createInfo.nextStage = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -1415,7 +1415,7 @@ TEST_F(NegativeShaderObject, InvalidGeometryNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_GEOMETRY_BIT, kGeometryMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
     createInfo.nextStage = VK_SHADER_STAGE_GEOMETRY_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -1439,7 +1439,7 @@ TEST_F(NegativeShaderObject, InvalidFragmentNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.nextStage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -1459,7 +1459,7 @@ TEST_F(NegativeShaderObject, InvalidTaskNextStage) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderCreateInfoEXT-nextStage-08435");
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&meshShaderFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.taskShader == VK_FALSE) {
@@ -1471,7 +1471,7 @@ TEST_F(NegativeShaderObject, InvalidTaskNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_TASK_BIT_EXT, kTaskMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_TASK_BIT_EXT;
     createInfo.nextStage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -1491,7 +1491,7 @@ TEST_F(NegativeShaderObject, InvalidMeshNextStage) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderCreateInfoEXT-nextStage-08436");
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&meshShaderFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
@@ -1500,7 +1500,7 @@ TEST_F(NegativeShaderObject, InvalidMeshNextStage) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_MESH_BIT_EXT, kMeshMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_MESH_BIT_EXT;
     createInfo.nextStage = VK_SHADER_STAGE_GEOMETRY_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -1580,7 +1580,7 @@ TEST_F(NegativeShaderObject, DrawWithShadersInNonDynamicRenderPass) {
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1u;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1u;
@@ -1592,7 +1592,7 @@ TEST_F(NegativeShaderObject, DrawWithShadersInNonDynamicRenderPass) {
     image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto framebuffer_info = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo framebuffer_info = vku::InitStructHelper();
     framebuffer_info.renderPass = render_pass.handle();
     framebuffer_info.attachmentCount = 1;
     framebuffer_info.pAttachments = &image_view;
@@ -1608,7 +1608,7 @@ TEST_F(NegativeShaderObject, DrawWithShadersInNonDynamicRenderPass) {
     clear_value.color.float32[2] = 0.25f;
     clear_value.color.float32[3] = 0.0f;
 
-    auto beginInfo = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo beginInfo = vku::InitStructHelper();
     beginInfo.renderPass = render_pass.handle();
     beginInfo.framebuffer = framebuffer.handle();
     beginInfo.renderArea.extent.width = 32;
@@ -1758,7 +1758,7 @@ TEST_F(NegativeShaderObject, InvalidShadingRatePaletteViewportCount) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08637");
 
     AddRequiredExtensions(VK_NV_SHADING_RATE_IMAGE_EXTENSION_NAME);
-    auto shadingRateImageFeatures = vku::InitStruct<VkPhysicalDeviceShadingRateImageFeaturesNV>();
+    VkPhysicalDeviceShadingRateImageFeaturesNV shadingRateImageFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&shadingRateImageFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (shadingRateImageFeatures.shadingRateImage == VK_FALSE) {
@@ -1802,7 +1802,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetExclusiveScissorEnableNV) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-exclusiveScissor-09235");
 
     AddRequiredExtensions(VK_NV_SCISSOR_EXCLUSIVE_EXTENSION_NAME);
-    auto exclusiveScissorFeatures = vku::InitStruct<VkPhysicalDeviceExclusiveScissorFeaturesNV>();
+    VkPhysicalDeviceExclusiveScissorFeaturesNV exclusiveScissorFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&exclusiveScissorFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (exclusiveScissorFeatures.exclusiveScissor == VK_FALSE) {
@@ -1831,7 +1831,7 @@ TEST_F(NegativeShaderObject, InvalidExclusiveScissorCount) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08638");
 
     AddRequiredExtensions(VK_NV_SCISSOR_EXCLUSIVE_EXTENSION_NAME);
-    auto exclusiveScissorFeatures = vku::InitStruct<VkPhysicalDeviceExclusiveScissorFeaturesNV>();
+    VkPhysicalDeviceExclusiveScissorFeaturesNV exclusiveScissorFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&exclusiveScissorFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (exclusiveScissorFeatures.exclusiveScissor == VK_FALSE) {
@@ -1934,8 +1934,8 @@ TEST_F(NegativeShaderObject, MissingCmdSetLogicOp) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
     if (shaderObjectFeatures.shaderObject == VK_FALSE) {
         GTEST_SKIP() << "shaderObject not supported.";
@@ -2031,7 +2031,7 @@ TEST_F(NegativeShaderObject, MissingColorWriteEnable) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08646");
 
     AddRequiredExtensions(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
-    auto color_write_enable_features = vku::InitStruct<VkPhysicalDeviceColorWriteEnableFeaturesEXT>();
+    VkPhysicalDeviceColorWriteEnableFeaturesEXT color_write_enable_features = vku::InitStructHelper();
     InitBasicShaderObject(&color_write_enable_features);
     if (::testing::Test::IsSkipped()) return;
     if (!color_write_enable_features.colorWriteEnable) {
@@ -2061,7 +2061,7 @@ TEST_F(NegativeShaderObject, ColorWriteEnableAttachmentCount) {
     AddRequiredExtensions(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08647");
 
-    auto color_write_enable_features = vku::InitStruct<VkPhysicalDeviceColorWriteEnableFeaturesEXT>();
+    VkPhysicalDeviceColorWriteEnableFeaturesEXT color_write_enable_features = vku::InitStructHelper();
     InitBasicShaderObject(&color_write_enable_features);
     if (::testing::Test::IsSkipped()) return;
     if (!color_write_enable_features.colorWriteEnable) {
@@ -2097,7 +2097,7 @@ TEST_F(NegativeShaderObject, ColorWriteEnableAttachmentCount) {
     attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 
-    auto renderingInfo = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR renderingInfo = vku::InitStructHelper();
     renderingInfo.renderArea = {{0, 0}, {100u, 100u}};
     renderingInfo.layerCount = 1u;
     renderingInfo.colorAttachmentCount = 2u;
@@ -2379,8 +2379,8 @@ TEST_F(NegativeShaderObject, MissingCmdSetLogicOpEnableEXT) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
     if (shaderObjectFeatures.shaderObject == VK_FALSE) {
         GTEST_SKIP() << "shaderObject not supported.";
@@ -2493,7 +2493,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetFragmentShadingRateKHR) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-pipelineFragmentShadingRate-09238");
 
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
     InitBasicShaderObject(&fsr_features);
     if (::testing::Test::IsSkipped()) return;
     if (!fsr_features.pipelineFragmentShadingRate) {
@@ -2546,7 +2546,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetRasterizationStreamEXT) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08660");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
-    auto transformFeedbackFeatures = vku::InitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT transformFeedbackFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&transformFeedbackFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (transformFeedbackFeatures.geometryStreams == VK_FALSE) {
@@ -2630,7 +2630,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthClipEnableEXT) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08663");
 
-    auto depthClipEnableFeatures = vku::InitStruct<VkPhysicalDeviceDepthClipEnableFeaturesEXT>();
+    VkPhysicalDeviceDepthClipEnableFeaturesEXT depthClipEnableFeatures = vku::InitStructHelper();
     AddRequiredExtensions(VK_EXT_DEPTH_CLIP_ENABLE_EXTENSION_NAME);
     InitBasicShaderObject(&depthClipEnableFeatures);
     if (::testing::Test::IsSkipped()) return;
@@ -2844,7 +2844,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthClipNegativeOneToOneEXT) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08673");
 
     AddRequiredExtensions(VK_EXT_DEPTH_CLIP_CONTROL_EXTENSION_NAME);
-    auto depthClipControlFeatures = vku::InitStruct<VkPhysicalDeviceDepthClipControlFeaturesEXT>();
+    VkPhysicalDeviceDepthClipControlFeaturesEXT depthClipControlFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&depthClipControlFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (depthClipControlFeatures.depthClipControl == VK_FALSE) {
@@ -3079,7 +3079,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetShadingRateImageEnableNV) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08681");
 
     AddRequiredExtensions(VK_NV_SHADING_RATE_IMAGE_EXTENSION_NAME);
-    auto shadingRateImageFeatures = vku::InitStruct<VkPhysicalDeviceShadingRateImageFeaturesNV>();
+    VkPhysicalDeviceShadingRateImageFeaturesNV shadingRateImageFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&shadingRateImageFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (shadingRateImageFeatures.shadingRateImage == VK_FALSE) {
@@ -3109,7 +3109,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetViewportShadingRatePaletteNV) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-shadingRateImage-09234");
 
     AddRequiredExtensions(VK_NV_SHADING_RATE_IMAGE_EXTENSION_NAME);
-    auto shadingRateImageFeatures = vku::InitStruct<VkPhysicalDeviceShadingRateImageFeaturesNV>();
+    VkPhysicalDeviceShadingRateImageFeaturesNV shadingRateImageFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&shadingRateImageFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (shadingRateImageFeatures.shadingRateImage == VK_FALSE) {
@@ -3140,7 +3140,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoarseSampleOrderNV) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-shadingRateImage-09233");
 
     AddRequiredExtensions(VK_NV_SHADING_RATE_IMAGE_EXTENSION_NAME);
-    auto shadingRateImageFeatures = vku::InitStruct<VkPhysicalDeviceShadingRateImageFeaturesNV>();
+    VkPhysicalDeviceShadingRateImageFeaturesNV shadingRateImageFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&shadingRateImageFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (shadingRateImageFeatures.shadingRateImage == VK_FALSE) {
@@ -3170,7 +3170,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetRepresentativeFragmentTestEnableNV) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08682");
 
     AddRequiredExtensions(VK_NV_REPRESENTATIVE_FRAGMENT_TEST_EXTENSION_NAME);
-    auto representativeFragmentTestFeatures = vku::InitStruct<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV>();
+    VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV representativeFragmentTestFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&representativeFragmentTestFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (representativeFragmentTestFeatures.representativeFragmentTest == VK_FALSE) {
@@ -3199,7 +3199,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoverageReductionModeNV) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08683");
 
     AddRequiredExtensions(VK_NV_COVERAGE_REDUCTION_MODE_EXTENSION_NAME);
-    auto coverageReductionFeatures = vku::InitStruct<VkPhysicalDeviceCoverageReductionModeFeaturesNV>();
+    VkPhysicalDeviceCoverageReductionModeFeaturesNV coverageReductionFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&coverageReductionFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (coverageReductionFeatures.coverageReductionMode == VK_FALSE) {
@@ -3263,8 +3263,8 @@ TEST_F(NegativeShaderObject, MissingTessellationControlBind) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
     if (!shaderObjectFeatures.shaderObject) {
         GTEST_SKIP() << "shaderObject not supported.";
@@ -3307,8 +3307,8 @@ TEST_F(NegativeShaderObject, MissingTessellationEvaluationBind) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
     if (!shaderObjectFeatures.shaderObject) {
         GTEST_SKIP() << "shaderObject not supported.";
@@ -3351,8 +3351,8 @@ TEST_F(NegativeShaderObject, MissingGeometryBind) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
     if (!shaderObjectFeatures.shaderObject) {
         GTEST_SKIP() << "shaderObject not supported.";
@@ -3414,7 +3414,7 @@ TEST_F(NegativeShaderObject, MissingTaskShaderBind) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08689");
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&meshShaderFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.taskShader == VK_FALSE) {
@@ -3449,7 +3449,7 @@ TEST_F(NegativeShaderObject, MissingMeshShaderBind) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08690");
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&meshShaderFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
@@ -3486,8 +3486,8 @@ TEST_F(NegativeShaderObject, VertAndMeshShaderBothBound) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
@@ -3531,8 +3531,8 @@ TEST_F(NegativeShaderObject, MeshShaderWithMissingTaskShader) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.taskShader == VK_FALSE) {
@@ -3581,8 +3581,8 @@ TEST_F(NegativeShaderObject, TaskAndMeshShaderWithNoTaskFlag) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.taskShader == VK_FALSE) {
@@ -3602,7 +3602,7 @@ TEST_F(NegativeShaderObject, TaskAndMeshShaderWithNoTaskFlag) {
                                  GLSLToSPV(VK_SHADER_STAGE_TASK_BIT_EXT, kTaskMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3));
 
     const auto mesh_spv = GLSLToSPV(VK_SHADER_STAGE_MESH_BIT_EXT, kMeshMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
-    auto meshCreateInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT meshCreateInfo = vku::InitStructHelper();
     meshCreateInfo.flags = VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT;
     meshCreateInfo.stage = VK_SHADER_STAGE_MESH_BIT_EXT;
     meshCreateInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -3641,8 +3641,8 @@ TEST_F(NegativeShaderObject, VertAndTaskShadersBound) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.taskShader == VK_FALSE) {
@@ -3657,7 +3657,7 @@ TEST_F(NegativeShaderObject, VertAndTaskShadersBound) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
     const auto mesh_spv = GLSLToSPV(VK_SHADER_STAGE_MESH_BIT_EXT, kMeshMinimalGlsl, "main", nullptr, SPV_ENV_VULKAN_1_3);
-    auto meshCreateInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT meshCreateInfo = vku::InitStructHelper();
     meshCreateInfo.flags = VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT;
     meshCreateInfo.stage = VK_SHADER_STAGE_MESH_BIT_EXT;
     meshCreateInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -3866,8 +3866,8 @@ TEST_F(NegativeShaderObject, MissingCmdSetAttachmentFeedbackLoopEnableEXT) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08880");
 
     AddRequiredExtensions(VK_EXT_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_EXTENSION_NAME);
-    auto attachmentFeedbackLoopDynamicStateFeatures =
-        vku::InitStruct<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT>();
+    VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT attachmentFeedbackLoopDynamicStateFeatures =
+        vku::InitStructHelper();
     InitBasicShaderObject(&attachmentFeedbackLoopDynamicStateFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (attachmentFeedbackLoopDynamicStateFeatures.attachmentFeedbackLoopDynamicState == VK_FALSE) {
@@ -4043,8 +4043,8 @@ TEST_F(NegativeShaderObject, DrawWithGraphicsShadersWhenMeshShaderIsBound) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
-    auto maintenance4Features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>(&meshShaderFeatures);
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceMaintenance4Features maintenance4Features = vku::InitStructHelper(&meshShaderFeatures);
     InitBasicShaderObject(&maintenance4Features);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
@@ -4642,7 +4642,7 @@ TEST_F(NegativeShaderObject, SharedMemoryOverLimit) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, csSource.str().c_str());
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -4665,7 +4665,7 @@ TEST_F(NegativeShaderObject, InvalidRequireFullSubgroupsFlag) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.flags = VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT;
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -4710,7 +4710,7 @@ TEST_F(NegativeShaderObject, SpecializationMapEntryOffset) {
     specializationInfo.dataSize = sizeof(uint32_t);
     specializationInfo.pData = &data;
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -4755,7 +4755,7 @@ TEST_F(NegativeShaderObject, SpecializationMapEntrySize) {
     specializationInfo.dataSize = sizeof(uint32_t);
     specializationInfo.pData = &data;
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -4800,7 +4800,7 @@ TEST_F(NegativeShaderObject, SpecializationMismatch) {
     specializationInfo.dataSize = sizeof(uint32_t) * 2;
     specializationInfo.pData = &data;
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -4848,7 +4848,7 @@ TEST_F(NegativeShaderObject, SpecializationSameConstantId) {
     specializationInfo.dataSize = sizeof(uint32_t);
     specializationInfo.pData = &data;
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -4872,7 +4872,7 @@ TEST_F(NegativeShaderObject, MissingEntrypoint) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -4940,7 +4940,7 @@ TEST_F(NegativeShaderObject, SpecializationApplied) {
     specializationInfo.dataSize = sizeof(uint32_t);
     specializationInfo.pData = &data;
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = fs_spv.size() * sizeof(fs_spv[0]);
@@ -5024,7 +5024,7 @@ TEST_F(NegativeShaderObject, MinTexelGatherOffset) {
                                            {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                                        });
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = cs_spv.size() * sizeof(cs_spv[0]);
@@ -5103,7 +5103,7 @@ TEST_F(NegativeShaderObject, UnsupportedSpirvCapability) {
     std::vector<uint32_t> vs_spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, vs_src, vs_spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = vs_spv.size() * sizeof(vs_spv[0]);
@@ -5142,7 +5142,7 @@ TEST_F(NegativeShaderObject, UnsupportedSpirvExtension) {
     std::vector<uint32_t> vs_spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, vs_src, vs_spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = vs_spv.size() * sizeof(vs_spv[0]);
@@ -5181,7 +5181,7 @@ TEST_F(NegativeShaderObject, SpirvExtensionRequirementsNotMet) {
     std::vector<uint32_t> cs_spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, cs_src, cs_spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = cs_spv.size() * sizeof(cs_spv[0]);
@@ -5206,8 +5206,8 @@ TEST_F(NegativeShaderObject, MemoryModelNotEnabled) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>();
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>(&shaderObjectFeatures);
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper(&shaderObjectFeatures);
     auto features2 = GetPhysicalDeviceFeatures2(features12);
     features12.vulkanMemoryModelDeviceScope = VK_FALSE;
     if (features12.vulkanMemoryModel == VK_FALSE) {
@@ -5229,7 +5229,7 @@ TEST_F(NegativeShaderObject, MemoryModelNotEnabled) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, cs_src);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -5248,7 +5248,7 @@ TEST_F(NegativeShaderObject, MaxTransformFeedbackStream) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpEmitStreamVertex-06310");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
-    auto transform_feedback_features = vku::InitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT transform_feedback_features = vku::InitStructHelper();
     InitBasicShaderObject(&transform_feedback_features);
     if (::testing::Test::IsSkipped()) return;
     auto features2 = GetPhysicalDeviceFeatures2(transform_feedback_features);
@@ -5259,7 +5259,7 @@ TEST_F(NegativeShaderObject, MaxTransformFeedbackStream) {
         GTEST_SKIP() << "transformFeedback or geometryStreams feature is not supported";
     }
 
-    auto transform_feedback_props = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transform_feedback_props);
 
     // seen sometimes when using profiles and will crash
@@ -5314,7 +5314,7 @@ TEST_F(NegativeShaderObject, MaxTransformFeedbackStream) {
     std::vector<uint32_t> gs_spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, gsSource.str().c_str(), gs_spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = gs_spv.size() * sizeof(gs_spv[0]);
@@ -5333,7 +5333,7 @@ TEST_F(NegativeShaderObject, TransformFeedbackStride) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-XfbStride-06313");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
-    auto transform_feedback_features = vku::InitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT transform_feedback_features = vku::InitStructHelper();
     InitBasicShaderObject(&transform_feedback_features);
     if (::testing::Test::IsSkipped()) return;
     auto features2 = GetPhysicalDeviceFeatures2(transform_feedback_features);
@@ -5344,7 +5344,7 @@ TEST_F(NegativeShaderObject, TransformFeedbackStride) {
         GTEST_SKIP() << "transformFeedback or geometryStreams feature is not supported";
     }
 
-    auto transform_feedback_props = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transform_feedback_props);
 
     // seen sometimes when using profiles and will crash
@@ -5389,7 +5389,7 @@ TEST_F(NegativeShaderObject, TransformFeedbackStride) {
     std::vector<uint32_t> vs_spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, vsSource.str().c_str(), vs_spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = vs_spv.size() * sizeof(vs_spv[0]);
@@ -5408,14 +5408,14 @@ TEST_F(NegativeShaderObject, MeshOutputVertices) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-MeshEXT-07115");
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
-    auto meshShaderFeatures = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>();
+    VkPhysicalDeviceMeshShaderFeaturesEXT meshShaderFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&meshShaderFeatures, VK_API_VERSION_1_2);
     if (::testing::Test::IsSkipped()) return;
     if (meshShaderFeatures.meshShader == VK_FALSE) {
         GTEST_SKIP() << "meshShader not supported.";
     }
 
-    auto mesh_shader_properties = vku::InitStruct<VkPhysicalDeviceMeshShaderPropertiesEXT>();
+    VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
     std::string mesh_src = R"(
@@ -5445,7 +5445,7 @@ TEST_F(NegativeShaderObject, MeshOutputVertices) {
     std::vector<uint32_t> spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, mesh_src.c_str(), spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_MESH_BIT_EXT;
     createInfo.nextStage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -5488,7 +5488,7 @@ TEST_F(NegativeShaderObject, Atomics) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, cs_src.c_str());
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -5515,10 +5515,10 @@ TEST_F(NegativeShaderObject, ExtendedTypesDisabled) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
-    auto maintenance4 = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>();
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>(&maintenance4);
-    auto extended_types_features = vku::InitStruct<VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR>(&float16_features);
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&extended_types_features);
+    VkPhysicalDeviceMaintenance4Features maintenance4 = vku::InitStructHelper();
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper(&maintenance4);
+    VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR extended_types_features = vku::InitStructHelper(&float16_features);
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper(&extended_types_features);
     GetPhysicalDeviceFeatures2(shaderObjectFeatures);
     extended_types_features.shaderSubgroupExtendedTypes = VK_FALSE;
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
@@ -5552,7 +5552,7 @@ TEST_F(NegativeShaderObject, ExtendedTypesDisabled) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, cs_src, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -5585,7 +5585,7 @@ TEST_F(NegativeShaderObject, ReadShaderClock) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_src, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -5638,7 +5638,7 @@ TEST_F(NegativeShaderObject, WriteLessComponent) {
     std::vector<uint32_t> spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_3, 0, cs_src, spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -5681,7 +5681,7 @@ TEST_F(NegativeShaderObject, LocalSizeIdExecutionMode) {
     std::vector<uint32_t> spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_3, 0, cs_src, spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -5728,7 +5728,7 @@ TEST_F(NegativeShaderObject, ZeroInitializeWorkgroupMemory) {
     std::vector<uint32_t> spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_3, 0, cs_src, spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -5793,7 +5793,7 @@ TEST_F(NegativeShaderObject, MissingNonReadableDecorationFormatRead) {
     std::vector<uint32_t> spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, cs_src, spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -5822,8 +5822,8 @@ TEST_F(NegativeShaderObject, MaxSampleMaskWords) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>();
-    auto shaderObjectFeatures = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderObjectFeaturesEXT shaderObjectFeatures = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(shaderObjectFeatures);
     if (!shaderObjectFeatures.shaderObject) {
         GTEST_SKIP() << "shaderObject not supported.";
@@ -5855,7 +5855,7 @@ TEST_F(NegativeShaderObject, MaxSampleMaskWords) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, fs_src, "main", nullptr, SPV_ENV_VULKAN_1_3);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -5879,7 +5879,7 @@ TEST_F(NegativeShaderObject, ConservativeRasterizationPostDepthCoverage) {
     InitBasicShaderObject(nullptr, VK_API_VERSION_1_2);
     if (::testing::Test::IsSkipped()) return;
 
-    auto conservative_rasterization_props = vku::InitStruct<VkPhysicalDeviceConservativeRasterizationPropertiesEXT>();
+    VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_rasterization_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(conservative_rasterization_props);
     if (conservative_rasterization_props.conservativeRasterizationPostDepthCoverage) {
         GTEST_SKIP() << "conservativeRasterizationPostDepthCoverage not supported";
@@ -5911,7 +5911,7 @@ TEST_F(NegativeShaderObject, ConservativeRasterizationPostDepthCoverage) {
     std::vector<uint32_t> spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_3, 0, fs_src, spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -5969,7 +5969,7 @@ TEST_F(NegativeShaderObject, LocalSizeExceedLimits) {
     std::vector<uint32_t> spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, cs_src.c_str(), spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -6029,7 +6029,7 @@ TEST_F(NegativeShaderObject, InvalidViewportCount) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-primitiveFragmentShadingRateWithMultipleViewports-08642");
 
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
-    auto fsr_features = vku::InitStruct<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>();
+    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
     InitBasicShaderObject(&fsr_features);
     if (::testing::Test::IsSkipped()) return;
     if (!fsr_features.pipelineFragmentShadingRate) {
@@ -6037,7 +6037,7 @@ TEST_F(NegativeShaderObject, InvalidViewportCount) {
     }
     InitDynamicRenderTarget();
 
-    auto fsr_properties = vku::InitStruct<VkPhysicalDeviceFragmentShadingRatePropertiesKHR>();
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
     if (fsr_properties.primitiveFragmentShadingRateWithMultipleViewports) {
         GTEST_SKIP() << "required primitiveFragmentShadingRateWithMultipleViewports to be unsupported.";
@@ -6213,12 +6213,12 @@ TEST_F(NegativeShaderObject, InvalidColorWriteMask) {
         GTEST_SKIP() << "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 not supported as color attachment.";
     }
 
-    auto imageFormatInfo = vku::InitStruct<VkPhysicalDeviceImageFormatInfo2>();
+    VkPhysicalDeviceImageFormatInfo2 imageFormatInfo = vku::InitStructHelper();
     imageFormatInfo.format = format;
     imageFormatInfo.type = VK_IMAGE_TYPE_2D;
     imageFormatInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     imageFormatInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    auto imageFormatProperties = vku::InitStruct<VkImageFormatProperties2>();
+    VkImageFormatProperties2 imageFormatProperties = vku::InitStructHelper();
     auto res = vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy(), &imageFormatInfo, &imageFormatProperties);
     if (res == VK_ERROR_FORMAT_NOT_SUPPORTED) {
         GTEST_SKIP() << "image format not supported as color attachment.";
@@ -6256,7 +6256,7 @@ TEST_F(NegativeShaderObject, Mismatched64BitAttributeType) {
 
     const VkFormat format = VK_FORMAT_R64_SINT;
 
-    auto formatProperties = vku::InitStruct<VkFormatProperties2>();
+    VkFormatProperties2 formatProperties = vku::InitStructHelper();
     vk::GetPhysicalDeviceFormatProperties2(m_device->phy(), format, &formatProperties);
 
     if ((formatProperties.formatProperties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
@@ -6280,13 +6280,13 @@ TEST_F(NegativeShaderObject, Mismatched64BitAttributeType) {
     SetDefaultDynamicStates();
     BindVertFragShader(vertShader, fragShader);
 
-    auto vertexBindingDescription = vku::InitStruct<VkVertexInputBindingDescription2EXT>();
+    VkVertexInputBindingDescription2EXT vertexBindingDescription = vku::InitStructHelper();
     vertexBindingDescription.binding = 0u;
     vertexBindingDescription.stride = 16u;
     vertexBindingDescription.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
     vertexBindingDescription.divisor = 1u;
 
-    auto vertexAttributeDescription = vku::InitStruct<VkVertexInputAttributeDescription2EXT>();
+    VkVertexInputAttributeDescription2EXT vertexAttributeDescription = vku::InitStructHelper();
     vertexAttributeDescription.location = 0u;
     vertexAttributeDescription.binding = 0u;
     vertexAttributeDescription.format = format;
@@ -6328,13 +6328,13 @@ TEST_F(NegativeShaderObject, Mismatched32BitAttributeType) {
     SetDefaultDynamicStates();
     BindVertFragShader(vertShader, fragShader);
 
-    auto vertexBindingDescription = vku::InitStruct<VkVertexInputBindingDescription2EXT>();
+    VkVertexInputBindingDescription2EXT vertexBindingDescription = vku::InitStructHelper();
     vertexBindingDescription.binding = 0u;
     vertexBindingDescription.stride = 16u;
     vertexBindingDescription.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
     vertexBindingDescription.divisor = 1u;
 
-    auto vertexAttributeDescription = vku::InitStruct<VkVertexInputAttributeDescription2EXT>();
+    VkVertexInputAttributeDescription2EXT vertexAttributeDescription = vku::InitStructHelper();
     vertexAttributeDescription.location = 0u;
     vertexAttributeDescription.binding = 0u;
     vertexAttributeDescription.format = VK_FORMAT_R32_SINT;
@@ -6360,7 +6360,7 @@ TEST_F(NegativeShaderObject, MismatchedFormat64Components) {
 
     const VkFormat format = VK_FORMAT_R64G64B64_SINT;
 
-    auto formatProperties = vku::InitStruct<VkFormatProperties2>();
+    VkFormatProperties2 formatProperties = vku::InitStructHelper();
     vk::GetPhysicalDeviceFormatProperties2(m_device->phy(), format, &formatProperties);
 
     if ((formatProperties.formatProperties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
@@ -6385,13 +6385,13 @@ TEST_F(NegativeShaderObject, MismatchedFormat64Components) {
     SetDefaultDynamicStates();
     BindVertFragShader(vertShader, fragShader);
 
-    auto vertexBindingDescription = vku::InitStruct<VkVertexInputBindingDescription2EXT>();
+    VkVertexInputBindingDescription2EXT vertexBindingDescription = vku::InitStructHelper();
     vertexBindingDescription.binding = 0u;
     vertexBindingDescription.stride = 16u;
     vertexBindingDescription.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
     vertexBindingDescription.divisor = 1u;
 
-    auto vertexAttributeDescription = vku::InitStruct<VkVertexInputAttributeDescription2EXT>();
+    VkVertexInputAttributeDescription2EXT vertexAttributeDescription = vku::InitStructHelper();
     vertexAttributeDescription.location = 0u;
     vertexAttributeDescription.binding = 0u;
     vertexAttributeDescription.format = format;
@@ -6453,7 +6453,7 @@ TEST_F(NegativeShaderObject, DescriptorNotUpdated) {
 
     VkDescriptorSetLayout descriptor_set_layouts[] = {vert_descriptor_set.layout_.handle(), frag_descriptor_set.layout_.handle()};
 
-    auto vert_create_info = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT vert_create_info = vku::InitStructHelper();
     vert_create_info.stage = VK_SHADER_STAGE_VERTEX_BIT;
     vert_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     vert_create_info.codeSize = vert_spv.size() * sizeof(vert_spv[0]);
@@ -6462,7 +6462,7 @@ TEST_F(NegativeShaderObject, DescriptorNotUpdated) {
     vert_create_info.setLayoutCount = 2u;
     vert_create_info.pSetLayouts = descriptor_set_layouts;
 
-    auto frag_create_info = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT frag_create_info = vku::InitStructHelper();
     frag_create_info.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     frag_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     frag_create_info.codeSize = frag_spv.size() * sizeof(frag_spv[0]);
@@ -6502,7 +6502,7 @@ TEST_F(NegativeShaderObject, ComputeVaryingAndFullSubgroups) {
     InitBasicShaderObject();
     if (::testing::Test::IsSkipped()) return;
 
-    auto subgroup_size_control_properties = vku::InitStruct<VkPhysicalDeviceSubgroupSizeControlPropertiesEXT>();
+    VkPhysicalDeviceSubgroupSizeControlPropertiesEXT subgroup_size_control_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(subgroup_size_control_properties);
 
     std::string comp_src = R"glsl(
@@ -6515,7 +6515,7 @@ TEST_F(NegativeShaderObject, ComputeVaryingAndFullSubgroups) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, comp_src.c_str());
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.flags = VK_SHADER_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT | VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT;
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -6538,7 +6538,7 @@ TEST_F(NegativeShaderObject, ComputeVaryingSubgroups) {
     InitBasicShaderObject(nullptr, VK_API_VERSION_1_2);
     if (::testing::Test::IsSkipped()) return;
 
-    auto properties11 = vku::InitStruct<VkPhysicalDeviceVulkan11Properties>();
+    VkPhysicalDeviceVulkan11Properties properties11 = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(properties11);
 
     std::string comp_src = R"glsl(
@@ -6551,7 +6551,7 @@ TEST_F(NegativeShaderObject, ComputeVaryingSubgroups) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, comp_src.c_str());
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.flags = VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT;
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
@@ -6636,7 +6636,7 @@ TEST_F(NegativeShaderObject, GeometryShaderMaxOutputVertices) {
     std::vector<uint32_t> spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, geom_src.c_str(), spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -6720,7 +6720,7 @@ TEST_F(NegativeShaderObject, GeometryShaderMaxInvocations) {
     std::vector<uint32_t> spv;
     ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, geom_src.c_str(), spv);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_GEOMETRY_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -6803,7 +6803,7 @@ TEST_F(NegativeShaderObject, MaxMultiviewInstanceIndex) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-maxMultiviewInstanceIndex-02688");
 
-    auto features11 = vku::InitStruct<VkPhysicalDeviceVulkan11Features>();
+    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper();
     InitBasicShaderObject(&features11, VK_API_VERSION_1_2);
     if (::testing::Test::IsSkipped()) return;
 
@@ -6813,7 +6813,7 @@ TEST_F(NegativeShaderObject, MaxMultiviewInstanceIndex) {
 
     InitDynamicRenderTarget();
 
-    auto multiview_properties = vku::InitStruct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceMultiviewProperties multiview_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(multiview_properties);
 
     const vkt::Shader vertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl));
@@ -6825,13 +6825,13 @@ TEST_F(NegativeShaderObject, MaxMultiviewInstanceIndex) {
     img.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
     VkImageView view = img.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfo>();
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
     color_attachment.imageView = view;
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 
-    auto renderingInfo = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR renderingInfo = vku::InitStructHelper();
     renderingInfo.renderArea = {{0, 0}, {100u, 100u}};
     renderingInfo.layerCount = 1u;
     renderingInfo.colorAttachmentCount = 1u;
@@ -6906,7 +6906,7 @@ TEST_F(NegativeShaderObject, DISABLED_MaxFragmentDualSrcAttachmentsDynamicBlendE
     attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 
-    auto renderingInfo = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR renderingInfo = vku::InitStructHelper();
     renderingInfo.renderArea = {{0, 0}, {100u, 100u}};
     renderingInfo.layerCount = 1u;
     renderingInfo.colorAttachmentCount = 2u;
@@ -6960,7 +6960,7 @@ TEST_F(NegativeShaderObject, PrimitivesGeneratedQuery) {
     AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_PRIMITIVES_GENERATED_QUERY_EXTENSION_NAME);
-    auto pgq_features = vku::InitStruct<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>();
+    VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT pgq_features = vku::InitStructHelper();
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (DeviceValidationVersion() < m_attempted_api_version) {
@@ -6970,8 +6970,8 @@ TEST_F(NegativeShaderObject, PrimitivesGeneratedQuery) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>(&pgq_features);
-    auto shader_object_features = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper(&pgq_features);
+    VkPhysicalDeviceShaderObjectFeaturesEXT shader_object_features = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(shader_object_features);
 
     pgq_features.primitivesGeneratedQueryWithRasterizerDiscard = VK_FALSE;
@@ -6992,7 +6992,7 @@ TEST_F(NegativeShaderObject, PrimitivesGeneratedQuery) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    auto query_pool_ci = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo query_pool_ci = vku::InitStructHelper();
     query_pool_ci.queryCount = 1;
     query_pool_ci.queryType = VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT;
 
@@ -7023,9 +7023,9 @@ TEST_F(NegativeShaderObject, CooperativeMatrix) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME);
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto cooperative_matrix_features = vku::InitStruct<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(&float16_features);
-    auto memory_model_features = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(&cooperative_matrix_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDeviceCooperativeMatrixFeaturesKHR cooperative_matrix_features = vku::InitStructHelper(&float16_features);
+    VkPhysicalDeviceVulkanMemoryModelFeaturesKHR memory_model_features = vku::InitStructHelper(&cooperative_matrix_features);
 
     InitBasicShaderObject(&memory_model_features);
     if (::testing::Test::IsSkipped()) return;
@@ -7050,7 +7050,7 @@ TEST_F(NegativeShaderObject, CooperativeMatrix) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, comp_src);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -23,8 +23,8 @@ void ShaderObjectTest::InitBasicShaderObject(void *pNextFeatures, APIVersion tar
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto dynamic_rendering_features = vku::InitStruct<VkPhysicalDeviceDynamicRenderingFeatures>(pNextFeatures);
-    auto shader_object_features = vku::InitStruct<VkPhysicalDeviceShaderObjectFeaturesEXT>(&dynamic_rendering_features);
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper(pNextFeatures);
+    VkPhysicalDeviceShaderObjectFeaturesEXT shader_object_features = vku::InitStructHelper(&dynamic_rendering_features);
     auto features2 = GetPhysicalDeviceFeatures2(shader_object_features);
     if (!coreFeatures) {
         features2 = vku::InitStructHelper(&shader_object_features);
@@ -126,7 +126,7 @@ TEST_F(PositiveShaderObject, CreateAndDestroyShaderObject) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
 
-    auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
     createInfo.stage = VK_SHADER_STAGE_VERTEX_BIT;
     createInfo.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     createInfo.codeSize = spv.size() * sizeof(spv[0]);
@@ -364,7 +364,7 @@ TEST_F(PositiveShaderObject, VertFragShaderDraw) {
     vkt::Buffer buffer(*m_device, sizeof(float) * 4u, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
                        VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
-    auto imageInfo = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo imageInfo = vku::InitStructHelper();
     imageInfo.imageType = VK_IMAGE_TYPE_2D;
     imageInfo.format = VK_FORMAT_R32G32B32A32_SFLOAT;
     imageInfo.extent = {static_cast<uint32_t>(m_width), static_cast<uint32_t>(m_height), 1};
@@ -381,11 +381,11 @@ TEST_F(PositiveShaderObject, VertFragShaderDraw) {
     image.init(&imageInfo);
     VkImageView view = image.targetView(imageInfo.format);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfo>();
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = view;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfo>();
+    VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.renderArea.extent.width = static_cast<uint32_t>(m_width);
     begin_rendering_info.renderArea.extent.height = static_cast<uint32_t>(m_height);
     begin_rendering_info.layerCount = 1u;
@@ -399,7 +399,7 @@ TEST_F(PositiveShaderObject, VertFragShaderDraw) {
     m_commandBuffer->begin();
 
     {
-        auto imageMemoryBarrier = vku::InitStruct<VkImageMemoryBarrier>();
+        VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
         imageMemoryBarrier.srcAccessMask = VK_ACCESS_NONE;
         imageMemoryBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -427,7 +427,7 @@ TEST_F(PositiveShaderObject, VertFragShaderDraw) {
     vkCmdEndRenderingKHR(m_commandBuffer->handle());
 
     {
-        auto imageMemoryBarrier = vku::InitStruct<VkImageMemoryBarrier>();
+        VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
         imageMemoryBarrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         imageMemoryBarrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
         imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -460,7 +460,7 @@ TEST_F(PositiveShaderObject, VertFragShaderDraw) {
     m_commandBuffer->end();
 
     VkCommandBuffer commandBufferHandle = m_commandBuffer->handle();
-    auto submitInfo = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submitInfo = vku::InitStructHelper();
     submitInfo.commandBufferCount = 1u;
     submitInfo.pCommandBuffers = &commandBufferHandle;
     vk::QueueSubmit(m_device->m_queue, 1, &submitInfo, VK_NULL_HANDLE);
@@ -566,7 +566,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
     VkShaderEXT shaders[5] = {vertShader.handle(), tescShader.handle(), teseShader.handle(), geomShader.handle(),
                               fragShader.handle()};
 
-    auto imageInfo = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo imageInfo = vku::InitStructHelper();
     imageInfo.flags = 0;
     imageInfo.imageType = VK_IMAGE_TYPE_2D;
     imageInfo.format = VK_FORMAT_R32G32B32A32_SFLOAT;
@@ -584,11 +584,11 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
     image.init(&imageInfo);
     VkImageView view = image.targetView(imageInfo.format);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfo>();
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = view;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfo>();
+    VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.flags = 0u;
     begin_rendering_info.renderArea.offset.x = 0;
     begin_rendering_info.renderArea.offset.y = 0;
@@ -606,7 +606,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
     m_commandBuffer->begin();
 
     {
-        auto imageMemoryBarrier = vku::InitStruct<VkImageMemoryBarrier>();
+        VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
         imageMemoryBarrier.srcAccessMask = VK_ACCESS_NONE;
         imageMemoryBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -632,7 +632,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
     m_commandBuffer->end();
 
     VkCommandBuffer commandBufferHandle = m_commandBuffer->handle();
-    auto submitInfo = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submitInfo = vku::InitStructHelper();
     submitInfo.commandBufferCount = 1u;
     submitInfo.pCommandBuffers = &commandBufferHandle;
     vk::QueueSubmit(m_device->m_queue, 1, &submitInfo, VK_NULL_HANDLE);
@@ -666,7 +666,7 @@ TEST_F(PositiveShaderObject, ComputeShader) {
     ds_type_count.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     ds_type_count.descriptorCount = 1;
 
-    auto ds_pool_ci = vku::InitStruct<VkDescriptorPoolCreateInfo>();
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.maxSets = 1;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.flags = 0;
@@ -684,7 +684,7 @@ TEST_F(PositiveShaderObject, ComputeShader) {
     const vkt::DescriptorSetLayout ds_layout(*m_device, {dsl_binding});
 
     VkDescriptorSet descriptorSet;
-    auto alloc_info = vku::InitStruct<VkDescriptorSetAllocateInfo>();
+    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.descriptorSetCount = 1;
     alloc_info.descriptorPool = ds_pool.handle();
     alloc_info.pSetLayouts = &ds_layout.handle();
@@ -692,7 +692,7 @@ TEST_F(PositiveShaderObject, ComputeShader) {
 
     VkDescriptorBufferInfo storage_buffer_info = {storageBuffer.handle(), 0, sizeof(uint32_t)};
 
-    auto descriptorWrite = vku::InitStruct<VkWriteDescriptorSet>();
+    VkWriteDescriptorSet descriptorWrite = vku::InitStructHelper();
     descriptorWrite.dstSet = descriptorSet;
     descriptorWrite.dstBinding = 0;
     descriptorWrite.descriptorCount = 1;
@@ -720,7 +720,7 @@ TEST_F(PositiveShaderObject, ComputeShader) {
     m_commandBuffer->end();
 
     VkCommandBuffer commandBufferHandle = m_commandBuffer->handle();
-    auto submitInfo = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submitInfo = vku::InitStructHelper();
     submitInfo.commandBufferCount = 1u;
     submitInfo.pCommandBuffers = &commandBufferHandle;
     vk::QueueSubmit(m_device->m_queue, 1, &submitInfo, VK_NULL_HANDLE);
@@ -732,8 +732,8 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
 
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
-    auto maintenance_4_features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>();
-    auto mesh_shader_features = vku::InitStruct<VkPhysicalDeviceMeshShaderFeaturesEXT>(&maintenance_4_features);
+    VkPhysicalDeviceMaintenance4Features maintenance_4_features = vku::InitStructHelper();
+    VkPhysicalDeviceMeshShaderFeaturesEXT mesh_shader_features = vku::InitStructHelper(&maintenance_4_features);
     InitBasicShaderObject(&mesh_shader_features, VK_API_VERSION_1_3);
 
     VkPhysicalDeviceFeatures features;
@@ -791,7 +791,7 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
 
     VkShaderEXT shaders[3] = {taskShader.handle(), meshShader.handle(), fragShader.handle()};
 
-    auto imageInfo = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo imageInfo = vku::InitStructHelper();
     imageInfo.flags = 0;
     imageInfo.imageType = VK_IMAGE_TYPE_2D;
     imageInfo.format = VK_FORMAT_R32G32B32A32_SFLOAT;
@@ -809,11 +809,11 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
     image.init(&imageInfo);
     VkImageView view = image.targetView(imageInfo.format);
 
-    auto color_attachment = vku::InitStruct<VkRenderingAttachmentInfo>();
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.imageView = view;
 
-    auto begin_rendering_info = vku::InitStruct<VkRenderingInfo>();
+    VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.flags = 0u;
     begin_rendering_info.renderArea.offset.x = 0;
     begin_rendering_info.renderArea.offset.y = 0;
@@ -833,7 +833,7 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
     m_commandBuffer->begin();
 
     {
-        auto imageMemoryBarrier = vku::InitStruct<VkImageMemoryBarrier>();
+        VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
         imageMemoryBarrier.srcAccessMask = VK_ACCESS_NONE;
         imageMemoryBarrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
         imageMemoryBarrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -872,7 +872,7 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
     m_commandBuffer->end();
 
     VkCommandBuffer commandBufferHandle = m_commandBuffer->handle();
-    auto submitInfo = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submitInfo = vku::InitStructHelper();
     submitInfo.commandBufferCount = 1u;
     submitInfo.pCommandBuffers = &commandBufferHandle;
     vk::QueueSubmit(m_device->m_queue, 1, &submitInfo, VK_NULL_HANDLE);
@@ -1127,7 +1127,7 @@ TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
 
     VkDescriptorSetLayout descriptor_set_layouts[] = {vert_descriptor_set.layout_.handle(), frag_descriptor_set.layout_.handle()};
 
-    auto vert_create_info = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT vert_create_info = vku::InitStructHelper();
     vert_create_info.stage = VK_SHADER_STAGE_VERTEX_BIT;
     vert_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     vert_create_info.codeSize = vert_spv.size() * sizeof(vert_spv[0]);
@@ -1136,7 +1136,7 @@ TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
     vert_create_info.setLayoutCount = 2u;
     vert_create_info.pSetLayouts = descriptor_set_layouts;
 
-    auto frag_create_info = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT frag_create_info = vku::InitStructHelper();
     frag_create_info.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     frag_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     frag_create_info.codeSize = frag_spv.size() * sizeof(frag_spv[0]);
@@ -1217,7 +1217,7 @@ TEST_F(PositiveShaderObject, MultiplePushConstants) {
     push_constant_ranges[1].size = sizeof(float);
     vkt::PipelineLayout pipeline_layout(*m_device, {}, {push_constant_ranges[0], push_constant_ranges[1]});
 
-    auto vert_create_info = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT vert_create_info = vku::InitStructHelper();
     vert_create_info.stage = VK_SHADER_STAGE_VERTEX_BIT;
     vert_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     vert_create_info.codeSize = vert_spv.size() * sizeof(vert_spv[0]);
@@ -1226,7 +1226,7 @@ TEST_F(PositiveShaderObject, MultiplePushConstants) {
     vert_create_info.pushConstantRangeCount = 2u;
     vert_create_info.pPushConstantRanges = push_constant_ranges;
 
-    auto frag_create_info = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT frag_create_info = vku::InitStructHelper();
     frag_create_info.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     frag_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     frag_create_info.codeSize = frag_spv.size() * sizeof(frag_spv[0]);
@@ -1300,7 +1300,7 @@ TEST_F(PositiveShaderObject, MultipleSpecializationConstants) {
     specialization_info.dataSize = sizeof(int) + sizeof(float);
     specialization_info.pData = &data;
 
-    auto vert_create_info = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT vert_create_info = vku::InitStructHelper();
     vert_create_info.stage = VK_SHADER_STAGE_VERTEX_BIT;
     vert_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     vert_create_info.codeSize = vert_spv.size() * sizeof(vert_spv[0]);
@@ -1308,7 +1308,7 @@ TEST_F(PositiveShaderObject, MultipleSpecializationConstants) {
     vert_create_info.pName = "main";
     vert_create_info.pSpecializationInfo = &specialization_info;
 
-    auto frag_create_info = vku::InitStruct<VkShaderCreateInfoEXT>();
+    VkShaderCreateInfoEXT frag_create_info = vku::InitStructHelper();
     frag_create_info.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     frag_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
     frag_create_info.codeSize = frag_spv.size() * sizeof(frag_spv[0]);
@@ -1511,7 +1511,7 @@ TEST_F(PositiveShaderObject, OutputToMultipleAttachments) {
     attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 
-    auto renderingInfo = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR renderingInfo = vku::InitStructHelper();
     renderingInfo.renderArea = {{0, 0}, {100u, 100u}};
     renderingInfo.layerCount = 1u;
     renderingInfo.colorAttachmentCount = 2u;
@@ -1574,12 +1574,12 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffersWithRenderPassContinue
 
     vkt::CommandPool command_pool(*m_device, graphics_queue_family_index.value());
     VkCommandBufferObj command_buffer(m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    auto rendering_info = vku::InitStruct<VkCommandBufferInheritanceRenderingInfo>();
+    VkCommandBufferInheritanceRenderingInfo rendering_info = vku::InitStructHelper();
     rendering_info.colorAttachmentCount = 1;
     rendering_info.pColorAttachmentFormats = &m_render_target_fmt;
     rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-    auto hinfo = vku::InitStruct<VkCommandBufferInheritanceInfo>(&rendering_info);
-    auto begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferInheritanceInfo hinfo = vku::InitStructHelper(&rendering_info);
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     begin_info.pInheritanceInfo = &hinfo;
     command_buffer.begin(&begin_info);
@@ -1598,7 +1598,7 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffersWithRenderPassContinue
     color_attachment.imageView = GetDynamicRenderTarget();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    auto renderingInfo = vku::InitStruct<VkRenderingInfoKHR>();
+    VkRenderingInfoKHR renderingInfo = vku::InitStructHelper();
     renderingInfo.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT;
     renderingInfo.colorAttachmentCount = 1;
     renderingInfo.pColorAttachments = &color_attachment;
@@ -1664,7 +1664,7 @@ TEST_F(PositiveShaderObject, DrawRebindingShaders) {
 TEST_F(PositiveShaderObject, TestVertexAttributeMatching) {
     TEST_DESCRIPTION("Test vertex inputs.");
 
-    auto vulkanMemoryModelFeatures = vku::InitStruct<VkPhysicalDeviceVulkanMemoryModelFeatures>();
+    VkPhysicalDeviceVulkanMemoryModelFeatures vulkanMemoryModelFeatures = vku::InitStructHelper();
     InitBasicShaderObject(&vulkanMemoryModelFeatures);
     if (::testing::Test::IsSkipped()) return;
     if (!vulkanMemoryModelFeatures.vulkanMemoryModel || !vulkanMemoryModelFeatures.vulkanMemoryModelDeviceScope) {
@@ -1692,13 +1692,13 @@ TEST_F(PositiveShaderObject, TestVertexAttributeMatching) {
     SetDefaultDynamicStates();
     BindVertFragShader(vertShader, fragShader);
 
-    auto vertexBindingDescription = vku::InitStruct<VkVertexInputBindingDescription2EXT>();
+    VkVertexInputBindingDescription2EXT vertexBindingDescription = vku::InitStructHelper();
     vertexBindingDescription.binding = 0u;
     vertexBindingDescription.stride = 16u;
     vertexBindingDescription.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
     vertexBindingDescription.divisor = 1u;
 
-    auto vertexAttributeDescription = vku::InitStruct<VkVertexInputAttributeDescription2EXT>();
+    VkVertexInputAttributeDescription2EXT vertexAttributeDescription = vku::InitStructHelper();
     vertexAttributeDescription.location = 0u;
     vertexAttributeDescription.binding = 0u;
     vertexAttributeDescription.format = VK_FORMAT_R32G32B32A32_UINT;
@@ -1735,7 +1735,7 @@ TEST_F(PositiveShaderObject, DrawWithBinaryShaders) {
     VkShaderEXT shaders[5];
     VkShaderEXT binaryShaders[5];
     for (uint32_t i = 0; i < 5u; ++i) {
-        auto createInfo = vku::InitStruct<VkShaderCreateInfoEXT>();
+        VkShaderCreateInfoEXT createInfo = vku::InitStructHelper();
         createInfo.stage = shaderStages[i];
         createInfo.nextStage = 0u;
         if (i < 4) {

--- a/tests/unit/shader_push_constants.cpp
+++ b/tests/unit/shader_push_constants.cpp
@@ -288,7 +288,7 @@ TEST_F(NegativeShaderPushConstants, DrawWithoutUpdate) {
     VkPushConstantRange push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0, 128};
     VkPushConstantRange push_constant_range_small = {VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 4, 4};
 
-    auto pipeline_layout_info = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo pipeline_layout_info = vku::InitStructHelper();
     pipeline_layout_info.pushConstantRangeCount = 1;
     pipeline_layout_info.pPushConstantRanges = &push_constant_range;
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_info);
@@ -427,7 +427,7 @@ TEST_F(NegativeShaderPushConstants, MultipleEntryPoint) {
 
     // Push constant are in the vertex Entrypoint
     VkPushConstantRange push_constant_range = {VK_SHADER_STAGE_FRAGMENT_BIT, 0, 16};
-    auto pipeline_layout_info = vku::InitStruct<VkPipelineLayoutCreateInfo>();
+    VkPipelineLayoutCreateInfo pipeline_layout_info = vku::InitStructHelper();
     pipeline_layout_info.pushConstantRangeCount = 1;
     pipeline_layout_info.pPushConstantRanges = &push_constant_range;
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_info);

--- a/tests/unit/shader_push_constants_positive.cpp
+++ b/tests/unit/shader_push_constants_positive.cpp
@@ -529,7 +529,7 @@ TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferBasic) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);
     if (VK_TRUE != features12.bufferDeviceAddress) {
         GTEST_SKIP() << "bufferDeviceAddress not supported and is required";
@@ -594,7 +594,7 @@ TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferVertFrag) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);
     if (VK_TRUE != features12.bufferDeviceAddress) {
         GTEST_SKIP() << "VkPhysicalDeviceVulkan12Features::bufferDeviceAddress not supported and is required";

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -29,7 +29,7 @@ TEST_F(NegativeShaderSpirv, CodeSize) {
 
     {
         VkShaderModule module;
-        auto module_create_info = vku::InitStruct<VkShaderModuleCreateInfo>();
+        VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
 
         constexpr icd_spv_header spv = {};
         module_create_info.pCode = reinterpret_cast<const uint32_t *>(&spv);
@@ -42,7 +42,7 @@ TEST_F(NegativeShaderSpirv, CodeSize) {
 
     {
         std::vector<uint32_t> shader;
-        auto module_create_info = vku::InitStruct<VkShaderModuleCreateInfo>();
+        VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
         VkShaderModule module;
         this->GLSLtoSPV(&m_device->props.limits, VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl, shader);
         module_create_info.pCode = shader.data();
@@ -62,7 +62,7 @@ TEST_F(NegativeShaderSpirv, Magic) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     VkShaderModule module;
-    auto module_create_info = vku::InitStruct<VkShaderModuleCreateInfo>();
+    VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
 
     constexpr uint32_t bad_magic = 4175232508U;
     constexpr icd_spv_header spv = {bad_magic};
@@ -96,7 +96,7 @@ TEST_F(NegativeShaderSpirv, ShaderFloatControl) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto shader_float_control = vku::InitStruct<VkPhysicalDeviceFloatControlsProperties>();
+    VkPhysicalDeviceFloatControlsProperties shader_float_control = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(shader_float_control);
 
     if (shader_float_control.denormBehaviorIndependence == VK_SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE) {
@@ -634,7 +634,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitFeatures) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16Int8 = vku::InitStruct<VkPhysicalDeviceShaderFloat16Int8Features>();
+    VkPhysicalDeviceShaderFloat16Int8Features float16Int8 = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(float16Int8);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -1261,9 +1261,9 @@ TEST_F(NegativeShaderSpirv, SpecializationOffsetOutOfBoundsWithIdentifier) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto shader_cache_control_features = vku::InitStruct<VkPhysicalDevicePipelineCreationCacheControlFeatures>();
-    auto shader_module_id_features =
-        vku::InitStruct<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(&shader_cache_control_features);
+    VkPhysicalDevicePipelineCreationCacheControlFeatures shader_cache_control_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT shader_module_id_features =
+        vku::InitStructHelper(&shader_cache_control_features);
     GetPhysicalDeviceFeatures2(shader_module_id_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &shader_module_id_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -1277,8 +1277,8 @@ TEST_F(NegativeShaderSpirv, SpecializationOffsetOutOfBoundsWithIdentifier) {
     )glsl";
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto sm_id_create_info = vku::InitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
-    auto get_identifier = vku::InitStruct<VkShaderModuleIdentifierEXT>();
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
+    VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
     vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
@@ -1293,7 +1293,7 @@ TEST_F(NegativeShaderSpirv, SpecializationOffsetOutOfBoundsWithIdentifier) {
         &data,
     };
 
-    auto stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&sm_id_create_info);
+    VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper(&sm_id_create_info);
     stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
     stage_ci.module = VK_NULL_HANDLE;
     stage_ci.pName = "main";
@@ -1406,7 +1406,7 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeMismatch) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     features12.shaderInt8 = VK_TRUE;
     auto features2 = GetPhysicalDeviceFeatures2(features12);
     if (features12.shaderInt8 == VK_TRUE) {
@@ -1774,7 +1774,7 @@ TEST_F(NegativeShaderSpirv, ShaderImageFootprintEnabled) {
     auto features = m_device->phy().features();
 
     // Disable the image footprint feature.
-    auto image_footprint_features = vku::InitStruct<VkPhysicalDeviceShaderImageFootprintFeaturesNV>();
+    VkPhysicalDeviceShaderImageFootprintFeaturesNV image_footprint_features = vku::InitStructHelper();
     image_footprint_features.imageFootprint = VK_FALSE;
 
     VkDeviceObj test_device(0, gpu(), device_extension_names, &features, &image_footprint_features);
@@ -1851,7 +1851,7 @@ TEST_F(NegativeShaderSpirv, FragmentShaderBarycentricEnabled) {
     auto features = m_device->phy().features();
 
     // Disable the fragment shader barycentric feature.
-    auto fragment_shader_barycentric_features = vku::InitStruct<VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV>();
+    VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV fragment_shader_barycentric_features = vku::InitStructHelper();
     fragment_shader_barycentric_features.fragmentShaderBarycentric = VK_FALSE;
 
     VkDeviceObj test_device(0, gpu(), m_device_extension_names, &features, &fragment_shader_barycentric_features);
@@ -1918,7 +1918,7 @@ TEST_F(NegativeShaderSpirv, ComputeShaderDerivativesEnabled) {
     auto features = m_device->phy().features();
 
     // Disable the compute shader derivatives features.
-    auto compute_shader_derivatives_features = vku::InitStruct<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV>();
+    VkPhysicalDeviceComputeShaderDerivativesFeaturesNV compute_shader_derivatives_features = vku::InitStructHelper();
     compute_shader_derivatives_features.computeDerivativeGroupLinear = VK_FALSE;
     compute_shader_derivatives_features.computeDerivativeGroupQuads = VK_FALSE;
 
@@ -1980,7 +1980,7 @@ TEST_F(NegativeShaderSpirv, FragmentShaderInterlockEnabled) {
     auto features = m_device->phy().features();
 
     // Disable the fragment shader interlock feature.
-    auto fragment_shader_interlock_features = vku::InitStruct<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>();
+    VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT fragment_shader_interlock_features = vku::InitStructHelper();
     fragment_shader_interlock_features.fragmentShaderSampleInterlock = VK_FALSE;
     fragment_shader_interlock_features.fragmentShaderPixelInterlock = VK_FALSE;
     fragment_shader_interlock_features.fragmentShaderShadingRateInterlock = VK_FALSE;
@@ -2048,7 +2048,7 @@ TEST_F(NegativeShaderSpirv, DemoteToHelperInvocation) {
     auto features = m_device->phy().features();
 
     // Disable the demote to helper invocation feature.
-    auto demote_features = vku::InitStruct<VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT>();
+    VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT demote_features = vku::InitStructHelper();
     demote_features.shaderDemoteToHelperInvocation = VK_FALSE;
 
     VkDeviceObj test_device(0, gpu(), m_device_extension_names, &features, &demote_features);
@@ -2282,7 +2282,7 @@ TEST_F(NegativeShaderSpirv, DeviceMemoryScope) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(features12);
     features12.vulkanMemoryModelDeviceScope = VK_FALSE;
     if (features12.vulkanMemoryModel == VK_FALSE) {
@@ -2314,7 +2314,7 @@ TEST_F(NegativeShaderSpirv, QueueFamilyMemoryScope) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(features12);
     features12.vulkanMemoryModel = VK_FALSE;
     if (features12.vulkanMemoryModelDeviceScope == VK_FALSE) {
@@ -2350,7 +2350,7 @@ TEST_F(NegativeShaderSpirv, ConservativeRasterizationPostDepthCoverage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto conservative_rasterization_props = vku::InitStruct<VkPhysicalDeviceConservativeRasterizationPropertiesEXT>();
+    VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_rasterization_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(conservative_rasterization_props);
     if (conservative_rasterization_props.conservativeRasterizationPostDepthCoverage) {
         GTEST_SKIP() << "need conservativeRasterizationPostDepthCoverage to not be supported";

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -322,7 +322,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithFeature) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features11 = vku::InitStruct<VkPhysicalDeviceVulkan11Features>();
+    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper();
     features11.shaderDrawParameters = VK_TRUE;
     auto features2 = GetPhysicalDeviceFeatures2(features11);
 
@@ -367,9 +367,9 @@ TEST_F(PositiveShaderSpirv, Std430SpirvOptFlags10) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto uniform_buffer_standard_layout_features = vku::InitStruct<VkPhysicalDeviceUniformBufferStandardLayoutFeatures>();
-    auto scalar_block_layout_features =
-        vku::InitStruct<VkPhysicalDeviceScalarBlockLayoutFeatures>(&uniform_buffer_standard_layout_features);
+    VkPhysicalDeviceUniformBufferStandardLayoutFeatures uniform_buffer_standard_layout_features = vku::InitStructHelper();
+    VkPhysicalDeviceScalarBlockLayoutFeatures scalar_block_layout_features =
+        vku::InitStructHelper(&uniform_buffer_standard_layout_features);
     GetPhysicalDeviceFeatures2(scalar_block_layout_features);
     if (scalar_block_layout_features.scalarBlockLayout == VK_FALSE ||
         uniform_buffer_standard_layout_features.uniformBufferStandardLayout == VK_FALSE) {
@@ -429,7 +429,7 @@ TEST_F(PositiveShaderSpirv, Std430SpirvOptFlags12) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);
     if (features12.scalarBlockLayout == VK_FALSE || features12.uniformBufferStandardLayout == VK_FALSE) {
         GTEST_SKIP() << "scalarBlockLayout and uniformBufferStandardLayout are not supported";
@@ -489,7 +489,7 @@ TEST_F(PositiveShaderSpirv, SpecializationWordBoundryOffset) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16int8_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16int8_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(float16int8_features);
     if (float16int8_features.shaderInt8 == VK_FALSE) {
         GTEST_SKIP() << "shaderInt8 feature not supported";
@@ -627,7 +627,7 @@ TEST_F(PositiveShaderSpirv, SpecializationWordBoundryOffset) {
     pipe.CreateComputePipeline();
 
     // Submit shader to see SSBO output
-    auto bci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo bci = vku::InitStructHelper();
     bci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     bci.size = 1024;
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
@@ -813,8 +813,8 @@ TEST_F(PositiveShaderSpirv, UnnormalizedCoordinatesNotSampled) {
     // Verify that it is allowed on this implementation if
     // VK_KHR_format_feature_flags2 is available.
     if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
-        auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-        auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
         vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
 
@@ -988,7 +988,7 @@ TEST_F(PositiveShaderSpirv, SpecializeInt8) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16int8_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16int8_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(float16int8_features);
     if (float16int8_features.shaderInt8 == VK_FALSE) {
         GTEST_SKIP() << "shaderInt8 feature not supported";
@@ -1049,7 +1049,7 @@ TEST_F(PositiveShaderSpirv, SpecializeInt16) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>();
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features2);
     if (features2.features.shaderInt16 == VK_FALSE) {
         GTEST_SKIP() << "shaderInt16 feature not supported";
@@ -1160,7 +1160,7 @@ TEST_F(PositiveShaderSpirv, SpecializeInt64) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>();
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features2);
     if (features2.features.shaderInt64 == VK_FALSE) {
         GTEST_SKIP() << "shaderInt64 feature not supported";
@@ -1282,7 +1282,7 @@ TEST_F(PositiveShaderSpirv, ShaderFloatControl) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto shader_float_control = vku::InitStruct<VkPhysicalDeviceFloatControlsProperties>();
+    VkPhysicalDeviceFloatControlsProperties shader_float_control = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(shader_float_control);
 
     bool signed_zero_inf_nan_preserve = (shader_float_control.shaderSignedZeroInfNanPreserveFloat32 == VK_TRUE);
@@ -1418,9 +1418,9 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         GTEST_SKIP() << "Extension not supported";
     }
 
-    auto storage_8_bit_features = vku::InitStruct<VkPhysicalDevice8BitStorageFeaturesKHR>();
-    auto storage_16_bit_features = vku::InitStruct<VkPhysicalDevice16BitStorageFeaturesKHR>(&storage_8_bit_features);
-    auto float_16_int_8_features = vku::InitStruct<VkPhysicalDeviceShaderFloat16Int8Features>(&storage_16_bit_features);
+    VkPhysicalDevice8BitStorageFeaturesKHR storage_8_bit_features = vku::InitStructHelper();
+    VkPhysicalDevice16BitStorageFeaturesKHR storage_16_bit_features = vku::InitStructHelper(&storage_8_bit_features);
+    VkPhysicalDeviceShaderFloat16Int8Features float_16_int_8_features = vku::InitStructHelper(&storage_16_bit_features);
     auto features2 = GetPhysicalDeviceFeatures2(float_16_int_8_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -1698,7 +1698,7 @@ TEST_F(PositiveShaderSpirv, ReadShaderClock) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto shader_clock_features = vku::InitStruct<VkPhysicalDeviceShaderClockFeaturesKHR>();
+    VkPhysicalDeviceShaderClockFeaturesKHR shader_clock_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(shader_clock_features);
     if ((shader_clock_features.shaderDeviceClock == VK_FALSE) && (shader_clock_features.shaderSubgroupClock == VK_FALSE)) {
         // shaderSubgroupClock should be supported, but extra check
@@ -1760,7 +1760,7 @@ TEST_F(PositiveShaderSpirv, PhysicalStorageBufferStructRecursion) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(features12);
     if (VK_TRUE != features12.bufferDeviceAddress) {
         GTEST_SKIP() << "VkPhysicalDeviceVulkan12Features::bufferDeviceAddress not supported and is required";
@@ -1804,7 +1804,7 @@ TEST_F(PositiveShaderSpirv, OpCopyObjectSampler) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
 
-    auto features12 = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
+    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(features12);
     if (VK_TRUE != features12.shaderStorageTexelBufferArrayNonUniformIndexing) {
         GTEST_SKIP()

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -193,8 +193,8 @@ TEST_F(NegativeShaderStorageImage, MissingFormatReadForFormat) {
     for (uint32_t fmt = VK_FORMAT_R4G4_UNORM_PACK8; fmt < VK_FORMAT_D16_UNORM; fmt++) {
         if (has_without_format_test && has_with_format_test) break;
 
-        auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-        auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
         vk::GetPhysicalDeviceFormatProperties2KHR(gpu(), (VkFormat)fmt, &fmt_props);
 
@@ -356,8 +356,8 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWriteForFormat) {
     for (uint32_t fmt = VK_FORMAT_R4G4_UNORM_PACK8; fmt < VK_FORMAT_D16_UNORM; fmt++) {
         if (has_without_format_test && has_with_format_test) break;
 
-        auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-        auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+        VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+        VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
         vk::GetPhysicalDeviceFormatProperties2KHR(gpu(), (VkFormat)fmt, &fmt_props);
 

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -133,8 +133,8 @@ TEST_F(NegativeShaderStorageTexel, UnknownWriteLessComponent) {
         GTEST_SKIP() << "Format doesn't support storage texel buffer";
     }
 
-    auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>();
-    auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+    VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
+    VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
     vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UINT, &fmt_props);
     if ((fmt_props_3.bufferFeatures & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR) == 0) {
         GTEST_SKIP() << "Format doesn't support storage write without format";
@@ -194,8 +194,8 @@ TEST_F(NegativeShaderStorageTexel, MissingFormatWriteForFormat) {
     }
 
     const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    auto fmt_props_3 = vku::InitStruct<VkFormatProperties3>();
-    auto fmt_props = vku::InitStruct<VkFormatProperties2>(&fmt_props_3);
+    VkFormatProperties3 fmt_props_3 = vku::InitStructHelper();
+    VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
     // set so format can be used as a storage texel buffer, but no WITHOUT_FORMAT support
     fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(gpu(), format, &fmt_props);

--- a/tests/unit/sparse_buffer.cpp
+++ b/tests/unit/sparse_buffer.cpp
@@ -265,7 +265,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy) {
     buffer_memory_bind_infos[1].bindCount = 1;
     buffer_memory_bind_infos[1].pBinds = &buffer_memory_bind;
 
-    auto bind_info = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo bind_info = vku::InitStructHelper();
     bind_info.bufferBindCount = 2;
     bind_info.pBufferBinds = buffer_memory_bind_infos;
     bind_info.signalSemaphoreCount = 1;
@@ -285,7 +285,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy) {
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.waitSemaphoreCount = 1;
     submit_info.pWaitSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &mask;
@@ -357,7 +357,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy2) {
     buffer_memory_bind_infos[0].bindCount = 1;
     buffer_memory_bind_infos[0].pBinds = &buffer_memory_bind_1;
 
-    auto bind_info = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo bind_info = vku::InitStructHelper();
     bind_info.bufferBindCount = size32(buffer_memory_bind_infos);
     bind_info.pBufferBinds = buffer_memory_bind_infos.data();
     bind_info.signalSemaphoreCount = 1;
@@ -376,7 +376,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy2) {
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.waitSemaphoreCount = 1;
     submit_info.pWaitSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &mask;
@@ -443,7 +443,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy3) {
     buffer_memory_bind_info.bindCount = size32(buffer_memory_binds);
     buffer_memory_bind_info.pBinds = buffer_memory_binds.data();
 
-    auto bind_info = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo bind_info = vku::InitStructHelper();
     bind_info.bufferBindCount = 1;
     bind_info.pBufferBinds = &buffer_memory_bind_info;
     bind_info.signalSemaphoreCount = 1;
@@ -466,7 +466,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy3) {
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.waitSemaphoreCount = 1;
     submit_info.pWaitSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &mask;
@@ -493,7 +493,7 @@ TEST_F(NegativeSparseBuffer, BufferFlagsFeature) {
     ASSERT_NO_FATAL_FAILURE(InitFramework());
     ASSERT_NO_FATAL_FAILURE(InitState(&features));
 
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = 64;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 

--- a/tests/unit/sparse_buffer_positive.cpp
+++ b/tests/unit/sparse_buffer_positive.cpp
@@ -66,7 +66,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy) {
     buffer_memory_bind_infos[1].bindCount = 1;
     buffer_memory_bind_infos[1].pBinds = &buffer_memory_bind;
 
-    auto bind_info = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo bind_info = vku::InitStructHelper();
     bind_info.bufferBindCount = 2;
     bind_info.pBufferBinds = buffer_memory_bind_infos;
     bind_info.signalSemaphoreCount = 1;
@@ -93,7 +93,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy) {
 
     // Submitting copy command with non overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.waitSemaphoreCount = 1;
     submit_info.pWaitSemaphores = &semaphore2.handle();
     submit_info.pWaitDstStageMask = &mask;
@@ -158,7 +158,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy2) {
     buffer_memory_bind_infos[0].bindCount = 1;
     buffer_memory_bind_infos[0].pBinds = &buffer_memory_bind_1;
 
-    auto bind_info = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo bind_info = vku::InitStructHelper();
     bind_info.bufferBindCount = size32(buffer_memory_bind_infos);
     bind_info.pBufferBinds = buffer_memory_bind_infos.data();
     bind_info.signalSemaphoreCount = 1;
@@ -177,7 +177,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy2) {
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.waitSemaphoreCount = 1;
     submit_info.pWaitSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &mask;
@@ -241,7 +241,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy3) {
     buffer_memory_bind_info.bindCount = size32(buffer_memory_binds);
     buffer_memory_bind_info.pBinds = buffer_memory_binds.data();
 
-    auto bind_info = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo bind_info = vku::InitStructHelper();
     bind_info.bufferBindCount = 1;
     bind_info.pBufferBinds = &buffer_memory_bind_info;
     bind_info.signalSemaphoreCount = 1;
@@ -259,7 +259,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy3) {
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.waitSemaphoreCount = 1;
     submit_info.pWaitSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &mask;
@@ -321,7 +321,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy4) {
     buffer_memory_bind_info.bindCount = size32(buffer_memory_binds);
     buffer_memory_bind_info.pBinds = buffer_memory_binds.data();
 
-    auto bind_info = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo bind_info = vku::InitStructHelper();
     bind_info.bufferBindCount = 1;
     bind_info.pBufferBinds = &buffer_memory_bind_info;
     bind_info.signalSemaphoreCount = 1;
@@ -344,7 +344,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy4) {
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.waitSemaphoreCount = 1;
     submit_info.pWaitSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &mask;

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -234,7 +234,7 @@ TEST_F(NegativeSparseImage, ImageUsageBits) {
         GTEST_SKIP() << "No sparseBinding feature";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -397,13 +397,13 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType) {
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &buffer_mem_reqs);
-    auto buffer_mem_alloc = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo buffer_mem_alloc = vku::InitStructHelper();
     buffer_mem_alloc.allocationSize = buffer_mem_reqs.size;
     buffer_mem_alloc.memoryTypeIndex = lazily_allocated_index;
 
     VkMemoryRequirements image_mem_reqs;
     vk::GetImageMemoryRequirements(device(), image.handle(), &image_mem_reqs);
-    auto image_mem_alloc = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo image_mem_alloc = vku::InitStructHelper();
     image_mem_alloc.allocationSize = image_mem_reqs.size;
     image_mem_alloc.memoryTypeIndex = lazily_allocated_index;
 

--- a/tests/unit/sparse_image_positive.cpp
+++ b/tests/unit/sparse_image_positive.cpp
@@ -28,7 +28,7 @@ TEST_F(PositiveSparseImage, MultipleBinds) {
     }
 
     VkImageObj image(m_device);
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
     image_create_info.extent.width = 64;
@@ -57,7 +57,7 @@ TEST_F(PositiveSparseImage, MultipleBinds) {
     }
     // Allocate 2 memory regions of minimum alignment size, bind one at 0, the other
     // at the end of the first
-    auto memory_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = memory_reqs.alignment;
     bool pass = m_device->phy().set_memory_type(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
@@ -79,7 +79,7 @@ TEST_F(PositiveSparseImage, MultipleBinds) {
     opaqueBindInfo.bindCount = size32(binds);
     opaqueBindInfo.pBinds = binds.data();
 
-    auto bindSparseInfo = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo bindSparseInfo = vku::InitStructHelper();
     bindSparseInfo.imageOpaqueBindCount = 1;
     bindSparseInfo.pImageOpaqueBinds = &opaqueBindInfo;
 
@@ -120,7 +120,7 @@ TEST_F(PositiveSparseImage, BindFreeMemory) {
     VkMemoryRequirements memory_reqs;
 
     vk::GetImageMemoryRequirements(m_device->device(), image, &memory_reqs);
-    auto memory_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = memory_reqs.size;
     bool pass = m_device->phy().set_memory_type(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
@@ -139,7 +139,7 @@ TEST_F(PositiveSparseImage, BindFreeMemory) {
     opaqueBindInfo.bindCount = 1;
     opaqueBindInfo.pBinds = &bind;
 
-    auto bindSparseInfo = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo bindSparseInfo = vku::InitStructHelper();
     bindSparseInfo.imageOpaqueBindCount = 1;
     bindSparseInfo.pImageOpaqueBinds = &opaqueBindInfo;
 
@@ -157,7 +157,7 @@ TEST_F(PositiveSparseImage, BindFreeMemory) {
 
     m_commandBuffer->begin();
 
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     img_barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
     img_barrier.image = image;
@@ -176,7 +176,7 @@ TEST_F(PositiveSparseImage, BindFreeMemory) {
     vk::CmdClearColorImage(m_commandBuffer->handle(), image, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
     m_commandBuffer->end();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
@@ -255,7 +255,7 @@ TEST_F(PositiveSparseImage, BindMetadata) {
     opaque_bind_info.bindCount = 1;
     opaque_bind_info.pBinds = &sparse_bind;
 
-    auto bind_info = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo bind_info = vku::InitStructHelper();
     bind_info.imageOpaqueBindCount = 1;
     bind_info.pImageOpaqueBinds = &opaque_bind_info;
 
@@ -282,7 +282,7 @@ TEST_F(PositiveSparseImage, OpImageSparse) {
     }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
     image_create_info.extent.width = 64;

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -319,7 +319,7 @@ TEST_F(NegativeSubgroup, DISABLED_pNextDisabled) {
     ASSERT_NO_FATAL_FAILURE(InitState());
 
     VkPhysicalDeviceSubgroupProperties subgroup_prop = vku::InitStructHelper();
-    auto props2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&subgroup_prop);
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&subgroup_prop);
     vk::GetPhysicalDeviceProperties2(gpu_, &props2);
 }
 
@@ -335,8 +335,8 @@ TEST_F(NegativeSubgroup, ExtendedTypesEnabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto extended_types_features = vku::InitStruct<VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR>(&float16_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR extended_types_features = vku::InitStructHelper(&float16_features);
     auto features2 = GetPhysicalDeviceFeatures2(extended_types_features);
 
     VkPhysicalDeviceSubgroupProperties subgroup_prop = vku::InitStructHelper();
@@ -382,8 +382,8 @@ TEST_F(NegativeSubgroup, ExtendedTypesDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto float16_features = vku::InitStruct<VkPhysicalDeviceFloat16Int8FeaturesKHR>();
-    auto extended_types_features = vku::InitStruct<VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR>(&float16_features);
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR extended_types_features = vku::InitStructHelper(&float16_features);
     auto features2 = GetPhysicalDeviceFeatures2(extended_types_features);
 
     VkPhysicalDeviceSubgroupProperties subgroup_prop = vku::InitStructHelper();
@@ -444,15 +444,15 @@ TEST_F(NegativeSubgroup, PipelineSubgroupSizeControl) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sscf));
 
-    auto subgroup_properties = vku::InitStruct<VkPhysicalDeviceSubgroupSizeControlPropertiesEXT>();
-    auto props11 = vku::InitStruct<VkPhysicalDeviceVulkan11Properties>(&subgroup_properties);
+    VkPhysicalDeviceSubgroupSizeControlPropertiesEXT subgroup_properties = vku::InitStructHelper();
+    VkPhysicalDeviceVulkan11Properties props11 = vku::InitStructHelper(&subgroup_properties);
     GetPhysicalDeviceProperties2(props11);
 
     if ((subgroup_properties.requiredSubgroupSizeStages & VK_SHADER_STAGE_COMPUTE_BIT) == 0) {
         GTEST_SKIP() << "Required shader stage not present in requiredSubgroupSizeStages";
     }
 
-    auto subgroup_size_control = vku::InitStruct<VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT>();
+    VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT subgroup_size_control = vku::InitStructHelper();
     subgroup_size_control.requiredSubgroupSize = subgroup_properties.minSubgroupSize;
 
     {
@@ -612,26 +612,26 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeaturesWithIdentifierGraphics) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto shader_cache_control_features = vku::InitStruct<VkPhysicalDevicePipelineCreationCacheControlFeatures>();
-    auto shader_module_id_features =
-        vku::InitStruct<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(&shader_cache_control_features);
+    VkPhysicalDevicePipelineCreationCacheControlFeatures shader_cache_control_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT shader_module_id_features =
+        vku::InitStructHelper(&shader_cache_control_features);
     GetPhysicalDeviceFeatures2(shader_module_id_features);
 
-    auto subgroup_size_control_features = vku::InitStruct<VkPhysicalDeviceSubgroupSizeControlFeaturesEXT>();
+    VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_size_control_features = vku::InitStructHelper();
     subgroup_size_control_features.subgroupSizeControl = VK_FALSE;
     shader_cache_control_features.pNext = &subgroup_size_control_features;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &shader_module_id_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto sm_id_create_info = vku::InitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto get_identifier = vku::InitStruct<VkShaderModuleIdentifierEXT>();
+    VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
     vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
 
-    auto stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&sm_id_create_info);
+    VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper(&sm_id_create_info);
     stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
     stage_ci.module = VK_NULL_HANDLE;
     stage_ci.pName = "main";
@@ -665,25 +665,25 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeaturesWithIdentifierCompute) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto shader_cache_control_features = vku::InitStruct<VkPhysicalDevicePipelineCreationCacheControlFeatures>();
-    auto shader_module_id_features =
-        vku::InitStruct<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(&shader_cache_control_features);
+    VkPhysicalDevicePipelineCreationCacheControlFeatures shader_cache_control_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT shader_module_id_features =
+        vku::InitStructHelper(&shader_cache_control_features);
     GetPhysicalDeviceFeatures2(shader_module_id_features);
 
-    auto subgroup_size_control_features = vku::InitStruct<VkPhysicalDeviceSubgroupSizeControlFeaturesEXT>();
+    VkPhysicalDeviceSubgroupSizeControlFeaturesEXT subgroup_size_control_features = vku::InitStructHelper();
     subgroup_size_control_features.subgroupSizeControl = VK_FALSE;
     shader_cache_control_features.pNext = &subgroup_size_control_features;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &shader_module_id_features));
 
-    auto sm_id_create_info = vku::InitStruct<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>();
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
     VkShaderObj cs(this, kMinimalShaderGlsl, VK_SHADER_STAGE_COMPUTE_BIT);
 
-    auto get_identifier = vku::InitStruct<VkShaderModuleIdentifierEXT>();
+    VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
     vk::GetShaderModuleIdentifierEXT(device(), cs.handle(), &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
 
-    auto stage_ci = vku::InitStruct<VkPipelineShaderStageCreateInfo>(&sm_id_create_info);
+    VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper(&sm_id_create_info);
     stage_ci.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     stage_ci.module = VK_NULL_HANDLE;
     stage_ci.pName = "main";
@@ -717,7 +717,7 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlStage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto sscf = vku::InitStruct<VkPhysicalDeviceSubgroupSizeControlFeaturesEXT>();
+    VkPhysicalDeviceSubgroupSizeControlFeaturesEXT sscf = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(sscf);
     if (sscf.subgroupSizeControl == VK_FALSE || sscf.computeFullSubgroups == VK_FALSE || sscf.subgroupSizeControl == VK_FALSE) {
         GTEST_SKIP() << "Required features are not supported";
@@ -762,7 +762,7 @@ TEST_F(NegativeSubgroup, SubgroupUniformControlFlow) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "Test requires at least Vulkan 1.1";
     }
-    auto ssucff = vku::InitStruct<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR>();
+    VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR ssucff = vku::InitStructHelper();
     ssucff.shaderSubgroupUniformControlFlow = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &ssucff));
 
@@ -819,21 +819,21 @@ TEST_F(NegativeSubgroup, ComputeLocalWorkgroupSize) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto sscf = vku::InitStruct<VkPhysicalDeviceSubgroupSizeControlFeaturesEXT>();
+    VkPhysicalDeviceSubgroupSizeControlFeaturesEXT sscf = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(sscf);
     if (sscf.subgroupSizeControl == VK_FALSE || sscf.computeFullSubgroups == VK_FALSE || sscf.subgroupSizeControl == VK_FALSE) {
         GTEST_SKIP() << "Required features are not supported";
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto subgroup_properties = vku::InitStruct<VkPhysicalDeviceSubgroupSizeControlPropertiesEXT>();
+    VkPhysicalDeviceSubgroupSizeControlPropertiesEXT subgroup_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(subgroup_properties);
 
     if ((subgroup_properties.requiredSubgroupSizeStages & VK_SHADER_STAGE_COMPUTE_BIT) == 0) {
         GTEST_SKIP() << "Required shader stage not present in requiredSubgroupSizeStages";
     }
 
-    auto subgroup_size_control = vku::InitStruct<VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT>();
+    VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT subgroup_size_control = vku::InitStructHelper();
     subgroup_size_control.requiredSubgroupSize = subgroup_properties.minSubgroupSize;
 
     uint32_t size = static_cast<uint32_t>(
@@ -902,9 +902,9 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeature) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    auto subgroup_properties = vku::InitStruct<VkPhysicalDeviceSubgroupSizeControlPropertiesEXT>();
+    VkPhysicalDeviceSubgroupSizeControlPropertiesEXT subgroup_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(subgroup_properties);
-    auto subgroup_size_control = vku::InitStruct<VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT>();
+    VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT subgroup_size_control = vku::InitStructHelper();
     subgroup_size_control.requiredSubgroupSize = subgroup_properties.minSubgroupSize;
 
     CreateComputePipelineHelper pipe(*this);

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -49,18 +49,18 @@ TEST_F(NegativeSubpass, InputAttachmentParameters) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R32_UINT;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto reference = vku::InitStruct<VkAttachmentReference2>();
+    VkAttachmentReference2 reference = vku::InitStructHelper();
     reference.attachment = 0;
     reference.layout = VK_IMAGE_LAYOUT_GENERAL;
     reference.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    auto subpass = vku::InitStruct<VkSubpassDescription2KHR>();
+    VkSubpassDescription2KHR subpass = vku::InitStructHelper();
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     subpass.viewMask = 0;
     subpass.inputAttachmentCount = 1;
@@ -104,7 +104,7 @@ TEST_F(NegativeSubpass, SubpassDependencies) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "multiview feature not supported";
@@ -334,7 +334,7 @@ TEST_F(NegativeSubpass, NextSubpassExcessive) {
 
     if (rp2Supported) {
         auto subpassBeginInfo = vku::InitStruct<VkSubpassBeginInfoKHR>(nullptr, VK_SUBPASS_CONTENTS_INLINE);
-        auto subpassEndInfo = vku::InitStruct<VkSubpassEndInfoKHR>();
+        VkSubpassEndInfoKHR subpassEndInfo = vku::InitStructHelper();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdNextSubpass2-None-03102");
 
@@ -380,7 +380,7 @@ TEST_F(NegativeSubpass, RenderPassEndBeforeFinalSubpass) {
     m_errorMonitor->VerifyFound();
 
     if (rp2Supported) {
-        auto subpassEndInfo = vku::InitStruct<VkSubpassEndInfoKHR>();
+        VkSubpassEndInfoKHR subpassEndInfo = vku::InitStructHelper();
 
         m_commandBuffer->reset();
         m_commandBuffer->begin();
@@ -421,7 +421,7 @@ TEST_F(NegativeSubpass, SubpassIndices) {
     dependency.srcStageMask = kGraphicsStages;
     dependency.dstStageMask = kGraphicsStages;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 2;
     rpci.pSubpasses = sci;
     rpci.dependencyCount = 1;
@@ -552,7 +552,7 @@ TEST_F(NegativeSubpass, ImageBarrierSubpassConflict) {
 
     auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp.handle(), fb.handle(), VkRect2D{{0, 0}, {32u, 32u}}, 0u, nullptr);
 
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     img_barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -621,7 +621,7 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
     vkt::RenderPass rp(*m_device, rpci);
     ASSERT_TRUE(rp.initialized());
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.renderPass = rp.handle();
     fbci.attachmentCount = 1u;
     fbci.pAttachments = &view_input;
@@ -713,13 +713,13 @@ TEST_F(NegativeSubpass, SubpassDescriptionViewMask) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto multiview_features = vku::InitStruct<VkPhysicalDeviceMultiviewFeatures>();
+    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "multiview feature not supported";
     }
 
-    auto render_pass_multiview_props = vku::InitStruct<VkPhysicalDeviceMultiviewProperties>();
+    VkPhysicalDeviceMultiviewProperties render_pass_multiview_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(render_pass_multiview_props);
 
     if (render_pass_multiview_props.maxMultiviewViewCount >= 32) {
@@ -728,7 +728,7 @@ TEST_F(NegativeSubpass, SubpassDescriptionViewMask) {
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
@@ -738,12 +738,13 @@ TEST_F(NegativeSubpass, SubpassDescriptionViewMask) {
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
 
-    auto subpass = vku::InitStruct<VkSubpassDescription2>();  //{0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 0, nullptr, nullptr,
-                                                            // nullptr, 0, nullptr};
+    VkSubpassDescription2 subpass =
+        vku::InitStructHelper();  //{0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 0, nullptr, nullptr,
+                                  // nullptr, 0, nullptr};
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     subpass.viewMask = 1 << render_pass_multiview_props.maxMultiviewViewCount;
 
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 render_pass_ci = vku::InitStructHelper();
     render_pass_ci.attachmentCount = 1;
     render_pass_ci.pAttachments = &attach_desc;
     render_pass_ci.subpassCount = 1;
@@ -790,7 +791,7 @@ TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     dependency.srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
     dependency.dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
-    auto render_pass_ci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper();
     render_pass_ci.subpassCount = 2;
     render_pass_ci.pSubpasses = sci;
     render_pass_ci.dependencyCount = 1;
@@ -804,7 +805,7 @@ TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto framebuffer_ci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
     framebuffer_ci.renderPass = render_pass.handle();
     framebuffer_ci.attachmentCount = 1;
     framebuffer_ci.pAttachments = &imageView;
@@ -829,7 +830,7 @@ TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     VkClearValue clear_value = {};
     clear_value.color = {{0, 0, 0, 0}};
 
-    auto render_pass_bi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo render_pass_bi = vku::InitStructHelper();
     render_pass_bi.renderPass = render_pass.handle();
     render_pass_bi.framebuffer = framebuffer.handle();
     render_pass_bi.renderArea = {{0, 0}, {32, 32}};
@@ -873,21 +874,21 @@ TEST_F(NegativeSubpass, SubpassDependencyMasksSync2) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto attach_ref = vku::InitStruct<VkAttachmentReference2>();
+    VkAttachmentReference2 attach_ref = vku::InitStructHelper();
     attach_ref.attachment = 0;
     attach_ref.layout = VK_IMAGE_LAYOUT_GENERAL;
-    auto subpass = vku::InitStruct<VkSubpassDescription2>();
+    VkSubpassDescription2 subpass = vku::InitStructHelper();
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &attach_ref;
     subpass.viewMask = 0;
 
-    auto attach_desc = vku::InitStruct<VkAttachmentDescription2>();
+    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
@@ -895,13 +896,13 @@ TEST_F(NegativeSubpass, SubpassDependencyMasksSync2) {
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto mem_barrier = vku::InitStruct<VkMemoryBarrier2>();
+    VkMemoryBarrier2 mem_barrier = vku::InitStructHelper();
     mem_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     mem_barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     mem_barrier.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
     mem_barrier.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 
-    auto dependency = vku::InitStruct<VkSubpassDependency2>();
+    VkSubpassDependency2 dependency = vku::InitStructHelper();
     dependency.srcSubpass = 0;
     dependency.dstSubpass = 0;
     dependency.srcStageMask = 0X8000000;  // not real value, VK_PIPELINE_STAGE_VIDEO_ENCODE_BIT_KHR doesn't exist
@@ -911,7 +912,7 @@ TEST_F(NegativeSubpass, SubpassDependencyMasksSync2) {
     dependency.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
     dependency.viewOffset = 0;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo2>();
+    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
@@ -1156,7 +1157,7 @@ TEST_F(NegativeSubpass, InputAttachmentSharingVariable) {
                                                      0,
                                                      nullptr};
 
-    auto renderPassInfo = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo renderPassInfo = vku::InitStructHelper();
     renderPassInfo.attachmentCount = 1;
     renderPassInfo.pAttachments = &inputAttachmentDescription;
     renderPassInfo.subpassCount = 1;

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -24,7 +24,7 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -47,7 +47,7 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
     const VkAttachmentReference ref = {0, VK_IMAGE_LAYOUT_GENERAL};
     const VkSubpassDescription subpass = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 1, &ref, 1, &ref, nullptr, nullptr, 0, nullptr};
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attachment;
     rpci.subpassCount = 1;
@@ -61,7 +61,7 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
                        VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.renderPass = render_pass;
     fbci.attachmentCount = 1;
     fbci.pAttachments = &image_view;
@@ -70,13 +70,13 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
     fbci.layers = 1;
     vkt::Framebuffer framebuffer(*m_device, fbci);
 
-    auto render_pass_begin = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo render_pass_begin = vku::InitStructHelper();
     render_pass_begin.renderPass = render_pass;
     render_pass_begin.framebuffer = framebuffer;
     render_pass_begin.renderArea = VkRect2D{{0, 0}, {32, 32}};
 
     // VkImageMemoryBarrier
-    auto barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier barrier = vku::InitStructHelper();
     barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -93,7 +93,7 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
     // VkDependencyInfo with VkImageMemoryBarrier2
     const safe_VkImageMemoryBarrier2 safe_barrier2 = ConvertVkImageMemoryBarrierToV2(
         barrier, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-    auto dependency_info = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
     dependency_info.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
     dependency_info.imageMemoryBarrierCount = 1;
     dependency_info.pImageMemoryBarriers = safe_barrier2.ptr();
@@ -122,7 +122,7 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -145,7 +145,7 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
     const VkAttachmentReference ref = {0, VK_IMAGE_LAYOUT_GENERAL};
     const VkSubpassDescription subpass = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 1, &ref, 1, &ref, nullptr, nullptr, 0, nullptr};
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attachment;
     rpci.subpassCount = 1;
@@ -159,7 +159,7 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
                        VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
     VkImageView image_view = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.renderPass = render_pass;
     fbci.attachmentCount = 1;
     fbci.pAttachments = &image_view;
@@ -168,13 +168,13 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
     fbci.layers = 1;
     vkt::Framebuffer framebuffer(*m_device, fbci);
 
-    auto render_pass_begin = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo render_pass_begin = vku::InitStructHelper();
     render_pass_begin.renderPass = render_pass;
     render_pass_begin.framebuffer = framebuffer;
     render_pass_begin.renderArea = VkRect2D{{0, 0}, {32, 32}};
 
     // VkImageMemoryBarrier
-    auto barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier barrier = vku::InitStructHelper();
     barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -191,7 +191,7 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
     // VkDependencyInfo with VkImageMemoryBarrier2
     const safe_VkImageMemoryBarrier2 safe_barrier2 = ConvertVkImageMemoryBarrierToV2(
         barrier, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
-    auto dependency_info = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
     dependency_info.dependencyFlags = 0;
     dependency_info.imageMemoryBarrierCount = 1;
     dependency_info.pImageMemoryBarriers = safe_barrier2.ptr();

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -251,7 +251,7 @@ TEST_F(NegativeSyncObject, Barriers) {
     const bool video_decode_queue = IsExtensionsEnabled(VK_KHR_VIDEO_DECODE_QUEUE_EXTENSION_NAME);
     const bool video_encode_queue = IsExtensionsEnabled(VK_KHR_VIDEO_ENCODE_QUEUE_EXTENSION_NAME);
 
-    auto separate_depth_stencil_layouts_features = vku::InitStruct<VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR>();
+    VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR separate_depth_stencil_layouts_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(separate_depth_stencil_layouts_features);
     if (separate_depth_stencil_layouts_features.separateDepthStencilLayouts != VK_TRUE) {
         GTEST_SKIP() << "separateDepthStencilLayouts feature not supported";
@@ -775,7 +775,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -826,7 +826,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     vk::CmdEndRenderPass(m_commandBuffer->handle());
 
     // Duplicate barriers that change layout
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier2KHR>();
+    VkImageMemoryBarrier2KHR img_barrier = vku::InitStructHelper();
     img_barrier.image = image.handle();
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     img_barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -843,7 +843,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     img_barrier.subresourceRange.levelCount = 1;
     VkImageMemoryBarrier2KHR img_barriers[2] = {img_barrier, img_barrier};
 
-    auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dep_info = vku::InitStructHelper();
     dep_info.imageMemoryBarrierCount = 2;
     dep_info.pImageMemoryBarriers = img_barriers;
     dep_info.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
@@ -1160,7 +1160,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
         GTEST_SKIP() << "No non-graphics queue supporting compute found";
     }
 
-    auto buf_barrier = vku::InitStruct<VkBufferMemoryBarrier2KHR>();
+    VkBufferMemoryBarrier2KHR buf_barrier = vku::InitStructHelper();
     buf_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     buf_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
     buf_barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
@@ -1247,7 +1247,7 @@ TEST_F(NegativeSyncObject, DepthStencilImageNonSeparateSync2) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2Features>();
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -1404,19 +1404,19 @@ TEST_F(NegativeSyncObject, BufferBarrierWithHostStage) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     sync2_features.synchronization2 = VK_TRUE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     vkt::Buffer buffer(*m_device, 32);
-    auto barrier = vku::InitStruct<VkBufferMemoryBarrier2>();
+    VkBufferMemoryBarrier2 barrier = vku::InitStructHelper();
     barrier.buffer = buffer.handle();
     barrier.size = VK_WHOLE_SIZE;
     // source and destination families should be equal if HOST stage is used
     barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     barrier.dstQueueFamilyIndex = 0;
 
-    auto dependency_info = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
     dependency_info.bufferMemoryBarrierCount = 1;
     dependency_info.pBufferMemoryBarriers = &barrier;
 
@@ -1450,13 +1450,13 @@ TEST_F(NegativeSyncObject, ImageBarrierWithHostStage) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     sync2_features.synchronization2 = VK_TRUE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     VkImageObj image(m_device);
     image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
-    auto barrier = vku::InitStruct<VkImageMemoryBarrier2>();
+    VkImageMemoryBarrier2 barrier = vku::InitStructHelper();
     barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
     barrier.image = image.handle();
@@ -1465,7 +1465,7 @@ TEST_F(NegativeSyncObject, ImageBarrierWithHostStage) {
     barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     barrier.dstQueueFamilyIndex = 0;
 
-    auto dependency_info = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
     dependency_info.imageMemoryBarrierCount = 1;
     dependency_info.pImageMemoryBarriers = &barrier;
 
@@ -1750,7 +1750,7 @@ TEST_F(NegativeSyncObject, Sync2BarrierQueueFamily) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -1814,7 +1814,7 @@ TEST_F(NegativeSyncObject, BarrierAccessSync2) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -2019,7 +2019,7 @@ TEST_F(NegativeSyncObject, BarrierAccessVideoDecode) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -2064,7 +2064,7 @@ TEST_F(NegativeSyncObject, Sync2LayoutFeature) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto features_13 = vku::InitStruct<VkPhysicalDeviceVulkan13Features>();
+    VkPhysicalDeviceVulkan13Features features_13 = vku::InitStructHelper();
     features_13.synchronization2 = VK_FALSE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features_13));
 
@@ -2075,7 +2075,7 @@ TEST_F(NegativeSyncObject, Sync2LayoutFeature) {
     image.init(&info);
 
     m_commandBuffer->begin();
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier2>();
+    VkImageMemoryBarrier2 img_barrier = vku::InitStructHelper();
     img_barrier.image = image.handle();
     img_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     img_barrier.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -2083,7 +2083,7 @@ TEST_F(NegativeSyncObject, Sync2LayoutFeature) {
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
     img_barrier.newLayout = VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL;
 
-    auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dep_info = vku::InitStructHelper();
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &img_barrier;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdPipelineBarrier2-synchronization2-03848");
@@ -2132,7 +2132,7 @@ TEST_F(NegativeSyncObject, QueueSubmitWaitingSameSemaphore) {
     AddOptionalExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
 
@@ -2145,12 +2145,12 @@ TEST_F(NegativeSyncObject, QueueSubmitWaitingSameSemaphore) {
     VkQueue other = m_device->graphics_queues()[1]->handle();
 
     {
-        auto signal_submit = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo signal_submit = vku::InitStructHelper();
         signal_submit.signalSemaphoreCount = 1;
         signal_submit.pSignalSemaphores = &semaphore.handle();
 
         VkPipelineStageFlags stage_flags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-        auto wait_submit = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo wait_submit = vku::InitStructHelper();
         wait_submit.waitSemaphoreCount = 1;
         wait_submit.pWaitSemaphores = &semaphore.handle();
         wait_submit.pWaitDstStageMask = &stage_flags;
@@ -2164,11 +2164,11 @@ TEST_F(NegativeSyncObject, QueueSubmitWaitingSameSemaphore) {
         vk::QueueWaitIdle(other);
     }
     if (m_device->queue_props[m_device->m_queue_obj->get_family_index()].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) {
-        auto signal_bind = vku::InitStruct<VkBindSparseInfo>();
+        VkBindSparseInfo signal_bind = vku::InitStructHelper();
         signal_bind.signalSemaphoreCount = 1;
         signal_bind.pSignalSemaphores = &semaphore.handle();
 
-        auto wait_bind = vku::InitStruct<VkBindSparseInfo>();
+        VkBindSparseInfo wait_bind = vku::InitStructHelper();
         wait_bind.waitSemaphoreCount = 1;
         wait_bind.pWaitSemaphores = &semaphore.handle();
 
@@ -2185,19 +2185,19 @@ TEST_F(NegativeSyncObject, QueueSubmitWaitingSameSemaphore) {
 
     // sync 2
     if (IsExtensionsEnabled(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
-        auto signal_sem_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+        VkSemaphoreSubmitInfo signal_sem_info = vku::InitStructHelper();
         signal_sem_info.semaphore = semaphore.handle();
         signal_sem_info.stageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
-        auto signal_submit = vku::InitStruct<VkSubmitInfo2>();
+        VkSubmitInfo2 signal_submit = vku::InitStructHelper();
         signal_submit.signalSemaphoreInfoCount = 1;
         signal_submit.pSignalSemaphoreInfos = &signal_sem_info;
 
-        auto wait_sem_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+        VkSemaphoreSubmitInfo wait_sem_info = vku::InitStructHelper();
         wait_sem_info.semaphore = semaphore.handle();
         wait_sem_info.stageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
-        auto wait_submit = vku::InitStruct<VkSubmitInfo2>();
+        VkSubmitInfo2 wait_submit = vku::InitStructHelper();
         wait_submit.waitSemaphoreInfoCount = 1;
         wait_submit.pWaitSemaphoreInfos = &wait_sem_info;
 
@@ -2224,7 +2224,7 @@ TEST_F(NegativeSyncObject, QueueSubmit2KHRUsedButSynchronizaion2Disabled) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo2KHR>();
+    VkSubmitInfo2KHR submit_info = vku::InitStructHelper();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkQueueSubmit2-synchronization2-03866");
     vk::QueueSubmit2KHR(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
@@ -2366,11 +2366,11 @@ TEST_F(NegativeSyncObject, MixedTimelineAndBinarySemaphores) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
-    auto timelineproperties = vku::InitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
+    VkPhysicalDeviceTimelineSemaphorePropertiesKHR timelineproperties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(timelineproperties);
 
     VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
@@ -2460,7 +2460,7 @@ TEST_F(NegativeSyncObject, QueueSubmitNoTimelineSemaphoreInfo) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
@@ -2512,21 +2512,21 @@ TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreValue) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
-    auto timelineproperties = vku::InitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
+    VkPhysicalDeviceTimelineSemaphorePropertiesKHR timelineproperties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(timelineproperties);
 
-    auto semaphore_type_create_info = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>();
+    VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
 
-    auto semaphore_create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_create_info);
+    VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper(&semaphore_type_create_info);
 
     vkt::Semaphore semaphore(*m_device, semaphore_create_info);
 
-    auto timeline_semaphore_submit_info = vku::InitStruct<VkTimelineSemaphoreSubmitInfoKHR>();
+    VkTimelineSemaphoreSubmitInfoKHR timeline_semaphore_submit_info = vku::InitStructHelper();
     uint64_t signalValue = 1;
     uint64_t waitValue = 3;
     timeline_semaphore_submit_info.signalSemaphoreValueCount = 1;
@@ -2535,7 +2535,7 @@ TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreValue) {
     timeline_semaphore_submit_info.pWaitSemaphoreValues = &waitValue;
 
     VkPipelineStageFlags stageFlags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-    auto submit_info = vku::InitStruct<VkSubmitInfo>(&timeline_semaphore_submit_info);
+    VkSubmitInfo submit_info = vku::InitStructHelper(&timeline_semaphore_submit_info);
     submit_info.signalSemaphoreCount = 1;
     submit_info.pSignalSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &stageFlags;
@@ -2556,7 +2556,7 @@ TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreValue) {
 
     signalValue = 5;
     {
-        auto semaphore_signal_info = vku::InitStruct<VkSemaphoreSignalInfo>();
+        VkSemaphoreSignalInfo semaphore_signal_info = vku::InitStructHelper();
         semaphore_signal_info.semaphore = semaphore.handle();
         semaphore_signal_info.value = signalValue;
         ASSERT_VK_SUCCESS(vk::SignalSemaphoreKHR(m_device->device(), &semaphore_signal_info));
@@ -2585,11 +2585,11 @@ TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreValue) {
         uint64_t signal_values[2] = {signalValue, signalValue};
         VkSemaphore signal_sems[2] = {semaphore.handle(), semaphore.handle()};
 
-        auto tl_info_2 = vku::InitStruct<VkTimelineSemaphoreSubmitInfoKHR>();
+        VkTimelineSemaphoreSubmitInfoKHR tl_info_2 = vku::InitStructHelper();
         tl_info_2.signalSemaphoreValueCount = 2;
         tl_info_2.pSignalSemaphoreValues = signal_values;
 
-        auto submit_info2 = vku::InitStruct<VkSubmitInfo>(&tl_info_2);
+        VkSubmitInfo submit_info2 = vku::InitStructHelper(&tl_info_2);
         submit_info2.signalSemaphoreCount = 2;
         submit_info2.pSignalSemaphores = signal_sems;
 
@@ -2634,7 +2634,7 @@ TEST_F(NegativeSyncObject, QueueBindSparseTimelineSemaphoreValue) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
@@ -2643,17 +2643,17 @@ TEST_F(NegativeSyncObject, QueueBindSparseTimelineSemaphoreValue) {
         GTEST_SKIP() << "Sparse binding not supported, skipping test";
     }
 
-    auto timelineproperties = vku::InitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
+    VkPhysicalDeviceTimelineSemaphorePropertiesKHR timelineproperties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(timelineproperties);
 
-    auto semaphore_type_create_info = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>();
+    VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
 
-    auto semaphore_create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_create_info);
+    VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper(&semaphore_type_create_info);
 
     vkt::Semaphore semaphore(*m_device, semaphore_create_info);
 
-    auto timeline_semaphore_submit_info = vku::InitStruct<VkTimelineSemaphoreSubmitInfoKHR>();
+    VkTimelineSemaphoreSubmitInfoKHR timeline_semaphore_submit_info = vku::InitStructHelper();
     uint64_t signalValue = 1;
     uint64_t waitValue = 3;
     timeline_semaphore_submit_info.signalSemaphoreValueCount = 1;
@@ -2661,7 +2661,7 @@ TEST_F(NegativeSyncObject, QueueBindSparseTimelineSemaphoreValue) {
     timeline_semaphore_submit_info.waitSemaphoreValueCount = 1;
     timeline_semaphore_submit_info.pWaitSemaphoreValues = &waitValue;
 
-    auto submit_info = vku::InitStruct<VkBindSparseInfo>();
+    VkBindSparseInfo submit_info = vku::InitStructHelper();
     submit_info.signalSemaphoreCount = 1;
     submit_info.pSignalSemaphores = &semaphore.handle();
     submit_info.waitSemaphoreCount = 1;
@@ -2691,7 +2691,7 @@ TEST_F(NegativeSyncObject, QueueBindSparseTimelineSemaphoreValue) {
 
     signalValue = 5;
     {
-        auto semaphore_signal_info = vku::InitStruct<VkSemaphoreSignalInfo>();
+        VkSemaphoreSignalInfo semaphore_signal_info = vku::InitStructHelper();
         semaphore_signal_info.semaphore = semaphore.handle();
         semaphore_signal_info.value = signalValue;
         ASSERT_VK_SUCCESS(vk::SignalSemaphoreKHR(m_device->device(), &semaphore_signal_info));
@@ -2721,11 +2721,11 @@ TEST_F(NegativeSyncObject, QueueBindSparseTimelineSemaphoreValue) {
         uint64_t signal_values[2] = {signalValue, signalValue};
         VkSemaphore signal_sems[2] = {semaphore.handle(), semaphore.handle()};
 
-        auto tl_info_2 = vku::InitStruct<VkTimelineSemaphoreSubmitInfoKHR>();
+        VkTimelineSemaphoreSubmitInfoKHR tl_info_2 = vku::InitStructHelper();
         tl_info_2.signalSemaphoreValueCount = 2;
         tl_info_2.pSignalSemaphoreValues = signal_values;
 
-        auto submit_info2 = vku::InitStruct<VkBindSparseInfo>(&tl_info_2);
+        VkBindSparseInfo submit_info2 = vku::InitStructHelper(&tl_info_2);
         submit_info2.signalSemaphoreCount = 2;
         submit_info2.pSignalSemaphores = signal_sems;
 
@@ -2772,28 +2772,28 @@ TEST_F(NegativeSyncObject, Sync2QueueSubmitTimelineSemaphoreValue) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto vk12_features = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&vk12_features);
+    VkPhysicalDeviceVulkan12Features vk12_features = vku::InitStructHelper();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper(&vk12_features);
     GetPhysicalDeviceFeatures2(sync2_features);
     InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
 
-    auto timelineproperties = vku::InitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
+    VkPhysicalDeviceTimelineSemaphorePropertiesKHR timelineproperties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(timelineproperties);
 
-    auto semaphore_type_create_info = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>();
+    VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
     semaphore_type_create_info.initialValue = 5;
 
-    auto semaphore_create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_create_info);
+    VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper(&semaphore_type_create_info);
 
     vkt::Semaphore semaphore(*m_device, semaphore_create_info);
 
-    auto signal_sem_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+    VkSemaphoreSubmitInfo signal_sem_info = vku::InitStructHelper();
     signal_sem_info.value = semaphore_type_create_info.initialValue;
     signal_sem_info.semaphore = semaphore.handle();
     signal_sem_info.stageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo2>();
+    VkSubmitInfo2 submit_info = vku::InitStructHelper();
     submit_info.signalSemaphoreInfoCount = 1;
     submit_info.pSignalSemaphoreInfos = &signal_sem_info;
 
@@ -2840,7 +2840,7 @@ TEST_F(NegativeSyncObject, Sync2QueueSubmitTimelineSemaphoreValue) {
         m_errorMonitor->VerifyFound();
 
         if (signal_sem_info.value < vvl::kU64Max) {
-            auto wait_sem_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+            VkSemaphoreSubmitInfo wait_sem_info = vku::InitStructHelper();
             wait_sem_info.semaphore = semaphore.handle();
             wait_sem_info.value = signal_sem_info.value + 1;
             wait_sem_info.stageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
@@ -2867,12 +2867,12 @@ TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    auto timeline_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>();
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&timeline_features);
+    VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_features = vku::InitStructHelper();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper(&timeline_features);
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
 
-    auto semaphore_create_info = vku::InitStruct<VkSemaphoreCreateInfo>();
+    VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper();
     // VUIDs reported change if the extension is enabled, even if the timelineSemaphore feature isn't supported.
 
     {
@@ -3004,7 +3004,7 @@ TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreOutOfOrder) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
@@ -3048,7 +3048,7 @@ TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreOutOfOrder) {
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     timeline_semaphore_features.timelineSemaphore = true;
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&timeline_semaphore_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&timeline_semaphore_features);
     dev_info.pNext = &features2;
 
     VkDevice dev;
@@ -3104,7 +3104,7 @@ TEST_F(NegativeSyncObject, WaitSemaphoresType) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
@@ -3143,7 +3143,7 @@ TEST_F(NegativeSyncObject, SignalSemaphoreType) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>();
+    VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
@@ -3167,11 +3167,11 @@ TEST_F(NegativeSyncObject, SignalSemaphoreValue) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
-    auto timelineproperties = vku::InitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
+    VkPhysicalDeviceTimelineSemaphorePropertiesKHR timelineproperties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(timelineproperties);
 
     VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
@@ -3301,37 +3301,37 @@ TEST_F(NegativeSyncObject, Sync2SignalSemaphoreValue) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto vk12_features = vku::InitStruct<VkPhysicalDeviceVulkan12Features>();
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>(&vk12_features);
+    VkPhysicalDeviceVulkan12Features vk12_features = vku::InitStructHelper();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper(&vk12_features);
     GetPhysicalDeviceFeatures2(sync2_features);
     InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
 
-    auto timelineproperties = vku::InitStruct<VkPhysicalDeviceTimelineSemaphorePropertiesKHR>();
+    VkPhysicalDeviceTimelineSemaphorePropertiesKHR timelineproperties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(timelineproperties);
 
-    auto semaphore_type_create_info = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>();
+    VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
     semaphore_type_create_info.initialValue = 5;
 
-    auto semaphore_create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_create_info);
+    VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper(&semaphore_type_create_info);
 
     vkt::Semaphore semaphore[2];
     semaphore[0].init(*m_device, semaphore_create_info);
     semaphore[1].init(*m_device, semaphore_create_info);
 
-    auto semaphore_signal_info = vku::InitStruct<VkSemaphoreSignalInfo>();
+    VkSemaphoreSignalInfo semaphore_signal_info = vku::InitStructHelper();
     semaphore_signal_info.semaphore = semaphore[0].handle();
     semaphore_signal_info.value = 10;
     ASSERT_VK_SUCCESS(vk::SignalSemaphore(m_device->device(), &semaphore_signal_info));
 
-    auto signal_info = vku::InitStruct<VkSemaphoreSubmitInfoKHR>();
+    VkSemaphoreSubmitInfoKHR signal_info = vku::InitStructHelper();
     signal_info.semaphore = semaphore[0].handle();
 
-    auto wait_info = vku::InitStruct<VkSemaphoreSubmitInfoKHR>();
+    VkSemaphoreSubmitInfoKHR wait_info = vku::InitStructHelper();
     wait_info.semaphore = semaphore[0].handle();
     wait_info.stageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo2KHR>();
+    VkSubmitInfo2KHR submit_info = vku::InitStructHelper();
     submit_info.signalSemaphoreInfoCount = 1;
     submit_info.pSignalSemaphoreInfos = &signal_info;
     submit_info.waitSemaphoreInfoCount = 1;
@@ -3402,7 +3402,7 @@ TEST_F(NegativeSyncObject, SemaphoreCounterType) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto timelinefeatures = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>();
+    VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timelinefeatures = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timelinefeatures);
     ASSERT_NO_FATAL_FAILURE(InitState());
 
@@ -3560,7 +3560,7 @@ TEST_F(NegativeSyncObject, PipelineStageConditionalRenderingWithWrongQueue) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto cond_rendering_feature = vku::InitStruct<VkPhysicalDeviceConditionalRenderingFeaturesEXT>();
+    VkPhysicalDeviceConditionalRenderingFeaturesEXT cond_rendering_feature = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(cond_rendering_feature);
     if (cond_rendering_feature.conditionalRendering == VK_FALSE) {
         GTEST_SKIP() << "conditionalRendering feature not supported";

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -26,7 +26,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersImage) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -76,7 +76,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -745,7 +745,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithTimelineSemaphoreAnd
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -1229,9 +1229,9 @@ TEST_F(PositiveSyncObject, ExternalSemaphore) {
     VkResult err;
 
     // Create a semaphore to export payload from
-    auto esci = vku::InitStruct<VkExportSemaphoreCreateInfoKHR>();
+    VkExportSemaphoreCreateInfoKHR esci = vku::InitStructHelper();
     esci.handleTypes = handle_type;
-    auto sci = vku::InitStruct<VkSemaphoreCreateInfo>(&esci);
+    VkSemaphoreCreateInfo sci = vku::InitStructHelper(&esci);
 
     vkt::Semaphore export_semaphore(*m_device, sci);
 
@@ -1301,18 +1301,18 @@ TEST_F(PositiveSyncObject, ExternalTimelineSemaphore) {
     if (IsPlatform(kMockICD)) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     // Check for external semaphore import and export capability
-    auto tci = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>();
+    VkSemaphoreTypeCreateInfoKHR tci = vku::InitStructHelper();
     tci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
 
-    auto esi = vku::InitStruct<VkPhysicalDeviceExternalSemaphoreInfoKHR>(&tci);
+    VkPhysicalDeviceExternalSemaphoreInfoKHR esi = vku::InitStructHelper(&tci);
     esi.handleType = handle_type;
 
-    auto esp = vku::InitStruct<VkExternalSemaphorePropertiesKHR>();
+    VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
 
     vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
 
@@ -1323,11 +1323,11 @@ TEST_F(PositiveSyncObject, ExternalTimelineSemaphore) {
     VkResult err;
 
     // Create a semaphore to export payload from
-    auto esci = vku::InitStruct<VkExportSemaphoreCreateInfoKHR>();
+    VkExportSemaphoreCreateInfoKHR esci = vku::InitStructHelper();
     esci.handleTypes = handle_type;
-    auto stci = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>(&esci);
+    VkSemaphoreTypeCreateInfoKHR stci = vku::InitStructHelper(&esci);
     stci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
-    auto sci = vku::InitStruct<VkSemaphoreCreateInfo>(&stci);
+    VkSemaphoreCreateInfo sci = vku::InitStructHelper(&stci);
 
     vkt::Semaphore export_semaphore(*m_device, sci);
 
@@ -1398,9 +1398,9 @@ TEST_F(PositiveSyncObject, ExternalFence) {
     }
 
     // Check for external fence import and export capability
-    auto efi = vku::InitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
+    VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
-    auto efp = vku::InitStruct<VkExternalFencePropertiesKHR>();
+    VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1411,9 +1411,9 @@ TEST_F(PositiveSyncObject, ExternalFence) {
     VkResult err;
 
     // Create a fence to export payload from
-    auto efci = vku::InitStruct<VkExportFenceCreateInfoKHR>();
+    VkExportFenceCreateInfoKHR efci = vku::InitStructHelper();
     efci.handleTypes = handle_type;
-    auto fci = vku::InitStruct<VkFenceCreateInfo>(&efci);
+    VkFenceCreateInfo fci = vku::InitStructHelper(&efci);
     vkt::Fence export_fence(*m_device, fci);
 
     // Create a fence to import payload into
@@ -1462,9 +1462,9 @@ TEST_F(PositiveSyncObject, ExternalFenceSyncFdLoop) {
     }
 
     // Check for external fence import and export capability
-    auto efi = vku::InitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
+    VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
-    auto efp = vku::InitStruct<VkExternalFencePropertiesKHR>();
+    VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
@@ -1476,9 +1476,9 @@ TEST_F(PositiveSyncObject, ExternalFenceSyncFdLoop) {
     VkResult err;
 
     // Create a fence to export payload from
-    auto efci = vku::InitStruct<VkExportFenceCreateInfoKHR>();
+    VkExportFenceCreateInfoKHR efci = vku::InitStructHelper();
     efci.handleTypes = handle_type;
-    auto fci = vku::InitStruct<VkFenceCreateInfo>(&efci);
+    VkFenceCreateInfo fci = vku::InitStructHelper(&efci);
     vkt::Fence export_fence(*m_device, fci);
 
     fci.pNext = nullptr;
@@ -1527,9 +1527,9 @@ TEST_F(PositiveSyncObject, ExternalFenceSubmitCmdBuffer) {
     }
 
     // Check for external fence export capability
-    auto efi = vku::InitStruct<VkPhysicalDeviceExternalFenceInfoKHR>();
+    VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
-    auto efp = vku::InitStruct<VkExternalFencePropertiesKHR>();
+    VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR)) {
@@ -1540,16 +1540,16 @@ TEST_F(PositiveSyncObject, ExternalFenceSubmitCmdBuffer) {
     VkResult err;
 
     // Create a fence to export payload from
-    auto efci = vku::InitStruct<VkExportFenceCreateInfoKHR>();
+    VkExportFenceCreateInfoKHR efci = vku::InitStructHelper();
     efci.handleTypes = handle_type;
-    auto fci = vku::InitStruct<VkFenceCreateInfo>(&efci);
+    VkFenceCreateInfo fci = vku::InitStructHelper(&efci);
     vkt::Fence export_fence(*m_device, fci);
 
     for (uint32_t i = 0; i < 1000; i++) {
         m_commandBuffer->begin();
         m_commandBuffer->end();
 
-        auto submit_info = vku::InitStruct<VkSubmitInfo>();
+        VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.commandBufferCount = 1;
         submit_info.pCommandBuffers = &m_commandBuffer->handle();
         err = vk::QueueSubmit(m_device->m_queue, 1, &submit_info, export_fence.handle());
@@ -1698,7 +1698,7 @@ TEST_F(PositiveSyncObject, QueueSubmitTimelineSemaphore2Queue) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -1747,10 +1747,10 @@ TEST_F(PositiveSyncObject, QueueSubmitTimelineSemaphore2Queue) {
     vk::CmdCopyBuffer(cb1.handle(), buffer_c.handle(), buffer_b.handle(), 1, &region);
     cb1.end();
 
-    auto semaphore_type_create_info = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>();
+    VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
 
-    auto semaphore_create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_create_info);
+    VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper(&semaphore_type_create_info);
     vkt::Semaphore semaphore(*m_device, semaphore_create_info);
 
     // timeline values, Begins will be signaled by host, Ends by the queues
@@ -1762,14 +1762,14 @@ TEST_F(PositiveSyncObject, QueueSubmitTimelineSemaphore2Queue) {
     uint64_t submit_wait_value = kQ0Begin;
     uint64_t submit_signal_value = kQ0End;
 
-    auto timeline_semaphore_submit_info = vku::InitStruct<VkTimelineSemaphoreSubmitInfoKHR>();
+    VkTimelineSemaphoreSubmitInfoKHR timeline_semaphore_submit_info = vku::InitStructHelper();
     timeline_semaphore_submit_info.waitSemaphoreValueCount = 1;
     timeline_semaphore_submit_info.pWaitSemaphoreValues = &submit_wait_value;
     timeline_semaphore_submit_info.signalSemaphoreValueCount = 1;
     timeline_semaphore_submit_info.pSignalSemaphoreValues = &submit_signal_value;
 
     VkPipelineStageFlags stageFlags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-    auto submit_info = vku::InitStruct<VkSubmitInfo>(&timeline_semaphore_submit_info);
+    VkSubmitInfo submit_info = vku::InitStructHelper(&timeline_semaphore_submit_info);
     submit_info.pWaitDstStageMask = &stageFlags;
     submit_info.signalSemaphoreCount = 1;
     submit_info.pSignalSemaphores = &semaphore.handle();
@@ -1788,14 +1788,14 @@ TEST_F(PositiveSyncObject, QueueSubmitTimelineSemaphore2Queue) {
     vk::QueueSubmit(q1->handle(), 1, &submit_info, VK_NULL_HANDLE);
 
     // signal semaphore to allow q0 to proceed
-    auto signal_info = vku::InitStruct<VkSemaphoreSignalInfo>();
+    VkSemaphoreSignalInfo signal_info = vku::InitStructHelper();
     signal_info.semaphore = semaphore.handle();
     signal_info.value = kQ0Begin;
     vk::SignalSemaphoreKHR(m_device->device(), &signal_info);
 
     // buffer_a is only used by the q0 commands
     uint64_t wait_info_value = kQ0End;
-    auto wait_info = vku::InitStruct<VkSemaphoreWaitInfo>();
+    VkSemaphoreWaitInfo wait_info = vku::InitStructHelper();
     wait_info.semaphoreCount = 1;
     wait_info.pSemaphores = &semaphore.handle();
     wait_info.pValues = &wait_info_value;
@@ -1904,7 +1904,7 @@ struct FenceSemRaceData {
 
 void WaitTimelineSem(FenceSemRaceData *data) {
     uint64_t wait_value = data->wait_value;
-    auto wait_info = vku::InitStruct<VkSemaphoreWaitInfo>();
+    VkSemaphoreWaitInfo wait_info = vku::InitStructHelper();
     wait_info.semaphoreCount = 1;
     wait_info.pSemaphores = &data->sem;
     wait_info.pValues = &wait_value;
@@ -1927,28 +1927,28 @@ TEST_F(PositiveSyncObject, FenceSemThreadRace) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
-    auto fence_ci = vku::InitStruct<VkFenceCreateInfo>();
+    VkFenceCreateInfo fence_ci = vku::InitStructHelper();
     vkt::Fence fence(*m_device, fence_ci);
     auto fence_handle = fence.handle();
 
-    auto timeline_ci = vku::InitStruct<VkSemaphoreTypeCreateInfo>();
+    VkSemaphoreTypeCreateInfo timeline_ci = vku::InitStructHelper();
     timeline_ci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
     timeline_ci.initialValue = 0;
 
-    auto sem_ci = vku::InitStruct<VkSemaphoreCreateInfo>(&timeline_ci);
+    VkSemaphoreCreateInfo sem_ci = vku::InitStructHelper(&timeline_ci);
     vkt::Semaphore sem(*m_device, sem_ci);
     auto sem_handle = sem.handle();
 
     uint64_t signal_value = 1;
-    auto timeline_info = vku::InitStruct<VkTimelineSemaphoreSubmitInfo>();
+    VkTimelineSemaphoreSubmitInfo timeline_info = vku::InitStructHelper();
     timeline_info.signalSemaphoreValueCount = 1;
     timeline_info.pSignalSemaphoreValues = &signal_value;
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>(&timeline_info);
+    VkSubmitInfo submit_info = vku::InitStructHelper(&timeline_info);
     submit_info.signalSemaphoreCount = 1;
     submit_info.pSignalSemaphores = &sem_handle;
 
@@ -1994,19 +1994,19 @@ TEST_F(PositiveSyncObject, SubmitFenceButWaitIdle) {
     std::vector<VkImage> swapchainImages(image_count, VK_NULL_HANDLE);
     vk::GetSwapchainImagesKHR(m_device->handle(), m_swapchain, &image_count, swapchainImages.data());
 
-    auto fence_create_info = vku::InitStruct<VkFenceCreateInfo>();
+    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
     vkt::Fence fence(*m_device, fence_create_info);
 
     vkt::Semaphore sem(*m_device);
 
-    auto pool_create_info = vku::InitStruct<VkCommandPoolCreateInfo>();
+    VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
     pool_create_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     std::optional<vkt::CommandPool> command_pool(vvl::in_place, *m_device, pool_create_info);
 
     // create a raw command buffer because we'll just the destroy the pool.
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
-    auto alloc_info = vku::InitStruct<VkCommandBufferAllocateInfo>();
+    VkCommandBufferAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.commandPool = command_pool->handle();
     alloc_info.commandBufferCount = 1;
     alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -2017,7 +2017,7 @@ TEST_F(PositiveSyncObject, SubmitFenceButWaitIdle) {
     err = vk::AcquireNextImageKHR(m_device->handle(), m_swapchain, kWaitTimeout, sem.handle(), VK_NULL_HANDLE, &image_index);
     ASSERT_VK_SUCCESS(err);
 
-    auto begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     err = vk::BeginCommandBuffer(command_buffer, &begin_info);
     ASSERT_VK_SUCCESS(err);
 
@@ -2035,7 +2035,7 @@ TEST_F(PositiveSyncObject, SubmitFenceButWaitIdle) {
     err = vk::EndCommandBuffer(command_buffer);
     ASSERT_VK_SUCCESS(err);
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &command_buffer;
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, fence.handle());
@@ -2047,11 +2047,11 @@ TEST_F(PositiveSyncObject, SubmitFenceButWaitIdle) {
 
 struct SemBufferRaceData {
     SemBufferRaceData(VkDeviceObj &dev_) : dev(dev_) {
-        auto timeline_ci = vku::InitStruct<VkSemaphoreTypeCreateInfo>();
+        VkSemaphoreTypeCreateInfo timeline_ci = vku::InitStructHelper();
         timeline_ci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
         timeline_ci.initialValue = 0;
 
-        auto sem_ci = vku::InitStruct<VkSemaphoreCreateInfo>(&timeline_ci);
+        VkSemaphoreCreateInfo sem_ci = vku::InitStructHelper(&timeline_ci);
         sem.init(dev, sem_ci);
     }
 
@@ -2067,7 +2067,7 @@ struct SemBufferRaceData {
     virtual VkResult Wait(uint64_t sem_value) = 0;
 
     virtual VkResult Signal(uint64_t sem_value) {
-        auto signal_info = vku::InitStruct<VkSemaphoreSignalInfo>();
+        VkSemaphoreSignalInfo signal_info = vku::InitStructHelper();
         signal_info.semaphore = sem.handle();
         signal_info.value = sem_value;
         return vk::SignalSemaphoreKHR(dev.handle(), &signal_info);
@@ -2095,14 +2095,14 @@ struct SemBufferRaceData {
 
     void Run(vkt::CommandPool &command_pool, ErrorMonitor &error_mon) {
         uint64_t gpu_wait_value, gpu_signal_value;
-        auto timeline_info = vku::InitStruct<VkTimelineSemaphoreSubmitInfo>();
+        VkTimelineSemaphoreSubmitInfo timeline_info = vku::InitStructHelper();
         timeline_info.waitSemaphoreValueCount = 1;
         timeline_info.pWaitSemaphoreValues = &gpu_wait_value;
         timeline_info.signalSemaphoreValueCount = 1;
         timeline_info.pSignalSemaphoreValues = &gpu_signal_value;
 
         VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-        auto submit_info = vku::InitStruct<VkSubmitInfo>(&timeline_info);
+        VkSubmitInfo submit_info = vku::InitStructHelper(&timeline_info);
         submit_info.waitSemaphoreCount = 1;
         submit_info.pWaitSemaphores = &sem.handle();
         submit_info.pWaitDstStageMask = &wait_stage;
@@ -2164,7 +2164,7 @@ struct WaitTimelineSemThreadData : public SemBufferRaceData {
     WaitTimelineSemThreadData(VkDeviceObj &dev_) : SemBufferRaceData(dev_) {}
 
     VkResult Wait(uint64_t sem_value) {
-        auto wait_info = vku::InitStruct<VkSemaphoreWaitInfo>();
+        VkSemaphoreWaitInfo wait_info = vku::InitStructHelper();
         wait_info.semaphoreCount = 1;
         wait_info.pSemaphores = &sem.handle();
         wait_info.pValues = &sem_value;
@@ -2180,7 +2180,7 @@ TEST_F(PositiveSyncObject, WaitTimelineSemThreadRace) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     WaitTimelineSemThreadData data(*m_device);
@@ -2208,7 +2208,7 @@ TEST_F(PositiveSyncObject, WaitTimelineSemaphoreWithWin32HandleRetrieved) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
@@ -2217,14 +2217,14 @@ TEST_F(PositiveSyncObject, WaitTimelineSemaphoreWithWin32HandleRetrieved) {
     }
 
     // Create exportable timeline semaphore
-    auto semaphore_type_create_info = vku::InitStruct<VkSemaphoreTypeCreateInfo>();
+    VkSemaphoreTypeCreateInfo semaphore_type_create_info = vku::InitStructHelper();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
     semaphore_type_create_info.initialValue = 0;
 
-    auto export_info = vku::InitStruct<VkExportSemaphoreCreateInfo>(&semaphore_type_create_info);
+    VkExportSemaphoreCreateInfo export_info = vku::InitStructHelper(&semaphore_type_create_info);
     export_info.handleTypes = handle_type;
 
-    const auto create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&export_info);
+    const VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&export_info);
     vkt::Semaphore semaphore(*m_device, create_info);
 
     // This caused original issue: exported semaphore failed to retire queue operations.
@@ -2233,17 +2233,17 @@ TEST_F(PositiveSyncObject, WaitTimelineSemaphoreWithWin32HandleRetrieved) {
 
     // Put semaphore to work
     const uint64_t signal_value = 1;
-    auto timeline_submit_info = vku::InitStruct<VkTimelineSemaphoreSubmitInfo>();
+    VkTimelineSemaphoreSubmitInfo timeline_submit_info = vku::InitStructHelper();
     timeline_submit_info.signalSemaphoreValueCount = 1;
     timeline_submit_info.pSignalSemaphoreValues = &signal_value;
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>(&timeline_submit_info);
+    VkSubmitInfo submit_info = vku::InitStructHelper(&timeline_submit_info);
     submit_info.signalSemaphoreCount = 1;
     submit_info.pSignalSemaphores = &semaphore.handle();
     ASSERT_VK_SUCCESS(vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE));
 
     // This wait (with exported semaphore) should properly retire all queue operations
-    auto wait_info = vku::InitStruct<VkSemaphoreWaitInfo>();
+    VkSemaphoreWaitInfo wait_info = vku::InitStructHelper();
     wait_info.semaphoreCount = 1;
     wait_info.pSemaphores = &semaphore.handle();
     wait_info.pValues = &signal_value;
@@ -2268,14 +2268,14 @@ TEST_F(PositiveSyncObject, SubpassBarrierWithExpandableStages) {
     subpass_dependency.srcAccessMask = VK_ACCESS_INDEX_READ_BIT;
     subpass_dependency.dstAccessMask = VK_ACCESS_INDEX_READ_BIT;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.dependencyCount = 1;
     rpci.pDependencies = &subpass_dependency;
     const vkt::RenderPass rp(*m_device, rpci);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.renderPass = rp;
     fbci.width = m_width;
     fbci.height = m_height;
@@ -2285,7 +2285,7 @@ TEST_F(PositiveSyncObject, SubpassBarrierWithExpandableStages) {
     m_renderPassBeginInfo.renderPass = rp;
     m_renderPassBeginInfo.framebuffer = fb;
 
-    auto barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier barrier = vku::InitStructHelper();
     barrier.srcAccessMask = VK_ACCESS_INDEX_READ_BIT;
     barrier.dstAccessMask = VK_ACCESS_INDEX_READ_BIT;
 
@@ -2309,13 +2309,13 @@ TEST_F(PositiveSyncObject, BarrierWithHostStage) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     sync2_features.synchronization2 = VK_TRUE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     // HOST stage as source
     vkt::Buffer buffer(*m_device, 32);
-    auto buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier2>();
+    VkBufferMemoryBarrier2 buffer_barrier = vku::InitStructHelper();
     buffer_barrier.srcStageMask = VK_PIPELINE_STAGE_2_HOST_BIT;
     buffer_barrier.srcAccessMask = VK_ACCESS_2_HOST_WRITE_BIT;
     buffer_barrier.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
@@ -2325,7 +2325,7 @@ TEST_F(PositiveSyncObject, BarrierWithHostStage) {
     buffer_barrier.buffer = buffer.handle();
     buffer_barrier.size = VK_WHOLE_SIZE;
 
-    auto buffer_dependency = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo buffer_dependency = vku::InitStructHelper();
     buffer_dependency.bufferMemoryBarrierCount = 1;
     buffer_dependency.pBufferMemoryBarriers = &buffer_barrier;
 
@@ -2336,7 +2336,7 @@ TEST_F(PositiveSyncObject, BarrierWithHostStage) {
     // HOST stage as destination
     VkImageObj image(m_device);
     image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier2>();
+    VkImageMemoryBarrier2 image_barrier = vku::InitStructHelper();
     image_barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
     image_barrier.srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT;
     image_barrier.dstStageMask = VK_PIPELINE_STAGE_2_HOST_BIT;
@@ -2348,7 +2348,7 @@ TEST_F(PositiveSyncObject, BarrierWithHostStage) {
     image_barrier.image = image.handle();
     image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    auto image_dependency = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo image_dependency = vku::InitStructHelper();
     image_dependency.imageMemoryBarrierCount = 1;
     image_dependency.pImageMemoryBarriers = &image_barrier;
 

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -46,7 +46,7 @@ TEST_F(NegativeSyncVal, BufferCopyHazards) {
     m_errorMonitor->VerifyFound();
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
-    auto buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+    VkBufferMemoryBarrier buffer_barrier = vku::InitStructHelper();
     buffer_barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
     buffer_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     buffer_barrier.buffer = buffer_a.handle();
@@ -70,7 +70,7 @@ TEST_F(NegativeSyncVal, BufferCopyHazards) {
     //       record the write operation to b.  So we'll need to repeat it successfully to set up for the *next* test.
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
-    auto mem_barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier mem_barrier = vku::InitStructHelper();
     mem_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     mem_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     vk::CmdPipelineBarrier(cb, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 1, &mem_barrier, 0, nullptr, 0,
@@ -211,7 +211,7 @@ TEST_F(NegativeSyncVal, BufferCopyHazardsSync2) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -237,7 +237,7 @@ TEST_F(NegativeSyncVal, BufferCopyHazardsSync2) {
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
     {
-        auto buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier2KHR>();
+        VkBufferMemoryBarrier2KHR buffer_barrier = vku::InitStructHelper();
         buffer_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
         buffer_barrier.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
         buffer_barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT_KHR;
@@ -245,7 +245,7 @@ TEST_F(NegativeSyncVal, BufferCopyHazardsSync2) {
         buffer_barrier.buffer = buffer_a.handle();
         buffer_barrier.offset = 0;
         buffer_barrier.size = 256;
-        auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+        VkDependencyInfoKHR dep_info = vku::InitStructHelper();
         dep_info.bufferMemoryBarrierCount = 1;
         dep_info.pBufferMemoryBarriers = &buffer_barrier;
         vk::CmdPipelineBarrier2KHR(cb, &dep_info);
@@ -267,12 +267,12 @@ TEST_F(NegativeSyncVal, BufferCopyHazardsSync2) {
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
     {
-        auto mem_barrier = vku::InitStruct<VkMemoryBarrier2KHR>();
+        VkMemoryBarrier2KHR mem_barrier = vku::InitStructHelper();
         mem_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
         mem_barrier.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
         mem_barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR;
         mem_barrier.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT_KHR;
-        auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+        VkDependencyInfoKHR dep_info = vku::InitStructHelper();
         dep_info.memoryBarrierCount = 1;
         dep_info.pMemoryBarriers = &mem_barrier;
         vk::CmdPipelineBarrier2KHR(cb, &dep_info);
@@ -354,14 +354,14 @@ TEST_F(NegativeSyncVal, CmdClearAttachmentsHazards) {
     subpass.pColorAttachments = &color_ref;
     subpass.pDepthStencilAttachment = &depth_ref;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = size32(attachments);
     rpci.pAttachments = attachments;
     vkt::RenderPass render_pass(*m_device, rpci);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.flags = 0;
     fbci.renderPass = render_pass;
     fbci.attachmentCount = size32(views);
@@ -371,13 +371,13 @@ TEST_F(NegativeSyncVal, CmdClearAttachmentsHazards) {
     fbci.layers = 1;
     vkt::Framebuffer framebuffer(*m_device, fbci);
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer;
     rpbi.renderPass = render_pass;
     rpbi.renderArea.extent.width = width;
     rpbi.renderArea.extent.height = height;
 
-    const auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    const VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.renderPass = render_pass;
     pipe.gp_ci_.pDepthStencilState = &ds_ci;
@@ -580,7 +580,7 @@ TEST_F(NegativeSyncVal, CopyOptimalImageHazards) {
     m_errorMonitor->VerifyFound();
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
     image_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     image_barrier.image = image_a.handle();
@@ -605,7 +605,7 @@ TEST_F(NegativeSyncVal, CopyOptimalImageHazards) {
     //       record the write operation to b.  So we'll need to repeat it successfully to set up for the *next* test.
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
-    auto mem_barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier mem_barrier = vku::InitStructHelper();
     mem_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     mem_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     vk::CmdPipelineBarrier(cb, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 1, &mem_barrier, 0, nullptr, 0,
@@ -749,7 +749,7 @@ TEST_F(NegativeSyncVal, CopyOptimalImageHazardsSync2) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -800,7 +800,7 @@ TEST_F(NegativeSyncVal, CopyOptimalImageHazardsSync2) {
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
     {
-        auto image_barrier = vku::InitStruct<VkImageMemoryBarrier2KHR>();
+        VkImageMemoryBarrier2KHR image_barrier = vku::InitStructHelper();
         image_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
         image_barrier.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
         image_barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT_KHR;
@@ -809,7 +809,7 @@ TEST_F(NegativeSyncVal, CopyOptimalImageHazardsSync2) {
         image_barrier.subresourceRange = full_subresource_range;
         image_barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
         image_barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-        auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+        VkDependencyInfoKHR dep_info = vku::InitStructHelper();
         dep_info.imageMemoryBarrierCount = 1;
         dep_info.pImageMemoryBarriers = &image_barrier;
         vk::CmdPipelineBarrier2KHR(cb, &dep_info);
@@ -831,12 +831,12 @@ TEST_F(NegativeSyncVal, CopyOptimalImageHazardsSync2) {
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
     {
-        auto mem_barrier = vku::InitStruct<VkMemoryBarrier2KHR>();
+        VkMemoryBarrier2KHR mem_barrier = vku::InitStructHelper();
         mem_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
         mem_barrier.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT_KHR;
         mem_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         mem_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-        auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+        VkDependencyInfoKHR dep_info = vku::InitStructHelper();
         dep_info.memoryBarrierCount = 1;
         dep_info.pMemoryBarriers = &mem_barrier;
         vk::CmdPipelineBarrier2KHR(cb, &dep_info);
@@ -925,7 +925,7 @@ TEST_F(NegativeSyncVal, CopyOptimalMultiPlanarHazards) {
     m_errorMonitor->VerifyFound();
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
     image_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     image_barrier.image = image_a.handle();
@@ -954,7 +954,7 @@ TEST_F(NegativeSyncVal, CopyOptimalMultiPlanarHazards) {
     //       record the write operation to b.  So we'll need to repeat it successfully to set up for the *next* test.
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
-    auto mem_barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier mem_barrier = vku::InitStructHelper();
     mem_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     mem_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     vk::CmdPipelineBarrier(cb, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 1, &mem_barrier, 0, nullptr, 0,
@@ -1025,7 +1025,7 @@ TEST_F(NegativeSyncVal, CopyLinearImageHazards) {
     m_errorMonitor->VerifyFound();
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     image_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     image_barrier.image = image_b.handle();
@@ -1114,7 +1114,7 @@ TEST_F(NegativeSyncVal, CopyLinearMultiPlanarHazards) {
     m_errorMonitor->VerifyFound();
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
     image_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     image_barrier.image = image_a.handle();
@@ -1143,7 +1143,7 @@ TEST_F(NegativeSyncVal, CopyLinearMultiPlanarHazards) {
     //       record the write operation to b.  So we'll need to repeat it successfully to set up for the *next* test.
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
-    auto mem_barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier mem_barrier = vku::InitStructHelper();
     mem_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     mem_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     vk::CmdPipelineBarrier(cb, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 1, &mem_barrier, 0, nullptr, 0,
@@ -1240,7 +1240,7 @@ TEST_F(NegativeSyncVal, CopyBufferImageHazards) {
 
     vk::CmdCopyImageToBuffer(cb, image_a.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer_a.handle(), 1, &region_buffer_back_image_0_back);
 
-    auto buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+    VkBufferMemoryBarrier buffer_barrier = vku::InitStructHelper();
     buffer_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     buffer_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     buffer_barrier.buffer = buffer_a.handle();
@@ -1401,7 +1401,7 @@ TEST_F(NegativeSyncVal, RenderPassBeginTransitionHazard) {
 
     // Use the barrier to clean up the WAW, and try again. (and show that validation is accounting for the barrier effect too.)
     VkImageSubresourceRange rt_full_subresource_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     image_barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     image_barrier.image = rt_0->handle();
@@ -1475,7 +1475,7 @@ TEST_F(NegativeSyncVal, CmdDispatchDrawHazards) {
     buffer_b.init(*m_device, buffer_b.create_info(2048, buffer_usage, nullptr), mem_prop);
 
     vkt::BufferView bufferview;
-    auto bvci = vku::InitStruct<VkBufferViewCreateInfo>();
+    VkBufferViewCreateInfo bvci = vku::InitStructHelper();
     bvci.buffer = buffer_a.handle();
     bvci.format = VK_FORMAT_R32_SFLOAT;
     bvci.offset = 0;
@@ -1662,7 +1662,7 @@ TEST_F(NegativeSyncVal, CmdDispatchDrawHazards) {
 
     vk::CmdCopyBuffer(m_commandBuffer->handle(), vbo2.handle(), vbo.handle(), 1, &buffer_region);
 
-    auto vbo_barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+    VkBufferMemoryBarrier vbo_barrier = vku::InitStructHelper();
     vbo_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     vbo_barrier.dstAccessMask = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT;
     vbo_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -2104,7 +2104,7 @@ TEST_F(NegativeSyncVal, CmdDrawDepthStencil) {
     stencil.depthFailOp = VK_STENCIL_OP_KEEP;
     stencil.compareOp = VK_COMPARE_OP_NEVER;
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     ds_ci.depthTestEnable = VK_TRUE;
     ds_ci.depthWriteEnable = VK_TRUE;
     ds_ci.depthCompareOp = VK_COMPARE_OP_NEVER;
@@ -2378,7 +2378,7 @@ TEST_F(NegativeSyncVal, RenderPassWithWrongDepthStencilInitialLayout) {
     stencil.depthFailOp = VK_STENCIL_OP_KEEP;
     stencil.compareOp = VK_COMPARE_OP_NEVER;
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     ds_ci.depthTestEnable = VK_TRUE;
     ds_ci.depthWriteEnable = VK_TRUE;
     ds_ci.depthCompareOp = VK_COMPARE_OP_NEVER;
@@ -3383,7 +3383,7 @@ TEST_F(NegativeSyncVal, EventsBufferCopy) {
     m_commandBuffer->begin();
     vk::CmdCopyBuffer(cb, buffer_a.handle(), buffer_b.handle(), 1, &region);
     m_commandBuffer->SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
-    auto mem_barrier_waw = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier mem_barrier_waw = vku::InitStructHelper();
     mem_barrier_waw.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     mem_barrier_waw.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     m_commandBuffer->WaitEvents(1, &event_handle, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 1,
@@ -3395,7 +3395,7 @@ TEST_F(NegativeSyncVal, EventsBufferCopy) {
     m_commandBuffer->end();
 
     // Barrier range check for WAW
-    auto buffer_barrier_front_waw = vku::InitStruct<VkBufferMemoryBarrier>();
+    VkBufferMemoryBarrier buffer_barrier_front_waw = vku::InitStructHelper();
     buffer_barrier_front_waw.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     buffer_barrier_front_waw.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     buffer_barrier_front_waw.buffer = buffer_b.handle();
@@ -3503,7 +3503,7 @@ TEST_F(NegativeSyncVal, EventsCopyImageHazards) {
     set_layouts();
     copy_general(image_a, image_b, full_region);
     m_commandBuffer->SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
-    auto mem_barrier_waw = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier mem_barrier_waw = vku::InitStructHelper();
     mem_barrier_waw.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     mem_barrier_waw.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     m_commandBuffer->WaitEvents(1, &event_handle, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 1,
@@ -3515,7 +3515,7 @@ TEST_F(NegativeSyncVal, EventsCopyImageHazards) {
     m_commandBuffer->end();
 
     // Barrier range check for WAW
-    auto image_barrier_region0_waw = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier image_barrier_region0_waw = vku::InitStructHelper();
     image_barrier_region0_waw.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     image_barrier_region0_waw.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     image_barrier_region0_waw.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -3608,7 +3608,7 @@ TEST_F(NegativeSyncVal, EventsCommandHazards) {
     VkBufferCopy front2front = {0, 0, 128};
 
     // Barrier range check for WAW
-    auto buffer_barrier_front_waw = vku::InitStruct<VkBufferMemoryBarrier>();
+    VkBufferMemoryBarrier buffer_barrier_front_waw = vku::InitStructHelper();
     buffer_barrier_front_waw.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     buffer_barrier_front_waw.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     buffer_barrier_front_waw.buffer = buffer_b.handle();
@@ -3764,7 +3764,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto indexing_features = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(indexing_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     if (!indexing_features.descriptorBindingPartiallyBound) {
@@ -3802,7 +3802,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
                                        0, &layout_createinfo_binding_flags, 0);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
     uint32_t qfi = 0;
-    auto buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = 32;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_create_info.queueFamilyIndexCount = 1;
@@ -3824,7 +3824,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
     vkt::Buffer texel_buffer(*m_device, buffer_create_info);
 
-    auto bvci = vku::InitStruct<VkBufferViewCreateInfo>();
+    VkBufferViewCreateInfo bvci = vku::InitStructHelper();
     bvci.buffer = texel_buffer.handle();
     bvci.format = VK_FORMAT_R32_SFLOAT;
     bvci.offset = 0;
@@ -3833,7 +3833,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     auto texel_bufferview = std::make_unique<vkt::BufferView>();
     texel_bufferview->init(*m_device, bvci);
 
-    auto index_buffer_create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo index_buffer_create_info = vku::InitStructHelper();
     index_buffer_create_info.size = sizeof(uint32_t);
     index_buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
     vkt::Buffer index_buffer(*m_device, index_buffer_create_info);
@@ -3947,7 +3947,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
-    VkCommandBufferBeginInfo begin_info = vku::InitStruct<VkCommandBufferBeginInfo>();
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     m_commandBuffer->begin(&begin_info);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
@@ -4006,7 +4006,7 @@ TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {
     attachment_description.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     attachment_description.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto rp_ci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper();
     rp_ci.subpassCount = 1;
     rp_ci.pSubpasses = subpass_descriptions;
     rp_ci.attachmentCount = 1;
@@ -4048,7 +4048,7 @@ TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {
 
     VkImageView framebuffer_attachments[1] = {image_view1.handle()};
 
-    auto fb_ci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
     fb_ci.renderPass = render_pass.handle();
     fb_ci.attachmentCount = 1;
     fb_ci.pAttachments = framebuffer_attachments;
@@ -4058,7 +4058,7 @@ TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {
 
     vkt::Framebuffer framebuffer(*m_device, fb_ci);
 
-    auto rp_bi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rp_bi = vku::InitStructHelper();
     rp_bi.renderPass = render_pass.handle();
     rp_bi.framebuffer = framebuffer.handle();
     rp_bi.renderArea.extent.width = 32;
@@ -4066,7 +4066,7 @@ TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {
     rp_bi.clearValueCount = 1;
     rp_bi.pClearValues = &clear_value;
 
-    auto ds_ci = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    VkPipelineDepthStencilStateCreateInfo ds_ci = vku::InitStructHelper();
     ds_ci.depthTestEnable = VK_FALSE;
     ds_ci.depthWriteEnable = VK_FALSE;
     ds_ci.depthCompareOp = VK_COMPARE_OP_NEVER;
@@ -4176,7 +4176,7 @@ TEST_F(NegativeSyncVal, TestCopyingToCompressedImage) {
         copy_regions2[1].dstOffset = {4, 0, 0};
         copy_regions2[1].extent = {1, 1, 1};
 
-        auto copy_image_info = vku::InitStruct<VkCopyImageInfo2KHR>();
+        VkCopyImageInfo2KHR copy_image_info = vku::InitStructHelper();
         copy_image_info.srcImage = src_image.handle();
         copy_image_info.srcImageLayout = VK_IMAGE_LAYOUT_GENERAL;
         copy_image_info.dstImage = dst_image.handle();
@@ -4238,7 +4238,7 @@ TEST_F(NegativeSyncVal, StageAccessExpansion) {
     buffer_b.init(*m_device, buffer_b.create_info(2048, buffer_usage, nullptr), mem_prop);
 
     vkt::BufferView bufferview;
-    auto bvci = vku::InitStruct<VkBufferViewCreateInfo>();
+    VkBufferViewCreateInfo bvci = vku::InitStructHelper();
     bvci.buffer = buffer_a.handle();
     bvci.format = VK_FORMAT_R32_SFLOAT;
     bvci.offset = 0;
@@ -4311,7 +4311,7 @@ TEST_F(NegativeSyncVal, StageAccessExpansion) {
     vk::CmdCopyImage(m_commandBuffer->handle(), image_s_b.handle(), VK_IMAGE_LAYOUT_GENERAL, image_s_a.handle(),
                      VK_IMAGE_LAYOUT_GENERAL, 1, &image_region);
 
-    auto barrier = vku::InitStruct<VkMemoryBarrier>();
+    VkMemoryBarrier barrier = vku::InitStructHelper();
     barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 
@@ -4531,7 +4531,7 @@ QSTestContext::QSTestContext(VkDeviceObj* device, VkQueueObj* force_q0, VkQueueO
     h_cbb = InitFromPool(cbb);
     h_cbc = InitFromPool(cbc);
 
-    auto semaphore_ci = vku::InitStruct<VkSemaphoreCreateInfo>();
+    VkSemaphoreCreateInfo semaphore_ci = vku::InitStructHelper();
     semaphore.init(*device, semaphore_ci);
 
     VkEventCreateInfo eci = vku::InitStructHelper();
@@ -4559,7 +4559,7 @@ void QSTestContext::End() {
 }
 
 VkBufferMemoryBarrier QSTestContext::InitBufferBarrier(const vkt::Buffer& buffer, VkAccessFlags src, VkAccessFlags dst) {
-    auto buffer_barrier = vku::InitStruct<VkBufferMemoryBarrier>();
+    VkBufferMemoryBarrier buffer_barrier = vku::InitStructHelper();
     buffer_barrier.srcAccessMask = src;
     buffer_barrier.dstAccessMask = dst;
     buffer_barrier.buffer = buffer.handle();
@@ -4586,7 +4586,7 @@ void QSTestContext::TransferBarrierRAW(const vkt::Buffer& buffer) { TransferBarr
 
 void QSTestContext::Submit(VkQueue q, VkCommandBufferObj& cb, VkSemaphore wait, VkPipelineStageFlags wait_mask, VkSemaphore signal,
                            VkFence fence) {
-    auto submit1 = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit1 = vku::InitStructHelper();
     submit1.commandBufferCount = 1;
     VkCommandBuffer h_cb = cb.handle();
     submit1.pCommandBuffers = &h_cb;
@@ -4604,10 +4604,10 @@ void QSTestContext::Submit(VkQueue q, VkCommandBufferObj& cb, VkSemaphore wait, 
 
 void QSTestContext::SubmitX(VkQueue q, VkCommandBufferObj& cb, VkSemaphore wait, VkPipelineStageFlags wait_mask, VkSemaphore signal,
                             VkPipelineStageFlags signal_mask, VkFence fence) {
-    auto submit1 = vku::InitStruct<VkSubmitInfo2>();
-    auto cb_info = vku::InitStruct<VkCommandBufferSubmitInfo>();
-    auto wait_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
-    auto signal_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+    VkSubmitInfo2 submit1 = vku::InitStructHelper();
+    VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
+    VkSemaphoreSubmitInfo wait_info = vku::InitStructHelper();
+    VkSemaphoreSubmitInfo signal_info = vku::InitStructHelper();
 
     cb_info.commandBuffer = cb.handle();
     submit1.commandBufferInfoCount = 1;
@@ -4647,7 +4647,7 @@ TEST_F(NegativeSyncVal, QSBufferCopyHazards) {
     test.RecordCopy(test.cba, test.buffer_a, test.buffer_b);
     test.RecordCopy(test.cbb, test.buffer_c, test.buffer_a);
 
-    auto submit1 = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit1 = vku::InitStructHelper();
     submit1.commandBufferCount = 2;
     VkCommandBuffer two_cbs[2] = {test.h_cba, test.h_cbb};
     submit1.pCommandBuffers = two_cbs;
@@ -4700,7 +4700,7 @@ TEST_F(NegativeSyncVal, QSSubmit2) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(sync2_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
@@ -5119,7 +5119,7 @@ TEST_F(NegativeSyncVal, QSRenderPass) {
     cb1.EndRenderPass();
     cb1.end();
 
-    auto submit2 = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit2 = vku::InitStructHelper();
     VkCommandBuffer two_cbs[2] = {cb0.handle(), cb1.handle()};
     submit2.commandBufferCount = 2;
     submit2.pCommandBuffers = two_cbs;
@@ -5223,7 +5223,7 @@ TEST_F(NegativeSyncVal, QSPresentAcquire) {
     const VkQueue q = m_device->m_queue;
     const VkDevice dev = m_device->handle();
 
-    auto fence_ci = vku::InitStruct<VkFenceCreateInfo>();
+    VkFenceCreateInfo fence_ci = vku::InitStructHelper();
     vkt::Fence fence(*m_device, fence_ci);
     VkFence h_fence = fence.handle();
 
@@ -5242,7 +5242,7 @@ TEST_F(NegativeSyncVal, QSPresentAcquire) {
         }
 
         if (VK_SUCCESS == result) {
-            auto present_info = vku::InitStruct<VkPresentInfoKHR>();
+            VkPresentInfoKHR present_info = vku::InitStructHelper();
             present_info.swapchainCount = 1;
             present_info.pSwapchains = &m_swapchain;
             present_info.pImageIndices = &index;
@@ -5279,7 +5279,7 @@ TEST_F(NegativeSyncVal, QSPresentAcquire) {
 
     auto write_barrier_cb = [this](const VkImage h_image, VkImageLayout from, VkImageLayout to) {
         VkImageSubresourceRange full_image{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-        auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+        VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
         image_barrier.srcAccessMask = 0U;
         image_barrier.dstAccessMask = 0U;
         image_barrier.oldLayout = from;
@@ -5295,7 +5295,7 @@ TEST_F(NegativeSyncVal, QSPresentAcquire) {
     write_barrier_cb(images[acquired_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
     // Look for errors between the acquire and first use...
-    auto submit1 = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit1 = vku::InitStructHelper();
     submit1.commandBufferCount = 1;
     submit1.pCommandBuffers = &cb;
     // No sync operations...
@@ -5382,7 +5382,7 @@ TEST_F(NegativeSyncVal, PresentDoesNotWaitForSubmit2) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     sync2_features.synchronization2 = VK_TRUE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
     if (!InitSwapchain()) {
@@ -5396,7 +5396,7 @@ TEST_F(NegativeSyncVal, PresentDoesNotWaitForSubmit2) {
     ASSERT_VK_SUCCESS(
         vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore, VK_NULL_HANDLE, &image_index));
 
-    auto layout_transition = vku::InitStruct<VkImageMemoryBarrier2>();
+    VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
     layout_transition.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
     layout_transition.srcAccessMask = 0;
     layout_transition.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -5410,7 +5410,7 @@ TEST_F(NegativeSyncVal, PresentDoesNotWaitForSubmit2) {
     layout_transition.subresourceRange.baseArrayLayer = 0;
     layout_transition.subresourceRange.layerCount = 1;
 
-    auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dep_info = vku::InitStructHelper();
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &layout_transition;
 
@@ -5418,18 +5418,18 @@ TEST_F(NegativeSyncVal, PresentDoesNotWaitForSubmit2) {
     vk::CmdPipelineBarrier2(*m_commandBuffer, &dep_info);
     m_commandBuffer->end();
 
-    auto wait_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+    VkSemaphoreSubmitInfo wait_info = vku::InitStructHelper();
     wait_info.semaphore = acquire_semaphore;
     wait_info.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
 
-    auto command_buffer_info = vku::InitStruct<VkCommandBufferSubmitInfo>();
+    VkCommandBufferSubmitInfo command_buffer_info = vku::InitStructHelper();
     command_buffer_info.commandBuffer = *m_commandBuffer;
 
-    auto signal_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+    VkSemaphoreSubmitInfo signal_info = vku::InitStructHelper();
     signal_info.semaphore = submit_semaphore;
     signal_info.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
 
-    auto submit = vku::InitStruct<VkSubmitInfo2>();
+    VkSubmitInfo2 submit = vku::InitStructHelper();
     submit.waitSemaphoreInfoCount = 1;
     submit.pWaitSemaphoreInfos = &wait_info;
     submit.commandBufferInfoCount = 1;
@@ -5438,7 +5438,7 @@ TEST_F(NegativeSyncVal, PresentDoesNotWaitForSubmit2) {
     submit.pSignalSemaphoreInfos = &signal_info;
     ASSERT_VK_SUCCESS(vk::QueueSubmit2(m_device->m_queue, 1, &submit, VK_NULL_HANDLE));
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.waitSemaphoreCount = 0;  // DO NOT wait on submit. This should generate present after write (ILT) harard.
     present.pWaitSemaphores = nullptr;
     present.swapchainCount = 1;
@@ -5469,7 +5469,7 @@ TEST_F(NegativeSyncVal, PresentDoesNotWaitForSubmit) {
     ASSERT_VK_SUCCESS(
         vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore, VK_NULL_HANDLE, &image_index));
 
-    auto layout_transition = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier layout_transition = vku::InitStructHelper();
     layout_transition.srcAccessMask = 0;
     layout_transition.dstAccessMask = 0;
 
@@ -5488,7 +5488,7 @@ TEST_F(NegativeSyncVal, PresentDoesNotWaitForSubmit) {
     m_commandBuffer->end();
 
     constexpr VkPipelineStageFlags semaphore_wait_stage = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
-    auto submit = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit = vku::InitStructHelper();
     submit.waitSemaphoreCount = 1;
     submit.pWaitSemaphores = &acquire_semaphore.handle();
     submit.pWaitDstStageMask = &semaphore_wait_stage;
@@ -5498,7 +5498,7 @@ TEST_F(NegativeSyncVal, PresentDoesNotWaitForSubmit) {
     submit.pSignalSemaphores = &submit_semaphore.handle();
     ASSERT_VK_SUCCESS(vk::QueueSubmit(m_device->m_queue, 1, &submit, VK_NULL_HANDLE));
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.waitSemaphoreCount = 0;  // DO NOT wait on submit. This should generate present after write (ILT) harard.
     present.pWaitSemaphores = nullptr;
     present.swapchainCount = 1;

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -66,14 +66,14 @@ TEST_F(PositiveSyncVal, CmdClearAttachmentLayer) {
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &color_ref;
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attachment;
     vkt::RenderPass render_pass(*m_device, rpci);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.flags = 0;
     fbci.renderPass = render_pass;
     fbci.attachmentCount = 1;
@@ -83,7 +83,7 @@ TEST_F(PositiveSyncVal, CmdClearAttachmentLayer) {
     fbci.layers = layers;
     vkt::Framebuffer framebuffer(*m_device, fbci);
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer;
     rpbi.renderPass = render_pass;
     rpbi.renderArea.extent.width = width;
@@ -138,7 +138,7 @@ TEST_F(PositiveSyncVal, WriteToImageAfterTransition) {
     VkImageObj image(m_device);
     image.InitNoLayout(width, height, 1, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_OPTIMAL);
 
-    auto barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier barrier = vku::InitStructHelper();
     barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
@@ -177,15 +177,15 @@ TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOnHost) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     constexpr uint64_t max_signal_value = 10'000;
 
-    auto semaphore_type_info = vku::InitStruct<VkSemaphoreTypeCreateInfo>();
+    VkSemaphoreTypeCreateInfo semaphore_type_info = vku::InitStructHelper();
     semaphore_type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-    const auto create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_info);
+    const VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&semaphore_type_info);
     vkt::Semaphore semaphore(*m_device, create_info);
 
     std::atomic<bool> bailout{false};
@@ -195,7 +195,7 @@ TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOnHost) {
     auto signaling_thread = std::thread{[&] {
         uint64_t last_signalled_value = 0;
         while (last_signalled_value != max_signal_value) {
-            auto signal_info = vku::InitStruct<VkSemaphoreSignalInfo>();
+            VkSemaphoreSignalInfo signal_info = vku::InitStructHelper();
             signal_info.semaphore = semaphore;
             signal_info.value = ++last_signalled_value;
             ASSERT_VK_SUCCESS(vk::SignalSemaphore(*m_device, &signal_info));
@@ -207,7 +207,7 @@ TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOnHost) {
     // Wait for each signal
     uint64_t wait_value = 1;
     while (wait_value <= max_signal_value) {
-        auto wait_info = vku::InitStruct<VkSemaphoreWaitInfo>();
+        VkSemaphoreWaitInfo wait_info = vku::InitStructHelper();
         wait_info.flags = VK_SEMAPHORE_WAIT_ANY_BIT;
         wait_info.semaphoreCount = 1;
         wait_info.pSemaphores = &semaphore.handle();
@@ -235,15 +235,15 @@ TEST_F(PositiveSyncVal, SignalAndGetSemaphoreCounter) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     constexpr uint64_t max_signal_value = 1'000;
 
-    auto semaphore_type_info = vku::InitStruct<VkSemaphoreTypeCreateInfo>();
+    VkSemaphoreTypeCreateInfo semaphore_type_info = vku::InitStructHelper();
     semaphore_type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-    const auto create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_info);
+    const VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&semaphore_type_info);
     vkt::Semaphore semaphore(*m_device, create_info);
 
     std::atomic<bool> bailout{false};
@@ -253,7 +253,7 @@ TEST_F(PositiveSyncVal, SignalAndGetSemaphoreCounter) {
     auto signaling_thread = std::thread{[&] {
         uint64_t last_signalled_value = 0;
         while (last_signalled_value != max_signal_value) {
-            auto signal_info = vku::InitStruct<VkSemaphoreSignalInfo>();
+            VkSemaphoreSignalInfo signal_info = vku::InitStructHelper();
             signal_info.semaphore = semaphore;
             signal_info.value = ++last_signalled_value;
             ASSERT_VK_SUCCESS(vk::SignalSemaphore(*m_device, &signal_info));
@@ -284,15 +284,15 @@ TEST_F(PositiveSyncVal, GetSemaphoreCounterFromMultipleThreads) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
 
     constexpr uint64_t max_signal_value = 15'000;
 
-    auto semaphore_type_info = vku::InitStruct<VkSemaphoreTypeCreateInfo>();
+    VkSemaphoreTypeCreateInfo semaphore_type_info = vku::InitStructHelper();
     semaphore_type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-    const auto create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_info);
+    const VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&semaphore_type_info);
     vkt::Semaphore semaphore(*m_device, create_info);
 
     std::atomic<bool> bailout{false};
@@ -321,7 +321,7 @@ TEST_F(PositiveSyncVal, GetSemaphoreCounterFromMultipleThreads) {
         auto timeout_guard = timeout_helper.ThreadGuard();
         uint64_t last_signalled_value = 0;
         while (last_signalled_value != max_signal_value) {
-            auto signal_info = vku::InitStruct<VkSemaphoreSignalInfo>();
+            VkSemaphoreSignalInfo signal_info = vku::InitStructHelper();
             signal_info.semaphore = semaphore;
             signal_info.value = ++last_signalled_value;
             ASSERT_VK_SUCCESS(vk::SignalSemaphore(*m_device, &signal_info));
@@ -407,7 +407,7 @@ TEST_F(PositiveSyncVal, PresentAfterSubmit2AutomaticVisibility) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
-    auto sync2_features = vku::InitStruct<VkPhysicalDeviceSynchronization2FeaturesKHR>();
+    VkPhysicalDeviceSynchronization2FeaturesKHR sync2_features = vku::InitStructHelper();
     sync2_features.synchronization2 = VK_TRUE;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &sync2_features));
     if (!InitSwapchain()) {
@@ -421,7 +421,7 @@ TEST_F(PositiveSyncVal, PresentAfterSubmit2AutomaticVisibility) {
     ASSERT_VK_SUCCESS(
         vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore, VK_NULL_HANDLE, &image_index));
 
-    auto layout_transition = vku::InitStruct<VkImageMemoryBarrier2>();
+    VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
     // this creates execution dependency with submit's wait semaphore, so layout
     // transition does not start before image is acquired.
     layout_transition.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -446,7 +446,7 @@ TEST_F(PositiveSyncVal, PresentAfterSubmit2AutomaticVisibility) {
     layout_transition.subresourceRange.baseArrayLayer = 0;
     layout_transition.subresourceRange.layerCount = 1;
 
-    auto dep_info = vku::InitStruct<VkDependencyInfoKHR>();
+    VkDependencyInfoKHR dep_info = vku::InitStructHelper();
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &layout_transition;
 
@@ -454,18 +454,18 @@ TEST_F(PositiveSyncVal, PresentAfterSubmit2AutomaticVisibility) {
     vk::CmdPipelineBarrier2(*m_commandBuffer, &dep_info);
     m_commandBuffer->end();
 
-    auto wait_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+    VkSemaphoreSubmitInfo wait_info = vku::InitStructHelper();
     wait_info.semaphore = acquire_semaphore;
     wait_info.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
 
-    auto command_buffer_info = vku::InitStruct<VkCommandBufferSubmitInfo>();
+    VkCommandBufferSubmitInfo command_buffer_info = vku::InitStructHelper();
     command_buffer_info.commandBuffer = *m_commandBuffer;
 
-    auto signal_info = vku::InitStruct<VkSemaphoreSubmitInfo>();
+    VkSemaphoreSubmitInfo signal_info = vku::InitStructHelper();
     signal_info.semaphore = submit_semaphore;
     signal_info.stageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
 
-    auto submit = vku::InitStruct<VkSubmitInfo2>();
+    VkSubmitInfo2 submit = vku::InitStructHelper();
     submit.waitSemaphoreInfoCount = 1;
     submit.pWaitSemaphoreInfos = &wait_info;
     submit.commandBufferInfoCount = 1;
@@ -474,7 +474,7 @@ TEST_F(PositiveSyncVal, PresentAfterSubmit2AutomaticVisibility) {
     submit.pSignalSemaphoreInfos = &signal_info;
     ASSERT_VK_SUCCESS(vk::QueueSubmit2(m_device->m_queue, 1, &submit, VK_NULL_HANDLE));
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.waitSemaphoreCount = 1;
     present.pWaitSemaphores = &submit_semaphore.handle();
     present.swapchainCount = 1;
@@ -503,7 +503,7 @@ TEST_F(PositiveSyncVal, PresentAfterSubmitAutomaticVisibility) {
     ASSERT_VK_SUCCESS(
         vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore, VK_NULL_HANDLE, &image_index));
 
-    auto layout_transition = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier layout_transition = vku::InitStructHelper();
     layout_transition.srcAccessMask = 0;
 
     // dstAccessMask makes accesses visible only to the device.
@@ -527,7 +527,7 @@ TEST_F(PositiveSyncVal, PresentAfterSubmitAutomaticVisibility) {
     m_commandBuffer->end();
 
     constexpr VkPipelineStageFlags semaphore_wait_stage = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
-    auto submit = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit = vku::InitStructHelper();
     submit.waitSemaphoreCount = 1;
     submit.pWaitSemaphores = &acquire_semaphore.handle();
     submit.pWaitDstStageMask = &semaphore_wait_stage;
@@ -537,7 +537,7 @@ TEST_F(PositiveSyncVal, PresentAfterSubmitAutomaticVisibility) {
     submit.pSignalSemaphores = &submit_semaphore.handle();
     ASSERT_VK_SUCCESS(vk::QueueSubmit(m_device->m_queue, 1, &submit, VK_NULL_HANDLE));
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.waitSemaphoreCount = 1;
     present.pWaitSemaphores = &submit_semaphore.handle();
     present.swapchainCount = 1;

--- a/tests/unit/threading_positive.cpp
+++ b/tests/unit/threading_positive.cpp
@@ -79,7 +79,7 @@ TEST_F(PositiveThreading, UpdateDescriptorUpdateAfterBindNoCollision) {
     }
 
     // Create a device that enables descriptorBindingStorageBufferUpdateAfterBind
-    auto indexing_features = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>();
+    VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(indexing_features);
     if (VK_FALSE == indexing_features.descriptorBindingStorageBufferUpdateAfterBind) {
         GTEST_SKIP() << "Test requires (unsupported) descriptorBindingStorageBufferUpdateAfterBind";
@@ -91,7 +91,7 @@ TEST_F(PositiveThreading, UpdateDescriptorUpdateAfterBindNoCollision) {
 
     std::array<VkDescriptorBindingFlagsEXT, 2> flags = {
         {VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT, VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT_EXT}};
-    auto flags_create_info = vku::InitStruct<VkDescriptorSetLayoutBindingFlagsCreateInfoEXT>();
+    VkDescriptorSetLayoutBindingFlagsCreateInfoEXT flags_create_info = vku::InitStructHelper();
     flags_create_info.bindingCount = (uint32_t)flags.size();
     flags_create_info.pBindingFlags = flags.data();
 

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -61,7 +61,7 @@ void NegativeTransformFeedback::InitBasicTransformFeedback(void *pNextFeatures) 
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto tf_features = vku::InitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(pNextFeatures);
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT tf_features = vku::InitStructHelper(pNextFeatures);
     GetPhysicalDeviceFeatures2(tf_features);
     if (tf_features.transformFeedback == VK_FALSE) {
         GTEST_SKIP() << "transformFeedback not supported";
@@ -94,7 +94,7 @@ TEST_F(NegativeTransformFeedback, FeatureEnabled) {
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
     {
-        auto info = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo info = vku::InitStructHelper();
         info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
         info.size = 4;
         vkt::Buffer buffer(*m_device, info);
@@ -158,10 +158,10 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
     {
-        auto tf_properties = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+        VkPhysicalDeviceTransformFeedbackPropertiesEXT tf_properties = vku::InitStructHelper();
         GetPhysicalDeviceProperties2(tf_properties);
 
-        auto info = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo info = vku::InitStructHelper();
         info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
         info.size = 8;
         vkt::Buffer const buffer_obj(*m_device, info);
@@ -203,7 +203,7 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
     }
 
     {
-        auto info = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo info = vku::InitStructHelper();
         info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
         info.size = 8;
         vkt::Buffer const buffer_obj(*m_device, info);
@@ -262,7 +262,7 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
 
     // Don't set VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT.
     {
-        auto info = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo info = vku::InitStructHelper();
         info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
         info.size = 4;
         vkt::Buffer const buffer_obj(*m_device, info);
@@ -278,7 +278,7 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
     {
         vkt::Buffer buffer;
         {
-            auto info = vku::InitStruct<VkBufferCreateInfo>();
+            VkBufferCreateInfo info = vku::InitStructHelper();
             info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
             info.size = 4;
             buffer.init_no_mem(*m_device, info);
@@ -314,7 +314,7 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackEXT) {
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
     {
-        auto tf_properties = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+        VkPhysicalDeviceTransformFeedbackPropertiesEXT tf_properties = vku::InitStructHelper();
         GetPhysicalDeviceProperties2(tf_properties);
 
         // Request a firstCounterBuffer that is too large.
@@ -339,7 +339,7 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackEXT) {
 
     // Request an out-of-bounds location.
     {
-        auto info = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo info = vku::InitStructHelper();
         info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
         info.size = 4;
         vkt::Buffer const buffer_obj(*m_device, info);
@@ -362,7 +362,7 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackEXT) {
 
     // Don't set VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT.
     {
-        auto info = vku::InitStruct<VkBufferCreateInfo>();
+        VkBufferCreateInfo info = vku::InitStructHelper();
         info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
         info.size = 4;
         vkt::Buffer const buffer_obj(*m_device, info);
@@ -410,7 +410,7 @@ TEST_F(NegativeTransformFeedback, CmdEndTransformFeedbackEXT) {
             vk::CmdBeginTransformFeedbackEXT(m_commandBuffer->handle(), 0, 1, nullptr, nullptr);
 
             {
-                auto tf_properties = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+                VkPhysicalDeviceTransformFeedbackPropertiesEXT tf_properties = vku::InitStructHelper();
                 GetPhysicalDeviceProperties2(tf_properties);
 
                 // Request a firstCounterBuffer that is too large.
@@ -435,7 +435,7 @@ TEST_F(NegativeTransformFeedback, CmdEndTransformFeedbackEXT) {
 
             // Request an out-of-bounds location.
             {
-                auto info = vku::InitStruct<VkBufferCreateInfo>();
+                VkBufferCreateInfo info = vku::InitStructHelper();
                 info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
                 info.size = 4;
                 vkt::Buffer const buffer_obj(*m_device, info);
@@ -458,7 +458,7 @@ TEST_F(NegativeTransformFeedback, CmdEndTransformFeedbackEXT) {
 
             // Don't set VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT.
             {
-                auto info = vku::InitStruct<VkBufferCreateInfo>();
+                VkBufferCreateInfo info = vku::InitStructHelper();
                 info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
                 info.size = 4;
                 vkt::Buffer const buffer_obj(*m_device, info);
@@ -584,7 +584,7 @@ TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto tf_properties = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT tf_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(tf_properties);
 
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
@@ -680,16 +680,16 @@ TEST_F(NegativeTransformFeedback, UsingRasterizationStateStreamExtDisabled) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto transform_feedback_features = vku::InitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT transform_feedback_features = vku::InitStructHelper();
     transform_feedback_features.geometryStreams = VK_FALSE;  // Invalid
 
     // Extension enabled via VK_EXT_transform_feedback dependency
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&transform_feedback_features);
+    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&transform_feedback_features);
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     CreatePipelineHelper pipe(*this);
-    auto rasterization_state_stream_ci = vku::InitStruct<VkPipelineRasterizationStateStreamCreateInfoEXT>();
+    VkPipelineRasterizationStateStreamCreateInfoEXT rasterization_state_stream_ci = vku::InitStructHelper();
     pipe.rs_state_ci_.pNext = &rasterization_state_stream_ci;
     pipe.InitState();
 
@@ -735,7 +735,7 @@ TEST_F(NegativeTransformFeedback, RuntimeSpirv) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto transform_feedback_props = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transform_feedback_props);
 
     // seen sometimes when using profiles and will crash
@@ -1098,7 +1098,7 @@ TEST_F(NegativeTransformFeedback, PipelineRasterizationStateStreamCreateInfoEXT)
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto transform_feedback_features = vku::InitStruct<VkPhysicalDeviceTransformFeedbackFeaturesEXT>();
+    VkPhysicalDeviceTransformFeedbackFeaturesEXT transform_feedback_features = vku::InitStructHelper();
     transform_feedback_features.geometryStreams = VK_TRUE;
 
     // Extension enabled via dependencies
@@ -1106,7 +1106,7 @@ TEST_F(NegativeTransformFeedback, PipelineRasterizationStateStreamCreateInfoEXT)
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto transfer_feedback_props = vku::InitStruct<VkPhysicalDeviceTransformFeedbackPropertiesEXT>();
+    VkPhysicalDeviceTransformFeedbackPropertiesEXT transfer_feedback_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transfer_feedback_props);
 
     if (!transfer_feedback_props.transformFeedbackRasterizationStreamSelect &&
@@ -1115,7 +1115,7 @@ TEST_F(NegativeTransformFeedback, PipelineRasterizationStateStreamCreateInfoEXT)
     }
 
     CreatePipelineHelper pipe(*this);
-    auto rasterization_state_stream_ci = vku::InitStruct<VkPipelineRasterizationStateStreamCreateInfoEXT>();
+    VkPipelineRasterizationStateStreamCreateInfoEXT rasterization_state_stream_ci = vku::InitStructHelper();
     rasterization_state_stream_ci.rasterizationStream = transfer_feedback_props.maxTransformFeedbackStreams;
     pipe.rs_state_ci_.pNext = &rasterization_state_stream_ci;
     pipe.InitState();
@@ -1156,7 +1156,7 @@ TEST_F(NegativeTransformFeedback, CmdNextSubpass) {
                                VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
                                VK_DEPENDENCY_BY_REGION_BIT};
 
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.attachmentCount = 1;
     rpci.pAttachments = attach;
     rpci.subpassCount = 2;
@@ -1170,7 +1170,7 @@ TEST_F(NegativeTransformFeedback, CmdNextSubpass) {
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     VkImageView imageView = image.targetView(VK_FORMAT_R8G8B8A8_UNORM);
 
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
     fbci.renderPass = rp.handle();
     fbci.attachmentCount = 1;
     fbci.pAttachments = &imageView;
@@ -1190,7 +1190,7 @@ TEST_F(NegativeTransformFeedback, CmdNextSubpass) {
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
-    auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>();
+    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.renderPass = rp.handle();
     rpbi.framebuffer = fb.handle();
     rpbi.renderArea.offset = {0, 0};
@@ -1216,7 +1216,7 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackOutsideRenderPass) {
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
-    auto info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo info = vku::InitStructHelper();
     info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT;
     info.size = 4;
     vkt::Buffer const buffer_obj(*m_device, info);

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -64,7 +64,7 @@ TEST_F(NegativeVertexInput, DivisorExtension) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     const VkPhysicalDeviceLimits &dev_limits = m_device->props.limits;
-    auto pdvad_props = vku::InitStruct<VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
+    VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT pdvad_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(pdvad_props);
 
     VkVertexInputBindingDivisorDescriptionEXT vibdd = {};
@@ -147,7 +147,7 @@ TEST_F(NegativeVertexInput, DivisorDisabled) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &pd_features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    auto pdvad_props = vku::InitStruct<VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
+    VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT pdvad_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(pdvad_props);
 
     VkVertexInputBindingDivisorDescriptionEXT vibdd = {};
@@ -411,7 +411,7 @@ TEST_F(NegativeVertexInput, UsingProvokingVertexModeLastVertexExtDisabled) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     CreatePipelineHelper pipe(*this);
-    auto provoking_vertex_state_ci = vku::InitStruct<VkPipelineRasterizationProvokingVertexStateCreateInfoEXT>();
+    VkPipelineRasterizationProvokingVertexStateCreateInfoEXT provoking_vertex_state_ci = vku::InitStructHelper();
     provoking_vertex_state_ci.provokingVertexMode = VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT;
     pipe.rs_state_ci_.pNext = &provoking_vertex_state_ci;
     pipe.InitState();
@@ -437,21 +437,21 @@ TEST_F(NegativeVertexInput, ProvokingVertexModePerPipeline) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto provoking_vertex_properties = vku::InitStruct<VkPhysicalDeviceProvokingVertexPropertiesEXT>();
+    VkPhysicalDeviceProvokingVertexPropertiesEXT provoking_vertex_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(provoking_vertex_properties);
     if (provoking_vertex_properties.provokingVertexModePerPipeline == VK_TRUE) {
         GTEST_SKIP() << "provokingVertexModePerPipeline is VK_TRUE";
     }
 
-    auto provoking_vertex_features = vku::InitStruct<VkPhysicalDeviceProvokingVertexFeaturesEXT>();
+    VkPhysicalDeviceProvokingVertexFeaturesEXT provoking_vertex_features = vku::InitStructHelper();
     provoking_vertex_features.provokingVertexLast = VK_TRUE;
-    auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2>(&provoking_vertex_features);
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&provoking_vertex_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     CreatePipelineHelper pipe1(*this);
-    auto provoking_vertex_state_ci = vku::InitStruct<VkPipelineRasterizationProvokingVertexStateCreateInfoEXT>();
+    VkPipelineRasterizationProvokingVertexStateCreateInfoEXT provoking_vertex_state_ci = vku::InitStructHelper();
     provoking_vertex_state_ci.provokingVertexMode = VK_PROVOKING_VERTEX_MODE_FIRST_VERTEX_EXT;
     pipe1.rs_state_ci_.pNext = &provoking_vertex_state_ci;
     pipe1.InitState();
@@ -583,7 +583,7 @@ TEST_F(NegativeVertexInput, AttributeAlignment) {
 
     VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-    auto vi_state = vku::InitStruct<VkPipelineVertexInputStateCreateInfo>();
+    VkPipelineVertexInputStateCreateInfo vi_state = vku::InitStructHelper();
     vi_state.flags = 0;
     vi_state.vertexBindingDescriptionCount = 1;
     vi_state.pVertexBindingDescriptions = &input_binding;

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -142,9 +142,9 @@ TEST_F(VkVideoLayerTest, CapabilityQueryMissingChain) {
     if (GetConfigDecodeH264()) {
         VideoConfig config = GetConfigDecodeH264();
 
-        auto caps = vku::InitStruct<VkVideoCapabilitiesKHR>();
-        auto decode_caps = vku::InitStruct<VkVideoDecodeCapabilitiesKHR>();
-        auto decode_h264_caps = vku::InitStruct<VkVideoDecodeH264CapabilitiesKHR>();
+        VkVideoCapabilitiesKHR caps = vku::InitStructHelper();
+        VkVideoDecodeCapabilitiesKHR decode_caps = vku::InitStructHelper();
+        VkVideoDecodeH264CapabilitiesKHR decode_h264_caps = vku::InitStructHelper();
 
         // Missing decode caps struct for decode profile
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07183");
@@ -162,9 +162,9 @@ TEST_F(VkVideoLayerTest, CapabilityQueryMissingChain) {
     if (GetConfigDecodeH265()) {
         VideoConfig config = GetConfigDecodeH265();
 
-        auto caps = vku::InitStruct<VkVideoCapabilitiesKHR>();
-        auto decode_caps = vku::InitStruct<VkVideoDecodeCapabilitiesKHR>();
-        auto decode_h265_caps = vku::InitStruct<VkVideoDecodeH265CapabilitiesKHR>();
+        VkVideoCapabilitiesKHR caps = vku::InitStructHelper();
+        VkVideoDecodeCapabilitiesKHR decode_caps = vku::InitStructHelper();
+        VkVideoDecodeH265CapabilitiesKHR decode_h265_caps = vku::InitStructHelper();
 
         // Missing decode caps struct for decode profile
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07183");
@@ -189,7 +189,7 @@ TEST_F(VkVideoLayerTest, VideoFormatQueryMissingProfile) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    auto format_info = vku::InitStruct<VkPhysicalDeviceVideoFormatInfoKHR>();
+    VkPhysicalDeviceVideoFormatInfoKHR format_info = vku::InitStructHelper();
     format_info.imageUsage = VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR;
     uint32_t format_count = 0;
 
@@ -197,7 +197,7 @@ TEST_F(VkVideoLayerTest, VideoFormatQueryMissingProfile) {
     vk.GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &format_info, &format_count, nullptr);
     m_errorMonitor->VerifyFound();
 
-    auto profile_list = vku::InitStruct<VkVideoProfileListInfoKHR>();
+    VkVideoProfileListInfoKHR profile_list = vku::InitStructHelper();
     format_info.pNext = &profile_list;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPhysicalDeviceVideoFormatPropertiesKHR-pNext-06812");
@@ -732,7 +732,7 @@ TEST_F(VkVideoLayerTest, CreateSessionParamsMissingCodecInfo) {
 
         VkVideoSessionParametersKHR params;
         VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
-        auto other_codec_info = vku::InitStruct<VkVideoDecodeH265SessionParametersCreateInfoKHR>();
+        VkVideoDecodeH265SessionParametersCreateInfoKHR other_codec_info = vku::InitStructHelper();
         other_codec_info.maxStdVPSCount = 1;
         other_codec_info.maxStdSPSCount = 1;
         other_codec_info.maxStdPPSCount = 1;
@@ -750,7 +750,7 @@ TEST_F(VkVideoLayerTest, CreateSessionParamsMissingCodecInfo) {
 
         VkVideoSessionParametersKHR params;
         VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
-        auto other_codec_info = vku::InitStruct<VkVideoDecodeH264SessionParametersCreateInfoKHR>();
+        VkVideoDecodeH264SessionParametersCreateInfoKHR other_codec_info = vku::InitStructHelper();
         other_codec_info.maxStdSPSCount = 1;
         other_codec_info.maxStdPPSCount = 1;
         create_info.pNext = &other_codec_info;
@@ -773,8 +773,8 @@ TEST_F(VkVideoLayerTest, CreateSessionParamsH264ExceededCapacity) {
 
     VideoContext context(DeviceObj(), config);
 
-    auto h264_ci = vku::InitStruct<VkVideoDecodeH264SessionParametersCreateInfoKHR>();
-    auto h264_ai = vku::InitStruct<VkVideoDecodeH264SessionParametersAddInfoKHR>();
+    VkVideoDecodeH264SessionParametersCreateInfoKHR h264_ci = vku::InitStructHelper();
+    VkVideoDecodeH264SessionParametersAddInfoKHR h264_ai = vku::InitStructHelper();
 
     VkVideoSessionParametersKHR params, params2;
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -857,8 +857,8 @@ TEST_F(VkVideoLayerTest, CreateSessionParamsH265ExceededCapacity) {
 
     VideoContext context(DeviceObj(), config);
 
-    auto h265_ci = vku::InitStruct<VkVideoDecodeH265SessionParametersCreateInfoKHR>();
-    auto h265_ai = vku::InitStruct<VkVideoDecodeH265SessionParametersAddInfoKHR>();
+    VkVideoDecodeH265SessionParametersCreateInfoKHR h265_ci = vku::InitStructHelper();
+    VkVideoDecodeH265SessionParametersAddInfoKHR h265_ai = vku::InitStructHelper();
 
     VkVideoSessionParametersKHR params, params2;
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -982,8 +982,8 @@ TEST_F(VkVideoLayerTest, H264ParametersAddInfoUniqueness) {
 
     VideoContext context(DeviceObj(), config);
 
-    auto h264_ci = vku::InitStruct<VkVideoDecodeH264SessionParametersCreateInfoKHR>();
-    auto h264_ai = vku::InitStruct<VkVideoDecodeH264SessionParametersAddInfoKHR>();
+    VkVideoDecodeH264SessionParametersCreateInfoKHR h264_ci = vku::InitStructHelper();
+    VkVideoDecodeH264SessionParametersAddInfoKHR h264_ai = vku::InitStructHelper();
 
     VkVideoSessionParametersKHR params;
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -994,7 +994,7 @@ TEST_F(VkVideoLayerTest, H264ParametersAddInfoUniqueness) {
     h264_ci.maxStdPPSCount = 20;
     h264_ci.pParametersAddInfo = &h264_ai;
 
-    auto update_info = vku::InitStruct<VkVideoSessionParametersUpdateInfoKHR>();
+    VkVideoSessionParametersUpdateInfoKHR update_info = vku::InitStructHelper();
     update_info.pNext = &h264_ai;
     update_info.updateSequenceCount = 1;
 
@@ -1052,8 +1052,8 @@ TEST_F(VkVideoLayerTest, H265ParametersAddInfoUniqueness) {
     VideoContext context(DeviceObj(), config);
     context.CreateAndBindSessionMemory();
 
-    auto h265_ci = vku::InitStruct<VkVideoDecodeH265SessionParametersCreateInfoKHR>();
-    auto h265_ai = vku::InitStruct<VkVideoDecodeH265SessionParametersAddInfoKHR>();
+    VkVideoDecodeH265SessionParametersCreateInfoKHR h265_ci = vku::InitStructHelper();
+    VkVideoDecodeH265SessionParametersAddInfoKHR h265_ai = vku::InitStructHelper();
 
     VkVideoSessionParametersKHR params;
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -1065,7 +1065,7 @@ TEST_F(VkVideoLayerTest, H265ParametersAddInfoUniqueness) {
     h265_ci.maxStdPPSCount = 30;
     h265_ci.pParametersAddInfo = &h265_ai;
 
-    auto update_info = vku::InitStruct<VkVideoSessionParametersUpdateInfoKHR>();
+    VkVideoSessionParametersUpdateInfoKHR update_info = vku::InitStructHelper();
     update_info.pNext = &h265_ai;
     update_info.updateSequenceCount = 1;
 
@@ -1146,7 +1146,7 @@ TEST_F(VkVideoLayerTest, UpdateSessionParamsIncorrectSequenceCount) {
 
     VideoContext context(DeviceObj(), config);
 
-    auto update_info = vku::InitStruct<VkVideoSessionParametersUpdateInfoKHR>();
+    VkVideoSessionParametersUpdateInfoKHR update_info = vku::InitStructHelper();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkUpdateVideoSessionParametersKHR-pUpdateInfo-07215");
     update_info.updateSequenceCount = 2;
@@ -1181,8 +1181,8 @@ TEST_F(VkVideoLayerTest, UpdateSessionParamsH264ConflictingKeys) {
 
     VideoContext context(DeviceObj(), config);
 
-    auto h264_ci = vku::InitStruct<VkVideoDecodeH264SessionParametersCreateInfoKHR>();
-    auto h264_ai = vku::InitStruct<VkVideoDecodeH264SessionParametersAddInfoKHR>();
+    VkVideoDecodeH264SessionParametersCreateInfoKHR h264_ci = vku::InitStructHelper();
+    VkVideoDecodeH264SessionParametersAddInfoKHR h264_ai = vku::InitStructHelper();
 
     VkVideoSessionParametersKHR params;
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -1193,7 +1193,7 @@ TEST_F(VkVideoLayerTest, UpdateSessionParamsH264ConflictingKeys) {
     h264_ci.maxStdPPSCount = 20;
     h264_ci.pParametersAddInfo = &h264_ai;
 
-    auto update_info = vku::InitStruct<VkVideoSessionParametersUpdateInfoKHR>();
+    VkVideoSessionParametersUpdateInfoKHR update_info = vku::InitStructHelper();
     update_info.pNext = &h264_ai;
     update_info.updateSequenceCount = 1;
 
@@ -1248,8 +1248,8 @@ TEST_F(VkVideoLayerTest, UpdateSessionParamsH265ConflictingKeys) {
     VideoContext context(DeviceObj(), config);
     context.CreateAndBindSessionMemory();
 
-    auto h265_ci = vku::InitStruct<VkVideoDecodeH265SessionParametersCreateInfoKHR>();
-    auto h265_ai = vku::InitStruct<VkVideoDecodeH265SessionParametersAddInfoKHR>();
+    VkVideoDecodeH265SessionParametersCreateInfoKHR h265_ci = vku::InitStructHelper();
+    VkVideoDecodeH265SessionParametersAddInfoKHR h265_ai = vku::InitStructHelper();
 
     VkVideoSessionParametersKHR params;
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -1261,7 +1261,7 @@ TEST_F(VkVideoLayerTest, UpdateSessionParamsH265ConflictingKeys) {
     h265_ci.maxStdPPSCount = 30;
     h265_ci.pParametersAddInfo = &h265_ai;
 
-    auto update_info = vku::InitStruct<VkVideoSessionParametersUpdateInfoKHR>();
+    VkVideoSessionParametersUpdateInfoKHR update_info = vku::InitStructHelper();
     update_info.pNext = &h265_ai;
     update_info.updateSequenceCount = 1;
 
@@ -1336,8 +1336,8 @@ TEST_F(VkVideoLayerTest, UpdateSessionParamsH264ExceededCapacity) {
 
     VideoContext context(DeviceObj(), config);
 
-    auto h264_ci = vku::InitStruct<VkVideoDecodeH264SessionParametersCreateInfoKHR>();
-    auto h264_ai = vku::InitStruct<VkVideoDecodeH264SessionParametersAddInfoKHR>();
+    VkVideoDecodeH264SessionParametersCreateInfoKHR h264_ci = vku::InitStructHelper();
+    VkVideoDecodeH264SessionParametersAddInfoKHR h264_ai = vku::InitStructHelper();
 
     VkVideoSessionParametersKHR params;
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -1348,7 +1348,7 @@ TEST_F(VkVideoLayerTest, UpdateSessionParamsH264ExceededCapacity) {
     h264_ci.maxStdPPSCount = 9;
     h264_ci.pParametersAddInfo = &h264_ai;
 
-    auto update_info = vku::InitStruct<VkVideoSessionParametersUpdateInfoKHR>();
+    VkVideoSessionParametersUpdateInfoKHR update_info = vku::InitStructHelper();
     update_info.pNext = &h264_ai;
     update_info.updateSequenceCount = 1;
 
@@ -1401,8 +1401,8 @@ TEST_F(VkVideoLayerTest, UpdateSessionParamsH265ExceededCapacity) {
     VideoContext context(DeviceObj(), config);
     context.CreateAndBindSessionMemory();
 
-    auto h265_ci = vku::InitStruct<VkVideoDecodeH265SessionParametersCreateInfoKHR>();
-    auto h265_ai = vku::InitStruct<VkVideoDecodeH265SessionParametersAddInfoKHR>();
+    VkVideoDecodeH265SessionParametersCreateInfoKHR h265_ci = vku::InitStructHelper();
+    VkVideoDecodeH265SessionParametersAddInfoKHR h265_ai = vku::InitStructHelper();
 
     VkVideoSessionParametersKHR params;
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -1414,7 +1414,7 @@ TEST_F(VkVideoLayerTest, UpdateSessionParamsH265ExceededCapacity) {
     h265_ci.maxStdPPSCount = 9;
     h265_ci.pParametersAddInfo = &h265_ai;
 
-    auto update_info = vku::InitStruct<VkVideoSessionParametersUpdateInfoKHR>();
+    VkVideoSessionParametersUpdateInfoKHR update_info = vku::InitStructHelper();
     update_info.pNext = &h265_ai;
     update_info.updateSequenceCount = 1;
 
@@ -1663,7 +1663,7 @@ TEST_F(VkVideoLayerTest, BeginCodingSessionMemoryNotBound) {
         ASSERT_VK_SUCCESS(vk::AllocateMemory(m_device->device(), &alloc_info, nullptr, &memory));
         session_memory.push_back(memory);
 
-        auto bind_info = vku::InitStruct<VkBindVideoSessionMemoryInfoKHR>();
+        VkBindVideoSessionMemoryInfoKHR bind_info = vku::InitStructHelper();
         bind_info.memoryBindIndex = mem_reqs[i].memoryBindIndex;
         bind_info.memory = memory;
         bind_info.memoryOffset = 0;
@@ -1708,7 +1708,7 @@ TEST_F(VkVideoLayerTest, BeginCodingSessionUninitialized) {
 
     VkCommandBufferObj& cb = context.CmdBuffer();
 
-    auto control_info = vku::InitStruct<VkVideoCodingControlInfoKHR>();
+    VkVideoCodingControlInfoKHR control_info = vku::InitStructHelper();
     control_info.flags = VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_BIT_KHR;
 
     cb.begin();
@@ -2229,10 +2229,10 @@ TEST_F(VkVideoLayerTest, BeginCodingMissingDecodeDpbUsage) {
 
     VkVideoPictureResourceInfoKHR res = context.Dpb()->Picture(0);
 
-    auto view_usage_ci = vku::InitStruct<VkImageViewUsageCreateInfo>();
+    VkImageViewUsageCreateInfo view_usage_ci = vku::InitStructHelper();
     view_usage_ci.usage = config.DpbFormatProps()->imageUsageFlags ^ VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR;
 
-    auto image_view_ci = vku::InitStruct<VkImageViewCreateInfo>(&view_usage_ci);
+    VkImageViewCreateInfo image_view_ci = vku::InitStructHelper(&view_usage_ci);
     image_view_ci.image = context.Dpb()->Image();
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     image_view_ci.format = config.DpbFormatProps()->format;
@@ -2613,11 +2613,11 @@ TEST_F(VkVideoLayerTest, DecodeBufferMissingDecodeSrcUsage) {
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
-    auto profile_list = vku::InitStruct<VkVideoProfileListInfoKHR>();
+    VkVideoProfileListInfoKHR profile_list = vku::InitStructHelper();
     profile_list.profileCount = 1;
     profile_list.pProfiles = config.Profile();
 
-    auto create_info = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo create_info = vku::InitStructHelper();
     create_info.flags = 0;
     create_info.pNext = &profile_list;
     create_info.size = std::max((VkDeviceSize)4096, config.Caps()->minBitstreamBufferSizeAlignment);
@@ -3077,10 +3077,10 @@ TEST_F(VkVideoLayerTest, DecodeOutputMissingDecodeDstUsage) {
 
     VkCommandBufferObj& cb = context.CmdBuffer();
 
-    auto view_usage_ci = vku::InitStruct<VkImageViewUsageCreateInfo>();
+    VkImageViewUsageCreateInfo view_usage_ci = vku::InitStructHelper();
     view_usage_ci.usage = config.PictureFormatProps()->imageUsageFlags ^ VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR;
 
-    auto image_view_ci = vku::InitStruct<VkImageViewCreateInfo>(&view_usage_ci);
+    VkImageViewCreateInfo image_view_ci = vku::InitStructHelper(&view_usage_ci);
     image_view_ci.image = context.DecodeOutput()->Image();
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     image_view_ci.format = config.PictureFormatProps()->format;
@@ -3659,7 +3659,7 @@ TEST_F(VkVideoLayerTest, DecodeInvalidCodecInfoH264) {
     VideoDecodeInfo decode_info = context.DecodeFrame();
 
     StdVideoDecodeH264PictureInfo std_picture_info{};
-    auto picture_info = vku::InitStruct<VkVideoDecodeH264PictureInfoKHR>();
+    VkVideoDecodeH264PictureInfoKHR picture_info = vku::InitStructHelper();
     uint32_t slice_offset = 0;
     picture_info.pStdPictureInfo = &std_picture_info;
     picture_info.sliceCount = 1;
@@ -3722,7 +3722,7 @@ TEST_F(VkVideoLayerTest, DecodeInvalidCodecInfoH264) {
 
     // Missing H.264 setup reference info
     {
-        auto slot = vku::InitStruct<VkVideoReferenceSlotInfoKHR>();
+        VkVideoReferenceSlotInfoKHR slot = vku::InitStructHelper();
         slot.pNext = nullptr;
         slot.slotIndex = 0;
         slot.pPictureResource = &context.Dpb()->Picture(0);
@@ -3752,7 +3752,7 @@ TEST_F(VkVideoLayerTest, DecodeInvalidCodecInfoH264) {
 
     // Missing H.264 reference info
     {
-        auto slot = vku::InitStruct<VkVideoReferenceSlotInfoKHR>();
+        VkVideoReferenceSlotInfoKHR slot = vku::InitStructHelper();
         slot.pNext = nullptr;
         slot.slotIndex = 0;
         slot.pPictureResource = &context.Dpb()->Picture(0);
@@ -3866,7 +3866,7 @@ TEST_F(VkVideoLayerTest, DecodeInvalidCodecInfoH265) {
     VideoDecodeInfo decode_info = context.DecodeFrame();
 
     StdVideoDecodeH265PictureInfo std_picture_info{};
-    auto picture_info = vku::InitStruct<VkVideoDecodeH265PictureInfoKHR>();
+    VkVideoDecodeH265PictureInfoKHR picture_info = vku::InitStructHelper();
     uint32_t slice_segment_offset = 0;
     picture_info.pStdPictureInfo = &std_picture_info;
     picture_info.sliceSegmentCount = 1;
@@ -3926,7 +3926,7 @@ TEST_F(VkVideoLayerTest, DecodeInvalidCodecInfoH265) {
 
     // Missing H.265 setup reference info
     {
-        auto slot = vku::InitStruct<VkVideoReferenceSlotInfoKHR>();
+        VkVideoReferenceSlotInfoKHR slot = vku::InitStructHelper();
         slot.pNext = nullptr;
         slot.slotIndex = 0;
         slot.pPictureResource = &context.Dpb()->Picture(0);
@@ -3943,7 +3943,7 @@ TEST_F(VkVideoLayerTest, DecodeInvalidCodecInfoH265) {
 
     // Missing H.265 reference info
     {
-        auto slot = vku::InitStruct<VkVideoReferenceSlotInfoKHR>();
+        VkVideoReferenceSlotInfoKHR slot = vku::InitStructHelper();
         slot.pNext = nullptr;
         slot.slotIndex = 0;
         slot.pPictureResource = &context.Dpb()->Picture(0);
@@ -4125,7 +4125,7 @@ TEST_F(VkVideoLayerTest, BeginQueryIncompatibleQueueFamily) {
         GTEST_SKIP() << "Test requires a queue family with no support for result status queries";
     }
 
-    auto create_info = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo create_info = vku::InitStructHelper();
     create_info.queryType = VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR;
     create_info.queryCount = 1;
     vkt::QueryPool query_pool(*m_device, create_info);
@@ -4221,7 +4221,7 @@ TEST_F(VkVideoLayerTest, BeginQueryVideoCodingScopeIncompatibleQueryType) {
     VideoContext context(DeviceObj(), config);
     context.CreateAndBindSessionMemory();
 
-    auto create_info = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo create_info = vku::InitStructHelper();
     create_info.queryType = VK_QUERY_TYPE_OCCLUSION;
     create_info.queryCount = 1;
     vkt::QueryPool query_pool(*m_device, create_info);
@@ -4250,7 +4250,7 @@ TEST_F(VkVideoLayerTest, GetQueryPoolResultsStatusBit) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    auto create_info = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo create_info = vku::InitStructHelper();
     create_info.queryType = VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR;
     create_info.queryCount = 1;
     vkt::QueryPool query_pool(*m_device, create_info);
@@ -4278,14 +4278,14 @@ TEST_F(VkVideoLayerTest, CopyQueryPoolResultsStatusBit) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    auto create_info = vku::InitStruct<VkQueryPoolCreateInfo>();
+    VkQueryPoolCreateInfo create_info = vku::InitStructHelper();
     create_info.queryType = VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR;
     create_info.queryCount = 1;
     vkt::QueryPool query_pool(*m_device, create_info);
 
     VkQueryResultFlags flags;
 
-    auto buffer_ci = vku::InitStruct<VkBufferCreateInfo>();
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = sizeof(uint32_t);
     buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     vkt::Buffer buffer(*m_device, buffer_ci);
@@ -4326,14 +4326,14 @@ TEST_F(VkVideoLayerTest, ImageLayoutUsageMismatch) {
 
     VkCommandBufferObj& cb = context.CmdBuffer();
 
-    auto image_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     image_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     image_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     image_barrier.subresourceRange.levelCount = 1;
     image_barrier.subresourceRange.layerCount = 1;
 
-    auto image_barrier2 = vku::InitStruct<VkImageMemoryBarrier2>();
+    VkImageMemoryBarrier2 image_barrier2 = vku::InitStructHelper();
     image_barrier2.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     image_barrier2.dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     image_barrier2.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -4342,7 +4342,7 @@ TEST_F(VkVideoLayerTest, ImageLayoutUsageMismatch) {
     image_barrier2.subresourceRange.levelCount = 1;
     image_barrier2.subresourceRange.layerCount = 1;
 
-    auto dep_info = vku::InitStruct<VkDependencyInfo>();
+    VkDependencyInfo dep_info = vku::InitStructHelper();
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &image_barrier2;
 
@@ -4418,7 +4418,7 @@ TEST_F(VkVideoBestPracticesLayerTest, GetVideoSessionMemoryRequirements) {
 
     VideoContext context(DeviceObj(), config);
 
-    auto mem_req = vku::InitStruct<VkVideoSessionMemoryRequirementsKHR>();
+    VkVideoSessionMemoryRequirementsKHR mem_req = vku::InitStructHelper();
     uint32_t mem_req_count = 1;
 
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit,
@@ -4454,7 +4454,7 @@ TEST_F(VkVideoBestPracticesLayerTest, BindVideoSessionMemory) {
     vkt::DeviceMemory memory(*m_device, alloc_info);
 
     // Set VkBindVideoSessionMemoryInfoKHR::memory to an allocation created before GetVideoSessionMemoryRequirementsKHR was called
-    auto bind_info = vku::InitStruct<VkBindVideoSessionMemoryInfoKHR>();
+    VkBindVideoSessionMemoryInfoKHR bind_info = vku::InitStructHelper();
     bind_info.memory = memory;
     bind_info.memoryOffset = 0;
     bind_info.memorySize = alloc_info.allocationSize;
@@ -4474,7 +4474,7 @@ TEST_F(VkVideoBestPracticesLayerTest, BindVideoSessionMemory) {
         m_errorMonitor->VerifyFound();
 
         if (mem_req_count > 1) {
-            auto mem_req = vku::InitStruct<VkVideoSessionMemoryRequirementsKHR>();
+            VkVideoSessionMemoryRequirementsKHR mem_req = vku::InitStructHelper();
             mem_req_count = 1;
 
             context.vk.GetVideoSessionMemoryRequirementsKHR(m_device->device(), context.Session(), &mem_req_count, &mem_req);

--- a/tests/unit/viewport_inheritance.cpp
+++ b/tests/unit/viewport_inheritance.cpp
@@ -931,7 +931,7 @@ TEST_F(NegativeViewportInheritance, PipelineMissingDynamicStateDiscardRectangle)
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto discard_rect_props = vku::InitStruct<VkPhysicalDeviceDiscardRectanglePropertiesEXT>();
+    VkPhysicalDeviceDiscardRectanglePropertiesEXT discard_rect_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(discard_rect_props);
     if (discard_rect_props.maxDiscardRectangles < 1) {
         GTEST_SKIP() << "maxDiscardRectangles property is less than 1.";

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -42,7 +42,7 @@ TEST_F(NegativeWsi, InitSwapchainPotentiallyIncompatibleFlag) {
     }
     InitSwapchainInfo();
 
-    auto swapchain_ci = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_ci = vku::InitStructHelper();
     swapchain_ci.surface = m_surface;
     swapchain_ci.minImageCount = m_surface_capabilities.minImageCount;
     swapchain_ci.imageFormat = m_surface_formats[0].format;
@@ -62,10 +62,10 @@ TEST_F(NegativeWsi, InitSwapchainPotentiallyIncompatibleFlag) {
         swapchain_ci.flags = VK_SWAPCHAIN_CREATE_PROTECTED_BIT_KHR;
 
         // Get surface protected capabilities
-        auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+        VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
         surface_info.surface = swapchain_ci.surface;
-        auto surface_protected_capabilities = vku::InitStruct<VkSurfaceProtectedCapabilitiesKHR>();
-        auto surface_capabilities = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+        VkSurfaceProtectedCapabilitiesKHR surface_protected_capabilities = vku::InitStructHelper();
+        VkSurfaceCapabilities2KHR surface_capabilities = vku::InitStructHelper();
         surface_capabilities.pNext = &surface_protected_capabilities;
         vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_capabilities);
 
@@ -125,7 +125,7 @@ TEST_F(NegativeWsi, BindImageMemorySwapchain) {
         GTEST_SKIP() << "Cannot create surface or swapchain, skipping BindSwapchainImageMemory test";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = m_surface_formats[0].format;
     image_create_info.extent.width = m_surface_capabilities.minImageExtent.width;
@@ -139,7 +139,7 @@ TEST_F(NegativeWsi, BindImageMemorySwapchain) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-    auto image_swapchain_create_info = vku::InitStruct<VkImageSwapchainCreateInfoKHR>();
+    VkImageSwapchainCreateInfoKHR image_swapchain_create_info = vku::InitStructHelper();
     image_swapchain_create_info.swapchain = m_swapchain;
     image_create_info.pNext = &image_swapchain_create_info;
 
@@ -148,7 +148,7 @@ TEST_F(NegativeWsi, BindImageMemorySwapchain) {
     VkMemoryRequirements mem_reqs = {};
     vk::GetImageMemoryRequirements(device(), image_from_swapchain.handle(), &mem_reqs);
 
-    auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>();
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.memoryTypeIndex = 0;
     alloc_info.allocationSize = mem_reqs.size;
     if (alloc_info.allocationSize == 0) {
@@ -163,7 +163,7 @@ TEST_F(NegativeWsi, BindImageMemorySwapchain) {
         ASSERT_TRUE(mem.initialized());
     }
 
-    auto bind_info = vku::InitStruct<VkBindImageMemoryInfo>();
+    VkBindImageMemoryInfo bind_info = vku::InitStructHelper();
     bind_info.image = image_from_swapchain.handle();
     bind_info.memory = VK_NULL_HANDLE;
     bind_info.memoryOffset = 0;
@@ -173,7 +173,7 @@ TEST_F(NegativeWsi, BindImageMemorySwapchain) {
     vk::BindImageMemory2(m_device->device(), 1, &bind_info);
     m_errorMonitor->VerifyFound();
 
-    auto bind_swapchain_info = vku::InitStruct<VkBindImageMemorySwapchainInfoKHR>();
+    VkBindImageMemorySwapchainInfoKHR bind_swapchain_info = vku::InitStructHelper();
     bind_swapchain_info.swapchain = VK_NULL_HANDLE;
     bind_swapchain_info.imageIndex = 0;
     bind_info.pNext = &bind_swapchain_info;
@@ -220,10 +220,10 @@ TEST_F(NegativeWsi, SwapchainImage) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
-    auto image_swapchain_create_info = vku::InitStruct<VkImageSwapchainCreateInfoKHR>();
+    VkImageSwapchainCreateInfoKHR image_swapchain_create_info = vku::InitStructHelper();
     image_swapchain_create_info.swapchain = m_swapchain;
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>(&image_swapchain_create_info);
+    VkImageCreateInfo image_create_info = vku::InitStructHelper(&image_swapchain_create_info);
     image_create_info.flags = 0;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -307,7 +307,7 @@ TEST_F(NegativeWsi, TransferImageToSwapchainLayoutDeviceGroup) {
     std::vector<VkPhysicalDeviceGroupProperties> physical_device_group(physical_device_group_count,
                                                                        {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, physical_device_group.data());
-    auto create_device_pnext = vku::InitStruct<VkDeviceGroupDeviceCreateInfo>();
+    VkDeviceGroupDeviceCreateInfo create_device_pnext = vku::InitStructHelper();
     create_device_pnext.physicalDeviceCount = physical_device_group[0].physicalDeviceCount;
     create_device_pnext.pPhysicalDevices = physical_device_group[0].physicalDevices;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &create_device_pnext));
@@ -322,7 +322,7 @@ TEST_F(NegativeWsi, TransferImageToSwapchainLayoutDeviceGroup) {
         GTEST_SKIP() << "minImageExtent is not large enough";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = m_surface_formats[0].format;
     image_create_info.extent.width = m_surface_capabilities.minImageExtent.width;
@@ -341,24 +341,24 @@ TEST_F(NegativeWsi, TransferImageToSwapchainLayoutDeviceGroup) {
 
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
-    auto image_swapchain_create_info = vku::InitStruct<VkImageSwapchainCreateInfoKHR>();
+    VkImageSwapchainCreateInfoKHR image_swapchain_create_info = vku::InitStructHelper();
     image_swapchain_create_info.swapchain = m_swapchain;
     image_create_info.pNext = &image_swapchain_create_info;
 
     vkt::Image peer_image(*m_device, image_create_info, vkt::no_mem);
 
-    auto bind_devicegroup_info = vku::InitStruct<VkBindImageMemoryDeviceGroupInfo>();
+    VkBindImageMemoryDeviceGroupInfo bind_devicegroup_info = vku::InitStructHelper();
     bind_devicegroup_info.deviceIndexCount = 1;
     std::array<uint32_t, 1> deviceIndices = {{0}};
     bind_devicegroup_info.pDeviceIndices = deviceIndices.data();
     bind_devicegroup_info.splitInstanceBindRegionCount = 0;
     bind_devicegroup_info.pSplitInstanceBindRegions = nullptr;
 
-    auto bind_swapchain_info = vku::InitStruct<VkBindImageMemorySwapchainInfoKHR>(&bind_devicegroup_info);
+    VkBindImageMemorySwapchainInfoKHR bind_swapchain_info = vku::InitStructHelper(&bind_devicegroup_info);
     bind_swapchain_info.swapchain = m_swapchain;
     bind_swapchain_info.imageIndex = 0;
 
-    auto bind_info = vku::InitStruct<VkBindImageMemoryInfo>(&bind_swapchain_info);
+    VkBindImageMemoryInfo bind_info = vku::InitStructHelper(&bind_swapchain_info);
     bind_info.image = peer_image.handle();
     bind_info.memory = VK_NULL_HANDLE;
     bind_info.memoryOffset = 0;
@@ -382,7 +382,7 @@ TEST_F(NegativeWsi, TransferImageToSwapchainLayoutDeviceGroup) {
 
     m_commandBuffer->end();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
 
@@ -407,7 +407,7 @@ TEST_F(NegativeWsi, SwapchainImageParams) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto device_group_ci = vku::InitStruct<VkDeviceGroupDeviceCreateInfo>();
+    VkDeviceGroupDeviceCreateInfo device_group_ci = vku::InitStructHelper();
     device_group_ci.physicalDeviceCount = 1;
     VkPhysicalDevice pdev = gpu();
     device_group_ci.pPhysicalDevices = &pdev;
@@ -418,7 +418,7 @@ TEST_F(NegativeWsi, SwapchainImageParams) {
     }
     InitSwapchainInfo();
 
-    auto good_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR good_create_info = vku::InitStructHelper();
     good_create_info.surface = m_surface;
     good_create_info.minImageCount = m_surface_capabilities.minImageCount;
     good_create_info.imageFormat = m_surface_formats[0].format;
@@ -539,7 +539,7 @@ TEST_F(NegativeWsi, SwapchainAcquireImageNoSync2KHR) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAcquireNextImageInfoKHR-semaphore-01782");
-        auto acquire_info = vku::InitStruct<VkAcquireNextImageInfoKHR>();
+        VkAcquireNextImageInfoKHR acquire_info = vku::InitStructHelper();
         acquire_info.swapchain = m_swapchain;
         acquire_info.timeout = kWaitTimeout;
         acquire_info.semaphore = VK_NULL_HANDLE;
@@ -563,9 +563,9 @@ TEST_F(NegativeWsi, SwapchainAcquireImageNoBinarySemaphore) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    auto timeline_semaphore_props = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreProperties>();
+    VkPhysicalDeviceTimelineSemaphoreProperties timeline_semaphore_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(timeline_semaphore_props);
     if (timeline_semaphore_props.maxTimelineSemaphoreValueDifference == 0) {
         // If using MockICD and profiles the value might be zero'ed and cause false errors
@@ -574,10 +574,10 @@ TEST_F(NegativeWsi, SwapchainAcquireImageNoBinarySemaphore) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &timeline_semaphore_features));
     ASSERT_TRUE(InitSwapchain());
 
-    auto semaphore_type_create_info = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>();
+    VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
 
-    auto semaphore_create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_create_info);
+    VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper(&semaphore_type_create_info);
 
     vkt::Semaphore semaphore(*m_device, semaphore_create_info);
 
@@ -606,9 +606,9 @@ TEST_F(NegativeWsi, SwapchainAcquireImageNoBinarySemaphore2KHR) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto timeline_semaphore_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeatures>();
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
-    auto timeline_semaphore_props = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreProperties>();
+    VkPhysicalDeviceTimelineSemaphoreProperties timeline_semaphore_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(timeline_semaphore_props);
     if (timeline_semaphore_props.maxTimelineSemaphoreValueDifference == 0) {
         // If using MockICD and profiles the value might be zero'ed and cause false errors
@@ -619,14 +619,14 @@ TEST_F(NegativeWsi, SwapchainAcquireImageNoBinarySemaphore2KHR) {
 
     ASSERT_TRUE(InitSwapchain());
 
-    auto semaphore_type_create_info = vku::InitStruct<VkSemaphoreTypeCreateInfoKHR>();
+    VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
 
-    auto semaphore_create_info = vku::InitStruct<VkSemaphoreCreateInfo>(&semaphore_type_create_info);
+    VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper(&semaphore_type_create_info);
 
     vkt::Semaphore semaphore(*m_device, semaphore_create_info);
 
-    auto acquire_info = vku::InitStruct<VkAcquireNextImageInfoKHR>();
+    VkAcquireNextImageInfoKHR acquire_info = vku::InitStructHelper();
     acquire_info.swapchain = m_swapchain;
     acquire_info.timeout = kWaitTimeout;
     acquire_info.semaphore = semaphore.handle();
@@ -738,12 +738,12 @@ TEST_F(NegativeWsi, SwapchainNotSupported) {
         GTEST_SKIP() << "All queues support surface present";
     }
     float queue_priority = 1.0f;
-    auto queue_create_info = vku::InitStruct<VkDeviceQueueCreateInfo>();
+    VkDeviceQueueCreateInfo queue_create_info = vku::InitStructHelper();
     queue_create_info.queueFamilyIndex = qfi;
     queue_create_info.queueCount = 1;
     queue_create_info.pQueuePriorities = &queue_priority;
 
-    auto device_create_info = vku::InitStruct<VkDeviceCreateInfo>();
+    VkDeviceCreateInfo device_create_info = vku::InitStructHelper();
     device_create_info.queueCreateInfoCount = 1;
     device_create_info.pQueueCreateInfos = &queue_create_info;
     device_create_info.enabledExtensionCount = m_device_extension_names.size();
@@ -758,7 +758,7 @@ TEST_F(NegativeWsi, SwapchainNotSupported) {
     }
 
     // try creating a swapchain, using surface info queried from the default device
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper();
     swapchain_create_info.flags = 0;
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
@@ -813,7 +813,7 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages2KHR) {
     error_fence.init(*m_device, vkt::Fence::create_info());
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAcquireNextImage2KHR-surface-07784");
-    auto acquire_info = vku::InitStruct<VkAcquireNextImageInfoKHR>();
+    VkAcquireNextImageInfoKHR acquire_info = vku::InitStructHelper();
 
     acquire_info.swapchain = m_swapchain;
     acquire_info.timeout = vvl::kU64Max;  // NOTE: timeout MUST be UINT64_MAX to trigger the VUID
@@ -873,11 +873,11 @@ TEST_F(NegativeWsi, SwapchainImageFormatList) {
     // Use sampled formats that will always be supported
     // Last format is not compatible with the rest
     const VkFormat formats[4] = {VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_R8G8B8A8_SNORM, VK_FORMAT_R8G8B8A8_UINT, VK_FORMAT_R8_UNORM};
-    auto format_list = vku::InitStruct<VkImageFormatListCreateInfo>();
+    VkImageFormatListCreateInfo format_list = vku::InitStructHelper();
     format_list.viewFormatCount = 3;  // first 3 are compatible
     format_list.pViewFormats = formats;
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>(&format_list);
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper(&format_list);
     swapchain_create_info.flags = 0;
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
@@ -958,7 +958,7 @@ TEST_F(NegativeWsi, SwapchainMinImageCountNonShared) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper();
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = 1;  // invalid
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
@@ -1019,9 +1019,9 @@ TEST_F(NegativeWsi, SwapchainMinImageCountShared) {
         GTEST_SKIP() << "Cannot find supported shared present mode";
     }
 
-    auto shared_present_capabilities = vku::InitStruct<VkSharedPresentSurfaceCapabilitiesKHR>();
-    auto capabilities = vku::InitStruct<VkSurfaceCapabilities2KHR>(&shared_present_capabilities);
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+    VkSharedPresentSurfaceCapabilitiesKHR shared_present_capabilities = vku::InitStructHelper();
+    VkSurfaceCapabilities2KHR capabilities = vku::InitStructHelper(&shared_present_capabilities);
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = m_surface;
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &capabilities);
 
@@ -1030,7 +1030,7 @@ TEST_F(NegativeWsi, SwapchainMinImageCountShared) {
         GTEST_SKIP() << "Driver was suppose to support VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT";
     }
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper();
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = 2;  // invalid
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
@@ -1081,7 +1081,7 @@ TEST_F(NegativeWsi, SwapchainUsageNonShared) {
         GTEST_SKIP() << "Test has supported usage already the test is using";
     }
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper();
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
@@ -1139,9 +1139,9 @@ TEST_F(NegativeWsi, SwapchainUsageShared) {
         GTEST_SKIP() << "Cannot find supported shared present mode";
     }
 
-    auto shared_present_capabilities = vku::InitStruct<VkSharedPresentSurfaceCapabilitiesKHR>();
-    auto capabilities = vku::InitStruct<VkSurfaceCapabilities2KHR>(&shared_present_capabilities);
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+    VkSharedPresentSurfaceCapabilitiesKHR shared_present_capabilities = vku::InitStructHelper();
+    VkSurfaceCapabilities2KHR capabilities = vku::InitStructHelper(&shared_present_capabilities);
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = m_surface;
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &capabilities);
 
@@ -1150,7 +1150,7 @@ TEST_F(NegativeWsi, SwapchainUsageShared) {
         GTEST_SKIP() << "Test has supported usage already the test is using";
     }
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper();
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = 1;
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
@@ -1208,9 +1208,9 @@ TEST_F(NegativeWsi, SwapchainPresentShared) {
         GTEST_SKIP() << "Cannot find supported shared present mode";
     }
 
-    auto shared_present_capabilities = vku::InitStruct<VkSharedPresentSurfaceCapabilitiesKHR>();
-    auto capabilities = vku::InitStruct<VkSurfaceCapabilities2KHR>(&shared_present_capabilities);
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+    VkSharedPresentSurfaceCapabilitiesKHR shared_present_capabilities = vku::InitStructHelper();
+    VkSurfaceCapabilities2KHR capabilities = vku::InitStructHelper(&shared_present_capabilities);
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = m_surface;
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &capabilities);
 
@@ -1219,7 +1219,7 @@ TEST_F(NegativeWsi, SwapchainPresentShared) {
         GTEST_SKIP() << "Driver was suppose to support VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT";
     }
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper();
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = 1;
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
@@ -1241,7 +1241,7 @@ TEST_F(NegativeWsi, SwapchainPresentShared) {
 
     // Try to Present without Acquire...
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPresentInfoKHR-pImageIndices-01430");
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.waitSemaphoreCount = 0;
     present.swapchainCount = 1;
     present.pSwapchains = &m_swapchain;
@@ -1275,7 +1275,7 @@ TEST_F(NegativeWsi, DeviceMask) {
     std::vector<VkPhysicalDeviceGroupProperties> physical_device_group(physical_device_group_count,
                                                                        {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, physical_device_group.data());
-    auto create_device_pnext = vku::InitStruct<VkDeviceGroupDeviceCreateInfo>();
+    VkDeviceGroupDeviceCreateInfo create_device_pnext = vku::InitStructHelper();
     create_device_pnext.physicalDeviceCount = physical_device_group[0].physicalDeviceCount;
     create_device_pnext.pPhysicalDevices = physical_device_group[0].physicalDevices;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &create_device_pnext, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
@@ -1286,10 +1286,10 @@ TEST_F(NegativeWsi, DeviceMask) {
     }
 
     // Test VkMemoryAllocateFlagsInfo
-    auto alloc_flags_info = vku::InitStruct<VkMemoryAllocateFlagsInfo>();
+    VkMemoryAllocateFlagsInfo alloc_flags_info = vku::InitStructHelper();
     alloc_flags_info.flags = VK_MEMORY_ALLOCATE_DEVICE_MASK_BIT;
     alloc_flags_info.deviceMask = 0xFFFFFFFF;
-    auto alloc_info = vku::InitStruct<VkMemoryAllocateInfo>(&alloc_flags_info);
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags_info);
     alloc_info.memoryTypeIndex = 0;
     alloc_info.allocationSize = 1024;
 
@@ -1334,9 +1334,9 @@ TEST_F(NegativeWsi, DeviceMask) {
     }
 
     // Test VkDeviceGroupCommandBufferBeginInfo
-    auto dev_grp_cmd_buf_info = vku::InitStruct<VkDeviceGroupCommandBufferBeginInfo>();
+    VkDeviceGroupCommandBufferBeginInfo dev_grp_cmd_buf_info = vku::InitStructHelper();
     dev_grp_cmd_buf_info.deviceMask = 0xFFFFFFFF;
-    auto cmd_buf_info = vku::InitStruct<VkCommandBufferBeginInfo>(&dev_grp_cmd_buf_info);
+    VkCommandBufferBeginInfo cmd_buf_info = vku::InitStructHelper(&dev_grp_cmd_buf_info);
 
     m_commandBuffer->reset();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceGroupCommandBufferBeginInfo-deviceMask-00106");
@@ -1354,7 +1354,7 @@ TEST_F(NegativeWsi, DeviceMask) {
     m_commandBuffer->reset();
     vk::BeginCommandBuffer(m_commandBuffer->handle(), &cmd_buf_info);
 
-    auto dev_grp_rp_info = vku::InitStruct<VkDeviceGroupRenderPassBeginInfo>();
+    VkDeviceGroupRenderPassBeginInfo dev_grp_rp_info = vku::InitStructHelper();
     dev_grp_rp_info.deviceMask = 0xFFFFFFFF;
     m_renderPassBeginInfo.pNext = &dev_grp_rp_info;
 
@@ -1397,7 +1397,7 @@ TEST_F(NegativeWsi, DeviceMask) {
 
     // Test VkAcquireNextImageInfoKHR
     uint32_t imageIndex;
-    auto acquire_next_image_info = vku::InitStruct<VkAcquireNextImageInfoKHR>();
+    VkAcquireNextImageInfoKHR acquire_next_image_info = vku::InitStructHelper();
     acquire_next_image_info.semaphore = semaphore.handle();
     acquire_next_image_info.swapchain = m_swapchain;
     acquire_next_image_info.fence = fence.handle();
@@ -1417,12 +1417,12 @@ TEST_F(NegativeWsi, DeviceMask) {
     m_errorMonitor->VerifyFound();
 
     // Test VkDeviceGroupSubmitInfo
-    auto device_group_submit_info = vku::InitStruct<VkDeviceGroupSubmitInfo>();
+    VkDeviceGroupSubmitInfo device_group_submit_info = vku::InitStructHelper();
     device_group_submit_info.commandBufferCount = 1;
     std::array<uint32_t, 1> command_buffer_device_masks = {{0xFFFFFFFF}};
     device_group_submit_info.pCommandBufferDeviceMasks = command_buffer_device_masks.data();
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>(&device_group_submit_info);
+    VkSubmitInfo submit_info = vku::InitStructHelper(&device_group_submit_info);
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
 
@@ -1505,7 +1505,7 @@ TEST_F(NegativeWsi, DisplayPlaneSurface) {
     ASSERT_VK_SUCCESS(vk::GetDisplayPlaneCapabilitiesKHR(gpu(), display_mode, 0, &plane_capabilities));
 
     VkSurfaceKHR surface;
-    auto display_surface_info = vku::InitStruct<VkDisplaySurfaceCreateInfoKHR>();
+    VkDisplaySurfaceCreateInfoKHR display_surface_info = vku::InitStructHelper();
     display_surface_info.flags = 0;
     display_surface_info.displayMode = display_mode;
     display_surface_info.planeIndex = 0;
@@ -1596,23 +1596,23 @@ TEST_F(NegativeWsi, DeviceGroupSubmitInfoSemaphoreCount) {
     std::vector<VkPhysicalDeviceGroupProperties> physical_device_group(physical_device_group_count,
                                                                        {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, physical_device_group.data());
-    auto create_device_pnext = vku::InitStruct<VkDeviceGroupDeviceCreateInfo>();
+    VkDeviceGroupDeviceCreateInfo create_device_pnext = vku::InitStructHelper();
     create_device_pnext.physicalDeviceCount = physical_device_group[0].physicalDeviceCount;
     create_device_pnext.pPhysicalDevices = physical_device_group[0].physicalDevices;
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &create_device_pnext, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    auto dev_grp_cmd_buf_info = vku::InitStruct<VkDeviceGroupCommandBufferBeginInfo>();
+    VkDeviceGroupCommandBufferBeginInfo dev_grp_cmd_buf_info = vku::InitStructHelper();
     dev_grp_cmd_buf_info.deviceMask = 0x1;
-    auto cmd_buf_info = vku::InitStruct<VkCommandBufferBeginInfo>(&dev_grp_cmd_buf_info);
+    VkCommandBufferBeginInfo cmd_buf_info = vku::InitStructHelper(&dev_grp_cmd_buf_info);
 
     vkt::Semaphore semaphore(*m_device);
 
-    auto device_group_submit_info = vku::InitStruct<VkDeviceGroupSubmitInfo>();
+    VkDeviceGroupSubmitInfo device_group_submit_info = vku::InitStructHelper();
     device_group_submit_info.commandBufferCount = 1;
     uint32_t command_buffer_device_masks = 0;
     device_group_submit_info.pCommandBufferDeviceMasks = &command_buffer_device_masks;
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>(&device_group_submit_info);
+    VkSubmitInfo submit_info = vku::InitStructHelper(&device_group_submit_info);
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     submit_info.signalSemaphoreCount = 1;
@@ -1626,7 +1626,7 @@ TEST_F(NegativeWsi, DeviceGroupSubmitInfoSemaphoreCount) {
     m_errorMonitor->VerifyFound();
     vk::QueueWaitIdle(m_device->m_queue);
 
-    auto signal_submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo signal_submit_info = vku::InitStructHelper();
     signal_submit_info.signalSemaphoreCount = 1;
     signal_submit_info.pSignalSemaphores = &semaphore.handle();
     vk::QueueSubmit(m_device->m_queue, 1, &signal_submit_info, VK_NULL_HANDLE);
@@ -1672,13 +1672,13 @@ TEST_F(NegativeWsi, SwapchainAcquireImageWithSignaledSemaphore) {
 
     vkt::Semaphore semaphore(*m_device);
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.signalSemaphoreCount = 1;
     submit_info.pSignalSemaphores = &semaphore.handle();
     vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     vk::QueueWaitIdle(m_device->m_queue);
 
-    auto acquire_info = vku::InitStruct<VkAcquireNextImageInfoKHR>();
+    VkAcquireNextImageInfoKHR acquire_info = vku::InitStructHelper();
     acquire_info.swapchain = m_swapchain;
     acquire_info.timeout = kWaitTimeout;
     acquire_info.semaphore = semaphore.handle();
@@ -1709,7 +1709,7 @@ TEST_F(NegativeWsi, DisplayPresentInfoSrcRect) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     uint32_t current_buffer;
-    auto semaphore_create_info = vku::InitStruct<VkSemaphoreCreateInfo>();
+    VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper();
     vkt::Semaphore image_acquired(*m_device, semaphore_create_info);
     ASSERT_TRUE(image_acquired.initialized());
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, image_acquired.handle(), VK_NULL_HANDLE, &current_buffer);
@@ -1722,13 +1722,13 @@ TEST_F(NegativeWsi, DisplayPresentInfoSrcRect) {
     uint32_t swapchain_width = m_surface_capabilities.minImageExtent.width;
     uint32_t swapchain_height = m_surface_capabilities.minImageExtent.height;
 
-    auto display_present_info = vku::InitStruct<VkDisplayPresentInfoKHR>();
+    VkDisplayPresentInfoKHR display_present_info = vku::InitStructHelper();
     display_present_info.srcRect.extent.width = swapchain_width + 1;  // Invalid
     display_present_info.srcRect.extent.height = swapchain_height;
     display_present_info.dstRect.extent.width = swapchain_width;
     display_present_info.dstRect.extent.height = swapchain_height;
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>(&display_present_info);
+    VkPresentInfoKHR present = vku::InitStructHelper(&display_present_info);
     present.waitSemaphoreCount = 1;
     present.pWaitSemaphores = &image_acquired.handle();
     present.pSwapchains = &m_swapchain;
@@ -1788,8 +1788,8 @@ TEST_F(NegativeWsi, PresentIdWait) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto present_id_features = vku::InitStruct<VkPhysicalDevicePresentIdFeaturesKHR>();
-    auto present_wait_features = vku::InitStruct<VkPhysicalDevicePresentWaitFeaturesKHR>(&present_id_features);
+    VkPhysicalDevicePresentIdFeaturesKHR present_id_features = vku::InitStructHelper();
+    VkPhysicalDevicePresentWaitFeaturesKHR present_wait_features = vku::InitStructHelper(&present_id_features);
     GetPhysicalDeviceFeatures2(present_wait_features);
 
     if (!present_id_features.presentId || !present_wait_features.presentWait) {
@@ -1828,10 +1828,10 @@ TEST_F(NegativeWsi, PresentIdWait) {
     VkSwapchainKHR swap_chains[2] = {m_swapchain, swapchain2};
     uint64_t present_ids[2] = {};
     present_ids[0] = 4;  // Try setting 3 later
-    auto present_id = vku::InitStruct<VkPresentIdKHR>();
+    VkPresentIdKHR present_id = vku::InitStructHelper();
     present_id.swapchainCount = 2;
     present_id.pPresentIds = present_ids;
-    auto present = vku::InitStruct<VkPresentInfoKHR>(&present_id);
+    VkPresentInfoKHR present = vku::InitStructHelper(&present_id);
     present.pSwapchains = swap_chains;
     present.pImageIndices = image_indices;
     present.swapchainCount = 2;
@@ -1909,11 +1909,11 @@ TEST_F(NegativeWsi, PresentIdWaitFeatures) {
     SetImageLayout(m_device, VK_IMAGE_ASPECT_COLOR_BIT, images[image_index], VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
     uint64_t present_id_index = 1;
-    auto present_id = vku::InitStruct<VkPresentIdKHR>();
+    VkPresentIdKHR present_id = vku::InitStructHelper();
     present_id.swapchainCount = 1;
     present_id.pPresentIds = &present_id_index;
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>(&present_id);
+    VkPresentInfoKHR present = vku::InitStructHelper(&present_id);
     present.pSwapchains = &m_swapchain;
     present.pImageIndices = &image_index;
     present.swapchainCount = 1;
@@ -1950,7 +1950,7 @@ TEST_F(NegativeWsi, GetSwapchainImagesCountButNotImages) {
     VkExtent2D img_ext = {std::min(m_surface_capabilities.maxImageExtent.width, img_format_props.maxExtent.width),
                           std::min(m_surface_capabilities.maxImageExtent.height, img_format_props.maxExtent.height)};
 
-    auto swapchain_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_info = vku::InitStructHelper();
     swapchain_info.surface = m_surface;
     swapchain_info.minImageCount = m_surface_capabilities.minImageCount;
     swapchain_info.imageFormat = m_surface_formats[0].format;
@@ -1972,7 +1972,7 @@ TEST_F(NegativeWsi, GetSwapchainImagesCountButNotImages) {
     vk::GetSwapchainImagesKHR(device(), m_swapchain, &imageCount, nullptr);
 
     const uint32_t image_index = 0;
-    auto present_info = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present_info = vku::InitStructHelper();
     present_info.pImageIndices = &image_index;
     present_info.pSwapchains = &m_swapchain;
     present_info.swapchainCount = 1;
@@ -2027,7 +2027,7 @@ TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     if (full_screen_exclusive) {
-        auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+        VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
         surface_info.surface = m_surface;
         VkDeviceGroupPresentModeFlagsKHR flags = VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHR;
 
@@ -2053,7 +2053,7 @@ TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
     }
 
     if (display_surface_counter) {
-        auto capabilities = vku::InitStruct<VkSurfaceCapabilities2EXT>();
+        VkSurfaceCapabilities2EXT capabilities = vku::InitStructHelper();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2EXT-surface-06211");
         vk::GetPhysicalDeviceSurfaceCapabilities2EXT(gpu(), m_surface, &capabilities);
@@ -2061,9 +2061,9 @@ TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
     }
 
     if (get_surface_capabilities2) {
-        auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+        VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
         surface_info.surface = m_surface;
-        auto capabilities = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+        VkSurfaceCapabilities2KHR capabilities = vku::InitStructHelper();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pSurfaceInfo-06522");
         vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &capabilities);
@@ -2078,7 +2078,7 @@ TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
     }
 
     if (get_surface_capabilities2) {
-        auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+        VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
         surface_info.surface = m_surface;
         uint32_t count;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceInfo-06522");
@@ -2134,7 +2134,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
     VkImageUsageFlags imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     VkSurfaceTransformFlagBitsKHR preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper();
     swapchain_create_info.surface = surface;
     swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
@@ -2163,8 +2163,8 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
     std::vector<VkPresentModeKHR> pdev_surface_present_modes(count);
     vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), m_surface, &count, pdev_surface_present_modes.data());
 
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
-    auto surface_caps = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
+    VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
     surface_info.surface = m_surface;
 
     // Set a present_mode in VkSurfacePresentModeEXT that's NOT returned by GetPhsyicalDeviceSurfaceCapabilities2KHR
@@ -2177,7 +2177,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
         }
     }
 
-    auto present_mode = vku::InitStruct<VkSurfacePresentModeEXT>();
+    VkSurfacePresentModeEXT present_mode = vku::InitStructHelper();
     present_mode.presentMode = mismatched_present_mode;
 
     surface_info.pNext = &present_mode;
@@ -2186,7 +2186,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
     m_errorMonitor->VerifyFound();
 
-    auto present_mode_compatibility = vku::InitStruct<VkSurfacePresentModeCompatibilityEXT>();
+    VkSurfacePresentModeCompatibilityEXT present_mode_compatibility = vku::InitStructHelper();
     present_mode.presentMode = pdev_surface_present_modes[0];
     surface_caps.pNext = &present_mode_compatibility;
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
@@ -2195,13 +2195,13 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
     present_mode_compatibility.pPresentModes = compatible_present_modes.data();
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
 
-    auto scaling_capabilities = vku::InitStruct<VkSurfacePresentScalingCapabilitiesEXT>();
+    VkSurfacePresentScalingCapabilitiesEXT scaling_capabilities = vku::InitStructHelper();
     surface_caps.pNext = &scaling_capabilities;
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
 
     mismatched_present_mode = VK_PRESENT_MODE_MAX_ENUM_KHR;
 
-    auto present_modes_ci = vku::InitStruct<VkSwapchainPresentModesCreateInfoEXT>();
+    VkSwapchainPresentModesCreateInfoEXT present_modes_ci = vku::InitStructHelper();
     swapchain_create_info.pNext = &present_modes_ci;
     present_modes_ci.presentModeCount = 1;
     present_modes_ci.pPresentModes = &mismatched_present_mode;
@@ -2254,7 +2254,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
     }
 
     swapchain_create_info.presentMode = compatible_present_modes[0];
-    auto present_scaling_info = vku::InitStruct<VkSwapchainPresentScalingCreateInfoEXT>();
+    VkSwapchainPresentScalingCreateInfoEXT present_scaling_info = vku::InitStructHelper();
     present_scaling_info.pNext = swapchain_create_info.pNext;
     swapchain_create_info.pNext = &present_scaling_info;
 
@@ -2405,7 +2405,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
     vk::QueueWaitIdle(m_device->m_queue);
 
     uint32_t release_index = static_cast<uint32_t>(swapchain_images.size()) + 2;
-    auto release_info = vku::InitStruct<VkReleaseSwapchainImagesInfoEXT>();
+    VkReleaseSwapchainImagesInfoEXT release_info = vku::InitStructHelper();
     release_info.swapchain = m_swapchain;
     release_info.imageIndexCount = 1;
     release_info.pImageIndices = &release_index;
@@ -2453,7 +2453,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionCaps) {
     VkImageUsageFlags imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     VkSurfaceTransformFlagBitsKHR preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper();
     swapchain_create_info.surface = surface;
     swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
@@ -2470,7 +2470,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionCaps) {
     swapchain_create_info.flags = VK_SWAPCHAIN_CREATE_DEFERRED_MEMORY_ALLOCATION_BIT_EXT;
 
     VkPresentModeKHR old_present_mode = m_surface_non_shared_present_mode;
-    auto present_modes_ci = vku::InitStruct<VkSwapchainPresentModesCreateInfoEXT>();
+    VkSwapchainPresentModesCreateInfoEXT present_modes_ci = vku::InitStructHelper();
     swapchain_create_info.pNext = &present_modes_ci;
     present_modes_ci.presentModeCount = 1;
     present_modes_ci.pPresentModes = &old_present_mode;
@@ -2479,7 +2479,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionCaps) {
 
     const auto swapchain_images = GetSwapchainImages(m_swapchain);
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = m_surface_formats[0].format;
     image_create_info.extent.width = m_surface_capabilities.minImageExtent.width;
@@ -2493,18 +2493,18 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionCaps) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-    auto image_swapchain_create_info = vku::InitStruct<VkImageSwapchainCreateInfoKHR>();
+    VkImageSwapchainCreateInfoKHR image_swapchain_create_info = vku::InitStructHelper();
     image_swapchain_create_info.swapchain = m_swapchain;
     image_create_info.pNext = &image_swapchain_create_info;
 
     vkt::Image image_from_swapchain(*m_device, image_create_info, vkt::no_mem);
 
-    auto bind_info = vku::InitStruct<VkBindImageMemoryInfo>();
+    VkBindImageMemoryInfo bind_info = vku::InitStructHelper();
     bind_info.image = image_from_swapchain.handle();
     bind_info.memory = VK_NULL_HANDLE;
     bind_info.memoryOffset = 0;
 
-    auto bind_swapchain_info = vku::InitStruct<VkBindImageMemorySwapchainInfoKHR>();
+    VkBindImageMemorySwapchainInfoKHR bind_swapchain_info = vku::InitStructHelper();
     bind_swapchain_info.imageIndex = 0;
     bind_info.pNext = &bind_swapchain_info;
     bind_swapchain_info.swapchain = m_swapchain;
@@ -2518,12 +2518,12 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionCaps) {
     std::vector<VkPresentModeKHR> present_modes(count);
     vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), m_surface, &count, present_modes.data());
 
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
-    auto surface_caps = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
+    VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
     surface_info.surface = m_surface;
 
-    auto present_mode = vku::InitStruct<VkSurfacePresentModeEXT>();
-    auto present_mode_compatibility = vku::InitStruct<VkSurfacePresentModeCompatibilityEXT>();
+    VkSurfacePresentModeEXT present_mode = vku::InitStructHelper();
+    VkSurfacePresentModeCompatibilityEXT present_mode_compatibility = vku::InitStructHelper();
     present_mode.presentMode = present_modes[0];
     surface_caps.pNext = &present_mode_compatibility;
 
@@ -2539,7 +2539,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionCaps) {
     present_mode_compatibility.pPresentModes = compatible_present_modes.data();
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
 
-    auto scaling_capabilities = vku::InitStruct<VkSurfacePresentScalingCapabilitiesEXT>();
+    VkSurfacePresentScalingCapabilitiesEXT scaling_capabilities = vku::InitStructHelper();
     surface_caps.pNext = &scaling_capabilities;
     surface_info.pNext = nullptr;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-07777");
@@ -2752,14 +2752,14 @@ TEST_F(NegativeWsi, AcquireFullScreenExclusiveModeEXT) {
 
     const POINT pt_zero = {0, 0};
 
-    auto surface_full_screen_exlusive_info_win32 = vku::InitStruct<VkSurfaceFullScreenExclusiveWin32InfoEXT>();
+    VkSurfaceFullScreenExclusiveWin32InfoEXT surface_full_screen_exlusive_info_win32 = vku::InitStructHelper();
     surface_full_screen_exlusive_info_win32.hmonitor = MonitorFromPoint(pt_zero, MONITOR_DEFAULTTOPRIMARY);
 
-    auto surface_full_screen_exlusive_info =
-        vku::InitStruct<VkSurfaceFullScreenExclusiveInfoEXT>(&surface_full_screen_exlusive_info_win32);
+    VkSurfaceFullScreenExclusiveInfoEXT surface_full_screen_exlusive_info =
+        vku::InitStructHelper(&surface_full_screen_exlusive_info_win32);
     surface_full_screen_exlusive_info.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT;
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>(&surface_full_screen_exlusive_info);
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper(&surface_full_screen_exlusive_info);
     swapchain_create_info.flags = 0;
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
@@ -2824,9 +2824,9 @@ TEST_F(NegativeWsi, CreateSwapchainFullscreenExclusive) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
-    auto surface_full_screen_exlusive_info = vku::InitStruct<VkSurfaceFullScreenExclusiveInfoEXT>();
+    VkSurfaceFullScreenExclusiveInfoEXT surface_full_screen_exlusive_info = vku::InitStructHelper();
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>(&surface_full_screen_exlusive_info);
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper(&surface_full_screen_exlusive_info);
     swapchain_create_info.flags = 0;
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
@@ -2875,13 +2875,13 @@ TEST_F(NegativeWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullScreenEXT) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
-    auto fullscreen_exclusive_info = vku::InitStruct<VkSurfaceFullScreenExclusiveInfoEXT>();
+    VkSurfaceFullScreenExclusiveInfoEXT fullscreen_exclusive_info = vku::InitStructHelper();
     fullscreen_exclusive_info.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT;
     // no VkSurfaceFullScreenExclusiveWin32InfoEXT in pNext chain
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>(&fullscreen_exclusive_info);
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper(&fullscreen_exclusive_info);
     surface_info.surface = m_surface;
 
-    auto surface_caps = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceSurfaceInfo2KHR-pNext-02672");
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(m_device->phy(), &surface_info, &surface_caps);
     m_errorMonitor->VerifyFound();
@@ -2897,7 +2897,7 @@ TEST_F(NegativeWsi, CreatingWin32Surface) {
     AddSurfaceExtension();
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    auto surface_create_info = vku::InitStruct<VkWin32SurfaceCreateInfoKHR>();
+    VkWin32SurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
     surface_create_info.hinstance = GetModuleHandle(0);
     surface_create_info.hwnd = NULL;  // Invalid
 
@@ -2970,7 +2970,7 @@ TEST_F(NegativeWsi, CreatingWaylandSurface) {
 
     // Invalid display
     {
-        auto surface_create_info = vku::InitStruct<VkWaylandSurfaceCreateInfoKHR>();
+        VkWaylandSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
         surface_create_info.display = nullptr;
         surface_create_info.surface = surface;
 
@@ -2982,7 +2982,7 @@ TEST_F(NegativeWsi, CreatingWaylandSurface) {
 
     // Invalid surface
     {
-        auto surface_create_info = vku::InitStruct<VkWaylandSurfaceCreateInfoKHR>();
+        VkWaylandSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
         surface_create_info.display = display;
         surface_create_info.surface = nullptr;
 
@@ -3028,7 +3028,7 @@ TEST_F(NegativeWsi, CreatingXcbSurface) {
 
     // Invalid connection
     {
-        auto surface_create_info = vku::InitStruct<VkXcbSurfaceCreateInfoKHR>();
+        VkXcbSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
         surface_create_info.connection = nullptr;
         surface_create_info.window = xcb_window;
 
@@ -3040,7 +3040,7 @@ TEST_F(NegativeWsi, CreatingXcbSurface) {
 
     // Invalid window
     {
-        auto surface_create_info = vku::InitStruct<VkXcbSurfaceCreateInfoKHR>();
+        VkXcbSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
         surface_create_info.connection = xcb_connection;
         surface_create_info.window = 0;
 
@@ -3089,7 +3089,7 @@ TEST_F(NegativeWsi, CreatingX11Surface) {
     // Invalid display
     {
         VkSurfaceKHR vulkan_surface;
-        auto surface_create_info = vku::InitStruct<VkXlibSurfaceCreateInfoKHR>();
+        VkXlibSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
         surface_create_info.dpy = nullptr;
         surface_create_info.window = x11_window;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkXlibSurfaceCreateInfoKHR-dpy-01313");
@@ -3100,7 +3100,7 @@ TEST_F(NegativeWsi, CreatingX11Surface) {
     // Invalid window
     {
         VkSurfaceKHR vulkan_surface;
-        auto surface_create_info = vku::InitStruct<VkXlibSurfaceCreateInfoKHR>();
+        VkXlibSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
         surface_create_info.dpy = x11_display;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkXlibSurfaceCreateInfoKHR-window-01314");
         vk::CreateXlibSurfaceKHR(instance(), &surface_create_info, nullptr, &vulkan_surface);
@@ -3136,7 +3136,7 @@ TEST_F(NegativeWsi, UseSwapchainImageBeforeWait) {
     uint32_t image_index = 0;
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore.handle(), VK_NULL_HANDLE, &image_index);
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.waitSemaphoreCount = 0;  // Invalid, acquire_semaphore should be waited on
     present.swapchainCount = 1;
     present.pSwapchains = &m_swapchain;
@@ -3169,7 +3169,7 @@ TEST_F(NegativeWsi, CreatingSwapchainWithExtent) {
     VkSurfaceCapabilitiesKHR surface_capabilities;
     vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(gpu(), m_surface, &surface_capabilities);
 
-    auto swapchain_ci = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_ci = vku::InitStructHelper();
     swapchain_ci.surface = m_surface;
     swapchain_ci.minImageCount = m_surface_capabilities.minImageCount;
     swapchain_ci.imageFormat = m_surface_formats[0].format;
@@ -3204,7 +3204,7 @@ TEST_F(NegativeWsi, SurfaceQueryImageCompressionControlWithoutExtension) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    auto image_compression_control = vku::InitStruct<VkPhysicalDeviceImageCompressionControlFeaturesEXT>();
+    VkPhysicalDeviceImageCompressionControlFeaturesEXT image_compression_control = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(image_compression_control);
 
     if (image_compression_control.imageCompressionControl) {
@@ -3219,8 +3219,8 @@ TEST_F(NegativeWsi, SurfaceQueryImageCompressionControlWithoutExtension) {
         GTEST_SKIP() << "Cannot create surface";
     }
 
-    auto compression_properties = vku::InitStruct<VkImageCompressionPropertiesEXT>();
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>(&compression_properties);
+    VkImageCompressionPropertiesEXT compression_properties = vku::InitStructHelper();
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper(&compression_properties);
     surface_info.surface = m_surface;
     uint32_t count;
 
@@ -3247,12 +3247,12 @@ TEST_F(NegativeWsi, PhysicalDeviceSurfaceCapabilities) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_TRUE(InitSwapchain());
 
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = m_surface;
 
-    auto capabilities_full_screen_exclusive = vku::InitStruct<VkSurfaceCapabilitiesFullScreenExclusiveEXT>();
+    VkSurfaceCapabilitiesFullScreenExclusiveEXT capabilities_full_screen_exclusive = vku::InitStructHelper();
 
-    auto surface_capabilities = vku::InitStruct<VkSurfaceCapabilities2KHR>(&capabilities_full_screen_exclusive);
+    VkSurfaceCapabilities2KHR surface_capabilities = vku::InitStructHelper(&capabilities_full_screen_exclusive);
     surface_capabilities.surfaceCapabilities = m_surface_capabilities;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-02671");
@@ -3291,14 +3291,14 @@ TEST_F(NegativeWsi, QueuePresentWaitingSameSemaphore) {
     VkQueue other = m_device->graphics_queues()[1]->handle();
 
     VkPipelineStageFlags stage_flags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-    auto wait_submit = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo wait_submit = vku::InitStructHelper();
     wait_submit.waitSemaphoreCount = 1;
     wait_submit.pWaitSemaphores = &semaphore.handle();
     wait_submit.pWaitDstStageMask = &stage_flags;
 
     vk::QueueSubmit(m_device->m_queue, 1, &wait_submit, VK_NULL_HANDLE);
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.pSwapchains = &m_swapchain;
     present.pImageIndices = &image_index;
     present.swapchainCount = 1;
@@ -3322,7 +3322,7 @@ TEST_F(NegativeWsi, QueuePresentBinarySemaphoreNotSignaled) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    auto timeline_features = vku::InitStruct<VkPhysicalDeviceTimelineSemaphoreFeaturesKHR>();
+    VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(timeline_features);
 
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
@@ -3343,14 +3343,14 @@ TEST_F(NegativeWsi, QueuePresentBinarySemaphoreNotSignaled) {
     SetImageLayout(m_device, VK_IMAGE_ASPECT_COLOR_BIT, images[image_index], VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
     VkPipelineStageFlags stage_flags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.waitSemaphoreCount = 1;
     submit_info.pWaitSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &stage_flags;
     err = vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE);
     ASSERT_VK_SUCCESS(err);
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.pSwapchains = &m_swapchain;
     present.pImageIndices = &image_index;
     present.swapchainCount = 1;
@@ -3384,7 +3384,7 @@ TEST_F(NegativeWsi, SwapchainAcquireImageRetired) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_TRUE(InitSwapchain());
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper();
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
@@ -3404,7 +3404,7 @@ TEST_F(NegativeWsi, SwapchainAcquireImageRetired) {
 
     vkt::Semaphore semaphore(*m_device);
 
-    auto acquire_info = vku::InitStruct<VkAcquireNextImageInfoKHR>();
+    VkAcquireNextImageInfoKHR acquire_info = vku::InitStructHelper();
     acquire_info.swapchain = m_swapchain;
     acquire_info.timeout = kWaitTimeout;
     acquire_info.semaphore = semaphore.handle();
@@ -3442,7 +3442,7 @@ TEST_F(NegativeWsi, PresentInfoParameters) {
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
     vk::WaitForFences(device(), 1, &fence.handle(), true, kWaitTimeout);
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.waitSemaphoreCount = 0;
     present.swapchainCount = 0;
     present.pSwapchains = &m_swapchain;
@@ -3479,8 +3479,8 @@ TEST_F(NegativeWsi, PresentRegionsKHR) {
     // Allowed to have zero rectangleCount
     VkPresentRegionKHR region[2] = {{0, nullptr}, {0, nullptr}};
 
-    auto regions = vku::InitStruct<VkPresentRegionsKHR>();
-    auto present = vku::InitStruct<VkPresentInfoKHR>(&regions);
+    VkPresentRegionsKHR regions = vku::InitStructHelper();
+    VkPresentInfoKHR present = vku::InitStructHelper(&regions);
     present.waitSemaphoreCount = 0;
     present.swapchainCount = 1;
     present.pSwapchains = &m_swapchain;

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -76,7 +76,7 @@ TEST_F(PositiveWsi, CreateWaylandSurface) {
         ASSERT_TRUE(version > 0);
     }
 
-    auto surface_create_info = vku::InitStruct<VkWaylandSurfaceCreateInfoKHR>();
+    VkWaylandSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
     surface_create_info.display = display;
     surface_create_info.surface = surface;
 
@@ -117,7 +117,7 @@ TEST_F(PositiveWsi, CreateXcbSurface) {
     xcb_window_t xcb_window = xcb_generate_id(xcb_connection);
     ASSERT_TRUE(xcb_window != 0);
 
-    auto surface_create_info = vku::InitStruct<VkXcbSurfaceCreateInfoKHR>();
+    VkXcbSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
     surface_create_info.connection = xcb_connection;
     surface_create_info.window = xcb_window;
 
@@ -161,7 +161,7 @@ TEST_F(PositiveWsi, CreateX11Surface) {
                                                   BlackPixel(x11_display, screen), WhitePixel(x11_display, screen));
 
     VkSurfaceKHR vulkan_surface;
-    auto surface_create_info = vku::InitStruct<VkXlibSurfaceCreateInfoKHR>();
+    VkXlibSurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
     surface_create_info.dpy = x11_display;
     surface_create_info.window = x11_window;
     vk::CreateXlibSurfaceKHR(instance(), &surface_create_info, nullptr, &vulkan_surface);
@@ -199,15 +199,15 @@ TEST_F(PositiveWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullScreenEXT) {
 
     const POINT pt_zero = {0, 0};
 
-    auto fullscreen_exclusive_win32_info = vku::InitStruct<VkSurfaceFullScreenExclusiveWin32InfoEXT>();
+    VkSurfaceFullScreenExclusiveWin32InfoEXT fullscreen_exclusive_win32_info = vku::InitStructHelper();
     fullscreen_exclusive_win32_info.hmonitor = MonitorFromPoint(pt_zero, MONITOR_DEFAULTTOPRIMARY);
-    auto fullscreen_exclusive_info = vku::InitStruct<VkSurfaceFullScreenExclusiveInfoEXT>(&fullscreen_exclusive_win32_info);
+    VkSurfaceFullScreenExclusiveInfoEXT fullscreen_exclusive_info = vku::InitStructHelper(&fullscreen_exclusive_win32_info);
     fullscreen_exclusive_info.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT;
 
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>(&fullscreen_exclusive_info);
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper(&fullscreen_exclusive_info);
     surface_info.surface = m_surface;
 
-    auto surface_caps = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(m_device->phy(), &surface_info, &surface_caps);
 }
 #endif
@@ -246,7 +246,7 @@ TEST_F(PositiveWsi, CmdCopySwapchainImage) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = m_surface_formats[0].format;
     image_create_info.extent.width = m_surface_capabilities.minImageExtent.width;
@@ -265,17 +265,17 @@ TEST_F(PositiveWsi, CmdCopySwapchainImage) {
 
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
-    auto image_swapchain_create_info = vku::InitStruct<VkImageSwapchainCreateInfoKHR>();
+    VkImageSwapchainCreateInfoKHR image_swapchain_create_info = vku::InitStructHelper();
     image_swapchain_create_info.swapchain = m_swapchain;
     image_create_info.pNext = &image_swapchain_create_info;
 
     vkt::Image image_from_swapchain(*m_device, image_create_info, vkt::no_mem);
 
-    auto bind_swapchain_info = vku::InitStruct<VkBindImageMemorySwapchainInfoKHR>();
+    VkBindImageMemorySwapchainInfoKHR bind_swapchain_info = vku::InitStructHelper();
     bind_swapchain_info.swapchain = m_swapchain;
     bind_swapchain_info.imageIndex = 0;
 
-    auto bind_info = vku::InitStruct<VkBindImageMemoryInfo>(&bind_swapchain_info);
+    VkBindImageMemoryInfo bind_info = vku::InitStructHelper(&bind_swapchain_info);
     bind_info.image = image_from_swapchain.handle();
     bind_info.memory = VK_NULL_HANDLE;
     bind_info.memoryOffset = 0;
@@ -352,7 +352,7 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
         GTEST_SKIP() << "minImageExtent is not large enough";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = m_surface_formats[0].format;
     image_create_info.extent.width = m_surface_capabilities.minImageExtent.width;
@@ -371,24 +371,24 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
 
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
-    auto image_swapchain_create_info = vku::InitStruct<VkImageSwapchainCreateInfoKHR>();
+    VkImageSwapchainCreateInfoKHR image_swapchain_create_info = vku::InitStructHelper();
     image_swapchain_create_info.swapchain = m_swapchain;
     image_create_info.pNext = &image_swapchain_create_info;
 
     vkt::Image peer_image(*m_device, image_create_info, vkt::no_mem);
 
-    auto bind_devicegroup_info = vku::InitStruct<VkBindImageMemoryDeviceGroupInfo>();
+    VkBindImageMemoryDeviceGroupInfo bind_devicegroup_info = vku::InitStructHelper();
     std::array<uint32_t, 1> deviceIndices = {{0}};
     bind_devicegroup_info.deviceIndexCount = static_cast<uint32_t>(deviceIndices.size());
     bind_devicegroup_info.pDeviceIndices = deviceIndices.data();
     bind_devicegroup_info.splitInstanceBindRegionCount = 0;
     bind_devicegroup_info.pSplitInstanceBindRegions = nullptr;
 
-    auto bind_swapchain_info = vku::InitStruct<VkBindImageMemorySwapchainInfoKHR>(&bind_devicegroup_info);
+    VkBindImageMemorySwapchainInfoKHR bind_swapchain_info = vku::InitStructHelper(&bind_devicegroup_info);
     bind_swapchain_info.swapchain = m_swapchain;
     bind_swapchain_info.imageIndex = 0;
 
-    auto bind_info = vku::InitStruct<VkBindImageMemoryInfo>(&bind_swapchain_info);
+    VkBindImageMemoryInfo bind_info = vku::InitStructHelper(&bind_swapchain_info);
     bind_info.image = peer_image.handle();
     bind_info.memory = VK_NULL_HANDLE;
     bind_info.memoryOffset = 0;
@@ -407,7 +407,7 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
 
     m_commandBuffer->begin();
 
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     img_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     img_barrier.image = swapchain_images[image_index];
@@ -457,7 +457,7 @@ TEST_F(PositiveWsi, SwapchainAcquireImageAndPresent) {
     ASSERT_VK_SUCCESS(
         vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore, VK_NULL_HANDLE, &image_index));
 
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.srcAccessMask = 0;
     img_barrier.dstAccessMask = 0;
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -478,7 +478,7 @@ TEST_F(PositiveWsi, SwapchainAcquireImageAndPresent) {
 
     constexpr VkPipelineStageFlags stage_mask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     submit_info.waitSemaphoreCount = 1;
@@ -488,7 +488,7 @@ TEST_F(PositiveWsi, SwapchainAcquireImageAndPresent) {
     submit_info.pSignalSemaphores = &submit_semaphore.handle();
     ASSERT_VK_SUCCESS(vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE));
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.waitSemaphoreCount = 1;
     present.pWaitSemaphores = &submit_semaphore.handle();
     present.swapchainCount = 1;
@@ -517,7 +517,7 @@ TEST_F(PositiveWsi, SwapchainAcquireImageAndWaitForFence) {
     ASSERT_VK_SUCCESS(vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence, &image_index));
     ASSERT_VK_SUCCESS(vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout));
 
-    auto img_barrier = vku::InitStruct<VkImageMemoryBarrier>();
+    VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.srcAccessMask = 0;
     img_barrier.dstAccessMask = 0;
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -538,14 +538,14 @@ TEST_F(PositiveWsi, SwapchainAcquireImageAndWaitForFence) {
 
     constexpr VkPipelineStageFlags stage_mask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
-    auto submit_info = vku::InitStruct<VkSubmitInfo>();
+    VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_commandBuffer->handle();
     submit_info.pWaitDstStageMask = &stage_mask;
     ASSERT_VK_SUCCESS(vk::QueueSubmit(m_device->m_queue, 1, &submit_info, VK_NULL_HANDLE));
     ASSERT_VK_SUCCESS(vk::QueueWaitIdle(m_device->m_queue));
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.swapchainCount = 1;
     present.pSwapchains = &m_swapchain;
     present.pImageIndices = &image_index;
@@ -577,7 +577,7 @@ TEST_F(PositiveWsi, SwapchainImageLayout) {
     VkAttachmentReference att_ref = {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
 
     VkSubpassDescription subpass = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, &att_ref, nullptr, nullptr, 0, nullptr};
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>();
+    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
     rpci.attachmentCount = 1;
     rpci.pAttachments = attach;
     rpci.subpassCount = 1;
@@ -589,7 +589,7 @@ TEST_F(PositiveWsi, SwapchainImageLayout) {
     vkt::RenderPass rp2(*m_device, rpci);
     ASSERT_TRUE(rp2.initialized());
 
-    auto ivci = vku::InitStruct<VkImageViewCreateInfo>();
+    VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = swapchainImages[image_index];
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = m_surface_formats[0].format;
@@ -598,7 +598,7 @@ TEST_F(PositiveWsi, SwapchainImageLayout) {
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     vkt::ImageView view(*m_device, ivci);
     ASSERT_TRUE(view.initialized());
-    auto fci = vku::InitStruct<VkFramebufferCreateInfo>();
+    VkFramebufferCreateInfo fci = vku::InitStructHelper();
     fci.renderPass = rp1.handle();
     fci.attachmentCount = 1;
     fci.pAttachments = &view.handle();
@@ -688,9 +688,9 @@ TEST_F(PositiveWsi, SwapchainPresentShared) {
         GTEST_SKIP() << "Cannot find supported shared present mode";
     }
 
-    auto shared_present_capabilities = vku::InitStruct<VkSharedPresentSurfaceCapabilitiesKHR>();
-    auto capabilities = vku::InitStruct<VkSurfaceCapabilities2KHR>(&shared_present_capabilities);
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>();
+    VkSharedPresentSurfaceCapabilitiesKHR shared_present_capabilities = vku::InitStructHelper();
+    VkSurfaceCapabilities2KHR capabilities = vku::InitStructHelper(&shared_present_capabilities);
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = m_surface;
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &capabilities);
 
@@ -699,7 +699,7 @@ TEST_F(PositiveWsi, SwapchainPresentShared) {
         GTEST_SKIP() << "Driver was suppose to support VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT";
     }
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>();
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper();
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = 1;
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
@@ -725,7 +725,7 @@ TEST_F(PositiveWsi, SwapchainPresentShared) {
 
     SetImageLayout(m_device, VK_IMAGE_ASPECT_COLOR_BIT, images[image_index], VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR);
 
-    auto present = vku::InitStruct<VkPresentInfoKHR>();
+    VkPresentInfoKHR present = vku::InitStructHelper();
     present.waitSemaphoreCount = 0;
     present.swapchainCount = 1;
     present.pSwapchains = &m_swapchain;
@@ -787,10 +787,10 @@ TEST_F(PositiveWsi, CreateSwapchainFullscreenExclusive) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
-    auto surface_full_screen_exlusive_info = vku::InitStruct<VkSurfaceFullScreenExclusiveInfoEXT>();
+    VkSurfaceFullScreenExclusiveInfoEXT surface_full_screen_exlusive_info = vku::InitStructHelper();
     surface_full_screen_exlusive_info.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_DEFAULT_EXT;
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>(&surface_full_screen_exlusive_info);
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper(&surface_full_screen_exlusive_info);
     swapchain_create_info.flags = 0;
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
@@ -840,12 +840,12 @@ TEST_F(PositiveWsi, CreateSwapchainFullscreenExclusive2) {
 
     const POINT pt_zero = {0, 0};
 
-    auto fullscreen_exclusive_win32_info = vku::InitStruct<VkSurfaceFullScreenExclusiveWin32InfoEXT>();
+    VkSurfaceFullScreenExclusiveWin32InfoEXT fullscreen_exclusive_win32_info = vku::InitStructHelper();
     fullscreen_exclusive_win32_info.hmonitor = MonitorFromPoint(pt_zero, MONITOR_DEFAULTTOPRIMARY);
-    auto surface_full_screen_exlusive_info = vku::InitStruct<VkSurfaceFullScreenExclusiveInfoEXT>(&fullscreen_exclusive_win32_info);
+    VkSurfaceFullScreenExclusiveInfoEXT surface_full_screen_exlusive_info = vku::InitStructHelper(&fullscreen_exclusive_win32_info);
     surface_full_screen_exlusive_info.fullScreenExclusive = VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT;
 
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>(&surface_full_screen_exlusive_info);
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper(&surface_full_screen_exlusive_info);
     swapchain_create_info.flags = 0;
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = m_surface_capabilities.minImageCount;
@@ -1083,7 +1083,7 @@ TEST_F(VkPositiveLayerTest, DestroySwapchainWithBoundImages) {
         GTEST_SKIP() << "Cannot create surface or swapchain";
     }
 
-    auto image_create_info = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = m_surface_formats[0].format;
     image_create_info.extent.width = m_surface_capabilities.minImageExtent.width;
@@ -1097,7 +1097,7 @@ TEST_F(VkPositiveLayerTest, DestroySwapchainWithBoundImages) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-    auto image_swapchain_create_info = vku::InitStruct<VkImageSwapchainCreateInfoKHR>();
+    VkImageSwapchainCreateInfoKHR image_swapchain_create_info = vku::InitStructHelper();
     image_swapchain_create_info.swapchain = m_swapchain;
 
     image_create_info.pNext = &image_swapchain_create_info;
@@ -1106,11 +1106,11 @@ TEST_F(VkPositiveLayerTest, DestroySwapchainWithBoundImages) {
     int i = 0;
     for (auto &image : images) {
         image.init_no_mem(*m_device, image_create_info);
-        auto bind_swapchain_info = vku::InitStruct<VkBindImageMemorySwapchainInfoKHR>();
+        VkBindImageMemorySwapchainInfoKHR bind_swapchain_info = vku::InitStructHelper();
         bind_swapchain_info.swapchain = m_swapchain;
         bind_swapchain_info.imageIndex = i++;
 
-        auto bind_info = vku::InitStruct<VkBindImageMemoryInfo>(&bind_swapchain_info);
+        VkBindImageMemoryInfo bind_info = vku::InitStructHelper(&bind_swapchain_info);
         bind_info.image = image.handle();
         bind_info.memory = VK_NULL_HANDLE;
         bind_info.memoryOffset = 0;
@@ -1143,7 +1143,7 @@ TEST_F(PositiveWsi, ProtectedSwapchainImageColorAttachment) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";
     }
 
-    auto protected_memory_features = vku::InitStruct<VkPhysicalDeviceProtectedMemoryFeatures>();
+    VkPhysicalDeviceProtectedMemoryFeatures protected_memory_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(protected_memory_features);
 
     if (protected_memory_features.protectedMemory == VK_FALSE) {
@@ -1280,18 +1280,18 @@ TEST_F(PositiveWsi, CreateSwapchainWithPresentModeInfo) {
     // (although this is implementation dependant)
     const auto present_mode = VK_PRESENT_MODE_FIFO_KHR;
 
-    auto surface_present_mode = vku::InitStruct<VkSurfacePresentModeEXT>();
+    VkSurfacePresentModeEXT surface_present_mode = vku::InitStructHelper();
     surface_present_mode.presentMode = present_mode;
-    auto surface_info = vku::InitStruct<VkPhysicalDeviceSurfaceInfo2KHR>(&surface_present_mode);
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper(&surface_present_mode);
     surface_info.surface = m_surface;
 
-    auto surface_caps = vku::InitStruct<VkSurfaceCapabilities2KHR>();
+    VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
     vk::GetPhysicalDeviceSurfaceCapabilities2KHR(m_device->phy(), &surface_info, &surface_caps);
 
-    auto swapchain_present_mode_create_info = vku::InitStruct<VkSwapchainPresentModesCreateInfoEXT>();
+    VkSwapchainPresentModesCreateInfoEXT swapchain_present_mode_create_info = vku::InitStructHelper();
     swapchain_present_mode_create_info.presentModeCount = 1;
     swapchain_present_mode_create_info.pPresentModes = &present_mode;
-    auto swapchain_create_info = vku::InitStruct<VkSwapchainCreateInfoKHR>(&swapchain_present_mode_create_info);
+    VkSwapchainCreateInfoKHR swapchain_create_info = vku::InitStructHelper(&swapchain_present_mode_create_info);
     swapchain_create_info.surface = m_surface;
     swapchain_create_info.minImageCount = surface_caps.surfaceCapabilities.minImageCount;
     swapchain_create_info.imageFormat = m_surface_formats[0].format;

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -673,10 +673,10 @@ TEST_F(NegativeYcbcr, WriteDescriptorSet) {
     image_obj.init(&image_ci);
     ASSERT_TRUE(image_obj.initialized());
 
-    auto ycbcr_info = vku::InitStruct<VkSamplerYcbcrConversionInfo>();
+    VkSamplerYcbcrConversionInfo ycbcr_info = vku::InitStructHelper();
     ycbcr_info.conversion = conversion.handle();
 
-    auto image_view_create_info = vku::InitStruct<VkImageViewCreateInfo>(&ycbcr_info);
+    VkImageViewCreateInfo image_view_create_info = vku::InitStructHelper(&ycbcr_info);
     image_view_create_info.image = image_obj.handle();
     image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_create_info.format = mp_format;
@@ -894,7 +894,7 @@ TEST_F(NegativeYcbcr, BindMemory2Disjoint) {
     bool amd_coherent_mem = IsExtensionsEnabled(VK_AMD_DEVICE_COHERENT_MEMORY_EXTENSION_NAME);
 
     if (amd_coherent_mem) {
-        auto coherent_mem_features = vku::InitStruct<VkPhysicalDeviceCoherentMemoryFeaturesAMD>();
+        VkPhysicalDeviceCoherentMemoryFeaturesAMD coherent_mem_features = vku::InitStructHelper();
         GetPhysicalDeviceFeatures2(coherent_mem_features);
         ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &coherent_mem_features));
     } else {
@@ -1185,7 +1185,7 @@ TEST_F(NegativeYcbcr, MismatchedImageViewAndSamplerFormat) {
     image.Init(128, 128, 1, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     ASSERT_TRUE(image.initialized());
 
-    auto sampler_conversion_ci = vku::InitStruct<VkSamplerYcbcrConversionCreateInfo>();
+    VkSamplerYcbcrConversionCreateInfo sampler_conversion_ci = vku::InitStructHelper();
     sampler_conversion_ci.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
     sampler_conversion_ci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
     sampler_conversion_ci.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
@@ -1198,7 +1198,7 @@ TEST_F(NegativeYcbcr, MismatchedImageViewAndSamplerFormat) {
 
     vkt::SamplerYcbcrConversion sampler_conversion(*m_device, sampler_conversion_ci, false);
 
-    auto sampler_ycbcr_conversion_info = vku::InitStruct<VkSamplerYcbcrConversionInfo>();
+    VkSamplerYcbcrConversionInfo sampler_ycbcr_conversion_info = vku::InitStructHelper();
     sampler_ycbcr_conversion_info.conversion = sampler_conversion.handle();
 
     VkImageViewCreateInfo view_info = vku::InitStructHelper(&sampler_ycbcr_conversion_info);
@@ -1440,7 +1440,7 @@ TEST_F(NegativeYcbcr, MultiplaneAspectBits) {
     image_obj.init(&image_ci);
     ASSERT_TRUE(image_obj.initialized());
 
-    auto ycbcr_create_info = vku::InitStruct<VkSamplerYcbcrConversionCreateInfo>();
+    VkSamplerYcbcrConversionCreateInfo ycbcr_create_info = vku::InitStructHelper();
     ycbcr_create_info.format = mp_format;
     ycbcr_create_info.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;
     ycbcr_create_info.ycbcrRange = VK_SAMPLER_YCBCR_RANGE_ITU_FULL;
@@ -1453,7 +1453,7 @@ TEST_F(NegativeYcbcr, MultiplaneAspectBits) {
 
     vkt::SamplerYcbcrConversion conversion(*m_device, ycbcr_create_info, DeviceValidationVersion() < VK_API_VERSION_1_1);
 
-    auto ycbcr_info = vku::InitStruct<VkSamplerYcbcrConversionInfo>();
+    VkSamplerYcbcrConversionInfo ycbcr_info = vku::InitStructHelper();
     ycbcr_info.conversion = conversion.handle();
 
     auto image_view_ci = image_obj.BasicViewCreatInfo();

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -29,8 +29,8 @@ void YcbcrTest::InitBasicYcbcr(void *pNextFeatures) {
         GTEST_SKIP() << "At least Vulkan version 1." << m_attempted_api_version.Minor() << " is required";
     }
 
-    auto features11 = vku::InitStruct<VkPhysicalDeviceVulkan11Features>(pNextFeatures);
-    auto ycbcr_features = vku::InitStruct<VkPhysicalDeviceSamplerYcbcrConversionFeatures>(pNextFeatures);
+    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper(pNextFeatures);
+    VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcr_features = vku::InitStructHelper(pNextFeatures);
     VkPhysicalDeviceFeatures2 features2;
     if (use_12) {
         features2 = GetPhysicalDeviceFeatures2(features11);
@@ -54,7 +54,7 @@ TEST_F(PositiveYcbcr, PlaneAspectNone) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_3) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
-    auto image_createinfo = vku::InitStruct<VkImageCreateInfo>();
+    VkImageCreateInfo image_createinfo = vku::InitStructHelper();
     image_createinfo.imageType = VK_IMAGE_TYPE_2D;
     image_createinfo.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR;
     image_createinfo.extent = {128, 128, 1};
@@ -65,10 +65,10 @@ TEST_F(PositiveYcbcr, PlaneAspectNone) {
     image_createinfo.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_createinfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_createinfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    auto image_mem_reqs = vku::InitStruct<VkDeviceImageMemoryRequirements>();
+    VkDeviceImageMemoryRequirements image_mem_reqs = vku::InitStructHelper();
     image_mem_reqs.pCreateInfo = &image_createinfo;
     image_mem_reqs.planeAspect = VK_IMAGE_ASPECT_NONE;
-    auto mem_reqs_2 = vku::InitStruct<VkMemoryRequirements2>();
+    VkMemoryRequirements2 mem_reqs_2 = vku::InitStructHelper();
     vk::GetDeviceImageMemoryRequirements(device(), &image_mem_reqs, &mem_reqs_2);
 }
 

--- a/tests/vvl_utils/pnext_chain_extraction.cpp
+++ b/tests/vvl_utils/pnext_chain_extraction.cpp
@@ -30,10 +30,10 @@ bool FindSTypes(void* chain, const std::vector<VkStructureType>& sTypes_list) {
 // Extract all structs from a pNext chain
 TEST(PnextChainExtract, Extract1) {
     // Those structs extend VkPhysicalDeviceImageFormatInfo2
-    auto s1 = vku::InitStruct<VkImageCompressionControlEXT>();
-    auto s2 = vku::InitStruct<VkImageFormatListCreateInfo>(&s1);
-    auto s3 = vku::InitStruct<VkImageStencilUsageCreateInfo>(&s2);
-    auto s4 = vku::InitStruct<VkOpticalFlowImageFormatInfoNV>(&s3);
+    VkImageCompressionControlEXT s1 = vku::InitStructHelper();
+    VkImageFormatListCreateInfo s2 = vku::InitStructHelper(&s1);
+    VkImageStencilUsageCreateInfo s3 = vku::InitStructHelper(&s2);
+    VkOpticalFlowImageFormatInfoNV s4 = vku::InitStructHelper(&s3);
 
     vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 extracted_chain{};
     void* chain_begin = vvl::PnextChainExtract(&s4, extracted_chain);
@@ -45,17 +45,17 @@ TEST(PnextChainExtract, Extract1) {
 // Extract all structs mentioned in tuple vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 and found in input pNext chain
 TEST(PnextChainExtract, Extract2) {
     // Those structs extend VkPhysicalDeviceImageFormatInfo2
-    auto s1 = vku::InitStruct<VkImageCompressionControlEXT>();
-    auto s2 = vku::InitStruct<VkImageFormatListCreateInfo>(&s1);
-    auto s3 = vku::InitStruct<VkImageStencilUsageCreateInfo>(&s2);
-    auto s4 = vku::InitStruct<VkOpticalFlowImageFormatInfoNV>(&s3);
+    VkImageCompressionControlEXT s1 = vku::InitStructHelper();
+    VkImageFormatListCreateInfo s2 = vku::InitStructHelper(&s1);
+    VkImageStencilUsageCreateInfo s3 = vku::InitStructHelper(&s2);
+    VkOpticalFlowImageFormatInfoNV s4 = vku::InitStructHelper(&s3);
 
     // Those do not
-    auto wrong1 = vku::InitStruct<VkExternalMemoryImageCreateInfo>(&s4);
-    auto wrong2 = vku::InitStruct<VkImageDrmFormatModifierListCreateInfoEXT>(&wrong1);
+    VkExternalMemoryImageCreateInfo wrong1 = vku::InitStructHelper(&s4);
+    VkImageDrmFormatModifierListCreateInfoEXT wrong2 = vku::InitStructHelper(&wrong1);
 
     // And this one does
-    auto s5 = vku::InitStruct<VkVideoProfileListInfoKHR>(&wrong2);
+    VkVideoProfileListInfoKHR s5 = vku::InitStructHelper(&wrong2);
 
     vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 extracted_chain{};
     void* chain_begin = vvl::PnextChainExtract(&s5, extracted_chain);
@@ -68,8 +68,8 @@ TEST(PnextChainExtract, Extract2) {
 // VkPhysicalDeviceImageFormatInfo2
 TEST(PnextChainExtract, Extract3) {
     // Those structs do not extend VkPhysicalDeviceImageFormatInfo2
-    auto wrong1 = vku::InitStruct<VkExternalMemoryImageCreateInfo>();
-    auto wrong2 = vku::InitStruct<VkImageDrmFormatModifierListCreateInfoEXT>(&wrong1);
+    VkExternalMemoryImageCreateInfo wrong1 = vku::InitStructHelper();
+    VkImageDrmFormatModifierListCreateInfoEXT wrong2 = vku::InitStructHelper(&wrong1);
 
     vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 extracted_chain{};
     void* chain_begin = vvl::PnextChainExtract(&wrong2, extracted_chain);
@@ -81,10 +81,10 @@ TEST(PnextChainExtract, Extract3) {
 // Extract all structs from a pNext chain, add a new element, then remove it
 TEST(PnextChainExtract, ExtractAddRemove1) {
     // Those structs extend VkPhysicalDeviceImageFormatInfo2
-    auto s1 = vku::InitStruct<VkImageCompressionControlEXT>();
-    auto s2 = vku::InitStruct<VkImageFormatListCreateInfo>(&s1);
-    auto s3 = vku::InitStruct<VkImageStencilUsageCreateInfo>(&s2);
-    auto s4 = vku::InitStruct<VkOpticalFlowImageFormatInfoNV>(&s3);
+    VkImageCompressionControlEXT s1 = vku::InitStructHelper();
+    VkImageFormatListCreateInfo s2 = vku::InitStructHelper(&s1);
+    VkImageStencilUsageCreateInfo s3 = vku::InitStructHelper(&s2);
+    VkOpticalFlowImageFormatInfoNV s4 = vku::InitStructHelper(&s3);
 
     vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 extracted_chain{};
     void* chain_begin = vvl::PnextChainExtract(&s4, extracted_chain);
@@ -93,7 +93,7 @@ TEST(PnextChainExtract, ExtractAddRemove1) {
     ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
 
     {
-        auto s5 = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+        VkPhysicalDeviceImageDrmFormatModifierInfoEXT s5 = vku::InitStructHelper();
         vvl::PnextChainScopedAdd scoped_add_s5(chain_begin, &s5);
         expected_sTypes.emplace_back(s5.sType);
         ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
@@ -106,10 +106,10 @@ TEST(PnextChainExtract, ExtractAddRemove1) {
 // Extract all structs from a pNext chain, add two new elements, in a nested fashion, then remove them
 TEST(PnextChainExtract, ExtractAddRemove2) {
     // Those structs extend VkPhysicalDeviceImageFormatInfo2
-    auto s1 = vku::InitStruct<VkImageCompressionControlEXT>();
-    auto s2 = vku::InitStruct<VkImageFormatListCreateInfo>(&s1);
-    auto s3 = vku::InitStruct<VkImageStencilUsageCreateInfo>(&s2);
-    auto s4 = vku::InitStruct<VkOpticalFlowImageFormatInfoNV>(&s3);
+    VkImageCompressionControlEXT s1 = vku::InitStructHelper();
+    VkImageFormatListCreateInfo s2 = vku::InitStructHelper(&s1);
+    VkImageStencilUsageCreateInfo s3 = vku::InitStructHelper(&s2);
+    VkOpticalFlowImageFormatInfoNV s4 = vku::InitStructHelper(&s3);
 
     vvl::PnextChainVkPhysicalDeviceImageFormatInfo2 extracted_chain{};
     void* chain_begin = vvl::PnextChainExtract(&s4, extracted_chain);
@@ -118,13 +118,13 @@ TEST(PnextChainExtract, ExtractAddRemove2) {
     ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
 
     {
-        auto s5 = vku::InitStruct<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>();
+        VkPhysicalDeviceImageDrmFormatModifierInfoEXT s5 = vku::InitStructHelper();
         vvl::PnextChainScopedAdd scoped_add_s5(chain_begin, &s5);
         expected_sTypes.emplace_back(s5.sType);
         ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));
 
         {
-            auto s6 = vku::InitStruct<VkPhysicalDeviceImageViewImageFormatInfoEXT>();
+            VkPhysicalDeviceImageViewImageFormatInfoEXT s6 = vku::InitStructHelper();
             vvl::PnextChainScopedAdd scoped_add_s6(chain_begin, &s6);
             expected_sTypes.emplace_back(s6.sType);
             ASSERT_TRUE(FindSTypes(chain_begin, expected_sTypes));


### PR DESCRIPTION
Replace vku::InitStruct calls by vku::InitStructHelper where it makes sense

![image](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/111733687/bf7ba706-692a-4bb6-9e8d-a22e57b0dd29)
