### PR TITLE
Test invalid pipeline rendering formats

### DIFF
--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -545,7 +545,9 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
             total_resources += rp_state->dynamic_rendering_pipeline_create_info.colorAttachmentCount;
         } else {
             // "For the fragment shader stage the framebuffer color attachments also count against this limit"
-            total_resources += rp_state->createInfo.pSubpasses[pipeline.Subpass()].colorAttachmentCount;
+            if (pipeline.Subpass() < rp_state->createInfo.subpassCount) {
+                total_resources += rp_state->createInfo.pSubpasses[pipeline.Subpass()].colorAttachmentCount;
+            }
         }
     }
 

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -1149,7 +1149,9 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                         if (subpasses_uses.subpasses_using_depthstencil_attachment.count(create_info.subpass)) {
                             uses_depthstencil_attachment = true;
                         }
-                        subpass_flags = subpasses_uses.subpasses_flags[create_info.subpass];
+                        if (create_info.subpass < subpasses_uses.subpasses_flags.size()) {
+                            subpass_flags = subpasses_uses.subpasses_flags[create_info.subpass];
+                        }
 
                         color_attachment_count = subpasses_uses.color_attachment_count;
                     }


### PR DESCRIPTION
Part of #5842

VUID-VkGraphicsPipelineCreateInfo-renderPass-06046
VUID-VkGraphicsPipelineCreateInfo-renderPass-06583
VUID-VkGraphicsPipelineCreateInfo-renderPass-06584