### PR TITLE
layers: Ensure available accesses are not hazardous during ILT

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -8975,6 +8975,11 @@ bool ResourceAccessWriteState::IsWriteBarrierHazard(QueueId queue_id, VkPipeline
             return !WriteInChain(src_exec_scope);
         }
     }
+    // In dep chain means that the write is *available*.
+    // Available writes are automatically made visible and can't cause hazards during transition.
+    if (WriteInChain(src_exec_scope)) {
+        return false;
+    }
     // Otherwise treat as an ordinary write hazard check with ordering rules.
     return IsOrderedWriteHazard(src_exec_scope, src_access_scope);
 }

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -530,15 +530,12 @@ class ResourceAccessWriteState {
     }
     bool WriteInChain(VkPipelineStageFlags2KHR src_exec_scope) const;
     bool WriteInScope(const SyncStageAccessFlags &src_access_scope) const;
-    bool WriteBarrierInScope(const SyncStageAccessFlags &src_access_scope) const;
     bool WriteInSourceScopeOrChain(VkPipelineStageFlags2KHR src_exec_scope, SyncStageAccessFlags src_access_scope) const;
     bool WriteInQueueSourceScopeOrChain(QueueId queue, VkPipelineStageFlags2KHR src_exec_scope,
                                         const SyncStageAccessFlags &src_access_scope) const;
 
     bool WriteInEventScope(VkPipelineStageFlags2KHR src_exec_scope, const SyncStageAccessFlags &src_access_scope,
                            QueueId scope_queue, ResourceUsageTag scope_tag) const;
-
-    bool WriteInChainedScope(VkPipelineStageFlags2KHR src_exec_scope, const SyncStageAccessFlags &src_access_scope) const;
 
     ResourceAccessWriteState(const SyncStageAccessInfoType &usage_info, ResourceUsageTag tag);
     ResourceAccessWriteState() = default;
@@ -551,8 +548,6 @@ class ResourceAccessWriteState {
     ResourceUsageTag Tag() const { return tag_; }
     bool IsWriteHazard(const SyncStageAccessInfoType &usage_info) const;
     bool IsOrdered(const OrderingBarrier &ordering, QueueId queue_id) const;
-
-    bool IsOrderedWriteHazard(VkPipelineStageFlags2KHR src_exec_scope, const SyncStageAccessFlags &src_access_scope) const;
 
     bool IsWriteBarrierHazard(QueueId queue_id, VkPipelineStageFlags2KHR src_exec_scope,
                               const SyncStageAccessFlags &src_access_scope) const;


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6508

`PositiveSyncVal.LayoutTransitionWithAlreadyAvailableImage` recreates scenario described in the issue. When synchronize with *available* write it should not cause WAW hazard during ILT which makes this write visible.

Other tests are added to illustrate additional scenarios but they worked before.