### PR TITLE
layers: Detect inter-queue event usage

### DIFF
--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -91,7 +91,8 @@ struct CommandBufferSubmitState {
             skip |= function(*core, *queue_state, cb_state);
         }
         for (auto &function : cb_state.eventUpdates) {
-            skip |= function(const_cast<CMD_BUFFER_STATE &>(cb_state), /*do_validate*/ true, local_event_signal_info);
+            skip |= function(const_cast<CMD_BUFFER_STATE &>(cb_state), /*do_validate*/ true, local_event_signal_info,
+                             queue_state->Queue());
         }
         VkQueryPool first_perf_query_pool = VK_NULL_HANDLE;
         for (auto &function : cb_state.queryUpdates) {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -844,8 +844,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateActionState(const CMD_BUFFER_STATE& cb_state, const VkPipelineBindPoint bind_point, const Location& loc) const;
     bool ValidateCmdRayQueryState(const CMD_BUFFER_STATE& cb_state, const VkPipelineBindPoint bind_point,
                                   const Location& loc) const;
-    static bool ValidateWaitEventsAtSubmit(const CMD_BUFFER_STATE& cb_state, size_t eventCount, size_t firstEventIndex,
-                                           VkPipelineStageFlags2 sourceStageMask, const EventToStageMap& local_event_signal_info);
+    static bool ValidateWaitEventsAtSubmit(vvl::Func command, const CMD_BUFFER_STATE& cb_state, size_t eventCount,
+                                           size_t firstEventIndex, VkPipelineStageFlags2 sourceStageMask,
+                                           const EventToStageMap& local_event_signal_info, VkQueue waiting_queue);
     bool ValidateQueueFamilyIndices(const Location& loc, const CMD_BUFFER_STATE& cb_state, VkQueue queue) const;
     VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,
                                                const VkAllocationCallbacks* pAllocator, VkValidationCacheEXT* pValidationCache);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -844,8 +844,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateActionState(const CMD_BUFFER_STATE& cb_state, const VkPipelineBindPoint bind_point, const Location& loc) const;
     bool ValidateCmdRayQueryState(const CMD_BUFFER_STATE& cb_state, const VkPipelineBindPoint bind_point,
                                   const Location& loc) const;
