### PR TITLE
tests: Add support to Mock AHB 

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -110,6 +110,38 @@ jobs:
         env:
           VK_KHRONOS_PROFILES_PROFILE_FILE: ${{ github.workspace }}/tests/device_profiles/pixel_6_adreno.json
 
+  androidOnLinux:
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: 3.17.2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: androidOnLinux-ccache
+      - name: Install python dependencies
+        run: python3 -m pip install jsonschema pyparsing
+      - name: Install WSI dependencies
+        run: sudo apt-get -qq update && sudo apt-get install -y libwayland-dev xorg-dev
+      - name: Build
+        run: python scripts/tests.py --build --mockAndroid --config release --cmake='-DVVL_CPP_STANDARD=20 -DUSE_ROBIN_HOOD_HASHING=ON'
+        env:
+          CC: clang
+          CXX: clang++
+      - name: Test Max Profile
+        run: python scripts/tests.py --test --mockAndroid
+        env:
+          VK_KHRONOS_PROFILES_PROFILE_FILE: ${{ github.workspace }}/tests/device_profiles/max_profile.json
+
   windows:
     runs-on: windows-2022
     strategy:

--- a/scripts/macos.py
+++ b/scripts/macos.py
@@ -45,7 +45,7 @@ def main():
     SetupDarwin(osx)
 
     try:
-        common_ci.BuildVVL(config = config, cmake_args = args.cmake, build_tests = "OFF")
+        common_ci.BuildVVL(config = config, cmake_args = args.cmake, build_tests = "OFF", mock_android = None)
     except subprocess.CalledProcessError as proc_error:
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))
         sys.exit(proc_error.returncode)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -32,10 +32,10 @@ def Build(args):
             sys.exit(1)
 
     try:
-        common_ci.BuildVVL(config = config, cmake_args = args.cmake, build_tests = "ON")
+        common_ci.BuildVVL(config = config, cmake_args = args.cmake, build_tests = "ON", mock_android = args.mockAndroid)
         common_ci.BuildLoader()
         common_ci.BuildProfileLayer()
-        common_ci.BuildMockICD()
+        common_ci.BuildMockICD(args.mockAndroid)
 
     except subprocess.CalledProcessError as proc_error:
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))
@@ -46,9 +46,9 @@ def Build(args):
 
     sys.exit(0)
 
-def Test():
+def Test(args):
     try:
-        common_ci.RunVVLTests()
+        common_ci.RunVVLTests(args)
 
     except subprocess.CalledProcessError as proc_error:
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))
@@ -61,9 +61,13 @@ def Test():
 
 if __name__ == '__main__':
     parser = common_ci.GetArgParser()
+    parser.add_argument(
+        '--mockAndroid', dest='mockAndroid',
+        action='store_true', help='Use Mock Android')
+
     args = parser.parse_args()
 
     if (args.build):
         Build(args)
     if (args.test):
-        Test()
+        Test(args)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -237,7 +237,14 @@ else()
     message(FATAL_ERROR "Cannot determine SPIRV-Tools target name")
 endif()
 
-if (ANDROID)
+# More details in tests/android/mock/README.md
+option(VVL_MOCK_ANDROID "Enable building for Android on desktop for testing with MockICD setup")
+if(VVL_MOCK_ANDROID)
+    # We don't want to build the android APK, so we just set the minimum Android settings
+    target_sources(VkLayer_utils PRIVATE android/mock/android/hardware_buffer.cpp)
+    target_compile_definitions(VkLayer_utils PUBLIC VK_USE_PLATFORM_ANDROID_KHR VVL_MOCK_ANDROID __ANDROID__)
+    target_include_directories(VkLayer_utils SYSTEM PUBLIC android/mock)
+elseif (ANDROID)
     add_subdirectory(android)
     return()
 endif()

--- a/tests/android/mock/README.md
+++ b/tests/android/mock/README.md
@@ -1,0 +1,11 @@
+# Android Mock
+
+When dealing with AndroidHardwareBuffers (`VK_ANDROID_external_memory_android_hardware_buffer`) there are API calls that are only found when deploying on Android.
+
+In order to easily and properly do some testing for extensions that don't have devices yet (`VK_ANDROID_external_format_resolve`) we need a way to have a MockICD driver.
+
+Instead of trying to deploy a MockICD driver for android, we are leaving the MockICD alone and instead just mocking the bare minimum AHB calls in order to run the tests locally.
+
+This allows both developers and GitHub CI to test the AHB logic against something instead of having to rely on a phyiscal Android device.
+
+This is not a **replacement** for the Android devices as the same way MockICD is not a replacement for phyiscal hardware

