### PR TITLE
Add GPU-AV option to select which shaders are instrumented

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -158,6 +158,7 @@ core_validation_sources = [
   "layers/gpu_validation/gpu_descriptor_set.h",
   "layers/gpu_validation/gpu_error_message.cpp",
   "layers/gpu_validation/gpu_error_message.h",
+  "layers/gpu_validation/gpu_settings.h",
   "layers/gpu_validation/gpu_state_tracker.cpp",
   "layers/gpu_validation/gpu_state_tracker.h",
   "layers/gpu_validation/gpu_subclasses.cpp",

--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -112,6 +112,11 @@ GPU-Assisted Validation code keeps track of all such addresses, along with the s
 Shader code is instrumented to validate buffer_reference addresses and report any reads or writes that do no fall within the listed address/size regions.
 Note: The mapping between a `VkBuffer` and a GPU address is not necessarily one to one. For instance, if multiple `VkBuffer` are bound to the same memory region, they can have the same GPU address.
 
+### Selective Shader Instrumentation
+With the khronos_validation.select_instrumented_shaders feature, an application can control which shaders are instrumented and thus, will return GPU-AV errors.
+After enabling the feature, the application will need to include a VkValidationFeaturesEXT structure with VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT in the pEnabledFeatures list 
+in the pNext chain of the VkShaderModuleCreateInfo used to create the shader. Otherwise, the shader will not be instrumented.
+
 ## GPU-Assisted Validation Limitations
 
 There are several limitations that may impede the operation of GPU-Assisted Validation:

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -950,6 +950,26 @@
                                             }
                                         },
                                         {
+                                            "key": "select_instrumented_shaders",
+                                            "label": "Enable instrumenting shaders selectively",
+                                            "description": "Select which shaders to instrument passing a VkValidationFeaturesEXT struct with GPU-AV enabled in the VkShaderModuleCreateInfo pNext",
+                                            "type": "BOOL",
+                                            "default": false,
+                                            "platforms": [
+                                                "WINDOWS",
+                                                "LINUX"
+                                            ],
+                                            "dependence": {
+                                                "mode": "ALL",
+                                                "settings": [
+                                                    {
+                                                        "key": "validate_gpu_based",
+                                                        "value": "GPU_BASED_GPU_ASSISTED"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
                                             "key": "max_buffer_device_addresses",
                                             "label": "Specify the maximum number of buffer device addresses in use at one time",
                                             "description": "Specify maximum number of buffer device addresses",

--- a/layers/gpu_validation/gpu_settings.h
+++ b/layers/gpu_validation/gpu_settings.h
@@ -1,0 +1,28 @@
+
+/* Copyright (c) 2020-2023 The Khronos Group Inc.
+ * Copyright (c) 2020-2023 Valve Corporation
+ * Copyright (c) 2020-2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */ 
+#pragma once
+typedef struct {
+    bool validate_descriptors;
+    bool validate_draw_indirect;
+    bool validate_dispatch_indirect;
+    bool vma_linear_output;
+    bool warn_on_robust_oob;
+    bool cache_instrumented_shaders;
+    bool select_instrumented_shaders;
+    uint32_t gpuav_max_buffer_device_addresses;
+} GpuAVSettings;

--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -993,11 +993,11 @@ void GpuAssistedBase::PreCallRecordPipelineCreations(uint32_t count, const Creat
                         auto sm_ci =
                             const_cast<safe_VkShaderModuleCreateInfo *>(reinterpret_cast<const safe_VkShaderModuleCreateInfo *>(
                                 vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(stage_ci.pNext)));
-                        if (select_instrumented_shaders && sm_ci && !CheckForGpuAvEnabled(sm_ci->pNext)) continue;
+                        if (gpuav_settings.select_instrumented_shaders && sm_ci && !CheckForGpuAvEnabled(sm_ci->pNext)) continue;
                         auto &csm_state = cgpl_state.shader_states[pipeline][stage];
                         bool cached = false;
                         bool pass = false;
-                        if (cache_instrumented_shaders) {
+                        if (gpuav_settings.cache_instrumented_shaders) {
                             csm_state.unique_shader_id = ValidationCache::MakeShaderHash(module_state->spirv->words_.data(),
                                                                                          module_state->spirv->words_.size());
                             auto it = instrumented_shaders.find(csm_state.unique_shader_id);
@@ -1019,7 +1019,7 @@ void GpuAssistedBase::PreCallRecordPipelineCreations(uint32_t count, const Creat
                             if (sm_ci) {
                                 sm_ci->SetCode(csm_state.instrumented_spirv);
                             }
-                            if (cache_instrumented_shaders && !cached) {
+                            if (gpuav_settings.cache_instrumented_shaders && !cached) {
                                 instrumented_shaders.emplace(
                                     csm_state.unique_shader_id,
                                     std::make_pair(csm_state.instrumented_spirv.size(), csm_state.instrumented_spirv));

--- a/layers/gpu_validation/gpu_state_tracker.h
+++ b/layers/gpu_validation/gpu_state_tracker.h
@@ -175,11 +175,6 @@ class GpuAssistedBase : public ValidationStateTracker {
         }
         LogError(object, setup_vuid, "Setup Error. Detail: (%s)", logit.c_str());
     }
-    bool GpuGetOption(const char *option, bool default_value) {
-        std::string option_string = getLayerOption(option);
-        vvl::ToLower(option_string);
-        return !option_string.empty() ? !option_string.compare("true") : default_value;
-    }
     bool CheckForGpuAvEnabled(const void *pNext);
 
   protected:
@@ -215,8 +210,6 @@ class GpuAssistedBase : public ValidationStateTracker {
   public:
     bool aborted = false;
     bool force_buffer_device_address;
-    bool cache_instrumented_shaders;
-    bool select_instrumented_shaders;
     vvl::unordered_map<uint32_t, std::pair<size_t, std::vector<uint32_t>>> instrumented_shaders;
     PFN_vkSetDeviceLoaderData vkSetDeviceLoaderData;
     const char *setup_vuid;

--- a/layers/gpu_validation/gpu_state_tracker.h
+++ b/layers/gpu_validation/gpu_state_tracker.h
@@ -180,6 +180,7 @@ class GpuAssistedBase : public ValidationStateTracker {
         vvl::ToLower(option_string);
         return !option_string.empty() ? !option_string.compare("true") : default_value;
     }
+    bool CheckForGpuAvEnabled(const void *pNext);
 
   protected:
     bool CommandBufferNeedsProcessing(VkCommandBuffer command_buffer) const;
@@ -215,6 +216,7 @@ class GpuAssistedBase : public ValidationStateTracker {
     bool aborted = false;
     bool force_buffer_device_address;
     bool cache_instrumented_shaders;
+    bool select_instrumented_shaders;
     vvl::unordered_map<uint32_t, std::pair<size_t, std::vector<uint32_t>>> instrumented_shaders;
     PFN_vkSetDeviceLoaderData vkSetDeviceLoaderData;
     const char *setup_vuid;

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -272,10 +272,6 @@ class GpuAssisted : public GpuAssistedBase {
     VkPipeline GetValidationPipeline(VkRenderPass render_pass);
 
     VkBool32 shaderInt64;
-    bool validate_descriptors;
-    bool validate_draw_indirect;
-    bool validate_dispatch_indirect;
-    bool warn_on_robust_oob;
     bool validate_instrumented_shaders;
     std::string instrumented_shader_cache_path;
     gpuav_state::AccelerationStructureBuildValidationState acceleration_structure_validation_state;
@@ -283,7 +279,6 @@ class GpuAssisted : public GpuAssistedBase {
     gpuav_state::PreDispatchValidationState pre_dispatch_validation_state;
     gpuav_state::DeviceMemoryBlock app_buffer_device_addresses{};
     size_t app_bda_buffer_size{};
-    size_t app_bda_max_addresses{};
     uint32_t gpuav_bda_buffer_version = 0;
 
     bool buffer_device_address;

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -54,6 +54,15 @@ const char *SETTING_CUSTOM_STYPE_LIST = "custom_stype_list";
 const char *SETTING_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
 const char *SETTING_FINE_GRAINED_LOCKING = "fine_grained_locking";
 
+const char *SETTING_GPUAV_VALIDATE_DESCRIPTORS = "gpuav_descriptor_checks";
+const char *SETTING_GPUAV_VALIDATE_DRAW_INDIRECT = "validate_draw_indirect";
+const char *SETTING_GPUAV_VALIDATE_DISPATCH_INDIRECT = "validate_dispatch_indirect";
+const char *SETTING_GPUAV_VMA_LINEAR_OUTPUT = "vma_linear_output";
+const char *SETTING_GPUAV_WARN_ON_ROBUST_OOB = "warn_on_robust_oob";
+const char *SETTING_GPUAV_USE_INSTRUMENTED_SHADER_CACHE = "use_instrumented_shader_cache";
+const char *SETTING_GPUAV_SELECT_INSTRUMENTED_SHADERS = "select_instrumented_shaders";
+const char *SETTING_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS = "gpuav_max_buffer_device_addresses";
+
 // Set the local disable flag for the appropriate VALIDATION_CHECK_DISABLE enum
 void SetValidationDisable(CHECK_DISABLED &disable_data, const ValidationCheckDisables disable_id) {
     switch (disable_id) {
@@ -382,6 +391,46 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
 
     if (vkuHasLayerSetting(layer_setting_set, SETTING_CUSTOM_STYPE_LIST)) {
         vkuGetLayerSettingValues(layer_setting_set, SETTING_CUSTOM_STYPE_LIST, custom_stype_info);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VALIDATE_DESCRIPTORS)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VALIDATE_DESCRIPTORS,
+                                settings_data->gpuav_settings->validate_descriptors);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VALIDATE_DRAW_INDIRECT)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VALIDATE_DRAW_INDIRECT,
+                                settings_data->gpuav_settings->validate_draw_indirect);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VALIDATE_DISPATCH_INDIRECT)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VALIDATE_DISPATCH_INDIRECT,
+                                settings_data->gpuav_settings->validate_dispatch_indirect);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VMA_LINEAR_OUTPUT)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VMA_LINEAR_OUTPUT,
+                                settings_data->gpuav_settings->vma_linear_output);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_WARN_ON_ROBUST_OOB)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_WARN_ON_ROBUST_OOB,
+                                settings_data->gpuav_settings->warn_on_robust_oob);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_USE_INSTRUMENTED_SHADER_CACHE)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_USE_INSTRUMENTED_SHADER_CACHE,
+                                settings_data->gpuav_settings->cache_instrumented_shaders);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_SELECT_INSTRUMENTED_SHADERS)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_SELECT_INSTRUMENTED_SHADERS,
+                                settings_data->gpuav_settings->select_instrumented_shaders);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS,
+                                settings_data->gpuav_settings->gpuav_max_buffer_device_addresses);
     }
 
     const auto *validation_features_ext = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(settings_data->create_info);

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -18,6 +18,7 @@
 
 #pragma once
 #include "generated/chassis.h"
