### PR TITLE
layers: Add EntryPoint access to fragment_sub_state

### DIFF
--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -212,6 +212,11 @@ void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const Validatio
             if (module_state) {
                 fs_state.fragment_shader = std::move(module_state);
                 fs_state.fragment_shader_ci = ToShaderStageCI(create_info.pStages[i]);
+                // can be null if using VK_EXT_shader_module_identifier
+                if (fs_state.fragment_shader->spirv) {
+                    fs_state.fragment_entry_point = fs_state.fragment_shader->spirv->FindEntrypoint(
+                        fs_state.fragment_shader_ci->pName, fs_state.fragment_shader_ci->stage);
+                }
             }
         }
     }

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -24,6 +24,7 @@
 //
 class RENDER_PASS_STATE;
 struct SHADER_MODULE_STATE;
+struct EntryPoint;
 
 template <typename CreateInfoType>
 static inline VkGraphicsPipelineLibraryFlagsEXT GetGraphicsLibType(const CreateInfoType &create_info) {
@@ -135,6 +136,8 @@ struct FragmentShaderState : public PipelineSubState {
 
     std::shared_ptr<const SHADER_MODULE_STATE> fragment_shader;
     std::unique_ptr<const safe_VkPipelineShaderStageCreateInfo> fragment_shader_ci;
+    // many times we need to quickly get the entry point to access the SPIR-V static data
+    std::shared_ptr<const EntryPoint> fragment_entry_point;
 
   private:
     static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,


### PR DESCRIPTION
Remove `todo` to provide a cleaner way to access the Fragment Shader entrypoint when using to get values from it later