### PR TITLE
tests: Fix shader object invalid draw test

### DIFF
--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -1543,7 +1543,7 @@ TEST_F(NegativeShaderObject, DrawWithShadersOutsideRenderPass) {
 
     VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
-    const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentUniformGlsl));
+    const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
     m_commandBuffer->begin();
     SetDefaultDynamicStates();


### PR DESCRIPTION
`kFragmentMinimalGlsl` requires a descriptor, but one was not provided.