+#include "gpu_validation/gpu_settings.h"
 
 #define OBJECT_LAYER_NAME "VK_LAYER_KHRONOS_validation"
 
@@ -33,6 +34,7 @@ typedef struct {
     std::unordered_set<uint32_t> &message_filter_list;
     uint32_t *duplicate_message_limit;
     bool *fine_grained_locking;
+    GpuAVSettings *gpuav_settings;
 } ConfigAndEnvSettings;
 
 static const vvl::unordered_map<std::string, VkValidationFeatureDisableEXT> VkValFeatureDisableLookup = {

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -98,6 +98,12 @@ khronos_validation.enables =
 # Enable instrumented shader caching
 #khronos_validation.use_instrumented_shader_cache = true
 
+# Select which shaders to instrument by passing a VkValidationFeaturesEXT struct with GPU-AV enabled in the VkShaderModuleCreateInfo pNext
+# =====================
+# <LayerIdentifier>.
+# Enable selection of shaders to instrument
+#khronos_validation.select_instrumented_shaders = false
+
 # Use linear vma allocator for GPU-AV output buffers
 # =====================
 # <LayerIdentifier>.gpuav_vma_linear_output

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -52,6 +52,7 @@
 #include "vk_dispatch_table_helper.h"
 #include "vk_extension_helper.h"
 #include "vk_safe_struct.h"
+#include "gpu_validation/gpu_settings.h"
 
 extern std::atomic<uint64_t> global_unique_id;
 
@@ -2274,6 +2275,7 @@ class ValidationObject {
     CHECK_DISABLED disabled = {};
     CHECK_ENABLED enabled = {};
     bool fine_grained_locking{true};
+    GpuAVSettings gpuav_settings = {};
 
     VkInstance instance = VK_NULL_HANDLE;
     VkPhysicalDevice physical_device = VK_NULL_HANDLE;

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -309,6 +309,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
             #include "vk_dispatch_table_helper.h"
             #include "vk_extension_helper.h"
             #include "vk_safe_struct.h"
+            #include "gpu_validation/gpu_settings.h"
 
             extern std::atomic<uint64_t> global_unique_id;
 
@@ -450,6 +451,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 CHECK_DISABLED disabled = {};
                 CHECK_ENABLED enabled = {};
                 bool fine_grained_locking{true};
+                GpuAVSettings gpuav_settings = {};
 
                 VkInstance instance = VK_NULL_HANDLE;
                 VkPhysicalDevice physical_device = VK_NULL_HANDLE;
@@ -1091,13 +1093,16 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 CHECK_ENABLED local_enables{};
                 CHECK_DISABLED local_disables{};
                 bool lock_setting;
+                // select_instrumented_shaders is the only gpu-av setting that is off by default
+                GpuAVSettings local_gpuav_settings = {true, true, true, true, true, true, false, 10000};
                 ConfigAndEnvSettings config_and_env_settings_data{OBJECT_LAYER_DESCRIPTION,
                                                                 pCreateInfo,
                                                                 local_enables,
                                                                 local_disables,
                                                                 report_data->filter_message_ids,
                                                                 &report_data->duplicate_message_limit,
-                                                                &lock_setting};
+                                                                &lock_setting,
+                                                                &local_gpuav_settings};
                 ProcessConfigAndEnvSettings(&config_and_env_settings_data);
                 layer_debug_messenger_actions(report_data, OBJECT_LAYER_DESCRIPTION);
 
@@ -1153,6 +1158,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 framework->disabled = local_disables;
                 framework->enabled = local_enables;
                 framework->fine_grained_locking = lock_setting;
+                framework->gpuav_settings = local_gpuav_settings;
 
                 framework->instance = *pInstance;
                 layer_init_instance_dispatch_table(*pInstance, &framework->instance_dispatch_table, fpGetInstanceProcAddr);
@@ -1171,6 +1177,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     intercept->enabled = framework->enabled;
                     intercept->disabled = framework->disabled;
                     intercept->fine_grained_locking = framework->fine_grained_locking;
+                    intercept->gpuav_settings = framework->gpuav_settings;
                     intercept->instance = *pInstance;
                 }
 
