### PR TITLE
tests: Remove IsPlatform for android devices

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -639,7 +639,7 @@ bool VkLayerTest::IsDriver(VkDriverId driver_id) {
 bool VkLayerTest::LoadDeviceProfileLayer(
     PFN_vkSetPhysicalDeviceFormatPropertiesEXT &fpvkSetPhysicalDeviceFormatPropertiesEXT,
     PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT &fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT) {
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         printf("Device Profile layer is for real GPU, if using MockICD with profiles, just adjust the profile json file instead\n");
         return false;
     }
@@ -663,7 +663,7 @@ bool VkLayerTest::LoadDeviceProfileLayer(
 bool VkLayerTest::LoadDeviceProfileLayer(
     PFN_vkSetPhysicalDeviceFormatProperties2EXT &fpvkSetPhysicalDeviceFormatProperties2EXT,
     PFN_vkGetOriginalPhysicalDeviceFormatProperties2EXT &fpvkGetOriginalPhysicalDeviceFormatProperties2EXT) {
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         printf("Device Profile layer is for real GPU, if using MockICD with profiles, just adjust the profile json file instead\n");
         return false;
     }
@@ -687,7 +687,7 @@ bool VkLayerTest::LoadDeviceProfileLayer(
 
 bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceLimitsEXT &fpvkSetPhysicalDeviceLimitsEXT,
                                          PFN_vkGetOriginalPhysicalDeviceLimitsEXT &fpvkGetOriginalPhysicalDeviceLimitsEXT) {
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         printf("Device Profile layer is for real GPU, if using MockICD with profiles, just adjust the profile json file instead\n");
         return false;
     }
@@ -710,7 +710,7 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceLimitsEXT &fpvkS
 
 bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceFeaturesEXT &fpvkSetPhysicalDeviceFeaturesEXT,
                                          PFN_vkGetOriginalPhysicalDeviceFeaturesEXT &fpvkGetOriginalPhysicalDeviceFeaturesEXT) {
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         printf("Device Profile layer is for real GPU, if using MockICD with profiles, just adjust the profile json file instead\n");
         return false;
     }
@@ -732,7 +732,7 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_vkSetPhysicalDeviceFeaturesEXT &fpv
 }
 
 bool VkLayerTest::LoadDeviceProfileLayer(PFN_VkSetPhysicalDeviceProperties2EXT &fpvkSetPhysicalDeviceProperties2EXT) {
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         printf("Device Profile layer is for real GPU, if using MockICD with profiles, just adjust the profile json file instead\n");
         return false;
     }

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -503,15 +503,12 @@ bool VkRenderFramework::IgnoreDisableChecks() {
     return skip_disable_checks;
 }
 
