### PR TITLE
Don't dereference missing multisample state

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -481,7 +481,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LAST_BOUND_STATE& last_b
 
     if (!pipeline.IsDynamic(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT) &&
         pipeline.IsDynamic(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT) &&
-        cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT]) {
+        cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT] && pipeline.MultisampleState()) {
         const auto sample_locations =
             vku::FindStructInPNextChain<VkPipelineSampleLocationsStateCreateInfoEXT>(pipeline.MultisampleState()->pNext);
         if (sample_locations &&


### PR DESCRIPTION
Fixes crashes (after error) in:
dEQP-VK.pipeline.monolithic.extended_dynamic_state.cmd_buffer_start.null_multisample_state
dEQP-VK.pipeline.monolithic.extended_dynamic_state.before_draw.null_multisample_state
dEQP-VK.pipeline.fast_linked_library.extended_dynamic_state.cmd_buffer_start.null_multisample_state
dEQP-VK.pipeline.monolithic.extended_dynamic_state.mesh_shader.cmd_buffer_start.null_multisample_state