### PR TITLE
layers: Remove PRIxLEAST64 for sizes

### DIFF
--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -457,15 +457,14 @@ bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
 
     if (dstOffset >= buffer_state->createInfo.size) {
         skip |= LogError("VUID-vkCmdFillBuffer-dstOffset-00024", objlist, error_obj.location.dot(Field::dstOffset),
-                         "(0x%" PRIxLEAST64 ") is not less than destination buffer (%s) size (0x%" PRIxLEAST64 ").", dstOffset,
+                         "(%" PRIu64 ") is not less than destination buffer (%s) size (%" PRIu64 ").", dstOffset,
                          FormatHandle(dstBuffer).c_str(), buffer_state->createInfo.size);
     }
 
     if ((size != VK_WHOLE_SIZE) && (size > (buffer_state->createInfo.size - dstOffset))) {
         skip |= LogError("VUID-vkCmdFillBuffer-size-00027", objlist, error_obj.location.dot(Field::size),
-                         "(0x%" PRIxLEAST64 ") is greater than dstBuffer (%s) size (0x%" PRIxLEAST64
-                         ") minus dstOffset (0x%" PRIxLEAST64 ").",
-                         size, FormatHandle(dstBuffer).c_str(), buffer_state->createInfo.size, dstOffset);
+                         "(%" PRIu64 ") is greater than dstBuffer (%s) size (%" PRIu64 ") minus dstOffset (%" PRIu64 ").", size,
+                         FormatHandle(dstBuffer).c_str(), buffer_state->createInfo.size, dstOffset);
     }
 
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance1)) {

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -257,7 +257,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
                                                  error_obj.location.dot(Field::pDynamicOffsets, cur_dyn_offset),
                                                  "is %" PRIu32
                                                  ", but must be a multiple of "
-                                                 "device limit minUniformBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
+                                                 "device limit minUniformBufferOffsetAlignment %" PRIu64 ".",
                                                  offset, limits.minUniformBufferOffsetAlignment);
                             }
                             if ((binding->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC) &&
@@ -266,7 +266,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
                                                  error_obj.location.dot(Field::pDynamicOffsets, cur_dyn_offset),
                                                  "is %" PRIu32
                                                  ", but must be a multiple of "
-                                                 "device limit minStorageBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
+                                                 "device limit minStorageBufferOffsetAlignment %" PRIu64 ".",
                                                  offset, limits.minStorageBufferOffsetAlignment);
                             }
 
@@ -298,14 +298,14 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets(VkCommandBuffer commandBuf
                                            ((offset + bound_range + bound_offset) > buffer_state->createInfo.size)) {
                                     const LogObjectList objlist(commandBuffer, pDescriptorSets[set_idx],
                                                                 buffer_descriptor->GetBuffer());
-                                    skip |= LogError(
-                                        "VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979", objlist,
-                                        error_obj.location.dot(Field::pDynamicOffsets, cur_dyn_offset),
-                                        "is %" PRIu32 ", which when added to the buffer descriptor's range (0x%" PRIxLEAST64
-                                        ") and offset (0x%" PRIxLEAST64 ") is greater than the size of the buffer (0x%" PRIxLEAST64
-                                        ") in descriptorSet #%" PRIu32 " binding #%" PRIu32 " descriptor[%" PRIu32 "].",
-                                        offset, bound_range, bound_offset, buffer_state->createInfo.size, set_idx, binding_index,
-                                        j);
+                                    skip |=
+                                        LogError("VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979", objlist,
+                                                 error_obj.location.dot(Field::pDynamicOffsets, cur_dyn_offset),
+                                                 "is %" PRIu32 ", which when added to the buffer descriptor's range (%" PRIu64
+                                                 ") and offset (%" PRIu64 ") is greater than the size of the buffer (%" PRIu64
+                                                 ") in descriptorSet #%" PRIu32 " binding #%" PRIu32 " descriptor[%" PRIu32 "].",
+                                                 offset, bound_range, bound_offset, buffer_state->createInfo.size, set_idx,
+                                                 binding_index, j);
                                 }
                             }
                             cur_dyn_offset++;

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -410,8 +410,8 @@ bool CoreChecks::ValidateInsertMemoryRange(const VulkanTypedHandle &typed_handle
 
         LogObjectList objlist(mem_info->deviceMemory(), typed_handle);
         skip = LogError(vuid, objlist, loc,
-                        "attempting to bind %s to %s, memoryOffset=0x%" PRIxLEAST64
-                        " must be less than the memory allocation size 0x%" PRIxLEAST64 ".",
+                        "attempting to bind %s to %s, memoryOffset (%" PRIu64
+                        ") must be less than the memory allocation size (%" PRIu64 ").",
                         FormatHandle(mem_info->deviceMemory()).c_str(), FormatHandle(typed_handle).c_str(), memoryOffset,
                         mem_info->alloc_info.allocationSize);
     }
