### PR TITLE
layers: Workaround sync validation of descriptor arrays

### DIFF
--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -839,6 +839,10 @@ SPIRV_MODULE_STATE::StaticData::StaticData(const SPIRV_MODULE_STATE& module_stat
 
             case spv::OpCapability:
                 capability_list.push_back(static_cast<spv::Capability>(insn.Word(1)));
+                // Cache frequently checked capabilities
+                if (capability_list.back() == spv::CapabilityRuntimeDescriptorArray) {
+                    has_capability_runtime_descriptor_array = true;
+                }
                 break;
 
             case spv::OpVariable:

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -474,7 +474,10 @@ struct SPIRV_MODULE_STATE {
         std::vector<const Instruction *> group_inst;
         std::vector<const Instruction *> read_clock_inst;
         std::vector<const Instruction *> cooperative_matrix_inst;
+
         std::vector<spv::Capability> capability_list;
+        // Code on the hot path can cache capabilities for fast access.
+        bool has_capability_runtime_descriptor_array{false};
 
         bool has_specialization_constants{false};
         bool has_invocation_repack_instruction{false};


### PR DESCRIPTION
Addresses https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3450

Currently, validation of memory accesses based on declared descriptors can produce false-positives. The shader can decide not to do such accesses, it can perform accesses with more narrow scope (e.g. read access, when both reads and writes are allowed) or for an array of descriptors, not all elements are accessed in the general case.

This workaround disables validation for the runtime descriptor array case (`OpCapability RuntimeDescriptorArray`).