### PR TITLE
layers: Add missing VkAttachmentReference VU

### DIFF
--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -1278,9 +1278,10 @@ bool CoreChecks::ValidateAttachmentReference(VkAttachmentReference2 reference, c
         case VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL:
             // First need to make sure feature bit is enabled and the format is actually a depth and/or stencil
             if (!enabled_features.core12.separateDepthStencilLayouts) {
-                skip |=
-                    LogError("VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313", device, loc,
-                             "is %s (and separateDepthStencilLayouts was not enabled).", string_VkImageLayout(reference.layout));
+                vuid = (use_rp2) ? "VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313"
+                                 : "VUID-VkAttachmentReference-separateDepthStencilLayouts-03313";
+                skip |= LogError(vuid, device, loc, "is %s (and separateDepthStencilLayouts was not enabled).",
+                                 string_VkImageLayout(reference.layout));
             } else if (IsImageLayoutDepthOnly(reference.layout)) {
                 if (attachment_reference_stencil_layout) {
                     // This check doesn't rely on the aspect mask value

--- a/tests/unit/renderpass.cpp
+++ b/tests/unit/renderpass.cpp
@@ -743,8 +743,6 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayout) {
         // set valid values to start
         rpci2.pSubpasses[0].pColorAttachments[0].aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         rpci2.pSubpasses[0].pColorAttachments[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-        rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-        rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
 
         rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
         rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
@@ -766,6 +764,13 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayout) {
             *m_errorMonitor, *m_device, *rpci2.ptr(),
             {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313", "VUID-VkRenderPassCreateInfo2-attachment-06245"});
     }
+
+    // test RenderPass 1
+    refs[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    refs[1].layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL_KHR;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassCreateInfo2-attachment-06244");
+    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkAttachmentReference-separateDepthStencilLayouts-03313",
+                         nullptr);
 }
 
 TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsFeature) {


### PR DESCRIPTION
already had `VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313` but was missing the RenderPass1 version (`VUID-VkAttachmentReference-separateDepthStencilLayouts-03313`)