@@ -485,8 +485,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
             bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memoryOffset-01036" : "VUID-vkBindBufferMemory-memoryOffset-01036";
         const LogObjectList objlist(buffer, memory);
         skip |= LogError(vuid, objlist, loc.dot(Field::memoryOffset),
-                         "is 0x%" PRIxLEAST64
-                         " but must be an integer multiple of the VkMemoryRequirements::alignment value 0x%" PRIxLEAST64
+                         "is %" PRIu64 " but must be an integer multiple of the VkMemoryRequirements::alignment value %" PRIu64
                          ", returned from a call to vkGetBufferMemoryRequirements with buffer.",
                          memoryOffset, buffer_state->requirements.alignment);
     }
@@ -563,8 +562,8 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
             const char *vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-size-01037" : "VUID-vkBindBufferMemory-size-01037";
             const LogObjectList objlist(buffer, memory);
             skip |= LogError(vuid, objlist, loc,
-                             "allocationSize (0x%" PRIxLEAST64 ") minus memoryOffset (0x%" PRIxLEAST64 ") is 0x%" PRIxLEAST64
-                             " but must be at least as large as VkMemoryRequirements::size value 0x%" PRIxLEAST64
+                             "allocationSize (%" PRIu64 ") minus memoryOffset (%" PRIu64 ") is %" PRIu64
+                             " but must be at least as large as VkMemoryRequirements::size value %" PRIu64
                              ", returned from a call to vkGetBufferMemoryRequirements with buffer.",
                              mem_info->alloc_info.allocationSize, memoryOffset, mem_info->alloc_info.allocationSize - memoryOffset,
                              buffer_state->requirements.size);
@@ -577,7 +576,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
             const LogObjectList objlist(buffer, memory, mem_info->dedicated->handle);
             skip |= LogError(vuid, objlist, loc.dot(Field::memory),
                              "(%s) is dedicated allocation, but VkMemoryDedicatedAllocateInfo::buffer %s must be equal "
-                             "to %s and memoryOffset 0x%" PRIxLEAST64 " must be zero.",
+                             "to %s and memoryOffset %" PRIu64 " must be zero.",
                              FormatHandle(memory).c_str(), FormatHandle(mem_info->dedicated->handle).c_str(),
                              FormatHandle(buffer).c_str(), memoryOffset);
         }
