### PR TITLE
layers: Fix image layout transition for depth stencil image when only one aspect is supplied

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -852,7 +852,16 @@ void CoreChecks::TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE *cb_state, co
                 sub_range.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
                 cb_state->SetImageInitialLayout(*image_state, sub_range, stencil_initial_layout);
             } else {
-                cb_state->SetImageInitialLayout(*image_state, view_state->normalized_subresource_range, initial_layout);
+                // If layoutStencil is kInvalidLayout (meaning no separate depth/stencil layout), image view format has both depth
+                // and stencil aspects, and subresource has only one of aspect out of depth or stencil, then the missing aspect will
+                // also be transitioned and thus must be included explicitly
+                auto subresource_range = view_state->normalized_subresource_range;
+                if (const VkFormat format = view_state->create_info.format; vkuFormatIsDepthAndStencil(format)) {
+                    if (subresource_range.aspectMask & (VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_DEPTH_BIT)) {
+                        subresource_range.aspectMask |= VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+                    }
+                }
+                cb_state->SetImageInitialLayout(*image_state, subresource_range, initial_layout);
             }
         }
     }

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -24,13 +24,13 @@
 std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info{};
 
 VkFormat FindSupportedDepthOnlyFormat(VkPhysicalDevice phy) {
-    const VkFormat ds_formats[] = {VK_FORMAT_D16_UNORM, VK_FORMAT_X8_D24_UNORM_PACK32, VK_FORMAT_D32_SFLOAT};
-    for (uint32_t i = 0; i < size(ds_formats); ++i) {
+    constexpr std::array depth_formats = {VK_FORMAT_D16_UNORM, VK_FORMAT_X8_D24_UNORM_PACK32, VK_FORMAT_D32_SFLOAT};
+    for (VkFormat depth_format : depth_formats) {
         VkFormatProperties format_props;
-        vk::GetPhysicalDeviceFormatProperties(phy, ds_formats[i], &format_props);
+        vk::GetPhysicalDeviceFormatProperties(phy, depth_format, &format_props);
 
         if (format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) {
-            return ds_formats[i];
+            return depth_format;
         }
     }
     assert(false);  // Vulkan drivers are guaranteed to have at least one supported format
@@ -38,13 +38,13 @@ VkFormat FindSupportedDepthOnlyFormat(VkPhysicalDevice phy) {
 }
 
 VkFormat FindSupportedStencilOnlyFormat(VkPhysicalDevice phy) {
-    const VkFormat ds_formats[] = {VK_FORMAT_S8_UINT};
-    for (uint32_t i = 0; i < size(ds_formats); ++i) {
+    constexpr std::array stencil_formats = {VK_FORMAT_S8_UINT};
+    for (VkFormat stencil_format : stencil_formats) {
         VkFormatProperties format_props;
-        vk::GetPhysicalDeviceFormatProperties(phy, ds_formats[i], &format_props);
+        vk::GetPhysicalDeviceFormatProperties(phy, stencil_format, &format_props);
 
         if (format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) {
-            return ds_formats[i];
+            return stencil_format;
         }
     }
     return VK_FORMAT_UNDEFINED;

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -1765,3 +1765,89 @@ TEST_F(PositiveRenderPass, InputResolve) {
 
     PositiveTestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported);
 }
+
+TEST_F(PositiveRenderPass, TestDepthStencilRenderPassTransition) {
+    TEST_DESCRIPTION(
+        "Create framebuffer with a depth/stencil attachment that has only depth or stencil aspect and transition it in render "
+        "pass. Then create a barrier on both aspect, for this to be valid *both* aspects must have been correctly tracked as "
+        "transitioned to the new layout.");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    ASSERT_NO_FATAL_FAILURE(InitFramework());
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        GTEST_SKIP() << "At least Vulkan version 1.1 is required";
+    }
+    ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(m_device->phy());
+    VkImageObj depthImage(m_device);
+    depthImage.Init(32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
+
+    for (size_t i = 0; i < 2; i++) {
+        const VkImageView depthView =
+            depthImage.targetView(ds_format, i == 0 ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_STENCIL_BIT);
+
+        VkAttachmentReference depthAttachment = {};
+        depthAttachment.attachment = 0;
+        depthAttachment.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        VkSubpassDescription subpass = {};
+        subpass.pDepthStencilAttachment = &depthAttachment;
+        VkAttachmentDescription depth_attach_desc = {};
+        depth_attach_desc.format = ds_format;
+        depth_attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
+        depth_attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        depth_attach_desc.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        depth_attach_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        depth_attach_desc.stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
+        depth_attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        depth_attach_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+        VkRenderPassCreateInfo rpci = vku::InitStructHelper();
+        rpci.attachmentCount = 1;
+        rpci.pAttachments = &depth_attach_desc;
+        rpci.subpassCount = 1;
+        rpci.pSubpasses = &subpass;
+        const vkt::RenderPass render_pass(*m_device, rpci);
+
+        VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
+        fb_ci.renderPass = render_pass.handle();
+        fb_ci.attachmentCount = 1;
+        fb_ci.pAttachments = &depthView;
+        fb_ci.width = 32;
+        fb_ci.height = 32;
+        fb_ci.layers = 1;
+        const vkt::Framebuffer fb(*m_device, fb_ci);
+
+        VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
+        rpbinfo.renderPass = render_pass.handle();
+        rpbinfo.framebuffer = fb.handle();
+        rpbinfo.renderArea.extent.width = 32;
+        rpbinfo.renderArea.extent.height = 32;
+
+        m_commandBuffer->begin();
+
+        m_commandBuffer->BeginRenderPass(rpbinfo);
+        m_commandBuffer->EndRenderPass();
+
+        VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
+        img_barrier.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+        img_barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+        img_barrier.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        img_barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+        img_barrier.image = depthImage.handle();
+        img_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+        img_barrier.subresourceRange.layerCount = 1;
+        img_barrier.subresourceRange.levelCount = 1;
+
+        vk::CmdPipelineBarrier(m_commandBuffer->handle(),
+                               VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                               VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &img_barrier);
+        m_commandBuffer->end();
+
+        VkSubmitInfo submit_info = vku::InitStructHelper();
+        submit_info.commandBufferCount = 1;
+        submit_info.pCommandBuffers = &m_commandBuffer->handle();
+
+        vk::QueueSubmit(m_default_queue, 1, &submit_info, VK_NULL_HANDLE);
+        vk::QueueWaitIdle(m_default_queue);
+    }
+}


### PR DESCRIPTION
- Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4696

Fix image layout transition for depth stencil image when only one aspect is supplied