### PR TITLE
layers: Compatibility for VK_EXT_nested_command_buffers

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1171,7 +1171,7 @@ void CoreChecks::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
                     const auto &render_area = prim_cb->active_render_pass_begin_info.renderArea;
                     bool skip = false;
 
-                    if (fb) {
+                    if (fb && prim_cb->IsPrimary()) {
                         const Location loc(Func::vkCmdClearAttachments);
                         skip = ValidateClearAttachmentExtent(secondary, render_area, fb->createInfo.layers, rectCount,
                                                              clear_rect_copy->data(), loc);

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -3022,7 +3022,8 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
     }
 
     if ((cb_state->createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) &&
-        ((pRenderingInfo->flags & VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR) != 0)) {
+        ((pRenderingInfo->flags & VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR) != 0) &&
+        !enabled_features.nested_command_buffer_features.nestedCommandBuffer) {
         skip |= LogError("VUID-vkCmdBeginRendering-commandBuffer-06068", commandBuffer, rendering_info.dot(Field::flags),
                          "must not include VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR in a secondary command buffer.");
     }

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -113,6 +113,7 @@ struct DeviceFeatures {
     VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV representative_fragment_test_features_nv;
     VkPhysicalDeviceCoverageReductionModeFeaturesNV coverage_reduction_mode_features_nv;
     VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV device_generated_commands_compute_features_nv;
+    VkPhysicalDeviceNestedCommandBufferFeaturesEXT nested_command_buffer_features;
     // If a new feature is added here that involves a SPIR-V capability add also in spirv_validation_generator.py
     // This is known by checking the table in the spec or if the struct is in a <spirvcapability> in vk.xml
 };

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1445,6 +1445,11 @@ void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo)
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>(pCreateInfo->pNext)) {
             enabled_features.device_generated_commands_compute_features_nv = *device_generated_commands_compute_features_nv;
         }
+
+        if (const auto nested_command_buffer_features =
+                vku::FindStructInPNextChain<VkPhysicalDeviceNestedCommandBufferFeaturesEXT>(pCreateInfo->pNext)) {
+            enabled_features.nested_command_buffer_features = *nested_command_buffer_features;
+        }
     }
 
     // Store physical device properties and physical device mem limits into CoreChecks structs


### PR DESCRIPTION
Minimal changes to allow VVL to work with an application that enables the nestedCommandBuffer feature. A follow on PR will include coverage for the new VK_EXT_nested_command_buffer VUIDs.