-    static bool ValidateEventStageMask(const CMD_BUFFER_STATE& cb_state, size_t eventCount, size_t firstEventIndex,
-                                       VkPipelineStageFlags2KHR sourceStageMask, EventToStageMap* localEventToStageMap);
+    static bool ValidateWaitEventsAtSubmit(const CMD_BUFFER_STATE& cb_state, size_t eventCount, size_t firstEventIndex,
+                                           VkPipelineStageFlags2 sourceStageMask, const EventToStageMap& local_event_signal_info);
     bool ValidateQueueFamilyIndices(const Location& loc, const CMD_BUFFER_STATE& cb_state, VkQueue queue) const;
     VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,
                                                const VkAllocationCallbacks* pAllocator, VkValidationCacheEXT* pValidationCache);

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1477,25 +1477,31 @@ void CMD_BUFFER_STATE::RecordWriteTimestamp(Func command, VkPipelineStageFlags2K
 }
 
 void CMD_BUFFER_STATE::Submit(uint32_t perf_submit_pass) {
-    VkQueryPool first_pool = VK_NULL_HANDLE;
-    EventToStageMap local_event_to_stage_map;
-    QueryMap local_query_to_state_map;
-    for (auto &function : queryUpdates) {
-        function(*this, /*do_validate*/ false, first_pool, perf_submit_pass, &local_query_to_state_map);
+    // Update QUERY_POOL_STATE with a query state at the end of the command buffer.
+    // Ultimately, it tracks the final query state for the entire submission.
+    {
+        VkQueryPool first_pool = VK_NULL_HANDLE;
+        QueryMap local_query_to_state_map;
+        for (auto &function : queryUpdates) {
+            function(*this, /*do_validate*/ false, first_pool, perf_submit_pass, &local_query_to_state_map);
+        }
+        for (const auto &query_state_pair : local_query_to_state_map) {
+            auto query_pool_state = dev_data->Get<QUERY_POOL_STATE>(query_state_pair.first.pool);
+            query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass, query_state_pair.second);
+        }
     }
 
-    for (const auto &query_state_pair : local_query_to_state_map) {
-        auto query_pool_state = dev_data->Get<QUERY_POOL_STATE>(query_state_pair.first.pool);
-        query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass, query_state_pair.second);
-    }
-
-    for (const auto &function : eventUpdates) {
-        function(*this, /*do_validate*/ false, &local_event_to_stage_map);
-    }
-
-    for (const auto &eventStagePair : local_event_to_stage_map) {
-        auto event_state = dev_data->Get<EVENT_STATE>(eventStagePair.first);
-        event_state->stageMask = eventStagePair.second;
+    // Update EVENT_STATE with src_stage from the last recorded SetEvent.
+    // Ultimately, it tracks the last SetEvent for the entire submission.
+    {
+        EventToStageMap local_event_to_stage_map;
+        for (const auto &function : eventUpdates) {
+            function(*this, /*do_validate*/ false, &local_event_to_stage_map);
+        }
+        for (const auto &eventStagePair : local_event_to_stage_map) {
+            auto event_state = dev_data->Get<EVENT_STATE>(eventStagePair.first);
+            event_state->stageMask = eventStagePair.second;
+        }
     }
 
     for (const auto &it : video_session_updates) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -60,8 +60,10 @@ class EVENT_STATE : public BASE_NODE {
 #ifdef VK_USE_PLATFORM_METAL_EXT
     const bool metal_event_export;
 #endif  // VK_USE_PLATFORM_METAL_EXT
-    VkPipelineStageFlags2KHR stageMask = VkPipelineStageFlags2KHR(0);
-    VkEventCreateFlags flags;
+    const VkEventCreateFlags flags;
+
+    // Source stage specified by the "set event" command
+    VkPipelineStageFlags2 signal_src_stage_mask = VK_PIPELINE_STAGE_2_NONE;
 
     EVENT_STATE(VkEvent event_, const VkEventCreateInfo *pCreateInfo)
         : BASE_NODE(event_, kVulkanObjectTypeEvent),
@@ -421,8 +423,11 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     // Validation functions run when secondary CB is executed in primary
     std::vector<std::function<bool(const CMD_BUFFER_STATE &secondary, const CMD_BUFFER_STATE *primary, const FRAMEBUFFER_STATE *)>>
         cmd_execute_commands_functions;
-    std::vector<std::function<bool(CMD_BUFFER_STATE &cb_state, bool do_validate, EventToStageMap *localEventToStageMap)>>
-        eventUpdates;
+
+    using EventCallback =
+        std::function<bool(CMD_BUFFER_STATE &cb_state, bool do_validate, EventToStageMap &local_event_signal_info)>;
+    std::vector<EventCallback> eventUpdates;
+
     std::vector<std::function<bool(CMD_BUFFER_STATE &cb_state, bool do_validate, VkQueryPool &firstPerfQueryPool,
                                    uint32_t perfQueryPass, QueryMap *localQueryToStateMap)>>
         queryUpdates;

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -66,7 +66,7 @@ uint64_t QUEUE_STATE::Submit(CB_SUBMISSION &&submission) {
             secondary_cmd_buffer->IncrementResources();
         }
         cb_state->IncrementResources();
-        cb_state->Submit(submission.perf_submit_pass);
+        cb_state->Submit(Queue(), submission.perf_submit_pass);
     }
     // seq_ is atomic so we don't need a lock until updating the deque below.
     // Note that this relies on the external synchonization requirements for the

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3316,6 +3316,7 @@ void ValidationStateTracker::PreCallRecordSetEvent(VkDevice device, VkEvent even
     auto event_state = Get<EVENT_STATE>(event);
     if (event_state) {
         event_state->signal_src_stage_mask = VK_PIPELINE_STAGE_HOST_BIT;
+        event_state->signaling_queue = VK_NULL_HANDLE;
     }
 }
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3315,7 +3315,7 @@ void ValidationStateTracker::PostCallRecordBindImageMemory2KHR(VkDevice device, 
 void ValidationStateTracker::PreCallRecordSetEvent(VkDevice device, VkEvent event, const RecordObject &record_obj) {
     auto event_state = Get<EVENT_STATE>(event);
     if (event_state) {
-        event_state->stageMask = VK_PIPELINE_STAGE_HOST_BIT;
+        event_state->signal_src_stage_mask = VK_PIPELINE_STAGE_HOST_BIT;
     }
 }
 


### PR DESCRIPTION
Main logic of this PR is implemented in the `layers: Detect inter-queue event usage` commit.
Other commits are cleanup of existing code: comments for non-trivial parts, updated naming.