### PR TITLE
layers: Add new LogError to LogInternalError

### DIFF
--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -68,7 +68,7 @@ bool CoreChecks::ValidateSwapchainPresentModesCreateInfo(VkPresentModeKHR presen
     bool skip = false;
     std::vector<VkPresentModeKHR> present_modes{};
     if (surface_state) {
-        present_modes = surface_state->GetPresentModes(physical_device, this);
+        present_modes = surface_state->GetPresentModes(physical_device, create_info_loc, this);
     } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
         present_modes = physical_device_state->surfaceless_query_state.present_modes;
     }
@@ -370,8 +370,9 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
         surface_caps_query_pnext = &present_mode_info;
     }
 
-    const auto surface_caps2 = surface_state->GetCapabilities(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                                              physical_device_state->PhysDev(), surface_caps_query_pnext, this);
+    const auto surface_caps2 =
+        surface_state->GetCapabilities(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
+                                       physical_device_state->PhysDev(), surface_caps_query_pnext, create_info_loc, this);
 
     bool skip = false;
     VkSurfaceTransformFlagBitsKHR current_transform = surface_caps2.surfaceCapabilities.currentTransform;
@@ -494,7 +495,7 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
         vvl::span<const safe_VkSurfaceFormat2KHR> formats{};
         if (surface_state) {
             formats = surface_state->GetFormats(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                                physical_device_state->PhysDev(), surface_caps_query_pnext, this);
+                                                physical_device_state->PhysDev(), surface_caps_query_pnext, create_info_loc, this);
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             formats = physical_device_state->surfaceless_query_state.formats;
         }
@@ -534,9 +535,9 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
                                   surface_caps2.surfaceCapabilities.maxImageExtent)) {
             safe_VkSurfaceCapabilities2KHR cached_capabilities{};
             if (surface_state) {
-                cached_capabilities =
-                    surface_state->GetCapabilities(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                                   physical_device_state->PhysDev(), surface_caps_query_pnext, this);
+                cached_capabilities = surface_state->GetCapabilities(
+                    IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2), physical_device_state->PhysDev(),
+                    surface_caps_query_pnext, create_info_loc, this);
             } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
                 cached_capabilities = physical_device_state->surfaceless_query_state.capabilities;
             }
@@ -1096,7 +1097,7 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, VkSwapchainKHR swapch
         safe_VkSurfaceCapabilities2KHR surface_caps2{};
         if (swapchain_data->surface) {
             surface_caps2 = swapchain_data->surface->GetCapabilities(
-                IsExtEnabled(device_extensions.vk_khr_get_surface_capabilities2), physical_device, nullptr, this);
+                IsExtEnabled(device_extensions.vk_khr_get_surface_capabilities2), physical_device, nullptr, loc, this);
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             surface_caps2 = physical_device_state->surfaceless_query_state.capabilities;
         }
