### PR TITLE
ci: Run vvl scripts in seperate action

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -249,3 +249,16 @@ jobs:
         run: sudo apt-get -qq update && sudo apt-get install -y libwayland-dev xorg-dev
       - name: Test chromium build
         run: python scripts/gn.py
+
+  check_vvl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install python dependencies
+        run: python3 -m pip install jsonschema pyparsing
+      - run: scripts/update_deps.py --dir ext --no-build
+      - run: scripts/generate_source.py --verify ext/Vulkan-Headers/registry/ ext/SPIRV-Headers/include/spirv/unified1/
+      - run: scripts/vk_validation_stats.py ext/Vulkan-Headers/registry/validusage.json -summary -c

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -102,29 +102,6 @@ def BuildVVL(config, cmake_args, build_tests):
     RunShellCmd(install_cmd)
 
 #
-# Run VVL scripts
-def CheckVVL():
-    vulkan_registry = f'{CI_EXTERNAL_DIR}/Vulkan-Headers/build/install/share/vulkan/registry'
-    if not os.path.exists(vulkan_registry):
-        print(f'Unable to find Vulkan Registry: {vulkan_registry}')
-        sys.exit(1)
-
-    spirv_unified = f'{CI_EXTERNAL_DIR}/SPIRV-Headers/build/install/include/spirv/unified1/'
-    if not os.path.exists(spirv_unified):
-        print(f'Unable to find Spirv Unified: {spirv_unified}')
-        sys.exit(1)
-
-    print("Check Generated Source Code Consistency")
-    gen_check_cmd = f'python scripts/generate_source.py --verify {vulkan_registry} {spirv_unified}'
-    RunShellCmd(gen_check_cmd)
-
-    print('Run vk_validation_stats.py')
-    valid_usage_json = f'{vulkan_registry}/validusage.json'
-    text_file = f'{CI_BUILD_DIR}/vuid_coverage_database.txt'
-    gen_check_cmd = f'python scripts/vk_validation_stats.py {valid_usage_json} -text {text_file}'
-    RunShellCmd(gen_check_cmd)
-
-#
 # Prepare Loader for executing Layer Validation Tests
 def BuildLoader():
     SRC_DIR = f'{CI_EXTERNAL_DIR}/Vulkan-Loader'

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -36,7 +36,6 @@ def Build(args):
         common_ci.BuildLoader()
         common_ci.BuildProfileLayer()
         common_ci.BuildMockICD()
-        common_ci.CheckVVL()
 
     except subprocess.CalledProcessError as proc_error:
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))


### PR DESCRIPTION
It can be very confusing when these scripts fail at the end of a long run. Especially for open source contributors.