@@ -943,8 +942,7 @@ bool CoreChecks::ValidateMappedMemoryRangeDeviceLimits(uint32_t mem_range_count,
 
         if (SafeModulo(offset, atom_size) != 0) {
             skip |= LogError("VUID-VkMappedMemoryRange-offset-00687", mem_ranges->memory, memory_range_loc.dot(Field::offset),
-                             "(0x%" PRIxLEAST64
-                             ") is not a multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize (0x%" PRIxLEAST64 ").",
+                             "(%" PRIu64 ") is not a multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize (%" PRIu64 ").",
                              offset, atom_size);
         }
         auto mem_info = Get<DEVICE_MEMORY_STATE>(mem_ranges[i].memory);
@@ -958,19 +956,18 @@ bool CoreChecks::ValidateMappedMemoryRangeDeviceLimits(uint32_t mem_range_count,
             const auto mapping_end = ((mapping_size == VK_WHOLE_SIZE) ? allocation_size : mapping_offset + mapping_size);
             if (SafeModulo(mapping_end, atom_size) != 0 && mapping_end != allocation_size) {
                 skip |= LogError("VUID-VkMappedMemoryRange-size-01389", mem_ranges->memory, memory_range_loc.dot(Field::size),
-                                 "is VK_WHOLE_SIZE and the mapping end (0x%" PRIxLEAST64 " = 0x%" PRIxLEAST64 " + 0x%" PRIxLEAST64
-                                 ") not a multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize (0x%" PRIxLEAST64
-                                 ") and not equal to the end of the memory object (0x%" PRIxLEAST64 ").",
+                                 "is VK_WHOLE_SIZE and the mapping end (%" PRIu64 " = %" PRIu64 " + %" PRIu64
+                                 ") not a multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize (%" PRIu64
+                                 ") and not equal to the end of the memory object (%" PRIu64 ").",
                                  mapping_end, mapping_offset, mapping_size, atom_size, allocation_size);
             }
         } else {
             const auto range_end = size + offset;
             if (range_end != allocation_size && SafeModulo(size, atom_size) != 0) {
                 skip |= LogError("VUID-VkMappedMemoryRange-size-01390", mem_ranges->memory, memory_range_loc.dot(Field::size),
-                                 "(0x%" PRIxLEAST64
-                                 ") is not a multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize (0x%" PRIxLEAST64
-                                 ") and offset + size (0x%" PRIxLEAST64 " + 0x%" PRIxLEAST64 " = 0x%" PRIxLEAST64
-                                 ") not equal to the memory size (0x%" PRIxLEAST64 ").",
+                                 "(%" PRIu64 ") is not a multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize (%" PRIu64
+                                 ") and offset + size (%" PRIu64 " + %" PRIu64 " = %" PRIu64
+                                 ") not equal to the memory size (%" PRIu64 ").",
                                  size, atom_size, offset, size, range_end, allocation_size);
             }
         }
@@ -1063,12 +1060,11 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                         const char *vuid = bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-pNext-01616"
                                                             : "VUID-vkBindImageMemory-memoryOffset-01048";
                         const LogObjectList objlist(bind_info.image, bind_info.memory);
-                        skip |=
-                            LogError(vuid, objlist, loc.dot(Field::memoryOffset),
-                                     "is 0x%" PRIxLEAST64
-                                     " but must be an integer multiple of the VkMemoryRequirements::alignment value 0x%" PRIxLEAST64
-                                     ", returned from a call to vkGetImageMemoryRequirements with image.",
-                                     bind_info.memoryOffset, mem_req.alignment);
+                        skip |= LogError(vuid, objlist, loc.dot(Field::memoryOffset),
+                                         "is %" PRIu64
+                                         " but must be an integer multiple of the VkMemoryRequirements::alignment value %" PRIu64
+                                         ", returned from a call to vkGetImageMemoryRequirements with image.",
+                                         bind_info.memoryOffset, mem_req.alignment);
                     }
 
                     if (mem_info) {
@@ -1079,9 +1075,8 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                                 bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-pNext-01617" : "VUID-vkBindImageMemory-size-01049";
                             const LogObjectList objlist(bind_info.image, bind_info.memory);
                             skip |= LogError(vuid, objlist, loc,
-                                             "allocationSize (0x%" PRIxLEAST64 ") minus memoryOffset (0x%" PRIxLEAST64
-                                             ") is 0x%" PRIxLEAST64
-                                             " but must be at least as large as VkMemoryRequirements::size value 0x%" PRIxLEAST64
+                                             "allocationSize (%" PRIu64 ") minus memoryOffset (%" PRIu64 ") is %" PRIu64
+                                             " but must be at least as large as VkMemoryRequirements::size value %" PRIu64
                                              ", returned from a call to vkGetImageMemoryRequirements with image.",
                                              alloc_info.allocationSize, bind_info.memoryOffset,
                                              alloc_info.allocationSize - bind_info.memoryOffset, mem_req.size);
@@ -1123,8 +1118,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                         const LogObjectList objlist(bind_info.image, bind_info.memory);
                         skip |= LogError(
                             "VUID-VkBindImageMemoryInfo-pNext-01620", objlist, loc.dot(Field::memoryOffset),
-                            "is 0x%" PRIxLEAST64
-                            " but must be an integer multiple of the VkMemoryRequirements::alignment value 0x%" PRIxLEAST64
+                            "is %" PRIu64 " but must be an integer multiple of the VkMemoryRequirements::alignment value %" PRIu64
                             ", returned from a call to vkGetImageMemoryRequirements2 with disjoint image for aspect plane %s.",
                             bind_info.memoryOffset, disjoint_mem_req.alignment, string_VkImageAspectFlagBits(aspect));
                     }
