### PR TITLE
layers: Fix pipeline rendering info validation

### DIFF
--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -587,6 +587,7 @@ class StatelessValidation : public ValidationObject {
                                                     const ErrorObject &error_obj) const;
 
     bool ValidatePipelineShaderStageCreateInfo(const VkPipelineShaderStageCreateInfo *pCreateInfo, const Location &loc) const;
+    bool ValidatePipelineRenderingCreateInfo(const VkPipelineRenderingCreateInfo &rendering_struct, const Location &loc) const;
     bool manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                        const VkGraphicsPipelineCreateInfo *pCreateInfos,
                                                        const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -3632,3 +3632,29 @@ TEST_F(NegativePipeline, MissingPipelineViewportState) {
         m_errorMonitor->VerifyFound();
     }
 }
+
+TEST_F(NegativePipeline, PipelineRenderingInfoInvalidFormatWithoutFragmentState) {
+    TEST_DESCRIPTION("Create pipeline with invalid pipeline rendering formats");
+
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitFramework())
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    GetPhysicalDeviceFeatures2(dynamic_rendering_features);
+    RETURN_IF_SKIP(InitState(nullptr, &dynamic_rendering_features));
+
+    VkPipelineRenderingCreateInfo pipeline_rendering_ci = vku::InitStructHelper();
+    pipeline_rendering_ci.stencilAttachmentFormat = VK_FORMAT_D16_UNORM;
+
+    VkPipelineDepthStencilStateCreateInfo ds = vku::InitStructHelper();
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
+    pipe.gp_ci_.pNext = &pipeline_rendering_ci;
+    pipe.gp_ci_.pColorBlendState = nullptr;
+    pipe.cb_ci_.attachmentCount = 0u;
+    pipe.ds_ci_ = ds;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06588");
+    pipe.CreateGraphicsPipeline();
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
Move `VkPipelineRenderingCreateInfo` out of the fragment shader state condition and into a separate function