### PR TITLE
layers: Check for bad descriptor type with known error

### DIFF
--- a/layers/best_practices/best_practices_error_enums.h
+++ b/layers/best_practices/best_practices_error_enums.h
@@ -131,7 +131,6 @@
 [[maybe_unused]] static const char *kVUID_BestPractices_SemaphoreCount = "UNASSIGNED-BestPractices-SemaphoreCount";
 [[maybe_unused]] static const char *kVUID_BestPractices_EmptyDescriptorPool =
     "UNASSIGNED-BestPractices-EmptyDescriptorPool";
-[[maybe_unused]] static const char *kVUID_BestPractices_DescriptorTypeNotInPool = "UNASSIGNED-BestPractices-DescriptorTypeNotInPool";
 [[maybe_unused]] static const char *kVUID_BestPractices_ClearValueWithoutLoadOpClear = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueWithoutLoadOpClear";
 [[maybe_unused]] static const char *kVUID_BestPractices_ClearValueCountHigherThanAttachmentCount = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueCountHigherThanAttachmentCount";
 [[maybe_unused]] static const char *kVUID_BestPractices_StoreOpDontCareThenLoadOpLoad = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-StoreOpDontCareThenLoadOpLoad";

--- a/layers/best_practices/bp_descriptor.cpp
+++ b/layers/best_practices/bp_descriptor.cpp
@@ -49,25 +49,6 @@ bool BestPractices::PreCallValidateAllocateDescriptorSets(VkDevice device, const
                                    pAllocateInfo->descriptorSetCount, FormatHandle(*pool_state).c_str(),
                                    pool_state->GetAvailableSets());
             }
-
-            for (uint32_t i = 0; i < pAllocateInfo->descriptorSetCount; i++) {
-                auto layout = Get<cvdescriptorset::DescriptorSetLayout>(pAllocateInfo->pSetLayouts[i]);
-                if (layout) {  // if null, this is validated/logged in object_tracker
-                    const uint32_t binding_count = layout->GetBindingCount();
-                    for (uint32_t j = 0; j < binding_count; ++j) {
-                        const VkDescriptorType type = layout->GetTypeFromIndex(j);
-                        if (!pool_state->IsAvailableType(type)) {
-                            // This check would be caught by validation if VK_KHR_maintenance1 was not enabled
-                            skip |=
-                                LogWarning(kVUID_BestPractices_DescriptorTypeNotInPool, pool_state->Handle(), error_obj.location,
-                                           "pSetLayouts[%" PRIu32 "] binding %" PRIu32
-                                           " was created with %s but the "
-                                           "Descriptor Pool was not created with this type",
-                                           i, j, string_VkDescriptorType(type));
-                        }
-                    }
-                }
-            }
         }
     }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1517,6 +1517,9 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                VkDescriptorSet* pDescriptorSets, const ErrorObject& error_obj,
                                                void* ads_state) const override;
+    void PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
+                                              VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj,
+                                              void* ads_state) override;
     bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                     const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                     const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -2175,55 +2175,6 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
     }
 }
 