-bool VkRenderFramework::IsPlatform(PlatformType platform) {
+static const std::string mock_icd_device_name = "Vulkan Mock Device";
+bool VkRenderFramework::IsPlatformMockICD() {
     if (VkRenderFramework::IgnoreDisableChecks()) {
         return false;
     } else {
-        const auto search = vk_gpu_table.find(platform);
-        if (search != vk_gpu_table.end()) {
-            return 0 == search->second.compare(physDevProps().deviceName);
-        }
-        return false;
+        return 0 == mock_icd_device_name.compare(physDevProps().deviceName);
     }
 }
 

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -41,19 +41,6 @@ static constexpr VkDeviceSize kZeroDeviceSize{0};
 
 class VkImageObj;
 
-typedef enum {
-    kGalaxyS10,
-    kPixel3,
-    kShieldTVb,
-    kMockICD,
-} PlatformType;
-
-const std::unordered_map<PlatformType, std::string, std::hash<int>> vk_gpu_table = {
-    {kGalaxyS10, "Mali-G76"},
-    {kPixel3, "Adreno (TM) 630"},
-    {kShieldTVb, "NVIDIA Tegra X1 (rev B) (nvgpu)"},
-    {kMockICD, "Vulkan Mock Device"},
-};
 struct SurfaceContext {
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     HWND m_win32Window{};
@@ -118,7 +105,7 @@ class VkRenderFramework : public VkTestFramework {
     void DestroyRenderTarget();
 
     static bool IgnoreDisableChecks();
-    bool IsPlatform(PlatformType platform);
+    bool IsPlatformMockICD();
     void GetPhysicalDeviceFeatures(VkPhysicalDeviceFeatures *features);
     void GetPhysicalDeviceProperties(VkPhysicalDeviceProperties *props);
     VkFormat GetRenderTargetFormat();

--- a/tests/unit/android_hardware_buffer.cpp
+++ b/tests/unit/android_hardware_buffer.cpp
@@ -175,10 +175,6 @@ TEST_F(NegativeAndroidHardwareBuffer, GpuDataBuffer) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on this device";
-    }
-
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -210,10 +206,6 @@ TEST_F(NegativeAndroidHardwareBuffer, AllocationSize) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on this device";
-    }
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -258,10 +250,6 @@ TEST_F(NegativeAndroidHardwareBuffer, DedicatedUsageColor) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on this device";
-    }
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -315,10 +303,6 @@ TEST_F(NegativeAndroidHardwareBuffer, DedicatedUsageDS) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on this device";
-    }
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -383,10 +367,6 @@ TEST_F(NegativeAndroidHardwareBuffer, MipmapChain) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on this device";
-    }
-
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -449,10 +429,6 @@ TEST_F(NegativeAndroidHardwareBuffer, ImageDimensions) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on this device";
-    }
-
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -513,10 +489,6 @@ TEST_F(NegativeAndroidHardwareBuffer, UnknownFormat) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on this device";
-    }
-
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -566,10 +538,6 @@ TEST_F(NegativeAndroidHardwareBuffer, GpuUsage) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on this device";
-    }
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -643,10 +611,6 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportMemoryAllocate) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on this device";
-    }
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -786,10 +750,6 @@ TEST_F(NegativeAndroidHardwareBuffer, CreateImageView) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -952,10 +912,6 @@ TEST_F(NegativeAndroidHardwareBuffer, ImportBuffer) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
-
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -996,10 +952,6 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportBufferHandleType) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
-
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -1026,10 +978,6 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportImageNonBound) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -1092,10 +1040,6 @@ TEST_F(NegativeAndroidHardwareBuffer, InvalidBindBufferMemory) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
-
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -1155,10 +1099,6 @@ TEST_F(NegativeAndroidHardwareBuffer, ImportBufferHandleType) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
-
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -1214,10 +1154,6 @@ TEST_F(NegativeAndroidHardwareBuffer, ImportImageHandleType) {
 
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -1343,10 +1279,6 @@ TEST_F(NegativeAndroidHardwareBuffer, NullAHBProperties) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10 - fails in gralloc";
-    }
-
     vkt::AHB ahb(AHARDWAREBUFFER_FORMAT_BLOB, AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER, 64);
 
     VkAndroidHardwareBufferPropertiesANDROID ahb_props = vku::InitStructHelper();
@@ -1366,10 +1298,6 @@ TEST_F(NegativeAndroidHardwareBuffer, NullAHBImport) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10 - fails in gralloc";
-    }
 
     vkt::AHB ahb(AHARDWAREBUFFER_FORMAT_BLOB, AHARDWAREBUFFER_USAGE_GPU_DATA_BUFFER, 64);
 

--- a/tests/unit/android_hardware_buffer_positive.cpp
+++ b/tests/unit/android_hardware_buffer_positive.cpp
@@ -23,10 +23,6 @@ TEST_F(PositiveAndroidHardwareBuffer, MemoryRequirements) {
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
-
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -65,10 +61,6 @@ TEST_F(PositiveAndroidHardwareBuffer, DepthStencil) {
 
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
 
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -137,10 +129,6 @@ TEST_F(PositiveAndroidHardwareBuffer, BindBufferMemory) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME);
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
 
     ASSERT_NO_FATAL_FAILURE(InitState());
 
@@ -310,10 +298,6 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalImage) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10 - fails in gralloc";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitState());
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required.";
@@ -403,10 +387,6 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalCameraFormat) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
-    }
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10 - fails in gralloc";
     }
 
     ASSERT_NO_FATAL_FAILURE(InitState());

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -201,11 +201,6 @@ TEST_F(VkArmBestPracticesLayerTest, AttachmentNeedsReadback) {
 TEST_F(VkArmBestPracticesLayerTest, ManySmallIndexedDrawcalls) {
     InitBestPracticesFramework(kEnableArmValidation);
     InitState();
-
-    if (IsPlatform(kShieldTVb)) {
-        return;
-    }
-
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
                                          "UNASSIGNED-BestPractices-vkCmdDrawIndexed-many-small-indexed-drawcalls");
 
@@ -334,7 +329,7 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
     InitState();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -442,7 +437,7 @@ TEST_F(VkArmBestPracticesLayerTest, PostTransformVertexCacheThrashingIndicesTest
     InitState();
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -891,11 +886,6 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
     TEST_DESCRIPTION("Test for appropriate warnings to be thrown when a redundant store is used.");
 
     InitBestPracticesFramework(kEnableArmValidation);
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "Test temporarily disabled on S10 device";
-    }
-
     InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-RenderPass-redundant-store");

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -78,7 +78,7 @@ TEST_F(VkBestPracticesLayerTest, ReturnCodes) {
         m_errorMonitor->VerifyFound();
     }
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD because will always return VK_SUCCESS";
     }
 
