### PR TITLE
layers: Add thread safety checks for vkQueuePresentKHR

### DIFF
--- a/layers/thread_tracker/thread_safety_validation.cpp
+++ b/layers/thread_tracker/thread_safety_validation.cpp
@@ -740,3 +740,34 @@ void ThreadSafety::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, V
         }
     }
 }
+
+void ThreadSafety::PreCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) {
+    StartWriteObject(queue, vvl::Func::vkQueuePresentKHR);
+    uint32_t waitSemaphoreCount = pPresentInfo->waitSemaphoreCount;
+    if (pPresentInfo->pWaitSemaphores != nullptr) {
+        for (uint32_t index = 0; index < waitSemaphoreCount; index++) {
+            StartReadObject(pPresentInfo->pWaitSemaphores[index], vvl::Func::vkQueuePresentKHR);
+        }
+    }
+    if (pPresentInfo->pSwapchains != nullptr) {
+        for (uint32_t index = 0; index < pPresentInfo->swapchainCount; ++index) {
+            StartWriteObject(pPresentInfo->pSwapchains[index], vvl::Func::vkQueuePresentKHR);
+        }
+    }
+}
+
+void ThreadSafety::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
+                                                 const RecordObject& record_obj) {
+    FinishWriteObject(queue, record_obj.location.function);
+    uint32_t waitSemaphoreCount = pPresentInfo->waitSemaphoreCount;
+    if (pPresentInfo->pWaitSemaphores != nullptr) {
+        for (uint32_t index = 0; index < waitSemaphoreCount; index++) {
+            FinishReadObject(pPresentInfo->pWaitSemaphores[index], record_obj.location.function);
+        }
+    }
+    if (pPresentInfo->pSwapchains != nullptr) {
+        for (uint32_t index = 0; index < pPresentInfo->swapchainCount; ++index) {
+            FinishWriteObject(pPresentInfo->pSwapchains[index], record_obj.location.function);
+        }
+    }
+}

--- a/layers/vulkan/generated/thread_safety_commands.h
+++ b/layers/vulkan/generated/thread_safety_commands.h
@@ -1212,6 +1212,10 @@ void PreCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain,
 void PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
                                        VkFence fence, uint32_t* pImageIndex, const RecordObject& record_obj) override;
 
+void PreCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) override;
+
+void PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo, const RecordObject& record_obj) override;
+
 void PreCallRecordGetDeviceGroupPresentCapabilitiesKHR(
     VkDevice device, VkDeviceGroupPresentCapabilitiesKHR* pDeviceGroupPresentCapabilities) override;
 

--- a/scripts/generators/thread_safety_generator.py
+++ b/scripts/generators/thread_safety_generator.py
@@ -65,10 +65,10 @@ class ThreadSafetyOutputGenerator(BaseGenerator):
             'vkDeviceWaitIdle',
             'vkRegisterDisplayEventEXT',
             'vkCreateRayTracingPipelinesKHR',
+            'vkQueuePresentKHR',
         ]
 
         self.blacklist = [
-            'vkQueuePresentKHR',
             # Currently not wrapping debug helper functions
             'vkSetDebugUtilsObjectNameEXT',
             'vkSetDebugUtilsObjectTagEXT',


### PR DESCRIPTION
This re-applies https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6400 by @AlinaKalyakina that was temporary reverted by https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6448 for investigation.

One change comparing to the original PR is that Swapchain have to use `StartWriteObject` instead of `StartWriteObjectParentInstance` in the old version (after https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/73ba61f6321391b246177d0c47e957ea8b50af9d).