### PR TITLE
tests: Remove unused VkBufferTest class

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -588,39 +588,6 @@ class ThreadingTest : public VkLayerTest {};
 class NegativeThreading : public ThreadingTest {};
 class PositiveThreading : public ThreadingTest {};
 
-class VkBufferTest {
-  public:
-    enum eTestEnFlags {
-        eDoubleDelete,
-        eInvalidDeviceOffset,
-        eInvalidMemoryOffset,
-        eBindNullBuffer,
-        eBindFakeBuffer,
-        eFreeInvalidHandle,
-        eNone,
-    };
-
-    enum eTestConditions { eOffsetAlignment = 1 };
-
-    static bool GetTestConditionValid(vkt::Device *aVulkanDevice, eTestEnFlags aTestFlag, VkBufferUsageFlags aBufferUsage = 0);
-    // A constructor which performs validation tests within construction.
-    VkBufferTest(vkt::Device *aVulkanDevice, VkBufferUsageFlags aBufferUsage, eTestEnFlags aTestFlag = eNone);
-    ~VkBufferTest();
-    bool GetBufferCurrent();
-    const VkBuffer &GetBuffer();
-    void TestDoubleDestroy();
-
-  protected:
-    bool AllocateCurrent;
-    bool BoundCurrent;
-    bool CreateCurrent;
-    bool InvalidDeleteEn;
-
-    VkBuffer VulkanBuffer;
-    VkDevice VulkanDevice;
-    VkDeviceMemory VulkanMemory;
-};
-
 struct OneOffDescriptorSet {
     vkt::Device *device_;
     VkDescriptorPool pool_;

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -2043,15 +2043,11 @@ TEST_F(NegativeDescriptors, DSUpdateOutOfBounds) {
                                                      {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                  });
 
-    VkBufferTest buffer_test(m_device, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
-    if (!buffer_test.GetBufferCurrent()) {
-        // Something prevented creation of buffer so abort
-        GTEST_SKIP() << "Buffer creation failed";
-    }
+    vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
     // Correctly update descriptor to avoid "NOT_UPDATED" error
     VkDescriptorBufferInfo buff_info = {};
-    buff_info.buffer = buffer_test.GetBuffer();
+    buff_info.buffer = buffer.handle();
     buff_info.offset = 0;
     buff_info.range = VK_WHOLE_SIZE;
 

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -825,14 +825,13 @@ TEST_F(NegativeObjectLifetime, InUseDestroyedSignaled) {
     VkFence fence;
     ASSERT_EQ(VK_SUCCESS, vk::CreateFence(m_device->device(), &fence_create_info, nullptr, &fence));
 
-    VkBufferTest buffer_test(m_device, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
-    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_test.GetBuffer(), 0, VK_WHOLE_SIZE,
-                                                    VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
     VkEvent event;


### PR DESCRIPTION
`VkBufferTest` was only being used for a single test and seems it wasn't even doing what it was expected