@@ -113,7 +113,7 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD - currently can't create 2 concurrent instances";
     }
 
@@ -256,11 +256,6 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTestSecondary) {
 
     InitBestPracticesFramework();
     InitState();
-
-    if (IsPlatform(PlatformType::kShieldTVb)) {
-        GTEST_SKIP() << "Test CmdClearAttachmentTestSecondary is unstable on ShieldTV";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     m_commandBuffer->begin();
@@ -657,10 +652,6 @@ TEST_F(VkBestPracticesLayerTest, AttachmentShouldNotBeTransient) {
     InitBestPracticesFramework();
     InitState();
 
-    if (IsPlatform(kPixel3) || IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test seems super-picky on Android platforms";
-    }
-
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
                                          "UNASSIGNED-BestPractices-vkCreateFramebuffer-attachment-should-not-be-transient");
 
@@ -885,10 +876,6 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
 
     InitBestPracticesFramework();
     InitState();
-
-    if (IsPlatform(PlatformType::kShieldTVb)) {
-        GTEST_SKIP() << "Test CmdClearAttachmentAfterLoadSecondary is unstable on ShieldTV";
-    }
 
     m_clear_via_load_op = false;  // Force LOAD_OP_LOAD
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());

--- a/tests/unit/best_practices_positive.cpp
+++ b/tests/unit/best_practices_positive.cpp
@@ -143,7 +143,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, DynStateIgnoreAttachments) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         // Several drivers have been observed to crash on the legal null pAttachments - restrict to MockICD for now
         GTEST_SKIP() << "This test only runs on MockICD";
     }

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -137,10 +137,6 @@ TEST_F(PositiveCommand, ClearAttachmentsCalledWithoutFbInSecondaryCB) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    if (IsPlatform(PlatformType::kShieldTVb)) {
-        GTEST_SKIP() << "Test is unstable on ShieldTV";
-    }
-
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
     m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
                          VK_IMAGE_TILING_OPTIMAL);
@@ -781,10 +777,6 @@ TEST_F(PositiveCommand, ClearAttachmentsDepthStencil) {
 
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on this device";
-    }
 
     m_commandBuffer->begin();
     vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -49,7 +49,7 @@ TEST_F(NegativeDebugPrintf, BasicUsage) {
 
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, Debug Printf test requires a driver that can draw";
     }
     // Make a uniform buffer to be passed to the shader that contains the test number
