### PR TITLE
layers: Add Location to Thread Tracker errors

### DIFF
--- a/layers/thread_tracker/thread_safety_validation.cpp
+++ b/layers/thread_tracker/thread_safety_validation.cpp
@@ -25,14 +25,14 @@ WriteLockGuard ThreadSafety::WriteLock() { return WriteLockGuard(validation_obje
 
 void ThreadSafety::PreCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                        VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartWriteObject(pAllocateInfo->commandPool, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(pAllocateInfo->commandPool, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                         VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishWriteObject(pAllocateInfo->commandPool, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(pAllocateInfo->commandPool, record_obj.location);
 
     // Record mapping from command buffer to command pool
     if (pCommandBuffers) {
@@ -49,13 +49,13 @@ void ThreadSafety::PostCallRecordAllocateCommandBuffers(VkDevice device, const V
 void ThreadSafety::PreCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
                                                           const VkAllocationCallbacks* pAllocator,
                                                           VkDescriptorSetLayout* pSetLayout, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
                                                            const VkAllocationCallbacks* pAllocator,
                                                            VkDescriptorSetLayout* pSetLayout, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pSetLayout);
 
@@ -78,15 +78,15 @@ void ThreadSafety::PostCallRecordCreateDescriptorSetLayout(VkDevice device, cons
 
 void ThreadSafety::PreCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                        VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartWriteObject(pAllocateInfo->descriptorPool, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(pAllocateInfo->descriptorPool, record_obj.location);
     // Host access to pAllocateInfo::descriptorPool must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                         VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishWriteObject(pAllocateInfo->descriptorPool, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(pAllocateInfo->descriptorPool, record_obj.location);
     // Host access to pAllocateInfo::descriptorPool must be externally synchronized
     if (VK_SUCCESS == record_obj.result) {
         auto lock = WriteLockGuard(thread_safety_lock);
@@ -107,11 +107,11 @@ void ThreadSafety::PostCallRecordAllocateDescriptorSets(VkDevice device, const V
 
 void ThreadSafety::PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t descriptorSetCount,
                                                    const VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartWriteObject(descriptorPool, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(descriptorPool, record_obj.location);
     if (pDescriptorSets) {
         for (uint32_t index = 0; index < descriptorSetCount; index++) {
-            StartWriteObject(pDescriptorSets[index], record_obj.location.function);
+            StartWriteObject(pDescriptorSets[index], record_obj.location);
         }
     }
     // Host access to descriptorPool must be externally synchronized
@@ -120,11 +120,11 @@ void ThreadSafety::PreCallRecordFreeDescriptorSets(VkDevice device, VkDescriptor
 
 void ThreadSafety::PostCallRecordFreeDescriptorSets(VkDevice device, VkDescriptorPool descriptorPool, uint32_t descriptorSetCount,
                                                     const VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishWriteObject(descriptorPool, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(descriptorPool, record_obj.location);
     if (pDescriptorSets) {
         for (uint32_t index = 0; index < descriptorSetCount; index++) {
-            FinishWriteObject(pDescriptorSets[index], record_obj.location.function);
+            FinishWriteObject(pDescriptorSets[index], record_obj.location);
         }
     }
     // Host access to descriptorPool must be externally synchronized
@@ -144,30 +144,30 @@ void ThreadSafety::PostCallRecordFreeDescriptorSets(VkDevice device, VkDescripto
 
 void ThreadSafety::PreCallRecordDestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
                                                       const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartWriteObject(descriptorPool, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(descriptorPool, record_obj.location);
     // Host access to descriptorPool must be externally synchronized
     auto lock = ReadLockGuard(thread_safety_lock);
     auto iterator = pool_descriptor_sets_map.find(descriptorPool);
     // Possible to have no descriptor sets allocated from pool
     if (iterator != pool_descriptor_sets_map.end()) {
         for (auto descriptor_set : pool_descriptor_sets_map[descriptorPool]) {
-            StartWriteObject(descriptor_set, record_obj.location.function);
+            StartWriteObject(descriptor_set, record_obj.location);
         }
     }
 }
 
 void ThreadSafety::PostCallRecordDestroyDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
                                                        const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishWriteObject(descriptorPool, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(descriptorPool, record_obj.location);
     DestroyObject(descriptorPool);
     // Host access to descriptorPool must be externally synchronized
     {
         auto lock = WriteLockGuard(thread_safety_lock);
         // remove references to implicitly freed descriptor sets
         for (auto descriptor_set : pool_descriptor_sets_map[descriptorPool]) {
-            FinishWriteObject(descriptor_set, record_obj.location.function);
+            FinishWriteObject(descriptor_set, record_obj.location);
             DestroyObject(descriptor_set);
             ds_read_only_map.erase(descriptor_set);
         }
@@ -178,8 +178,8 @@ void ThreadSafety::PostCallRecordDestroyDescriptorPool(VkDevice device, VkDescri
 
 void ThreadSafety::PreCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
                                                     VkDescriptorPoolResetFlags flags, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartWriteObject(descriptorPool, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(descriptorPool, record_obj.location);
     // Host access to descriptorPool must be externally synchronized
     // any sname:VkDescriptorSet objects allocated from pname:descriptorPool must be externally synchronized between host accesses
     auto lock = ReadLockGuard(thread_safety_lock);
@@ -187,22 +187,22 @@ void ThreadSafety::PreCallRecordResetDescriptorPool(VkDevice device, VkDescripto
     // Possible to have no descriptor sets allocated from pool
     if (iterator != pool_descriptor_sets_map.end()) {
         for (auto descriptor_set : pool_descriptor_sets_map[descriptorPool]) {
-            StartWriteObject(descriptor_set, record_obj.location.function);
+            StartWriteObject(descriptor_set, record_obj.location);
         }
     }
 }
 
 void ThreadSafety::PostCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool,
                                                      VkDescriptorPoolResetFlags flags, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishWriteObject(descriptorPool, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(descriptorPool, record_obj.location);
     // Host access to descriptorPool must be externally synchronized
     // any sname:VkDescriptorSet objects allocated from pname:descriptorPool must be externally synchronized between host accesses
     if (VK_SUCCESS == record_obj.result) {
         // remove references to implicitly freed descriptor sets
         auto lock = WriteLockGuard(thread_safety_lock);
         for (auto descriptor_set : pool_descriptor_sets_map[descriptorPool]) {
-            FinishWriteObject(descriptor_set, record_obj.location.function);
+            FinishWriteObject(descriptor_set, record_obj.location);
             DestroyObject(descriptor_set);
             ds_read_only_map.erase(descriptor_set);
         }
@@ -221,15 +221,15 @@ bool ThreadSafety::DsReadOnly(VkDescriptorSet set) const {
 void ThreadSafety::PreCallRecordUpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount,
                                                      const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
                                                      const VkCopyDescriptorSet* pDescriptorCopies, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
     if (pDescriptorWrites) {
         for (uint32_t index = 0; index < descriptorWriteCount; index++) {
             auto dstSet = pDescriptorWrites[index].dstSet;
             bool read_only = DsReadOnly(dstSet);
             if (read_only) {
-                StartReadObject(dstSet, record_obj.location.function);
+                StartReadObject(dstSet, record_obj.location);
             } else {
-                StartWriteObject(dstSet, record_obj.location.function);
+                StartWriteObject(dstSet, record_obj.location);
             }
         }
     }
@@ -238,11 +238,11 @@ void ThreadSafety::PreCallRecordUpdateDescriptorSets(VkDevice device, uint32_t d
             auto dstSet = pDescriptorCopies[index].dstSet;
             bool read_only = DsReadOnly(dstSet);
             if (read_only) {
-                StartReadObject(dstSet, record_obj.location.function);
+                StartReadObject(dstSet, record_obj.location);
             } else {
-                StartWriteObject(dstSet, record_obj.location.function);
+                StartWriteObject(dstSet, record_obj.location);
             }
-            StartReadObject(pDescriptorCopies[index].srcSet, record_obj.location.function);
+            StartReadObject(pDescriptorCopies[index].srcSet, record_obj.location);
         }
     }
     // Host access to pDescriptorWrites[].dstSet must be externally synchronized
@@ -253,15 +253,15 @@ void ThreadSafety::PostCallRecordUpdateDescriptorSets(VkDevice device, uint32_t 
                                                       const VkWriteDescriptorSet* pDescriptorWrites, uint32_t descriptorCopyCount,
                                                       const VkCopyDescriptorSet* pDescriptorCopies,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (pDescriptorWrites) {
         for (uint32_t index = 0; index < descriptorWriteCount; index++) {
             auto dstSet = pDescriptorWrites[index].dstSet;
             bool read_only = DsReadOnly(dstSet);
             if (read_only) {
-                FinishReadObject(dstSet, record_obj.location.function);
+                FinishReadObject(dstSet, record_obj.location);
             } else {
-                FinishWriteObject(dstSet, record_obj.location.function);
+                FinishWriteObject(dstSet, record_obj.location);
             }
         }
     }
@@ -270,11 +270,11 @@ void ThreadSafety::PostCallRecordUpdateDescriptorSets(VkDevice device, uint32_t 
             auto dstSet = pDescriptorCopies[index].dstSet;
             bool read_only = DsReadOnly(dstSet);
             if (read_only) {
-                FinishReadObject(dstSet, record_obj.location.function);
+                FinishReadObject(dstSet, record_obj.location);
             } else {
-                FinishWriteObject(dstSet, record_obj.location.function);
+                FinishWriteObject(dstSet, record_obj.location);
             }
-            FinishReadObject(pDescriptorCopies[index].srcSet, record_obj.location.function);
+            FinishReadObject(pDescriptorCopies[index].srcSet, record_obj.location);
         }
     }
     // Host access to pDescriptorWrites[].dstSet must be externally synchronized
@@ -284,14 +284,14 @@ void ThreadSafety::PostCallRecordUpdateDescriptorSets(VkDevice device, uint32_t 
 void ThreadSafety::PreCallRecordUpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
                                                                 VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                 const void* pData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartReadObject(descriptorUpdateTemplate, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(descriptorUpdateTemplate, record_obj.location);
 
     const bool read_only = DsReadOnly(descriptorSet);
     if (read_only) {
-        StartReadObject(descriptorSet, record_obj.location.function);
+        StartReadObject(descriptorSet, record_obj.location);
     } else {
-        StartWriteObject(descriptorSet, record_obj.location.function);
+        StartWriteObject(descriptorSet, record_obj.location);
     }
     // Host access to descriptorSet must be externally synchronized
 }
@@ -299,14 +299,14 @@ void ThreadSafety::PreCallRecordUpdateDescriptorSetWithTemplate(VkDevice device,
 void ThreadSafety::PostCallRecordUpdateDescriptorSetWithTemplate(VkDevice device, VkDescriptorSet descriptorSet,
                                                                  VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                  const void* pData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishReadObject(descriptorUpdateTemplate, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(descriptorUpdateTemplate, record_obj.location);
 
     const bool read_only = DsReadOnly(descriptorSet);
     if (read_only) {
-        FinishReadObject(descriptorSet, record_obj.location.function);
+        FinishReadObject(descriptorSet, record_obj.location);
     } else {
-        FinishWriteObject(descriptorSet, record_obj.location.function);
+        FinishWriteObject(descriptorSet, record_obj.location);
     }
     // Host access to descriptorSet must be externally synchronized
 }
@@ -314,14 +314,14 @@ void ThreadSafety::PostCallRecordUpdateDescriptorSetWithTemplate(VkDevice device
 void ThreadSafety::PreCallRecordUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet,
                                                                    VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                    const void* pData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartReadObject(descriptorUpdateTemplate, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(descriptorUpdateTemplate, record_obj.location);
 
     const bool read_only = DsReadOnly(descriptorSet);
     if (read_only) {
-        StartReadObject(descriptorSet, record_obj.location.function);
+        StartReadObject(descriptorSet, record_obj.location);
     } else {
-        StartWriteObject(descriptorSet, record_obj.location.function);
+        StartWriteObject(descriptorSet, record_obj.location);
     }
     // Host access to descriptorSet must be externally synchronized
 }
@@ -329,14 +329,14 @@ void ThreadSafety::PreCallRecordUpdateDescriptorSetWithTemplateKHR(VkDevice devi
 void ThreadSafety::PostCallRecordUpdateDescriptorSetWithTemplateKHR(VkDevice device, VkDescriptorSet descriptorSet,
                                                                     VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                     const void* pData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishReadObject(descriptorUpdateTemplate, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(descriptorUpdateTemplate, record_obj.location);
 
     const bool read_only = DsReadOnly(descriptorSet);
     if (read_only) {
-        FinishReadObject(descriptorSet, record_obj.location.function);
+        FinishReadObject(descriptorSet, record_obj.location);
     } else {
-        FinishWriteObject(descriptorSet, record_obj.location.function);
+        FinishWriteObject(descriptorSet, record_obj.location);
     }
     // Host access to descriptorSet must be externally synchronized
 }
@@ -344,8 +344,8 @@ void ThreadSafety::PostCallRecordUpdateDescriptorSetWithTemplateKHR(VkDevice dev
 void ThreadSafety::PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
                                                    const VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
     const bool lockCommandPool = false;  // pool is already directly locked
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartWriteObject(commandPool, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(commandPool, record_obj.location);
     if (pCommandBuffers) {
         // Even though we're immediately "finishing" below, we still are testing for concurrency with any call in process
         // so this isn't a no-op
@@ -354,8 +354,8 @@ void ThreadSafety::PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPoo
         auto lock = WriteLockGuard(thread_safety_lock);
         auto& pool_command_buffers = pool_command_buffers_map[commandPool];
         for (uint32_t index = 0; index < commandBufferCount; index++) {
-            StartWriteObject(pCommandBuffers[index], record_obj.location.function, lockCommandPool);
-            FinishWriteObject(pCommandBuffers[index], record_obj.location.function, lockCommandPool);
+            StartWriteObject(pCommandBuffers[index], record_obj.location, lockCommandPool);
+            FinishWriteObject(pCommandBuffers[index], record_obj.location, lockCommandPool);
             DestroyObject(pCommandBuffers[index]);
             pool_command_buffers.erase(pCommandBuffers[index]);
             command_pool_map.erase(pCommandBuffers[index]);
@@ -365,20 +365,20 @@ void ThreadSafety::PreCallRecordFreeCommandBuffers(VkDevice device, VkCommandPoo
 
 void ThreadSafety::PostCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
                                                     const VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishWriteObject(commandPool, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(commandPool, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pCommandPool);
         c_VkCommandPoolContents.CreateObject(*pCommandPool);
@@ -387,27 +387,27 @@ void ThreadSafety::PostCallRecordCreateCommandPool(VkDevice device, const VkComm
 
 void ThreadSafety::PreCallRecordResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartWriteObject(commandPool, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(commandPool, record_obj.location);
     // Check for any uses of non-externally sync'd command buffers (for example from vkCmdExecuteCommands)
-    c_VkCommandPoolContents.StartWrite(commandPool, record_obj.location.function);
+    c_VkCommandPoolContents.StartWrite(commandPool, record_obj.location);
     // Host access to commandPool must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishWriteObject(commandPool, record_obj.location.function);
-    c_VkCommandPoolContents.FinishWrite(commandPool, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(commandPool, record_obj.location);
+    c_VkCommandPoolContents.FinishWrite(commandPool, record_obj.location);
     // Host access to commandPool must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordDestroyCommandPool(VkDevice device, VkCommandPool commandPool,
                                                    const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartWriteObject(commandPool, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(commandPool, record_obj.location);
     // Check for any uses of non-externally sync'd command buffers (for example from vkCmdExecuteCommands)
-    c_VkCommandPoolContents.StartWrite(commandPool, record_obj.location.function);
+    c_VkCommandPoolContents.StartWrite(commandPool, record_obj.location);
     // Host access to commandPool must be externally synchronized
 
     auto lock = WriteLockGuard(thread_safety_lock);
@@ -423,10 +423,10 @@ void ThreadSafety::PreCallRecordDestroyCommandPool(VkDevice device, VkCommandPoo
 
 void ThreadSafety::PostCallRecordDestroyCommandPool(VkDevice device, VkCommandPool commandPool,
                                                     const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishWriteObject(commandPool, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(commandPool, record_obj.location);
     DestroyObject(commandPool);
-    c_VkCommandPoolContents.FinishWrite(commandPool, record_obj.location.function);
+    c_VkCommandPoolContents.FinishWrite(commandPool, record_obj.location);
     c_VkCommandPoolContents.DestroyObject(commandPool);
 }
 
@@ -434,14 +434,14 @@ void ThreadSafety::PostCallRecordDestroyCommandPool(VkDevice device, VkCommandPo
 // pSwapchainImages.
 void ThreadSafety::PreCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
                                                       VkImage* pSwapchainImages, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartReadObject(swapchain, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
                                                        VkImage* pSwapchainImages, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishReadObject(swapchain, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(swapchain, record_obj.location);
     if (pSwapchainImages != nullptr) {
         auto lock = WriteLockGuard(thread_safety_lock);
         auto& wrapped_swapchain_image_handles = swapchain_wrapped_image_handle_map[swapchain];
@@ -454,24 +454,24 @@ void ThreadSafety::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapch
 
 void ThreadSafety::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                     const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartWriteObject(swapchain, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(swapchain, record_obj.location);
     // Host access to swapchain must be externally synchronized
     auto lock = ReadLockGuard(thread_safety_lock);
     for (auto& image_handle : swapchain_wrapped_image_handle_map[swapchain]) {
-        StartWriteObject(image_handle, record_obj.location.function);
+        StartWriteObject(image_handle, record_obj.location);
     }
 }
 
 void ThreadSafety::PostCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain,
                                                      const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishWriteObject(swapchain, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(swapchain, record_obj.location);
     DestroyObject(swapchain);
     // Host access to swapchain must be externally synchronized
     auto lock = WriteLockGuard(thread_safety_lock);
     for (auto& image_handle : swapchain_wrapped_image_handle_map[swapchain]) {
-        FinishWriteObject(image_handle, record_obj.location.function);
+        FinishWriteObject(image_handle, record_obj.location);
         DestroyObject(image_handle);
     }
     swapchain_wrapped_image_handle_map.erase(swapchain);
@@ -479,13 +479,13 @@ void ThreadSafety::PostCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchai
 
 void ThreadSafety::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
                                               const RecordObject& record_obj) {
-    StartWriteObjectParentInstance(device, record_obj.location.function);
+    StartWriteObjectParentInstance(device, record_obj.location);
     // Host access to device must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
                                                const RecordObject& record_obj) {
-    FinishWriteObjectParentInstance(device, record_obj.location.function);
+    FinishWriteObjectParentInstance(device, record_obj.location);
     DestroyObjectParentInstance(device);
     // Host access to device must be externally synchronized
     auto lock = WriteLockGuard(thread_safety_lock);
@@ -497,12 +497,12 @@ void ThreadSafety::PostCallRecordDestroyDevice(VkDevice device, const VkAllocati
 
 void ThreadSafety::PreCallRecordGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue,
                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue,
                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
     CreateObject(*pQueue);
     auto lock = WriteLockGuard(thread_safety_lock);
     device_queues_map[device].insert(*pQueue);
@@ -510,12 +510,12 @@ void ThreadSafety::PostCallRecordGetDeviceQueue(VkDevice device, uint32_t queueF
 
 void ThreadSafety::PreCallRecordGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* pQueueInfo, VkQueue* pQueue,
                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceQueue2(VkDevice device, const VkDeviceQueueInfo2* pQueueInfo, VkQueue* pQueue,
                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
     CreateObject(*pQueue);
     auto lock = WriteLockGuard(thread_safety_lock);
     device_queues_map[device].insert(*pQueue);
@@ -587,13 +587,13 @@ void ThreadSafety::PostCallRecordGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalD
 void ThreadSafety::PreCallRecordGetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                             uint32_t* pPropertyCount, VkDisplayModePropertiesKHR* pProperties,
                                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(display, record_obj.location.function);
+    StartReadObjectParentInstance(display, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDisplayModePropertiesKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                              uint32_t* pPropertyCount, VkDisplayModePropertiesKHR* pProperties,
                                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(display, record_obj.location.function);
+    FinishReadObjectParentInstance(display, record_obj.location);
     if ((record_obj.result != VK_SUCCESS) && (record_obj.result != VK_INCOMPLETE)) return;
     if (pProperties != nullptr) {
         for (uint32_t index = 0; index < *pPropertyCount; index++) {
@@ -605,13 +605,13 @@ void ThreadSafety::PostCallRecordGetDisplayModePropertiesKHR(VkPhysicalDevice ph
 void ThreadSafety::PreCallRecordGetDisplayModeProperties2KHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                              uint32_t* pPropertyCount, VkDisplayModeProperties2KHR* pProperties,
                                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(display, record_obj.location.function);
+    StartReadObjectParentInstance(display, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDisplayModeProperties2KHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                               uint32_t* pPropertyCount, VkDisplayModeProperties2KHR* pProperties,
                                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(display, record_obj.location.function);
+    FinishReadObjectParentInstance(display, record_obj.location);
     if ((record_obj.result != VK_SUCCESS) && (record_obj.result != VK_INCOMPLETE)) return;
     if (pProperties != nullptr) {
         for (uint32_t index = 0; index < *pPropertyCount; index++) {
@@ -624,14 +624,14 @@ void ThreadSafety::PreCallRecordGetDisplayPlaneCapabilities2KHR(VkPhysicalDevice
                                                                 const VkDisplayPlaneInfo2KHR* pDisplayPlaneInfo,
                                                                 VkDisplayPlaneCapabilities2KHR* pCapabilities,
                                                                 const RecordObject& record_obj) {
-    StartWriteObject(pDisplayPlaneInfo->mode, record_obj.location.function);
+    StartWriteObject(pDisplayPlaneInfo->mode, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDisplayPlaneCapabilities2KHR(VkPhysicalDevice physicalDevice,
                                                                  const VkDisplayPlaneInfo2KHR* pDisplayPlaneInfo,
                                                                  VkDisplayPlaneCapabilities2KHR* pCapabilities,
                                                                  const RecordObject& record_obj) {
-    FinishWriteObject(pDisplayPlaneInfo->mode, record_obj.location.function);
+    FinishWriteObject(pDisplayPlaneInfo->mode, record_obj.location);
 }
 
 #ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
@@ -654,36 +654,36 @@ void ThreadSafety::PreCallRecordRegisterDisplayEventEXT(VkDevice device, VkDispl
                                                         const VkDisplayEventInfoEXT* pDisplayEventInfo,
                                                         const VkAllocationCallbacks* pAllocator, VkFence* pFence,
                                                         const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartReadObjectParentInstance(display, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObjectParentInstance(display, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display,
                                                          const VkDisplayEventInfoEXT* pDisplayEventInfo,
                                                          const VkAllocationCallbacks* pAllocator, VkFence* pFence,
                                                          const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
-    FinishReadObjectParentInstance(display, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObjectParentInstance(display, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pFence);
     }
 }
 
 void ThreadSafety::PreCallRecordDeviceWaitIdle(VkDevice device, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
     auto lock = ReadLockGuard(thread_safety_lock);
     const auto& queue_set = device_queues_map[device];
     for (const auto& queue : queue_set) {
-        StartWriteObject(queue, record_obj.location.function);
+        StartWriteObject(queue, record_obj.location);
     }
 }
 
 void ThreadSafety::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, record_obj.location.function);
+    FinishReadObjectParentInstance(device, record_obj.location);
     auto lock = ReadLockGuard(thread_safety_lock);
     const auto& queue_set = device_queues_map[device];
     for (const auto& queue : queue_set) {
-        FinishWriteObject(queue, record_obj.location.function);
+        FinishWriteObject(queue, record_obj.location);
     }
 }
 
@@ -692,9 +692,9 @@ void ThreadSafety::PreCallRecordCreateRayTracingPipelinesKHR(VkDevice device, Vk
                                                              const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
                                                              const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, record_obj.location.function);
-    StartReadObject(deferredOperation, record_obj.location.function);
-    StartReadObject(pipelineCache, record_obj.location.function);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(deferredOperation, record_obj.location);
+    StartReadObject(pipelineCache, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
@@ -703,9 +703,9 @@ void ThreadSafety::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, V
                                                               const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                               const RecordObject& record_obj) {
     auto unlock_objects = [this, device, deferredOperation, pipelineCache, record_obj]() {
-        this->FinishReadObjectParentInstance(device, record_obj.location.function);
-        this->FinishReadObject(deferredOperation, record_obj.location.function);
-        this->FinishReadObject(pipelineCache, record_obj.location.function);
+        this->FinishReadObjectParentInstance(device, record_obj.location);
+        this->FinishReadObject(deferredOperation, record_obj.location);
+        this->FinishReadObject(pipelineCache, record_obj.location);
     };
 
     auto register_objects = [this](const std::vector<VkPipeline>& pipelines) {
@@ -754,32 +754,32 @@ void ThreadSafety::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, V
 
 void ThreadSafety::PreCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
                                                 const RecordObject& record_obj) {
-    StartWriteObject(queue, record_obj.location.function);
+    StartWriteObject(queue, record_obj.location);
     uint32_t waitSemaphoreCount = pPresentInfo->waitSemaphoreCount;
     if (pPresentInfo->pWaitSemaphores != nullptr) {
         for (uint32_t index = 0; index < waitSemaphoreCount; index++) {
-            StartReadObject(pPresentInfo->pWaitSemaphores[index], record_obj.location.function);
+            StartReadObject(pPresentInfo->pWaitSemaphores[index], record_obj.location);
         }
     }
     if (pPresentInfo->pSwapchains != nullptr) {
         for (uint32_t index = 0; index < pPresentInfo->swapchainCount; ++index) {
-            StartWriteObject(pPresentInfo->pSwapchains[index], record_obj.location.function);
+            StartWriteObject(pPresentInfo->pSwapchains[index], record_obj.location);
         }
     }
 }
 
 void ThreadSafety::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
                                                  const RecordObject& record_obj) {
-    FinishWriteObject(queue, record_obj.location.function);
+    FinishWriteObject(queue, record_obj.location);
     uint32_t waitSemaphoreCount = pPresentInfo->waitSemaphoreCount;
     if (pPresentInfo->pWaitSemaphores != nullptr) {
         for (uint32_t index = 0; index < waitSemaphoreCount; index++) {
-            FinishReadObject(pPresentInfo->pWaitSemaphores[index], record_obj.location.function);
+            FinishReadObject(pPresentInfo->pWaitSemaphores[index], record_obj.location);
         }
     }
     if (pPresentInfo->pSwapchains != nullptr) {
         for (uint32_t index = 0; index < pPresentInfo->swapchainCount; ++index) {
-            FinishWriteObject(pPresentInfo->pSwapchains[index], record_obj.location.function);
+            FinishWriteObject(pPresentInfo->pSwapchains[index], record_obj.location);
         }
     }
 }

--- a/layers/vulkan/generated/thread_safety.cpp
+++ b/layers/vulkan/generated/thread_safety.cpp
@@ -37,14 +37,14 @@ void ThreadSafety::PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCre
 
 void ThreadSafety::PreCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator,
                                                 const RecordObject& record_obj) {
-    StartWriteObjectParentInstance(instance, vvl::Func::vkDestroyInstance);
+    StartWriteObjectParentInstance(instance, record_obj.location);
     // Host access to instance must be externally synchronized
     // all sname:VkPhysicalDevice objects enumerated from pname:instance must be externally synchronized between host accesses
 }
 
 void ThreadSafety::PostCallRecordDestroyInstance(VkInstance instance, const VkAllocationCallbacks* pAllocator,
                                                  const RecordObject& record_obj) {
-    FinishWriteObjectParentInstance(instance, vvl::Func::vkDestroyInstance);
+    FinishWriteObjectParentInstance(instance, record_obj.location);
     DestroyObjectParentInstance(instance);
     // Host access to instance must be externally synchronized
     // all sname:VkPhysicalDevice objects enumerated from pname:instance must be externally synchronized between host accesses
@@ -52,28 +52,28 @@ void ThreadSafety::PostCallRecordDestroyInstance(VkInstance instance, const VkAl
 
 void ThreadSafety::PreCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
                                                          VkPhysicalDevice* pPhysicalDevices, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkEnumeratePhysicalDevices);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
                                                           VkPhysicalDevice* pPhysicalDevices, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkEnumeratePhysicalDevices);
+    FinishReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetInstanceProcAddr(VkInstance instance, const char* pName, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkGetInstanceProcAddr);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetInstanceProcAddr(VkInstance instance, const char* pName, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkGetInstanceProcAddr);
+    FinishReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceProcAddr(VkDevice device, const char* pName, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceProcAddr);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceProcAddr(VkDevice device, const char* pName, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceProcAddr);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
@@ -90,40 +90,40 @@ void ThreadSafety::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, c
 
 void ThreadSafety::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                             const RecordObject& record_obj) {
-    StartWriteObject(queue, vvl::Func::vkQueueSubmit);
-    StartWriteObject(fence, vvl::Func::vkQueueSubmit);
+    StartWriteObject(queue, record_obj.location);
+    StartWriteObject(fence, record_obj.location);
     // Host access to queue must be externally synchronized
     // Host access to fence must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                              const RecordObject& record_obj) {
-    FinishWriteObject(queue, vvl::Func::vkQueueSubmit);
-    FinishWriteObject(fence, vvl::Func::vkQueueSubmit);
+    FinishWriteObject(queue, record_obj.location);
+    FinishWriteObject(fence, record_obj.location);
     // Host access to queue must be externally synchronized
     // Host access to fence must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordQueueWaitIdle(VkQueue queue, const RecordObject& record_obj) {
-    StartWriteObject(queue, vvl::Func::vkQueueWaitIdle);
+    StartWriteObject(queue, record_obj.location);
     // Host access to queue must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject& record_obj) {
-    FinishWriteObject(queue, vvl::Func::vkQueueWaitIdle);
+    FinishWriteObject(queue, record_obj.location);
     // Host access to queue must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                                const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkAllocateMemory);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkAllocateMemory);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pMemory);
     }
@@ -131,167 +131,167 @@ void ThreadSafety::PostCallRecordAllocateMemory(VkDevice device, const VkMemoryA
 
 void ThreadSafety::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator,
                                            const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkFreeMemory);
-    StartWriteObject(memory, vvl::Func::vkFreeMemory);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(memory, record_obj.location);
     // Host access to memory must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks* pAllocator,
                                             const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkFreeMemory);
-    FinishWriteObject(memory, vvl::Func::vkFreeMemory);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(memory, record_obj.location);
     DestroyObject(memory);
     // Host access to memory must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size,
                                           VkMemoryMapFlags flags, void** ppData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkMapMemory);
-    StartWriteObject(memory, vvl::Func::vkMapMemory);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(memory, record_obj.location);
     // Host access to memory must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size,
                                            VkMemoryMapFlags flags, void** ppData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkMapMemory);
-    FinishWriteObject(memory, vvl::Func::vkMapMemory);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(memory, record_obj.location);
     // Host access to memory must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordUnmapMemory(VkDevice device, VkDeviceMemory memory, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkUnmapMemory);
-    StartWriteObject(memory, vvl::Func::vkUnmapMemory);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(memory, record_obj.location);
     // Host access to memory must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordUnmapMemory(VkDevice device, VkDeviceMemory memory, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkUnmapMemory);
-    FinishWriteObject(memory, vvl::Func::vkUnmapMemory);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(memory, record_obj.location);
     // Host access to memory must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                         const VkMappedMemoryRange* pMemoryRanges, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkFlushMappedMemoryRanges);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                          const VkMappedMemoryRange* pMemoryRanges, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkFlushMappedMemoryRanges);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                              const VkMappedMemoryRange* pMemoryRanges,
                                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkInvalidateMappedMemoryRanges);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                               const VkMappedMemoryRange* pMemoryRanges,
                                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkInvalidateMappedMemoryRanges);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory memory,
                                                           VkDeviceSize* pCommittedMemoryInBytes, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceMemoryCommitment);
-    StartReadObject(memory, vvl::Func::vkGetDeviceMemoryCommitment);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(memory, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory memory,
                                                            VkDeviceSize* pCommittedMemoryInBytes, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceMemoryCommitment);
-    FinishReadObject(memory, vvl::Func::vkGetDeviceMemoryCommitment);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(memory, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBindBufferMemory);
-    StartWriteObject(buffer, vvl::Func::vkBindBufferMemory);
-    StartReadObject(memory, vvl::Func::vkBindBufferMemory);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(buffer, record_obj.location);
+    StartReadObject(memory, record_obj.location);
     // Host access to buffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
                                                   VkDeviceSize memoryOffset, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBindBufferMemory);
-    FinishWriteObject(buffer, vvl::Func::vkBindBufferMemory);
-    FinishReadObject(memory, vvl::Func::vkBindBufferMemory);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(buffer, record_obj.location);
+    FinishReadObject(memory, record_obj.location);
     // Host access to buffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBindImageMemory);
-    StartWriteObject(image, vvl::Func::vkBindImageMemory);
-    StartReadObject(memory, vvl::Func::vkBindImageMemory);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(image, record_obj.location);
+    StartReadObject(memory, record_obj.location);
     // Host access to image must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBindImageMemory);
-    FinishWriteObject(image, vvl::Func::vkBindImageMemory);
-    FinishReadObject(memory, vvl::Func::vkBindImageMemory);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(image, record_obj.location);
+    FinishReadObject(memory, record_obj.location);
     // Host access to image must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetBufferMemoryRequirements(VkDevice device, VkBuffer buffer,
                                                             VkMemoryRequirements* pMemoryRequirements,
                                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetBufferMemoryRequirements);
-    StartReadObject(buffer, vvl::Func::vkGetBufferMemoryRequirements);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetBufferMemoryRequirements(VkDevice device, VkBuffer buffer,
                                                              VkMemoryRequirements* pMemoryRequirements,
                                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetBufferMemoryRequirements);
-    FinishReadObject(buffer, vvl::Func::vkGetBufferMemoryRequirements);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageMemoryRequirements(VkDevice device, VkImage image,
                                                            VkMemoryRequirements* pMemoryRequirements,
                                                            const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageMemoryRequirements);
-    StartReadObject(image, vvl::Func::vkGetImageMemoryRequirements);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageMemoryRequirements(VkDevice device, VkImage image,
                                                             VkMemoryRequirements* pMemoryRequirements,
                                                             const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageMemoryRequirements);
-    FinishReadObject(image, vvl::Func::vkGetImageMemoryRequirements);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageSparseMemoryRequirements(VkDevice device, VkImage image,
                                                                  uint32_t* pSparseMemoryRequirementCount,
                                                                  VkSparseImageMemoryRequirements* pSparseMemoryRequirements,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageSparseMemoryRequirements);
-    StartReadObject(image, vvl::Func::vkGetImageSparseMemoryRequirements);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageSparseMemoryRequirements(VkDevice device, VkImage image,
                                                                   uint32_t* pSparseMemoryRequirementCount,
                                                                   VkSparseImageMemoryRequirements* pSparseMemoryRequirements,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageSparseMemoryRequirements);
-    FinishReadObject(image, vvl::Func::vkGetImageSparseMemoryRequirements);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
                                                 VkFence fence, const RecordObject& record_obj) {
-    StartWriteObject(queue, vvl::Func::vkQueueBindSparse);
-    StartWriteObject(fence, vvl::Func::vkQueueBindSparse);
+    StartWriteObject(queue, record_obj.location);
+    StartWriteObject(fence, record_obj.location);
     // Host access to queue must be externally synchronized
     // Host access to fence must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
                                                  VkFence fence, const RecordObject& record_obj) {
-    FinishWriteObject(queue, vvl::Func::vkQueueBindSparse);
-    FinishWriteObject(fence, vvl::Func::vkQueueBindSparse);
+    FinishWriteObject(queue, record_obj.location);
+    FinishWriteObject(fence, record_obj.location);
     // Host access to queue must be externally synchronized
     // Host access to fence must be externally synchronized
 }
@@ -299,13 +299,13 @@ void ThreadSafety::PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInf
 void ThreadSafety::PreCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo,
                                             const VkAllocationCallbacks* pAllocator, VkFence* pFence,
                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateFence);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo,
                                              const VkAllocationCallbacks* pAllocator, VkFence* pFence,
                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateFence);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pFence);
     }
@@ -313,26 +313,26 @@ void ThreadSafety::PostCallRecordCreateFence(VkDevice device, const VkFenceCreat
 
 void ThreadSafety::PreCallRecordDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks* pAllocator,
                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyFence);
-    StartWriteObject(fence, vvl::Func::vkDestroyFence);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(fence, record_obj.location);
     // Host access to fence must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyFence(VkDevice device, VkFence fence, const VkAllocationCallbacks* pAllocator,
                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyFence);
-    FinishWriteObject(fence, vvl::Func::vkDestroyFence);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(fence, record_obj.location);
     DestroyObject(fence);
     // Host access to fence must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordResetFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences,
                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkResetFences);
+    StartReadObjectParentInstance(device, record_obj.location);
 
     if (pFences) {
         for (uint32_t index = 0; index < fenceCount; index++) {
-            StartWriteObject(pFences[index], vvl::Func::vkResetFences);
+            StartWriteObject(pFences[index], record_obj.location);
         }
     }
     // Host access to each member of pFences must be externally synchronized
@@ -340,44 +340,44 @@ void ThreadSafety::PreCallRecordResetFences(VkDevice device, uint32_t fenceCount
 
 void ThreadSafety::PostCallRecordResetFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences,
                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkResetFences);
+    FinishReadObjectParentInstance(device, record_obj.location);
 
     if (pFences) {
         for (uint32_t index = 0; index < fenceCount; index++) {
-            FinishWriteObject(pFences[index], vvl::Func::vkResetFences);
+            FinishWriteObject(pFences[index], record_obj.location);
         }
     }
     // Host access to each member of pFences must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetFenceStatus(VkDevice device, VkFence fence, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetFenceStatus);
-    StartReadObject(fence, vvl::Func::vkGetFenceStatus);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(fence, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetFenceStatus);
-    FinishReadObject(fence, vvl::Func::vkGetFenceStatus);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(fence, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll,
                                               uint64_t timeout, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkWaitForFences);
+    StartReadObjectParentInstance(device, record_obj.location);
 
     if (pFences) {
         for (uint32_t index = 0; index < fenceCount; index++) {
-            StartReadObject(pFences[index], vvl::Func::vkWaitForFences);
+            StartReadObject(pFences[index], record_obj.location);
         }
     }
 }
 
 void ThreadSafety::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll,
                                                uint64_t timeout, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkWaitForFences);
+    FinishReadObjectParentInstance(device, record_obj.location);
 
     if (pFences) {
         for (uint32_t index = 0; index < fenceCount; index++) {
-            FinishReadObject(pFences[index], vvl::Func::vkWaitForFences);
+            FinishReadObject(pFences[index], record_obj.location);
         }
     }
 }
@@ -385,13 +385,13 @@ void ThreadSafety::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCo
 void ThreadSafety::PreCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateSemaphore);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
                                                  const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateSemaphore);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pSemaphore);
     }
@@ -399,15 +399,15 @@ void ThreadSafety::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaph
 
 void ThreadSafety::PreCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroySemaphore);
-    StartWriteObject(semaphore, vvl::Func::vkDestroySemaphore);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(semaphore, record_obj.location);
     // Host access to semaphore must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroySemaphore(VkDevice device, VkSemaphore semaphore, const VkAllocationCallbacks* pAllocator,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroySemaphore);
-    FinishWriteObject(semaphore, vvl::Func::vkDestroySemaphore);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(semaphore, record_obj.location);
     DestroyObject(semaphore);
     // Host access to semaphore must be externally synchronized
 }
@@ -415,13 +415,13 @@ void ThreadSafety::PostCallRecordDestroySemaphore(VkDevice device, VkSemaphore s
 void ThreadSafety::PreCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo,
                                             const VkAllocationCallbacks* pAllocator, VkEvent* pEvent,
                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateEvent);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo,
                                              const VkAllocationCallbacks* pAllocator, VkEvent* pEvent,
                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateEvent);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pEvent);
     }
@@ -429,63 +429,63 @@ void ThreadSafety::PostCallRecordCreateEvent(VkDevice device, const VkEventCreat
 
 void ThreadSafety::PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator,
                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyEvent);
-    StartWriteObject(event, vvl::Func::vkDestroyEvent);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(event, record_obj.location);
     // Host access to event must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator,
                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyEvent);
-    FinishWriteObject(event, vvl::Func::vkDestroyEvent);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(event, record_obj.location);
     DestroyObject(event);
     // Host access to event must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetEventStatus(VkDevice device, VkEvent event, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetEventStatus);
-    StartReadObject(event, vvl::Func::vkGetEventStatus);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(event, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetEventStatus(VkDevice device, VkEvent event, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetEventStatus);
-    FinishReadObject(event, vvl::Func::vkGetEventStatus);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(event, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordSetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSetEvent);
-    StartWriteObject(event, vvl::Func::vkSetEvent);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(event, record_obj.location);
     // Host access to event must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordSetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSetEvent);
-    FinishWriteObject(event, vvl::Func::vkSetEvent);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(event, record_obj.location);
     // Host access to event must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordResetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkResetEvent);
-    StartWriteObject(event, vvl::Func::vkResetEvent);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(event, record_obj.location);
     // Host access to event must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordResetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkResetEvent);
-    FinishWriteObject(event, vvl::Func::vkResetEvent);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(event, record_obj.location);
     // Host access to event must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool,
                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateQueryPool);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
                                                  const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool,
                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateQueryPool);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pQueryPool);
     }
@@ -493,15 +493,15 @@ void ThreadSafety::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryP
 
 void ThreadSafety::PreCallRecordDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks* pAllocator,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyQueryPool);
-    StartWriteObject(queryPool, vvl::Func::vkDestroyQueryPool);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(queryPool, record_obj.location);
     // Host access to queryPool must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks* pAllocator,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyQueryPool);
-    FinishWriteObject(queryPool, vvl::Func::vkDestroyQueryPool);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(queryPool, record_obj.location);
     DestroyObject(queryPool);
     // Host access to queryPool must be externally synchronized
 }
@@ -509,27 +509,27 @@ void ThreadSafety::PostCallRecordDestroyQueryPool(VkDevice device, VkQueryPool q
 void ThreadSafety::PreCallRecordGetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery,
                                                     uint32_t queryCount, size_t dataSize, void* pData, VkDeviceSize stride,
                                                     VkQueryResultFlags flags, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetQueryPoolResults);
-    StartReadObject(queryPool, vvl::Func::vkGetQueryPoolResults);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery,
                                                      uint32_t queryCount, size_t dataSize, void* pData, VkDeviceSize stride,
                                                      VkQueryResultFlags flags, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetQueryPoolResults);
-    FinishReadObject(queryPool, vvl::Func::vkGetQueryPoolResults);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
                                              const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,
                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateBuffer);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
                                               const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,
                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateBuffer);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pBuffer);
     }
@@ -537,15 +537,15 @@ void ThreadSafety::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCre
 
 void ThreadSafety::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator,
                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyBuffer);
-    StartWriteObject(buffer, vvl::Func::vkDestroyBuffer);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(buffer, record_obj.location);
     // Host access to buffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator,
                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyBuffer);
-    FinishWriteObject(buffer, vvl::Func::vkDestroyBuffer);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(buffer, record_obj.location);
     DestroyObject(buffer);
     // Host access to buffer must be externally synchronized
 }
@@ -553,13 +553,13 @@ void ThreadSafety::PostCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer,
 void ThreadSafety::PreCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
                                                  const VkAllocationCallbacks* pAllocator, VkBufferView* pView,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateBufferView);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkBufferView* pView,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateBufferView);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pView);
     }
@@ -567,15 +567,15 @@ void ThreadSafety::PostCallRecordCreateBufferView(VkDevice device, const VkBuffe
 
 void ThreadSafety::PreCallRecordDestroyBufferView(VkDevice device, VkBufferView bufferView, const VkAllocationCallbacks* pAllocator,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyBufferView);
-    StartWriteObject(bufferView, vvl::Func::vkDestroyBufferView);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(bufferView, record_obj.location);
     // Host access to bufferView must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyBufferView(VkDevice device, VkBufferView bufferView,
                                                    const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyBufferView);
-    FinishWriteObject(bufferView, vvl::Func::vkDestroyBufferView);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(bufferView, record_obj.location);
     DestroyObject(bufferView);
     // Host access to bufferView must be externally synchronized
 }
@@ -583,13 +583,13 @@ void ThreadSafety::PostCallRecordDestroyBufferView(VkDevice device, VkBufferView
 void ThreadSafety::PreCallRecordCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
                                             const VkAllocationCallbacks* pAllocator, VkImage* pImage,
                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateImage);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
                                              const VkAllocationCallbacks* pAllocator, VkImage* pImage,
                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateImage);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pImage);
     }
@@ -597,41 +597,41 @@ void ThreadSafety::PostCallRecordCreateImage(VkDevice device, const VkImageCreat
 
 void ThreadSafety::PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator,
                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyImage);
-    StartWriteObject(image, vvl::Func::vkDestroyImage);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(image, record_obj.location);
     // Host access to image must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator,
                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyImage);
-    FinishWriteObject(image, vvl::Func::vkDestroyImage);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(image, record_obj.location);
     DestroyObject(image);
     // Host access to image must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetImageSubresourceLayout(VkDevice device, VkImage image, const VkImageSubresource* pSubresource,
                                                           VkSubresourceLayout* pLayout, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageSubresourceLayout);
-    StartReadObject(image, vvl::Func::vkGetImageSubresourceLayout);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageSubresourceLayout(VkDevice device, VkImage image, const VkImageSubresource* pSubresource,
                                                            VkSubresourceLayout* pLayout, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageSubresourceLayout);
-    FinishReadObject(image, vvl::Func::vkGetImageSubresourceLayout);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkImageView* pView,
                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateImageView);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
                                                  const VkAllocationCallbacks* pAllocator, VkImageView* pView,
                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateImageView);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pView);
     }
