### PR TITLE
layers: Add `vkCmdBuildAccelerationStructuresKHR` VUIDs related to acceleration structures builds constraints

### DIFF
--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -854,20 +854,20 @@ namespace vvl {
 inline constexpr std::in_place_t in_place{};
 
 // Partial implementation of std::span for C++11
-template <typename T>
-class span {
+template <typename T, typename Iterator>
+class enumeration {
   public:
     using pointer = T *;
     using const_pointer = T const *;
-    using iterator = pointer;
-    using const_iterator = const_pointer;
+    using iterator = Iterator;
+    using const_iterator = const Iterator;
 
-    span() = default;
-    span(pointer start, size_t n) : data_(start), count_(n) {}
-    template <typename Iterator>
-    span(Iterator start, Iterator end) : data_(&(*start)), count_(end - start) {}
+    enumeration() = default;
+    enumeration(pointer start, size_t n) : data_(start), count_(n) {}
+    template <typename Position>
+    enumeration(Position start, Position end) : data_(&(*start)), count_(end - start) {}
     template <typename Container>
-    span(Container &c) : data_(c.data()), count_(c.size()) {}
+    enumeration(Container &c) : data_(c.data()), count_(c.size()) {}
 
     iterator begin() { return data_; }
     const_iterator begin() const { return data_; }
@@ -895,6 +895,47 @@ class span {
     size_t count_ = 0;
 };
 
+template <typename T, typename IndexType = size_t>
+class IndexedIterator {
+  public:
+    IndexedIterator(T *data, IndexType index = 0) : data_(data), index_(index) {}
+
+    IndexedIterator<T, IndexType> &operator*() { return *this /*IndexedIterator<T, IndexType>(data_ + index_, index_)*/; }
+    const IndexedIterator<T, IndexType> &operator*() const {
+        return *this /*IndexedIterator<T, IndexType>(data_ + index_, index_)*/;
+    }
+
+    // prefix increment
+    IndexedIterator<T, IndexType> &operator++() {
+        ++data_;
+        ++index_;
+        return *this;
+    }
+
+    // postfix increment
+    IndexedIterator<T, IndexType> operator++(int) {
+        IndexedIterator<T, IndexType> old = *this;
+        operator++();
+        return old;
+    }
+
+    bool operator==(const IndexedIterator<T, IndexType> &rhs) const {
+        // No need to compare indices, just compare pointers
+        // And given the implementation of enumeration::end(),
+        // where no index is given when constructing an iterator,
+        // index_ will default to 0 for end(), which is wrong, but we can live with it for now
+        return data_ == rhs.data_;
+    }
+    bool operator!=(const IndexedIterator<T, IndexType> &rhs) const { return data_ != rhs.data_; }
+
+  public:
+    T *data_;
+    IndexType index_ = 0;
+};
+
+template <typename T>
+using span = enumeration<T, T *>;
+
 //
 // Allow type inference that using the constructor doesn't allow in C++11
 template <typename T>
@@ -904,6 +945,15 @@ span<T> make_span(T *begin, size_t count) {
 template <typename T>
 span<T> make_span(T *begin, T *end) {
     return make_span<T>(begin, end);
+}
+
+template <typename T, typename IndexType>
+enumeration<T, IndexedIterator<T, IndexType>> enumerate(T *begin, IndexType count) {
+    return enumeration<T, IndexedIterator<T, IndexType>>(begin, count);
+}
+template <typename T>
+enumeration<T, IndexedIterator<T>> enumerate(T *begin, T *end) {
+    return enumeration<T, IndexedIterator<T>>(begin, end);
 }
 
 template <typename BaseType>

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -1149,6 +1149,8 @@ bool StatelessValidation::manual_PreCallValidateCmdBuildAccelerationStructuresKH
                              pInfos[i].scratchData.deviceAddress,
                              phys_dev_ext_props.acc_structure_props.minAccelerationStructureScratchOffsetAlignment);
         }
+        skip |= ValidateRangedEnum(info_loc.dot(Field::mode), "VkBuildAccelerationStructureModeKHR", pInfos[i].mode,
+                                   "VUID-vkCmdBuildAccelerationStructuresKHR-mode-04628");
         for (uint32_t k = 0; k < infoCount; ++k) {
             if (i == k) continue;
             if (pInfos[i].dstAccelerationStructure == pInfos[k].dstAccelerationStructure) {

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -18,6 +18,11 @@ namespace as {
 
 GeometryKHR::GeometryKHR() : vk_obj_(vku::InitStructHelper()) {}
 
+GeometryKHR &GeometryKHR::SetFlags(VkGeometryFlagsKHR flags) {
+    vk_obj_.flags = flags;
+    return *this;
+}
+
 GeometryKHR &GeometryKHR::SetType(Type type) {
     type_ = type;
     vk_obj_.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
@@ -113,6 +118,21 @@ GeometryKHR &GeometryKHR::SetTrianglesIndexType(VkIndexType index_type) {
     return *this;
 }
 
+GeometryKHR &GeometryKHR::SetTrianglesVertexFormat(VkFormat vertex_format) {
+    vk_obj_.geometry.triangles.vertexFormat = vertex_format;
+    return *this;
+}
+
+GeometryKHR &GeometryKHR::SetTrianglesMaxVertex(uint32_t max_vertex) {
+    vk_obj_.geometry.triangles.maxVertex = max_vertex;
+    return *this;
+}
+
+GeometryKHR &GeometryKHR::SetTrianglesTransformatData(VkDeviceAddress address) {
+    vk_obj_.geometry.triangles.transformData.deviceAddress = address;
+    return *this;
+}
+
 GeometryKHR &GeometryKHR::SetAABBsDeviceBuffer(vkt::Buffer &&buffer, VkDeviceSize stride /*= sizeof(VkAabbPositionsKHR)*/) {
     aabbs_.device_buffer = std::move(buffer);
     vk_obj_.geometry.aabbs.data.deviceAddress = aabbs_.device_buffer.address();
@@ -124,6 +144,11 @@ GeometryKHR &GeometryKHR::SetAABBsHostBuffer(std::unique_ptr<VkAabbPositionsKHR[
                                              VkDeviceSize stride /*= sizeof(VkAabbPositionsKHR)*/) {
     aabbs_.host_buffer = std::move(buffer);
     vk_obj_.geometry.aabbs.data.hostAddress = aabbs_.host_buffer.get();
+    vk_obj_.geometry.aabbs.stride = stride;
+    return *this;
+}
+
+GeometryKHR &GeometryKHR::SetAABBsStride(VkDeviceSize stride) {
     vk_obj_.geometry.aabbs.stride = stride;
     return *this;
 }

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -501,9 +501,6 @@ VkAccelerationStructureBuildSizesInfoKHR BuildGeometryInfoKHR::GetSizeInfo(VkDev
 }
 
 void BuildGeometryInfoKHR::BuildCommon(const vkt::Device &device, bool is_on_device_build, bool use_ppGeometries /*= true*/) {
-    assert(vk_info_.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR ||
-           vk_info_.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR);
-
     // Build geometries
     for (auto &geometry : geometries_) {
         geometry.Build();
@@ -521,7 +518,7 @@ void BuildGeometryInfoKHR::BuildCommon(const vkt::Device &device, bool is_on_dev
 
     const VkAccelerationStructureBuildSizesInfoKHR size_info = GetSizeInfo(device.handle(), use_ppGeometries);
     const VkDeviceSize scratch_size =
-        vk_info_.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR ? size_info.buildScratchSize : size_info.updateScratchSize;
+        vk_info_.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR ? size_info.updateScratchSize : size_info.buildScratchSize;
     if (is_on_device_build) {
         // Allocate device local scratch buffer
 

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -60,6 +60,7 @@ class GeometryKHR {
     GeometryKHR& operator=(const GeometryKHR&) = delete;
 
     // Common methods for all types
+    GeometryKHR& SetFlags(VkGeometryFlagsKHR flags);
     GeometryKHR& SetType(Type type);
     GeometryKHR& SetPrimitiveCount(uint32_t primitiveCount);
     GeometryKHR& SetStride(VkDeviceSize stride);
@@ -72,9 +73,13 @@ class GeometryKHR {
     GeometryKHR& SetTrianglesDeviceIndexBuffer(vkt::Buffer&& index_buffer, VkIndexType index_type = VK_INDEX_TYPE_UINT32);
     GeometryKHR& SetTrianglesHostIndexBuffer(std::unique_ptr<uint32_t[]> index_buffer);
     GeometryKHR& SetTrianglesIndexType(VkIndexType index_type);
+    GeometryKHR& SetTrianglesVertexFormat(VkFormat vertex_format);
+    GeometryKHR& SetTrianglesMaxVertex(uint32_t max_vertex);
+    GeometryKHR& SetTrianglesTransformatData(VkDeviceAddress address);
     // AABB
     GeometryKHR& SetAABBsDeviceBuffer(vkt::Buffer&& buffer, VkDeviceSize stride = sizeof(VkAabbPositionsKHR));
     GeometryKHR& SetAABBsHostBuffer(std::unique_ptr<VkAabbPositionsKHR[]> buffer, VkDeviceSize stride = sizeof(VkAabbPositionsKHR));
+    GeometryKHR& SetAABBsStride(VkDeviceSize stride);
     // Instance
     GeometryKHR& SetInstanceDeviceAccelStructRef(const vkt::Device& device, VkAccelerationStructureKHR bottom_level_as);
     GeometryKHR& SetInstanceHostAccelStructRef(VkAccelerationStructureKHR bottom_level_as);

--- a/tests/vvl_utils/small_vector.cpp
+++ b/tests/vvl_utils/small_vector.cpp
@@ -414,3 +414,14 @@ TEST(CustomContainer, SmallVectorAssign) {
     ASSERT_TRUE(v_src.empty());
     ASSERT_TRUE(HaveSameElements(ref_xxl, v_dst));
 }
+
+TEST(CustomContainer, Enumerate) {
+    small_vector<int, 2, size_t> sv = {1, 2, 3, 4};
+    std::array ref_elements = {1, 2, 3, 4};
+    size_t indices_i = 0;
+    for (auto [x, i] : vvl::enumerate(sv.data(), sv.size())) {
+        ASSERT_TRUE(i == indices_i);
+        ASSERT_TRUE(*x == ref_elements[indices_i]);
+        ++indices_i;
+    }
+}


### PR DESCRIPTION
- Partially addresses https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3792
Also add `04628`, that simply checks that the build mode is a valid value

Add a new utility similar to `vvl::span`, `vvl::enumerate`, that is basically a span where but with the addition of a loop variable holding the current iteration index. `vvl::make_span` and `vvl::enumerate` should cover the needs of the majority of our `for` loops, and probably should be preferred to the usual basic `for` loop. Usage example:
```cpp
std::vector<int> v = {1, 2, 3, 4};
for (auto [x, i] : vvl::enumerate(s.data(), s.size())) {// x is an int*
     std::cout << "Value at iteration " << i << ": " << *x << '\n';
}
```