### PR TITLE
layers: Fix non-Resolve flow in ExternalFormatResolve

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -781,7 +781,7 @@ bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolve(const PIPELINE_ST
         vku::FindStructInPNextChain<VkPipelineFragmentShadingRateStateCreateInfoKHR>(pipeline.PNext());
 
     if (rp_state && !rp_state->UsesDynamicRendering()) {
-        if (subpass_desc->colorAttachmentCount == 0) {
+        if (!subpass_desc || subpass_desc->colorAttachmentCount == 0 || !subpass_desc->pResolveAttachments) {
             return false;
         }
         // can only have 1 color attachment

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -38,6 +38,16 @@ void AndroidExternalResolveTest::InitBasicAndroidExternalResolve(void* pNextFeat
     nullColorAttachmentWithExternalFormatResolve = external_format_resolve_props.nullColorAttachmentWithExternalFormatResolve;
 }
 
+TEST_F(PositiveAndroidExternalResolve, NoResolve) {
+    TEST_DESCRIPTION("Make sure enabling the feature doesn't break normal usage of API.");
+    RETURN_IF_SKIP(InitBasicAndroidExternalResolve())
+    InitRenderTarget();
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.CreateGraphicsPipeline();
+}
+
 TEST_F(PositiveAndroidExternalResolve, RenderPassAndFramebuffer) {
     RETURN_IF_SKIP(InitBasicAndroidExternalResolve())
 


### PR DESCRIPTION
Fix bug when using normal, non-resolve path with `VK_ANDROID_external_format_resolve`