-TEST_F(VkBestPracticesLayerTest, DescriptorTypeNotInPool) {
-    TEST_DESCRIPTION("With maintenance1, allocate descriptor with type not in pool");
-
-    SetTargetApiVersion(VK_API_VERSION_1_1);  // Need VK_KHR_maintenance1
-    RETURN_IF_SKIP(InitBestPracticesFramework())
-    RETURN_IF_SKIP(InitState())
-    InitRenderTarget();
-
-    // Create Pool with 2 Sampler descriptors, but try to alloc
-    // - 1 Sampler
-    // - 1 Uniform Buffer
-    VkDescriptorPoolSize ds_type_count = {};
-    ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
-    ds_type_count.descriptorCount = 2;
-
-    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
-    ds_pool_ci.flags = 0;
-    ds_pool_ci.maxSets = 2;
-    ds_pool_ci.poolSizeCount = 1;
-    ds_pool_ci.pPoolSizes = &ds_type_count;
-
-    vkt::DescriptorPool ds_pool(*m_device, ds_pool_ci);
-
-    VkDescriptorSetLayoutBinding dsl_binding_sampler = {};
-    dsl_binding_sampler.binding = 0;
-    dsl_binding_sampler.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
-    dsl_binding_sampler.descriptorCount = 1;
-    dsl_binding_sampler.stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding_sampler.pImmutableSamplers = nullptr;
-
-    VkDescriptorSetLayoutBinding dsl_binding_uniform = {};
-    dsl_binding_uniform.binding = 1;
-    dsl_binding_uniform.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    dsl_binding_uniform.descriptorCount = 1;
-    dsl_binding_uniform.stageFlags = VK_SHADER_STAGE_ALL;
-    dsl_binding_uniform.pImmutableSamplers = nullptr;
-
-    const vkt::DescriptorSetLayout ds_layout(*m_device, {dsl_binding_sampler, dsl_binding_uniform});
-
-    VkDescriptorSet descriptor_set;
-    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
-    alloc_info.descriptorSetCount = 1;
-    alloc_info.descriptorPool = ds_pool.handle();
-    alloc_info.pSetLayouts = &ds_layout.handle();
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-DescriptorTypeNotInPool");
-    vk::AllocateDescriptorSets(m_device->device(), &alloc_info, &descriptor_set);
-    m_errorMonitor->VerifyFound();
-}
-
 TEST_F(VkBestPracticesLayerTest, NonSimultaneousSecondaryMarksPrimary) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState())

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -5316,3 +5316,54 @@ TEST_F(NegativeDescriptors, MaxInlineUniformTotalSize) {
     vk::CreatePipelineLayout(*m_device, &pipeline_layout_ci, nullptr, &pipeline_layout);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeDescriptors, DescriptorTypeNotInPool) {
+    TEST_DESCRIPTION("With maintenance1, allocate descriptor with type not in pool");
+    SetTargetApiVersion(VK_API_VERSION_1_1);  // Need VK_KHR_maintenance1
+    RETURN_IF_SKIP(Init())
+    InitRenderTarget();
+
+    // Create Pool with 2 Sampler descriptors, but try to alloc an Uniform Buffer
+    VkDescriptorPoolSize ds_type_count = {};
+    ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
+    ds_type_count.descriptorCount = 2;
+
+    VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
+    ds_pool_ci.flags = 0;
+    ds_pool_ci.maxSets = 2;
+    ds_pool_ci.poolSizeCount = 1;
+    ds_pool_ci.pPoolSizes = &ds_type_count;
+
+    vkt::DescriptorPool ds_pool(*m_device, ds_pool_ci);
+
+    VkDescriptorSetLayoutBinding dsl_binding_sampler = {};
+    dsl_binding_sampler.binding = 0;
+    dsl_binding_sampler.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+    dsl_binding_sampler.descriptorCount = 1;
+    dsl_binding_sampler.stageFlags = VK_SHADER_STAGE_ALL;
+    dsl_binding_sampler.pImmutableSamplers = nullptr;
+
+    VkDescriptorSetLayoutBinding dsl_binding_uniform = {};
+    dsl_binding_uniform.binding = 1;
+    dsl_binding_uniform.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    dsl_binding_uniform.descriptorCount = 1;
+    dsl_binding_uniform.stageFlags = VK_SHADER_STAGE_ALL;
+    dsl_binding_uniform.pImmutableSamplers = nullptr;
+
+    const vkt::DescriptorSetLayout ds_layout(*m_device, {dsl_binding_sampler, dsl_binding_uniform});
+
+    VkDescriptorSet descriptor_set;
+    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
+    alloc_info.descriptorSetCount = 1;
+    alloc_info.descriptorPool = ds_pool.handle();
+    alloc_info.pSetLayouts = &ds_layout.handle();
+    VkResult result = vk::AllocateDescriptorSets(m_device->device(), &alloc_info, &descriptor_set);
+
+    // not all implementations will return this exact error code
+    if (result != VK_ERROR_OUT_OF_POOL_MEMORY) {
+        GTEST_SKIP() << "Does not return expected VK_ERROR_OUT_OF_POOL_MEMORY";
+    }
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-CoreValidation-AllocateDescriptorSets-WrongType");
+    vk::AllocateDescriptorSets(m_device->device(), &alloc_info, &descriptor_set);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5167

as described in the comment (and more detail in https://gitlab.khronos.org/vulkan/vulkan/-/issues/3347) we decided to have a special check for a warning if `VK_ERROR_OUT_OF_POOL_MEMORY` is returned because the type is not in the descriptor pool