@@ -1525,7 +1526,7 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhysi
             VkPresentModeKHR present_mode = surface_present_mode->presentMode;
             std::vector<VkPresentModeKHR> present_modes{};
             if (surface_state) {
-                present_modes = surface_state->GetPresentModes(physicalDevice, this);
+                present_modes = surface_state->GetPresentModes(physicalDevice, error_obj.location, this);
             }
             bool found_match = std::find(present_modes.begin(), present_modes.end(), present_mode) != present_modes.end();
             if (!found_match) {

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -646,7 +646,7 @@ void SURFACE_STATE::SetPresentModes(VkPhysicalDevice phys_dev, vvl::span<const V
 }
 
 // Helper for data obtained from vkGetPhysicalDeviceSurfacePresentModesKHR
-std::vector<VkPresentModeKHR> SURFACE_STATE::GetPresentModes(VkPhysicalDevice phys_dev,
+std::vector<VkPresentModeKHR> SURFACE_STATE::GetPresentModes(VkPhysicalDevice phys_dev, const Location &loc,
                                                              const ValidationObject *validation_obj) const {
     auto guard = Lock();
     assert(phys_dev);
@@ -658,10 +658,10 @@ std::vector<VkPresentModeKHR> SURFACE_STATE::GetPresentModes(VkPhysicalDevice ph
         return result;
     }
 
-    const auto log_internal_error = [validation_obj](VkResult err, auto &&...objects) {
+    const auto log_internal_error = [validation_obj, loc](VkResult err, auto &&...objects) {
         if (validation_obj) {
             LogObjectList obj_list(std::forward<decltype(objects)>(objects)...);
-            validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, "vkGetPhysicalDeviceSurfacePresentModesKHR", err);
+            validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, loc, "vkGetPhysicalDeviceSurfacePresentModesKHR", err);
         }
     };
 
@@ -687,7 +687,7 @@ void SURFACE_STATE::SetFormats(VkPhysicalDevice phys_dev, std::vector<safe_VkSur
 }
 
 vvl::span<const safe_VkSurfaceFormat2KHR> SURFACE_STATE::GetFormats(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                                    const void *surface_info2_pnext,
+                                                                    const void *surface_info2_pnext, const Location &loc,
                                                                     const ValidationObject *validation_obj) const {
     auto guard = Lock();
     assert(phys_dev);
@@ -698,10 +698,10 @@ vvl::span<const safe_VkSurfaceFormat2KHR> SURFACE_STATE::GetFormats(bool get_sur
 
     std::vector<safe_VkSurfaceFormat2KHR> result;
     if (get_surface_capabilities2) {
-        const auto log_internal_error = [validation_obj](VkResult err, auto &&...objects) {
+        const auto log_internal_error = [validation_obj, loc](VkResult err, auto &&...objects) {
             if (validation_obj) {
                 LogObjectList obj_list(std::forward<decltype(objects)>(objects)...);
-                validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, "vkGetPhysicalDeviceSurfaceFormats2KHR", err);
+                validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, loc, "vkGetPhysicalDeviceSurfaceFormats2KHR", err);
             }
         };
 
@@ -726,10 +726,10 @@ vvl::span<const safe_VkSurfaceFormat2KHR> SURFACE_STATE::GetFormats(bool get_sur
         }
 
     } else {
-        const auto log_internal_error = [validation_obj](VkResult err, auto &&...objects) {
+        const auto log_internal_error = [validation_obj, loc](VkResult err, auto &&...objects) {
             if (validation_obj) {
                 LogObjectList obj_list(std::forward<decltype(objects)>(objects)...);
-                validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, "vkGetPhysicalDeviceSurfaceFormatsKHR", err);
+                validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, loc, "vkGetPhysicalDeviceSurfaceFormatsKHR", err);
             }
         };
 
@@ -766,7 +766,7 @@ void SURFACE_STATE::SetCapabilities(VkPhysicalDevice phys_dev, const safe_VkSurf
 }
 
 safe_VkSurfaceCapabilities2KHR SURFACE_STATE::GetCapabilities(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                              const void *surface_info2_pnext,
+                                                              const void *surface_info2_pnext, const Location &loc,
                                                               const ValidationObject *validation_obj) const {
     auto guard = Lock();
     assert(phys_dev);
@@ -775,10 +775,10 @@ safe_VkSurfaceCapabilities2KHR SURFACE_STATE::GetCapabilities(bool get_surface_c
         return search->second;
     }
 
-    const auto log_internal_error = [validation_obj](VkResult err, auto &&...objects) {
+    const auto log_internal_error = [validation_obj, loc](VkResult err, auto &&...objects) {
         if (validation_obj) {
             LogObjectList obj_list(std::forward<decltype(objects)>(objects)...);
-            validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, "vkGetPhysicalDeviceSurfaceCapabilities2KHR", err);
+            validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, loc, "vkGetPhysicalDeviceSurfaceCapabilities2KHR", err);
         }
     };
 

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -419,16 +419,18 @@ class SURFACE_STATE : public BASE_NODE {
     bool GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) const;
 
     void SetPresentModes(VkPhysicalDevice phys_dev, vvl::span<const VkPresentModeKHR> modes);
-    std::vector<VkPresentModeKHR> GetPresentModes(VkPhysicalDevice phys_dev, const ValidationObject *validation_obj) const;
+    std::vector<VkPresentModeKHR> GetPresentModes(VkPhysicalDevice phys_dev, const Location &loc,
+                                                  const ValidationObject *validation_obj) const;
 
     void SetFormats(VkPhysicalDevice phys_dev, std::vector<safe_VkSurfaceFormat2KHR> &&fmts);
     vvl::span<const safe_VkSurfaceFormat2KHR> GetFormats(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                         const void *surface_info2_pnext,
+                                                         const void *surface_info2_pnext, const Location &loc,
                                                          const ValidationObject *validation_obj) const;
 
     void SetCapabilities(VkPhysicalDevice phys_dev, const safe_VkSurfaceCapabilities2KHR &caps);
     safe_VkSurfaceCapabilities2KHR GetCapabilities(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                   const void *surface_info2_pnext, const ValidationObject *validation_obj) const;
+                                                   const void *surface_info2_pnext, const Location &loc,
+                                                   const ValidationObject *validation_obj) const;
 
     void SetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
                             vvl::span<const VkPresentModeKHR> compatible_modes);

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2373,12 +2373,12 @@ class ValidationObject {
         return result;
     }
 
-    void LogInternalError(std::string_view failure_location, const LogObjectList& obj_list, std::string_view entrypoint,
-                          VkResult err) const {
+    void LogInternalError(std::string_view failure_location, const LogObjectList& obj_list, const Location& loc,
+                          std::string_view entrypoint, VkResult err) const {
         const std::string_view err_string = string_VkResult(err);
         std::string vuid = "INTERNAL-ERROR-";
         vuid += entrypoint;
-        LogError(obj_list, vuid, "In %s: %s() was called in the Validation Layer state tracking and failed with result = %s.",
+        LogError(vuid, obj_list, loc, "at %s: %s() was called in the Validation Layer state tracking and failed with result = %s.",
                  failure_location.data(), entrypoint.data(), err_string.data());
     }
 

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -593,12 +593,12 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     return result;
                 }
 
-                void LogInternalError(std::string_view failure_location, const LogObjectList& obj_list, std::string_view entrypoint,
+                void LogInternalError(std::string_view failure_location, const LogObjectList& obj_list, const Location& loc, std::string_view entrypoint,
                                     VkResult err) const {
                     const std::string_view err_string = string_VkResult(err);
                     std::string vuid = "INTERNAL-ERROR-";
                     vuid += entrypoint;
-                    LogError(obj_list, vuid, "In %s: %s() was called in the Validation Layer state tracking and failed with result = %s.",
+                    LogError(vuid, obj_list, loc, "at %s: %s() was called in the Validation Layer state tracking and failed with result = %s.",
                             failure_location.data(), entrypoint.data(), err_string.data());
                 }
 


### PR DESCRIPTION
The `LogInternalError` was not using the new `LogError`, pass the `Location` when calling it