### PR TITLE
Fix vuid 04809 nullptr dereference

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2404,14 +2404,20 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const CMD_BUFFER_STATE *cb_st
         if ((discard_rectangle_state && discard_rectangle_state->discardRectangleCount != 0) ||
             (pipeline.IsDynamic(VK_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT))) {
             if (!pipeline.IsDynamic(VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT)) {
+                std::stringstream msg;
+                if (discard_rectangle_state) {
+                    msg << "VkPipelineDiscardRectangleStateCreateInfoEXT::discardRectangleCount = "
+                        << discard_rectangle_state->discardRectangleCount;
+                } else {
+                    msg << "VK_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT";
+                }
                 const LogObjectList objlist(cb_state->commandBuffer(), pipeline.pipeline());
-                skip |= LogError("VUID-vkCmdBindPipeline-commandBuffer-04809", objlist, loc.dot(Field::commandBuffer),
-                                 "is a secondary command buffer with "
-                                 "VkCommandBufferInheritanceViewportScissorInfoNV::viewportScissor2D enabled, pipelineBindPoint is "
-                                 "VK_PIPELINE_BIND_POINT_GRAPHICS and pipeline was created with "
-                                 "VkPipelineDiscardRectangleStateCreateInfoEXT::discardRectangleCount = %" PRIu32
-                                 ", but without VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT.",
-                                 discard_rectangle_state->discardRectangleCount);
+                skip |= LogError(
+                    "VUID-vkCmdBindPipeline-commandBuffer-04809", objlist, loc.dot(Field::commandBuffer),
+                    "is a secondary command buffer with VkCommandBufferInheritanceViewportScissorInfoNV::viewportScissor2D "
+                    "enabled, pipelineBindPoint is VK_PIPELINE_BIND_POINT_GRAPHICS and pipeline was created with %s, but without "
+                    "VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT.",
+                    msg.str().c_str());
             }
         }
     }

--- a/tests/unit/viewport_inheritance.cpp
+++ b/tests/unit/viewport_inheritance.cpp
@@ -963,12 +963,12 @@ TEST_F(NegativeViewportInheritance, PipelineMissingDynamicStateDiscardRectangle)
     cbbi.pInheritanceInfo = &cbii;
 
     VkRect2D discard_rectangle = {};
-    VkPipelineDiscardRectangleStateCreateInfoEXT discard_rectangle_state =
-        vku::InitStructHelper();
+    VkPipelineDiscardRectangleStateCreateInfoEXT discard_rectangle_state = vku::InitStructHelper();
     discard_rectangle_state.discardRectangleCount = 1;
     discard_rectangle_state.pDiscardRectangles = &discard_rectangle;
 
-    const VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+    const VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR,
+                                         VK_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT};
     VkPipelineDynamicStateCreateInfo dyn_state_ci = vku::InitStructHelper();
     dyn_state_ci.dynamicStateCount = 2;
     dyn_state_ci.pDynamicStates = dyn_states;
@@ -984,6 +984,18 @@ TEST_F(NegativeViewportInheritance, PipelineMissingDynamicStateDiscardRectangle)
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindPipeline-commandBuffer-04809");
     vk::CmdBindPipeline(secondary.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     m_errorMonitor->VerifyFound();
+
+    if (DeviceExtensionSupported(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME, 2)) {
+        dyn_state_ci.dynamicStateCount = 3;
+
+        CreatePipelineHelper pipe2(*this);
+        pipe2.gp_ci_.pDynamicState = &dyn_state_ci;
+        pipe2.InitState();
+        pipe2.CreateGraphicsPipeline();
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindPipeline-commandBuffer-04809");
+        vk::CmdBindPipeline(secondary.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe2.pipeline_);
+        m_errorMonitor->VerifyFound();
+    }
 }
 
 // SPIR-V blobs for graphics pipeline.


### PR DESCRIPTION
There are 2 paths for the VUID, one does not have the pointer to VkPipelineDiscardRectangleStateCreateInfoEXT