--- a/tests/android/mock/android/api-level.h
+++ b/tests/android/mock/android/api-level.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#define __ANDROID_API_FUTURE__ 10000
+
+#ifndef __ANDROID_API__
+#define __ANDROID_API__ __ANDROID_API_FUTURE__
+#endif
+
+#define __ANDROID_API_O__ 26
+#define __ANDROID_API_O_MR1__ 27
+#define __ANDROID_API_P__ 28
+#define __ANDROID_API_Q__ 29
+#define __ANDROID_API_R__ 30
+#define __ANDROID_API_S__ 31
+#define __ANDROID_API_T__ 33
+#define __ANDROID_API_U__ 34

--- a/tests/android/mock/android/hardware_buffer.cpp
+++ b/tests/android/mock/android/hardware_buffer.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "hardware_buffer.h"
+
+// Because test and layer have 2 instance of this file, store everything in the AHB
+struct AHardwareBuffer {
+    AHardwareBuffer_Desc desc;
+};
+
+// Just keep a single global AHB
+static AHardwareBuffer kAHB;
+static AHardwareBuffer* kpAHB = &kAHB;
+
+int AHardwareBuffer_allocate(const AHardwareBuffer_Desc* desc, AHardwareBuffer** outBuffer) {
+    *outBuffer = kpAHB;
+    kAHB.desc = *desc;
+    return 0;
+}
+
+void AHardwareBuffer_release(AHardwareBuffer* buffer) { (void)buffer; }
+
+void AHardwareBuffer_describe(const AHardwareBuffer* buffer, AHardwareBuffer_Desc* outDesc) { *outDesc = buffer->desc; };

--- a/tests/android/mock/android/hardware_buffer.h
+++ b/tests/android/mock/android/hardware_buffer.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+enum AHardwareBuffer_Format {
+    AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM           = 1,
+    AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM           = 2,
+    AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM             = 3,
+    AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM             = 4,
+    AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT       = 0x16,
+    AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM        = 0x2b,
+    AHARDWAREBUFFER_FORMAT_BLOB                     = 0x21,
+    AHARDWAREBUFFER_FORMAT_D16_UNORM                = 0x30,
+    AHARDWAREBUFFER_FORMAT_D24_UNORM                = 0x31,
+    AHARDWAREBUFFER_FORMAT_D24_UNORM_S8_UINT        = 0x32,
+    AHARDWAREBUFFER_FORMAT_D32_FLOAT                = 0x33,
+    AHARDWAREBUFFER_FORMAT_D32_FLOAT_S8_UINT        = 0x34,
+    AHARDWAREBUFFER_FORMAT_S8_UINT                  = 0x35,
+    AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420             = 0x23,
+    AHARDWAREBUFFER_FORMAT_YCbCr_P010               = 0x36,
+    AHARDWAREBUFFER_FORMAT_R8_UNORM                 = 0x38,
+};
+
+enum AHardwareBuffer_UsageFlags {
+    AHARDWAREBUFFER_USAGE_CPU_READ_NEVER        = 0UL,
+    AHARDWAREBUFFER_USAGE_CPU_READ_RARELY       = 2UL,
+    AHARDWAREBUFFER_USAGE_CPU_READ_OFTEN        = 3UL,
+    AHARDWAREBUFFER_USAGE_CPU_READ_MASK         = 0xFUL,
+    AHARDWAREBUFFER_USAGE_CPU_WRITE_NEVER       = 0UL << 4,
+    AHARDWAREBUFFER_USAGE_CPU_WRITE_RARELY      = 2UL << 4,
+    AHARDWAREBUFFER_USAGE_CPU_WRITE_OFTEN       = 3UL << 4,
+    AHARDWAREBUFFER_USAGE_CPU_WRITE_MASK        = 0xFUL << 4,
+    AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE     = 1UL << 8,
+    AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER       = 1UL << 9,
+    AHARDWAREBUFFER_USAGE_GPU_COLOR_OUTPUT      = AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER,
+    AHARDWAREBUFFER_USAGE_COMPOSER_OVERLAY      = 1ULL << 11,
+    AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT     = 1UL << 14,
+    AHARDWAREBUFFER_USAGE_VIDEO_ENCODE          = 1UL << 16,
+    AHARDWAREBUFFER_USAGE_SENSOR_DIRECT_DATA    = 1UL << 23,
+    AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER       = 1UL << 24,
+    AHARDWAREBUFFER_USAGE_GPU_CUBE_MAP          = 1UL << 25,
+    AHARDWAREBUFFER_USAGE_GPU_MIPMAP_COMPLETE   = 1UL << 26,
+};
+
+typedef struct AHardwareBuffer_Desc {
+    uint32_t width;
+    uint32_t height;
+    uint32_t layers;
+    uint32_t format;
+    uint64_t usage;
+    uint32_t stride;
+    uint32_t rfu0;
+    uint64_t rfu1;
+} AHardwareBuffer_Desc;
+
+typedef struct AHardwareBuffer AHardwareBuffer;
+
+int AHardwareBuffer_allocate(const AHardwareBuffer_Desc* _Nonnull desc,
+                             AHardwareBuffer* _Nullable* _Nonnull outBuffer);
+
+void AHardwareBuffer_release(AHardwareBuffer* _Nonnull buffer);
+
+void AHardwareBuffer_describe(const AHardwareBuffer* _Nonnull buffer,
+                              AHardwareBuffer_Desc* _Nonnull outDesc);

