### PR TITLE
layers: Improve ValidateMemoryTypes error message

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -102,9 +102,9 @@ bool CoreChecks::PreCallValidateBindAccelerationStructureMemoryNV(VkDevice devic
         if (mem_info) {
             skip |= ValidateInsertAccelerationStructureMemoryRange(info.accelerationStructure, mem_info.get(), info.memoryOffset,
                                                                    bind_info_loc.dot(Field::memoryOffset));
-            skip |=
-                ValidateMemoryTypes(mem_info.get(), as_state->memory_requirements.memoryTypeBits, bind_info_loc.dot(Field::memory),
-                                    "VUID-VkBindAccelerationStructureMemoryInfoNV-memory-03622");
+            skip |= ValidateMemoryTypes(mem_info.get(), as_state->memory_requirements.memoryTypeBits,
+                                        bind_info_loc.dot(Field::accelerationStructure),
+                                        "VUID-VkBindAccelerationStructureMemoryInfoNV-memory-03622");
         }
 
         // Validate memory requirements alignment

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -688,7 +688,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateInsertAccelerationStructureMemoryRange(VkAccelerationStructureNV as, const DEVICE_MEMORY_STATE* mem_info,
                                                         VkDeviceSize mem_offset, const Location& loc) const;
 
-    bool ValidateMemoryTypes(const DEVICE_MEMORY_STATE* mem_info, const uint32_t memory_type_bits, const Location& loc,
+    bool ValidateMemoryTypes(const DEVICE_MEMORY_STATE* mem_info, const uint32_t memory_type_bits, const Location& resource_loc,
                              const char* vuid) const;
     bool ValidateCommandBufferState(const CMD_BUFFER_STATE& cb_state, const Location& loc, uint32_t current_submit_count,
                                     const char* vuid) const;


### PR DESCRIPTION
before

> vkBindImageMemory2(): pBindInfos[0] MemoryRequirements->memoryTypeBits (0x8) for this object type are not compatible with the memory type (2) of VkDeviceMemory 0xf56c9b0000000004[].

and now

> vkBindImageMemory2(): pBindInfos[0].image require memoryTypeBits (0x8) but VkDeviceMemory 0xf56c9b0000000004[] was allocated with memoryTypeIndex (2).