@@ -317,7 +317,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaders) {
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
     InitDebugPrintfFramework();
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
 
@@ -410,7 +410,7 @@ TEST_F(NegativeDebugPrintf, GPL) {
     }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
     // Make a uniform buffer to be passed to the shader that contains the test number
@@ -727,7 +727,7 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
     VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper();
@@ -877,7 +877,7 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
     VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper();
@@ -1047,7 +1047,7 @@ TEST_F(NegativeDebugPrintf, BasicUsageShaderObjects) {
 
     ASSERT_NO_FATAL_FAILURE(InitDynamicRenderTarget());
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, Debug Printf test requires a driver that can draw";
     }
     // Make a uniform buffer to be passed to the shader that contains the test number
@@ -1337,7 +1337,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaderObjects) {
         GTEST_SKIP() << "At least Vulkan version 1.3 is required";
     }
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
 

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -2539,9 +2539,6 @@ TEST_F(NegativeDescriptors, InlineUniformBlockEXT) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
 
     // Enable descriptor indexing if supported, but don't require it.
     bool has_descriptor_indexing =

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -1020,7 +1020,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "External tests are not supported by MockICD, skipping tests";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -1506,7 +1506,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
     GetPhysicalDeviceProperties2(fsrProperties);
 
     if (!fsrProperties.layeredShadingRateAttachments) {
-        if (IsPlatform(kMockICD)) {
+        if (IsPlatformMockICD()) {
             GTEST_SKIP() << "Test not supported by MockICD, doesn't correctly advertise format support for fragment shading "
                             "rate attachments";
         } else {
@@ -2740,7 +2740,7 @@ TEST_F(NegativeFragmentShadingRate, DISABLED_Framebuffer) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
     // TODO - Currently not working on MockICD with Profiles
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -44,7 +44,7 @@ bool VkGpuAssistedLayerTest::CanEnableGpuAV() {
     if (!features2.features.fragmentStoresAndAtomics || !features2.features.vertexPipelineStoresAndAtomics) {
         printf("fragmentStoresAndAtomics and vertexPipelineStoresAndAtomics are required for GPU-AV\n");
         return false;
-    } else if (IsPlatform(kMockICD)) {
+    } else if (IsPlatformMockICD()) {
         printf("Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw\n");
         return false;
     }
@@ -66,10 +66,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayOOBGraphicsShaders) {
     }
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
-    }
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     VkPhysicalDeviceMaintenance4Features maintenance4_features = vku::InitStructHelper();
@@ -538,10 +534,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayEarlyDelete) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
-
     auto maintenance4_features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>();
     maintenance4_features.maintenance4 = true;
     auto features2 = vku::InitStruct<VkPhysicalDeviceFeatures2KHR>(&maintenance4_features);
@@ -741,10 +733,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationArrayEarlySamplerDelete) {
     }
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
-    }
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
     }
 
     auto maintenance4_features = vku::InitStruct<VkPhysicalDeviceMaintenance4Features>();
@@ -1212,12 +1200,6 @@ void VkGpuAssistedLayerTest::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDe
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, &validation_features));
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
-    }
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Shield TV";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -1994,9 +1976,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectFirstInstance) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     VkValidationFeaturesEXT validation_features = GetValidationFeatures();
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, &validation_features));
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
@@ -2098,9 +2077,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuValidationInlineUniformBlockAndMiscGpu) {
     }
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
-    }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Shield TV";
     }
     VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
     VkPhysicalDeviceInlineUniformBlockFeaturesEXT inline_uniform_block_features = vku::InitStructHelper(&indexing_features);
@@ -2394,9 +2370,6 @@ TEST_F(VkGpuAssistedLayerTest, DrawingWithUnboundUnusedSet) {
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Shield TV";
-    }
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
@@ -2463,11 +2436,8 @@ TEST_F(VkGpuAssistedLayerTest, DispatchIndirectWorkgroupSize) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     VkValidationFeaturesEXT validation_features = GetValidationFeatures();
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, &validation_features));
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "GPU-Assisted validation test requires a driver that can draw.";
-    }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Shield TV";
     }
 
     PFN_vkSetPhysicalDeviceLimitsEXT fpvkSetPhysicalDeviceLimitsEXT = nullptr;
@@ -2572,14 +2542,11 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPL) {
 
     auto validation_features = GetValidationFeatures();
     ASSERT_NO_FATAL_FAILURE(InitFramework(nullptr, &validation_features));
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
-    }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Shield TV";
     }
 
     VkPhysicalDeviceRobustness2FeaturesEXT robustness2_features = vku::InitStructHelper();
@@ -2753,11 +2720,8 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferOOBGPLIndependentSets) {
 
     auto validation_features = GetValidationFeatures();
     ASSERT_NO_FATAL_FAILURE(InitFramework(nullptr, &validation_features));
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, GPU-Assisted validation test requires a driver that can draw";
-    }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Shield TV";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
@@ -2969,11 +2933,8 @@ TEST_F(VkGpuAssistedLayerTest, DispatchIndirectWorkgroupSizeShaderObjects) {
     AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
     VkValidationFeaturesEXT validation_features = GetValidationFeatures();
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor, &validation_features));
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "GPU-Assisted validation test requires a driver that can draw.";
-    }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Shield TV";
     }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -32,9 +32,6 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOBindDescriptor) {
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
     }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Shield TV";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