@@ -639,15 +639,15 @@ void ThreadSafety::PostCallRecordCreateImageView(VkDevice device, const VkImageV
 
 void ThreadSafety::PreCallRecordDestroyImageView(VkDevice device, VkImageView imageView, const VkAllocationCallbacks* pAllocator,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyImageView);
-    StartWriteObject(imageView, vvl::Func::vkDestroyImageView);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(imageView, record_obj.location);
     // Host access to imageView must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyImageView(VkDevice device, VkImageView imageView, const VkAllocationCallbacks* pAllocator,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyImageView);
-    FinishWriteObject(imageView, vvl::Func::vkDestroyImageView);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(imageView, record_obj.location);
     DestroyObject(imageView);
     // Host access to imageView must be externally synchronized
 }
@@ -655,13 +655,13 @@ void ThreadSafety::PostCallRecordDestroyImageView(VkDevice device, VkImageView i
 void ThreadSafety::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateShaderModule);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateShaderModule);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pShaderModule);
     }
@@ -669,15 +669,15 @@ void ThreadSafety::PostCallRecordCreateShaderModule(VkDevice device, const VkSha
 
 void ThreadSafety::PreCallRecordDestroyShaderModule(VkDevice device, VkShaderModule shaderModule,
                                                     const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyShaderModule);
-    StartWriteObject(shaderModule, vvl::Func::vkDestroyShaderModule);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(shaderModule, record_obj.location);
     // Host access to shaderModule must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyShaderModule(VkDevice device, VkShaderModule shaderModule,
                                                      const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyShaderModule);
-    FinishWriteObject(shaderModule, vvl::Func::vkDestroyShaderModule);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(shaderModule, record_obj.location);
     DestroyObject(shaderModule);
     // Host access to shaderModule must be externally synchronized
 }
@@ -685,13 +685,13 @@ void ThreadSafety::PostCallRecordDestroyShaderModule(VkDevice device, VkShaderMo
 void ThreadSafety::PreCallRecordCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkPipelineCache* pPipelineCache,
                                                     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreatePipelineCache);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkPipelineCache* pPipelineCache,
                                                      const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreatePipelineCache);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pPipelineCache);
     }
@@ -699,39 +699,39 @@ void ThreadSafety::PostCallRecordCreatePipelineCache(VkDevice device, const VkPi
 
 void ThreadSafety::PreCallRecordDestroyPipelineCache(VkDevice device, VkPipelineCache pipelineCache,
                                                      const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyPipelineCache);
-    StartWriteObject(pipelineCache, vvl::Func::vkDestroyPipelineCache);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(pipelineCache, record_obj.location);
     // Host access to pipelineCache must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyPipelineCache(VkDevice device, VkPipelineCache pipelineCache,
                                                       const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyPipelineCache);
-    FinishWriteObject(pipelineCache, vvl::Func::vkDestroyPipelineCache);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(pipelineCache, record_obj.location);
     DestroyObject(pipelineCache);
     // Host access to pipelineCache must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache, size_t* pDataSize, void* pData,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPipelineCacheData);
-    StartReadObject(pipelineCache, vvl::Func::vkGetPipelineCacheData);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipelineCache, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache, size_t* pDataSize,
                                                       void* pData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPipelineCacheData);
-    FinishReadObject(pipelineCache, vvl::Func::vkGetPipelineCacheData);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipelineCache, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordMergePipelineCaches(VkDevice device, VkPipelineCache dstCache, uint32_t srcCacheCount,
                                                     const VkPipelineCache* pSrcCaches, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkMergePipelineCaches);
-    StartWriteObject(dstCache, vvl::Func::vkMergePipelineCaches);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(dstCache, record_obj.location);
 
     if (pSrcCaches) {
         for (uint32_t index = 0; index < srcCacheCount; index++) {
-            StartReadObject(pSrcCaches[index], vvl::Func::vkMergePipelineCaches);
+            StartReadObject(pSrcCaches[index], record_obj.location);
         }
     }
     // Host access to dstCache must be externally synchronized
@@ -739,12 +739,12 @@ void ThreadSafety::PreCallRecordMergePipelineCaches(VkDevice device, VkPipelineC
 
 void ThreadSafety::PostCallRecordMergePipelineCaches(VkDevice device, VkPipelineCache dstCache, uint32_t srcCacheCount,
                                                      const VkPipelineCache* pSrcCaches, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkMergePipelineCaches);
-    FinishWriteObject(dstCache, vvl::Func::vkMergePipelineCaches);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(dstCache, record_obj.location);
 
     if (pSrcCaches) {
         for (uint32_t index = 0; index < srcCacheCount; index++) {
-            FinishReadObject(pSrcCaches[index], vvl::Func::vkMergePipelineCaches);
+            FinishReadObject(pSrcCaches[index], record_obj.location);
         }
     }
     // Host access to dstCache must be externally synchronized
@@ -754,16 +754,16 @@ void ThreadSafety::PreCallRecordCreateGraphicsPipelines(VkDevice device, VkPipel
                                                         const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                         const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                         const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateGraphicsPipelines);
-    StartReadObject(pipelineCache, vvl::Func::vkCreateGraphicsPipelines);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipelineCache, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                          const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                          const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                          const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateGraphicsPipelines);
-    FinishReadObject(pipelineCache, vvl::Func::vkCreateGraphicsPipelines);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipelineCache, record_obj.location);
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
             if (!pPipelines[index]) continue;
@@ -776,16 +776,16 @@ void ThreadSafety::PreCallRecordCreateComputePipelines(VkDevice device, VkPipeli
                                                        const VkComputePipelineCreateInfo* pCreateInfos,
                                                        const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateComputePipelines);
-    StartReadObject(pipelineCache, vvl::Func::vkCreateComputePipelines);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipelineCache, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                         const VkComputePipelineCreateInfo* pCreateInfos,
                                                         const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateComputePipelines);
-    FinishReadObject(pipelineCache, vvl::Func::vkCreateComputePipelines);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipelineCache, record_obj.location);
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
             if (!pPipelines[index]) continue;
@@ -796,15 +796,15 @@ void ThreadSafety::PostCallRecordCreateComputePipelines(VkDevice device, VkPipel
 
 void ThreadSafety::PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks* pAllocator,
                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyPipeline);
-    StartWriteObject(pipeline, vvl::Func::vkDestroyPipeline);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(pipeline, record_obj.location);
     // Host access to pipeline must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks* pAllocator,
                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyPipeline);
-    FinishWriteObject(pipeline, vvl::Func::vkDestroyPipeline);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(pipeline, record_obj.location);
     DestroyObject(pipeline);
     // Host access to pipeline must be externally synchronized
 }
@@ -812,13 +812,13 @@ void ThreadSafety::PostCallRecordDestroyPipeline(VkDevice device, VkPipeline pip
 void ThreadSafety::PreCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreatePipelineLayout);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreatePipelineLayout);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pPipelineLayout);
     }
@@ -826,15 +826,15 @@ void ThreadSafety::PostCallRecordCreatePipelineLayout(VkDevice device, const VkP
 
 void ThreadSafety::PreCallRecordDestroyPipelineLayout(VkDevice device, VkPipelineLayout pipelineLayout,
                                                       const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyPipelineLayout);
-    StartWriteObject(pipelineLayout, vvl::Func::vkDestroyPipelineLayout);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(pipelineLayout, record_obj.location);
     // Host access to pipelineLayout must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyPipelineLayout(VkDevice device, VkPipelineLayout pipelineLayout,
                                                        const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyPipelineLayout);
-    FinishWriteObject(pipelineLayout, vvl::Func::vkDestroyPipelineLayout);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(pipelineLayout, record_obj.location);
     DestroyObject(pipelineLayout);
     // Host access to pipelineLayout must be externally synchronized
 }
@@ -842,13 +842,13 @@ void ThreadSafety::PostCallRecordDestroyPipelineLayout(VkDevice device, VkPipeli
 void ThreadSafety::PreCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
                                               const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateSampler);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
                                                const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateSampler);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pSampler);
     }
@@ -856,15 +856,15 @@ void ThreadSafety::PostCallRecordCreateSampler(VkDevice device, const VkSamplerC
 
 void ThreadSafety::PreCallRecordDestroySampler(VkDevice device, VkSampler sampler, const VkAllocationCallbacks* pAllocator,
                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroySampler);
-    StartWriteObject(sampler, vvl::Func::vkDestroySampler);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(sampler, record_obj.location);
     // Host access to sampler must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroySampler(VkDevice device, VkSampler sampler, const VkAllocationCallbacks* pAllocator,
                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroySampler);
-    FinishWriteObject(sampler, vvl::Func::vkDestroySampler);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(sampler, record_obj.location);
     DestroyObject(sampler);
     // Host access to sampler must be externally synchronized
 }
@@ -872,16 +872,16 @@ void ThreadSafety::PostCallRecordDestroySampler(VkDevice device, VkSampler sampl
 void ThreadSafety::PreCallRecordDestroyDescriptorSetLayout(VkDevice device, VkDescriptorSetLayout descriptorSetLayout,
                                                            const VkAllocationCallbacks* pAllocator,
                                                            const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyDescriptorSetLayout);
-    StartWriteObject(descriptorSetLayout, vvl::Func::vkDestroyDescriptorSetLayout);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(descriptorSetLayout, record_obj.location);
     // Host access to descriptorSetLayout must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyDescriptorSetLayout(VkDevice device, VkDescriptorSetLayout descriptorSetLayout,
                                                             const VkAllocationCallbacks* pAllocator,
                                                             const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyDescriptorSetLayout);
-    FinishWriteObject(descriptorSetLayout, vvl::Func::vkDestroyDescriptorSetLayout);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(descriptorSetLayout, record_obj.location);
     DestroyObject(descriptorSetLayout);
     // Host access to descriptorSetLayout must be externally synchronized
 }
@@ -889,13 +889,13 @@ void ThreadSafety::PostCallRecordDestroyDescriptorSetLayout(VkDevice device, VkD
 void ThreadSafety::PreCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkDescriptorPool* pDescriptorPool,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateDescriptorPool);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkDescriptorPool* pDescriptorPool,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateDescriptorPool);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pDescriptorPool);
     }
@@ -904,13 +904,13 @@ void ThreadSafety::PostCallRecordCreateDescriptorPool(VkDevice device, const VkD
 void ThreadSafety::PreCallRecordCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateFramebuffer);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateFramebuffer);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pFramebuffer);
     }
@@ -918,15 +918,15 @@ void ThreadSafety::PostCallRecordCreateFramebuffer(VkDevice device, const VkFram
 
 void ThreadSafety::PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer,
                                                    const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyFramebuffer);
-    StartWriteObject(framebuffer, vvl::Func::vkDestroyFramebuffer);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(framebuffer, record_obj.location);
     // Host access to framebuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer,
                                                     const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyFramebuffer);
-    FinishWriteObject(framebuffer, vvl::Func::vkDestroyFramebuffer);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(framebuffer, record_obj.location);
     DestroyObject(framebuffer);
     // Host access to framebuffer must be externally synchronized
 }
@@ -934,13 +934,13 @@ void ThreadSafety::PostCallRecordDestroyFramebuffer(VkDevice device, VkFramebuff
 void ThreadSafety::PreCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
                                                  const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateRenderPass);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateRenderPass);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pRenderPass);
     }
@@ -948,188 +948,188 @@ void ThreadSafety::PostCallRecordCreateRenderPass(VkDevice device, const VkRende
 
 void ThreadSafety::PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyRenderPass);
-    StartWriteObject(renderPass, vvl::Func::vkDestroyRenderPass);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(renderPass, record_obj.location);
     // Host access to renderPass must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass,
                                                    const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyRenderPass);
-    FinishWriteObject(renderPass, vvl::Func::vkDestroyRenderPass);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(renderPass, record_obj.location);
     DestroyObject(renderPass);
     // Host access to renderPass must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetRenderAreaGranularity(VkDevice device, VkRenderPass renderPass, VkExtent2D* pGranularity,
                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetRenderAreaGranularity);
-    StartReadObject(renderPass, vvl::Func::vkGetRenderAreaGranularity);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(renderPass, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetRenderAreaGranularity(VkDevice device, VkRenderPass renderPass, VkExtent2D* pGranularity,
                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetRenderAreaGranularity);
-    FinishReadObject(renderPass, vvl::Func::vkGetRenderAreaGranularity);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(renderPass, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkBeginCommandBuffer);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
     // the sname:VkCommandPool that pname:commandBuffer was allocated from must be externally synchronized between host accesses
 }
 
 void ThreadSafety::PostCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkBeginCommandBuffer);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
     // the sname:VkCommandPool that pname:commandBuffer was allocated from must be externally synchronized between host accesses
 }
 
 void ThreadSafety::PreCallRecordEndCommandBuffer(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkEndCommandBuffer);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
     // the sname:VkCommandPool that pname:commandBuffer was allocated from must be externally synchronized between host accesses
 }
 
 void ThreadSafety::PostCallRecordEndCommandBuffer(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkEndCommandBuffer);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
     // the sname:VkCommandPool that pname:commandBuffer was allocated from must be externally synchronized between host accesses
 }
 
 void ThreadSafety::PreCallRecordResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags,
                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkResetCommandBuffer);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
     // the sname:VkCommandPool that pname:commandBuffer was allocated from must be externally synchronized between host accesses
 }
 
 void ThreadSafety::PostCallRecordResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags,
                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkResetCommandBuffer);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
     // the sname:VkCommandPool that pname:commandBuffer was allocated from must be externally synchronized between host accesses
 }
 
 void ThreadSafety::PreCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                 VkPipeline pipeline, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindPipeline);
-    StartReadObject(pipeline, vvl::Func::vkCmdBindPipeline);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(pipeline, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                  VkPipeline pipeline, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindPipeline);
-    FinishReadObject(pipeline, vvl::Func::vkCmdBindPipeline);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(pipeline, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                                const VkViewport* pViewports, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetViewport);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetViewport(VkCommandBuffer commandBuffer, uint32_t firstViewport, uint32_t viewportCount,
                                                 const VkViewport* pViewports, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetViewport);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t firstScissor, uint32_t scissorCount,
                                               const VkRect2D* pScissors, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetScissor);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetScissor(VkCommandBuffer commandBuffer, uint32_t firstScissor, uint32_t scissorCount,
                                                const VkRect2D* pScissors, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetScissor);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetLineWidth);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetLineWidth(VkCommandBuffer commandBuffer, float lineWidth, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetLineWidth);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor, float depthBiasClamp,
                                                 float depthBiasSlopeFactor, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBias);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthBias(VkCommandBuffer commandBuffer, float depthBiasConstantFactor, float depthBiasClamp,
                                                  float depthBiasSlopeFactor, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBias);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4],
                                                      const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetBlendConstants);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetBlendConstants(VkCommandBuffer commandBuffer, const float blendConstants[4],
                                                       const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetBlendConstants);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthBounds(VkCommandBuffer commandBuffer, float minDepthBounds, float maxDepthBounds,
                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBounds);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthBounds(VkCommandBuffer commandBuffer, float minDepthBounds, float maxDepthBounds,
                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBounds);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetStencilCompareMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                          uint32_t compareMask, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilCompareMask);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetStencilCompareMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                           uint32_t compareMask, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilCompareMask);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                        uint32_t writeMask, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilWriteMask);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetStencilWriteMask(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                         uint32_t writeMask, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilWriteMask);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                        uint32_t reference, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilReference);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask,
                                                         uint32_t reference, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilReference);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -1137,12 +1137,12 @@ void ThreadSafety::PreCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuf
                                                       VkPipelineLayout layout, uint32_t firstSet, uint32_t descriptorSetCount,
                                                       const VkDescriptorSet* pDescriptorSets, uint32_t dynamicOffsetCount,
                                                       const uint32_t* pDynamicOffsets, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindDescriptorSets);
-    StartReadObject(layout, vvl::Func::vkCmdBindDescriptorSets);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(layout, record_obj.location);
 
     if (pDescriptorSets) {
         for (uint32_t index = 0; index < descriptorSetCount; index++) {
-            StartReadObject(pDescriptorSets[index], vvl::Func::vkCmdBindDescriptorSets);
+            StartReadObject(pDescriptorSets[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -1152,12 +1152,12 @@ void ThreadSafety::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBu
                                                        VkPipelineLayout layout, uint32_t firstSet, uint32_t descriptorSetCount,
                                                        const VkDescriptorSet* pDescriptorSets, uint32_t dynamicOffsetCount,
                                                        const uint32_t* pDynamicOffsets, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindDescriptorSets);
-    FinishReadObject(layout, vvl::Func::vkCmdBindDescriptorSets);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(layout, record_obj.location);
 
     if (pDescriptorSets) {
         for (uint32_t index = 0; index < descriptorSetCount; index++) {
-            FinishReadObject(pDescriptorSets[index], vvl::Func::vkCmdBindDescriptorSets);
+            FinishReadObject(pDescriptorSets[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -1165,26 +1165,26 @@ void ThreadSafety::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBu
 
 void ThreadSafety::PreCallRecordCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                    VkIndexType indexType, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindIndexBuffer);
-    StartReadObject(buffer, vvl::Func::vkCmdBindIndexBuffer);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                     VkIndexType indexType, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindIndexBuffer);
-    FinishReadObject(buffer, vvl::Func::vkCmdBindIndexBuffer);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
                                                      const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
                                                      const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindVertexBuffers);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pBuffers) {
         for (uint32_t index = 0; index < bindingCount; index++) {
-            StartReadObject(pBuffers[index], vvl::Func::vkCmdBindVertexBuffers);
+            StartReadObject(pBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -1193,11 +1193,11 @@ void ThreadSafety::PreCallRecordCmdBindVertexBuffers(VkCommandBuffer commandBuff
 void ThreadSafety::PostCallRecordCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
                                                       const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
                                                       const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindVertexBuffers);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pBuffers) {
         for (uint32_t index = 0; index < bindingCount; index++) {
-            FinishReadObject(pBuffers[index], vvl::Func::vkCmdBindVertexBuffers);
+            FinishReadObject(pBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -1205,289 +1205,289 @@ void ThreadSafety::PostCallRecordCmdBindVertexBuffers(VkCommandBuffer commandBuf
 
 void ThreadSafety::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                                         uint32_t firstVertex, uint32_t firstInstance, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDraw);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                                          uint32_t firstVertex, uint32_t firstInstance, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDraw);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                                uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndexed);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                                 uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndexed);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                 uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndirect);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawIndirect);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                  uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndirect);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawIndirect);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                        uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndexedIndirect);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawIndexedIndirect);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                         uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndexedIndirect);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawIndexedIndirect);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                             uint32_t groupCountZ, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDispatch);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                              uint32_t groupCountZ, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDispatch);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                     const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDispatchIndirect);
-    StartReadObject(buffer, vvl::Func::vkCmdDispatchIndirect);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                      const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDispatchIndirect);
-    FinishReadObject(buffer, vvl::Func::vkCmdDispatchIndirect);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
                                               uint32_t regionCount, const VkBufferCopy* pRegions, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyBuffer);
-    StartReadObject(srcBuffer, vvl::Func::vkCmdCopyBuffer);
-    StartReadObject(dstBuffer, vvl::Func::vkCmdCopyBuffer);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(srcBuffer, record_obj.location);
+    StartReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
                                                uint32_t regionCount, const VkBufferCopy* pRegions, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyBuffer);
-    FinishReadObject(srcBuffer, vvl::Func::vkCmdCopyBuffer);
-    FinishReadObject(dstBuffer, vvl::Func::vkCmdCopyBuffer);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(srcBuffer, record_obj.location);
+    FinishReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                              const VkImageCopy* pRegions, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyImage);
-    StartReadObject(srcImage, vvl::Func::vkCmdCopyImage);
-    StartReadObject(dstImage, vvl::Func::vkCmdCopyImage);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(srcImage, record_obj.location);
+    StartReadObject(dstImage, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                               VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                               const VkImageCopy* pRegions, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyImage);
-    FinishReadObject(srcImage, vvl::Func::vkCmdCopyImage);
-    FinishReadObject(dstImage, vvl::Func::vkCmdCopyImage);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(srcImage, record_obj.location);
+    FinishReadObject(dstImage, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                              VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                              const VkImageBlit* pRegions, VkFilter filter, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBlitImage);
-    StartReadObject(srcImage, vvl::Func::vkCmdBlitImage);
-    StartReadObject(dstImage, vvl::Func::vkCmdBlitImage);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(srcImage, record_obj.location);
+    StartReadObject(dstImage, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                               VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                               const VkImageBlit* pRegions, VkFilter filter, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBlitImage);
-    FinishReadObject(srcImage, vvl::Func::vkCmdBlitImage);
-    FinishReadObject(dstImage, vvl::Func::vkCmdBlitImage);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(srcImage, record_obj.location);
+    FinishReadObject(dstImage, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                      VkImageLayout dstImageLayout, uint32_t regionCount,
                                                      const VkBufferImageCopy* pRegions, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyBufferToImage);
-    StartReadObject(srcBuffer, vvl::Func::vkCmdCopyBufferToImage);
-    StartReadObject(dstImage, vvl::Func::vkCmdCopyBufferToImage);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(srcBuffer, record_obj.location);
+    StartReadObject(dstImage, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                       VkImageLayout dstImageLayout, uint32_t regionCount,
                                                       const VkBufferImageCopy* pRegions, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyBufferToImage);
-    FinishReadObject(srcBuffer, vvl::Func::vkCmdCopyBufferToImage);
-    FinishReadObject(dstImage, vvl::Func::vkCmdCopyBufferToImage);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(srcBuffer, record_obj.location);
+    FinishReadObject(dstImage, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                      VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions,
                                                      const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyImageToBuffer);
-    StartReadObject(srcImage, vvl::Func::vkCmdCopyImageToBuffer);
-    StartReadObject(dstBuffer, vvl::Func::vkCmdCopyImageToBuffer);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(srcImage, record_obj.location);
+    StartReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                       VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy* pRegions,
                                                       const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyImageToBuffer);
-    FinishReadObject(srcImage, vvl::Func::vkCmdCopyImageToBuffer);
-    FinishReadObject(dstBuffer, vvl::Func::vkCmdCopyImageToBuffer);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(srcImage, record_obj.location);
+    FinishReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                 VkDeviceSize dataSize, const void* pData, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdUpdateBuffer);
-    StartReadObject(dstBuffer, vvl::Func::vkCmdUpdateBuffer);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                  VkDeviceSize dataSize, const void* pData, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdUpdateBuffer);
-    FinishReadObject(dstBuffer, vvl::Func::vkCmdUpdateBuffer);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                               VkDeviceSize size, uint32_t data, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdFillBuffer);
-    StartReadObject(dstBuffer, vvl::Func::vkCmdFillBuffer);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                VkDeviceSize size, uint32_t data, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdFillBuffer);
-    FinishReadObject(dstBuffer, vvl::Func::vkCmdFillBuffer);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                    const VkClearColorValue* pColor, uint32_t rangeCount,
                                                    const VkImageSubresourceRange* pRanges, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdClearColorImage);
-    StartReadObject(image, vvl::Func::vkCmdClearColorImage);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(image, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                     const VkClearColorValue* pColor, uint32_t rangeCount,
                                                     const VkImageSubresourceRange* pRanges, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdClearColorImage);
-    FinishReadObject(image, vvl::Func::vkCmdClearColorImage);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(image, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                           const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
                                                           const VkImageSubresourceRange* pRanges, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdClearDepthStencilImage);
-    StartReadObject(image, vvl::Func::vkCmdClearDepthStencilImage);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(image, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                            const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
                                                            const VkImageSubresourceRange* pRanges, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdClearDepthStencilImage);
-    FinishReadObject(image, vvl::Func::vkCmdClearDepthStencilImage);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(image, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                     const VkClearAttachment* pAttachments, uint32_t rectCount,
                                                     const VkClearRect* pRects, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdClearAttachments);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                      const VkClearAttachment* pAttachments, uint32_t rectCount,
                                                      const VkClearRect* pRects, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdClearAttachments);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                 VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                                 const VkImageResolve* pRegions, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdResolveImage);
-    StartReadObject(srcImage, vvl::Func::vkCmdResolveImage);
-    StartReadObject(dstImage, vvl::Func::vkCmdResolveImage);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(srcImage, record_obj.location);
+    StartReadObject(dstImage, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                  VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                                  const VkImageResolve* pRegions, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdResolveImage);
-    FinishReadObject(srcImage, vvl::Func::vkCmdResolveImage);
-    FinishReadObject(dstImage, vvl::Func::vkCmdResolveImage);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(srcImage, record_obj.location);
+    FinishReadObject(dstImage, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                             const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetEvent);
-    StartReadObject(event, vvl::Func::vkCmdSetEvent);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                              const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetEvent);
-    FinishReadObject(event, vvl::Func::vkCmdSetEvent);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                               const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdResetEvent);
-    StartReadObject(event, vvl::Func::vkCmdResetEvent);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                                const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdResetEvent);
-    FinishReadObject(event, vvl::Func::vkCmdResetEvent);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -1497,11 +1497,11 @@ void ThreadSafety::PreCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uin
                                               uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers,
                                               uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers,
                                               const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWaitEvents);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pEvents) {
         for (uint32_t index = 0; index < eventCount; index++) {
-            StartReadObject(pEvents[index], vvl::Func::vkCmdWaitEvents);
+            StartReadObject(pEvents[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -1513,11 +1513,11 @@ void ThreadSafety::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, ui
                                                uint32_t bufferMemoryBarrierCount,
                                                const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
                                                const VkImageMemoryBarrier* pImageMemoryBarriers, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWaitEvents);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pEvents) {
         for (uint32_t index = 0; index < eventCount; index++) {
-            FinishReadObject(pEvents[index], vvl::Func::vkCmdWaitEvents);
+            FinishReadObject(pEvents[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -1528,7 +1528,7 @@ void ThreadSafety::PreCallRecordCmdPipelineBarrier(
     VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdPipelineBarrier);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -1537,63 +1537,63 @@ void ThreadSafety::PostCallRecordCmdPipelineBarrier(
     VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdPipelineBarrier);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                               VkQueryControlFlags flags, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginQuery);
-    StartReadObject(queryPool, vvl::Func::vkCmdBeginQuery);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                                VkQueryControlFlags flags, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginQuery);
-    FinishReadObject(queryPool, vvl::Func::vkCmdBeginQuery);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                             const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndQuery);
-    StartReadObject(queryPool, vvl::Func::vkCmdEndQuery);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                              const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndQuery);
-    FinishReadObject(queryPool, vvl::Func::vkCmdEndQuery);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                                   uint32_t queryCount, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdResetQueryPool);
-    StartReadObject(queryPool, vvl::Func::vkCmdResetQueryPool);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                                    uint32_t queryCount, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdResetQueryPool);
-    FinishReadObject(queryPool, vvl::Func::vkCmdResetQueryPool);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                   VkQueryPool queryPool, uint32_t query, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWriteTimestamp);
-    StartReadObject(queryPool, vvl::Func::vkCmdWriteTimestamp);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                    VkQueryPool queryPool, uint32_t query, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWriteTimestamp);
-    FinishReadObject(queryPool, vvl::Func::vkCmdWriteTimestamp);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -1601,9 +1601,9 @@ void ThreadSafety::PreCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandB
                                                         uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                         VkDeviceSize stride, VkQueryResultFlags flags,
                                                         const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyQueryPoolResults);
