### PR TITLE
Validate cmd buffer begin flags

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -322,6 +322,16 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                                          begin_info_loc.pNext(Struct::VkDeviceGroupCommandBufferBeginInfo, Field::deviceMask),
                                          "VUID-VkDeviceGroupCommandBufferBeginInfo-deviceMask-00107");
     }
+    if ((pBeginInfo->flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT) != 0) {
+        if ((cb_state->command_pool->queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
+            const LogObjectList objlist(commandBuffer, cb_state->command_pool->Handle());
+            skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-09123", objlist, begin_info_loc.dot(Field::flags),
+                             "contain VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT, but the command pool (created with "
+                             "queueFamilyIndex %" PRIu32 ") the command buffer %s was allocated from only supports %s.",
+                             cb_state->command_pool->queueFamilyIndex, FormatHandle(commandBuffer).c_str(),
+                             string_VkQueueFlags(cb_state->command_pool->queue_flags).c_str());
+        }
+    }
     return skip;
 }
 

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -7339,3 +7339,25 @@ TEST_F(NegativeCommand, DebugLabelSecondaryCommandBuffer) {
 
     cb.end();
 }
+
+TEST_F(NegativeCommand, RenderPassContinueNotSupportedByCommandPool) {
+    TEST_DESCRIPTION("Use render pass continue bit with unsupported command pool.");
+
+    ASSERT_NO_FATAL_FAILURE(Init());
+
+    const std::optional<uint32_t> non_graphics_queue_family_index = m_device->QueueFamilyMatching(0u, VK_QUEUE_GRAPHICS_BIT);
+
+    if (!non_graphics_queue_family_index) {
+        GTEST_SKIP() << "No suitable queue found.";
+    }
+
+    vkt::CommandPool command_pool(*m_device, non_graphics_queue_family_index.value());
+    VkCommandBufferObj command_buffer(m_device, &command_pool);
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferBeginInfo-flags-09123");
+    vk::BeginCommandBuffer(command_buffer.handle(), &begin_info);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
Validate VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT is supported by command pool