### PR TITLE
tests: Improve feature requirements handling

### DIFF
--- a/docs/creating_tests.md
+++ b/docs/creating_tests.md
@@ -96,6 +96,26 @@ if (copy_commands2) {
 }
 ```
 
+### Pattern for feature requirements
+
+A set of helper functions and macro are available to help defining feature requirements. Use them to specify that you want some feature to be enabled or disabled. Test will be skipped if the required features are not supported by the device. Typical flow looks like this:
+
+```cpp
+AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
+RETURN_IF_SKIP(InitFramework())
+
+auto feature_requirements = MakeFeatureRequirementsCollection(
+    FEATURE_REQUIREMENTS(VkPhysicalDeviceFeatures2,
+       FEATURE_MANDATORY(features.logicOp), FEATURE_DISABLED(features.fillModeNonSolid)),
+    FEATURE_REQUIREMENTS(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, FEATURE_MANDATORY(extendedDynamicState3PolygonMode)));
+
+RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
+```
+`MakeFeatureRequirementsCollection` is a variadic function taking a collection of feature requirements as an input.
+`FEATURE_REQUIREMENTS` is a variadic macro. Start by specifying the name of your Vulkan physical device features struct, then use either `FEATURE_MANDATORY` to specify that you want a feature to be enabled, or `FEATURE_DISABLED` to specify that you want a feature to be disabled.
+
+Note: Every Vulkan physical device features must appear at most once in the collection. 
+
 ### Vulkan Version
 
 As [raised in a previous issue](https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1553), when a Vulkan version is enabled, all extensions that are required are exposed. (For example, if the test is created as a Vulkan 1.1 application, then the `VK_KHR_16bit_storage` extension would be supported regardless as it was promoted to Vulkan 1.1 core)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     framework/descriptor_helper.cpp
     framework/thread_timeout_helper.h
     framework/thread_timeout_helper.cpp
+    framework/feature_requirements.h
     unit/amd_best_practices.cpp
     unit/android_hardware_buffer.cpp
     unit/android_hardware_buffer_positive.cpp
@@ -199,6 +200,8 @@ elseif(MSVC)
     target_compile_options(vk_layer_validation_tests PRIVATE
         /wd4389 # signed/unsigned mismatch
         /wd4267 # Disable some signed/unsigned mismatch warnings.
+            # To enable better MSVC support of variadic macros (still not conformant to standard witout /std:c++20)
+        /Zc:preprocessor
     )
 
     set_target_properties(vk_layer_validation_tests PROPERTIES VS_DEBUGGER_ENVIRONMENT "VK_LAYER_PATH=$<TARGET_FILE_DIR:vvl>")

--- a/tests/framework/feature_requirements.h
+++ b/tests/framework/feature_requirements.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include "test_common.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <tuple>
+#include <utility>
+
+template <typename VkFeatureA, typename VkFeatureB>
+void pnext_connect(VkFeatureA &feature_a, VkFeatureB &feature_b) {
+    feature_a.feature_struct.pNext = &feature_b.feature_struct;
+}
+
+// Adapted from https://stackoverflow.com/questions/4832949/c-iterating-over-a-tuple-resolution-of-type-vs-constant-parameters
+
+template <std::size_t I = 0, typename... Tp>
+inline typename std::enable_if<(I + 1) >= sizeof...(Tp), void>::type pnext_connect_vk_tuple(std::tuple<Tp...> &) {}
+
+template <std::size_t I = 0, typename... Tp>
+inline typename std::enable_if<(I + 1) < sizeof...(Tp), void>::type pnext_connect_vk_tuple(std::tuple<Tp...> &t) {
+    pnext_connect(*std::get<I>(t), *std::get<I + 1>(t));
+    pnext_connect_vk_tuple<I + 1, Tp...>(t);
+}
+
+template <std::size_t I = 0, typename... Tp>
+inline typename std::enable_if<I >= sizeof...(Tp), void>::type enforce_disabled_features(std::tuple<Tp...> &) {}
+
+template <std::size_t I = 0, typename... Tp>
+    inline typename std::enable_if < I<sizeof...(Tp), void>::type enforce_disabled_features(std::tuple<Tp...> &t) {
+    for (auto &disabled_feature : std::get<I>(t)->disabled_features) {
+        *disabled_feature.feature = VK_FALSE;
+    }
+    enforce_disabled_features<I + 1, Tp...>(t);
+}
+
+template <std::size_t I = 0, typename... Tp>
+inline typename std::enable_if<I >= sizeof...(Tp), void>::type skip_if_mandatory_feature_disabled(const std::tuple<Tp...> &) {}
+
+template <std::size_t I = 0, typename... Tp>
+    inline typename std::enable_if < I<sizeof...(Tp), void>::type skip_if_mandatory_feature_disabled(const std::tuple<Tp...> &t) {
+    for (auto &mandatory_feature : std::get<I>(t)->mandatory_features) {
+        if (*mandatory_feature.feature == VK_FALSE) {
+            GTEST_SKIP() << "Requested feature " << std::get<I>(t)->feature_struct_name << "::" << mandatory_feature.feature_name
+                         << " is not available on test device, skipping test";
+        }
+    }
+    skip_if_mandatory_feature_disabled<I + 1, Tp...>(t);
+}
+
+struct SingleFeature {
+    VkBool32 *feature;
+    const char *feature_name;
+    SingleFeature(VkBool32 *feature, const char *feature_name) : feature(feature), feature_name(feature_name) {}
+};
+
+template <typename T>
+struct FeatureRequirements {
+    T feature_struct{};
+    const char *feature_struct_name = nullptr;
+    std::vector<SingleFeature> mandatory_features;
+    std::vector<SingleFeature> optional_features;
+    std::vector<SingleFeature> disabled_features;
+
+    FeatureRequirements(const char *feature_struct_name)
+        : feature_struct(vku::InitStructHelper()), feature_struct_name(feature_struct_name) {}
+    void AddMandatoryFeature(VkBool32 *p, const char *feature_name) {
+        mandatory_features.emplace_back(SingleFeature(p, feature_name));
+    }
+    void AddDisabledFeature(VkBool32 *p, const char *feature_name) {
+        disabled_features.emplace_back(SingleFeature(p, feature_name));
+    }
+};
+
+template <typename... T>
+class FeatureRequirementsCollection {
+  public:
+    FeatureRequirementsCollection(T &&...args) : feature_structs(std::forward<T>(args)...) {
+        if constexpr (sizeof...(T) > 1) {
+            pnext_connect_vk_tuple(feature_structs);
+        }
+    }
+
+    auto &GetFirstFeatureStruct() { return std::get<0>(feature_structs)->feature_struct; }
+    void EnforceDisabledFeatures() { enforce_disabled_features(feature_structs); }
+    void SkipIfMandatoryFeatureDisabled() const { skip_if_mandatory_feature_disabled(feature_structs); }
+
+  private:
+    std::tuple<T...> feature_structs;
+};
+
+// Use this to specify that a feature needs to be enabled
+// eg: FEATURE_REQUIREMENTS(VkPhysicalDeviceFeatures2, FEATURE_MANDATORY(features.fillModeNonSolid))
+#define FEATURE_MANDATORY(field) feature_req->AddMandatoryFeature(&feature_req->feature_struct.field, #field);
+// Use this to specify that a feature needs to be disabled
+// eg: FEATURE_REQUIREMENTS(VkPhysicalDeviceFeatures2, FEATURE_DISABLED(features.fillModeNonSolid))
+#define FEATURE_DISABLED(field) feature_req->AddDisabledFeature(&feature_req->feature_struct.field, #field);
+
+// Cannot have recursive macros, so use this instead. In practice, 10 level deep recursion is enough
+#define POOR_MAN_RECURSION_11(...)
+#define POOR_MAN_RECURSION_10(x, ...) x POOR_MAN_RECURSION_11(__VA_ARGS__)
+#define POOR_MAN_RECURSION_9(x, ...) x POOR_MAN_RECURSION_10(__VA_ARGS__)
+#define POOR_MAN_RECURSION_8(x, ...) x POOR_MAN_RECURSION_9(__VA_ARGS__)
+#define POOR_MAN_RECURSION_7(x, ...) x POOR_MAN_RECURSION_8(__VA_ARGS__)
+#define POOR_MAN_RECURSION_6(x, ...) x POOR_MAN_RECURSION_7(__VA_ARGS__)
+#define POOR_MAN_RECURSION_5(x, ...) x POOR_MAN_RECURSION_6(__VA_ARGS__)
+#define POOR_MAN_RECURSION_4(x, ...) x POOR_MAN_RECURSION_5(__VA_ARGS__)
+#define POOR_MAN_RECURSION_3(x, ...) x POOR_MAN_RECURSION_4(__VA_ARGS__)
+#define POOR_MAN_RECURSION_2(x, ...) x POOR_MAN_RECURSION_3(__VA_ARGS__)
+#define POOR_MAN_RECURSION_1(x, ...) x POOR_MAN_RECURSION_2(__VA_ARGS__)
+
+#define FEATURE_REQUIREMENTS(VkPhysicalFeature, ...)                                                     \
+    []() {                                                                                               \
+        auto feature_req = std::make_unique<FeatureRequirements<VkPhysicalFeature>>(#VkPhysicalFeature); \
+        POOR_MAN_RECURSION_1(__VA_ARGS__)                                                                \
+        return feature_req;                                                                              \
+    }()
+
+/// Typical feature requirements flow:
+/// ---
+//
+// AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
+// RETURN_IF_SKIP(InitFramework())
+//
+// auto feature_requirements = MakeFeatureRequirementsCollection(
+//     FEATURE_REQUIREMENTS(VkPhysicalDeviceFeatures2,
+//        FEATURE_MANDATORY(features.logicOp), FEATURE_DISABLED(features.fillModeNonSolid)),
+//     FEATURE_REQUIREMENTS(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, FEATURE_MANDATORY(extendedDynamicState3PolygonMode)));
+//
+// RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
+
+template <typename... T>
+auto MakeFeatureRequirementsCollection(T &&...args) {
+    return FeatureRequirementsCollection<T...>(std::forward<T>(args)...);
+}

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -32,6 +32,7 @@
 #include "render.h"
 #include "utils/convert_utils.h"
 #include "shader_templates.h"
+#include "feature_requirements.h"
 
 #include <algorithm>
 #include <cmath>
@@ -42,6 +43,8 @@
 #include <unordered_set>
 #include <vector>
 #include <condition_variable>
+#include <tuple>
+#include <utility>
 
 using std::string;
 using std::vector;
@@ -153,6 +156,13 @@ class VkLayerTest : public VkLayerTestBase {
     const char *kValidationLayerName = "VK_LAYER_KHRONOS_validation";
     const char *kSynchronization2LayerName = "VK_LAYER_KHRONOS_synchronization2";
 
+    template <typename... T>
+    void InitStateWithRequirements(FeatureRequirementsCollection<T...> &feature_requirements) {
+        GetPhysicalDeviceFeatures2(feature_requirements.GetFirstFeatureStruct());
+        feature_requirements.SkipIfMandatoryFeatureDisabled();
+        feature_requirements.EnforceDisabledFeatures();
+        InitState(nullptr, &feature_requirements.GetFirstFeatureStruct(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+    }
     void Init(VkPhysicalDeviceFeatures *features = nullptr, VkPhysicalDeviceFeatures2 *features2 = nullptr,
               const VkCommandPoolCreateFlags flags = 0, void *instance_pnext = nullptr);
     void AddSurfaceExtension();

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -1632,12 +1632,11 @@ TEST_F(NegativeDynamicState, DrawNotSetTessellationDomainOrigin) {
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())
 
-    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
-    if (!extended_dynamic_state3_features.extendedDynamicState3TessellationDomainOrigin) {
-        GTEST_SKIP() << "extendedDynamicState3TessellationDomainOrigin not supported";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &extended_dynamic_state3_features));
+    auto feature_requirements = MakeFeatureRequirementsCollection(FEATURE_REQUIREMENTS(
+        VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, FEATURE_MANDATORY(extendedDynamicState3TessellationDomainOrigin)));
+
+    RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
+
     InitRenderTarget();
 
     m_commandBuffer->begin();
@@ -1668,13 +1667,13 @@ TEST_F(NegativeDynamicState, DrawNotSetDepthClampEnable) {
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())
 
-    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
-    if (!extended_dynamic_state3_features.extendedDynamicState3DepthClampEnable) {
-        GTEST_SKIP() << "extendedDynamicState3DepthClampEnable not supported";
-    }
-    features2.features.depthClamp = VK_FALSE;
-    RETURN_IF_SKIP(InitState(nullptr, &features2))
+    auto feature_requirements =
+        MakeFeatureRequirementsCollection(FEATURE_REQUIREMENTS(VkPhysicalDeviceFeatures2, FEATURE_DISABLED(features.depthClamp)),
+                                          FEATURE_REQUIREMENTS(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+                                                               FEATURE_MANDATORY(extendedDynamicState3DepthClampEnable)));
+
+    RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
+
     InitRenderTarget();
 
     m_commandBuffer->begin();
@@ -1699,16 +1698,17 @@ TEST_F(NegativeDynamicState, DrawNotSetDepthClampEnable) {
 
 TEST_F(NegativeDynamicState, DrawNotSetPolygonMode) {
     TEST_DESCRIPTION("VK_EXT_extended_dynamic_state3 dynamic state not set before drawing");
+
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())
 
-    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
-    if (!extended_dynamic_state3_features.extendedDynamicState3PolygonMode) {
-        GTEST_SKIP() << "extendedDynamicState3PolygonMode not supported";
-    }
-    features2.features.fillModeNonSolid = VK_FALSE;
-    RETURN_IF_SKIP(InitState(nullptr, &features2))
+    auto feature_requirements = MakeFeatureRequirementsCollection(
+        FEATURE_REQUIREMENTS(VkPhysicalDeviceFeatures2, FEATURE_DISABLED(features.fillModeNonSolid)),
+        FEATURE_REQUIREMENTS(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+                             FEATURE_MANDATORY(extendedDynamicState3PolygonMode)));
+
+    RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
+
     InitRenderTarget();
 
     m_commandBuffer->begin();
@@ -1744,13 +1744,13 @@ TEST_F(NegativeDynamicState, DrawNotSetAlphaToOneEnable) {
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())
 
-    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
-    if (!extended_dynamic_state3_features.extendedDynamicState3AlphaToOneEnable) {
-        GTEST_SKIP() << "extendedDynamicState3AlphaToOneEnable not supported";
-    }
-    features2.features.alphaToOne = VK_FALSE;
-    RETURN_IF_SKIP(InitState(nullptr, &features2))
+    auto feature_requirements =
+        MakeFeatureRequirementsCollection(FEATURE_REQUIREMENTS(VkPhysicalDeviceFeatures2, FEATURE_DISABLED(features.alphaToOne)),
+                                          FEATURE_REQUIREMENTS(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+                                                               FEATURE_MANDATORY(extendedDynamicState3AlphaToOneEnable)));
+
+    RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
+
     InitRenderTarget();
 
     m_commandBuffer->begin();
@@ -1777,13 +1777,13 @@ TEST_F(NegativeDynamicState, DrawNotSetLogicOpEnable) {
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())
 
-    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
-    if (!extended_dynamic_state3_features.extendedDynamicState3LogicOpEnable) {
-        GTEST_SKIP() << "extendedDynamicState3LogicOpEnable not supported";
-    }
-    features2.features.logicOp = VK_FALSE;
-    RETURN_IF_SKIP(InitState(nullptr, &features2))
+    auto feature_requirements =
+        MakeFeatureRequirementsCollection(FEATURE_REQUIREMENTS(VkPhysicalDeviceFeatures2, FEATURE_DISABLED(features.logicOp)),
+                                          FEATURE_REQUIREMENTS(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+                                                               FEATURE_MANDATORY(extendedDynamicState3LogicOpEnable)));
+
+    RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
+
     InitRenderTarget();
 
     m_commandBuffer->begin();
@@ -1812,13 +1812,13 @@ TEST_F(NegativeDynamicState, DrawNotSetColorBlendEquation) {
     AddRequiredExtensions(VK_EXT_BLEND_OPERATION_ADVANCED_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())
 
-    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
-    if (!extended_dynamic_state3_features.extendedDynamicState3ColorBlendEquation) {
-        GTEST_SKIP() << "extendedDynamicState3ColorBlendEquation not supported";
-    }
-    features2.features.dualSrcBlend = VK_FALSE;
-    RETURN_IF_SKIP(InitState(nullptr, &features2))
+    auto feature_requirements =
+        MakeFeatureRequirementsCollection(FEATURE_REQUIREMENTS(VkPhysicalDeviceFeatures2, FEATURE_DISABLED(features.dualSrcBlend)),
+                                          FEATURE_REQUIREMENTS(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+                                                               FEATURE_MANDATORY(extendedDynamicState3ColorBlendEquation)));
+
+    RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
+
     InitRenderTarget();
 
     m_commandBuffer->begin();
@@ -2051,18 +2051,13 @@ TEST_F(NegativeDynamicState, DrawNotSetLineStippleEnable) {
     AddRequiredExtensions(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())
 
-    VkPhysicalDeviceLineRasterizationFeaturesEXT line_raster_features = vku::InitStructHelper();
-    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features =
-        vku::InitStructHelper(&line_raster_features);
-    GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
-    if (!extended_dynamic_state3_features.extendedDynamicState3LineStippleEnable) {
-        GTEST_SKIP() << "dynamic state 3 features not supported";
-    }
-    if (!line_raster_features.stippledRectangularLines) {
-        GTEST_SKIP() << "stippledRectangularLines features not supported";
-    }
+    auto feature_requirements = MakeFeatureRequirementsCollection(
+        FEATURE_REQUIREMENTS(VkPhysicalDeviceLineRasterizationFeaturesEXT, FEATURE_MANDATORY(stippledRectangularLines)),
+        FEATURE_REQUIREMENTS(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT,
+                             FEATURE_MANDATORY(extendedDynamicState3LineStippleEnable)));
 
-    RETURN_IF_SKIP(InitState(nullptr, &extended_dynamic_state3_features));
+    RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
+
     InitRenderTarget();
 
     m_commandBuffer->begin();
@@ -2086,12 +2081,10 @@ TEST_F(NegativeDynamicState, DrawNotSetColorWriteMask) {
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())
 
-    VkPhysicalDeviceExtendedDynamicState3FeaturesEXT extended_dynamic_state3_features = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(extended_dynamic_state3_features);
-    if (!extended_dynamic_state3_features.extendedDynamicState3ColorWriteMask) {
-        GTEST_SKIP() << "extendedDynamicState3ColorWriteMask not supported";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &extended_dynamic_state3_features));
+    auto feature_requirements = MakeFeatureRequirementsCollection(FEATURE_REQUIREMENTS(
+        VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, FEATURE_MANDATORY(extendedDynamicState3ColorWriteMask)));
+
+    RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
 
     m_commandBuffer->begin();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetColorWriteMaskEXT-pColorWriteMasks-parameter");


### PR DESCRIPTION
Improve how feature requirements are handled in tests. See updates to `docs/creating_tests.md` for details.

I started using it in some tests, and plan to expand usage if everyone is happy about this change.

For a quick example, here is the new flow I propose to specify feature requirements:

```cpp
AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
RETURN_IF_SKIP(InitFramework())

auto feature_requirements = MakeFeatureRequirementsCollection(
    FEATURE_REQUIREMENTS(VkPhysicalDeviceFeatures2,
       FEATURE_MANDATORY(features.logicOp), FEATURE_DISABLED(features.fillModeNonSolid)),
    FEATURE_REQUIREMENTS(VkPhysicalDeviceExtendedDynamicState3FeaturesEXT, FEATURE_MANDATORY(extendedDynamicState3PolygonMode)));

RETURN_IF_SKIP(InitStateWithRequirements(feature_requirements))
```