### PR TITLE
tests: Remove IsDriver

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -600,17 +600,6 @@ VkPhysicalDeviceProperties2 VkLayerTest::GetPhysicalDeviceProperties2(VkPhysical
     return props2;
 }
 
-bool VkLayerTest::IsDriver(VkDriverId driver_id) {
-    if (VkRenderFramework::IgnoreDisableChecks()) {
-        return false;
-    } else {
-        VkPhysicalDeviceDriverProperties driver_properties = vku::InitStructHelper();
-        VkPhysicalDeviceProperties2 physical_device_properties2 = vku::InitStructHelper(&driver_properties);
-        GetPhysicalDeviceProperties2(physical_device_properties2);
-        return (driver_properties.driverID == driver_id);
-    }
-}
-
 bool VkLayerTest::LoadDeviceProfileLayer(
     PFN_vkSetPhysicalDeviceFormatPropertiesEXT &fpvkSetPhysicalDeviceFormatPropertiesEXT,
     PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT &fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT) {

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -192,8 +192,6 @@ class VkLayerTest : public VkLayerTestBase {
         return proc;
     }
 
-    bool IsDriver(VkDriverId driver_id);
-
   protected:
     void SetTargetApiVersion(APIVersion target_api_version);
     APIVersion DeviceValidationVersion() const;

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -2277,10 +2277,6 @@ TEST_F(VkBestPracticesLayerTest, PipelineWithoutRenderPassOrRenderingInfo) {
     }
     RETURN_IF_SKIP(InitState(nullptr, &dynamic_rendering_features));
 
-    if (IsDriver(VK_DRIVER_ID_MESA_RADV) || IsDriver(VK_DRIVER_ID_ARM_PROPRIETARY)) {
-        GTEST_SKIP() << "Temporarily disabling on Pixel 7 and RADV due to driver crash";
-    }
-
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -933,10 +933,6 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        GTEST_SKIP() << "This test is crashing on some AMD + Windows platforms without any validation errors getting hit; requires "
-                        "investigation.";
-    }
 
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -1366,12 +1366,6 @@ TEST_F(VkGpuAssistedLayerTest, GpuBufferDeviceAddressOOB) {
     AddOptionalExtensions(VK_NV_MESH_SHADER_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuAvFramework())
 
-    if (IsDriver(VK_DRIVER_ID_MESA_RADV)) {
-        GTEST_SKIP() << "This test should not be run on the RADV driver.";
-    }
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        GTEST_SKIP() << "This test should not be run on the AMD proprietary driver.";
-    }
     const bool mesh_shader_supported = IsExtensionsEnabled(VK_NV_MESH_SHADER_EXTENSION_NAME);
 
     VkPhysicalDeviceMeshShaderFeaturesNV mesh_shader_features = vku::InitStructHelper();
@@ -1689,7 +1683,7 @@ TEST_F(VkGpuAssistedLayerTest, GpuDrawIndirectCountDeviceLimit) {
     ASSERT_EQ(VK_SUCCESS, vk::QueueWaitIdle(m_default_queue));
     m_errorMonitor->VerifyFound();
 
-    if (!IsDriver(VK_DRIVER_ID_MESA_RADV) && features13.dynamicRendering) {
+    if (features13.dynamicRendering) {
         m_commandBuffer->begin();
         m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -213,12 +213,6 @@ TEST_F(PositiveGpuAssistedLayer, GpuBufferDeviceAddress) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuAvFramework())
-    if (IsDriver(VK_DRIVER_ID_MESA_RADV)) {
-        GTEST_SKIP() << "This test should not be run on the RADV driver.";
-    }
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        GTEST_SKIP() << "This test should not be run on the AMD proprietary driver.";
-    }
     VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper();
     VkPhysicalDeviceFeatures2KHR features2 = GetPhysicalDeviceFeatures2(bda_features);
     if (!features2.features.shaderInt64) {

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -493,11 +493,6 @@ TEST_F(PositiveImage, ImagelessLayoutTracking) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework())
 
-    if (IsDriver(VK_DRIVER_ID_MESA_RADV)) {
-        // According to valid usage, VkBindImageMemoryInfo-memory should be NULL. But RADV will crash if memory is NULL, "
-        GTEST_SKIP() << "This test should not be run on the RADV driver";
-    }
-
     VkPhysicalDeviceImagelessFramebufferFeaturesKHR physicalDeviceImagelessFramebufferFeatures =
         vku::InitStructHelper();
     physicalDeviceImagelessFramebufferFeatures.imagelessFramebuffer = VK_TRUE;

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -249,10 +249,6 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation))
 
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        GTEST_SKIP() << "Test is crashing on AMD hardware for unknown reasons.";
-    }
-
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR rt_pipeline_features = vku::InitStructHelper();
     VkPhysicalDeviceAccelerationStructureFeaturesKHR as_features = vku::InitStructHelper(&rt_pipeline_features);
     VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&as_features);

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -421,12 +421,7 @@ TEST_F(VkPositiveLayerTest, QueueThreading) {
     using namespace std::chrono;
     using std::thread;
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    // Test randomly fails with VK_TIMEOUT, most likely a driver bug
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        GTEST_SKIP() << "Test does not run on AMD proprietary driver";
-    }
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init())
 
     const auto queue_family = m_device->graphics_queues()[0]->get_family_index();
     constexpr uint32_t queue_index = 0;

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -1419,14 +1419,8 @@ TEST_F(PositivePipeline, DISABLED_CreationFeedbackCount0) {
     TEST_DESCRIPTION("Test graphics pipeline feedback stage count check with 0.");
 
     AddRequiredExtensions(VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
-    // need for IsDriver check
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    // This test hits a bug in the driver, CTS was written, but incase using an old driver
-    if (IsDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY)) {
-        GTEST_SKIP() << "This test should not be run on the NVIDIA proprietary driver.";
-    }
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init())
     InitRenderTarget();
 
     VkPipelineCreationFeedbackCreateInfoEXT feedback_info = vku::InitStructHelper();

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -353,12 +353,6 @@ TEST_F(NegativeProtectedMemory, GetDeviceQueue) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())
 
