### PR TITLE
tests: Throw exception upon ASSERT_* failure

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -1244,7 +1244,8 @@ void VkSyncValTest::InitSyncValFramework(bool enable_queue_submit_validation) {
     const char *kEnableQueuSubmitSyncValidation[] = {"VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT"};
     const VkLayerSettingEXT settings[] = {
         {OBJECT_LAYER_NAME, "enables", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, kEnableQueuSubmitSyncValidation}};
-    const VkLayerSettingsCreateInfoEXT qs_settings{VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, static_cast<uint32_t>(std::size(settings)), settings};
+    const VkLayerSettingsCreateInfoEXT qs_settings{VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr,
+                                                   static_cast<uint32_t>(std::size(settings)), settings};
 
     if (enable_queue_submit_validation) {
         features_.pNext = &qs_settings;
@@ -1469,6 +1470,20 @@ void android_main(struct android_app *app) {
 #include <crtdbg.h>
 #endif
 
+// Makes any failed assertion throw, allowing for graceful cleanup of resources instead of hard aborts
+class ThrowListener : public testing::EmptyTestEventListener {
+    void OnTestPartResult(const testing::TestPartResult &result) override {
+        if (result.type() == testing::TestPartResult::kFatalFailure) {
+            // We need to make sure an exception wasn't already thrown so we dont throw another exception at the same time
+            std::exception_ptr ex = std::current_exception();
+            if (ex) {
+                return;
+            }
+            throw testing::AssertionException(result);
+        }
+    }
+};
+
 // Defining VVL_TESTS_USE_CUSTOM_TEST_FRAMEWORK allows downstream users
 // to inject custom test framework changes. This includes the ability
 // to override the main entry point of the test executable in order to
@@ -1482,19 +1497,23 @@ int main(int argc, char **argv) {
 #if defined(_WIN32)
 #if !defined(NDEBUG)
     _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
     _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
 #endif
     // Avoid "Abort, Retry, Ignore" dialog boxes
+    _set_error_mode(_OUT_TO_STDERR);
     _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
-    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
-    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
 #endif
 
     ::testing::InitGoogleTest(&argc, argv);
     VkTestFramework::InitArgs(&argc, argv);
 
     ::testing::AddGlobalTestEnvironment(new TestEnvironment);
+    ::testing::UnitTest::GetInstance()->listeners().Append(new ThrowListener);
 
     result = RUN_ALL_TESTS();
 


### PR DESCRIPTION
This change adds a 'listener' to the googletest framework so that whenever a fatal assertion is made, an exception is thrown forcing the test to stop executing at the point the assertion was made. This is important to ensure that any failed assertions in nested function calls are caught.

Without the change, assertions deep within the test framework's init code will not cause execution to halt, potentially causing hard crashes which reduce debuggability.

The googletest framework sets up exception handlers so that the exception thrown by the failed assertion doesn't escape up the callstack, causing the process to abort.