@@ -136,9 +133,6 @@ TEST_F(PositiveGpuAssistedLayer, SetSSBOPushDescriptor) {
     }
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
-    }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Shield TV";
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
@@ -398,9 +392,6 @@ TEST_F(PositiveGpuAssistedLayer, MutableBuffer) {
     }
     if (!CanEnableGpuAV()) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
-    }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "This test should not run on Shield TV";
     }
     VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT mutable_descriptor_type_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(mutable_descriptor_type_features);

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -84,7 +84,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     InitHostImageCopyTest(image_ci);
     if (::testing::Test::IsSkipped()) return;
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Positive host image copy test requires a driver that can copy.";
     }
     if (!CopyLayoutSupported(copy_src_layouts, copy_dst_layouts, VK_IMAGE_LAYOUT_GENERAL)) {

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -6060,7 +6060,7 @@ TEST_F(NegativeImage, ImageViewTextureSampleWeighted) {
 TEST_F(NegativeImage, CubeCompatibleMustBeImageType2D) {
     TEST_DESCRIPTION("If flags contains VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, imageType must be VK_IMAGE_TYPE_2D");
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         // The following create info is malformed will cause validation issues on various GPUs.
         // EX: MoltenVK, GalaxyS10, and Pixel6.
         GTEST_SKIP() << "Only run on MockICD.";
@@ -6196,7 +6196,7 @@ TEST_F(NegativeImage, GetPhysicalDeviceImageFormatProperties) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
     // VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 is a hardcoded format that is known to fail in MockICD
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         GTEST_SKIP() << "Test only supported by MockICD";
     }
     if (!ImageFormatAndFeaturesSupported(gpu(), VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, VK_IMAGE_TILING_OPTIMAL,

--- a/tests/unit/instance_positive.cpp
+++ b/tests/unit/instance_positive.cpp
@@ -19,7 +19,7 @@ TEST_F(PositiveInstance, TwoInstances) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 

--- a/tests/unit/instanceless.cpp
+++ b/tests/unit/instanceless.cpp
@@ -235,7 +235,7 @@ TEST_F(NegativeInstanceless, DestroyInstanceAllocationCallbacksCompatibility) {
 TEST_F(NegativeInstanceless, DISABLED_DestroyInstanceHandleLeak) {
     TEST_DESCRIPTION("Test vkDestroyInstance while leaking a VkDevice object.");
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         // This test leaks a device (on purpose) and should not be run on a real driver
         GTEST_SKIP() << "This test only runs on the mock ICD";
     }

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -1811,7 +1811,7 @@ TEST_F(NegativeMemory, DeviceCoherentMemoryDisabledAMD) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, does not support the necessary memory type";
     }
 

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -342,7 +342,7 @@ TEST_F(PositiveMemory, MappingWithMultiInstanceHeapFlag) {
 TEST_F(PositiveMemory, BindImageMemoryMultiThreaded) {
     ASSERT_NO_FATAL_FAILURE(Init());
 
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         GTEST_SKIP() << "This test can crash drivers with threading issues";
     }
 

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -186,7 +186,7 @@ TEST_F(VkPositiveLayerTest, SurfacelessQueryTest) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "VK_GOOGLE_surfaceless_query not supported on desktop";
     }
 

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -43,7 +43,7 @@ TEST_F(VkLayerTest, VersionCheckPromotedAPIs) {
 
     // TODO - Currently not working on MockICD with Profiles using 1.0
     // Seems API version is not being passed through correctly
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -95,7 +95,7 @@ TEST_F(VkLayerTest, PrivateDataExtTest) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework());
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -806,7 +806,7 @@ TEST_F(VkLayerTest, DebugMarkerNameTest) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Skipping object naming test with MockICD.";
     }
 
@@ -898,7 +898,7 @@ TEST_F(VkLayerTest, DebugUtilsNameTest) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Skipping object naming test with MockICD.";
     }
 
@@ -1208,7 +1208,7 @@ TEST_F(VkLayerTest, LeakAnObject) {
     TEST_DESCRIPTION("Create a fence and destroy its device without first destroying the fence.");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         // This test leaks a fence (on purpose) and should not be run on a real driver
         GTEST_SKIP() << "This test only runs on the mock ICD";
     }
@@ -1249,7 +1249,7 @@ TEST_F(VkLayerTest, LeakABuffer) {
     TEST_DESCRIPTION("Create a fence and destroy its device without first destroying the buffer.");
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         // This test leaks a buffer (on purpose) and should not be run on a real driver
         GTEST_SKIP() << "This test only runs on the mock ICD";
     }

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -1678,7 +1678,7 @@ TEST_F(NegativePipeline, CreationFeedbackCount) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Driver data writeback check not supported by MockICD";
     }
 
@@ -2025,7 +2025,7 @@ TEST_F(NegativePipeline, PipelineExecutablePropertiesFeature) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // MockICD will return 0 for the executable count
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -754,9 +754,6 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
 
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "CreateImageView calls crash ShieldTV";
-    }
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }

