### PR TITLE
tests: Fix test that breaks nvidia driver

### DIFF
--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -5001,6 +5001,7 @@ TEST_F(NegativeSyncVal, QSBufferEvents) {
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_ERROR_BIT_EXT, "SYNC-HAZARD-WRITE-AFTER-READ");
     test.Submit1Wait(test.cbb, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
     m_errorMonitor->VerifyFound();
+    m_device->wait();
 }
 
 TEST_F(NegativeSyncVal, QSOBarrierHazard) {


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6537
Reverts https://github.com/LunarG/VulkanTests/pull/454

The bug was 100% reproducible on the local machine with regular nvidia drivers. Run `QSBufferEvents` test with `gtest_repeat=100` and run 3 or 4 such sessions in parallel. It fails like this:

<img src="https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/121836235/4efe2c76-0457-459f-8e58-ffc5ecc3f9a5" width=65% height=65%>

Corruption due to `QSBufferEvents` affected `QSOBarrierHazard` that runs after it, but `QSOBarrierHazard` never fails when run alone. 

The issue was not detected by the core validation because it's disabled for syncval tests. There are other failures of core validation in syncval tests. The plan to fix them and also to have a separate run of syncval tests with core validation enabled.
