### PR TITLE
layers: Check for explicit signedness

### DIFF
--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -410,7 +410,7 @@ IMAGE_VIEW_STATE::IMAGE_VIEW_STATE(const std::shared_ptr<IMAGE_STATE> &im, VkIma
       // When the image has a external format the views format must be VK_FORMAT_UNDEFINED and it is required to use a sampler
       // Ycbcr conversion. Thus we can't extract any meaningful information from the format parameter. As a Sampler Ycbcr
       // conversion must be used the shader type is always float.
-      descriptor_format_bits(im->HasAHBFormat() ? static_cast<unsigned>(NumericTypeFloat) : GetFormatType(ci->format)),
+      descriptor_format_bits(im->HasAHBFormat() ? static_cast<uint32_t>(NumericTypeFloat) : GetFormatType(ci->format)),
       samplerConversion(GetSamplerConversion(ci)),
       filter_cubic_props(cubic_props),
       min_lod(GetImageViewMinLod(ci)),

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -276,7 +276,7 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
     const VkImageSubresourceRange normalized_subresource_range;
     const image_layout_map::RangeGenerator range_generator;
     const VkSampleCountFlagBits samples;
-    const unsigned descriptor_format_bits;
+    const uint32_t descriptor_format_bits;
     const VkSamplerYcbcrConversion samplerConversion;  // Handle of the ycbcr sampler conversion the image was created with, if any
     const VkFilterCubicImageViewImageFormatPropertiesEXT filter_cubic_props;
     const float min_lod;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -176,6 +176,8 @@ struct ImageAccess {
     bool is_sampler_bias_offset = false;
     bool is_written_to = false;
     bool is_read_from = false;
+    bool is_sign_extended = false;
+    bool is_zero_extended = false;
 
     uint32_t image_access_chain_index = kInvalidSpirvValue;    // OpAccessChain's Index 0
     uint32_t sampler_access_chain_index = kInvalidSpirvValue;  // OpAccessChain's Index 0
@@ -327,6 +329,11 @@ struct ResourceInterfaceVariable : public VariableBase {
         bool is_read_without_format{false};   // For storage images
         bool is_write_without_format{false};  // For storage images
         bool is_dref{false};
+
+        // vkspec.html#spirvenv-image-signedness describes how SignExtend/ZeroExtend can be used per-access to adjust the Signedness
+        // Only need to check if one access has explicit signedness, mixing should be caught in spirv-val
+        bool is_sign_extended{false};  // if at least one access has SignExtended
+        bool is_zero_extended{false};  // if at least one access has ZeroExtended
     } info;
     uint64_t descriptor_hash = 0;
     bool IsImage() const { return info.image_format_type != NumericTypeUnknown; }

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -3352,7 +3352,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidMode) {
 
     VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(ASSERT_NO_FATAL_FAILURE(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT)));
+    RETURN_IF_SKIP(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
     auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     build_info.SetMode(static_cast<VkBuildAccelerationStructureModeKHR>(42));


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4355

The spec has a section that describes `SignExtended` and `ZeroExtended` can override the sign of the image access

![image](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/115671160/0ce97fe0-e8c6-4753-9bfc-97e4e8140de8)