@@ -1137,8 +1131,8 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                             const LogObjectList objlist(bind_info.image, bind_info.memory);
                             skip |= LogError(
                                 "VUID-VkBindImageMemoryInfo-pNext-01621", objlist, loc,
-                                "allocationSize (0x%" PRIxLEAST64 ") minus memoryOffset (0x%" PRIxLEAST64 ") is 0x%" PRIxLEAST64
-                                " but must be at least as large as VkMemoryRequirements::size value 0x%" PRIxLEAST64
+                                "allocationSize (%" PRIu64 ") minus memoryOffset (%" PRIu64 ") is %" PRIu64
+                                " but must be at least as large as VkMemoryRequirements::size value %" PRIu64
                                 ", returned from a call to vkGetImageMemoryRequirements with disjoint image for aspect plane %s.",
                                 alloc_info.allocationSize, bind_info.memoryOffset,
                                 alloc_info.allocationSize - bind_info.memoryOffset, disjoint_mem_req.size,
@@ -1192,7 +1186,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                             skip |= LogError(
                                 vuid, objlist, loc.dot(Field::memory),
                                 "(%s) is a dedicated memory allocation, but VkMemoryDedicatedAllocateInfo:: %s must compatible "
-                                "with %s and memoryOffset 0x%" PRIxLEAST64 " must be zero.",
+                                "with %s and memoryOffset %" PRIu64 " must be zero.",
                                 FormatHandle(bind_info.memory).c_str(), FormatHandle(mem_info->dedicated->handle).c_str(),
                                 FormatHandle(bind_info.image).c_str(), bind_info.memoryOffset);
                         }
@@ -1204,7 +1198,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                             skip |= LogError(
                                 vuid, objlist, loc.dot(Field::memory),
                                 "(%s) is a dedicated memory allocation, but VkMemoryDedicatedAllocateInfo:: %s must be equal "
-                                "to %s and memoryOffset 0x%" PRIxLEAST64 " must be zero.",
+                                "to %s and memoryOffset %" PRIu64 " must be zero.",
                                 FormatHandle(bind_info.memory).c_str(), FormatHandle(mem_info->dedicated->handle).c_str(),
                                 FormatHandle(bind_info.image).c_str(), bind_info.memoryOffset);
                         }

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -4458,7 +4458,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, V
     }
     if (offset & 3) {
         skip |= LogError("VUID-vkCmdDrawIndirect-offset-02710", cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
-                         error_obj.location.dot(Field::offset), "(%" PRIxLEAST64 ") must be a multiple of 4.", offset);
+                         error_obj.location.dot(Field::offset), "(%" PRIu64 ") must be a multiple of 4.", offset);
     }
     if (drawCount > 1) {
         skip |= ValidateCmdDrawStrideWithStruct(cb_state, "VUID-vkCmdDrawIndirect-drawCount-00476", stride,
@@ -4514,7 +4514,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBu
                                                 drawCount, offset, buffer_state.get(), error_obj.location);
     } else if (offset & 3) {
         skip |= LogError("VUID-vkCmdDrawIndexedIndirect-offset-02710", cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
-                         error_obj.location.dot(Field::offset), "(%" PRIxLEAST64 ") must be a multiple of 4.", offset);
+                         error_obj.location.dot(Field::offset), "(%" PRIu64 ") must be a multiple of 4.", offset);
     } else if ((drawCount == 1) && (offset + sizeof(VkDrawIndexedIndirectCommand)) > buffer_state->createInfo.size) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
         objlist.add(buffer);