-    StartReadObject(queryPool, vvl::Func::vkCmdCopyQueryPoolResults);
-    StartReadObject(dstBuffer, vvl::Func::vkCmdCopyQueryPoolResults);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
+    StartReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -1611,69 +1611,69 @@ void ThreadSafety::PostCallRecordCmdCopyQueryPoolResults(VkCommandBuffer command
                                                          uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                          VkDeviceSize stride, VkQueryResultFlags flags,
                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyQueryPoolResults);
-    FinishReadObject(queryPool, vvl::Func::vkCmdCopyQueryPoolResults);
-    FinishReadObject(dstBuffer, vvl::Func::vkCmdCopyQueryPoolResults);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
+    FinishReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                                  VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void* pValues,
                                                  const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdPushConstants);
-    StartReadObject(layout, vvl::Func::vkCmdPushConstants);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(layout, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                                   VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
                                                   const void* pValues, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdPushConstants);
-    FinishReadObject(layout, vvl::Func::vkCmdPushConstants);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(layout, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                                    VkSubpassContents contents, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginRenderPass);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                                     VkSubpassContents contents, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginRenderPass);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdNextSubpass);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdNextSubpass);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndRenderPass);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndRenderPass);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                                    const VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdExecuteCommands);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pCommandBuffers) {
         for (uint32_t index = 0; index < commandBufferCount; index++) {
-            StartReadObject(pCommandBuffers[index], vvl::Func::vkCmdExecuteCommands);
+            StartReadObject(pCommandBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -1681,11 +1681,11 @@ void ThreadSafety::PreCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffer
 
 void ThreadSafety::PostCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                                     const VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdExecuteCommands);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pCommandBuffers) {
         for (uint32_t index = 0; index < commandBufferCount; index++) {
-            FinishReadObject(pCommandBuffers[index], vvl::Func::vkCmdExecuteCommands);
+            FinishReadObject(pCommandBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -1693,98 +1693,98 @@ void ThreadSafety::PostCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffe
 
 void ThreadSafety::PreCallRecordBindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBindBufferMemory2);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordBindBufferMemory2(VkDevice device, uint32_t bindInfoCount,
                                                    const VkBindBufferMemoryInfo* pBindInfos, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBindBufferMemory2);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBindImageMemory2);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBindImageMemory2);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceGroupPeerMemoryFeatures(VkDevice device, uint32_t heapIndex, uint32_t localDeviceIndex,
                                                                  uint32_t remoteDeviceIndex,
                                                                  VkPeerMemoryFeatureFlags* pPeerMemoryFeatures,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceGroupPeerMemoryFeatures);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceGroupPeerMemoryFeatures(VkDevice device, uint32_t heapIndex, uint32_t localDeviceIndex,
                                                                   uint32_t remoteDeviceIndex,
                                                                   VkPeerMemoryFeatureFlags* pPeerMemoryFeatures,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceGroupPeerMemoryFeatures);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask,
                                                  const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDeviceMask);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDeviceMask(VkCommandBuffer commandBuffer, uint32_t deviceMask,
                                                   const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDeviceMask);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                 uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
                                                 uint32_t groupCountZ, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDispatchBase);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                  uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
                                                  uint32_t groupCountZ, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDispatchBase);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
                                                               VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkEnumeratePhysicalDeviceGroups);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordEnumeratePhysicalDeviceGroups(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
                                                                VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkEnumeratePhysicalDeviceGroups);
+    FinishReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageMemoryRequirements2(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
                                                             VkMemoryRequirements2* pMemoryRequirements,
                                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageMemoryRequirements2);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageMemoryRequirements2(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
                                                              VkMemoryRequirements2* pMemoryRequirements,
                                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageMemoryRequirements2);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetBufferMemoryRequirements2(VkDevice device, const VkBufferMemoryRequirementsInfo2* pInfo,
                                                              VkMemoryRequirements2* pMemoryRequirements,
                                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetBufferMemoryRequirements2);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetBufferMemoryRequirements2(VkDevice device, const VkBufferMemoryRequirementsInfo2* pInfo,
                                                               VkMemoryRequirements2* pMemoryRequirements,
                                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetBufferMemoryRequirements2);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageSparseMemoryRequirements2(VkDevice device,
@@ -1792,7 +1792,7 @@ void ThreadSafety::PreCallRecordGetImageSparseMemoryRequirements2(VkDevice devic
                                                                   uint32_t* pSparseMemoryRequirementCount,
                                                                   VkSparseImageMemoryRequirements2* pSparseMemoryRequirements,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageSparseMemoryRequirements2);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageSparseMemoryRequirements2(VkDevice device,
@@ -1800,20 +1800,20 @@ void ThreadSafety::PostCallRecordGetImageSparseMemoryRequirements2(VkDevice devi
                                                                    uint32_t* pSparseMemoryRequirementCount,
                                                                    VkSparseImageMemoryRequirements2* pSparseMemoryRequirements,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageSparseMemoryRequirements2);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordTrimCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags,
                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkTrimCommandPool);
-    StartWriteObject(commandPool, vvl::Func::vkTrimCommandPool);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(commandPool, record_obj.location);
     // Host access to commandPool must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordTrimCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags,
                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkTrimCommandPool);
-    FinishWriteObject(commandPool, vvl::Func::vkTrimCommandPool);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(commandPool, record_obj.location);
     // Host access to commandPool must be externally synchronized
 }
 
@@ -1821,7 +1821,7 @@ void ThreadSafety::PreCallRecordCreateSamplerYcbcrConversion(VkDevice device, co
                                                              const VkAllocationCallbacks* pAllocator,
                                                              VkSamplerYcbcrConversion* pYcbcrConversion,
                                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateSamplerYcbcrConversion);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateSamplerYcbcrConversion(VkDevice device,
@@ -1829,7 +1829,7 @@ void ThreadSafety::PostCallRecordCreateSamplerYcbcrConversion(VkDevice device,
                                                               const VkAllocationCallbacks* pAllocator,
                                                               VkSamplerYcbcrConversion* pYcbcrConversion,
                                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateSamplerYcbcrConversion);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pYcbcrConversion);
     }
@@ -1838,16 +1838,16 @@ void ThreadSafety::PostCallRecordCreateSamplerYcbcrConversion(VkDevice device,
 void ThreadSafety::PreCallRecordDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                               const VkAllocationCallbacks* pAllocator,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroySamplerYcbcrConversion);
-    StartWriteObject(ycbcrConversion, vvl::Func::vkDestroySamplerYcbcrConversion);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(ycbcrConversion, record_obj.location);
     // Host access to ycbcrConversion must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroySamplerYcbcrConversion);
-    FinishWriteObject(ycbcrConversion, vvl::Func::vkDestroySamplerYcbcrConversion);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(ycbcrConversion, record_obj.location);
     DestroyObject(ycbcrConversion);
     // Host access to ycbcrConversion must be externally synchronized
 }
@@ -1857,7 +1857,7 @@ void ThreadSafety::PreCallRecordCreateDescriptorUpdateTemplate(VkDevice device,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
                                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateDescriptorUpdateTemplate);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateDescriptorUpdateTemplate(VkDevice device,
@@ -1865,7 +1865,7 @@ void ThreadSafety::PostCallRecordCreateDescriptorUpdateTemplate(VkDevice device,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
                                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateDescriptorUpdateTemplate);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pDescriptorUpdateTemplate);
     }
@@ -1875,8 +1875,8 @@ void ThreadSafety::PreCallRecordDestroyDescriptorUpdateTemplate(VkDevice device,
                                                                 VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyDescriptorUpdateTemplate);
-    StartWriteObject(descriptorUpdateTemplate, vvl::Func::vkDestroyDescriptorUpdateTemplate);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(descriptorUpdateTemplate, record_obj.location);
     // Host access to descriptorUpdateTemplate must be externally synchronized
 }
 
@@ -1884,8 +1884,8 @@ void ThreadSafety::PostCallRecordDestroyDescriptorUpdateTemplate(VkDevice device
                                                                  VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                  const VkAllocationCallbacks* pAllocator,
                                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyDescriptorUpdateTemplate);
-    FinishWriteObject(descriptorUpdateTemplate, vvl::Func::vkDestroyDescriptorUpdateTemplate);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(descriptorUpdateTemplate, record_obj.location);
     DestroyObject(descriptorUpdateTemplate);
     // Host access to descriptorUpdateTemplate must be externally synchronized
 }
@@ -1893,30 +1893,30 @@ void ThreadSafety::PostCallRecordDestroyDescriptorUpdateTemplate(VkDevice device
 void ThreadSafety::PreCallRecordGetDescriptorSetLayoutSupport(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
                                                               VkDescriptorSetLayoutSupport* pSupport,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetLayoutSupport);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDescriptorSetLayoutSupport(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
                                                                VkDescriptorSetLayoutSupport* pSupport,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetLayoutSupport);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                      VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                      uint32_t stride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndirectCount);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawIndirectCount);
-    StartReadObject(countBuffer, vvl::Func::vkCmdDrawIndirectCount);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
+    StartReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                       VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                       uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndirectCount);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawIndirectCount);
-    FinishReadObject(countBuffer, vvl::Func::vkCmdDrawIndirectCount);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
+    FinishReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -1924,9 +1924,9 @@ void ThreadSafety::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer comm
                                                             VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                             uint32_t maxDrawCount, uint32_t stride,
                                                             const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndexedIndirectCount);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawIndexedIndirectCount);
-    StartReadObject(countBuffer, vvl::Func::vkCmdDrawIndexedIndirectCount);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
+    StartReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -1934,22 +1934,22 @@ void ThreadSafety::PostCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer com
                                                              VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                              uint32_t maxDrawCount, uint32_t stride,
                                                              const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndexedIndirectCount);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawIndexedIndirectCount);
-    FinishReadObject(countBuffer, vvl::Func::vkCmdDrawIndexedIndirectCount);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
+    FinishReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateRenderPass2);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateRenderPass2);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pRenderPass);
     }
@@ -1957,126 +1957,126 @@ void ThreadSafety::PostCallRecordCreateRenderPass2(VkDevice device, const VkRend
 
 void ThreadSafety::PreCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                                     const VkSubpassBeginInfo* pSubpassBeginInfo, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginRenderPass2);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                                      const VkSubpassBeginInfo* pSubpassBeginInfo, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginRenderPass2);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                                 const VkSubpassEndInfo* pSubpassEndInfo, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdNextSubpass2);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                                  const VkSubpassEndInfo* pSubpassEndInfo, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdNextSubpass2);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndRenderPass2);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndRenderPass2);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkResetQueryPool);
-    StartReadObject(queryPool, vvl::Func::vkResetQueryPool);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkResetQueryPool);
-    FinishReadObject(queryPool, vvl::Func::vkResetQueryPool);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetSemaphoreCounterValue);
-    StartReadObject(semaphore, vvl::Func::vkGetSemaphoreCounterValue);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(semaphore, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetSemaphoreCounterValue);
-    FinishReadObject(semaphore, vvl::Func::vkGetSemaphoreCounterValue);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(semaphore, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkWaitSemaphores);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkWaitSemaphores);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSignalSemaphore);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSignalSemaphore);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetBufferDeviceAddress);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetBufferDeviceAddress);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetBufferOpaqueCaptureAddress(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetBufferOpaqueCaptureAddress);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetBufferOpaqueCaptureAddress(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetBufferOpaqueCaptureAddress);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceMemoryOpaqueCaptureAddress(VkDevice device,
                                                                     const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo,
                                                                     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceMemoryOpaqueCaptureAddress);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceMemoryOpaqueCaptureAddress(VkDevice device,
                                                                      const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo,
                                                                      const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceMemoryOpaqueCaptureAddress);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreatePrivateDataSlot(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkPrivateDataSlot* pPrivateDataSlot,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreatePrivateDataSlot);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreatePrivateDataSlot(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkPrivateDataSlot* pPrivateDataSlot,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreatePrivateDataSlot);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pPrivateDataSlot);
     }
@@ -2084,79 +2084,79 @@ void ThreadSafety::PostCallRecordCreatePrivateDataSlot(VkDevice device, const Vk
 
 void ThreadSafety::PreCallRecordDestroyPrivateDataSlot(VkDevice device, VkPrivateDataSlot privateDataSlot,
                                                        const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyPrivateDataSlot);
-    StartWriteObject(privateDataSlot, vvl::Func::vkDestroyPrivateDataSlot);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(privateDataSlot, record_obj.location);
     // Host access to privateDataSlot must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyPrivateDataSlot(VkDevice device, VkPrivateDataSlot privateDataSlot,
                                                         const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyPrivateDataSlot);
-    FinishWriteObject(privateDataSlot, vvl::Func::vkDestroyPrivateDataSlot);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(privateDataSlot, record_obj.location);
     DestroyObject(privateDataSlot);
     // Host access to privateDataSlot must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordSetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
                                                VkPrivateDataSlot privateDataSlot, uint64_t data, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSetPrivateData);
-    StartReadObject(privateDataSlot, vvl::Func::vkSetPrivateData);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(privateDataSlot, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
                                                 VkPrivateDataSlot privateDataSlot, uint64_t data, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSetPrivateData);
-    FinishReadObject(privateDataSlot, vvl::Func::vkSetPrivateData);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(privateDataSlot, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
                                                VkPrivateDataSlot privateDataSlot, uint64_t* pData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPrivateData);
-    StartReadObject(privateDataSlot, vvl::Func::vkGetPrivateData);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(privateDataSlot, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
                                                 VkPrivateDataSlot privateDataSlot, uint64_t* pData,
                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPrivateData);
-    FinishReadObject(privateDataSlot, vvl::Func::vkGetPrivateData);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(privateDataSlot, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo,
                                              const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetEvent2);
-    StartReadObject(event, vvl::Func::vkCmdSetEvent2);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo,
                                               const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetEvent2);
-    FinishReadObject(event, vvl::Func::vkCmdSetEvent2);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdResetEvent2);
-    StartReadObject(event, vvl::Func::vkCmdResetEvent2);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdResetEvent2);
-    FinishReadObject(event, vvl::Func::vkCmdResetEvent2);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                                const VkDependencyInfo* pDependencyInfos, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWaitEvents2);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pEvents) {
         for (uint32_t index = 0; index < eventCount; index++) {
-            StartReadObject(pEvents[index], vvl::Func::vkCmdWaitEvents2);
+            StartReadObject(pEvents[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -2164,11 +2164,11 @@ void ThreadSafety::PreCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, ui
 
 void ThreadSafety::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                                 const VkDependencyInfo* pDependencyInfos, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWaitEvents2);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pEvents) {
         for (uint32_t index = 0; index < eventCount; index++) {
-            FinishReadObject(pEvents[index], vvl::Func::vkCmdWaitEvents2);
+            FinishReadObject(pEvents[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -2176,201 +2176,201 @@ void ThreadSafety::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, u
 
 void ThreadSafety::PreCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
                                                     const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdPipelineBarrier2);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
                                                      const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdPipelineBarrier2);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                                    VkQueryPool queryPool, uint32_t query, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWriteTimestamp2);
-    StartReadObject(queryPool, vvl::Func::vkCmdWriteTimestamp2);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                                     VkQueryPool queryPool, uint32_t query, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWriteTimestamp2);
-    FinishReadObject(queryPool, vvl::Func::vkCmdWriteTimestamp2);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                              const RecordObject& record_obj) {
-    StartWriteObject(queue, vvl::Func::vkQueueSubmit2);
-    StartWriteObject(fence, vvl::Func::vkQueueSubmit2);
+    StartWriteObject(queue, record_obj.location);
+    StartWriteObject(fence, record_obj.location);
     // Host access to queue must be externally synchronized
     // Host access to fence must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                               const RecordObject& record_obj) {
-    FinishWriteObject(queue, vvl::Func::vkQueueSubmit2);
-    FinishWriteObject(fence, vvl::Func::vkQueueSubmit2);
+    FinishWriteObject(queue, record_obj.location);
+    FinishWriteObject(fence, record_obj.location);
     // Host access to queue must be externally synchronized
     // Host access to fence must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo,
                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyBuffer2);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo,
                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyBuffer2);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo,
                                               const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyImage2);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo,
                                                const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyImage2);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
                                                       const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo,
                                                       const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyBufferToImage2);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
                                                        const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo,
                                                        const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyBufferToImage2);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
                                                       const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo,
                                                       const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyImageToBuffer2);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
                                                        const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo,
                                                        const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyImageToBuffer2);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo,
                                               const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBlitImage2);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo,
                                                const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBlitImage2);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
                                                  const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdResolveImage2);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
                                                   const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdResolveImage2);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginRendering);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginRendering);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdEndRendering(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndRendering);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEndRendering(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndRendering);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode,
                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetCullMode);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetCullMode(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode,
                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetCullMode);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFace frontFace,
                                                 const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetFrontFace);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetFrontFace(VkCommandBuffer commandBuffer, VkFrontFace frontFace,
                                                  const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetFrontFace);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetPrimitiveTopology(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology,
                                                         const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetPrimitiveTopology);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetPrimitiveTopology(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology,
                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetPrimitiveTopology);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetViewportWithCount(VkCommandBuffer commandBuffer, uint32_t viewportCount,
                                                         const VkViewport* pViewports, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportWithCount);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetViewportWithCount(VkCommandBuffer commandBuffer, uint32_t viewportCount,
                                                          const VkViewport* pViewports, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportWithCount);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetScissorWithCount(VkCommandBuffer commandBuffer, uint32_t scissorCount,
                                                        const VkRect2D* pScissors, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetScissorWithCount);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetScissorWithCount(VkCommandBuffer commandBuffer, uint32_t scissorCount,
                                                         const VkRect2D* pScissors, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetScissorWithCount);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -2378,11 +2378,11 @@ void ThreadSafety::PreCallRecordCmdBindVertexBuffers2(VkCommandBuffer commandBuf
                                                       const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
                                                       const VkDeviceSize* pSizes, const VkDeviceSize* pStrides,
                                                       const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindVertexBuffers2);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pBuffers) {
         for (uint32_t index = 0; index < bindingCount; index++) {
-            StartReadObject(pBuffers[index], vvl::Func::vkCmdBindVertexBuffers2);
+            StartReadObject(pBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -2392,11 +2392,11 @@ void ThreadSafety::PostCallRecordCmdBindVertexBuffers2(VkCommandBuffer commandBu
                                                        const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
                                                        const VkDeviceSize* pSizes, const VkDeviceSize* pStrides,
                                                        const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindVertexBuffers2);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pBuffers) {
         for (uint32_t index = 0; index < bindingCount; index++) {
-            FinishReadObject(pBuffers[index], vvl::Func::vkCmdBindVertexBuffers2);
+            FinishReadObject(pBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -2404,136 +2404,136 @@ void ThreadSafety::PostCallRecordCmdBindVertexBuffers2(VkCommandBuffer commandBu
 
 void ThreadSafety::PreCallRecordCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable,
                                                       const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthTestEnable);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable,
                                                        const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthTestEnable);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthWriteEnable(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable,
                                                        const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthWriteEnable);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthWriteEnable(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable,
                                                         const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthWriteEnable);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp,
                                                      const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthCompareOp);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp,
                                                       const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthCompareOp);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthBoundsTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable,
                                                             const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBoundsTestEnable);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthBoundsTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable,
                                                              const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBoundsTestEnable);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable,
                                                         const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilTestEnable);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetStencilTestEnable(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable,
                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilTestEnable);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetStencilOp(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                                 VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp,
                                                 const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilOp);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetStencilOp(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                                  VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp,
                                                  const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilOp);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable,
                                                               const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetRasterizerDiscardEnable);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetRasterizerDiscardEnable(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable,
                                                                const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetRasterizerDiscardEnable);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable,
                                                       const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBiasEnable);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthBiasEnable(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable,
                                                        const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBiasEnable);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetPrimitiveRestartEnable(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable,
                                                              const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetPrimitiveRestartEnable);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetPrimitiveRestartEnable(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable,
                                                               const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetPrimitiveRestartEnable);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetDeviceBufferMemoryRequirements(VkDevice device, const VkDeviceBufferMemoryRequirements* pInfo,
                                                                   VkMemoryRequirements2* pMemoryRequirements,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceBufferMemoryRequirements);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceBufferMemoryRequirements(VkDevice device, const VkDeviceBufferMemoryRequirements* pInfo,
                                                                    VkMemoryRequirements2* pMemoryRequirements,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceBufferMemoryRequirements);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceImageMemoryRequirements(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo,
                                                                  VkMemoryRequirements2* pMemoryRequirements,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceImageMemoryRequirements);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceImageMemoryRequirements(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo,
                                                                   VkMemoryRequirements2* pMemoryRequirements,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceImageMemoryRequirements);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceImageSparseMemoryRequirements(VkDevice device,
@@ -2541,7 +2541,7 @@ void ThreadSafety::PreCallRecordGetDeviceImageSparseMemoryRequirements(VkDevice 
                                                                        uint32_t* pSparseMemoryRequirementCount,
                                                                        VkSparseImageMemoryRequirements2* pSparseMemoryRequirements,
                                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceImageSparseMemoryRequirements);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceImageSparseMemoryRequirements(VkDevice device,
@@ -2549,20 +2549,20 @@ void ThreadSafety::PostCallRecordGetDeviceImageSparseMemoryRequirements(VkDevice
                                                                         uint32_t* pSparseMemoryRequirementCount,
                                                                         VkSparseImageMemoryRequirements2* pSparseMemoryRequirements,
                                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceImageSparseMemoryRequirements);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
                                                   const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkDestroySurfaceKHR);
-    StartWriteObjectParentInstance(surface, vvl::Func::vkDestroySurfaceKHR);
+    StartReadObjectParentInstance(instance, record_obj.location);
+    StartWriteObjectParentInstance(surface, record_obj.location);
     // Host access to surface must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroySurfaceKHR(VkInstance instance, VkSurfaceKHR surface,
                                                    const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkDestroySurfaceKHR);
-    FinishWriteObjectParentInstance(surface, vvl::Func::vkDestroySurfaceKHR);
+    FinishReadObjectParentInstance(instance, record_obj.location);
+    FinishWriteObjectParentInstance(surface, record_obj.location);
     DestroyObjectParentInstance(surface);
     // Host access to surface must be externally synchronized
 }