--- a/tests/android/mock/android/log.h
+++ b/tests/android/mock/android/log.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+typedef enum android_LogPriority {
+  ANDROID_LOG_UNKNOWN = 0,
+  ANDROID_LOG_DEFAULT,
+  ANDROID_LOG_VERBOSE,
+  ANDROID_LOG_DEBUG,
+  ANDROID_LOG_INFO,
+  ANDROID_LOG_WARN,
+  ANDROID_LOG_ERROR,
+  ANDROID_LOG_FATAL,
+  ANDROID_LOG_SILENT,
+} android_LogPriority;
+
+static int __android_log_print(int prio, const char* tag, const char* fmt, ...) {
+    return 0;
+}

--- a/tests/android/mock/android/ndk-version.h
+++ b/tests/android/mock/android/ndk-version.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#define __ANDROID_NDK__ 1
+#define __NDK_MAJOR__ 25
+#define __NDK_MINOR__ 1
+#define __NDK_BETA__ 0
+#define __NDK_BUILD__ 8937393
+#define __NDK_CANARY__ 0

--- a/tests/android/mock/android_native_app_glue.h
+++ b/tests/android/mock/android_native_app_glue.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once

--- a/tests/android/mock/sys/system_properties.h
+++ b/tests/android/mock/sys/system_properties.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+typedef struct prop_info prop_info;
+
+static const prop_info* __system_property_find(const char* __name) {
+    return nullptr;
+}
+
+static void __system_property_read_callback(const prop_info* __pi,
+    void (*__callback)(void* __cookie, const char* __name, const char* __value, uint32_t __serial),
+    void* __cookie) {
+
+}

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -1996,6 +1996,29 @@
                 "VK_EXT_dynamic_rendering_unused_attachments": 1
             },
             "formats": {
+                "VK_FORMAT_UNDEFINED": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"
+                        ],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT",
+                            "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT",
+                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"
+                        ],
+                        "bufferFeatures": []
+                    }
+                },
                 "VK_FORMAT_R4G4_UNORM_PACK8": {
                     "VkFormatProperties3": {
                         "linearTilingFeatures": [

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -1258,7 +1258,7 @@ void print_android(const char *c) {
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 }
 
-#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+#if defined(VK_USE_PLATFORM_ANDROID_KHR) && !defined(VVL_MOCK_ANDROID)
 const char *appTag = "VulkanLayerValidationTests";
 static bool initialized = false;
 static bool active = false;

--- a/tests/unit/android_hardware_buffer.cpp
+++ b/tests/unit/android_hardware_buffer.cpp
@@ -246,6 +246,9 @@ TEST_F(NegativeAndroidHardwareBuffer, AllocationSize) {
     {
         memory_allocate_info.allocationSize = ahb_props.allocationSize;
         memory_allocate_info.memoryTypeIndex++;
+#if defined(VVL_MOCK_ANDROID)
+        m_errorMonitor->SetUnexpectedError("VUID-vkAllocateMemory-pAllocateInfo-01714");  // incase at last index
+#endif
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-memoryTypeIndex-02385");
         vkt::DeviceMemory memory(*m_device, memory_allocate_info);
         m_errorMonitor->VerifyFound();


### PR DESCRIPTION
Problem: No way to test `VK_ANDROID_external_format_resolve` (or `VK_ANDROID_external_memory_android_hardware_buffer`) with out an Android device that supports it (even then it is not fun). This means no coverage is done in Github CI and development is hard

Solution: Add a "Mock AHB" so we can simulate the Android Hardware Buffer to allow the tests to run on local desktop devices

This change

- Adds a bunch headers to allow things to compile
- CI job to test `--gtest_filter=*AndroidHardwareBuffer*` tests
- CMake support for this with a `-DVVL_MOCK_ANDROID=ON` flag to toggle it on