@@ -4651,7 +4651,7 @@ bool CoreChecks::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffe
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     if (offset & 3) {
         skip |= LogError("VUID-vkCmdDispatchIndirect-offset-02710", cb_state.GetObjectList(VK_SHADER_STAGE_COMPUTE_BIT),
-                         error_obj.location.dot(Field::offset), "(%" PRIxLEAST64 ") must be a multiple of 4.", offset);
+                         error_obj.location.dot(Field::offset), "(%" PRIu64 ") must be a multiple of 4.", offset);
     }
     if ((offset + sizeof(VkDispatchIndirectCommand)) > buffer_state->createInfo.size) {
         skip |= LogError("VUID-vkCmdDispatchIndirect-offset-00407", cb_state.GetObjectList(VK_SHADER_STAGE_COMPUTE_BIT),
@@ -4673,13 +4673,13 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuff
 
     if (offset & 3) {
         skip |= LogError("VUID-vkCmdDrawIndirectCount-offset-02710", cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
-                         error_obj.location.dot(Field::offset), "(0x%" PRIxLEAST64 "), is not a multiple of 4.", offset);
+                         error_obj.location.dot(Field::offset), "(%" PRIu64 "), is not a multiple of 4.", offset);
     }
 
     if (countBufferOffset & 3) {
-        skip |= LogError("VUID-vkCmdDrawIndirectCount-countBufferOffset-02716",
-                         cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS), error_obj.location.dot(Field::countBufferOffset),
-                         "(0x%" PRIxLEAST64 "), is not a multiple of 4.", countBufferOffset);
+        skip |=
+            LogError("VUID-vkCmdDrawIndirectCount-countBufferOffset-02716", cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
+                     error_obj.location.dot(Field::countBufferOffset), "(%" PRIu64 "), is not a multiple of 4.", countBufferOffset);
     }
 
     if ((device_extensions.vk_khr_draw_indirect_count != kEnabledByCreateinfo) &&
@@ -4724,12 +4724,12 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer comm
 
     if (offset & 3) {
         skip |= LogError("VUID-vkCmdDrawIndexedIndirectCount-offset-02710", cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
-                         error_obj.location.dot(Field::offset), "(0x%" PRIxLEAST64 "), is not a multiple of 4.", offset);
+                         error_obj.location.dot(Field::offset), "(%" PRIu64 "), is not a multiple of 4.", offset);
     }
     if (countBufferOffset & 3) {
         skip |= LogError("VUID-vkCmdDrawIndexedIndirectCount-countBufferOffset-02716",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS), error_obj.location.dot(Field::countBufferOffset),
-                         "(0x%" PRIxLEAST64 "), is not a multiple of 4.", countBufferOffset);
+                         "(%" PRIu64 "), is not a multiple of 4.", countBufferOffset);
     }
     if ((device_extensions.vk_khr_draw_indirect_count != kEnabledByCreateinfo) &&
         ((api_version >= VK_API_VERSION_1_2) && (enabled_features.core12.drawIndirectCount == VK_FALSE))) {
@@ -5415,7 +5415,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer comma
     }
     if (offset & 3) {
         skip |= LogError("VUID-vkCmdDrawMeshTasksIndirectNV-offset-02710", cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
-                         error_obj.location.dot(Field::offset), "(0x%" PRIxLEAST64 "), is not a multiple of 4.", offset);
+                         error_obj.location.dot(Field::offset), "(%" PRIu64 "), is not a multiple of 4.", offset);
     }
     if (drawCount > phys_dev_props.limits.maxDrawIndirectCount) {
         skip |= LogError("VUID-vkCmdDrawMeshTasksIndirectNV-drawCount-02719",
@@ -5439,12 +5439,12 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
     if (offset & 3) {
         skip |=
             LogError("VUID-vkCmdDrawMeshTasksIndirectCountNV-offset-02710", cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
-                     error_obj.location.dot(Field::offset), "(0x%" PRIxLEAST64 "), is not a multiple of 4.", offset);
+                     error_obj.location.dot(Field::offset), "(%" PRIu64 "), is not a multiple of 4.", offset);
     }
     if (countBufferOffset & 3) {
         skip |= LogError("VUID-vkCmdDrawMeshTasksIndirectCountNV-countBufferOffset-02716",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS), error_obj.location.dot(Field::countBufferOffset),
-                         "(0x%" PRIxLEAST64 "), is not a multiple of 4.", countBufferOffset);
+                         "(%" PRIu64 "), is not a multiple of 4.", countBufferOffset);
     }
 
     skip = ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -295,8 +295,8 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
 
             if (total_size > format_limits.maxResourceSize) {
                 skip |= LogWarning(device, kVUID_Core_Image_InvalidFormatLimitsViolation,
-                                   "vkCreateImage(): resource size exceeds allowable maximum Image resource size = 0x%" PRIxLEAST64
-                                   ", maximum resource size = 0x%" PRIxLEAST64 " for format %s.",
+                                   "vkCreateImage(): resource size exceeds allowable maximum Image resource size = %" PRIu64
+                                   ", maximum resource size = %" PRIu64 " for format %s.",
                                    total_size, format_limits.maxResourceSize, string_VkFormat(pCreateInfo->format));
             }
         }

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -954,14 +954,14 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandB
 
     if (dstOffset >= dst_buff_state->requirements.size) {
         skip |= LogError("VUID-vkCmdCopyQueryPoolResults-dstOffset-00819", buffer_objlist, error_obj.location.dot(Field::dstOffset),
-                         "(0x%" PRIxLEAST64 ") is not less than the size (0x%" PRIxLEAST64 ") of buffer (%s).", dstOffset,
+                         "(%" PRIu64 ") is not less than the size (%" PRIu64 ") of buffer (%s).", dstOffset,
                          dst_buff_state->requirements.size, FormatHandle(dst_buff_state->buffer()).c_str());
     } else if (dstOffset + (queryCount * stride) > dst_buff_state->requirements.size) {
-        skip |= LogError(
-            "VUID-vkCmdCopyQueryPoolResults-dstBuffer-00824", buffer_objlist, error_obj.location,
-            "storage required (0x%" PRIxLEAST64
-            ") equal to dstOffset + (queryCount * stride) is greater than the size (0x%" PRIxLEAST64 ") of buffer (%s).",
-            dstOffset + (queryCount * stride), dst_buff_state->requirements.size, FormatHandle(dst_buff_state->buffer()).c_str());
+        skip |= LogError("VUID-vkCmdCopyQueryPoolResults-dstBuffer-00824", buffer_objlist, error_obj.location,
+                         "storage required (%" PRIu64
+                         ") equal to dstOffset + (queryCount * stride) is greater than the size (%" PRIu64 ") of buffer (%s).",
+                         dstOffset + (queryCount * stride), dst_buff_state->requirements.size,
+                         FormatHandle(dst_buff_state->buffer()).c_str());
     }
 
     if ((flags & VK_QUERY_RESULT_WITH_STATUS_BIT_KHR) && (flags & VK_QUERY_RESULT_WITH_AVAILABILITY_BIT)) {

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -111,7 +111,7 @@ bool CoreChecks::PreCallValidateBindAccelerationStructureMemoryNV(VkDevice devic
         if (SafeModulo(info.memoryOffset, as_state->memory_requirements.alignment) != 0) {
             skip |= LogError("VUID-VkBindAccelerationStructureMemoryInfoNV-memoryOffset-03623", info.accelerationStructure,
                              bind_info_loc.dot(Field::memoryOffset),
-                             "(0x%" PRIxLEAST64 ") must be a multiple of the alignment (0x%" PRIxLEAST64
+                             "(%" PRIu64 ") must be a multiple of the alignment (%" PRIu64
                              ") member of the VkMemoryRequirements structure returned from "
                              "a call to vkGetAccelerationStructureMemoryRequirementsNV with accelerationStructure %s and type of "
                              "VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV",
@@ -124,10 +124,10 @@ bool CoreChecks::PreCallValidateBindAccelerationStructureMemoryNV(VkDevice devic
             if (as_state->memory_requirements.size > (mem_info->alloc_info.allocationSize - info.memoryOffset)) {
                 skip |= LogError("VUID-VkBindAccelerationStructureMemoryInfoNV-size-03624", info.accelerationStructure,
                                  bind_info_loc.dot(Field::memory),
-                                 "'s size (0x%" PRIxLEAST64 ") minus %s (0x%" PRIxLEAST64 ") is 0x%" PRIxLEAST64
+                                 "'s size (%" PRIu64 ") minus %s (%" PRIu64 ") is %" PRIu64
                                  ", but the size member of the VkMemoryRequirements structure returned from a call to "
                                  "vkGetAccelerationStructureMemoryRequirementsNV with accelerationStructure %s and type of "
-                                 "VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV is 0x%" PRIxLEAST64 ".",
+                                 "VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV is %" PRIu64 ".",
                                  as_state->memory_requirements.size, bind_info_loc.dot(Field::memoryOffset).Fields().c_str(),
                                  info.memoryOffset, mem_info->alloc_info.allocationSize - info.memoryOffset,
                                  FormatHandle(info.accelerationStructure).c_str(), as_state->memory_requirements.size);

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -108,9 +108,8 @@ bool StatelessValidation::manual_PreCallValidateCmdBindTransformFeedbackBuffersE
 
     for (uint32_t i = 0; i < bindingCount; ++i) {
         if (pOffsets[i] & 3) {
-            skip |=
-                LogError("VUID-vkCmdBindTransformFeedbackBuffersEXT-pOffsets-02359", commandBuffer,
-                         error_obj.location.dot(Field::pOffsets, i), "(0x%" PRIxLEAST64 ") is not a multiple of 4.", pOffsets[i]);
+            skip |= LogError("VUID-vkCmdBindTransformFeedbackBuffersEXT-pOffsets-02359", commandBuffer,
+                             error_obj.location.dot(Field::pOffsets, i), "(%" PRIu64 ") is not a multiple of 4.", pOffsets[i]);
         }
     }
 
@@ -136,7 +135,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBindTransformFeedbackBuffersE
                 pSizes[i] > phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackBufferSize) {
                 skip |= LogError("VUID-vkCmdBindTransformFeedbackBuffersEXT-pSize-02361", commandBuffer,
                                  error_obj.location.dot(Field::pSizes, i),
-                                 "(0x%" PRIxLEAST64
+                                 "(%" PRIu64
                                  ") is not VK_WHOLE_SIZE and is greater than "
                                  "maxTransformFeedbackBufferSize.",
                                  pSizes[i]);
@@ -799,15 +798,15 @@ bool StatelessValidation::manual_PreCallValidateCmdUpdateBuffer(VkCommandBuffer 
 
     if (dstOffset & 3) {
         skip |= LogError("VUID-vkCmdUpdateBuffer-dstOffset-00036", commandBuffer, error_obj.location.dot(Field::dstOffset),
-                         "(0x%" PRIxLEAST64 "), is not a multiple of 4.", dstOffset);
+                         "(%" PRIu64 "), is not a multiple of 4.", dstOffset);
     }
 
     if ((dataSize <= 0) || (dataSize > 65536)) {
         skip |= LogError("VUID-vkCmdUpdateBuffer-dataSize-00037", commandBuffer, error_obj.location.dot(Field::dataSize),
-                         "(0x%" PRIxLEAST64 "), must be greater than zero and less than or equal to 65536.", dataSize);
+                         "(%" PRIu64 "), must be greater than zero and less than or equal to 65536.", dataSize);
     } else if (dataSize & 3) {
         skip |= LogError("VUID-vkCmdUpdateBuffer-dataSize-00038", commandBuffer, error_obj.location.dot(Field::dataSize),
-                         "(0x%" PRIxLEAST64 "), is not a multiple of 4.", dataSize);
+                         "(%" PRIu64 "), is not a multiple of 4.", dataSize);
     }
     return skip;
 }
@@ -819,16 +818,16 @@ bool StatelessValidation::manual_PreCallValidateCmdFillBuffer(VkCommandBuffer co
 
     if (dstOffset & 3) {
         skip |= LogError("VUID-vkCmdFillBuffer-dstOffset-00025", dstBuffer, error_obj.location.dot(Field::dstOffset),
-                         "(0x%" PRIxLEAST64 ") is not a multiple of 4.", dstOffset);
+                         "(%" PRIu64 ") is not a multiple of 4.", dstOffset);
     }
 
     if (size != VK_WHOLE_SIZE) {
         if (size <= 0) {
             skip |= LogError("VUID-vkCmdFillBuffer-size-00026", dstBuffer, error_obj.location.dot(Field::size),
-                             "(0x%" PRIxLEAST64 ") must be greater than zero.", size);
+                             "(%" PRIu64 ") must be greater than zero.", size);
         } else if (size & 3) {
             skip |= LogError("VUID-vkCmdFillBuffer-size-00028", dstBuffer, error_obj.location.dot(Field::size),
-                             "(0x%" PRIxLEAST64 ") is not a multiple of 4.", size);
+                             "(%" PRIu64 ") is not a multiple of 4.", size);
         }
     }
     return skip;

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -746,8 +746,8 @@ bool StatelessValidation::ValidateWriteDescriptorSet(const Location &loc, const 
                 if (pDescriptorWrites[i].pBufferInfo != NULL) {
                     if (SafeModulo(pDescriptorWrites[i].pBufferInfo[j].offset, uniform_alignment) != 0) {
                         skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00327",
-                                         "%s(): pDescriptorWrites[%" PRIu32 "].pBufferInfo[%" PRIu32 "].offset (0x%" PRIxLEAST64
-                                         ") must be a multiple of device limit minUniformBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
+                                         "%s(): pDescriptorWrites[%" PRIu32 "].pBufferInfo[%" PRIu32 "].offset (%" PRIu64
+                                         ") must be a multiple of device limit minUniformBufferOffsetAlignment %" PRIu64 ".",
                                          vkCallingFunction, i, j, pDescriptorWrites[i].pBufferInfo[j].offset, uniform_alignment);
                     }
                 }
@@ -759,8 +759,8 @@ bool StatelessValidation::ValidateWriteDescriptorSet(const Location &loc, const 
                 if (pDescriptorWrites[i].pBufferInfo != NULL) {
                     if (SafeModulo(pDescriptorWrites[i].pBufferInfo[j].offset, storage_alignment) != 0) {
                         skip |= LogError(device, "VUID-VkWriteDescriptorSet-descriptorType-00328",
-                                         "%s(): pDescriptorWrites[%" PRIu32 "].pBufferInfo[%" PRIu32 "].offset (0x%" PRIxLEAST64
-                                         ") must be a multiple of device limit minStorageBufferOffsetAlignment 0x%" PRIxLEAST64 ".",
+                                         "%s(): pDescriptorWrites[%" PRIu32 "].pBufferInfo[%" PRIu32 "].offset (%" PRIu64
+                                         ") must be a multiple of device limit minStorageBufferOffsetAlignment %" PRIu64 ".",
                                          vkCallingFunction, i, j, pDescriptorWrites[i].pBufferInfo[j].offset, storage_alignment);
                     }
                 }


### PR DESCRIPTION
For any error message that uses sizes, we should use the decimal and not a hex as it a decimal everywhere else