--- a/tests/unit/protected_memory_positive.cpp
+++ b/tests/unit/protected_memory_positive.cpp
@@ -25,12 +25,6 @@ TEST_F(PositiveProtectedMemory, MixProtectedQueue) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    // NOTE (ncesario): This appears to be failing in the driver on the Shield.
-    //      It's clear what is causing this; more investigation is necessary.
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "Test not supported by Shield TV";
-    }
-
     // Needed for both protected memory and vkGetDeviceQueue2
     if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
         GTEST_SKIP() << "At least Vulkan version 1.1 is required";

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -544,7 +544,7 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
     if (!performance_features.performanceCounterQueryPools) {
         GTEST_SKIP() << "Performance query pools are not supported.";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR doesn't match up with profile queues";
     }
 

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -38,7 +38,7 @@ void RayTracingTest::OOBRayTracingShadersTestBody(bool gpu_assisted) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (gpu_assisted && IsPlatform(kMockICD)) {
+    if (gpu_assisted && IsPlatformMockICD()) {
         GTEST_SKIP() << "GPU-AV can't run on MockICD";
     }
 
@@ -1710,7 +1710,7 @@ TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructureKHR) {
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {
         GTEST_SKIP() << "At least Vulkan version 1.2 is required";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -1757,7 +1757,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructureKHR) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -2068,7 +2068,7 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     // Needed for Ray Tracing

--- a/tests/unit/ray_tracing_pipeline.cpp
+++ b/tests/unit/ray_tracing_pipeline.cpp
@@ -883,7 +883,7 @@ TEST_F(NegativeRayTracingPipeline, DeferredOp) {
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "vkGetDeferredOperationResultKHR not supported by MockICD";
     }
     // Needed for Ray Tracing

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -164,7 +164,7 @@ TEST_F(PositiveRayTracing, StridedDeviceAddressRegion) {
     if (!InitFrameworkForRayTracingTest(this, true, &features2)) {
         GTEST_SKIP() << "unable to init ray tracing test";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     // Needed for Ray Tracing

--- a/tests/unit/renderpass.cpp
+++ b/tests/unit/renderpass.cpp
@@ -1095,9 +1095,6 @@ TEST_F(NegativeRenderPass, BeginRenderArea) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kShieldTVb)) {
-        GTEST_SKIP() << "ShieldTV reports api version 1.1, but does not list VK_KHR_device_group";
-    }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -125,12 +125,6 @@ TEST_F(VkPositiveLayerTest, TestShaderInputAndOutputStructComponents) {
     TEST_DESCRIPTION("Test shader interface with structs.");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-
-    // There is a crash inside the driver on S10
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     char const *vsSource = R"glsl(

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -856,7 +856,7 @@ TEST_F(NegativeShaderObject, GetShaderBinaryDataInvalidPointer) {
 
     InitBasicShaderObject();
     if (::testing::Test::IsSkipped()) return;
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -1263,7 +1263,7 @@ TEST_F(NegativeShaderObject, LinkedStagesWithDifferentCodeType) {
 
     InitBasicShaderObject();
     if (::testing::Test::IsSkipped()) return;
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -179,7 +179,7 @@ TEST_F(PositiveShaderObject, DrawWithVertAndFragBinaryShaderObjects) {
 
     InitBasicShaderObject();
     if (::testing::Test::IsSkipped()) return;
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -884,7 +884,7 @@ TEST_F(PositiveShaderObject, FailCreateShaders) {
 
     InitBasicShaderObject();
     if (::testing::Test::IsSkipped()) return;
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -1716,7 +1716,7 @@ TEST_F(PositiveShaderObject, DrawWithBinaryShaders) {
 
     InitBasicShaderObject();
     if (::testing::Test::IsSkipped()) return;
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     InitDynamicRenderTarget();

--- a/tests/unit/shader_push_constants.cpp
+++ b/tests/unit/shader_push_constants.cpp
@@ -353,10 +353,6 @@ TEST_F(NegativeShaderPushConstants, MultipleEntryPoint) {
     ASSERT_NO_FATAL_FAILURE(Init());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kPixel3)) {
-        GTEST_SKIP() << "Pixel 3 compilers can't compile this valid SPIR-V";
-    }
-
     // #version 460
     // layout(push_constant) uniform Material {
     //     vec4 color;

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -498,7 +498,7 @@ TEST_F(PositiveShaderSpirv, SpecializationWordBoundryOffset) {
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2));
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD, need real device to produce output to check";
     }
 

--- a/tests/unit/shader_storage_image_positive.cpp
+++ b/tests/unit/shader_storage_image_positive.cpp
@@ -308,10 +308,6 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
     ASSERT_NO_FATAL_FAILURE(InitState());
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
-    if (IsPlatform(kPixel3)) {
-        GTEST_SKIP() << "Pixel 3 compilers can't compile this valid SPIR-V";
-    }
-
     // The vertex and fragment shader are just a passthrough
     // The compute shader has the invalid OpImageWrite
     const char *source = R"(

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -816,7 +816,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType4) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "External tests are not supported by MockICD, skipping tests";
     }
     ASSERT_NO_FATAL_FAILURE(Init());

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1270,7 +1270,7 @@ TEST_F(PositiveSyncObject, ExternalTimelineSemaphore) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
@@ -1476,7 +1476,7 @@ TEST_F(PositiveSyncObject, ExternalFenceSubmitCmdBuffer) {
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -2142,7 +2142,7 @@ TEST_F(PositiveSyncObject, WaitTimelineSemaphoreWithWin32HandleRetrieved) {
         // Older AMD driver does not like timeline + export properties combo
         GTEST_SKIP() << "Please update AMD drivers at least to Adrenalin 23.5.2 to run this test. Then remove this check.";
     }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     if (DeviceValidationVersion() < VK_API_VERSION_1_2) {

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -2925,10 +2925,6 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    if (IsPlatform(kPixel3)) {
-        GTEST_SKIP() << "Temporarily disabling on Pixel 3 and Pixel 3a XL due to driver crash";
-    }
-
     // overall set up:
     // subpass 0:
     //   write image 0

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -170,7 +170,7 @@ TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOnHost) {
     TEST_DESCRIPTION("Signal semaphore on the host and wait on the host");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         // Mock does not support proper ordering of events, e.g. wait can return before signal
         GTEST_SKIP() << "Test not supported by MockICD";
     }
@@ -228,7 +228,7 @@ TEST_F(PositiveSyncVal, SignalAndGetSemaphoreCounter) {
     TEST_DESCRIPTION("Singal semaphore on the host and regularly read semaphore payload value");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         // Mock does not support precise semaphore counter reporting
         GTEST_SKIP() << "Test not supported by MockICD";
     }
@@ -277,7 +277,7 @@ TEST_F(PositiveSyncVal, GetSemaphoreCounterFromMultipleThreads) {
     TEST_DESCRIPTION("Read semaphore counter value from multiple threads");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     ASSERT_NO_FATAL_FAILURE(InitSyncValFramework());
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         // Mock does not support precise semaphore counter reporting
         GTEST_SKIP() << "Test not supported by MockICD";
     }

--- a/tests/unit/threading.cpp
+++ b/tests/unit/threading.cpp
@@ -23,7 +23,7 @@ TEST_F(NegativeThreading, CommandBufferCollision) {
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     // Test takes magnitude of time longer for profiles and slows down testing
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 

--- a/tests/unit/tooling_positive.cpp
+++ b/tests/unit/tooling_positive.cpp
@@ -20,7 +20,7 @@ TEST_F(PositiveTooling, BasicUsage) {
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
     ASSERT_NO_FATAL_FAILURE(InitState());
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -142,9 +142,6 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
     InitBasicTransformFeedback();
     if (::testing::Test::IsSkipped()) return;
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "Test temporarily disabled on S10 device";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     CreatePipelineHelper pipe(*this);
@@ -297,10 +294,6 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackEXT) {
     InitBasicTransformFeedback();
     if (::testing::Test::IsSkipped()) return;
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "Test temporarily disabled on S10 device";
-    }
-
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     CreatePipelineHelper pipe(*this);
@@ -389,9 +382,6 @@ TEST_F(NegativeTransformFeedback, CmdEndTransformFeedbackEXT) {
     InitBasicTransformFeedback();
     if (::testing::Test::IsSkipped()) return;
 
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "Test temporarily disabled on S10 device";
-    }
     ASSERT_NO_FATAL_FAILURE(InitRenderTarget());
 
     CreatePipelineHelper pipe(*this);

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -299,7 +299,7 @@ TEST_F(VkVideoLayerTest, CreateSessionUnsupportedProfile) {
     TEST_DESCRIPTION("vkCreateVideoSessionKHR - unsupported profile");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -4309,7 +4309,7 @@ TEST_F(VkVideoLayerTest, ImageLayoutUsageMismatch) {
     TEST_DESCRIPTION("Image layout in image memory barrier is invalid for image usage");
 
     ASSERT_NO_FATAL_FAILURE(Init());
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -106,11 +106,7 @@ TEST_F(NegativeWsi, BindImageMemorySwapchain) {
 
     AddSurfaceExtension();
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "This test appears to leave the image created a swapchain in a weird state that leads to 00378 when it "
                         "shouldn't. Requires further investigation.";
     }
@@ -209,11 +205,6 @@ TEST_F(NegativeWsi, SwapchainImage) {
     AddSurfaceExtension();
 
     ASSERT_NO_FATAL_FAILURE(InitFramework(m_errorMonitor));
-
-    if (IsPlatform(kGalaxyS10)) {
-        GTEST_SKIP() << "This test should not run on Galaxy S10";
-    }
-
     if (!AreRequiredExtensionsEnabled()) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
@@ -1753,7 +1744,7 @@ TEST_F(NegativeWsi, LeakASwapchain) {
 
     AddSurfaceExtension();
     ASSERT_NO_FATAL_FAILURE(InitFramework());
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         // This test leaks a swapchain (on purpose) and should not be run on a real driver
         GTEST_SKIP() << "This test only runs on the mock ICD";
     }
@@ -2121,7 +2112,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -2439,7 +2430,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionCaps) {
     // Add this after check, surfacless checks are done conditionally
     AddOptionalExtensions(VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME);
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -2577,7 +2568,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionRelease) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    if (IsPlatform(kMockICD)) {
+    if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
 
@@ -2735,7 +2726,7 @@ TEST_F(NegativeWsi, AcquireFullScreenExclusiveModeEXT) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         GTEST_SKIP() << "Only run test MockICD due to CI stability";
     }
 
@@ -2817,7 +2808,7 @@ TEST_F(NegativeWsi, CreateSwapchainFullscreenExclusive) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         GTEST_SKIP() << "Only run test MockICD due to CI stability";
     }
 
@@ -2868,7 +2859,7 @@ TEST_F(NegativeWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullScreenEXT) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         GTEST_SKIP() << "Only run test MockICD due to CI stability";
     }
 

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -187,7 +187,7 @@ TEST_F(PositiveWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullScreenEXT) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         GTEST_SKIP() << "Only run test MockICD due to CI stability";
     }
 
@@ -777,7 +777,7 @@ TEST_F(PositiveWsi, CreateSwapchainFullscreenExclusive) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         GTEST_SKIP() << "Only run test MockICD due to CI stability";
     }
 
@@ -828,7 +828,7 @@ TEST_F(PositiveWsi, CreateSwapchainFullscreenExclusive2) {
         GTEST_SKIP() << RequiredExtensionsNotSupported() << " not supported.";
     }
 
-    if (!IsPlatform(kMockICD)) {
+    if (!IsPlatformMockICD()) {
         GTEST_SKIP() << "Only run test MockICD due to CI stability";
     }
 


### PR DESCRIPTION
Devices are not in CI anymore

No reason to be skipping things by platform, so created a dedicated `IsPlatformMockICD` as that is the only valid exception we should have to skip tests from code like this