### PR TITLE
ci: Prevent duplicate CI runs

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -24,9 +24,11 @@ concurrency:
 
 on:
     push:
+        branches:
+          - main
     pull_request:
         branches:
-            - main
+          - main
 
 env:
   CMAKE_GENERATOR: Ninja


### PR DESCRIPTION
Currently if a user doesn't developer in a fork they run twice the amount of CI.

This fixes that issue.

See:
https://github.com/orgs/community/discussions/26276