### PR TITLE
layers: Dont Skip on LogInfo

### DIFF
--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -156,9 +156,9 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
         std::string inst_api_name = StringAPIVersion(api_version);
         std::string dev_api_name = StringAPIVersion(device_api_version);
 
-        skip |= LogInfo(device, kVUID_BestPractices_CreateDevice_API_Mismatch,
-                        "vkCreateDevice(): API Version of current instance, %s is higher than API Version on device, %s",
-                        inst_api_name.c_str(), dev_api_name.c_str());
+        LogInfo(device, kVUID_BestPractices_CreateDevice_API_Mismatch,
+                "vkCreateDevice(): API Version of current instance, %s is higher than API Version on device, %s",
+                inst_api_name.c_str(), dev_api_name.c_str());
     }
 
     std::vector<std::string> extensions;
@@ -393,14 +393,14 @@ bool BestPractices::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCou
             skip |= CheckPipelineStageFlags("vkQueueSubmit", pSubmits[submit].pWaitDstStageMask[semaphore]);
         }
         if (pSubmits[submit].signalSemaphoreCount == 0 && pSubmits[submit].pSignalSemaphores != nullptr) {
-            skip |= LogInfo(device, kVUID_BestPractices_SemaphoreCount,
-                            "pSubmits[%" PRIu32 "].pSignalSemaphores is set, but pSubmits[%" PRIu32 "].signalSemaphoreCount is 0.",
-                            submit, submit);
+            LogInfo(device, kVUID_BestPractices_SemaphoreCount,
+                    "pSubmits[%" PRIu32 "].pSignalSemaphores is set, but pSubmits[%" PRIu32 "].signalSemaphoreCount is 0.", submit,
+                    submit);
         }
         if (pSubmits[submit].waitSemaphoreCount == 0 && pSubmits[submit].pWaitSemaphores != nullptr) {
-            skip |= LogInfo(device, kVUID_BestPractices_SemaphoreCount,
-                            "pSubmits[%" PRIu32 "].pWaitSemaphores is set, but pSubmits[%" PRIu32 "].waitSemaphoreCount is 0.",
-                            submit, submit);
+            LogInfo(device, kVUID_BestPractices_SemaphoreCount,
+                    "pSubmits[%" PRIu32 "].pWaitSemaphores is set, but pSubmits[%" PRIu32 "].waitSemaphoreCount is 0.", submit,
+                    submit);
         }
     }
 

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -6870,9 +6870,9 @@ bool SyncOpWaitEvents::Validate(const CommandBufferAccessContext &cb_context) co
         if (barrier_set.single_exec_scope) {
             if (barrier_set.src_exec_scope.mask_param & VK_PIPELINE_STAGE_HOST_BIT) {
                 const std::string vuid = std::string("SYNC-") + std::string(CmdName()) + std::string("-hostevent-unsupported");
-                skip = sync_state.LogInfo(command_buffer_handle, vuid,
-                                          "%s, srcStageMask includes %s, unsupported by synchronization validation.", CmdName(),
-                                          string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT));
+                sync_state.LogInfo(command_buffer_handle, vuid,
+                                   "%s, srcStageMask includes %s, unsupported by synchronization validation.", CmdName(),
+                                   string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT));
             } else {
                 const auto &barriers = barrier_set.memory_barriers;
                 for (size_t barrier_index = 0; barrier_index < barriers.size(); barrier_index++) {
@@ -6880,11 +6880,11 @@ bool SyncOpWaitEvents::Validate(const CommandBufferAccessContext &cb_context) co
                     if (barrier.src_exec_scope.mask_param & VK_PIPELINE_STAGE_HOST_BIT) {
                         const std::string vuid =
                             std::string("SYNC-") + std::string(CmdName()) + std::string("-hostevent-unsupported");
-                        skip =
-                            sync_state.LogInfo(command_buffer_handle, vuid,
-                                               "%s, srcStageMask %s of %s %zu, %s %zu, unsupported by synchronization validation.",
-                                               CmdName(), string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT),
-                                               "pDependencyInfo", barrier_set_index, "pMemoryBarriers", barrier_index);
+
+                        sync_state.LogInfo(command_buffer_handle, vuid,
+                                           "%s, srcStageMask %s of %s %zu, %s %zu, unsupported by synchronization validation.",
+                                           CmdName(), string_VkPipelineStageFlagBits(VK_PIPELINE_STAGE_HOST_BIT), "pDependencyInfo",
+                                           barrier_set_index, "pMemoryBarriers", barrier_index);
                     }
                 }
             }
@@ -7030,7 +7030,7 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
             "%s: srcStageMask 0x%" PRIx64 " contains stages not present in pEvents stageMask. Extra stages are %s.%s";
         const auto handle = exec_context.Handle();
         if (events_not_found) {
-            skip |= sync_state.LogInfo(handle, vuid, message, CmdName(), barrier_mask_params,
+            sync_state.LogInfo(handle, vuid, message, CmdName(), barrier_mask_params,
                                        sync_utils::StringPipelineStageFlags(extra_stage_bits).c_str(),
                                        " vkCmdSetEvent may be in previously submitted command buffer.");
         } else {


### PR DESCRIPTION
The LogInfo function now consistently does not cause skipping of subsequent calls into the driver.