### PR TITLE
layers: Disable syncval for all descriptor arrays

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1985,8 +1985,8 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
             // (e.g. read access, when both reads and writes are allowed) or for an array of descriptors, not all
             // elements are accessed in the general case.
             //
-            // This workaround disables validation for the runtime descriptor array case.
-            if (binding->count > 1 && stage_state.spirv_state->static_data_.has_capability_runtime_descriptor_array) {
+            // This workaround disables validation for the descriptor array case.
+            if (binding->count > 1) {
                 continue;
             }
 
@@ -2126,8 +2126,8 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
             SyncStageAccessIndex sync_index =
                 GetSyncStageAccessIndexsByDescriptorSet(descriptor_type, variable, stage_state.GetStage());
 
-            // Do not update state for runtime descriptor array (the same as in Validate function)
-            if (binding->count > 1 && stage_state.spirv_state->static_data_.has_capability_runtime_descriptor_array) {
+            // Do not update state for descriptor array (the same as in Validate function).
+            if (binding->count > 1) {
                 continue;
             }
 

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -674,7 +674,7 @@ TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0, rgba8) uniform image2D image_array[];
         void main() {
-           imageStore(image_array[int(gl_FragCoord.x) % 2], ivec2(1, 1), vec4(1.0, 0.5, 0.2, 1.0));
+           imageStore(image_array[nonuniformEXT(int(gl_FragCoord.x) % 2)], ivec2(1, 1), vec4(1.0, 0.5, 0.2, 1.0));
         }
     )glsl";
     const VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -689,7 +689,7 @@ TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0, rgba8) uniform image2D image_array[];
         void main() {
-            vec4 data = imageLoad(image_array[2 + (gl_LocalInvocationID.x % 2)], ivec2(1, 1));
+            vec4 data = imageLoad(image_array[nonuniformEXT(2 + (gl_LocalInvocationID.x % 2))], ivec2(1, 1));
         }
     )glsl";
     CreateComputePipelineHelper cs_pipe(*this);
@@ -720,8 +720,7 @@ TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
     vk::QueueWaitIdle(m_default_queue);
 }
 
-// TODO: enable this test when syncval can track array accesses for constant indices
-TEST_F(PositiveSyncVal, DISABLED_ImageArrayConstantIndexing) {
+TEST_F(PositiveSyncVal, ImageArrayConstantIndexing) {
     TEST_DESCRIPTION("Access different elements of the image array using constant indices. There should be no hazards");
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState());
@@ -791,8 +790,7 @@ TEST_F(PositiveSyncVal, DISABLED_ImageArrayConstantIndexing) {
     vk::QueueWaitIdle(m_default_queue);
 }
 
-// TODO: enable this test when syncval can track array accesses for constant indices
-TEST_F(PositiveSyncVal, DISABLED_TexelBufferArrayConstantIndexing) {
+TEST_F(PositiveSyncVal, TexelBufferArrayConstantIndexing) {
     TEST_DESCRIPTION("Access different elements of the texel buffer array using constant indices. There should be no hazards");
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState());


### PR DESCRIPTION
This is the follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6605

We still validate common case of a non-arrayed descriptor. And for the arrays we assert the absence of false-positive behavior.

Re-enables tests for constant indexing. Later these tests can also validate any potential development based on SPIR-V analysis for constant indices. We can incrementally increase coverage but the tests will guard against false positives.