@@ -1296,6 +1303,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     object->disabled = instance_interceptor->disabled;
                     object->enabled = instance_interceptor->enabled;
                     object->fine_grained_locking = instance_interceptor->fine_grained_locking;
+                    object->gpuav_settings = instance_interceptor->gpuav_settings;
                     object->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
                     object->instance_extensions = instance_interceptor->instance_extensions;
                     object->device_extensions = device_interceptor->device_extensions;

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -1559,7 +1559,7 @@ std::array<std::array<uint32_t, 16>, 16> VkImageObj::Read() {
 VkPipelineShaderStageCreateInfo const &VkShaderObj::GetStageCreateInfo() const { return m_stage_info; }
 
 VkShaderObj::VkShaderObj(VkRenderFramework *framework, const char *source, VkShaderStageFlagBits stage, const spv_target_env env,
-                         SpvSourceType source_type, const VkSpecializationInfo *spec_info, char const *entry_point, bool debug)
+                         SpvSourceType source_type, const VkSpecializationInfo *spec_info, char const *entry_point, bool debug, const void *pNext)
     : m_framework(*framework), m_device(*(framework->DeviceObj())), m_source(source), m_spv_env(env) {
     m_stage_info = vku::InitStructHelper();
     m_stage_info.flags = 0;
@@ -1568,17 +1568,18 @@ VkShaderObj::VkShaderObj(VkRenderFramework *framework, const char *source, VkSha
     m_stage_info.pName = entry_point;
     m_stage_info.pSpecializationInfo = spec_info;
     if (source_type == SPV_SOURCE_GLSL) {
-        InitFromGLSL(debug);
+        InitFromGLSL(debug, pNext);
     } else if (source_type == SPV_SOURCE_ASM) {
         InitFromASM();
     }
 }
 
-bool VkShaderObj::InitFromGLSL(bool debug) {
+bool VkShaderObj::InitFromGLSL(bool debug, const void *pNext) {
     std::vector<uint32_t> spv;
     m_framework.GLSLtoSPV(&m_device.phy().limits_, m_stage_info.stage, m_source, spv, debug, m_spv_env);
 
     VkShaderModuleCreateInfo moduleCreateInfo = vku::InitStructHelper();
+    moduleCreateInfo.pNext = pNext;
     moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
     moduleCreateInfo.pCode = spv.data();
 

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -394,10 +394,11 @@ class VkShaderObj : public vkt::ShaderModule {
     // optional arguments listed order of most likely to be changed manually by a test
     VkShaderObj(VkRenderFramework *framework, const char *source, VkShaderStageFlagBits stage,
                 const spv_target_env env = SPV_ENV_VULKAN_1_0, SpvSourceType source_type = SPV_SOURCE_GLSL,
-                const VkSpecializationInfo *spec_info = nullptr, char const *entry_point = "main", bool debug = false);
+                const VkSpecializationInfo *spec_info = nullptr, char const *entry_point = "main", bool debug = false,
+                const void *pNext = nullptr);
     VkPipelineShaderStageCreateInfo const &GetStageCreateInfo() const;
 
-    bool InitFromGLSL(bool debug = false);
+    bool InitFromGLSL(bool debug = false, const void *pNext = nullptr);
     VkResult InitFromGLSLTry(bool debug = false, const vkt::Device *custom_device = nullptr);
     bool InitFromASM();
     VkResult InitFromASMTry();

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -2916,3 +2916,88 @@ TEST_F(VkGpuAssistedLayerTest, DispatchIndirectWorkgroupSizeShaderObjects) {
     ASSERT_EQ(VK_SUCCESS, vk::QueueWaitIdle(m_default_queue));
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(VkGpuAssistedLayerTest, SelectInstrumentedShaders) {
+    TEST_DESCRIPTION("GPU validation: Validate selection of which shaders get instrumented for GPU-AV");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    const VkBool32 value = true;
+    const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "select_instrumented_shaders", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
+                                       &value};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                               &setting};
+    VkValidationFeaturesEXT validation_features = GetValidationFeatures();
+    validation_features.pNext = &layer_settings_create_info;
+    RETURN_IF_SKIP(InitFramework(&validation_features));
+    if (!CanEnableGpuAV()) {
+        GTEST_SKIP() << "Requirements for GPU-AV are not met";
+    }
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper();
+    GetPhysicalDeviceFeatures2(features2);
+    if (!features2.features.robustBufferAccess) {
+        GTEST_SKIP() << "Not safe to write outside of buffer memory";
+    }
+    // Robust buffer access will be on by default
+    VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    InitState(nullptr, nullptr, pool_flags);
+    InitRenderTarget();
+
+    VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    vkt::Buffer write_buffer(*m_device, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, reqs);
+    OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
+
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
+    descriptor_set.WriteDescriptorBufferInfo(0, write_buffer.handle(), 0, 4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set.UpdateDescriptorSets();
+    static const char vertshader[] =
+        "#version 450\n"
+        "layout(set = 0, binding = 0) buffer StorageBuffer { uint data[]; } Data;\n"
+        "void main() {\n"
+        "        Data.data[4] = 0xdeadca71;\n"
+        "}\n";
+
+    VkShaderObj vs(this, vertshader, VK_SHADER_STAGE_VERTEX_BIT);
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.shader_stages_[0] = vs.GetStageCreateInfo();
+    pipe.gp_ci_.layout = pipeline_layout.handle();
+    pipe.CreateGraphicsPipeline();
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    m_commandBuffer->begin(&begin_info);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
+                              &descriptor_set.set_, 0, nullptr);
+    vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+    // Should not get a warning since shader wasn't instrumented
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
+    m_commandBuffer->QueueCommandBuffer();
+    vk::QueueWaitIdle(m_default_queue);
+    VkValidationFeatureEnableEXT enabled[] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
+    VkValidationFeaturesEXT features = vku::InitStructHelper();
+    features.enabledValidationFeatureCount = 1;
+    features.pEnabledValidationFeatures = enabled;
+    VkShaderObj instrumented_vs(this, vertshader, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, nullptr, "main",
+                                false, &features);
+    CreatePipelineHelper pipe2(*this);
+    pipe2.InitState();
+    pipe2.shader_stages_[0] = instrumented_vs.GetStageCreateInfo();
+    pipe2.gp_ci_.layout = pipeline_layout.handle();
+    pipe2.CreateGraphicsPipeline();
+
+    m_commandBuffer->begin(&begin_info);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe2.Handle());
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
+                              &descriptor_set.set_, 0, nullptr);
+    vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+    // Should get a warning since shader was instrumented
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "VUID-vkCmdDraw-None-08613");
+    m_commandBuffer->QueueCommandBuffer();
+    vk::QueueWaitIdle(m_default_queue);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
Addresses #6009
Will also require a spec change to allow a VkValidationFeaturesEXT in the pNext chain of VkShaderModuleCreateInfo (06904)
Updated GPU-AV settings code to use the new utilities which made writing the test for this code much easier
The test does not get a 06904 error, because 06904 isn't implemented, presumably due to pNext being marked noautovalidity