-    // Needed for both protected memory and vkGetDeviceQueue2
-
-    if (IsDriver(VK_DRIVER_ID_MESA_RADV)) {
-        GTEST_SKIP() << "This test should not be run on the RADV driver.";
-    }
-
     VkDeviceQueueInfo2 queue_info_2 = vku::InitStructHelper();
     VkDevice test_device = VK_NULL_HANDLE;
     VkQueue test_queue = VK_NULL_HANDLE;

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -464,14 +464,11 @@ TEST_F(NegativePushDescriptor, CreateDescriptorUpdateTemplate) {
     do_test("VUID-VkDescriptorUpdateTemplateCreateInfo-templateType-00353");
 
     // Bad descriptorSetLayout handle, to be ignored if templateType is PUSH_DESCRIPTORS
-    // NOTE: AMD's Windows proprietary driver doesn't seem to ignore this handle
     create_info.set = 2;
     create_info.descriptorSetLayout = CastFromUint64<VkDescriptorSetLayout>(badhandle);
-    if (!IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        VkDescriptorUpdateTemplateKHR dut = VK_NULL_HANDLE;
-        if (VK_SUCCESS == vk::CreateDescriptorUpdateTemplateKHR(m_device->handle(), &create_info, nullptr, &dut)) {
-            vk::DestroyDescriptorUpdateTemplateKHR(m_device->handle(), dut, nullptr);
-        }
+    VkDescriptorUpdateTemplateKHR dut = VK_NULL_HANDLE;
+    if (VK_SUCCESS == vk::CreateDescriptorUpdateTemplateKHR(m_device->handle(), &create_info, nullptr, &dut)) {
+        vk::DestroyDescriptorUpdateTemplateKHR(m_device->handle(), dut, nullptr);
     }
     // Bad descriptorSetLayout handle
     create_info.templateType = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET;
@@ -790,10 +787,6 @@ TEST_F(NegativePushDescriptor, UnsupportedDescriptorTemplateBindPoint) {
     AddRequiredExtensions(VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init())
 
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        GTEST_SKIP() << "Test crashes on AMD.";
-    }
-
     const std::optional<uint32_t> no_gfx_qfi = m_device->QueueFamilyMatching(VK_QUEUE_COMPUTE_BIT, VK_QUEUE_GRAPHICS_BIT);
     if (!no_gfx_qfi.has_value()) {
         GTEST_SKIP() << "Required queue family capabilities not found.";
@@ -856,12 +849,7 @@ TEST_F(NegativePushDescriptor, InvalidDescriptorUpdateTemplateType) {
 
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
-
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        GTEST_SKIP() << "Test crashes on AMD.";
-    }
+    RETURN_IF_SKIP(Init())
 
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;
@@ -917,12 +905,7 @@ TEST_F(NegativePushDescriptor, DescriptorTemplateIncompatibleLayout) {
 
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
-
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        GTEST_SKIP() << "Test crashes on AMD.";
-    }
+    RETURN_IF_SKIP(Init())
 
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;

--- a/tests/unit/push_descriptor_positive.cpp
+++ b/tests/unit/push_descriptor_positive.cpp
@@ -436,12 +436,7 @@ TEST_F(PositivePushDescriptor, PushDescriptorWithTemplateMultipleSets) {
 
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DESCRIPTOR_UPDATE_TEMPLATE_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
-
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        GTEST_SKIP() << "Test crashes on AMD.";
-    }
+    RETURN_IF_SKIP(Init())
 
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -49,11 +49,6 @@ TEST_F(PositiveRayTracing, GetAccelerationStructureBuildSizes) {
 
     RETURN_IF_SKIP(InitFramework())
 
-    // Crashes without any warnings
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        GTEST_SKIP() << "Test does not run on AMD proprietary driver";
-    }
-
     VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_struct_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(accel_struct_features);
     RETURN_IF_SKIP(InitState(nullptr, &accel_struct_features));

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1836,9 +1836,6 @@ TEST_F(PositiveSyncObject, FenceSemThreadRace) {
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
 
     RETURN_IF_SKIP(InitFramework())
-    if (IsDriver(VK_DRIVER_ID_GOOGLE_SWIFTSHADER)) {
-        GTEST_SKIP() << "This test hangs on SwiftShader.";
-    }
     VkPhysicalDeviceTimelineSemaphoreFeatures timeline_semaphore_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(timeline_semaphore_features);
     RETURN_IF_SKIP(InitState(nullptr, &timeline_semaphore_features));
@@ -2096,10 +2093,6 @@ TEST_F(PositiveSyncObject, WaitTimelineSemaphoreWithWin32HandleRetrieved) {
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
 
     RETURN_IF_SKIP(InitFramework())
-    if (IsDriver(VK_DRIVER_ID_AMD_PROPRIETARY)) {
-        // Older AMD driver does not like timeline + export properties combo
-        GTEST_SKIP() << "Please update AMD drivers at least to Adrenalin 23.5.2 to run this test. Then remove this check.";
-    }
     if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -263,11 +263,6 @@ TEST_F(NegativeWsi, TransferImageToSwapchainLayoutDeviceGroup) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(InitFramework())
 
-    if (IsDriver(VK_DRIVER_ID_MESA_RADV)) {
-        // Seeing the same crash as the Android comment above
-        GTEST_SKIP() << "This test should not be run on the RADV driver";
-    }
-
     uint32_t physical_device_group_count = 0;
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, nullptr);
 

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -201,21 +201,15 @@ TEST_F(PositiveWsi, CmdCopySwapchainImage) {
     TEST_DESCRIPTION("Run vkCmdCopyImage with a swapchain image");
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-    printf(
-        "According to valid usage, VkBindImageMemoryInfo-memory should be NULL. But Android will crash if memory is NULL, "
-        "skipping CmdCopySwapchainImage test\n");
-    return;
+    GTEST_SKIP()
+        << "According to valid usage, VkBindImageMemoryInfo-memory should be NULL. But Android will crash if memory is NULL, "
+           "skipping test";
 #endif
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
     AddSurfaceExtension();
     RETURN_IF_SKIP(InitFramework())
-
-    if (IsDriver(VK_DRIVER_ID_MESA_RADV)) {
-        // Seeing the same crash as the Android comment above
-        GTEST_SKIP() << "This test should not be run on the RADV driver";
-    }
 
     RETURN_IF_SKIP(InitState())
     InitRenderTarget();
@@ -290,11 +284,6 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
     AddSurfaceExtension();
 
     RETURN_IF_SKIP(InitFramework())
-
-    if (IsDriver(VK_DRIVER_ID_MESA_RADV)) {
-        // Seeing the same crash as the Android comment above
-        GTEST_SKIP() << "This test should not be run on the RADV driver";
-    }
 
     uint32_t physical_device_group_count = 0;
     vk::EnumeratePhysicalDeviceGroups(instance(), &physical_device_group_count, nullptr);

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -1295,11 +1295,6 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitBasicYcbcr())
 
-    // This test hits a bug in the driver, CTS was written, but incase using an old driver
-    if (IsDriver(VK_DRIVER_ID_NVIDIA_PROPRIETARY)) {
-        GTEST_SKIP() << "This test should not be run on the NVIDIA proprietary driver.";
-    }
-
     if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";


### PR DESCRIPTION
all tests that are skipped are now moved to the internal blacklist so they can be triaged from a single location