@@ -2570,70 +2570,70 @@ void ThreadSafety::PostCallRecordDestroySurfaceKHR(VkInstance instance, VkSurfac
 void ThreadSafety::PreCallRecordGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
                                                                    VkSurfaceKHR surface, VkBool32* pSupported,
                                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(surface, vvl::Func::vkGetPhysicalDeviceSurfaceSupportKHR);
+    StartReadObjectParentInstance(surface, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
                                                                     VkSurfaceKHR surface, VkBool32* pSupported,
                                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(surface, vvl::Func::vkGetPhysicalDeviceSurfaceSupportKHR);
+    FinishReadObjectParentInstance(surface, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                         VkSurfaceCapabilitiesKHR* pSurfaceCapabilities,
                                                                         const RecordObject& record_obj) {
-    StartReadObjectParentInstance(surface, vvl::Func::vkGetPhysicalDeviceSurfaceCapabilitiesKHR);
+    StartReadObjectParentInstance(surface, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                          VkSurfaceCapabilitiesKHR* pSurfaceCapabilities,
                                                                          const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(surface, vvl::Func::vkGetPhysicalDeviceSurfaceCapabilitiesKHR);
+    FinishReadObjectParentInstance(surface, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                    uint32_t* pSurfaceFormatCount,
                                                                    VkSurfaceFormatKHR* pSurfaceFormats,
                                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(surface, vvl::Func::vkGetPhysicalDeviceSurfaceFormatsKHR);
+    StartReadObjectParentInstance(surface, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                     uint32_t* pSurfaceFormatCount,
                                                                     VkSurfaceFormatKHR* pSurfaceFormats,
                                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(surface, vvl::Func::vkGetPhysicalDeviceSurfaceFormatsKHR);
+    FinishReadObjectParentInstance(surface, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                         uint32_t* pPresentModeCount,
                                                                         VkPresentModeKHR* pPresentModes,
                                                                         const RecordObject& record_obj) {
-    StartReadObjectParentInstance(surface, vvl::Func::vkGetPhysicalDeviceSurfacePresentModesKHR);
+    StartReadObjectParentInstance(surface, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                          uint32_t* pPresentModeCount,
                                                                          VkPresentModeKHR* pPresentModes,
                                                                          const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(surface, vvl::Func::vkGetPhysicalDeviceSurfacePresentModesKHR);
+    FinishReadObjectParentInstance(surface, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain,
                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateSwapchainKHR);
-    StartWriteObjectParentInstance(pCreateInfo->surface, vvl::Func::vkCreateSwapchainKHR);
-    StartWriteObject(pCreateInfo->oldSwapchain, vvl::Func::vkCreateSwapchainKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObjectParentInstance(pCreateInfo->surface, record_obj.location);
+    StartWriteObject(pCreateInfo->oldSwapchain, record_obj.location);
     // Host access to pCreateInfo->surface,pCreateInfo->oldSwapchain must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain,
                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateSwapchainKHR);
-    FinishWriteObjectParentInstance(pCreateInfo->surface, vvl::Func::vkCreateSwapchainKHR);
-    FinishWriteObject(pCreateInfo->oldSwapchain, vvl::Func::vkCreateSwapchainKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObjectParentInstance(pCreateInfo->surface, record_obj.location);
+    FinishWriteObject(pCreateInfo->oldSwapchain, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pSwapchain);
     }
@@ -2643,10 +2643,10 @@ void ThreadSafety::PostCallRecordCreateSwapchainKHR(VkDevice device, const VkSwa
 void ThreadSafety::PreCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
                                                     VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex,
                                                     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkAcquireNextImageKHR);
-    StartWriteObject(swapchain, vvl::Func::vkAcquireNextImageKHR);
-    StartWriteObject(semaphore, vvl::Func::vkAcquireNextImageKHR);
-    StartWriteObject(fence, vvl::Func::vkAcquireNextImageKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(swapchain, record_obj.location);
+    StartWriteObject(semaphore, record_obj.location);
+    StartWriteObject(fence, record_obj.location);
     // Host access to swapchain must be externally synchronized
     // Host access to semaphore must be externally synchronized
     // Host access to fence must be externally synchronized
@@ -2655,10 +2655,10 @@ void ThreadSafety::PreCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchain
 void ThreadSafety::PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
                                                      VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex,
                                                      const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkAcquireNextImageKHR);
-    FinishWriteObject(swapchain, vvl::Func::vkAcquireNextImageKHR);
-    FinishWriteObject(semaphore, vvl::Func::vkAcquireNextImageKHR);
-    FinishWriteObject(fence, vvl::Func::vkAcquireNextImageKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(swapchain, record_obj.location);
+    FinishWriteObject(semaphore, record_obj.location);
+    FinishWriteObject(fence, record_obj.location);
     // Host access to swapchain must be externally synchronized
     // Host access to semaphore must be externally synchronized
     // Host access to fence must be externally synchronized
@@ -2666,59 +2666,59 @@ void ThreadSafety::PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchai
 
 void ThreadSafety::PreCallRecordGetDeviceGroupPresentCapabilitiesKHR(
     VkDevice device, VkDeviceGroupPresentCapabilitiesKHR* pDeviceGroupPresentCapabilities, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceGroupPresentCapabilitiesKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceGroupPresentCapabilitiesKHR(
     VkDevice device, VkDeviceGroupPresentCapabilitiesKHR* pDeviceGroupPresentCapabilities, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceGroupPresentCapabilitiesKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceGroupSurfacePresentModesKHR(VkDevice device, VkSurfaceKHR surface,
                                                                      VkDeviceGroupPresentModeFlagsKHR* pModes,
                                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceGroupSurfacePresentModesKHR);
-    StartWriteObjectParentInstance(surface, vvl::Func::vkGetDeviceGroupSurfacePresentModesKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObjectParentInstance(surface, record_obj.location);
     // Host access to surface must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordGetDeviceGroupSurfacePresentModesKHR(VkDevice device, VkSurfaceKHR surface,
                                                                       VkDeviceGroupPresentModeFlagsKHR* pModes,
                                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceGroupSurfacePresentModesKHR);
-    FinishWriteObjectParentInstance(surface, vvl::Func::vkGetDeviceGroupSurfacePresentModesKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObjectParentInstance(surface, record_obj.location);
     // Host access to surface must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetPhysicalDevicePresentRectanglesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                       uint32_t* pRectCount, VkRect2D* pRects,
                                                                       const RecordObject& record_obj) {
-    StartWriteObjectParentInstance(surface, vvl::Func::vkGetPhysicalDevicePresentRectanglesKHR);
+    StartWriteObjectParentInstance(surface, record_obj.location);
     // Host access to surface must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordGetPhysicalDevicePresentRectanglesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                        uint32_t* pRectCount, VkRect2D* pRects,
                                                                        const RecordObject& record_obj) {
-    FinishWriteObjectParentInstance(surface, vvl::Func::vkGetPhysicalDevicePresentRectanglesKHR);
+    FinishWriteObjectParentInstance(surface, record_obj.location);
     // Host access to surface must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo,
                                                      uint32_t* pImageIndex, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkAcquireNextImage2KHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo,
                                                       uint32_t* pImageIndex, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkAcquireNextImage2KHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateDisplayModeKHR(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                      const VkDisplayModeCreateInfoKHR* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkDisplayModeKHR* pMode,
                                                      const RecordObject& record_obj) {
-    StartWriteObjectParentInstance(display, vvl::Func::vkCreateDisplayModeKHR);
+    StartWriteObjectParentInstance(display, record_obj.location);
     // Host access to display must be externally synchronized
 }
 
@@ -2726,7 +2726,7 @@ void ThreadSafety::PostCallRecordCreateDisplayModeKHR(VkPhysicalDevice physicalD
                                                       const VkDisplayModeCreateInfoKHR* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkDisplayModeKHR* pMode,
                                                       const RecordObject& record_obj) {
-    FinishWriteObjectParentInstance(display, vvl::Func::vkCreateDisplayModeKHR);
+    FinishWriteObjectParentInstance(display, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pMode);
     }
@@ -2736,27 +2736,27 @@ void ThreadSafety::PostCallRecordCreateDisplayModeKHR(VkPhysicalDevice physicalD
 void ThreadSafety::PreCallRecordGetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkDisplayModeKHR mode,
                                                                uint32_t planeIndex, VkDisplayPlaneCapabilitiesKHR* pCapabilities,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(mode, vvl::Func::vkGetDisplayPlaneCapabilitiesKHR);
+    StartWriteObject(mode, record_obj.location);
     // Host access to mode must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordGetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkDisplayModeKHR mode,
                                                                 uint32_t planeIndex, VkDisplayPlaneCapabilitiesKHR* pCapabilities,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(mode, vvl::Func::vkGetDisplayPlaneCapabilitiesKHR);
+    FinishWriteObject(mode, record_obj.location);
     // Host access to mode must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateDisplayPlaneSurfaceKHR);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance instance, const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
                                                               const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateDisplayPlaneSurfaceKHR);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -2766,17 +2766,17 @@ void ThreadSafety::PreCallRecordCreateSharedSwapchainsKHR(VkDevice device, uint3
                                                           const VkSwapchainCreateInfoKHR* pCreateInfos,
                                                           const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains,
                                                           const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateSharedSwapchainsKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
     if (pCreateInfos) {
         for (uint32_t index = 0; index < swapchainCount; index++) {
-            StartWriteObjectParentInstance(pCreateInfos[index].surface, vvl::Func::vkCreateSharedSwapchainsKHR);
-            StartWriteObject(pCreateInfos[index].oldSwapchain, vvl::Func::vkCreateSharedSwapchainsKHR);
+            StartWriteObjectParentInstance(pCreateInfos[index].surface, record_obj.location);
+            StartWriteObject(pCreateInfos[index].oldSwapchain, record_obj.location);
         }
     }
 
     if (pSwapchains) {
         for (uint32_t index = 0; index < swapchainCount; index++) {
-            StartReadObject(pSwapchains[index], vvl::Func::vkCreateSharedSwapchainsKHR);
+            StartReadObject(pSwapchains[index], record_obj.location);
         }
     }
     // Host access to pCreateInfos[].surface,pCreateInfos[].oldSwapchain must be externally synchronized
@@ -2786,11 +2786,11 @@ void ThreadSafety::PostCallRecordCreateSharedSwapchainsKHR(VkDevice device, uint
                                                            const VkSwapchainCreateInfoKHR* pCreateInfos,
                                                            const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains,
                                                            const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateSharedSwapchainsKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (pCreateInfos) {
         for (uint32_t index = 0; index < swapchainCount; index++) {
-            FinishWriteObjectParentInstance(pCreateInfos[index].surface, vvl::Func::vkCreateSharedSwapchainsKHR);
-            FinishWriteObject(pCreateInfos[index].oldSwapchain, vvl::Func::vkCreateSharedSwapchainsKHR);
+            FinishWriteObjectParentInstance(pCreateInfos[index].surface, record_obj.location);
+            FinishWriteObject(pCreateInfos[index].oldSwapchain, record_obj.location);
         }
     }
     if (record_obj.result == VK_SUCCESS) {
@@ -2807,13 +2807,13 @@ void ThreadSafety::PostCallRecordCreateSharedSwapchainsKHR(VkDevice device, uint
 void ThreadSafety::PreCallRecordCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateXlibSurfaceKHR);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateXlibSurfaceKHR);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -2824,13 +2824,13 @@ void ThreadSafety::PostCallRecordCreateXlibSurfaceKHR(VkInstance instance, const
 void ThreadSafety::PreCallRecordCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateXcbSurfaceKHR);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                      const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateXcbSurfaceKHR);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -2841,13 +2841,13 @@ void ThreadSafety::PostCallRecordCreateXcbSurfaceKHR(VkInstance instance, const 
 void ThreadSafety::PreCallRecordCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
                                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                         const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateWaylandSurfaceKHR);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateWaylandSurfaceKHR(VkInstance instance, const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                          const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateWaylandSurfaceKHR);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -2858,13 +2858,13 @@ void ThreadSafety::PostCallRecordCreateWaylandSurfaceKHR(VkInstance instance, co
 void ThreadSafety::PreCallRecordCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
                                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                         const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateAndroidSurfaceKHR);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                          const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateAndroidSurfaceKHR);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -2875,13 +2875,13 @@ void ThreadSafety::PostCallRecordCreateAndroidSurfaceKHR(VkInstance instance, co
 void ThreadSafety::PreCallRecordCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateWin32SurfaceKHR);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateWin32SurfaceKHR);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -2891,13 +2891,13 @@ void ThreadSafety::PostCallRecordCreateWin32SurfaceKHR(VkInstance instance, cons
 void ThreadSafety::PreCallRecordCreateVideoSessionKHR(VkDevice device, const VkVideoSessionCreateInfoKHR* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkVideoSessionKHR* pVideoSession,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateVideoSessionKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateVideoSessionKHR(VkDevice device, const VkVideoSessionCreateInfoKHR* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkVideoSessionKHR* pVideoSession,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateVideoSessionKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pVideoSession);
     }
@@ -2905,15 +2905,15 @@ void ThreadSafety::PostCallRecordCreateVideoSessionKHR(VkDevice device, const Vk
 
 void ThreadSafety::PreCallRecordDestroyVideoSessionKHR(VkDevice device, VkVideoSessionKHR videoSession,
                                                        const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyVideoSessionKHR);
-    StartWriteObject(videoSession, vvl::Func::vkDestroyVideoSessionKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(videoSession, record_obj.location);
     // Host access to videoSession must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyVideoSessionKHR(VkDevice device, VkVideoSessionKHR videoSession,
                                                         const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyVideoSessionKHR);
-    FinishWriteObject(videoSession, vvl::Func::vkDestroyVideoSessionKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(videoSession, record_obj.location);
     DestroyObject(videoSession);
     // Host access to videoSession must be externally synchronized
 }
@@ -2922,24 +2922,24 @@ void ThreadSafety::PreCallRecordGetVideoSessionMemoryRequirementsKHR(VkDevice de
                                                                      uint32_t* pMemoryRequirementsCount,
                                                                      VkVideoSessionMemoryRequirementsKHR* pMemoryRequirements,
                                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetVideoSessionMemoryRequirementsKHR);
-    StartReadObject(videoSession, vvl::Func::vkGetVideoSessionMemoryRequirementsKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(videoSession, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetVideoSessionMemoryRequirementsKHR(VkDevice device, VkVideoSessionKHR videoSession,
                                                                       uint32_t* pMemoryRequirementsCount,
                                                                       VkVideoSessionMemoryRequirementsKHR* pMemoryRequirements,
                                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetVideoSessionMemoryRequirementsKHR);
-    FinishReadObject(videoSession, vvl::Func::vkGetVideoSessionMemoryRequirementsKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(videoSession, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordBindVideoSessionMemoryKHR(VkDevice device, VkVideoSessionKHR videoSession,
                                                           uint32_t bindSessionMemoryInfoCount,
                                                           const VkBindVideoSessionMemoryInfoKHR* pBindSessionMemoryInfos,
                                                           const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBindVideoSessionMemoryKHR);
-    StartWriteObject(videoSession, vvl::Func::vkBindVideoSessionMemoryKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(videoSession, record_obj.location);
     // Host access to videoSession must be externally synchronized
 }
 
@@ -2947,8 +2947,8 @@ void ThreadSafety::PostCallRecordBindVideoSessionMemoryKHR(VkDevice device, VkVi
                                                            uint32_t bindSessionMemoryInfoCount,
                                                            const VkBindVideoSessionMemoryInfoKHR* pBindSessionMemoryInfos,
                                                            const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBindVideoSessionMemoryKHR);
-    FinishWriteObject(videoSession, vvl::Func::vkBindVideoSessionMemoryKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(videoSession, record_obj.location);
     // Host access to videoSession must be externally synchronized
 }
 
@@ -2957,7 +2957,7 @@ void ThreadSafety::PreCallRecordCreateVideoSessionParametersKHR(VkDevice device,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 VkVideoSessionParametersKHR* pVideoSessionParameters,
                                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateVideoSessionParametersKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateVideoSessionParametersKHR(VkDevice device,
@@ -2965,7 +2965,7 @@ void ThreadSafety::PostCallRecordCreateVideoSessionParametersKHR(VkDevice device
                                                                  const VkAllocationCallbacks* pAllocator,
                                                                  VkVideoSessionParametersKHR* pVideoSessionParameters,
                                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateVideoSessionParametersKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pVideoSessionParameters);
     }
@@ -2974,24 +2974,24 @@ void ThreadSafety::PostCallRecordCreateVideoSessionParametersKHR(VkDevice device
 void ThreadSafety::PreCallRecordUpdateVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters,
                                                                 const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo,
                                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkUpdateVideoSessionParametersKHR);
-    StartReadObject(videoSessionParameters, vvl::Func::vkUpdateVideoSessionParametersKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(videoSessionParameters, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordUpdateVideoSessionParametersKHR(VkDevice device,
                                                                  VkVideoSessionParametersKHR videoSessionParameters,
                                                                  const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo,
                                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkUpdateVideoSessionParametersKHR);
-    FinishReadObject(videoSessionParameters, vvl::Func::vkUpdateVideoSessionParametersKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(videoSessionParameters, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordDestroyVideoSessionParametersKHR(VkDevice device,
                                                                  VkVideoSessionParametersKHR videoSessionParameters,
                                                                  const VkAllocationCallbacks* pAllocator,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyVideoSessionParametersKHR);
-    StartWriteObject(videoSessionParameters, vvl::Func::vkDestroyVideoSessionParametersKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(videoSessionParameters, record_obj.location);
     // Host access to videoSessionParameters must be externally synchronized
 }
 
@@ -2999,81 +2999,81 @@ void ThreadSafety::PostCallRecordDestroyVideoSessionParametersKHR(VkDevice devic
                                                                   VkVideoSessionParametersKHR videoSessionParameters,
                                                                   const VkAllocationCallbacks* pAllocator,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyVideoSessionParametersKHR);
-    FinishWriteObject(videoSessionParameters, vvl::Func::vkDestroyVideoSessionParametersKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(videoSessionParameters, record_obj.location);
     DestroyObject(videoSessionParameters);
     // Host access to videoSessionParameters must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoBeginCodingInfoKHR* pBeginInfo,
                                                        const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginVideoCodingKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBeginVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoBeginCodingInfoKHR* pBeginInfo,
                                                         const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginVideoCodingKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoEndCodingInfoKHR* pEndCodingInfo,
                                                      const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndVideoCodingKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEndVideoCodingKHR(VkCommandBuffer commandBuffer, const VkVideoEndCodingInfoKHR* pEndCodingInfo,
                                                       const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndVideoCodingKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
                                                          const VkVideoCodingControlInfoKHR* pCodingControlInfo,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdControlVideoCodingKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdControlVideoCodingKHR(VkCommandBuffer commandBuffer,
                                                           const VkVideoCodingControlInfoKHR* pCodingControlInfo,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdControlVideoCodingKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pDecodeInfo,
                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDecodeVideoKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoDecodeInfoKHR* pDecodeInfo,
                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDecodeVideoKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
                                                      const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginRenderingKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
                                                       const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginRenderingKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndRenderingKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEndRenderingKHR(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndRenderingKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -3081,166 +3081,166 @@ void ThreadSafety::PreCallRecordGetDeviceGroupPeerMemoryFeaturesKHR(VkDevice dev
                                                                     uint32_t remoteDeviceIndex,
                                                                     VkPeerMemoryFeatureFlags* pPeerMemoryFeatures,
                                                                     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceGroupPeerMemoryFeaturesKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceGroupPeerMemoryFeaturesKHR(VkDevice device, uint32_t heapIndex, uint32_t localDeviceIndex,
                                                                      uint32_t remoteDeviceIndex,
                                                                      VkPeerMemoryFeatureFlags* pPeerMemoryFeatures,
                                                                      const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceGroupPeerMemoryFeaturesKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask,
                                                     const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDeviceMaskKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDeviceMaskKHR(VkCommandBuffer commandBuffer, uint32_t deviceMask,
                                                      const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDeviceMaskKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                    uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
                                                    uint32_t groupCountZ, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDispatchBaseKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                                     uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
                                                     uint32_t groupCountZ, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDispatchBaseKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordTrimCommandPoolKHR(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags,
                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkTrimCommandPoolKHR);
-    StartWriteObject(commandPool, vvl::Func::vkTrimCommandPoolKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(commandPool, record_obj.location);
     // Host access to commandPool must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordTrimCommandPoolKHR(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags,
                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkTrimCommandPoolKHR);
-    FinishWriteObject(commandPool, vvl::Func::vkTrimCommandPoolKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(commandPool, record_obj.location);
     // Host access to commandPool must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
                                                                  VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkEnumeratePhysicalDeviceGroupsKHR);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordEnumeratePhysicalDeviceGroupsKHR(VkInstance instance, uint32_t* pPhysicalDeviceGroupCount,
                                                                   VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkEnumeratePhysicalDeviceGroupsKHR);
+    FinishReadObjectParentInstance(instance, record_obj.location);
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 void ThreadSafety::PreCallRecordGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                         HANDLE* pHandle, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMemoryWin32HandleKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                          HANDLE* pHandle, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMemoryWin32HandleKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetMemoryWin32HandlePropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType,
                                                                   HANDLE handle,
                                                                   VkMemoryWin32HandlePropertiesKHR* pMemoryWin32HandleProperties,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMemoryWin32HandlePropertiesKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMemoryWin32HandlePropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType,
                                                                    HANDLE handle,
                                                                    VkMemoryWin32HandlePropertiesKHR* pMemoryWin32HandleProperties,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMemoryWin32HandlePropertiesKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 void ThreadSafety::PreCallRecordGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR* pGetFdInfo, int* pFd,
                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMemoryFdKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR* pGetFdInfo, int* pFd,
                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMemoryFdKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetMemoryFdPropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, int fd,
                                                          VkMemoryFdPropertiesKHR* pMemoryFdProperties,
                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMemoryFdPropertiesKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMemoryFdPropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, int fd,
                                                           VkMemoryFdPropertiesKHR* pMemoryFdProperties,
                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMemoryFdPropertiesKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 void ThreadSafety::PreCallRecordImportSemaphoreWin32HandleKHR(
     VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkImportSemaphoreWin32HandleKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordImportSemaphoreWin32HandleKHR(
     VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkImportSemaphoreWin32HandleKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetSemaphoreWin32HandleKHR(VkDevice device,
                                                            const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                            HANDLE* pHandle, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetSemaphoreWin32HandleKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetSemaphoreWin32HandleKHR(VkDevice device,
                                                             const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                             HANDLE* pHandle, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetSemaphoreWin32HandleKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 void ThreadSafety::PreCallRecordImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkImportSemaphoreFdKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkImportSemaphoreFdKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetSemaphoreFdKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetSemaphoreFdKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                         VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
                                                         const VkWriteDescriptorSet* pDescriptorWrites,
                                                         const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdPushDescriptorSetKHR);
-    StartReadObject(layout, vvl::Func::vkCmdPushDescriptorSetKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(layout, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -3248,8 +3248,8 @@ void ThreadSafety::PostCallRecordCmdPushDescriptorSetKHR(VkCommandBuffer command
                                                          VkPipelineLayout layout, uint32_t set, uint32_t descriptorWriteCount,
                                                          const VkWriteDescriptorSet* pDescriptorWrites,
                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdPushDescriptorSetKHR);
-    FinishReadObject(layout, vvl::Func::vkCmdPushDescriptorSetKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(layout, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -3257,9 +3257,9 @@ void ThreadSafety::PreCallRecordCmdPushDescriptorSetWithTemplateKHR(VkCommandBuf
                                                                     VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                     VkPipelineLayout layout, uint32_t set, const void* pData,
                                                                     const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdPushDescriptorSetWithTemplateKHR);
-    StartReadObject(descriptorUpdateTemplate, vvl::Func::vkCmdPushDescriptorSetWithTemplateKHR);
-    StartReadObject(layout, vvl::Func::vkCmdPushDescriptorSetWithTemplateKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(descriptorUpdateTemplate, record_obj.location);
+    StartReadObject(layout, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -3267,9 +3267,9 @@ void ThreadSafety::PostCallRecordCmdPushDescriptorSetWithTemplateKHR(VkCommandBu
                                                                      VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                      VkPipelineLayout layout, uint32_t set, const void* pData,
                                                                      const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdPushDescriptorSetWithTemplateKHR);
-    FinishReadObject(descriptorUpdateTemplate, vvl::Func::vkCmdPushDescriptorSetWithTemplateKHR);
-    FinishReadObject(layout, vvl::Func::vkCmdPushDescriptorSetWithTemplateKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(descriptorUpdateTemplate, record_obj.location);
+    FinishReadObject(layout, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -3278,7 +3278,7 @@ void ThreadSafety::PreCallRecordCreateDescriptorUpdateTemplateKHR(VkDevice devic
                                                                   const VkAllocationCallbacks* pAllocator,
                                                                   VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateDescriptorUpdateTemplateKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateDescriptorUpdateTemplateKHR(VkDevice device,
@@ -3286,7 +3286,7 @@ void ThreadSafety::PostCallRecordCreateDescriptorUpdateTemplateKHR(VkDevice devi
                                                                    const VkAllocationCallbacks* pAllocator,
                                                                    VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateDescriptorUpdateTemplateKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pDescriptorUpdateTemplate);
     }
@@ -3296,8 +3296,8 @@ void ThreadSafety::PreCallRecordDestroyDescriptorUpdateTemplateKHR(VkDevice devi
                                                                    VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                    const VkAllocationCallbacks* pAllocator,
                                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyDescriptorUpdateTemplateKHR);
-    StartWriteObject(descriptorUpdateTemplate, vvl::Func::vkDestroyDescriptorUpdateTemplateKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(descriptorUpdateTemplate, record_obj.location);
     // Host access to descriptorUpdateTemplate must be externally synchronized
 }
 
@@ -3305,8 +3305,8 @@ void ThreadSafety::PostCallRecordDestroyDescriptorUpdateTemplateKHR(VkDevice dev
                                                                     VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                                     const VkAllocationCallbacks* pAllocator,
                                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyDescriptorUpdateTemplateKHR);
-    FinishWriteObject(descriptorUpdateTemplate, vvl::Func::vkDestroyDescriptorUpdateTemplateKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(descriptorUpdateTemplate, record_obj.location);
     DestroyObject(descriptorUpdateTemplate);
     // Host access to descriptorUpdateTemplate must be externally synchronized
 }
@@ -3314,13 +3314,13 @@ void ThreadSafety::PostCallRecordDestroyDescriptorUpdateTemplateKHR(VkDevice dev
 void ThreadSafety::PreCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateRenderPass2KHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateRenderPass2KHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pRenderPass);
     }
@@ -3329,7 +3329,7 @@ void ThreadSafety::PostCallRecordCreateRenderPass2KHR(VkDevice device, const VkR
 void ThreadSafety::PreCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                                        const VkSubpassBeginInfo* pSubpassBeginInfo,
                                                        const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginRenderPass2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -3337,43 +3337,43 @@ void ThreadSafety::PostCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandB
                                                         const VkRenderPassBeginInfo* pRenderPassBegin,
                                                         const VkSubpassBeginInfo* pSubpassBeginInfo,
                                                         const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginRenderPass2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                                    const VkSubpassEndInfo* pSubpassEndInfo, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdNextSubpass2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                                     const VkSubpassEndInfo* pSubpassEndInfo, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdNextSubpass2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
                                                      const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndRenderPass2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
                                                       const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndRenderPass2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetSwapchainStatusKHR(VkDevice device, VkSwapchainKHR swapchain, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetSwapchainStatusKHR);
-    StartWriteObject(swapchain, vvl::Func::vkGetSwapchainStatusKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(swapchain, record_obj.location);
     // Host access to swapchain must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordGetSwapchainStatusKHR(VkDevice device, VkSwapchainKHR swapchain, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetSwapchainStatusKHR);
-    FinishWriteObject(swapchain, vvl::Func::vkGetSwapchainStatusKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(swapchain, record_obj.location);
     // Host access to swapchain must be externally synchronized
 }
 
@@ -3381,86 +3381,86 @@ void ThreadSafety::PostCallRecordGetSwapchainStatusKHR(VkDevice device, VkSwapch
 void ThreadSafety::PreCallRecordImportFenceWin32HandleKHR(VkDevice device,
                                                           const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo,
                                                           const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkImportFenceWin32HandleKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordImportFenceWin32HandleKHR(VkDevice device,
                                                            const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo,
                                                            const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkImportFenceWin32HandleKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                        HANDLE* pHandle, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetFenceWin32HandleKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                         HANDLE* pHandle, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetFenceWin32HandleKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 void ThreadSafety::PreCallRecordImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkImportFenceFdKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkImportFenceFdKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd,
                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetFenceFdKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd,
                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetFenceFdKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR* pInfo,
                                                         const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkAcquireProfilingLockKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR* pInfo,
                                                          const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkAcquireProfilingLockKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordReleaseProfilingLockKHR(VkDevice device, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkReleaseProfilingLockKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordReleaseProfilingLockKHR(VkDevice device, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkReleaseProfilingLockKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageMemoryRequirements2KHR(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
                                                                VkMemoryRequirements2* pMemoryRequirements,
                                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageMemoryRequirements2KHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageMemoryRequirements2KHR(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
                                                                 VkMemoryRequirements2* pMemoryRequirements,
                                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageMemoryRequirements2KHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetBufferMemoryRequirements2KHR(VkDevice device, const VkBufferMemoryRequirementsInfo2* pInfo,
                                                                 VkMemoryRequirements2* pMemoryRequirements,
                                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetBufferMemoryRequirements2KHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetBufferMemoryRequirements2KHR(VkDevice device, const VkBufferMemoryRequirementsInfo2* pInfo,
                                                                  VkMemoryRequirements2* pMemoryRequirements,
                                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetBufferMemoryRequirements2KHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageSparseMemoryRequirements2KHR(VkDevice device,
@@ -3468,7 +3468,7 @@ void ThreadSafety::PreCallRecordGetImageSparseMemoryRequirements2KHR(VkDevice de
                                                                      uint32_t* pSparseMemoryRequirementCount,
                                                                      VkSparseImageMemoryRequirements2* pSparseMemoryRequirements,
                                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageSparseMemoryRequirements2KHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageSparseMemoryRequirements2KHR(VkDevice device,
@@ -3476,7 +3476,7 @@ void ThreadSafety::PostCallRecordGetImageSparseMemoryRequirements2KHR(VkDevice d
                                                                       uint32_t* pSparseMemoryRequirementCount,
                                                                       VkSparseImageMemoryRequirements2* pSparseMemoryRequirements,
                                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageSparseMemoryRequirements2KHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateSamplerYcbcrConversionKHR(VkDevice device,
@@ -3484,7 +3484,7 @@ void ThreadSafety::PreCallRecordCreateSamplerYcbcrConversionKHR(VkDevice device,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 VkSamplerYcbcrConversion* pYcbcrConversion,
                                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateSamplerYcbcrConversionKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateSamplerYcbcrConversionKHR(VkDevice device,
@@ -3492,7 +3492,7 @@ void ThreadSafety::PostCallRecordCreateSamplerYcbcrConversionKHR(VkDevice device
                                                                  const VkAllocationCallbacks* pAllocator,
                                                                  VkSamplerYcbcrConversion* pYcbcrConversion,
                                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateSamplerYcbcrConversionKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pYcbcrConversion);
     }
@@ -3501,69 +3501,69 @@ void ThreadSafety::PostCallRecordCreateSamplerYcbcrConversionKHR(VkDevice device
 void ThreadSafety::PreCallRecordDestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                                  const VkAllocationCallbacks* pAllocator,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroySamplerYcbcrConversionKHR);
-    StartWriteObject(ycbcrConversion, vvl::Func::vkDestroySamplerYcbcrConversionKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(ycbcrConversion, record_obj.location);
     // Host access to ycbcrConversion must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                                   const VkAllocationCallbacks* pAllocator,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroySamplerYcbcrConversionKHR);
-    FinishWriteObject(ycbcrConversion, vvl::Func::vkDestroySamplerYcbcrConversionKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(ycbcrConversion, record_obj.location);
     DestroyObject(ycbcrConversion);
     // Host access to ycbcrConversion must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount,
                                                      const VkBindBufferMemoryInfo* pBindInfos, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBindBufferMemory2KHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordBindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount,
                                                       const VkBindBufferMemoryInfo* pBindInfos, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBindBufferMemory2KHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount,
                                                     const VkBindImageMemoryInfo* pBindInfos, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBindImageMemory2KHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount,
                                                      const VkBindImageMemoryInfo* pBindInfos, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBindImageMemory2KHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDescriptorSetLayoutSupportKHR(VkDevice device,
                                                                  const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
                                                                  VkDescriptorSetLayoutSupport* pSupport,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetLayoutSupportKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDescriptorSetLayoutSupportKHR(VkDevice device,
                                                                   const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
                                                                   VkDescriptorSetLayoutSupport* pSupport,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetLayoutSupportKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                         VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                         uint32_t stride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndirectCountKHR);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawIndirectCountKHR);
-    StartReadObject(countBuffer, vvl::Func::vkCmdDrawIndirectCountKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
+    StartReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                          VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                          uint32_t maxDrawCount, uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndirectCountKHR);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawIndirectCountKHR);
-    FinishReadObject(countBuffer, vvl::Func::vkCmdDrawIndirectCountKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
+    FinishReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -3571,9 +3571,9 @@ void ThreadSafety::PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer c
                                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                uint32_t maxDrawCount, uint32_t stride,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndexedIndirectCountKHR);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawIndexedIndirectCountKHR);
-    StartReadObject(countBuffer, vvl::Func::vkCmdDrawIndexedIndirectCountKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
+    StartReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -3581,114 +3581,114 @@ void ThreadSafety::PostCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer 
                                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                 uint32_t maxDrawCount, uint32_t stride,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndexedIndirectCountKHR);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawIndexedIndirectCountKHR);
-    FinishReadObject(countBuffer, vvl::Func::vkCmdDrawIndexedIndirectCountKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
+    FinishReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
                                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetSemaphoreCounterValueKHR);
-    StartReadObject(semaphore, vvl::Func::vkGetSemaphoreCounterValueKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(semaphore, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
                                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetSemaphoreCounterValueKHR);
-    FinishReadObject(semaphore, vvl::Func::vkGetSemaphoreCounterValueKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(semaphore, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkWaitSemaphoresKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordWaitSemaphoresKHR(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkWaitSemaphoresKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSignalSemaphoreKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSignalSemaphoreKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer, const VkExtent2D* pFragmentSize,
                                                              const VkFragmentShadingRateCombinerOpKHR combinerOps[2],
                                                              const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetFragmentShadingRateKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer, const VkExtent2D* pFragmentSize,
                                                               const VkFragmentShadingRateCombinerOpKHR combinerOps[2],
                                                               const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetFragmentShadingRateKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordWaitForPresentKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t presentId, uint64_t timeout,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkWaitForPresentKHR);
-    StartWriteObject(swapchain, vvl::Func::vkWaitForPresentKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(swapchain, record_obj.location);
     // Host access to swapchain must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordWaitForPresentKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t presentId, uint64_t timeout,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkWaitForPresentKHR);
-    FinishWriteObject(swapchain, vvl::Func::vkWaitForPresentKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(swapchain, record_obj.location);
     // Host access to swapchain must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetBufferDeviceAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                           const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetBufferDeviceAddressKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetBufferDeviceAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                            const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetBufferDeviceAddressKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetBufferOpaqueCaptureAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetBufferOpaqueCaptureAddressKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetBufferOpaqueCaptureAddressKHR(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetBufferOpaqueCaptureAddressKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceMemoryOpaqueCaptureAddressKHR(VkDevice device,
                                                                        const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo,
                                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceMemoryOpaqueCaptureAddressKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceMemoryOpaqueCaptureAddressKHR(VkDevice device,
                                                                         const VkDeviceMemoryOpaqueCaptureAddressInfo* pInfo,
                                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceMemoryOpaqueCaptureAddressKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateDeferredOperationKHR(VkDevice device, const VkAllocationCallbacks* pAllocator,
                                                            VkDeferredOperationKHR* pDeferredOperation,
                                                            const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateDeferredOperationKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateDeferredOperationKHR(VkDevice device, const VkAllocationCallbacks* pAllocator,
                                                             VkDeferredOperationKHR* pDeferredOperation,
                                                             const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateDeferredOperationKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pDeferredOperation);
     }
@@ -3697,68 +3697,68 @@ void ThreadSafety::PostCallRecordCreateDeferredOperationKHR(VkDevice device, con
 void ThreadSafety::PreCallRecordDestroyDeferredOperationKHR(VkDevice device, VkDeferredOperationKHR operation,
                                                             const VkAllocationCallbacks* pAllocator,
                                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyDeferredOperationKHR);
-    StartWriteObject(operation, vvl::Func::vkDestroyDeferredOperationKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(operation, record_obj.location);
     // Host access to operation must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyDeferredOperationKHR(VkDevice device, VkDeferredOperationKHR operation,
                                                              const VkAllocationCallbacks* pAllocator,
                                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyDeferredOperationKHR);
-    FinishWriteObject(operation, vvl::Func::vkDestroyDeferredOperationKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(operation, record_obj.location);
     DestroyObject(operation);
     // Host access to operation must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetDeferredOperationMaxConcurrencyKHR(VkDevice device, VkDeferredOperationKHR operation,
                                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeferredOperationMaxConcurrencyKHR);
-    StartReadObject(operation, vvl::Func::vkGetDeferredOperationMaxConcurrencyKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(operation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeferredOperationMaxConcurrencyKHR(VkDevice device, VkDeferredOperationKHR operation,
                                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeferredOperationMaxConcurrencyKHR);
-    FinishReadObject(operation, vvl::Func::vkGetDeferredOperationMaxConcurrencyKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(operation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeferredOperationResultKHR(VkDevice device, VkDeferredOperationKHR operation,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeferredOperationResultKHR);
-    StartReadObject(operation, vvl::Func::vkGetDeferredOperationResultKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(operation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeferredOperationResultKHR(VkDevice device, VkDeferredOperationKHR operation,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeferredOperationResultKHR);
-    FinishReadObject(operation, vvl::Func::vkGetDeferredOperationResultKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(operation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordDeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKHR operation,
                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDeferredOperationJoinKHR);
-    StartReadObject(operation, vvl::Func::vkDeferredOperationJoinKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(operation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordDeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKHR operation,
                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDeferredOperationJoinKHR);
-    FinishReadObject(operation, vvl::Func::vkDeferredOperationJoinKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(operation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetPipelineExecutablePropertiesKHR(VkDevice device, const VkPipelineInfoKHR* pPipelineInfo,
                                                                    uint32_t* pExecutableCount,
                                                                    VkPipelineExecutablePropertiesKHR* pProperties,
                                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPipelineExecutablePropertiesKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPipelineExecutablePropertiesKHR(VkDevice device, const VkPipelineInfoKHR* pPipelineInfo,
                                                                     uint32_t* pExecutableCount,
                                                                     VkPipelineExecutablePropertiesKHR* pProperties,
                                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPipelineExecutablePropertiesKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetPipelineExecutableStatisticsKHR(VkDevice device,
@@ -3766,7 +3766,7 @@ void ThreadSafety::PreCallRecordGetPipelineExecutableStatisticsKHR(VkDevice devi
                                                                    uint32_t* pStatisticCount,
                                                                    VkPipelineExecutableStatisticKHR* pStatistics,
                                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPipelineExecutableStatisticsKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPipelineExecutableStatisticsKHR(VkDevice device,
@@ -3774,102 +3774,102 @@ void ThreadSafety::PostCallRecordGetPipelineExecutableStatisticsKHR(VkDevice dev
                                                                     uint32_t* pStatisticCount,
                                                                     VkPipelineExecutableStatisticKHR* pStatistics,
                                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPipelineExecutableStatisticsKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetPipelineExecutableInternalRepresentationsKHR(
     VkDevice device, const VkPipelineExecutableInfoKHR* pExecutableInfo, uint32_t* pInternalRepresentationCount,
     VkPipelineExecutableInternalRepresentationKHR* pInternalRepresentations, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPipelineExecutableInternalRepresentationsKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPipelineExecutableInternalRepresentationsKHR(
     VkDevice device, const VkPipelineExecutableInfoKHR* pExecutableInfo, uint32_t* pInternalRepresentationCount,
     VkPipelineExecutableInternalRepresentationKHR* pInternalRepresentations, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPipelineExecutableInternalRepresentationsKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordMapMemory2KHR(VkDevice device, const VkMemoryMapInfoKHR* pMemoryMapInfo, void** ppData,
                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkMapMemory2KHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordMapMemory2KHR(VkDevice device, const VkMemoryMapInfoKHR* pMemoryMapInfo, void** ppData,
                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkMapMemory2KHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordUnmapMemory2KHR(VkDevice device, const VkMemoryUnmapInfoKHR* pMemoryUnmapInfo,
                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkUnmapMemory2KHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordUnmapMemory2KHR(VkDevice device, const VkMemoryUnmapInfoKHR* pMemoryUnmapInfo,
                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkUnmapMemory2KHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 void ThreadSafety::PreCallRecordGetEncodedVideoSessionParametersKHR(
     VkDevice device, const VkVideoEncodeSessionParametersGetInfoKHR* pVideoSessionParametersInfo,
     VkVideoEncodeSessionParametersFeedbackInfoKHR* pFeedbackInfo, size_t* pDataSize, void* pData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetEncodedVideoSessionParametersKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetEncodedVideoSessionParametersKHR(
     VkDevice device, const VkVideoEncodeSessionParametersGetInfoKHR* pVideoSessionParametersInfo,
     VkVideoEncodeSessionParametersFeedbackInfoKHR* pFeedbackInfo, size_t* pDataSize, void* pData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetEncodedVideoSessionParametersKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo,
                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEncodeVideoKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, const VkVideoEncodeInfoKHR* pEncodeInfo,
                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEncodeVideoKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 void ThreadSafety::PreCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
                                                 const VkDependencyInfo* pDependencyInfo, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetEvent2KHR);
-    StartReadObject(event, vvl::Func::vkCmdSetEvent2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event,
                                                  const VkDependencyInfo* pDependencyInfo, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetEvent2KHR);
-    FinishReadObject(event, vvl::Func::vkCmdSetEvent2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdResetEvent2KHR);
-    StartReadObject(event, vvl::Func::vkCmdResetEvent2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdResetEvent2KHR);
-    FinishReadObject(event, vvl::Func::vkCmdResetEvent2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(event, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                                   const VkDependencyInfo* pDependencyInfos, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWaitEvents2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pEvents) {
         for (uint32_t index = 0; index < eventCount; index++) {
-            StartReadObject(pEvents[index], vvl::Func::vkCmdWaitEvents2KHR);
+            StartReadObject(pEvents[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -3877,11 +3877,11 @@ void ThreadSafety::PreCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer,
 
 void ThreadSafety::PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                                    const VkDependencyInfo* pDependencyInfos, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWaitEvents2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pEvents) {
         for (uint32_t index = 0; index < eventCount; index++) {
-            FinishReadObject(pEvents[index], vvl::Func::vkCmdWaitEvents2KHR);
+            FinishReadObject(pEvents[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -3889,42 +3889,42 @@ void ThreadSafety::PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer
 
 void ThreadSafety::PreCallRecordCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
                                                        const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdPipelineBarrier2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
                                                         const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdPipelineBarrier2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                                       VkQueryPool queryPool, uint32_t query, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWriteTimestamp2KHR);
-    StartReadObject(queryPool, vvl::Func::vkCmdWriteTimestamp2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                                        VkQueryPool queryPool, uint32_t query, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWriteTimestamp2KHR);
-    FinishReadObject(queryPool, vvl::Func::vkCmdWriteTimestamp2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                                 const RecordObject& record_obj) {
-    StartWriteObject(queue, vvl::Func::vkQueueSubmit2KHR);
-    StartWriteObject(fence, vvl::Func::vkQueueSubmit2KHR);
+    StartWriteObject(queue, record_obj.location);
+    StartWriteObject(fence, record_obj.location);
     // Host access to queue must be externally synchronized
     // Host access to fence must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                                  const RecordObject& record_obj) {
-    FinishWriteObject(queue, vvl::Func::vkQueueSubmit2KHR);
-    FinishWriteObject(fence, vvl::Func::vkQueueSubmit2KHR);
+    FinishWriteObject(queue, record_obj.location);
+    FinishWriteObject(fence, record_obj.location);
     // Host access to queue must be externally synchronized
     // Host access to fence must be externally synchronized
 }
@@ -3932,216 +3932,216 @@ void ThreadSafety::PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitC
 void ThreadSafety::PreCallRecordCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                                          VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWriteBufferMarker2AMD);
-    StartReadObject(dstBuffer, vvl::Func::vkCmdWriteBufferMarker2AMD);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                                           VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWriteBufferMarker2AMD);
-    FinishReadObject(dstBuffer, vvl::Func::vkCmdWriteBufferMarker2AMD);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetQueueCheckpointData2NV(VkQueue queue, uint32_t* pCheckpointDataCount,
                                                           VkCheckpointData2NV* pCheckpointData, const RecordObject& record_obj) {
-    StartReadObject(queue, vvl::Func::vkGetQueueCheckpointData2NV);
+    StartReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetQueueCheckpointData2NV(VkQueue queue, uint32_t* pCheckpointDataCount,
                                                            VkCheckpointData2NV* pCheckpointData, const RecordObject& record_obj) {
-    FinishReadObject(queue, vvl::Func::vkGetQueueCheckpointData2NV);
+    FinishReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo,
                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyBuffer2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo,
                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyBuffer2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo,
                                                  const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyImage2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo,
                                                   const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyImage2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
                                                          const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyBufferToImage2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
                                                           const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyBufferToImage2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
                                                          const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyImageToBuffer2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
                                                           const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyImageToBuffer2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo,
                                                  const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBlitImage2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo,
                                                   const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBlitImage2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
                                                     const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdResolveImage2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
                                                      const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdResolveImage2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdTraceRaysIndirect2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdTraceRaysIndirect2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetDeviceBufferMemoryRequirementsKHR(VkDevice device, const VkDeviceBufferMemoryRequirements* pInfo,
                                                                      VkMemoryRequirements2* pMemoryRequirements,
                                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceBufferMemoryRequirementsKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceBufferMemoryRequirementsKHR(VkDevice device,
                                                                       const VkDeviceBufferMemoryRequirements* pInfo,
                                                                       VkMemoryRequirements2* pMemoryRequirements,
                                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceBufferMemoryRequirementsKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceImageMemoryRequirementsKHR(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo,
                                                                     VkMemoryRequirements2* pMemoryRequirements,
                                                                     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceImageMemoryRequirementsKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceImageMemoryRequirementsKHR(VkDevice device, const VkDeviceImageMemoryRequirements* pInfo,
                                                                      VkMemoryRequirements2* pMemoryRequirements,
                                                                      const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceImageMemoryRequirementsKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceImageSparseMemoryRequirementsKHR(
     VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, uint32_t* pSparseMemoryRequirementCount,
     VkSparseImageMemoryRequirements2* pSparseMemoryRequirements, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceImageSparseMemoryRequirementsKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceImageSparseMemoryRequirementsKHR(
     VkDevice device, const VkDeviceImageMemoryRequirements* pInfo, uint32_t* pSparseMemoryRequirementCount,
     VkSparseImageMemoryRequirements2* pSparseMemoryRequirements, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceImageSparseMemoryRequirementsKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                        VkDeviceSize size, VkIndexType indexType, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindIndexBuffer2KHR);
-    StartReadObject(buffer, vvl::Func::vkCmdBindIndexBuffer2KHR);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                         VkDeviceSize size, VkIndexType indexType, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindIndexBuffer2KHR);
-    FinishReadObject(buffer, vvl::Func::vkCmdBindIndexBuffer2KHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetRenderingAreaGranularityKHR(VkDevice device, const VkRenderingAreaInfoKHR* pRenderingAreaInfo,
                                                                VkExtent2D* pGranularity, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetRenderingAreaGranularityKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetRenderingAreaGranularityKHR(VkDevice device, const VkRenderingAreaInfoKHR* pRenderingAreaInfo,
                                                                 VkExtent2D* pGranularity, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetRenderingAreaGranularityKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceImageSubresourceLayoutKHR(VkDevice device, const VkDeviceImageSubresourceInfoKHR* pInfo,
                                                                    VkSubresourceLayout2KHR* pLayout,
                                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceImageSubresourceLayoutKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceImageSubresourceLayoutKHR(VkDevice device, const VkDeviceImageSubresourceInfoKHR* pInfo,
                                                                     VkSubresourceLayout2KHR* pLayout,
                                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceImageSubresourceLayoutKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageSubresourceLayout2KHR(VkDevice device, VkImage image,
                                                               const VkImageSubresource2KHR* pSubresource,
                                                               VkSubresourceLayout2KHR* pLayout, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageSubresourceLayout2KHR);
-    StartReadObject(image, vvl::Func::vkGetImageSubresourceLayout2KHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageSubresourceLayout2KHR(VkDevice device, VkImage image,
                                                                const VkImageSubresource2KHR* pSubresource,
                                                                VkSubresourceLayout2KHR* pLayout, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageSubresourceLayout2KHR);
-    FinishReadObject(image, vvl::Func::vkGetImageSubresourceLayout2KHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateDebugReportCallbackEXT(VkInstance instance,
                                                              const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
                                                              const VkAllocationCallbacks* pAllocator,
                                                              VkDebugReportCallbackEXT* pCallback, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateDebugReportCallbackEXT);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateDebugReportCallbackEXT(VkInstance instance,
                                                               const VkDebugReportCallbackCreateInfoEXT* pCreateInfo,
                                                               const VkAllocationCallbacks* pAllocator,
                                                               VkDebugReportCallbackEXT* pCallback, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateDebugReportCallbackEXT);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pCallback);
     }
@@ -4150,16 +4150,16 @@ void ThreadSafety::PostCallRecordCreateDebugReportCallbackEXT(VkInstance instanc
 void ThreadSafety::PreCallRecordDestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCallbackEXT callback,
                                                               const VkAllocationCallbacks* pAllocator,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkDestroyDebugReportCallbackEXT);
-    StartWriteObjectParentInstance(callback, vvl::Func::vkDestroyDebugReportCallbackEXT);
+    StartReadObjectParentInstance(instance, record_obj.location);
+    StartWriteObjectParentInstance(callback, record_obj.location);
     // Host access to callback must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCallbackEXT callback,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkDestroyDebugReportCallbackEXT);
-    FinishWriteObjectParentInstance(callback, vvl::Func::vkDestroyDebugReportCallbackEXT);
+    FinishReadObjectParentInstance(instance, record_obj.location);
+    FinishWriteObjectParentInstance(callback, record_obj.location);
     DestroyObjectParentInstance(callback);
     // Host access to callback must be externally synchronized
 }
@@ -4168,25 +4168,25 @@ void ThreadSafety::PreCallRecordDebugReportMessageEXT(VkInstance instance, VkDeb
                                                       VkDebugReportObjectTypeEXT objectType, uint64_t object, size_t location,
                                                       int32_t messageCode, const char* pLayerPrefix, const char* pMessage,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkDebugReportMessageEXT);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordDebugReportMessageEXT(VkInstance instance, VkDebugReportFlagsEXT flags,
                                                        VkDebugReportObjectTypeEXT objectType, uint64_t object, size_t location,
                                                        int32_t messageCode, const char* pLayerPrefix, const char* pMessage,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkDebugReportMessageEXT);
+    FinishReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
                                                                    uint32_t bindingCount, const VkBuffer* pBuffers,
                                                                    const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
                                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindTransformFeedbackBuffersEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pBuffers) {
         for (uint32_t index = 0; index < bindingCount; index++) {
-            StartReadObject(pBuffers[index], vvl::Func::vkCmdBindTransformFeedbackBuffersEXT);
+            StartReadObject(pBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -4196,11 +4196,11 @@ void ThreadSafety::PostCallRecordCmdBindTransformFeedbackBuffersEXT(VkCommandBuf
                                                                     uint32_t bindingCount, const VkBuffer* pBuffers,
                                                                     const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
                                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindTransformFeedbackBuffersEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pBuffers) {
         for (uint32_t index = 0; index < bindingCount; index++) {
-            FinishReadObject(pBuffers[index], vvl::Func::vkCmdBindTransformFeedbackBuffersEXT);
+            FinishReadObject(pBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -4210,11 +4210,11 @@ void ThreadSafety::PreCallRecordCmdBeginTransformFeedbackEXT(VkCommandBuffer com
                                                              uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
                                                              const VkDeviceSize* pCounterBufferOffsets,
                                                              const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginTransformFeedbackEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pCounterBuffers) {
         for (uint32_t index = 0; index < counterBufferCount; index++) {
-            StartReadObject(pCounterBuffers[index], vvl::Func::vkCmdBeginTransformFeedbackEXT);
+            StartReadObject(pCounterBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -4224,11 +4224,11 @@ void ThreadSafety::PostCallRecordCmdBeginTransformFeedbackEXT(VkCommandBuffer co
                                                               uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
                                                               const VkDeviceSize* pCounterBufferOffsets,
                                                               const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginTransformFeedbackEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pCounterBuffers) {
         for (uint32_t index = 0; index < counterBufferCount; index++) {
-            FinishReadObject(pCounterBuffers[index], vvl::Func::vkCmdBeginTransformFeedbackEXT);
+            FinishReadObject(pCounterBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -4238,11 +4238,11 @@ void ThreadSafety::PreCallRecordCmdEndTransformFeedbackEXT(VkCommandBuffer comma
                                                            uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
                                                            const VkDeviceSize* pCounterBufferOffsets,
                                                            const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndTransformFeedbackEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pCounterBuffers) {
         for (uint32_t index = 0; index < counterBufferCount; index++) {
-            StartReadObject(pCounterBuffers[index], vvl::Func::vkCmdEndTransformFeedbackEXT);
+            StartReadObject(pCounterBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -4252,11 +4252,11 @@ void ThreadSafety::PostCallRecordCmdEndTransformFeedbackEXT(VkCommandBuffer comm
                                                             uint32_t counterBufferCount, const VkBuffer* pCounterBuffers,
                                                             const VkDeviceSize* pCounterBufferOffsets,
                                                             const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndTransformFeedbackEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pCounterBuffers) {
         for (uint32_t index = 0; index < counterBufferCount; index++) {
-            FinishReadObject(pCounterBuffers[index], vvl::Func::vkCmdEndTransformFeedbackEXT);
+            FinishReadObject(pCounterBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -4264,30 +4264,30 @@ void ThreadSafety::PostCallRecordCmdEndTransformFeedbackEXT(VkCommandBuffer comm
 
 void ThreadSafety::PreCallRecordCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                                         VkQueryControlFlags flags, uint32_t index, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginQueryIndexedEXT);
-    StartReadObject(queryPool, vvl::Func::vkCmdBeginQueryIndexedEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                                          VkQueryControlFlags flags, uint32_t index,
                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginQueryIndexedEXT);
-    FinishReadObject(queryPool, vvl::Func::vkCmdBeginQueryIndexedEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                                       uint32_t index, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndQueryIndexedEXT);
-    StartReadObject(queryPool, vvl::Func::vkCmdEndQueryIndexedEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                                        uint32_t index, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndQueryIndexedEXT);
-    FinishReadObject(queryPool, vvl::Func::vkCmdEndQueryIndexedEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -4295,8 +4295,8 @@ void ThreadSafety::PreCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer comm
                                                             uint32_t firstInstance, VkBuffer counterBuffer,
                                                             VkDeviceSize counterBufferOffset, uint32_t counterOffset,
                                                             uint32_t vertexStride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndirectByteCountEXT);
-    StartReadObject(counterBuffer, vvl::Func::vkCmdDrawIndirectByteCountEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(counterBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -4304,21 +4304,21 @@ void ThreadSafety::PostCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer com
                                                              uint32_t firstInstance, VkBuffer counterBuffer,
                                                              VkDeviceSize counterBufferOffset, uint32_t counterOffset,
                                                              uint32_t vertexStride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndirectByteCountEXT);
-    FinishReadObject(counterBuffer, vvl::Func::vkCmdDrawIndirectByteCountEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(counterBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCreateCuModuleNVX(VkDevice device, const VkCuModuleCreateInfoNVX* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkCuModuleNVX* pModule,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateCuModuleNVX);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateCuModuleNVX(VkDevice device, const VkCuModuleCreateInfoNVX* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkCuModuleNVX* pModule,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateCuModuleNVX);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pModule);
     }
@@ -4327,13 +4327,13 @@ void ThreadSafety::PostCallRecordCreateCuModuleNVX(VkDevice device, const VkCuMo
 void ThreadSafety::PreCallRecordCreateCuFunctionNVX(VkDevice device, const VkCuFunctionCreateInfoNVX* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkCuFunctionNVX* pFunction,
                                                     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateCuFunctionNVX);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateCuFunctionNVX(VkDevice device, const VkCuFunctionCreateInfoNVX* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkCuFunctionNVX* pFunction,
                                                      const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateCuFunctionNVX);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pFunction);
     }
@@ -4341,77 +4341,77 @@ void ThreadSafety::PostCallRecordCreateCuFunctionNVX(VkDevice device, const VkCu
 
 void ThreadSafety::PreCallRecordDestroyCuModuleNVX(VkDevice device, VkCuModuleNVX module, const VkAllocationCallbacks* pAllocator,
                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyCuModuleNVX);
-    StartReadObject(module, vvl::Func::vkDestroyCuModuleNVX);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(module, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordDestroyCuModuleNVX(VkDevice device, VkCuModuleNVX module, const VkAllocationCallbacks* pAllocator,
                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyCuModuleNVX);
-    FinishReadObject(module, vvl::Func::vkDestroyCuModuleNVX);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(module, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordDestroyCuFunctionNVX(VkDevice device, VkCuFunctionNVX function,
                                                      const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyCuFunctionNVX);
-    StartReadObject(function, vvl::Func::vkDestroyCuFunctionNVX);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(function, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordDestroyCuFunctionNVX(VkDevice device, VkCuFunctionNVX function,
                                                       const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyCuFunctionNVX);
-    FinishReadObject(function, vvl::Func::vkDestroyCuFunctionNVX);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(function, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer, const VkCuLaunchInfoNVX* pLaunchInfo,
                                                      const RecordObject& record_obj) {
-    StartReadObject(commandBuffer, vvl::Func::vkCmdCuLaunchKernelNVX);
+    StartReadObject(commandBuffer, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCmdCuLaunchKernelNVX(VkCommandBuffer commandBuffer, const VkCuLaunchInfoNVX* pLaunchInfo,
                                                       const RecordObject& record_obj) {
-    FinishReadObject(commandBuffer, vvl::Func::vkCmdCuLaunchKernelNVX);
+    FinishReadObject(commandBuffer, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageViewHandleNVX(VkDevice device, const VkImageViewHandleInfoNVX* pInfo,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageViewHandleNVX);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageViewHandleNVX(VkDevice device, const VkImageViewHandleInfoNVX* pInfo,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageViewHandleNVX);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageViewAddressNVX(VkDevice device, VkImageView imageView,
                                                        VkImageViewAddressPropertiesNVX* pProperties,
                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageViewAddressNVX);
-    StartReadObject(imageView, vvl::Func::vkGetImageViewAddressNVX);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(imageView, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageViewAddressNVX(VkDevice device, VkImageView imageView,
                                                         VkImageViewAddressPropertiesNVX* pProperties,
                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageViewAddressNVX);
-    FinishReadObject(imageView, vvl::Func::vkGetImageViewAddressNVX);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(imageView, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                         VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                         uint32_t stride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndirectCountAMD);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawIndirectCountAMD);
-    StartReadObject(countBuffer, vvl::Func::vkCmdDrawIndirectCountAMD);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
+    StartReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                          VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                          uint32_t maxDrawCount, uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndirectCountAMD);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawIndirectCountAMD);
-    FinishReadObject(countBuffer, vvl::Func::vkCmdDrawIndirectCountAMD);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
+    FinishReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -4419,9 +4419,9 @@ void ThreadSafety::PreCallRecordCmdDrawIndexedIndirectCountAMD(VkCommandBuffer c
                                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                uint32_t maxDrawCount, uint32_t stride,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndexedIndirectCountAMD);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawIndexedIndirectCountAMD);
-    StartReadObject(countBuffer, vvl::Func::vkCmdDrawIndexedIndirectCountAMD);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
+    StartReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -4429,24 +4429,24 @@ void ThreadSafety::PostCallRecordCmdDrawIndexedIndirectCountAMD(VkCommandBuffer 
                                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                 uint32_t maxDrawCount, uint32_t stride,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawIndexedIndirectCountAMD);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawIndexedIndirectCountAMD);
-    FinishReadObject(countBuffer, vvl::Func::vkCmdDrawIndexedIndirectCountAMD);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
+    FinishReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetShaderInfoAMD(VkDevice device, VkPipeline pipeline, VkShaderStageFlagBits shaderStage,
                                                  VkShaderInfoTypeAMD infoType, size_t* pInfoSize, void* pInfo,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetShaderInfoAMD);
-    StartReadObject(pipeline, vvl::Func::vkGetShaderInfoAMD);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetShaderInfoAMD(VkDevice device, VkPipeline pipeline, VkShaderStageFlagBits shaderStage,
                                                   VkShaderInfoTypeAMD infoType, size_t* pInfoSize, void* pInfo,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetShaderInfoAMD);
-    FinishReadObject(pipeline, vvl::Func::vkGetShaderInfoAMD);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipeline, record_obj.location);
 }
 
 #ifdef VK_USE_PLATFORM_GGP
@@ -4454,14 +4454,14 @@ void ThreadSafety::PreCallRecordCreateStreamDescriptorSurfaceGGP(VkInstance inst
                                                                  const VkStreamDescriptorSurfaceCreateInfoGGP* pCreateInfo,
                                                                  const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateStreamDescriptorSurfaceGGP);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateStreamDescriptorSurfaceGGP(VkInstance instance,
                                                                   const VkStreamDescriptorSurfaceCreateInfoGGP* pCreateInfo,
                                                                   const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateStreamDescriptorSurfaceGGP);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -4472,15 +4472,15 @@ void ThreadSafety::PostCallRecordCreateStreamDescriptorSurfaceGGP(VkInstance ins
 void ThreadSafety::PreCallRecordGetMemoryWin32HandleNV(VkDevice device, VkDeviceMemory memory,
                                                        VkExternalMemoryHandleTypeFlagsNV handleType, HANDLE* pHandle,
                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMemoryWin32HandleNV);
-    StartReadObject(memory, vvl::Func::vkGetMemoryWin32HandleNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(memory, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMemoryWin32HandleNV(VkDevice device, VkDeviceMemory memory,
                                                         VkExternalMemoryHandleTypeFlagsNV handleType, HANDLE* pHandle,
                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMemoryWin32HandleNV);
-    FinishReadObject(memory, vvl::Func::vkGetMemoryWin32HandleNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(memory, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_WIN32_KHR
@@ -4488,13 +4488,13 @@ void ThreadSafety::PostCallRecordGetMemoryWin32HandleNV(VkDevice device, VkDevic
 void ThreadSafety::PreCallRecordCreateViSurfaceNN(VkInstance instance, const VkViSurfaceCreateInfoNN* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateViSurfaceNN);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateViSurfaceNN(VkInstance instance, const VkViSurfaceCreateInfoNN* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateViSurfaceNN);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -4504,128 +4504,128 @@ void ThreadSafety::PostCallRecordCreateViSurfaceNN(VkInstance instance, const Vk
 void ThreadSafety::PreCallRecordCmdBeginConditionalRenderingEXT(
     VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin,
     const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginConditionalRenderingEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBeginConditionalRenderingEXT(
     VkCommandBuffer commandBuffer, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin,
     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginConditionalRenderingEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndConditionalRenderingEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEndConditionalRenderingEXT(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndConditionalRenderingEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                          uint32_t viewportCount, const VkViewportWScalingNV* pViewportWScalings,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportWScalingNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                           uint32_t viewportCount, const VkViewportWScalingNV* pViewportWScalings,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportWScalingNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordReleaseDisplayEXT(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(display, vvl::Func::vkReleaseDisplayEXT);
+    StartReadObjectParentInstance(display, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordReleaseDisplayEXT(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(display, vvl::Func::vkReleaseDisplayEXT);
+    FinishReadObjectParentInstance(display, record_obj.location);
 }
 
 #ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
 void ThreadSafety::PreCallRecordAcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, VkDisplayKHR display,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(display, vvl::Func::vkAcquireXlibDisplayEXT);
+    StartReadObjectParentInstance(display, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordAcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, VkDisplayKHR display,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(display, vvl::Func::vkAcquireXlibDisplayEXT);
+    FinishReadObjectParentInstance(display, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT
 void ThreadSafety::PreCallRecordGetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                          VkSurfaceCapabilities2EXT* pSurfaceCapabilities,
                                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(surface, vvl::Func::vkGetPhysicalDeviceSurfaceCapabilities2EXT);
+    StartReadObjectParentInstance(surface, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                           VkSurfaceCapabilities2EXT* pSurfaceCapabilities,
                                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(surface, vvl::Func::vkGetPhysicalDeviceSurfaceCapabilities2EXT);
+    FinishReadObjectParentInstance(surface, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordDisplayPowerControlEXT(VkDevice device, VkDisplayKHR display,
                                                        const VkDisplayPowerInfoEXT* pDisplayPowerInfo,
                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDisplayPowerControlEXT);
-    StartReadObjectParentInstance(display, vvl::Func::vkDisplayPowerControlEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObjectParentInstance(display, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordDisplayPowerControlEXT(VkDevice device, VkDisplayKHR display,
                                                         const VkDisplayPowerInfoEXT* pDisplayPowerInfo,
                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDisplayPowerControlEXT);
-    FinishReadObjectParentInstance(display, vvl::Func::vkDisplayPowerControlEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObjectParentInstance(display, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordRegisterDeviceEventEXT(VkDevice device, const VkDeviceEventInfoEXT* pDeviceEventInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkFence* pFence,
                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkRegisterDeviceEventEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordRegisterDeviceEventEXT(VkDevice device, const VkDeviceEventInfoEXT* pDeviceEventInfo,
                                                         const VkAllocationCallbacks* pAllocator, VkFence* pFence,
                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkRegisterDeviceEventEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchain,
                                                        VkSurfaceCounterFlagBitsEXT counter, uint64_t* pCounterValue,
                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetSwapchainCounterEXT);
-    StartReadObject(swapchain, vvl::Func::vkGetSwapchainCounterEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchain,
                                                         VkSurfaceCounterFlagBitsEXT counter, uint64_t* pCounterValue,
                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetSwapchainCounterEXT);
-    FinishReadObject(swapchain, vvl::Func::vkGetSwapchainCounterEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain,
                                                               VkRefreshCycleDurationGOOGLE* pDisplayTimingProperties,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetRefreshCycleDurationGOOGLE);
-    StartWriteObject(swapchain, vvl::Func::vkGetRefreshCycleDurationGOOGLE);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(swapchain, record_obj.location);
     // Host access to swapchain must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordGetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain,
                                                                VkRefreshCycleDurationGOOGLE* pDisplayTimingProperties,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetRefreshCycleDurationGOOGLE);
-    FinishWriteObject(swapchain, vvl::Func::vkGetRefreshCycleDurationGOOGLE);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(swapchain, record_obj.location);
     // Host access to swapchain must be externally synchronized
 }
 
@@ -4633,8 +4633,8 @@ void ThreadSafety::PreCallRecordGetPastPresentationTimingGOOGLE(VkDevice device,
                                                                 uint32_t* pPresentationTimingCount,
                                                                 VkPastPresentationTimingGOOGLE* pPresentationTimings,
                                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPastPresentationTimingGOOGLE);
-    StartWriteObject(swapchain, vvl::Func::vkGetPastPresentationTimingGOOGLE);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(swapchain, record_obj.location);
     // Host access to swapchain must be externally synchronized
 }
 
@@ -4642,69 +4642,69 @@ void ThreadSafety::PostCallRecordGetPastPresentationTimingGOOGLE(VkDevice device
                                                                  uint32_t* pPresentationTimingCount,
                                                                  VkPastPresentationTimingGOOGLE* pPresentationTimings,
                                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPastPresentationTimingGOOGLE);
-    FinishWriteObject(swapchain, vvl::Func::vkGetPastPresentationTimingGOOGLE);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(swapchain, record_obj.location);
     // Host access to swapchain must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
                                                           uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles,
                                                           const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDiscardRectangleEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
                                                            uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles,
                                                            const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDiscardRectangleEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 discardRectangleEnable,
                                                                 const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDiscardRectangleEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 discardRectangleEnable,
                                                                  const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDiscardRectangleEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer,
                                                               VkDiscardRectangleModeEXT discardRectangleMode,
                                                               const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDiscardRectangleModeEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer,
                                                                VkDiscardRectangleModeEXT discardRectangleMode,
                                                                const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDiscardRectangleModeEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordSetHdrMetadataEXT(VkDevice device, uint32_t swapchainCount, const VkSwapchainKHR* pSwapchains,
                                                   const VkHdrMetadataEXT* pMetadata, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSetHdrMetadataEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 
     if (pSwapchains) {
         for (uint32_t index = 0; index < swapchainCount; index++) {
-            StartReadObject(pSwapchains[index], vvl::Func::vkSetHdrMetadataEXT);
+            StartReadObject(pSwapchains[index], record_obj.location);
         }
     }
 }
 
 void ThreadSafety::PostCallRecordSetHdrMetadataEXT(VkDevice device, uint32_t swapchainCount, const VkSwapchainKHR* pSwapchains,
                                                    const VkHdrMetadataEXT* pMetadata, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSetHdrMetadataEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 
     if (pSwapchains) {
         for (uint32_t index = 0; index < swapchainCount; index++) {
-            FinishReadObject(pSwapchains[index], vvl::Func::vkSetHdrMetadataEXT);
+            FinishReadObject(pSwapchains[index], record_obj.location);
         }
     }
 }
@@ -4713,13 +4713,13 @@ void ThreadSafety::PostCallRecordSetHdrMetadataEXT(VkDevice device, uint32_t swa
 void ThreadSafety::PreCallRecordCreateIOSSurfaceMVK(VkInstance instance, const VkIOSSurfaceCreateInfoMVK* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateIOSSurfaceMVK);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateIOSSurfaceMVK(VkInstance instance, const VkIOSSurfaceCreateInfoMVK* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                      const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateIOSSurfaceMVK);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -4730,13 +4730,13 @@ void ThreadSafety::PostCallRecordCreateIOSSurfaceMVK(VkInstance instance, const 
 void ThreadSafety::PreCallRecordCreateMacOSSurfaceMVK(VkInstance instance, const VkMacOSSurfaceCreateInfoMVK* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateMacOSSurfaceMVK);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateMacOSSurfaceMVK(VkInstance instance, const VkMacOSSurfaceCreateInfoMVK* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateMacOSSurfaceMVK);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -4745,63 +4745,63 @@ void ThreadSafety::PostCallRecordCreateMacOSSurfaceMVK(VkInstance instance, cons
 #endif  // VK_USE_PLATFORM_MACOS_MVK
 void ThreadSafety::PreCallRecordQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo,
                                                              const RecordObject& record_obj) {
-    StartReadObject(queue, vvl::Func::vkQueueBeginDebugUtilsLabelEXT);
+    StartReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordQueueBeginDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo,
                                                               const RecordObject& record_obj) {
-    FinishReadObject(queue, vvl::Func::vkQueueBeginDebugUtilsLabelEXT);
+    FinishReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordQueueEndDebugUtilsLabelEXT(VkQueue queue, const RecordObject& record_obj) {
-    StartReadObject(queue, vvl::Func::vkQueueEndDebugUtilsLabelEXT);
+    StartReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordQueueEndDebugUtilsLabelEXT(VkQueue queue, const RecordObject& record_obj) {
-    FinishReadObject(queue, vvl::Func::vkQueueEndDebugUtilsLabelEXT);
+    FinishReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordQueueInsertDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo,
                                                               const RecordObject& record_obj) {
-    StartReadObject(queue, vvl::Func::vkQueueInsertDebugUtilsLabelEXT);
+    StartReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordQueueInsertDebugUtilsLabelEXT(VkQueue queue, const VkDebugUtilsLabelEXT* pLabelInfo,
                                                                const RecordObject& record_obj) {
-    FinishReadObject(queue, vvl::Func::vkQueueInsertDebugUtilsLabelEXT);
+    FinishReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
                                                            const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBeginDebugUtilsLabelEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
                                                             const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBeginDebugUtilsLabelEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdEndDebugUtilsLabelEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdEndDebugUtilsLabelEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
                                                             const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdInsertDebugUtilsLabelEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
                                                              const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdInsertDebugUtilsLabelEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -4809,7 +4809,7 @@ void ThreadSafety::PreCallRecordCreateDebugUtilsMessengerEXT(VkInstance instance
                                                              const VkDebugUtilsMessengerCreateInfoEXT* pCreateInfo,
                                                              const VkAllocationCallbacks* pAllocator,
                                                              VkDebugUtilsMessengerEXT* pMessenger, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateDebugUtilsMessengerEXT);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateDebugUtilsMessengerEXT(VkInstance instance,
@@ -4817,7 +4817,7 @@ void ThreadSafety::PostCallRecordCreateDebugUtilsMessengerEXT(VkInstance instanc
                                                               const VkAllocationCallbacks* pAllocator,
                                                               VkDebugUtilsMessengerEXT* pMessenger,
                                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateDebugUtilsMessengerEXT);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pMessenger);
     }
@@ -4826,16 +4826,16 @@ void ThreadSafety::PostCallRecordCreateDebugUtilsMessengerEXT(VkInstance instanc
 void ThreadSafety::PreCallRecordDestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT messenger,
                                                               const VkAllocationCallbacks* pAllocator,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkDestroyDebugUtilsMessengerEXT);
-    StartWriteObjectParentInstance(messenger, vvl::Func::vkDestroyDebugUtilsMessengerEXT);
+    StartReadObjectParentInstance(instance, record_obj.location);
+    StartWriteObjectParentInstance(messenger, record_obj.location);
     // Host access to messenger must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyDebugUtilsMessengerEXT(VkInstance instance, VkDebugUtilsMessengerEXT messenger,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkDestroyDebugUtilsMessengerEXT);
-    FinishWriteObjectParentInstance(messenger, vvl::Func::vkDestroyDebugUtilsMessengerEXT);
+    FinishReadObjectParentInstance(instance, record_obj.location);
+    FinishWriteObjectParentInstance(messenger, record_obj.location);
     DestroyObjectParentInstance(messenger);
     // Host access to messenger must be externally synchronized
 }
@@ -4845,7 +4845,7 @@ void ThreadSafety::PreCallRecordSubmitDebugUtilsMessageEXT(VkInstance instance,
                                                            VkDebugUtilsMessageTypeFlagsEXT messageTypes,
                                                            const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData,
                                                            const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkSubmitDebugUtilsMessageEXT);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSubmitDebugUtilsMessageEXT(VkInstance instance,
@@ -4853,34 +4853,34 @@ void ThreadSafety::PostCallRecordSubmitDebugUtilsMessageEXT(VkInstance instance,
                                                             VkDebugUtilsMessageTypeFlagsEXT messageTypes,
                                                             const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData,
                                                             const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkSubmitDebugUtilsMessageEXT);
+    FinishReadObjectParentInstance(instance, record_obj.location);
 }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 void ThreadSafety::PreCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
                                                                           VkAndroidHardwareBufferPropertiesANDROID* pProperties,
                                                                           const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetAndroidHardwareBufferPropertiesANDROID);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
                                                                            VkAndroidHardwareBufferPropertiesANDROID* pProperties,
                                                                            const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetAndroidHardwareBufferPropertiesANDROID);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetMemoryAndroidHardwareBufferANDROID(VkDevice device,
                                                                       const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo,
                                                                       struct AHardwareBuffer** pBuffer,
                                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMemoryAndroidHardwareBufferANDROID);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMemoryAndroidHardwareBufferANDROID(VkDevice device,
                                                                        const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo,
                                                                        struct AHardwareBuffer** pBuffer,
                                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMemoryAndroidHardwareBufferANDROID);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
@@ -4890,8 +4890,8 @@ void ThreadSafety::PreCallRecordCreateExecutionGraphPipelinesAMDX(VkDevice devic
                                                                   const VkExecutionGraphPipelineCreateInfoAMDX* pCreateInfos,
                                                                   const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateExecutionGraphPipelinesAMDX);
-    StartReadObject(pipelineCache, vvl::Func::vkCreateExecutionGraphPipelinesAMDX);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipelineCache, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateExecutionGraphPipelinesAMDX(VkDevice device, VkPipelineCache pipelineCache,
@@ -4899,8 +4899,8 @@ void ThreadSafety::PostCallRecordCreateExecutionGraphPipelinesAMDX(VkDevice devi
                                                                    const VkExecutionGraphPipelineCreateInfoAMDX* pCreateInfos,
                                                                    const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateExecutionGraphPipelinesAMDX);
-    FinishReadObject(pipelineCache, vvl::Func::vkCreateExecutionGraphPipelinesAMDX);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipelineCache, record_obj.location);
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
             if (!pPipelines[index]) continue;
@@ -4912,114 +4912,114 @@ void ThreadSafety::PostCallRecordCreateExecutionGraphPipelinesAMDX(VkDevice devi
 void ThreadSafety::PreCallRecordGetExecutionGraphPipelineScratchSizeAMDX(VkDevice device, VkPipeline executionGraph,
                                                                          VkExecutionGraphPipelineScratchSizeAMDX* pSizeInfo,
                                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetExecutionGraphPipelineScratchSizeAMDX);
-    StartReadObject(executionGraph, vvl::Func::vkGetExecutionGraphPipelineScratchSizeAMDX);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(executionGraph, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetExecutionGraphPipelineScratchSizeAMDX(VkDevice device, VkPipeline executionGraph,
                                                                           VkExecutionGraphPipelineScratchSizeAMDX* pSizeInfo,
                                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetExecutionGraphPipelineScratchSizeAMDX);
-    FinishReadObject(executionGraph, vvl::Func::vkGetExecutionGraphPipelineScratchSizeAMDX);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(executionGraph, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetExecutionGraphPipelineNodeIndexAMDX(VkDevice device, VkPipeline executionGraph,
                                                                        const VkPipelineShaderStageNodeCreateInfoAMDX* pNodeInfo,
                                                                        uint32_t* pNodeIndex, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetExecutionGraphPipelineNodeIndexAMDX);
-    StartReadObject(executionGraph, vvl::Func::vkGetExecutionGraphPipelineNodeIndexAMDX);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(executionGraph, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetExecutionGraphPipelineNodeIndexAMDX(VkDevice device, VkPipeline executionGraph,
                                                                         const VkPipelineShaderStageNodeCreateInfoAMDX* pNodeInfo,
                                                                         uint32_t* pNodeIndex, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetExecutionGraphPipelineNodeIndexAMDX);
-    FinishReadObject(executionGraph, vvl::Func::vkGetExecutionGraphPipelineNodeIndexAMDX);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(executionGraph, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdInitializeGraphScratchMemoryAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                                     const RecordObject& record_obj) {
-    StartReadObject(commandBuffer, vvl::Func::vkCmdInitializeGraphScratchMemoryAMDX);
+    StartReadObject(commandBuffer, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCmdInitializeGraphScratchMemoryAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                                      const RecordObject& record_obj) {
-    FinishReadObject(commandBuffer, vvl::Func::vkCmdInitializeGraphScratchMemoryAMDX);
+    FinishReadObject(commandBuffer, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdDispatchGraphAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                      const VkDispatchGraphCountInfoAMDX* pCountInfo,
                                                      const RecordObject& record_obj) {
-    StartReadObject(commandBuffer, vvl::Func::vkCmdDispatchGraphAMDX);
+    StartReadObject(commandBuffer, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCmdDispatchGraphAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                       const VkDispatchGraphCountInfoAMDX* pCountInfo,
                                                       const RecordObject& record_obj) {
-    FinishReadObject(commandBuffer, vvl::Func::vkCmdDispatchGraphAMDX);
+    FinishReadObject(commandBuffer, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdDispatchGraphIndirectAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                              const VkDispatchGraphCountInfoAMDX* pCountInfo,
                                                              const RecordObject& record_obj) {
-    StartReadObject(commandBuffer, vvl::Func::vkCmdDispatchGraphIndirectAMDX);
+    StartReadObject(commandBuffer, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCmdDispatchGraphIndirectAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                               const VkDispatchGraphCountInfoAMDX* pCountInfo,
                                                               const RecordObject& record_obj) {
-    FinishReadObject(commandBuffer, vvl::Func::vkCmdDispatchGraphIndirectAMDX);
+    FinishReadObject(commandBuffer, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdDispatchGraphIndirectCountAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                                   VkDeviceAddress countInfo, const RecordObject& record_obj) {
-    StartReadObject(commandBuffer, vvl::Func::vkCmdDispatchGraphIndirectCountAMDX);
+    StartReadObject(commandBuffer, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCmdDispatchGraphIndirectCountAMDX(VkCommandBuffer commandBuffer, VkDeviceAddress scratch,
                                                                    VkDeviceAddress countInfo, const RecordObject& record_obj) {
-    FinishReadObject(commandBuffer, vvl::Func::vkCmdDispatchGraphIndirectCountAMDX);
+    FinishReadObject(commandBuffer, record_obj.location);
 }
 
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 void ThreadSafety::PreCallRecordCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer,
                                                          const VkSampleLocationsInfoEXT* pSampleLocationsInfo,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetSampleLocationsEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer,
                                                           const VkSampleLocationsInfoEXT* pSampleLocationsInfo,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetSampleLocationsEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetImageDrmFormatModifierPropertiesEXT(VkDevice device, VkImage image,
                                                                        VkImageDrmFormatModifierPropertiesEXT* pProperties,
                                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageDrmFormatModifierPropertiesEXT);
-    StartReadObject(image, vvl::Func::vkGetImageDrmFormatModifierPropertiesEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageDrmFormatModifierPropertiesEXT(VkDevice device, VkImage image,
                                                                         VkImageDrmFormatModifierPropertiesEXT* pProperties,
                                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageDrmFormatModifierPropertiesEXT);
-    FinishReadObject(image, vvl::Func::vkGetImageDrmFormatModifierPropertiesEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,
                                                          const VkAllocationCallbacks* pAllocator,
                                                          VkValidationCacheEXT* pValidationCache, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateValidationCacheEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,
                                                           const VkAllocationCallbacks* pAllocator,
                                                           VkValidationCacheEXT* pValidationCache, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateValidationCacheEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pValidationCache);
     }
@@ -5027,28 +5027,28 @@ void ThreadSafety::PostCallRecordCreateValidationCacheEXT(VkDevice device, const
 
 void ThreadSafety::PreCallRecordDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache,
                                                           const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyValidationCacheEXT);
-    StartWriteObject(validationCache, vvl::Func::vkDestroyValidationCacheEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(validationCache, record_obj.location);
     // Host access to validationCache must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache,
                                                            const VkAllocationCallbacks* pAllocator,
                                                            const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyValidationCacheEXT);
-    FinishWriteObject(validationCache, vvl::Func::vkDestroyValidationCacheEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(validationCache, record_obj.location);
     DestroyObject(validationCache);
     // Host access to validationCache must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordMergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount,
                                                          const VkValidationCacheEXT* pSrcCaches, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkMergeValidationCachesEXT);
-    StartWriteObject(dstCache, vvl::Func::vkMergeValidationCachesEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(dstCache, record_obj.location);
 
     if (pSrcCaches) {
         for (uint32_t index = 0; index < srcCacheCount; index++) {
-            StartReadObject(pSrcCaches[index], vvl::Func::vkMergeValidationCachesEXT);
+            StartReadObject(pSrcCaches[index], record_obj.location);
         }
     }
     // Host access to dstCache must be externally synchronized
@@ -5056,12 +5056,12 @@ void ThreadSafety::PreCallRecordMergeValidationCachesEXT(VkDevice device, VkVali
 
 void ThreadSafety::PostCallRecordMergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT dstCache, uint32_t srcCacheCount,
                                                           const VkValidationCacheEXT* pSrcCaches, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkMergeValidationCachesEXT);
-    FinishWriteObject(dstCache, vvl::Func::vkMergeValidationCachesEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(dstCache, record_obj.location);
 
     if (pSrcCaches) {
         for (uint32_t index = 0; index < srcCacheCount; index++) {
-            FinishReadObject(pSrcCaches[index], vvl::Func::vkMergeValidationCachesEXT);
+            FinishReadObject(pSrcCaches[index], record_obj.location);
         }
     }
     // Host access to dstCache must be externally synchronized
@@ -5069,27 +5069,27 @@ void ThreadSafety::PostCallRecordMergeValidationCachesEXT(VkDevice device, VkVal
 
 void ThreadSafety::PreCallRecordGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize,
                                                           void* pData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetValidationCacheDataEXT);
-    StartReadObject(validationCache, vvl::Func::vkGetValidationCacheDataEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(validationCache, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize,
                                                            void* pData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetValidationCacheDataEXT);
-    FinishReadObject(validationCache, vvl::Func::vkGetValidationCacheDataEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(validationCache, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
                                                           VkImageLayout imageLayout, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindShadingRateImageNV);
-    StartReadObject(imageView, vvl::Func::vkCmdBindShadingRateImageNV);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(imageView, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView,
                                                            VkImageLayout imageLayout, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindShadingRateImageNV);
-    FinishReadObject(imageView, vvl::Func::vkCmdBindShadingRateImageNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(imageView, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5097,7 +5097,7 @@ void ThreadSafety::PreCallRecordCmdSetViewportShadingRatePaletteNV(VkCommandBuff
                                                                    uint32_t viewportCount,
                                                                    const VkShadingRatePaletteNV* pShadingRatePalettes,
                                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportShadingRatePaletteNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5105,7 +5105,7 @@ void ThreadSafety::PostCallRecordCmdSetViewportShadingRatePaletteNV(VkCommandBuf
                                                                     uint32_t viewportCount,
                                                                     const VkShadingRatePaletteNV* pShadingRatePalettes,
                                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportShadingRatePaletteNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5113,7 +5113,7 @@ void ThreadSafety::PreCallRecordCmdSetCoarseSampleOrderNV(VkCommandBuffer comman
                                                           uint32_t customSampleOrderCount,
                                                           const VkCoarseSampleOrderCustomNV* pCustomSampleOrders,
                                                           const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetCoarseSampleOrderNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5121,7 +5121,7 @@ void ThreadSafety::PostCallRecordCmdSetCoarseSampleOrderNV(VkCommandBuffer comma
                                                            uint32_t customSampleOrderCount,
                                                            const VkCoarseSampleOrderCustomNV* pCustomSampleOrders,
                                                            const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetCoarseSampleOrderNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5130,7 +5130,7 @@ void ThreadSafety::PreCallRecordCreateAccelerationStructureNV(VkDevice device,
                                                               const VkAllocationCallbacks* pAllocator,
                                                               VkAccelerationStructureNV* pAccelerationStructure,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateAccelerationStructureNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateAccelerationStructureNV(VkDevice device,
@@ -5138,7 +5138,7 @@ void ThreadSafety::PostCallRecordCreateAccelerationStructureNV(VkDevice device,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                VkAccelerationStructureNV* pAccelerationStructure,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateAccelerationStructureNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pAccelerationStructure);
     }
@@ -5147,16 +5147,16 @@ void ThreadSafety::PostCallRecordCreateAccelerationStructureNV(VkDevice device,
 void ThreadSafety::PreCallRecordDestroyAccelerationStructureNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyAccelerationStructureNV);
-    StartWriteObject(accelerationStructure, vvl::Func::vkDestroyAccelerationStructureNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(accelerationStructure, record_obj.location);
     // Host access to accelerationStructure must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyAccelerationStructureNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyAccelerationStructureNV);
-    FinishWriteObject(accelerationStructure, vvl::Func::vkDestroyAccelerationStructureNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(accelerationStructure, record_obj.location);
     DestroyObject(accelerationStructure);
     // Host access to accelerationStructure must be externally synchronized
 }
@@ -5164,25 +5164,25 @@ void ThreadSafety::PostCallRecordDestroyAccelerationStructureNV(VkDevice device,
 void ThreadSafety::PreCallRecordGetAccelerationStructureMemoryRequirementsNV(
     VkDevice device, const VkAccelerationStructureMemoryRequirementsInfoNV* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements,
     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetAccelerationStructureMemoryRequirementsNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetAccelerationStructureMemoryRequirementsNV(
     VkDevice device, const VkAccelerationStructureMemoryRequirementsInfoNV* pInfo, VkMemoryRequirements2KHR* pMemoryRequirements,
     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetAccelerationStructureMemoryRequirementsNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,
                                                                   const VkBindAccelerationStructureMemoryInfoNV* pBindInfos,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBindAccelerationStructureMemoryNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,
                                                                    const VkBindAccelerationStructureMemoryInfoNV* pBindInfos,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBindAccelerationStructureMemoryNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer commandBuffer,
@@ -5191,11 +5191,11 @@ void ThreadSafety::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer 
                                                                 VkAccelerationStructureNV dst, VkAccelerationStructureNV src,
                                                                 VkBuffer scratch, VkDeviceSize scratchOffset,
                                                                 const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBuildAccelerationStructureNV);
-    StartReadObject(instanceData, vvl::Func::vkCmdBuildAccelerationStructureNV);
-    StartReadObject(dst, vvl::Func::vkCmdBuildAccelerationStructureNV);
-    StartReadObject(src, vvl::Func::vkCmdBuildAccelerationStructureNV);
-    StartReadObject(scratch, vvl::Func::vkCmdBuildAccelerationStructureNV);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(instanceData, record_obj.location);
+    StartReadObject(dst, record_obj.location);
+    StartReadObject(src, record_obj.location);
+    StartReadObject(scratch, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5205,11 +5205,11 @@ void ThreadSafety::PostCallRecordCmdBuildAccelerationStructureNV(VkCommandBuffer
                                                                  VkAccelerationStructureNV dst, VkAccelerationStructureNV src,
                                                                  VkBuffer scratch, VkDeviceSize scratchOffset,
                                                                  const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBuildAccelerationStructureNV);
-    FinishReadObject(instanceData, vvl::Func::vkCmdBuildAccelerationStructureNV);
-    FinishReadObject(dst, vvl::Func::vkCmdBuildAccelerationStructureNV);
-    FinishReadObject(src, vvl::Func::vkCmdBuildAccelerationStructureNV);
-    FinishReadObject(scratch, vvl::Func::vkCmdBuildAccelerationStructureNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(instanceData, record_obj.location);
+    FinishReadObject(dst, record_obj.location);
+    FinishReadObject(src, record_obj.location);
+    FinishReadObject(scratch, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5217,9 +5217,9 @@ void ThreadSafety::PreCallRecordCmdCopyAccelerationStructureNV(VkCommandBuffer c
                                                                VkAccelerationStructureNV src,
                                                                VkCopyAccelerationStructureModeKHR mode,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyAccelerationStructureNV);
-    StartReadObject(dst, vvl::Func::vkCmdCopyAccelerationStructureNV);
-    StartReadObject(src, vvl::Func::vkCmdCopyAccelerationStructureNV);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(dst, record_obj.location);
+    StartReadObject(src, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5227,9 +5227,9 @@ void ThreadSafety::PostCallRecordCmdCopyAccelerationStructureNV(VkCommandBuffer 
                                                                 VkAccelerationStructureNV src,
                                                                 VkCopyAccelerationStructureModeKHR mode,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyAccelerationStructureNV);
-    FinishReadObject(dst, vvl::Func::vkCmdCopyAccelerationStructureNV);
-    FinishReadObject(src, vvl::Func::vkCmdCopyAccelerationStructureNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(dst, record_obj.location);
+    FinishReadObject(src, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5240,11 +5240,11 @@ void ThreadSafety::PreCallRecordCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
                                                VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
                                                VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
                                                uint32_t width, uint32_t height, uint32_t depth, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdTraceRaysNV);
-    StartReadObject(raygenShaderBindingTableBuffer, vvl::Func::vkCmdTraceRaysNV);
-    StartReadObject(missShaderBindingTableBuffer, vvl::Func::vkCmdTraceRaysNV);
-    StartReadObject(hitShaderBindingTableBuffer, vvl::Func::vkCmdTraceRaysNV);
-    StartReadObject(callableShaderBindingTableBuffer, vvl::Func::vkCmdTraceRaysNV);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(raygenShaderBindingTableBuffer, record_obj.location);
+    StartReadObject(missShaderBindingTableBuffer, record_obj.location);
+    StartReadObject(hitShaderBindingTableBuffer, record_obj.location);
+    StartReadObject(callableShaderBindingTableBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5255,11 +5255,11 @@ void ThreadSafety::PostCallRecordCmdTraceRaysNV(VkCommandBuffer commandBuffer, V
                                                 VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
                                                 VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
                                                 uint32_t width, uint32_t height, uint32_t depth, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdTraceRaysNV);
-    FinishReadObject(raygenShaderBindingTableBuffer, vvl::Func::vkCmdTraceRaysNV);
-    FinishReadObject(missShaderBindingTableBuffer, vvl::Func::vkCmdTraceRaysNV);
-    FinishReadObject(hitShaderBindingTableBuffer, vvl::Func::vkCmdTraceRaysNV);
-    FinishReadObject(callableShaderBindingTableBuffer, vvl::Func::vkCmdTraceRaysNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(raygenShaderBindingTableBuffer, record_obj.location);
+    FinishReadObject(missShaderBindingTableBuffer, record_obj.location);
+    FinishReadObject(hitShaderBindingTableBuffer, record_obj.location);
+    FinishReadObject(callableShaderBindingTableBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5268,8 +5268,8 @@ void ThreadSafety::PreCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkP
                                                             const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                             const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateRayTracingPipelinesNV);
-    StartReadObject(pipelineCache, vvl::Func::vkCreateRayTracingPipelinesNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipelineCache, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache,
@@ -5277,8 +5277,8 @@ void ThreadSafety::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, Vk
                                                              const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                              const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateRayTracingPipelinesNV);
-    FinishReadObject(pipelineCache, vvl::Func::vkCreateRayTracingPipelinesNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipelineCache, record_obj.location);
     if (pPipelines) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
             if (!pPipelines[index]) continue;
@@ -5290,41 +5290,41 @@ void ThreadSafety::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, Vk
 void ThreadSafety::PreCallRecordGetRayTracingShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline, uint32_t firstGroup,
                                                                    uint32_t groupCount, size_t dataSize, void* pData,
                                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetRayTracingShaderGroupHandlesKHR);
-    StartReadObject(pipeline, vvl::Func::vkGetRayTracingShaderGroupHandlesKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetRayTracingShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline, uint32_t firstGroup,
                                                                     uint32_t groupCount, size_t dataSize, void* pData,
                                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetRayTracingShaderGroupHandlesKHR);
-    FinishReadObject(pipeline, vvl::Func::vkGetRayTracingShaderGroupHandlesKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetRayTracingShaderGroupHandlesNV(VkDevice device, VkPipeline pipeline, uint32_t firstGroup,
                                                                   uint32_t groupCount, size_t dataSize, void* pData,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetRayTracingShaderGroupHandlesNV);
-    StartReadObject(pipeline, vvl::Func::vkGetRayTracingShaderGroupHandlesNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetRayTracingShaderGroupHandlesNV(VkDevice device, VkPipeline pipeline, uint32_t firstGroup,
                                                                    uint32_t groupCount, size_t dataSize, void* pData,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetRayTracingShaderGroupHandlesNV);
-    FinishReadObject(pipeline, vvl::Func::vkGetRayTracingShaderGroupHandlesNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetAccelerationStructureHandleNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
                                                                  size_t dataSize, void* pData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetAccelerationStructureHandleNV);
-    StartReadObject(accelerationStructure, vvl::Func::vkGetAccelerationStructureHandleNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(accelerationStructure, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetAccelerationStructureHandleNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
                                                                   size_t dataSize, void* pData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetAccelerationStructureHandleNV);
-    FinishReadObject(accelerationStructure, vvl::Func::vkGetAccelerationStructureHandleNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(accelerationStructure, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdWriteAccelerationStructuresPropertiesNV(VkCommandBuffer commandBuffer,
@@ -5332,70 +5332,70 @@ void ThreadSafety::PreCallRecordCmdWriteAccelerationStructuresPropertiesNV(VkCom
                                                                            const VkAccelerationStructureNV* pAccelerationStructures,
                                                                            VkQueryType queryType, VkQueryPool queryPool,
                                                                            uint32_t firstQuery, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWriteAccelerationStructuresPropertiesNV);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pAccelerationStructures) {
         for (uint32_t index = 0; index < accelerationStructureCount; index++) {
-            StartReadObject(pAccelerationStructures[index], vvl::Func::vkCmdWriteAccelerationStructuresPropertiesNV);
+            StartReadObject(pAccelerationStructures[index], record_obj.location);
         }
     }
-    StartReadObject(queryPool, vvl::Func::vkCmdWriteAccelerationStructuresPropertiesNV);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdWriteAccelerationStructuresPropertiesNV(
     VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures,
     VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWriteAccelerationStructuresPropertiesNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pAccelerationStructures) {
         for (uint32_t index = 0; index < accelerationStructureCount; index++) {
-            FinishReadObject(pAccelerationStructures[index], vvl::Func::vkCmdWriteAccelerationStructuresPropertiesNV);
+            FinishReadObject(pAccelerationStructures[index], record_obj.location);
         }
     }
-    FinishReadObject(queryPool, vvl::Func::vkCmdWriteAccelerationStructuresPropertiesNV);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCompileDeferredNV(VkDevice device, VkPipeline pipeline, uint32_t shader,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCompileDeferredNV);
-    StartReadObject(pipeline, vvl::Func::vkCompileDeferredNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCompileDeferredNV(VkDevice device, VkPipeline pipeline, uint32_t shader,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCompileDeferredNV);
-    FinishReadObject(pipeline, vvl::Func::vkCompileDeferredNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetMemoryHostPointerPropertiesEXT(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType,
                                                                   const void* pHostPointer,
                                                                   VkMemoryHostPointerPropertiesEXT* pMemoryHostPointerProperties,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMemoryHostPointerPropertiesEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMemoryHostPointerPropertiesEXT(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType,
                                                                    const void* pHostPointer,
                                                                    VkMemoryHostPointerPropertiesEXT* pMemoryHostPointerProperties,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMemoryHostPointerPropertiesEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                         VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
                                                         const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWriteBufferMarkerAMD);
-    StartReadObject(dstBuffer, vvl::Func::vkCmdWriteBufferMarkerAMD);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                          VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWriteBufferMarkerAMD);
-    FinishReadObject(dstBuffer, vvl::Func::vkCmdWriteBufferMarkerAMD);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(dstBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5403,39 +5403,39 @@ void ThreadSafety::PreCallRecordGetCalibratedTimestampsEXT(VkDevice device, uint
                                                            const VkCalibratedTimestampInfoEXT* pTimestampInfos,
                                                            uint64_t* pTimestamps, uint64_t* pMaxDeviation,
                                                            const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetCalibratedTimestampsEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetCalibratedTimestampsEXT(VkDevice device, uint32_t timestampCount,
                                                             const VkCalibratedTimestampInfoEXT* pTimestampInfos,
                                                             uint64_t* pTimestamps, uint64_t* pMaxDeviation,
                                                             const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetCalibratedTimestampsEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                            uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectNV);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawMeshTasksIndirectNV);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                             uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectNV);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawMeshTasksIndirectNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5443,9 +5443,9 @@ void ThreadSafety::PreCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
                                                                 VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                 uint32_t maxDrawCount, uint32_t stride,
                                                                 const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountNV);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountNV);
-    StartReadObject(countBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountNV);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
+    StartReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5453,9 +5453,9 @@ void ThreadSafety::PostCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer
                                                                  VkDeviceSize offset, VkBuffer countBuffer,
                                                                  VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                                  uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountNV);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountNV);
-    FinishReadObject(countBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
+    FinishReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5463,7 +5463,7 @@ void ThreadSafety::PreCallRecordCmdSetExclusiveScissorEnableNV(VkCommandBuffer c
                                                                uint32_t exclusiveScissorCount,
                                                                const VkBool32* pExclusiveScissorEnables,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetExclusiveScissorEnableNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5471,105 +5471,105 @@ void ThreadSafety::PostCallRecordCmdSetExclusiveScissorEnableNV(VkCommandBuffer 
                                                                 uint32_t exclusiveScissorCount,
                                                                 const VkBool32* pExclusiveScissorEnables,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetExclusiveScissorEnableNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
                                                          uint32_t exclusiveScissorCount, const VkRect2D* pExclusiveScissors,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetExclusiveScissorNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetExclusiveScissorNV(VkCommandBuffer commandBuffer, uint32_t firstExclusiveScissor,
                                                           uint32_t exclusiveScissorCount, const VkRect2D* pExclusiveScissors,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetExclusiveScissorNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const void* pCheckpointMarker,
                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetCheckpointNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetCheckpointNV(VkCommandBuffer commandBuffer, const void* pCheckpointMarker,
                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetCheckpointNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetQueueCheckpointDataNV(VkQueue queue, uint32_t* pCheckpointDataCount,
                                                          VkCheckpointDataNV* pCheckpointData, const RecordObject& record_obj) {
-    StartReadObject(queue, vvl::Func::vkGetQueueCheckpointDataNV);
+    StartReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetQueueCheckpointDataNV(VkQueue queue, uint32_t* pCheckpointDataCount,
                                                           VkCheckpointDataNV* pCheckpointData, const RecordObject& record_obj) {
-    FinishReadObject(queue, vvl::Func::vkGetQueueCheckpointDataNV);
+    FinishReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordInitializePerformanceApiINTEL(VkDevice device,
                                                               const VkInitializePerformanceApiInfoINTEL* pInitializeInfo,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkInitializePerformanceApiINTEL);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordInitializePerformanceApiINTEL(VkDevice device,
                                                                const VkInitializePerformanceApiInfoINTEL* pInitializeInfo,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkInitializePerformanceApiINTEL);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordUninitializePerformanceApiINTEL(VkDevice device, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkUninitializePerformanceApiINTEL);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordUninitializePerformanceApiINTEL(VkDevice device, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkUninitializePerformanceApiINTEL);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandBuffer,
                                                              const VkPerformanceMarkerInfoINTEL* pMarkerInfo,
                                                              const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetPerformanceMarkerINTEL);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandBuffer,
                                                               const VkPerformanceMarkerInfoINTEL* pMarkerInfo,
                                                               const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetPerformanceMarkerINTEL);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetPerformanceStreamMarkerINTEL(VkCommandBuffer commandBuffer,
                                                                    const VkPerformanceStreamMarkerInfoINTEL* pMarkerInfo,
                                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetPerformanceStreamMarkerINTEL);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetPerformanceStreamMarkerINTEL(VkCommandBuffer commandBuffer,
                                                                     const VkPerformanceStreamMarkerInfoINTEL* pMarkerInfo,
                                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetPerformanceStreamMarkerINTEL);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetPerformanceOverrideINTEL(VkCommandBuffer commandBuffer,
                                                                const VkPerformanceOverrideInfoINTEL* pOverrideInfo,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetPerformanceOverrideINTEL);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetPerformanceOverrideINTEL(VkCommandBuffer commandBuffer,
                                                                 const VkPerformanceOverrideInfoINTEL* pOverrideInfo,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetPerformanceOverrideINTEL);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5577,13 +5577,13 @@ void ThreadSafety::PreCallRecordAcquirePerformanceConfigurationINTEL(VkDevice de
                                                                      const VkPerformanceConfigurationAcquireInfoINTEL* pAcquireInfo,
                                                                      VkPerformanceConfigurationINTEL* pConfiguration,
                                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkAcquirePerformanceConfigurationINTEL);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordAcquirePerformanceConfigurationINTEL(
     VkDevice device, const VkPerformanceConfigurationAcquireInfoINTEL* pAcquireInfo,
     VkPerformanceConfigurationINTEL* pConfiguration, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkAcquirePerformanceConfigurationINTEL);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pConfiguration);
     }
@@ -5591,52 +5591,52 @@ void ThreadSafety::PostCallRecordAcquirePerformanceConfigurationINTEL(
 
 void ThreadSafety::PreCallRecordReleasePerformanceConfigurationINTEL(VkDevice device, VkPerformanceConfigurationINTEL configuration,
                                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkReleasePerformanceConfigurationINTEL);
-    StartWriteObject(configuration, vvl::Func::vkReleasePerformanceConfigurationINTEL);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(configuration, record_obj.location);
     // Host access to configuration must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordReleasePerformanceConfigurationINTEL(VkDevice device,
                                                                       VkPerformanceConfigurationINTEL configuration,
                                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkReleasePerformanceConfigurationINTEL);
-    FinishWriteObject(configuration, vvl::Func::vkReleasePerformanceConfigurationINTEL);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(configuration, record_obj.location);
     DestroyObject(configuration);
     // Host access to configuration must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordQueueSetPerformanceConfigurationINTEL(VkQueue queue, VkPerformanceConfigurationINTEL configuration,
                                                                       const RecordObject& record_obj) {
-    StartReadObject(queue, vvl::Func::vkQueueSetPerformanceConfigurationINTEL);
-    StartReadObject(configuration, vvl::Func::vkQueueSetPerformanceConfigurationINTEL);
+    StartReadObject(queue, record_obj.location);
+    StartReadObject(configuration, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordQueueSetPerformanceConfigurationINTEL(VkQueue queue, VkPerformanceConfigurationINTEL configuration,
                                                                        const RecordObject& record_obj) {
-    FinishReadObject(queue, vvl::Func::vkQueueSetPerformanceConfigurationINTEL);
-    FinishReadObject(configuration, vvl::Func::vkQueueSetPerformanceConfigurationINTEL);
+    FinishReadObject(queue, record_obj.location);
+    FinishReadObject(configuration, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetPerformanceParameterINTEL(VkDevice device, VkPerformanceParameterTypeINTEL parameter,
                                                              VkPerformanceValueINTEL* pValue, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPerformanceParameterINTEL);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPerformanceParameterINTEL(VkDevice device, VkPerformanceParameterTypeINTEL parameter,
                                                               VkPerformanceValueINTEL* pValue, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPerformanceParameterINTEL);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordSetLocalDimmingAMD(VkDevice device, VkSwapchainKHR swapChain, VkBool32 localDimmingEnable,
                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSetLocalDimmingAMD);
-    StartReadObject(swapChain, vvl::Func::vkSetLocalDimmingAMD);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(swapChain, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSetLocalDimmingAMD(VkDevice device, VkSwapchainKHR swapChain, VkBool32 localDimmingEnable,
                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSetLocalDimmingAMD);
-    FinishReadObject(swapChain, vvl::Func::vkSetLocalDimmingAMD);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(swapChain, record_obj.location);
 }
 
 #ifdef VK_USE_PLATFORM_FUCHSIA
@@ -5644,14 +5644,14 @@ void ThreadSafety::PreCallRecordCreateImagePipeSurfaceFUCHSIA(VkInstance instanc
                                                               const VkImagePipeSurfaceCreateInfoFUCHSIA* pCreateInfo,
                                                               const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateImagePipeSurfaceFUCHSIA);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateImagePipeSurfaceFUCHSIA(VkInstance instance,
                                                                const VkImagePipeSurfaceCreateInfoFUCHSIA* pCreateInfo,
                                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateImagePipeSurfaceFUCHSIA);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -5662,13 +5662,13 @@ void ThreadSafety::PostCallRecordCreateImagePipeSurfaceFUCHSIA(VkInstance instan
 void ThreadSafety::PreCallRecordCreateMetalSurfaceEXT(VkInstance instance, const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateMetalSurfaceEXT);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateMetalSurfaceEXT(VkInstance instance, const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateMetalSurfaceEXT);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -5677,64 +5677,64 @@ void ThreadSafety::PostCallRecordCreateMetalSurfaceEXT(VkInstance instance, cons
 #endif  // VK_USE_PLATFORM_METAL_EXT
 void ThreadSafety::PreCallRecordGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                           const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetBufferDeviceAddressEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetBufferDeviceAddressEXT(VkDevice device, const VkBufferDeviceAddressInfo* pInfo,
                                                            const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetBufferDeviceAddressEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 void ThreadSafety::PreCallRecordAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkAcquireFullScreenExclusiveModeEXT);
-    StartReadObject(swapchain, vvl::Func::vkAcquireFullScreenExclusiveModeEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkAcquireFullScreenExclusiveModeEXT);
-    FinishReadObject(swapchain, vvl::Func::vkAcquireFullScreenExclusiveModeEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkReleaseFullScreenExclusiveModeEXT);
-    StartReadObject(swapchain, vvl::Func::vkReleaseFullScreenExclusiveModeEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkReleaseFullScreenExclusiveModeEXT);
-    FinishReadObject(swapchain, vvl::Func::vkReleaseFullScreenExclusiveModeEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDeviceGroupSurfacePresentModes2EXT(VkDevice device,
                                                                       const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
                                                                       VkDeviceGroupPresentModeFlagsKHR* pModes,
                                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceGroupSurfacePresentModes2EXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceGroupSurfacePresentModes2EXT(VkDevice device,
                                                                        const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
                                                                        VkDeviceGroupPresentModeFlagsKHR* pModes,
                                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceGroupSurfacePresentModes2EXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 void ThreadSafety::PreCallRecordCreateHeadlessSurfaceEXT(VkInstance instance, const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateHeadlessSurfaceEXT);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateHeadlessSurfaceEXT(VkInstance instance, const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateHeadlessSurfaceEXT);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -5742,85 +5742,85 @@ void ThreadSafety::PostCallRecordCreateHeadlessSurfaceEXT(VkInstance instance, c
 
 void ThreadSafety::PreCallRecordCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
                                                      uint16_t lineStipplePattern, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetLineStippleEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineStippleFactor,
                                                       uint16_t lineStipplePattern, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetLineStippleEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkResetQueryPoolEXT);
-    StartReadObject(queryPool, vvl::Func::vkResetQueryPoolEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(queryPool, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkResetQueryPoolEXT);
-    FinishReadObject(queryPool, vvl::Func::vkResetQueryPoolEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(queryPool, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode,
                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetCullModeEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetCullModeEXT(VkCommandBuffer commandBuffer, VkCullModeFlags cullMode,
                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetCullModeEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace,
                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetFrontFaceEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetFrontFaceEXT(VkCommandBuffer commandBuffer, VkFrontFace frontFace,
                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetFrontFaceEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology,
                                                            const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetPrimitiveTopologyEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetPrimitiveTopologyEXT(VkCommandBuffer commandBuffer, VkPrimitiveTopology primitiveTopology,
                                                             const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetPrimitiveTopologyEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount,
                                                            const VkViewport* pViewports, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportWithCountEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetViewportWithCountEXT(VkCommandBuffer commandBuffer, uint32_t viewportCount,
                                                             const VkViewport* pViewports, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportWithCountEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount,
                                                           const VkRect2D* pScissors, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetScissorWithCountEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetScissorWithCountEXT(VkCommandBuffer commandBuffer, uint32_t scissorCount,
                                                            const VkRect2D* pScissors, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetScissorWithCountEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -5828,11 +5828,11 @@ void ThreadSafety::PreCallRecordCmdBindVertexBuffers2EXT(VkCommandBuffer command
                                                          uint32_t bindingCount, const VkBuffer* pBuffers,
                                                          const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
                                                          const VkDeviceSize* pStrides, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindVertexBuffers2EXT);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pBuffers) {
         for (uint32_t index = 0; index < bindingCount; index++) {
-            StartReadObject(pBuffers[index], vvl::Func::vkCmdBindVertexBuffers2EXT);
+            StartReadObject(pBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -5842,11 +5842,11 @@ void ThreadSafety::PostCallRecordCmdBindVertexBuffers2EXT(VkCommandBuffer comman
                                                           uint32_t bindingCount, const VkBuffer* pBuffers,
                                                           const VkDeviceSize* pOffsets, const VkDeviceSize* pSizes,
                                                           const VkDeviceSize* pStrides, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindVertexBuffers2EXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pBuffers) {
         for (uint32_t index = 0; index < bindingCount; index++) {
-            FinishReadObject(pBuffers[index], vvl::Func::vkCmdBindVertexBuffers2EXT);
+            FinishReadObject(pBuffers[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -5854,199 +5854,199 @@ void ThreadSafety::PostCallRecordCmdBindVertexBuffers2EXT(VkCommandBuffer comman
 
 void ThreadSafety::PreCallRecordCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthTestEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthTestEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable,
                                                           const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthWriteEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthWriteEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthWriteEnable,
                                                            const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthWriteEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp,
                                                         const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthCompareOpEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthCompareOpEXT(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp,
                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthCompareOpEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBoundsTestEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthBoundsTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBoundsTestEnable,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBoundsTestEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable,
                                                            const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilTestEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetStencilTestEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stencilTestEnable,
                                                             const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilTestEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                                    VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp,
                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilOpEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetStencilOpEXT(VkCommandBuffer commandBuffer, VkStencilFaceFlags faceMask, VkStencilOp failOp,
                                                     VkStencilOp passOp, VkStencilOp depthFailOp, VkCompareOp compareOp,
                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetStencilOpEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCopyMemoryToImageEXT(VkDevice device, const VkCopyMemoryToImageInfoEXT* pCopyMemoryToImageInfo,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCopyMemoryToImageEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCopyMemoryToImageEXT(VkDevice device, const VkCopyMemoryToImageInfoEXT* pCopyMemoryToImageInfo,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCopyMemoryToImageEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCopyImageToMemoryEXT(VkDevice device, const VkCopyImageToMemoryInfoEXT* pCopyImageToMemoryInfo,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCopyImageToMemoryEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCopyImageToMemoryEXT(VkDevice device, const VkCopyImageToMemoryInfoEXT* pCopyImageToMemoryInfo,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCopyImageToMemoryEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCopyImageToImageEXT(VkDevice device, const VkCopyImageToImageInfoEXT* pCopyImageToImageInfo,
                                                     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCopyImageToImageEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCopyImageToImageEXT(VkDevice device, const VkCopyImageToImageInfoEXT* pCopyImageToImageInfo,
                                                      const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCopyImageToImageEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordTransitionImageLayoutEXT(VkDevice device, uint32_t transitionCount,
                                                          const VkHostImageLayoutTransitionInfoEXT* pTransitions,
                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkTransitionImageLayoutEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordTransitionImageLayoutEXT(VkDevice device, uint32_t transitionCount,
                                                           const VkHostImageLayoutTransitionInfoEXT* pTransitions,
                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkTransitionImageLayoutEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageSubresourceLayout2EXT(VkDevice device, VkImage image,
                                                               const VkImageSubresource2KHR* pSubresource,
                                                               VkSubresourceLayout2KHR* pLayout, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageSubresourceLayout2EXT);
-    StartReadObject(image, vvl::Func::vkGetImageSubresourceLayout2EXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageSubresourceLayout2EXT(VkDevice device, VkImage image,
                                                                const VkImageSubresource2KHR* pSubresource,
                                                                VkSubresourceLayout2KHR* pLayout, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageSubresourceLayout2EXT);
-    FinishReadObject(image, vvl::Func::vkGetImageSubresourceLayout2EXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(image, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo,
                                                           const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkReleaseSwapchainImagesEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo,
                                                            const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkReleaseSwapchainImagesEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetGeneratedCommandsMemoryRequirementsNV(VkDevice device,
                                                                          const VkGeneratedCommandsMemoryRequirementsInfoNV* pInfo,
                                                                          VkMemoryRequirements2* pMemoryRequirements,
                                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetGeneratedCommandsMemoryRequirementsNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetGeneratedCommandsMemoryRequirementsNV(VkDevice device,
                                                                           const VkGeneratedCommandsMemoryRequirementsInfoNV* pInfo,
                                                                           VkMemoryRequirements2* pMemoryRequirements,
                                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetGeneratedCommandsMemoryRequirementsNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdPreprocessGeneratedCommandsNV(VkCommandBuffer commandBuffer,
                                                                  const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo,
                                                                  const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdPreprocessGeneratedCommandsNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdPreprocessGeneratedCommandsNV(VkCommandBuffer commandBuffer,
                                                                   const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo,
                                                                   const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdPreprocessGeneratedCommandsNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdExecuteGeneratedCommandsNV(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed,
                                                               const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo,
                                                               const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdExecuteGeneratedCommandsNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdExecuteGeneratedCommandsNV(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed,
                                                                const VkGeneratedCommandsInfoNV* pGeneratedCommandsInfo,
                                                                const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdExecuteGeneratedCommandsNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                              VkPipeline pipeline, uint32_t groupIndex,
                                                              const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindPipelineShaderGroupNV);
-    StartReadObject(pipeline, vvl::Func::vkCmdBindPipelineShaderGroupNV);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(pipeline, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                               VkPipeline pipeline, uint32_t groupIndex,
                                                               const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindPipelineShaderGroupNV);
-    FinishReadObject(pipeline, vvl::Func::vkCmdBindPipelineShaderGroupNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(pipeline, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6055,7 +6055,7 @@ void ThreadSafety::PreCallRecordCreateIndirectCommandsLayoutNV(VkDevice device,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                VkIndirectCommandsLayoutNV* pIndirectCommandsLayout,
                                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateIndirectCommandsLayoutNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateIndirectCommandsLayoutNV(VkDevice device,
@@ -6063,7 +6063,7 @@ void ThreadSafety::PostCallRecordCreateIndirectCommandsLayoutNV(VkDevice device,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 VkIndirectCommandsLayoutNV* pIndirectCommandsLayout,
                                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateIndirectCommandsLayoutNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pIndirectCommandsLayout);
     }
@@ -6072,52 +6072,52 @@ void ThreadSafety::PostCallRecordCreateIndirectCommandsLayoutNV(VkDevice device,
 void ThreadSafety::PreCallRecordDestroyIndirectCommandsLayoutNV(VkDevice device, VkIndirectCommandsLayoutNV indirectCommandsLayout,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyIndirectCommandsLayoutNV);
-    StartWriteObject(indirectCommandsLayout, vvl::Func::vkDestroyIndirectCommandsLayoutNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(indirectCommandsLayout, record_obj.location);
     // Host access to indirectCommandsLayout must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyIndirectCommandsLayoutNV(VkDevice device, VkIndirectCommandsLayoutNV indirectCommandsLayout,
                                                                  const VkAllocationCallbacks* pAllocator,
                                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyIndirectCommandsLayoutNV);
-    FinishWriteObject(indirectCommandsLayout, vvl::Func::vkDestroyIndirectCommandsLayoutNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(indirectCommandsLayout, record_obj.location);
     DestroyObject(indirectCommandsLayout);
     // Host access to indirectCommandsLayout must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const VkDepthBiasInfoEXT* pDepthBiasInfo,
                                                     const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBias2EXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const VkDepthBiasInfoEXT* pDepthBiasInfo,
                                                      const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBias2EXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordAcquireDrmDisplayEXT(VkPhysicalDevice physicalDevice, int32_t drmFd, VkDisplayKHR display,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(display, vvl::Func::vkAcquireDrmDisplayEXT);
+    StartReadObjectParentInstance(display, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordAcquireDrmDisplayEXT(VkPhysicalDevice physicalDevice, int32_t drmFd, VkDisplayKHR display,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(display, vvl::Func::vkAcquireDrmDisplayEXT);
+    FinishReadObjectParentInstance(display, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreatePrivateDataSlotEXT(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo,
                                                          const VkAllocationCallbacks* pAllocator,
                                                          VkPrivateDataSlot* pPrivateDataSlot, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreatePrivateDataSlotEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreatePrivateDataSlotEXT(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo,
                                                           const VkAllocationCallbacks* pAllocator,
                                                           VkPrivateDataSlot* pPrivateDataSlot, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreatePrivateDataSlotEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pPrivateDataSlot);
     }
@@ -6125,16 +6125,16 @@ void ThreadSafety::PostCallRecordCreatePrivateDataSlotEXT(VkDevice device, const
 
 void ThreadSafety::PreCallRecordDestroyPrivateDataSlotEXT(VkDevice device, VkPrivateDataSlot privateDataSlot,
                                                           const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyPrivateDataSlotEXT);
-    StartWriteObject(privateDataSlot, vvl::Func::vkDestroyPrivateDataSlotEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(privateDataSlot, record_obj.location);
     // Host access to privateDataSlot must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyPrivateDataSlotEXT(VkDevice device, VkPrivateDataSlot privateDataSlot,
                                                            const VkAllocationCallbacks* pAllocator,
                                                            const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyPrivateDataSlotEXT);
-    FinishWriteObject(privateDataSlot, vvl::Func::vkDestroyPrivateDataSlotEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(privateDataSlot, record_obj.location);
     DestroyObject(privateDataSlot);
     // Host access to privateDataSlot must be externally synchronized
 }
@@ -6142,41 +6142,41 @@ void ThreadSafety::PostCallRecordDestroyPrivateDataSlotEXT(VkDevice device, VkPr
 void ThreadSafety::PreCallRecordSetPrivateDataEXT(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
                                                   VkPrivateDataSlot privateDataSlot, uint64_t data,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSetPrivateDataEXT);
-    StartReadObject(privateDataSlot, vvl::Func::vkSetPrivateDataEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(privateDataSlot, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSetPrivateDataEXT(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
                                                    VkPrivateDataSlot privateDataSlot, uint64_t data,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSetPrivateDataEXT);
-    FinishReadObject(privateDataSlot, vvl::Func::vkSetPrivateDataEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(privateDataSlot, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetPrivateDataEXT(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
                                                   VkPrivateDataSlot privateDataSlot, uint64_t* pData,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPrivateDataEXT);
-    StartReadObject(privateDataSlot, vvl::Func::vkGetPrivateDataEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(privateDataSlot, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPrivateDataEXT(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
                                                    VkPrivateDataSlot privateDataSlot, uint64_t* pData,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPrivateDataEXT);
-    FinishReadObject(privateDataSlot, vvl::Func::vkGetPrivateDataEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(privateDataSlot, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateCudaModuleNV(VkDevice device, const VkCudaModuleCreateInfoNV* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkCudaModuleNV* pModule,
                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateCudaModuleNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateCudaModuleNV(VkDevice device, const VkCudaModuleCreateInfoNV* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkCudaModuleNV* pModule,
                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateCudaModuleNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pModule);
     }
@@ -6184,26 +6184,26 @@ void ThreadSafety::PostCallRecordCreateCudaModuleNV(VkDevice device, const VkCud
 
 void ThreadSafety::PreCallRecordGetCudaModuleCacheNV(VkDevice device, VkCudaModuleNV module, size_t* pCacheSize, void* pCacheData,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetCudaModuleCacheNV);
-    StartReadObject(module, vvl::Func::vkGetCudaModuleCacheNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(module, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetCudaModuleCacheNV(VkDevice device, VkCudaModuleNV module, size_t* pCacheSize, void* pCacheData,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetCudaModuleCacheNV);
-    FinishReadObject(module, vvl::Func::vkGetCudaModuleCacheNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(module, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateCudaFunctionNV(VkDevice device, const VkCudaFunctionCreateInfoNV* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkCudaFunctionNV* pFunction,
                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateCudaFunctionNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateCudaFunctionNV(VkDevice device, const VkCudaFunctionCreateInfoNV* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkCudaFunctionNV* pFunction,
                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateCudaFunctionNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pFunction);
     }
@@ -6211,97 +6211,97 @@ void ThreadSafety::PostCallRecordCreateCudaFunctionNV(VkDevice device, const VkC
 
 void ThreadSafety::PreCallRecordDestroyCudaModuleNV(VkDevice device, VkCudaModuleNV module, const VkAllocationCallbacks* pAllocator,
                                                     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyCudaModuleNV);
-    StartReadObject(module, vvl::Func::vkDestroyCudaModuleNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(module, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordDestroyCudaModuleNV(VkDevice device, VkCudaModuleNV module,
                                                      const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyCudaModuleNV);
-    FinishReadObject(module, vvl::Func::vkDestroyCudaModuleNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(module, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordDestroyCudaFunctionNV(VkDevice device, VkCudaFunctionNV function,
                                                       const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyCudaFunctionNV);
-    StartReadObject(function, vvl::Func::vkDestroyCudaFunctionNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(function, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordDestroyCudaFunctionNV(VkDevice device, VkCudaFunctionNV function,
                                                        const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyCudaFunctionNV);
-    FinishReadObject(function, vvl::Func::vkDestroyCudaFunctionNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(function, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdCudaLaunchKernelNV(VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo,
                                                       const RecordObject& record_obj) {
-    StartReadObject(commandBuffer, vvl::Func::vkCmdCudaLaunchKernelNV);
+    StartReadObject(commandBuffer, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCmdCudaLaunchKernelNV(VkCommandBuffer commandBuffer, const VkCudaLaunchInfoNV* pLaunchInfo,
                                                        const RecordObject& record_obj) {
-    FinishReadObject(commandBuffer, vvl::Func::vkCmdCudaLaunchKernelNV);
+    FinishReadObject(commandBuffer, record_obj.location);
 }
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
 void ThreadSafety::PreCallRecordExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT* pMetalObjectsInfo,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkExportMetalObjectsEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT* pMetalObjectsInfo,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkExportMetalObjectsEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_METAL_EXT
 void ThreadSafety::PreCallRecordGetDescriptorSetLayoutSizeEXT(VkDevice device, VkDescriptorSetLayout layout,
                                                               VkDeviceSize* pLayoutSizeInBytes, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetLayoutSizeEXT);
-    StartReadObject(layout, vvl::Func::vkGetDescriptorSetLayoutSizeEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(layout, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDescriptorSetLayoutSizeEXT(VkDevice device, VkDescriptorSetLayout layout,
                                                                VkDeviceSize* pLayoutSizeInBytes, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetLayoutSizeEXT);
-    FinishReadObject(layout, vvl::Func::vkGetDescriptorSetLayoutSizeEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(layout, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDescriptorSetLayoutBindingOffsetEXT(VkDevice device, VkDescriptorSetLayout layout,
                                                                        uint32_t binding, VkDeviceSize* pOffset,
                                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetLayoutBindingOffsetEXT);
-    StartReadObject(layout, vvl::Func::vkGetDescriptorSetLayoutBindingOffsetEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(layout, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDescriptorSetLayoutBindingOffsetEXT(VkDevice device, VkDescriptorSetLayout layout,
                                                                         uint32_t binding, VkDeviceSize* pOffset,
                                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetLayoutBindingOffsetEXT);
-    FinishReadObject(layout, vvl::Func::vkGetDescriptorSetLayoutBindingOffsetEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(layout, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT* pDescriptorInfo, size_t dataSize,
                                                  void* pDescriptor, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDescriptorEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT* pDescriptorInfo, size_t dataSize,
                                                   void* pDescriptor, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDescriptorEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
                                                             const VkDescriptorBufferBindingInfoEXT* pBindingInfos,
                                                             const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindDescriptorBuffersEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
                                                              const VkDescriptorBufferBindingInfoEXT* pBindingInfos,
                                                              const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindDescriptorBuffersEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6310,8 +6310,8 @@ void ThreadSafety::PreCallRecordCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer
                                                                  uint32_t firstSet, uint32_t setCount,
                                                                  const uint32_t* pBufferIndices, const VkDeviceSize* pOffsets,
                                                                  const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDescriptorBufferOffsetsEXT);
-    StartReadObject(layout, vvl::Func::vkCmdSetDescriptorBufferOffsetsEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(layout, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6320,8 +6320,8 @@ void ThreadSafety::PostCallRecordCmdSetDescriptorBufferOffsetsEXT(VkCommandBuffe
                                                                   uint32_t firstSet, uint32_t setCount,
                                                                   const uint32_t* pBufferIndices, const VkDeviceSize* pOffsets,
                                                                   const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDescriptorBufferOffsetsEXT);
-    FinishReadObject(layout, vvl::Func::vkCmdSetDescriptorBufferOffsetsEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(layout, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6329,8 +6329,8 @@ void ThreadSafety::PreCallRecordCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCom
                                                                            VkPipelineBindPoint pipelineBindPoint,
                                                                            VkPipelineLayout layout, uint32_t set,
                                                                            const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindDescriptorBufferEmbeddedSamplersEXT);
-    StartReadObject(layout, vvl::Func::vkCmdBindDescriptorBufferEmbeddedSamplersEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(layout, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6338,104 +6338,104 @@ void ThreadSafety::PostCallRecordCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCo
                                                                             VkPipelineBindPoint pipelineBindPoint,
                                                                             VkPipelineLayout layout, uint32_t set,
                                                                             const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindDescriptorBufferEmbeddedSamplersEXT);
-    FinishReadObject(layout, vvl::Func::vkCmdBindDescriptorBufferEmbeddedSamplersEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(layout, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetBufferOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                         const VkBufferCaptureDescriptorDataInfoEXT* pInfo,
                                                                         void* pData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetBufferOpaqueCaptureDescriptorDataEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetBufferOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                          const VkBufferCaptureDescriptorDataInfoEXT* pInfo,
                                                                          void* pData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetBufferOpaqueCaptureDescriptorDataEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                        const VkImageCaptureDescriptorDataInfoEXT* pInfo,
                                                                        void* pData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageOpaqueCaptureDescriptorDataEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                         const VkImageCaptureDescriptorDataInfoEXT* pInfo,
                                                                         void* pData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageOpaqueCaptureDescriptorDataEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetImageViewOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                            const VkImageViewCaptureDescriptorDataInfoEXT* pInfo,
                                                                            void* pData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetImageViewOpaqueCaptureDescriptorDataEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetImageViewOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                             const VkImageViewCaptureDescriptorDataInfoEXT* pInfo,
                                                                             void* pData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetImageViewOpaqueCaptureDescriptorDataEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetSamplerOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                          const VkSamplerCaptureDescriptorDataInfoEXT* pInfo,
                                                                          void* pData, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetSamplerOpaqueCaptureDescriptorDataEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetSamplerOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                           const VkSamplerCaptureDescriptorDataInfoEXT* pInfo,
                                                                           void* pData, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetSamplerOpaqueCaptureDescriptorDataEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetAccelerationStructureOpaqueCaptureDescriptorDataEXT(
     VkDevice device, const VkAccelerationStructureCaptureDescriptorDataInfoEXT* pInfo, void* pData,
     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetAccelerationStructureOpaqueCaptureDescriptorDataEXT(
     VkDevice device, const VkAccelerationStructureCaptureDescriptorDataInfoEXT* pInfo, void* pData,
     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetFragmentShadingRateEnumNV(VkCommandBuffer commandBuffer, VkFragmentShadingRateNV shadingRate,
                                                                 const VkFragmentShadingRateCombinerOpKHR combinerOps[2],
                                                                 const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetFragmentShadingRateEnumNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetFragmentShadingRateEnumNV(VkCommandBuffer commandBuffer, VkFragmentShadingRateNV shadingRate,
                                                                  const VkFragmentShadingRateCombinerOpKHR combinerOps[2],
                                                                  const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetFragmentShadingRateEnumNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetDeviceFaultInfoEXT(VkDevice device, VkDeviceFaultCountsEXT* pFaultCounts,
                                                       VkDeviceFaultInfoEXT* pFaultInfo, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceFaultInfoEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceFaultInfoEXT(VkDevice device, VkDeviceFaultCountsEXT* pFaultCounts,
                                                        VkDeviceFaultInfoEXT* pFaultInfo, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceFaultInfoEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 void ThreadSafety::PreCallRecordAcquireWinrtDisplayNV(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(display, vvl::Func::vkAcquireWinrtDisplayNV);
+    StartReadObjectParentInstance(display, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordAcquireWinrtDisplayNV(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(display, vvl::Func::vkAcquireWinrtDisplayNV);
+    FinishReadObjectParentInstance(display, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_WIN32_KHR
@@ -6443,13 +6443,13 @@ void ThreadSafety::PostCallRecordAcquireWinrtDisplayNV(VkPhysicalDevice physical
 void ThreadSafety::PreCallRecordCreateDirectFBSurfaceEXT(VkInstance instance, const VkDirectFBSurfaceCreateInfoEXT* pCreateInfo,
                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateDirectFBSurfaceEXT);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateDirectFBSurfaceEXT(VkInstance instance, const VkDirectFBSurfaceCreateInfoEXT* pCreateInfo,
                                                           const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateDirectFBSurfaceEXT);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -6461,7 +6461,7 @@ void ThreadSafety::PreCallRecordCmdSetVertexInputEXT(VkCommandBuffer commandBuff
                                                      uint32_t vertexAttributeDescriptionCount,
                                                      const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions,
                                                      const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetVertexInputEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6470,7 +6470,7 @@ void ThreadSafety::PostCallRecordCmdSetVertexInputEXT(VkCommandBuffer commandBuf
                                                       uint32_t vertexAttributeDescriptionCount,
                                                       const VkVertexInputAttributeDescription2EXT* pVertexAttributeDescriptions,
                                                       const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetVertexInputEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6478,49 +6478,49 @@ void ThreadSafety::PostCallRecordCmdSetVertexInputEXT(VkCommandBuffer commandBuf
 void ThreadSafety::PreCallRecordGetMemoryZirconHandleFUCHSIA(VkDevice device,
                                                              const VkMemoryGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo,
                                                              zx_handle_t* pZirconHandle, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMemoryZirconHandleFUCHSIA);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMemoryZirconHandleFUCHSIA(VkDevice device,
                                                               const VkMemoryGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo,
                                                               zx_handle_t* pZirconHandle, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMemoryZirconHandleFUCHSIA);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetMemoryZirconHandlePropertiesFUCHSIA(
     VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, zx_handle_t zirconHandle,
     VkMemoryZirconHandlePropertiesFUCHSIA* pMemoryZirconHandleProperties, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMemoryZirconHandlePropertiesFUCHSIA);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMemoryZirconHandlePropertiesFUCHSIA(
     VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, zx_handle_t zirconHandle,
     VkMemoryZirconHandlePropertiesFUCHSIA* pMemoryZirconHandleProperties, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMemoryZirconHandlePropertiesFUCHSIA);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordImportSemaphoreZirconHandleFUCHSIA(
     VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo,
     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkImportSemaphoreZirconHandleFUCHSIA);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordImportSemaphoreZirconHandleFUCHSIA(
     VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo,
     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkImportSemaphoreZirconHandleFUCHSIA);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetSemaphoreZirconHandleFUCHSIA(VkDevice device,
                                                                 const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo,
                                                                 zx_handle_t* pZirconHandle, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetSemaphoreZirconHandleFUCHSIA);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(VkDevice device,
                                                                  const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo,
                                                                  zx_handle_t* pZirconHandle, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetSemaphoreZirconHandleFUCHSIA);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateBufferCollectionFUCHSIA(VkDevice device,
@@ -6528,7 +6528,7 @@ void ThreadSafety::PreCallRecordCreateBufferCollectionFUCHSIA(VkDevice device,
                                                               const VkAllocationCallbacks* pAllocator,
                                                               VkBufferCollectionFUCHSIA* pCollection,
                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateBufferCollectionFUCHSIA);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateBufferCollectionFUCHSIA(VkDevice device,
@@ -6536,7 +6536,7 @@ void ThreadSafety::PostCallRecordCreateBufferCollectionFUCHSIA(VkDevice device,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                VkBufferCollectionFUCHSIA* pCollection,
                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateBufferCollectionFUCHSIA);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pCollection);
     }
@@ -6545,176 +6545,176 @@ void ThreadSafety::PostCallRecordCreateBufferCollectionFUCHSIA(VkDevice device,
 void ThreadSafety::PreCallRecordSetBufferCollectionImageConstraintsFUCHSIA(
     VkDevice device, VkBufferCollectionFUCHSIA collection, const VkImageConstraintsInfoFUCHSIA* pImageConstraintsInfo,
     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSetBufferCollectionImageConstraintsFUCHSIA);
-    StartReadObject(collection, vvl::Func::vkSetBufferCollectionImageConstraintsFUCHSIA);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(collection, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSetBufferCollectionImageConstraintsFUCHSIA(
     VkDevice device, VkBufferCollectionFUCHSIA collection, const VkImageConstraintsInfoFUCHSIA* pImageConstraintsInfo,
     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSetBufferCollectionImageConstraintsFUCHSIA);
-    FinishReadObject(collection, vvl::Func::vkSetBufferCollectionImageConstraintsFUCHSIA);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(collection, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordSetBufferCollectionBufferConstraintsFUCHSIA(
     VkDevice device, VkBufferCollectionFUCHSIA collection, const VkBufferConstraintsInfoFUCHSIA* pBufferConstraintsInfo,
     const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSetBufferCollectionBufferConstraintsFUCHSIA);
-    StartReadObject(collection, vvl::Func::vkSetBufferCollectionBufferConstraintsFUCHSIA);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(collection, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSetBufferCollectionBufferConstraintsFUCHSIA(
     VkDevice device, VkBufferCollectionFUCHSIA collection, const VkBufferConstraintsInfoFUCHSIA* pBufferConstraintsInfo,
     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSetBufferCollectionBufferConstraintsFUCHSIA);
-    FinishReadObject(collection, vvl::Func::vkSetBufferCollectionBufferConstraintsFUCHSIA);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(collection, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordDestroyBufferCollectionFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyBufferCollectionFUCHSIA);
-    StartReadObject(collection, vvl::Func::vkDestroyBufferCollectionFUCHSIA);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(collection, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordDestroyBufferCollectionFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyBufferCollectionFUCHSIA);
-    FinishReadObject(collection, vvl::Func::vkDestroyBufferCollectionFUCHSIA);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(collection, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetBufferCollectionPropertiesFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection,
                                                                      VkBufferCollectionPropertiesFUCHSIA* pProperties,
                                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetBufferCollectionPropertiesFUCHSIA);
-    StartReadObject(collection, vvl::Func::vkGetBufferCollectionPropertiesFUCHSIA);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(collection, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetBufferCollectionPropertiesFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection,
                                                                       VkBufferCollectionPropertiesFUCHSIA* pProperties,
                                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetBufferCollectionPropertiesFUCHSIA);
-    FinishReadObject(collection, vvl::Func::vkGetBufferCollectionPropertiesFUCHSIA);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(collection, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_FUCHSIA
 void ThreadSafety::PreCallRecordGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(VkDevice device, VkRenderPass renderpass,
                                                                               VkExtent2D* pMaxWorkgroupSize,
                                                                               const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI);
-    StartReadObject(renderpass, vvl::Func::vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(renderpass, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(VkDevice device, VkRenderPass renderpass,
                                                                                VkExtent2D* pMaxWorkgroupSize,
                                                                                const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI);
-    FinishReadObject(renderpass, vvl::Func::vkGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(renderpass, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSubpassShadingHUAWEI);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSubpassShadingHUAWEI);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView,
                                                             VkImageLayout imageLayout, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindInvocationMaskHUAWEI);
-    StartReadObject(imageView, vvl::Func::vkCmdBindInvocationMaskHUAWEI);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(imageView, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView,
                                                              VkImageLayout imageLayout, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindInvocationMaskHUAWEI);
-    FinishReadObject(imageView, vvl::Func::vkCmdBindInvocationMaskHUAWEI);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(imageView, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetMemoryRemoteAddressNV(VkDevice device,
                                                          const VkMemoryGetRemoteAddressInfoNV* pMemoryGetRemoteAddressInfo,
                                                          VkRemoteAddressNV* pAddress, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMemoryRemoteAddressNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMemoryRemoteAddressNV(VkDevice device,
                                                           const VkMemoryGetRemoteAddressInfoNV* pMemoryGetRemoteAddressInfo,
                                                           VkRemoteAddressNV* pAddress, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMemoryRemoteAddressNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetPipelinePropertiesEXT(VkDevice device, const VkPipelineInfoEXT* pPipelineInfo,
                                                          VkBaseOutStructure* pPipelineProperties, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPipelinePropertiesEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPipelinePropertiesEXT(VkDevice device, const VkPipelineInfoEXT* pPipelineInfo,
                                                           VkBaseOutStructure* pPipelineProperties, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPipelinePropertiesEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer, uint32_t patchControlPoints,
                                                             const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetPatchControlPointsEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetPatchControlPointsEXT(VkCommandBuffer commandBuffer, uint32_t patchControlPoints,
                                                              const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetPatchControlPointsEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable,
                                                                  const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetRasterizerDiscardEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetRasterizerDiscardEnableEXT(VkCommandBuffer commandBuffer, VkBool32 rasterizerDiscardEnable,
                                                                   const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetRasterizerDiscardEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBiasEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthBiasEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthBiasEnable,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthBiasEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetLogicOpEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetLogicOpEXT(VkCommandBuffer commandBuffer, VkLogicOp logicOp,
                                                   const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetLogicOpEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable,
                                                                 const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetPrimitiveRestartEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer commandBuffer, VkBool32 primitiveRestartEnable,
                                                                  const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetPrimitiveRestartEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6722,13 +6722,13 @@ void ThreadSafety::PostCallRecordCmdSetPrimitiveRestartEnableEXT(VkCommandBuffer
 void ThreadSafety::PreCallRecordCreateScreenSurfaceQNX(VkInstance instance, const VkScreenSurfaceCreateInfoQNX* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(instance, vvl::Func::vkCreateScreenSurfaceQNX);
+    StartReadObjectParentInstance(instance, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateScreenSurfaceQNX(VkInstance instance, const VkScreenSurfaceCreateInfoQNX* pCreateInfo,
                                                         const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(instance, vvl::Func::vkCreateScreenSurfaceQNX);
+    FinishReadObjectParentInstance(instance, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObjectParentInstance(*pSurface);
     }
@@ -6737,27 +6737,27 @@ void ThreadSafety::PostCallRecordCreateScreenSurfaceQNX(VkInstance instance, con
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
 void ThreadSafety::PreCallRecordCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                           const VkBool32* pColorWriteEnables, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetColorWriteEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetColorWriteEnableEXT(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                            const VkBool32* pColorWriteEnables, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetColorWriteEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
                                                 const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount,
                                                 uint32_t firstInstance, uint32_t stride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawMultiEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
                                                  const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount,
                                                  uint32_t firstInstance, uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawMultiEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6765,7 +6765,7 @@ void ThreadSafety::PreCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer commandBu
                                                        const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
                                                        uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset,
                                                        const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawMultiIndexedEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6773,20 +6773,20 @@ void ThreadSafety::PostCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer commandB
                                                         const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
                                                         uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset,
                                                         const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawMultiIndexedEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCreateMicromapEXT(VkDevice device, const VkMicromapCreateInfoEXT* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkMicromapEXT* pMicromap,
                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateMicromapEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateMicromapEXT(VkDevice device, const VkMicromapCreateInfoEXT* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkMicromapEXT* pMicromap,
                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateMicromapEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pMicromap);
     }
@@ -6794,91 +6794,91 @@ void ThreadSafety::PostCallRecordCreateMicromapEXT(VkDevice device, const VkMicr
 
 void ThreadSafety::PreCallRecordDestroyMicromapEXT(VkDevice device, VkMicromapEXT micromap, const VkAllocationCallbacks* pAllocator,
                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyMicromapEXT);
-    StartWriteObject(micromap, vvl::Func::vkDestroyMicromapEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(micromap, record_obj.location);
     // Host access to micromap must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyMicromapEXT(VkDevice device, VkMicromapEXT micromap,
                                                     const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyMicromapEXT);
-    FinishWriteObject(micromap, vvl::Func::vkDestroyMicromapEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(micromap, record_obj.location);
     DestroyObject(micromap);
     // Host access to micromap must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdBuildMicromapsEXT(VkCommandBuffer commandBuffer, uint32_t infoCount,
                                                      const VkMicromapBuildInfoEXT* pInfos, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBuildMicromapsEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBuildMicromapsEXT(VkCommandBuffer commandBuffer, uint32_t infoCount,
                                                       const VkMicromapBuildInfoEXT* pInfos, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBuildMicromapsEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordBuildMicromapsEXT(VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
                                                   const VkMicromapBuildInfoEXT* pInfos, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBuildMicromapsEXT);
-    StartReadObject(deferredOperation, vvl::Func::vkBuildMicromapsEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordBuildMicromapsEXT(VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
                                                    const VkMicromapBuildInfoEXT* pInfos, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBuildMicromapsEXT);
-    FinishReadObject(deferredOperation, vvl::Func::vkBuildMicromapsEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCopyMicromapEXT(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                 const VkCopyMicromapInfoEXT* pInfo, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCopyMicromapEXT);
-    StartReadObject(deferredOperation, vvl::Func::vkCopyMicromapEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCopyMicromapEXT(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                  const VkCopyMicromapInfoEXT* pInfo, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCopyMicromapEXT);
-    FinishReadObject(deferredOperation, vvl::Func::vkCopyMicromapEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCopyMicromapToMemoryEXT(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                         const VkCopyMicromapToMemoryInfoEXT* pInfo,
                                                         const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCopyMicromapToMemoryEXT);
-    StartReadObject(deferredOperation, vvl::Func::vkCopyMicromapToMemoryEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCopyMicromapToMemoryEXT(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                          const VkCopyMicromapToMemoryInfoEXT* pInfo,
                                                          const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCopyMicromapToMemoryEXT);
-    FinishReadObject(deferredOperation, vvl::Func::vkCopyMicromapToMemoryEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCopyMemoryToMicromapEXT(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                         const VkCopyMemoryToMicromapInfoEXT* pInfo,
                                                         const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCopyMemoryToMicromapEXT);
-    StartReadObject(deferredOperation, vvl::Func::vkCopyMemoryToMicromapEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCopyMemoryToMicromapEXT(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                          const VkCopyMemoryToMicromapInfoEXT* pInfo,
                                                          const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCopyMemoryToMicromapEXT);
-    FinishReadObject(deferredOperation, vvl::Func::vkCopyMemoryToMicromapEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordWriteMicromapsPropertiesEXT(VkDevice device, uint32_t micromapCount,
                                                             const VkMicromapEXT* pMicromaps, VkQueryType queryType, size_t dataSize,
                                                             void* pData, size_t stride, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkWriteMicromapsPropertiesEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 
     if (pMicromaps) {
         for (uint32_t index = 0; index < micromapCount; index++) {
-            StartReadObject(pMicromaps[index], vvl::Func::vkWriteMicromapsPropertiesEXT);
+            StartReadObject(pMicromaps[index], record_obj.location);
         }
     }
 }
@@ -6887,52 +6887,52 @@ void ThreadSafety::PostCallRecordWriteMicromapsPropertiesEXT(VkDevice device, ui
                                                              const VkMicromapEXT* pMicromaps, VkQueryType queryType,
                                                              size_t dataSize, void* pData, size_t stride,
                                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkWriteMicromapsPropertiesEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 
     if (pMicromaps) {
         for (uint32_t index = 0; index < micromapCount; index++) {
-            FinishReadObject(pMicromaps[index], vvl::Func::vkWriteMicromapsPropertiesEXT);
+            FinishReadObject(pMicromaps[index], record_obj.location);
         }
     }
 }
 
 void ThreadSafety::PreCallRecordCmdCopyMicromapEXT(VkCommandBuffer commandBuffer, const VkCopyMicromapInfoEXT* pInfo,
                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyMicromapEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyMicromapEXT(VkCommandBuffer commandBuffer, const VkCopyMicromapInfoEXT* pInfo,
                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyMicromapEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyMicromapToMemoryEXT(VkCommandBuffer commandBuffer,
                                                            const VkCopyMicromapToMemoryInfoEXT* pInfo,
                                                            const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyMicromapToMemoryEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyMicromapToMemoryEXT(VkCommandBuffer commandBuffer,
                                                             const VkCopyMicromapToMemoryInfoEXT* pInfo,
                                                             const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyMicromapToMemoryEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyMemoryToMicromapEXT(VkCommandBuffer commandBuffer,
                                                            const VkCopyMemoryToMicromapInfoEXT* pInfo,
                                                            const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyMemoryToMicromapEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyMemoryToMicromapEXT(VkCommandBuffer commandBuffer,
                                                             const VkCopyMemoryToMicromapInfoEXT* pInfo,
                                                             const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyMemoryToMicromapEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6940,14 +6940,14 @@ void ThreadSafety::PreCallRecordCmdWriteMicromapsPropertiesEXT(VkCommandBuffer c
                                                                const VkMicromapEXT* pMicromaps, VkQueryType queryType,
                                                                VkQueryPool queryPool, uint32_t firstQuery,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWriteMicromapsPropertiesEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pMicromaps) {
         for (uint32_t index = 0; index < micromapCount; index++) {
-            StartReadObject(pMicromaps[index], vvl::Func::vkCmdWriteMicromapsPropertiesEXT);
+            StartReadObject(pMicromaps[index], record_obj.location);
         }
     }
-    StartReadObject(queryPool, vvl::Func::vkCmdWriteMicromapsPropertiesEXT);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -6955,112 +6955,112 @@ void ThreadSafety::PostCallRecordCmdWriteMicromapsPropertiesEXT(VkCommandBuffer 
                                                                 const VkMicromapEXT* pMicromaps, VkQueryType queryType,
                                                                 VkQueryPool queryPool, uint32_t firstQuery,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWriteMicromapsPropertiesEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pMicromaps) {
         for (uint32_t index = 0; index < micromapCount; index++) {
-            FinishReadObject(pMicromaps[index], vvl::Func::vkCmdWriteMicromapsPropertiesEXT);
+            FinishReadObject(pMicromaps[index], record_obj.location);
         }
     }
-    FinishReadObject(queryPool, vvl::Func::vkCmdWriteMicromapsPropertiesEXT);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetDeviceMicromapCompatibilityEXT(VkDevice device, const VkMicromapVersionInfoEXT* pVersionInfo,
                                                                   VkAccelerationStructureCompatibilityKHR* pCompatibility,
                                                                   const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceMicromapCompatibilityEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceMicromapCompatibilityEXT(VkDevice device, const VkMicromapVersionInfoEXT* pVersionInfo,
                                                                    VkAccelerationStructureCompatibilityKHR* pCompatibility,
                                                                    const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceMicromapCompatibilityEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetMicromapBuildSizesEXT(VkDevice device, VkAccelerationStructureBuildTypeKHR buildType,
                                                          const VkMicromapBuildInfoEXT* pBuildInfo,
                                                          VkMicromapBuildSizesInfoEXT* pSizeInfo, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetMicromapBuildSizesEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetMicromapBuildSizesEXT(VkDevice device, VkAccelerationStructureBuildTypeKHR buildType,
                                                           const VkMicromapBuildInfoEXT* pBuildInfo,
                                                           VkMicromapBuildSizesInfoEXT* pSizeInfo, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetMicromapBuildSizesEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                                      uint32_t groupCountZ, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawClusterHUAWEI);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                                       uint32_t groupCountZ, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawClusterHUAWEI);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDrawClusterIndirectHUAWEI(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                              const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawClusterIndirectHUAWEI);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawClusterIndirectHUAWEI);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawClusterIndirectHUAWEI(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                               const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawClusterIndirectHUAWEI);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawClusterIndirectHUAWEI);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordSetDeviceMemoryPriorityEXT(VkDevice device, VkDeviceMemory memory, float priority,
                                                            const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSetDeviceMemoryPriorityEXT);
-    StartReadObject(memory, vvl::Func::vkSetDeviceMemoryPriorityEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(memory, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSetDeviceMemoryPriorityEXT(VkDevice device, VkDeviceMemory memory, float priority,
                                                             const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSetDeviceMemoryPriorityEXT);
-    FinishReadObject(memory, vvl::Func::vkSetDeviceMemoryPriorityEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(memory, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDescriptorSetLayoutHostMappingInfoVALVE(
     VkDevice device, const VkDescriptorSetBindingReferenceVALVE* pBindingReference,
     VkDescriptorSetLayoutHostMappingInfoVALVE* pHostMapping, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetLayoutHostMappingInfoVALVE);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDescriptorSetLayoutHostMappingInfoVALVE(
     VkDevice device, const VkDescriptorSetBindingReferenceVALVE* pBindingReference,
     VkDescriptorSetLayoutHostMappingInfoVALVE* pHostMapping, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetLayoutHostMappingInfoVALVE);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDescriptorSetHostMappingVALVE(VkDevice device, VkDescriptorSet descriptorSet, void** ppData,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetHostMappingVALVE);
-    StartReadObject(descriptorSet, vvl::Func::vkGetDescriptorSetHostMappingVALVE);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(descriptorSet, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDescriptorSetHostMappingVALVE(VkDevice device, VkDescriptorSet descriptorSet, void** ppData,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDescriptorSetHostMappingVALVE);
-    FinishReadObject(descriptorSet, vvl::Func::vkGetDescriptorSetHostMappingVALVE);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(descriptorSet, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdCopyMemoryIndirectNV(VkCommandBuffer commandBuffer, VkDeviceAddress copyBufferAddress,
                                                         uint32_t copyCount, uint32_t stride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyMemoryIndirectNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyMemoryIndirectNV(VkCommandBuffer commandBuffer, VkDeviceAddress copyBufferAddress,
                                                          uint32_t copyCount, uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyMemoryIndirectNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7069,8 +7069,8 @@ void ThreadSafety::PreCallRecordCmdCopyMemoryToImageIndirectNV(VkCommandBuffer c
                                                                VkImageLayout dstImageLayout,
                                                                const VkImageSubresourceLayers* pImageSubresources,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyMemoryToImageIndirectNV);
-    StartReadObject(dstImage, vvl::Func::vkCmdCopyMemoryToImageIndirectNV);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(dstImage, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7079,22 +7079,22 @@ void ThreadSafety::PostCallRecordCmdCopyMemoryToImageIndirectNV(VkCommandBuffer 
                                                                 VkImageLayout dstImageLayout,
                                                                 const VkImageSubresourceLayers* pImageSubresources,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyMemoryToImageIndirectNV);
-    FinishReadObject(dstImage, vvl::Func::vkCmdCopyMemoryToImageIndirectNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(dstImage, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDecompressMemoryNV(VkCommandBuffer commandBuffer, uint32_t decompressRegionCount,
                                                       const VkDecompressMemoryRegionNV* pDecompressMemoryRegions,
                                                       const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDecompressMemoryNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDecompressMemoryNV(VkCommandBuffer commandBuffer, uint32_t decompressRegionCount,
                                                        const VkDecompressMemoryRegionNV* pDecompressMemoryRegions,
                                                        const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDecompressMemoryNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7102,7 +7102,7 @@ void ThreadSafety::PreCallRecordCmdDecompressMemoryIndirectCountNV(VkCommandBuff
                                                                    VkDeviceAddress indirectCommandsAddress,
                                                                    VkDeviceAddress indirectCommandsCountAddress, uint32_t stride,
                                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDecompressMemoryIndirectCountNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7110,7 +7110,7 @@ void ThreadSafety::PostCallRecordCmdDecompressMemoryIndirectCountNV(VkCommandBuf
                                                                     VkDeviceAddress indirectCommandsAddress,
                                                                     VkDeviceAddress indirectCommandsCountAddress, uint32_t stride,
                                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDecompressMemoryIndirectCountNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7118,155 +7118,155 @@ void ThreadSafety::PreCallRecordGetPipelineIndirectMemoryRequirementsNV(VkDevice
                                                                         const VkComputePipelineCreateInfo* pCreateInfo,
                                                                         VkMemoryRequirements2* pMemoryRequirements,
                                                                         const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPipelineIndirectMemoryRequirementsNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPipelineIndirectMemoryRequirementsNV(VkDevice device,
                                                                          const VkComputePipelineCreateInfo* pCreateInfo,
                                                                          VkMemoryRequirements2* pMemoryRequirements,
                                                                          const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPipelineIndirectMemoryRequirementsNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdUpdatePipelineIndirectBufferNV(VkCommandBuffer commandBuffer,
                                                                   VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline,
                                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdUpdatePipelineIndirectBufferNV);
-    StartReadObject(pipeline, vvl::Func::vkCmdUpdatePipelineIndirectBufferNV);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(pipeline, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdUpdatePipelineIndirectBufferNV(VkCommandBuffer commandBuffer,
                                                                    VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline,
                                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdUpdatePipelineIndirectBufferNV);
-    FinishReadObject(pipeline, vvl::Func::vkCmdUpdatePipelineIndirectBufferNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(pipeline, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetPipelineIndirectDeviceAddressNV(VkDevice device,
                                                                    const VkPipelineIndirectDeviceAddressInfoNV* pInfo,
                                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetPipelineIndirectDeviceAddressNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetPipelineIndirectDeviceAddressNV(VkDevice device,
                                                                     const VkPipelineIndirectDeviceAddressInfoNV* pInfo,
                                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetPipelineIndirectDeviceAddressNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetTessellationDomainOriginEXT(VkCommandBuffer commandBuffer,
                                                                   VkTessellationDomainOrigin domainOrigin,
                                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetTessellationDomainOriginEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetTessellationDomainOriginEXT(VkCommandBuffer commandBuffer,
                                                                    VkTessellationDomainOrigin domainOrigin,
                                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetTessellationDomainOriginEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthClampEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClampEnable,
                                                           const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthClampEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthClampEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClampEnable,
                                                            const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthClampEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetPolygonModeEXT(VkCommandBuffer commandBuffer, VkPolygonMode polygonMode,
                                                      const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetPolygonModeEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetPolygonModeEXT(VkCommandBuffer commandBuffer, VkPolygonMode polygonMode,
                                                       const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetPolygonModeEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetRasterizationSamplesEXT(VkCommandBuffer commandBuffer,
                                                               VkSampleCountFlagBits rasterizationSamples,
                                                               const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetRasterizationSamplesEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetRasterizationSamplesEXT(VkCommandBuffer commandBuffer,
                                                                VkSampleCountFlagBits rasterizationSamples,
                                                                const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetRasterizationSamplesEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetSampleMaskEXT(VkCommandBuffer commandBuffer, VkSampleCountFlagBits samples,
                                                     const VkSampleMask* pSampleMask, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetSampleMaskEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetSampleMaskEXT(VkCommandBuffer commandBuffer, VkSampleCountFlagBits samples,
                                                      const VkSampleMask* pSampleMask, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetSampleMaskEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetAlphaToCoverageEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToCoverageEnable,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetAlphaToCoverageEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetAlphaToCoverageEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToCoverageEnable,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetAlphaToCoverageEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToOneEnable,
                                                           const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetAlphaToOneEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetAlphaToOneEnableEXT(VkCommandBuffer commandBuffer, VkBool32 alphaToOneEnable,
                                                            const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetAlphaToOneEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetLogicOpEnableEXT(VkCommandBuffer commandBuffer, VkBool32 logicOpEnable,
                                                        const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetLogicOpEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetLogicOpEnableEXT(VkCommandBuffer commandBuffer, VkBool32 logicOpEnable,
                                                         const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetLogicOpEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetColorBlendEnableEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                           uint32_t attachmentCount, const VkBool32* pColorBlendEnables,
                                                           const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetColorBlendEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetColorBlendEnableEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                            uint32_t attachmentCount, const VkBool32* pColorBlendEnables,
                                                            const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetColorBlendEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7274,7 +7274,7 @@ void ThreadSafety::PreCallRecordCmdSetColorBlendEquationEXT(VkCommandBuffer comm
                                                             uint32_t attachmentCount,
                                                             const VkColorBlendEquationEXT* pColorBlendEquations,
                                                             const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetColorBlendEquationEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7282,85 +7282,85 @@ void ThreadSafety::PostCallRecordCmdSetColorBlendEquationEXT(VkCommandBuffer com
                                                              uint32_t attachmentCount,
                                                              const VkColorBlendEquationEXT* pColorBlendEquations,
                                                              const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetColorBlendEquationEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetColorWriteMaskEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                         uint32_t attachmentCount, const VkColorComponentFlags* pColorWriteMasks,
                                                         const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetColorWriteMaskEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetColorWriteMaskEXT(VkCommandBuffer commandBuffer, uint32_t firstAttachment,
                                                          uint32_t attachmentCount, const VkColorComponentFlags* pColorWriteMasks,
                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetColorWriteMaskEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetRasterizationStreamEXT(VkCommandBuffer commandBuffer, uint32_t rasterizationStream,
                                                              const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetRasterizationStreamEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetRasterizationStreamEXT(VkCommandBuffer commandBuffer, uint32_t rasterizationStream,
                                                               const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetRasterizationStreamEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetConservativeRasterizationModeEXT(
     VkCommandBuffer commandBuffer, VkConservativeRasterizationModeEXT conservativeRasterizationMode,
     const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetConservativeRasterizationModeEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetConservativeRasterizationModeEXT(
     VkCommandBuffer commandBuffer, VkConservativeRasterizationModeEXT conservativeRasterizationMode,
     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetConservativeRasterizationModeEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetExtraPrimitiveOverestimationSizeEXT(VkCommandBuffer commandBuffer,
                                                                           float extraPrimitiveOverestimationSize,
                                                                           const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetExtraPrimitiveOverestimationSizeEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetExtraPrimitiveOverestimationSizeEXT(VkCommandBuffer commandBuffer,
                                                                            float extraPrimitiveOverestimationSize,
                                                                            const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetExtraPrimitiveOverestimationSizeEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClipEnable,
                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthClipEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthClipEnableEXT(VkCommandBuffer commandBuffer, VkBool32 depthClipEnable,
                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthClipEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetSampleLocationsEnableEXT(VkCommandBuffer commandBuffer, VkBool32 sampleLocationsEnable,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetSampleLocationsEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetSampleLocationsEnableEXT(VkCommandBuffer commandBuffer, VkBool32 sampleLocationsEnable,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetSampleLocationsEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7368,7 +7368,7 @@ void ThreadSafety::PreCallRecordCmdSetColorBlendAdvancedEXT(VkCommandBuffer comm
                                                             uint32_t attachmentCount,
                                                             const VkColorBlendAdvancedEXT* pColorBlendAdvanced,
                                                             const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetColorBlendAdvancedEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7376,137 +7376,137 @@ void ThreadSafety::PostCallRecordCmdSetColorBlendAdvancedEXT(VkCommandBuffer com
                                                              uint32_t attachmentCount,
                                                              const VkColorBlendAdvancedEXT* pColorBlendAdvanced,
                                                              const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetColorBlendAdvancedEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetProvokingVertexModeEXT(VkCommandBuffer commandBuffer,
                                                              VkProvokingVertexModeEXT provokingVertexMode,
                                                              const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetProvokingVertexModeEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetProvokingVertexModeEXT(VkCommandBuffer commandBuffer,
                                                               VkProvokingVertexModeEXT provokingVertexMode,
                                                               const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetProvokingVertexModeEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetLineRasterizationModeEXT(VkCommandBuffer commandBuffer,
                                                                VkLineRasterizationModeEXT lineRasterizationMode,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetLineRasterizationModeEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetLineRasterizationModeEXT(VkCommandBuffer commandBuffer,
                                                                 VkLineRasterizationModeEXT lineRasterizationMode,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetLineRasterizationModeEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetLineStippleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stippledLineEnable,
                                                            const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetLineStippleEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetLineStippleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 stippledLineEnable,
                                                             const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetLineStippleEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer commandBuffer, VkBool32 negativeOneToOne,
                                                                    const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthClipNegativeOneToOneEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetDepthClipNegativeOneToOneEXT(VkCommandBuffer commandBuffer, VkBool32 negativeOneToOne,
                                                                     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetDepthClipNegativeOneToOneEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetViewportWScalingEnableNV(VkCommandBuffer commandBuffer, VkBool32 viewportWScalingEnable,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportWScalingEnableNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetViewportWScalingEnableNV(VkCommandBuffer commandBuffer, VkBool32 viewportWScalingEnable,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportWScalingEnableNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetViewportSwizzleNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                         uint32_t viewportCount, const VkViewportSwizzleNV* pViewportSwizzles,
                                                         const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportSwizzleNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetViewportSwizzleNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
                                                          uint32_t viewportCount, const VkViewportSwizzleNV* pViewportSwizzles,
                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetViewportSwizzleNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetCoverageToColorEnableNV(VkCommandBuffer commandBuffer, VkBool32 coverageToColorEnable,
                                                               const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageToColorEnableNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetCoverageToColorEnableNV(VkCommandBuffer commandBuffer, VkBool32 coverageToColorEnable,
                                                                const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageToColorEnableNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetCoverageToColorLocationNV(VkCommandBuffer commandBuffer, uint32_t coverageToColorLocation,
                                                                 const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageToColorLocationNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetCoverageToColorLocationNV(VkCommandBuffer commandBuffer, uint32_t coverageToColorLocation,
                                                                  const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageToColorLocationNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetCoverageModulationModeNV(VkCommandBuffer commandBuffer,
                                                                VkCoverageModulationModeNV coverageModulationMode,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageModulationModeNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetCoverageModulationModeNV(VkCommandBuffer commandBuffer,
                                                                 VkCoverageModulationModeNV coverageModulationMode,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageModulationModeNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetCoverageModulationTableEnableNV(VkCommandBuffer commandBuffer,
                                                                       VkBool32 coverageModulationTableEnable,
                                                                       const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageModulationTableEnableNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetCoverageModulationTableEnableNV(VkCommandBuffer commandBuffer,
                                                                        VkBool32 coverageModulationTableEnable,
                                                                        const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageModulationTableEnableNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7514,7 +7514,7 @@ void ThreadSafety::PreCallRecordCmdSetCoverageModulationTableNV(VkCommandBuffer 
                                                                 uint32_t coverageModulationTableCount,
                                                                 const float* pCoverageModulationTable,
                                                                 const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageModulationTableNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7522,87 +7522,87 @@ void ThreadSafety::PostCallRecordCmdSetCoverageModulationTableNV(VkCommandBuffer
                                                                  uint32_t coverageModulationTableCount,
                                                                  const float* pCoverageModulationTable,
                                                                  const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageModulationTableNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetShadingRateImageEnableNV(VkCommandBuffer commandBuffer, VkBool32 shadingRateImageEnable,
                                                                const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetShadingRateImageEnableNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetShadingRateImageEnableNV(VkCommandBuffer commandBuffer, VkBool32 shadingRateImageEnable,
                                                                 const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetShadingRateImageEnableNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetRepresentativeFragmentTestEnableNV(VkCommandBuffer commandBuffer,
                                                                          VkBool32 representativeFragmentTestEnable,
                                                                          const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetRepresentativeFragmentTestEnableNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetRepresentativeFragmentTestEnableNV(VkCommandBuffer commandBuffer,
                                                                           VkBool32 representativeFragmentTestEnable,
                                                                           const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetRepresentativeFragmentTestEnableNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdSetCoverageReductionModeNV(VkCommandBuffer commandBuffer,
                                                               VkCoverageReductionModeNV coverageReductionMode,
                                                               const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageReductionModeNV);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetCoverageReductionModeNV(VkCommandBuffer commandBuffer,
                                                                VkCoverageReductionModeNV coverageReductionMode,
                                                                const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetCoverageReductionModeNV);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetShaderModuleIdentifierEXT(VkDevice device, VkShaderModule shaderModule,
                                                              VkShaderModuleIdentifierEXT* pIdentifier,
                                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetShaderModuleIdentifierEXT);
-    StartReadObject(shaderModule, vvl::Func::vkGetShaderModuleIdentifierEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(shaderModule, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetShaderModuleIdentifierEXT(VkDevice device, VkShaderModule shaderModule,
                                                               VkShaderModuleIdentifierEXT* pIdentifier,
                                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetShaderModuleIdentifierEXT);
-    FinishReadObject(shaderModule, vvl::Func::vkGetShaderModuleIdentifierEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(shaderModule, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetShaderModuleCreateInfoIdentifierEXT(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                                                        VkShaderModuleIdentifierEXT* pIdentifier,
                                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetShaderModuleCreateInfoIdentifierEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetShaderModuleCreateInfoIdentifierEXT(VkDevice device,
                                                                         const VkShaderModuleCreateInfo* pCreateInfo,
                                                                         VkShaderModuleIdentifierEXT* pIdentifier,
                                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetShaderModuleCreateInfoIdentifierEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateOpticalFlowSessionNV(VkDevice device, const VkOpticalFlowSessionCreateInfoNV* pCreateInfo,
                                                            const VkAllocationCallbacks* pAllocator,
                                                            VkOpticalFlowSessionNV* pSession, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateOpticalFlowSessionNV);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateOpticalFlowSessionNV(VkDevice device, const VkOpticalFlowSessionCreateInfoNV* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator,
                                                             VkOpticalFlowSessionNV* pSession, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateOpticalFlowSessionNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pSession);
     }
@@ -7611,58 +7611,58 @@ void ThreadSafety::PostCallRecordCreateOpticalFlowSessionNV(VkDevice device, con
 void ThreadSafety::PreCallRecordDestroyOpticalFlowSessionNV(VkDevice device, VkOpticalFlowSessionNV session,
                                                             const VkAllocationCallbacks* pAllocator,
                                                             const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyOpticalFlowSessionNV);
-    StartReadObject(session, vvl::Func::vkDestroyOpticalFlowSessionNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(session, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordDestroyOpticalFlowSessionNV(VkDevice device, VkOpticalFlowSessionNV session,
                                                              const VkAllocationCallbacks* pAllocator,
                                                              const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyOpticalFlowSessionNV);
-    FinishReadObject(session, vvl::Func::vkDestroyOpticalFlowSessionNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(session, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordBindOpticalFlowSessionImageNV(VkDevice device, VkOpticalFlowSessionNV session,
                                                               VkOpticalFlowSessionBindingPointNV bindingPoint, VkImageView view,
                                                               VkImageLayout layout, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBindOpticalFlowSessionImageNV);
-    StartReadObject(session, vvl::Func::vkBindOpticalFlowSessionImageNV);
-    StartReadObject(view, vvl::Func::vkBindOpticalFlowSessionImageNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(session, record_obj.location);
+    StartReadObject(view, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordBindOpticalFlowSessionImageNV(VkDevice device, VkOpticalFlowSessionNV session,
                                                                VkOpticalFlowSessionBindingPointNV bindingPoint, VkImageView view,
                                                                VkImageLayout layout, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBindOpticalFlowSessionImageNV);
-    FinishReadObject(session, vvl::Func::vkBindOpticalFlowSessionImageNV);
-    FinishReadObject(view, vvl::Func::vkBindOpticalFlowSessionImageNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(session, record_obj.location);
+    FinishReadObject(view, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdOpticalFlowExecuteNV(VkCommandBuffer commandBuffer, VkOpticalFlowSessionNV session,
                                                         const VkOpticalFlowExecuteInfoNV* pExecuteInfo,
                                                         const RecordObject& record_obj) {
-    StartReadObject(commandBuffer, vvl::Func::vkCmdOpticalFlowExecuteNV);
-    StartReadObject(session, vvl::Func::vkCmdOpticalFlowExecuteNV);
+    StartReadObject(commandBuffer, record_obj.location);
+    StartReadObject(session, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCmdOpticalFlowExecuteNV(VkCommandBuffer commandBuffer, VkOpticalFlowSessionNV session,
                                                          const VkOpticalFlowExecuteInfoNV* pExecuteInfo,
                                                          const RecordObject& record_obj) {
-    FinishReadObject(commandBuffer, vvl::Func::vkCmdOpticalFlowExecuteNV);
-    FinishReadObject(session, vvl::Func::vkCmdOpticalFlowExecuteNV);
+    FinishReadObject(commandBuffer, record_obj.location);
+    FinishReadObject(session, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
                                                  const VkShaderCreateInfoEXT* pCreateInfos, const VkAllocationCallbacks* pAllocator,
                                                  VkShaderEXT* pShaders, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateShadersEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
                                                   const VkShaderCreateInfoEXT* pCreateInfos,
                                                   const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateShadersEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (pShaders) {
         for (uint32_t index = 0; index < createInfoCount; index++) {
             if (!pShaders[index]) continue;
@@ -7673,39 +7673,39 @@ void ThreadSafety::PostCallRecordCreateShadersEXT(VkDevice device, uint32_t crea
 
 void ThreadSafety::PreCallRecordDestroyShaderEXT(VkDevice device, VkShaderEXT shader, const VkAllocationCallbacks* pAllocator,
                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyShaderEXT);
-    StartWriteObject(shader, vvl::Func::vkDestroyShaderEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(shader, record_obj.location);
     // Host access to shader must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyShaderEXT(VkDevice device, VkShaderEXT shader, const VkAllocationCallbacks* pAllocator,
                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyShaderEXT);
-    FinishWriteObject(shader, vvl::Func::vkDestroyShaderEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(shader, record_obj.location);
     DestroyObject(shader);
     // Host access to shader must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t* pDataSize, void* pData,
                                                        const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetShaderBinaryDataEXT);
-    StartReadObject(shader, vvl::Func::vkGetShaderBinaryDataEXT);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(shader, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t* pDataSize, void* pData,
                                                         const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetShaderBinaryDataEXT);
-    FinishReadObject(shader, vvl::Func::vkGetShaderBinaryDataEXT);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(shader, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t stageCount,
                                                   const VkShaderStageFlagBits* pStages, const VkShaderEXT* pShaders,
                                                   const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBindShadersEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pShaders) {
         for (uint32_t index = 0; index < stageCount; index++) {
-            StartReadObject(pShaders[index], vvl::Func::vkCmdBindShadersEXT);
+            StartReadObject(pShaders[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -7714,11 +7714,11 @@ void ThreadSafety::PreCallRecordCmdBindShadersEXT(VkCommandBuffer commandBuffer,
 void ThreadSafety::PostCallRecordCmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t stageCount,
                                                    const VkShaderStageFlagBits* pStages, const VkShaderEXT* pShaders,
                                                    const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBindShadersEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pShaders) {
         for (uint32_t index = 0; index < stageCount; index++) {
-            FinishReadObject(pShaders[index], vvl::Func::vkCmdBindShadersEXT);
+            FinishReadObject(pShaders[index], record_obj.location);
         }
     }
     // Host access to commandBuffer must be externally synchronized
@@ -7727,100 +7727,100 @@ void ThreadSafety::PostCallRecordCmdBindShadersEXT(VkCommandBuffer commandBuffer
 void ThreadSafety::PreCallRecordGetFramebufferTilePropertiesQCOM(VkDevice device, VkFramebuffer framebuffer,
                                                                  uint32_t* pPropertiesCount, VkTilePropertiesQCOM* pProperties,
                                                                  const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetFramebufferTilePropertiesQCOM);
-    StartReadObject(framebuffer, vvl::Func::vkGetFramebufferTilePropertiesQCOM);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(framebuffer, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetFramebufferTilePropertiesQCOM(VkDevice device, VkFramebuffer framebuffer,
                                                                   uint32_t* pPropertiesCount, VkTilePropertiesQCOM* pProperties,
                                                                   const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetFramebufferTilePropertiesQCOM);
-    FinishReadObject(framebuffer, vvl::Func::vkGetFramebufferTilePropertiesQCOM);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(framebuffer, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetDynamicRenderingTilePropertiesQCOM(VkDevice device, const VkRenderingInfo* pRenderingInfo,
                                                                       VkTilePropertiesQCOM* pProperties,
                                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDynamicRenderingTilePropertiesQCOM);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDynamicRenderingTilePropertiesQCOM(VkDevice device, const VkRenderingInfo* pRenderingInfo,
                                                                        VkTilePropertiesQCOM* pProperties,
                                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDynamicRenderingTilePropertiesQCOM);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordSetLatencySleepModeNV(VkDevice device, VkSwapchainKHR swapchain,
                                                       const VkLatencySleepModeInfoNV* pSleepModeInfo,
                                                       const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSetLatencySleepModeNV);
-    StartReadObject(swapchain, vvl::Func::vkSetLatencySleepModeNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSetLatencySleepModeNV(VkDevice device, VkSwapchainKHR swapchain,
                                                        const VkLatencySleepModeInfoNV* pSleepModeInfo,
                                                        const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSetLatencySleepModeNV);
-    FinishReadObject(swapchain, vvl::Func::vkSetLatencySleepModeNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepInfoNV* pSleepInfo,
                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkLatencySleepNV);
-    StartReadObject(swapchain, vvl::Func::vkLatencySleepNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepInfoNV* pSleepInfo,
                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkLatencySleepNV);
-    FinishReadObject(swapchain, vvl::Func::vkLatencySleepNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordSetLatencyMarkerNV(VkDevice device, VkSwapchainKHR swapchain,
                                                    const VkSetLatencyMarkerInfoNV* pLatencyMarkerInfo,
                                                    const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkSetLatencyMarkerNV);
-    StartReadObject(swapchain, vvl::Func::vkSetLatencyMarkerNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordSetLatencyMarkerNV(VkDevice device, VkSwapchainKHR swapchain,
                                                     const VkSetLatencyMarkerInfoNV* pLatencyMarkerInfo,
                                                     const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkSetLatencyMarkerNV);
-    FinishReadObject(swapchain, vvl::Func::vkSetLatencyMarkerNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetLatencyTimingsNV(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pTimingCount,
                                                     VkGetLatencyMarkerInfoNV* pLatencyMarkerInfo, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetLatencyTimingsNV);
-    StartReadObject(swapchain, vvl::Func::vkGetLatencyTimingsNV);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetLatencyTimingsNV(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pTimingCount,
                                                      VkGetLatencyMarkerInfoNV* pLatencyMarkerInfo, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetLatencyTimingsNV);
-    FinishReadObject(swapchain, vvl::Func::vkGetLatencyTimingsNV);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(swapchain, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordQueueNotifyOutOfBandNV(VkQueue queue, const VkOutOfBandQueueTypeInfoNV* pQueueTypeInfo,
                                                        const RecordObject& record_obj) {
-    StartReadObject(queue, vvl::Func::vkQueueNotifyOutOfBandNV);
+    StartReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordQueueNotifyOutOfBandNV(VkQueue queue, const VkOutOfBandQueueTypeInfoNV* pQueueTypeInfo,
                                                         const RecordObject& record_obj) {
-    FinishReadObject(queue, vvl::Func::vkQueueNotifyOutOfBandNV);
+    FinishReadObject(queue, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer, VkImageAspectFlags aspectMask,
                                                                       const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetAttachmentFeedbackLoopEnableEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandBuffer commandBuffer, VkImageAspectFlags aspectMask,
                                                                        const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetAttachmentFeedbackLoopEnableEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7828,13 +7828,13 @@ void ThreadSafety::PostCallRecordCmdSetAttachmentFeedbackLoopEnableEXT(VkCommand
 void ThreadSafety::PreCallRecordGetScreenBufferPropertiesQNX(VkDevice device, const struct _screen_buffer* buffer,
                                                              VkScreenBufferPropertiesQNX* pProperties,
                                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetScreenBufferPropertiesQNX);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetScreenBufferPropertiesQNX(VkDevice device, const struct _screen_buffer* buffer,
                                                               VkScreenBufferPropertiesQNX* pProperties,
                                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetScreenBufferPropertiesQNX);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
@@ -7843,7 +7843,7 @@ void ThreadSafety::PreCallRecordCreateAccelerationStructureKHR(VkDevice device,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                VkAccelerationStructureKHR* pAccelerationStructure,
                                                                const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCreateAccelerationStructureKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCreateAccelerationStructureKHR(VkDevice device,
@@ -7851,7 +7851,7 @@ void ThreadSafety::PostCallRecordCreateAccelerationStructureKHR(VkDevice device,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 VkAccelerationStructureKHR* pAccelerationStructure,
                                                                 const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCreateAccelerationStructureKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
     if (record_obj.result == VK_SUCCESS) {
         CreateObject(*pAccelerationStructure);
     }
@@ -7860,16 +7860,16 @@ void ThreadSafety::PostCallRecordCreateAccelerationStructureKHR(VkDevice device,
 void ThreadSafety::PreCallRecordDestroyAccelerationStructureKHR(VkDevice device, VkAccelerationStructureKHR accelerationStructure,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkDestroyAccelerationStructureKHR);
-    StartWriteObject(accelerationStructure, vvl::Func::vkDestroyAccelerationStructureKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartWriteObject(accelerationStructure, record_obj.location);
     // Host access to accelerationStructure must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordDestroyAccelerationStructureKHR(VkDevice device, VkAccelerationStructureKHR accelerationStructure,
                                                                  const VkAllocationCallbacks* pAllocator,
                                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkDestroyAccelerationStructureKHR);
-    FinishWriteObject(accelerationStructure, vvl::Func::vkDestroyAccelerationStructureKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishWriteObject(accelerationStructure, record_obj.location);
     DestroyObject(accelerationStructure);
     // Host access to accelerationStructure must be externally synchronized
 }
@@ -7877,14 +7877,14 @@ void ThreadSafety::PostCallRecordDestroyAccelerationStructureKHR(VkDevice device
 void ThreadSafety::PreCallRecordCmdBuildAccelerationStructuresKHR(
     VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBuildAccelerationStructuresKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdBuildAccelerationStructuresKHR(
     VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBuildAccelerationStructuresKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7894,7 +7894,7 @@ void ThreadSafety::PreCallRecordCmdBuildAccelerationStructuresIndirectKHR(VkComm
                                                                           const uint32_t* pIndirectStrides,
                                                                           const uint32_t* const* ppMaxPrimitiveCounts,
                                                                           const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdBuildAccelerationStructuresIndirectKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7902,7 +7902,7 @@ void ThreadSafety::PostCallRecordCmdBuildAccelerationStructuresIndirectKHR(
     VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkDeviceAddress* pIndirectDeviceAddresses, const uint32_t* pIndirectStrides, const uint32_t* const* ppMaxPrimitiveCounts,
     const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdBuildAccelerationStructuresIndirectKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -7910,69 +7910,69 @@ void ThreadSafety::PreCallRecordBuildAccelerationStructuresKHR(
     VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
     const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkBuildAccelerationStructuresKHR);
-    StartReadObject(deferredOperation, vvl::Func::vkBuildAccelerationStructuresKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordBuildAccelerationStructuresKHR(
     VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
     const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkBuildAccelerationStructuresKHR);
-    FinishReadObject(deferredOperation, vvl::Func::vkBuildAccelerationStructuresKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                              const VkCopyAccelerationStructureInfoKHR* pInfo,
                                                              const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCopyAccelerationStructureKHR);
-    StartReadObject(deferredOperation, vvl::Func::vkCopyAccelerationStructureKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                               const VkCopyAccelerationStructureInfoKHR* pInfo,
                                                               const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCopyAccelerationStructureKHR);
-    FinishReadObject(deferredOperation, vvl::Func::vkCopyAccelerationStructureKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCopyAccelerationStructureToMemoryKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                      const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
                                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCopyAccelerationStructureToMemoryKHR);
-    StartReadObject(deferredOperation, vvl::Func::vkCopyAccelerationStructureToMemoryKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCopyAccelerationStructureToMemoryKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                       const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
                                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCopyAccelerationStructureToMemoryKHR);
-    FinishReadObject(deferredOperation, vvl::Func::vkCopyAccelerationStructureToMemoryKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCopyMemoryToAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                      const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
                                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkCopyMemoryToAccelerationStructureKHR);
-    StartReadObject(deferredOperation, vvl::Func::vkCopyMemoryToAccelerationStructureKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordCopyMemoryToAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                       const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
                                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkCopyMemoryToAccelerationStructureKHR);
-    FinishReadObject(deferredOperation, vvl::Func::vkCopyMemoryToAccelerationStructureKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(deferredOperation, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordWriteAccelerationStructuresPropertiesKHR(VkDevice device, uint32_t accelerationStructureCount,
                                                                          const VkAccelerationStructureKHR* pAccelerationStructures,
                                                                          VkQueryType queryType, size_t dataSize, void* pData,
                                                                          size_t stride, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkWriteAccelerationStructuresPropertiesKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 
     if (pAccelerationStructures) {
         for (uint32_t index = 0; index < accelerationStructureCount; index++) {
-            StartReadObject(pAccelerationStructures[index], vvl::Func::vkWriteAccelerationStructuresPropertiesKHR);
+            StartReadObject(pAccelerationStructures[index], record_obj.location);
         }
     }
 }
@@ -7981,11 +7981,11 @@ void ThreadSafety::PostCallRecordWriteAccelerationStructuresPropertiesKHR(VkDevi
                                                                           const VkAccelerationStructureKHR* pAccelerationStructures,
                                                                           VkQueryType queryType, size_t dataSize, void* pData,
                                                                           size_t stride, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkWriteAccelerationStructuresPropertiesKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 
     if (pAccelerationStructures) {
         for (uint32_t index = 0; index < accelerationStructureCount; index++) {
-            FinishReadObject(pAccelerationStructures[index], vvl::Func::vkWriteAccelerationStructuresPropertiesKHR);
+            FinishReadObject(pAccelerationStructures[index], record_obj.location);
         }
     }
 }
@@ -7993,107 +7993,107 @@ void ThreadSafety::PostCallRecordWriteAccelerationStructuresPropertiesKHR(VkDevi
 void ThreadSafety::PreCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
                                                                 const VkCopyAccelerationStructureInfoKHR* pInfo,
                                                                 const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyAccelerationStructureKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffer commandBuffer,
                                                                  const VkCopyAccelerationStructureInfoKHR* pInfo,
                                                                  const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyAccelerationStructureKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer,
                                                                         const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
                                                                         const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyAccelerationStructureToMemoryKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyAccelerationStructureToMemoryKHR(VkCommandBuffer commandBuffer,
                                                                          const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
                                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyAccelerationStructureToMemoryKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer,
                                                                         const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
                                                                         const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdCopyMemoryToAccelerationStructureKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkCommandBuffer commandBuffer,
                                                                          const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
                                                                          const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdCopyMemoryToAccelerationStructureKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetAccelerationStructureDeviceAddressKHR(VkDevice device,
                                                                          const VkAccelerationStructureDeviceAddressInfoKHR* pInfo,
                                                                          const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetAccelerationStructureDeviceAddressKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetAccelerationStructureDeviceAddressKHR(VkDevice device,
                                                                           const VkAccelerationStructureDeviceAddressInfoKHR* pInfo,
                                                                           const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetAccelerationStructureDeviceAddressKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdWriteAccelerationStructuresPropertiesKHR(
     VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures,
     VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdWriteAccelerationStructuresPropertiesKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
 
     if (pAccelerationStructures) {
         for (uint32_t index = 0; index < accelerationStructureCount; index++) {
-            StartReadObject(pAccelerationStructures[index], vvl::Func::vkCmdWriteAccelerationStructuresPropertiesKHR);
+            StartReadObject(pAccelerationStructures[index], record_obj.location);
         }
     }
-    StartReadObject(queryPool, vvl::Func::vkCmdWriteAccelerationStructuresPropertiesKHR);
+    StartReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdWriteAccelerationStructuresPropertiesKHR(
     VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures,
     VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdWriteAccelerationStructuresPropertiesKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
 
     if (pAccelerationStructures) {
         for (uint32_t index = 0; index < accelerationStructureCount; index++) {
-            FinishReadObject(pAccelerationStructures[index], vvl::Func::vkCmdWriteAccelerationStructuresPropertiesKHR);
+            FinishReadObject(pAccelerationStructures[index], record_obj.location);
         }
     }
-    FinishReadObject(queryPool, vvl::Func::vkCmdWriteAccelerationStructuresPropertiesKHR);
+    FinishReadObject(queryPool, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetDeviceAccelerationStructureCompatibilityKHR(
     VkDevice device, const VkAccelerationStructureVersionInfoKHR* pVersionInfo,
     VkAccelerationStructureCompatibilityKHR* pCompatibility, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetDeviceAccelerationStructureCompatibilityKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetDeviceAccelerationStructureCompatibilityKHR(
     VkDevice device, const VkAccelerationStructureVersionInfoKHR* pVersionInfo,
     VkAccelerationStructureCompatibilityKHR* pCompatibility, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetDeviceAccelerationStructureCompatibilityKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordGetAccelerationStructureBuildSizesKHR(
     VkDevice device, VkAccelerationStructureBuildTypeKHR buildType, const VkAccelerationStructureBuildGeometryInfoKHR* pBuildInfo,
     const uint32_t* pMaxPrimitiveCounts, VkAccelerationStructureBuildSizesInfoKHR* pSizeInfo, const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetAccelerationStructureBuildSizesKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetAccelerationStructureBuildSizesKHR(
     VkDevice device, VkAccelerationStructureBuildTypeKHR buildType, const VkAccelerationStructureBuildGeometryInfoKHR* pBuildInfo,
     const uint32_t* pMaxPrimitiveCounts, VkAccelerationStructureBuildSizesInfoKHR* pSizeInfo, const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetAccelerationStructureBuildSizesKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
@@ -8102,7 +8102,7 @@ void ThreadSafety::PreCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                                 const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                                 const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, uint32_t width,
                                                 uint32_t height, uint32_t depth, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdTraceRaysKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -8112,7 +8112,7 @@ void ThreadSafety::PostCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                                  const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                                  const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable, uint32_t width,
                                                  uint32_t height, uint32_t depth, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdTraceRaysKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -8120,16 +8120,16 @@ void ThreadSafety::PreCallRecordGetRayTracingCaptureReplayShaderGroupHandlesKHR(
                                                                                 uint32_t firstGroup, uint32_t groupCount,
                                                                                 size_t dataSize, void* pData,
                                                                                 const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetRayTracingCaptureReplayShaderGroupHandlesKHR);
-    StartReadObject(pipeline, vvl::Func::vkGetRayTracingCaptureReplayShaderGroupHandlesKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetRayTracingCaptureReplayShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline,
                                                                                  uint32_t firstGroup, uint32_t groupCount,
                                                                                  size_t dataSize, void* pData,
                                                                                  const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetRayTracingCaptureReplayShaderGroupHandlesKHR);
-    FinishReadObject(pipeline, vvl::Func::vkGetRayTracingCaptureReplayShaderGroupHandlesKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
@@ -8138,7 +8138,7 @@ void ThreadSafety::PreCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer commandB
                                                         const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                                         const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                                         VkDeviceAddress indirectDeviceAddress, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdTraceRaysIndirectKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -8148,59 +8148,59 @@ void ThreadSafety::PostCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer command
                                                          const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
                                                          const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
                                                          VkDeviceAddress indirectDeviceAddress, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdTraceRaysIndirectKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordGetRayTracingShaderGroupStackSizeKHR(VkDevice device, VkPipeline pipeline, uint32_t group,
                                                                      VkShaderGroupShaderKHR groupShader,
                                                                      const RecordObject& record_obj) {
-    StartReadObjectParentInstance(device, vvl::Func::vkGetRayTracingShaderGroupStackSizeKHR);
-    StartReadObject(pipeline, vvl::Func::vkGetRayTracingShaderGroupStackSizeKHR);
+    StartReadObjectParentInstance(device, record_obj.location);
+    StartReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PostCallRecordGetRayTracingShaderGroupStackSizeKHR(VkDevice device, VkPipeline pipeline, uint32_t group,
                                                                       VkShaderGroupShaderKHR groupShader,
                                                                       const RecordObject& record_obj) {
-    FinishReadObjectParentInstance(device, vvl::Func::vkGetRayTracingShaderGroupStackSizeKHR);
-    FinishReadObject(pipeline, vvl::Func::vkGetRayTracingShaderGroupStackSizeKHR);
+    FinishReadObjectParentInstance(device, record_obj.location);
+    FinishReadObject(pipeline, record_obj.location);
 }
 
 void ThreadSafety::PreCallRecordCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer, uint32_t pipelineStackSize,
                                                                      const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdSetRayTracingPipelineStackSizeKHR);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdSetRayTracingPipelineStackSizeKHR(VkCommandBuffer commandBuffer, uint32_t pipelineStackSize,
                                                                       const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdSetRayTracingPipelineStackSizeKHR);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                                     uint32_t groupCountZ, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                                      uint32_t groupCountZ, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PreCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                             uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectEXT);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawMeshTasksIndirectEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
 void ThreadSafety::PostCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                              uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectEXT);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawMeshTasksIndirectEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -8208,9 +8208,9 @@ void ThreadSafety::PreCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer
                                                                  VkDeviceSize offset, VkBuffer countBuffer,
                                                                  VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                                  uint32_t stride, const RecordObject& record_obj) {
-    StartWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountEXT);
-    StartReadObject(buffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountEXT);
-    StartReadObject(countBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountEXT);
+    StartWriteObject(commandBuffer, record_obj.location);
+    StartReadObject(buffer, record_obj.location);
+    StartReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 
@@ -8218,9 +8218,9 @@ void ThreadSafety::PostCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffe
                                                                   VkDeviceSize offset, VkBuffer countBuffer,
                                                                   VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                                   uint32_t stride, const RecordObject& record_obj) {
-    FinishWriteObject(commandBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountEXT);
-    FinishReadObject(buffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountEXT);
-    FinishReadObject(countBuffer, vvl::Func::vkCmdDrawMeshTasksIndirectCountEXT);
+    FinishWriteObject(commandBuffer, record_obj.location);
+    FinishReadObject(buffer, record_obj.location);
+    FinishReadObject(countBuffer, record_obj.location);
     // Host access to commandBuffer must be externally synchronized
 }
 

--- a/scripts/generators/thread_safety_generator.py
+++ b/scripts/generators/thread_safety_generator.py
@@ -151,11 +151,11 @@ class ThreadSafetyOutputGenerator(BaseGenerator):
                             limit = limit[0:dotp+1] + limit[dotp+2:dotp+3].lower() + limit[dotp+3:]
                             out.append(f'for (uint32_t index2=0; index2 < {limit}; index2++) {{\n')
                             element = element.replace('[]','[index2]')
-                            out.append(f'    {prefix}WriteObject{suffix}({element}, vvl::Func::{command.name});')
+                            out.append(f'    {prefix}WriteObject{suffix}({element}, record_obj.location);')
                             out.append('}\n')
                             out.append('}\n')
                         else:
-                            out.append(f'{prefix}WriteObject{suffix}({element}, vvl::Func::{command.name});\n')
+                            out.append(f'{prefix}WriteObject{suffix}({element}, record_obj.location);\n')
                     out.append('}\n')
                     out.append('}\n')
                 else:
@@ -164,17 +164,17 @@ class ThreadSafetyOutputGenerator(BaseGenerator):
                         member = str(member).replace("::", "->")
                         member = str(member).replace(".", "->")
                         suffix = 'ParentInstance' if 'surface' in member else ''
-                        out.append(f'    {prefix}WriteObject{suffix}({member}, vvl::Func::{command.name});\n')
+                        out.append(f'    {prefix}WriteObject{suffix}({member}, record_obj.location);\n')
             elif param.externSync:
                 if param.length:
                     out.append(f'''
                         if ({param.name}) {{
                             for (uint32_t index = 0; index < {param.length}; index++) {{
-                                {prefix}WriteObject{GetParentInstance(param)}({param.name}[index], vvl::Func::{command.name});
+                                {prefix}WriteObject{GetParentInstance(param)}({param.name}[index], record_obj.location);
                             }}
                         }}\n''')
                 else:
-                    out.append(f'{prefix}WriteObject{GetParentInstance(param)}({param.name}, vvl::Func::{command.name});\n')
+                    out.append(f'{prefix}WriteObject{GetParentInstance(param)}({param.name}, record_obj.location);\n')
                     if ('Destroy' in command.name or 'Free' in command.name or 'ReleasePerformanceConfigurationINTEL' in command.name) and prefix == 'Finish':
                         out.append(f'DestroyObject{GetParentInstance(param)}({param.name});\n')
             elif param.pointer and ('Create' in command.name or 'Allocate' in command.name or 'AcquirePerformanceConfigurationINTEL' in command.name) and prefix == 'Finish':
@@ -224,13 +224,13 @@ class ThreadSafetyOutputGenerator(BaseGenerator):
                         out.append(f'''
                             if ({param.name}) {{
                                 for (uint32_t index = 0; index < {dereference}{param.length}; index++) {{
-                                    {prefix}ReadObject{GetParentInstance(param)}({param.name}[index], vvl::Func::{command.name});
+                                    {prefix}ReadObject{GetParentInstance(param)}({param.name}[index], record_obj.location);
                                 }}
                             }}\n''')
                     elif not param.pointer:
                         # Pointer params are often being created.
                         # They are not being read from.
-                        out.append(f'{prefix}ReadObject{GetParentInstance(param)}({param.name}, vvl::Func::{command.name});\n')
+                        out.append(f'{prefix}ReadObject{GetParentInstance(param)}({param.name}, record_obj.location);\n')
 
 
         for param in [x for x in command.params if x.externSync]:

--- a/tests/unit/threading.cpp
+++ b/tests/unit/threading.cpp
@@ -73,7 +73,7 @@ TEST_F(NegativeThreading, CommandBufferCollision) {
 TEST_F(NegativeThreading, UpdateDescriptorCollision) {
     TEST_DESCRIPTION("Two threads updating the same descriptor set, expected to generate a threading error");
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "THREADING ERROR : vkUpdateDescriptorSets");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "vkUpdateDescriptorSets():  THREADING ERROR");
     m_errorMonitor->SetAllowedFailureMsg("THREADING ERROR");  // Ignore any extra threading errors found beyond the first one
 
     RETURN_IF_SKIP(Init())


### PR DESCRIPTION
Pass `Location` for `FindObject`, `HandleErrorOnWrite`, and `HandleErrorOnRead` to know where the error occurred