### PR TITLE
layers: Add External memory/sync VU

### DIFF
--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -116,8 +116,7 @@ void BestPractices::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memo
         auto mem_info = Get<DEVICE_MEMORY_STATE>(memory);
 
         // Exclude memory free events on dedicated allocations, or imported/exported allocations.
-        if (mem_info->GetDedicatedBuffer() == VK_NULL_HANDLE && mem_info->GetDedicatedImage() == VK_NULL_HANDLE &&
-            !mem_info->IsExport() && !mem_info->IsImport()) {
+        if (!mem_info->IsDedicatedBuffer() && !mem_info->IsDedicatedImage() && !mem_info->IsExport() && !mem_info->IsImport()) {
             MemoryFreeEvent event;
             event.time = std::chrono::high_resolution_clock::now();
             event.memory_type_index = mem_info->alloc_info.memoryTypeIndex;

--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -116,7 +116,7 @@ void BestPractices::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memo
         auto mem_info = Get<DEVICE_MEMORY_STATE>(memory);
 
         // Exclude memory free events on dedicated allocations, or imported/exported allocations.
-        if (mem_info->GetDedicatedBuffer() != VK_NULL_HANDLE && mem_info->GetDedicatedImage() != VK_NULL_HANDLE &&
+        if (mem_info->GetDedicatedBuffer() == VK_NULL_HANDLE && mem_info->GetDedicatedImage() == VK_NULL_HANDLE &&
             !mem_info->IsExport() && !mem_info->IsImport()) {
             MemoryFreeEvent event;
             event.time = std::chrono::high_resolution_clock::now();

--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -116,7 +116,8 @@ void BestPractices::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memo
         auto mem_info = Get<DEVICE_MEMORY_STATE>(memory);
 
         // Exclude memory free events on dedicated allocations, or imported/exported allocations.
-        if (!mem_info->IsDedicatedBuffer() && !mem_info->IsDedicatedImage() && !mem_info->IsExport() && !mem_info->IsImport()) {
+        if (mem_info->GetDedicatedBuffer() != VK_NULL_HANDLE && mem_info->GetDedicatedImage() != VK_NULL_HANDLE &&
+            !mem_info->IsExport() && !mem_info->IsImport()) {
             MemoryFreeEvent event;
             event.time = std::chrono::high_resolution_clock::now();
             event.memory_type_index = mem_info->alloc_info.memoryTypeIndex;

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -150,15 +150,16 @@ bool CoreChecks::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(VkDevice d
 
     // If the pNext chain of the VkMemoryAllocateInfo used to allocate memory included a VkMemoryDedicatedAllocateInfo
     // with non-NULL image member, then that image must already be bound to memory.
-    if (mem_info->IsDedicatedImage()) {
-        auto image_state = Get<IMAGE_STATE>(mem_info->dedicated->handle.Cast<VkImage>());
+    VkImage dedicated_image = mem_info->GetDedicatedImage();
+    if (dedicated_image != VK_NULL_HANDLE) {
+        auto image_state = Get<IMAGE_STATE>(dedicated_image);
         if ((nullptr == image_state) || (0 == (image_state->CountDeviceMemory(mem_info->deviceMemory())))) {
-            const LogObjectList objlist(device, pInfo->memory, mem_info->dedicated->handle);
+            const LogObjectList objlist(device, pInfo->memory, dedicated_image);
             skip |= LogError("VUID-VkMemoryGetAndroidHardwareBufferInfoANDROID-pNext-01883", objlist,
                              error_obj.location.dot(Field::pInfo).dot(Field::memory),
                              "(%s) was allocated using a dedicated "
                              "%s, but that image is not bound to the VkDeviceMemory object.",
-                             FormatHandle(pInfo->memory).c_str(), FormatHandle(mem_info->dedicated->handle).c_str());
+                             FormatHandle(pInfo->memory).c_str(), FormatHandle(dedicated_image).c_str());
         }
     }
 

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -150,7 +150,7 @@ bool CoreChecks::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(VkDevice d
 
     // If the pNext chain of the VkMemoryAllocateInfo used to allocate memory included a VkMemoryDedicatedAllocateInfo
     // with non-NULL image member, then that image must already be bound to memory.
-    VkImage dedicated_image = mem_info->GetDedicatedImage();
+    const VkImage dedicated_image = mem_info->GetDedicatedImage();
     if (dedicated_image != VK_NULL_HANDLE) {
         auto image_state = Get<IMAGE_STATE>(dedicated_image);
         if ((nullptr == image_state) || (0 == (image_state->CountDeviceMemory(mem_info->deviceMemory())))) {

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -402,8 +402,9 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     const auto import_memory_win32_info = vku::FindStructInPNextChain<VkImportMemoryWin32HandleInfoKHR>(pAllocateInfo->pNext);
-    const bool imported_win32 = import_memory_win32_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT ||
-                                import_memory_win32_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
+    const bool imported_win32 =
+        import_memory_win32_info && (import_memory_win32_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT ||
+                                     import_memory_win32_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT);
     if (imported_win32) {
         if (const auto payload_info = GetOpaqueInfoFromWin32Handle(import_memory_win32_info->handle)) {
             const Location import_loc = allocate_info_loc.pNext(Struct::VkImportMemoryWin32HandleInfoKHR, Field::handle);

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -564,11 +564,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
                                      string_VkBufferUsageFlags(external_info.usage).c_str());
                 }
                 if ((external_features & VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT) != 0) {
-                    auto dedicated_info = vku::FindStructInPNextChain<VkMemoryDedicatedAllocateInfo>(mem_info->alloc_info.pNext);
-                    auto dedicated_info_nv = vku::FindStructInPNextChain<VkDedicatedAllocationMemoryAllocateInfoNV>(mem_info->alloc_info.pNext);
-                    const bool has_dedicated_info = dedicated_info && dedicated_info->buffer != VK_NULL_HANDLE;
-                    const bool has_dedicated_info_nv = dedicated_info_nv && dedicated_info_nv->buffer != VK_NULL_HANDLE;
-                    if (!has_dedicated_info && !has_dedicated_info_nv) {
+                    if (mem_info->GetDedicatedBuffer() == VK_NULL_HANDLE) {
                         const LogObjectList objlist(buffer, memory);
                         skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-00639", objlist, loc.dot(Field::memory),
                                          "(%s) has VkExportMemoryAllocateInfo::handleTypes with the %s flag "
@@ -1342,12 +1338,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                                              string_VkImageCreateFlags(image_info.flags).c_str());
                         }
                         if ((external_features & VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT) != 0) {
-                            auto dedicated_info = vku::FindStructInPNextChain<VkMemoryDedicatedAllocateInfo>(mem_info->alloc_info.pNext);
-                            auto dedicated_info_nv =
-                                vku::FindStructInPNextChain<VkDedicatedAllocationMemoryAllocateInfoNV>(mem_info->alloc_info.pNext);
-                            const bool has_dedicated_info = dedicated_info && dedicated_info->image != VK_NULL_HANDLE;
-                            const bool has_dedicated_info_nv = dedicated_info_nv && dedicated_info_nv->image != VK_NULL_HANDLE;
-                            if (!has_dedicated_info && !has_dedicated_info_nv) {
+                            if (mem_info->GetDedicatedImage() == VK_NULL_HANDLE) {
                                 const LogObjectList objlist(bind_info.image, bind_info.memory);
                                 skip |= LogError(
                                     "VUID-VkMemoryAllocateInfo-pNext-00639", objlist, loc.dot(Field::memory),

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -270,13 +270,14 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
         }
     }
 
-    bool imported_buffer = false;
+    bool imported_ahb_buffer = false;
+    bool imported_qnx_buffer = false;
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     //  "memory is not an imported Android Hardware Buffer" refers to VkImportAndroidHardwareBufferInfoANDROID with a non-NULL
     //  buffer value. Memory imported has another VUID to check size and allocationSize match up
     if (auto imported_ahb_info = vku::FindStructInPNextChain<VkImportAndroidHardwareBufferInfoANDROID>(pAllocateInfo->pNext);
         imported_ahb_info != nullptr) {
-        imported_buffer = imported_ahb_info->buffer != nullptr;
+        imported_ahb_buffer = imported_ahb_info->buffer != nullptr;
     }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 #if defined(VK_USE_PLATFORM_SCREEN_QNX)
@@ -284,109 +285,144 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
     //  buffer value. Memory imported has another VUID to check size and allocationSize match up
     if (auto imported_buffer_info = vku::FindStructInPNextChain<VkImportScreenBufferInfoQNX>(pAllocateInfo->pNext);
         imported_buffer_info != nullptr) {
-        imported_buffer = imported_buffer_info->buffer != nullptr;
+        imported_qnx_buffer = imported_buffer_info->buffer != nullptr;
     }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
+
+    VkBuffer dedicated_buffer = VK_NULL_HANDLE;
+    VkImage dedicated_image = VK_NULL_HANDLE;
     auto dedicated_allocate_info = vku::FindStructInPNextChain<VkMemoryDedicatedAllocateInfo>(pAllocateInfo->pNext);
     if (dedicated_allocate_info) {
-        if ((dedicated_allocate_info->buffer != VK_NULL_HANDLE) && (dedicated_allocate_info->image != VK_NULL_HANDLE)) {
+        dedicated_buffer = dedicated_allocate_info->buffer;
+        dedicated_image = dedicated_allocate_info->image;
+        if ((dedicated_buffer != VK_NULL_HANDLE) && (dedicated_image != VK_NULL_HANDLE)) {
             skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-01432", device, allocate_info_loc,
                              "pNext<VkMemoryDedicatedAllocateInfo> buffer (%s) or image (%s) has to be VK_NULL_HANDLE.",
-                             FormatHandle(dedicated_allocate_info->buffer).c_str(),
-                             FormatHandle(dedicated_allocate_info->image).c_str());
-        } else if (dedicated_allocate_info->image != VK_NULL_HANDLE) {
+                             FormatHandle(dedicated_buffer).c_str(), FormatHandle(dedicated_image).c_str());
+        } else if (dedicated_image != VK_NULL_HANDLE) {
             // Dedicated VkImage
-            const LogObjectList objlist(device, dedicated_allocate_info->image);
+            const LogObjectList objlist(device, dedicated_image);
             const Location image_loc = allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::image);
-            auto image_state = Get<IMAGE_STATE>(dedicated_allocate_info->image);
+            auto image_state = Get<IMAGE_STATE>(dedicated_image);
             if (image_state->disjoint == true) {
                 skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-01797", objlist, image_loc,
-                                 "(%s) was created with VK_IMAGE_CREATE_DISJOINT_BIT.",
-                                 FormatHandle(dedicated_allocate_info->image).c_str());
+                                 "(%s) was created with VK_IMAGE_CREATE_DISJOINT_BIT.", FormatHandle(dedicated_image).c_str());
             } else {
                 if (!IsZeroAllocationSizeAllowed(pAllocateInfo) &&
-                    (pAllocateInfo->allocationSize != image_state->requirements[0].size) && (imported_buffer == false)) {
+                    (pAllocateInfo->allocationSize != image_state->requirements[0].size) && !imported_ahb_buffer &&
+                    !imported_qnx_buffer) {
                     skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-02964", objlist,
                                      allocate_info_loc.dot(Field::allocationSize),
                                      "(%" PRIu64 ") needs to be equal to %s (%s) VkMemoryRequirements::size (%" PRIu64 ").",
                                      pAllocateInfo->allocationSize, image_loc.Fields().c_str(),
-                                     FormatHandle(dedicated_allocate_info->image).c_str(), image_state->requirements[0].size);
+                                     FormatHandle(dedicated_image).c_str(), image_state->requirements[0].size);
                 }
                 if ((image_state->createInfo.flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0) {
                     skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-01434", objlist, image_loc,
                                      "(%s): was created with VK_IMAGE_CREATE_SPARSE_BINDING_BIT.",
-                                     FormatHandle(dedicated_allocate_info->image).c_str());
+                                     FormatHandle(dedicated_image).c_str());
                 }
             }
-        } else if (dedicated_allocate_info->buffer != VK_NULL_HANDLE) {
+        } else if (dedicated_buffer != VK_NULL_HANDLE) {
             // Dedicated VkBuffer
-            const LogObjectList objlist(device, dedicated_allocate_info->buffer);
+            const LogObjectList objlist(device, dedicated_buffer);
             const Location buffer_loc = allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::buffer);
-            auto buffer_state = Get<BUFFER_STATE>(dedicated_allocate_info->buffer);
+            auto buffer_state = Get<BUFFER_STATE>(dedicated_buffer);
             if (!IsZeroAllocationSizeAllowed(pAllocateInfo) && (pAllocateInfo->allocationSize != buffer_state->requirements.size) &&
-                (imported_buffer == false)) {
+                !imported_ahb_buffer && !imported_qnx_buffer) {
                 skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-02965", objlist,
                                  allocate_info_loc.dot(Field::allocationSize),
                                  "(%" PRIu64 ") needs to be equal to %s (%s) VkMemoryRequirements::size (%" PRIu64 ").",
-                                 pAllocateInfo->allocationSize, buffer_loc.Fields().c_str(),
-                                 FormatHandle(dedicated_allocate_info->buffer).c_str(), buffer_state->requirements.size);
+                                 pAllocateInfo->allocationSize, buffer_loc.Fields().c_str(), FormatHandle(dedicated_buffer).c_str(),
+                                 buffer_state->requirements.size);
             }
             if ((buffer_state->createInfo.flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0) {
-                skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01436", objlist, buffer_loc,
-                                 "(%s) was created with VK_BUFFER_CREATE_SPARSE_BINDING_BIT.",
-                                 FormatHandle(dedicated_allocate_info->buffer).c_str());
+                skip |=
+                    LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01436", objlist, buffer_loc,
+                             "(%s) was created with VK_BUFFER_CREATE_SPARSE_BINDING_BIT.", FormatHandle(dedicated_buffer).c_str());
             }
         }
     }
 
-    if (const auto import_memory_fd_info = vku::FindStructInPNextChain<VkImportMemoryFdInfoKHR>(pAllocateInfo->pNext)) {
-        if (import_memory_fd_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT) {
-            if (const auto payload_info = GetAllocateInfoFromFdHandle(import_memory_fd_info->fd)) {
-                const Location import_loc = allocate_info_loc.pNext(Struct::VkImportMemoryFdInfoKHR, Field::fd);
-                if (pAllocateInfo->allocationSize != payload_info->allocationSize) {
-                    skip |= LogError("VUID-VkMemoryAllocateInfo-allocationSize-01742", device,
-                                     allocate_info_loc.dot(Field::allocationSize),
-                                     "allocationSize (%" PRIu64 ") does not match %s (%d) allocationSize (%" PRIu64 ").",
-                                     pAllocateInfo->allocationSize, import_loc.Fields().c_str(), import_memory_fd_info->fd,
-                                     payload_info->allocationSize);
+    const auto import_memory_fd_info = vku::FindStructInPNextChain<VkImportMemoryFdInfoKHR>(pAllocateInfo->pNext);
+    const bool imported_opaque_fd =
+        import_memory_fd_info && import_memory_fd_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+    if (imported_opaque_fd) {
+        if (const auto payload_info = GetAllocateInfoFromFdHandle(import_memory_fd_info->fd)) {
+            const Location import_loc = allocate_info_loc.pNext(Struct::VkImportMemoryFdInfoKHR, Field::fd);
+            if (pAllocateInfo->allocationSize != payload_info->allocation_size) {
+                skip |=
+                    LogError("VUID-VkMemoryAllocateInfo-allocationSize-01742", device, allocate_info_loc.dot(Field::allocationSize),
+                             "allocationSize (%" PRIu64 ") does not match %s (%d) allocationSize (%" PRIu64 ").",
+                             pAllocateInfo->allocationSize, import_loc.Fields().c_str(), import_memory_fd_info->fd,
+                             payload_info->allocation_size);
+            }
+            if (pAllocateInfo->memoryTypeIndex != payload_info->memory_type_index) {
+                skip |= LogError("VUID-VkMemoryAllocateInfo-allocationSize-01742", device,
+                                 allocate_info_loc.dot(Field::memoryTypeIndex),
+                                 "memoryTypeIndex (%" PRIu32 ") does not match %s (%d) memoryTypeIndex (%" PRIu32 ").",
+                                 pAllocateInfo->memoryTypeIndex, import_loc.Fields().c_str(), import_memory_fd_info->fd,
+                                 payload_info->memory_type_index);
+            }
+            if (dedicated_image != VK_NULL_HANDLE) {
+                if (payload_info->dedicated_image == VK_NULL_HANDLE) {
+                    skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-01878", dedicated_image,
+                                     allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::image),
+                                     "is %s but %s (%d) was not created with a dedicated image.",
+                                     FormatHandle(dedicated_image).c_str(), import_loc.Fields().c_str(), import_memory_fd_info->fd);
+
+                } else if (payload_info->dedicated_image != dedicated_image) {
+                    const LogObjectList objlist(payload_info->dedicated_image, dedicated_image);
+                    skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-01878", objlist,
+                                     allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::image),
+                                     "is %s but %s (%d) was created with a dedicated image %s.",
+                                     FormatHandle(dedicated_image).c_str(), import_loc.Fields().c_str(), import_memory_fd_info->fd,
+                                     FormatHandle(payload_info->dedicated_image).c_str());
                 }
-                if (pAllocateInfo->memoryTypeIndex != payload_info->memoryTypeIndex) {
-                    skip |= LogError("VUID-VkMemoryAllocateInfo-allocationSize-01742", device,
-                                     allocate_info_loc.dot(Field::memoryTypeIndex),
-                                     "memoryTypeIndex (%" PRIu32 ") does not match %s (%d) memoryTypeIndex (%" PRIu32 ").",
-                                     pAllocateInfo->memoryTypeIndex, import_loc.Fields().c_str(), import_memory_fd_info->fd,
-                                     payload_info->memoryTypeIndex);
+            }
+            if (dedicated_buffer != VK_NULL_HANDLE) {
+                if (payload_info->dedicated_buffer == VK_NULL_HANDLE) {
+                    skip |=
+                        LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01879", dedicated_buffer,
+                                 allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::buffer),
+                                 "is %s but %s (%d) was not created with a dedicated buffer.",
+                                 FormatHandle(dedicated_buffer).c_str(), import_loc.Fields().c_str(), import_memory_fd_info->fd);
+
+                } else if (payload_info->dedicated_buffer != dedicated_buffer) {
+                    const LogObjectList objlist(payload_info->dedicated_buffer, dedicated_buffer);
+                    skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01879", objlist,
+                                     allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::buffer),
+                                     "is %s but %s (%d) was created with a dedicated buffer %s.",
+                                     FormatHandle(dedicated_buffer).c_str(), import_loc.Fields().c_str(), import_memory_fd_info->fd,
+                                     FormatHandle(payload_info->dedicated_buffer).c_str());
                 }
             }
         }
     }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-    if (const auto import_memory_win32_info = vku::FindStructInPNextChain<VkImportMemoryWin32HandleInfoKHR>(pAllocateInfo->pNext)) {
-        if (import_memory_win32_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT ||
-            import_memory_win32_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT) {
-            if (const auto payload_info = GetAllocateInfoFromWin32Handle(import_memory_win32_info->handle)) {
-                const Location import_loc = allocate_info_loc.pNext(Struct::VkImportMemoryWin32HandleInfoKHR, Field::handle);
-                static_assert(sizeof(HANDLE) == sizeof(uintptr_t));  // to use PRIxPTR for HANDLE formatting
-                if (pAllocateInfo->allocationSize != payload_info->allocationSize) {
-                    skip |= LogError(
-                        "VUID-VkMemoryAllocateInfo-allocationSize-01743", device, allocate_info_loc.dot(Field::allocationSize),
-                        "allocationSize (%" PRIu64 ") does not match %s (0x%" PRIxPTR ") of type %s allocationSize (%" PRIu64 ").",
-                        pAllocateInfo->allocationSize, import_loc.Fields().c_str(),
-                        reinterpret_cast<std::uintptr_t>(import_memory_win32_info->handle),
-                        string_VkExternalMemoryHandleTypeFlagBits(import_memory_win32_info->handleType),
-                        payload_info->allocationSize);
-                }
-                if (pAllocateInfo->memoryTypeIndex != payload_info->memoryTypeIndex) {
-                    skip |= LogError("VUID-VkMemoryAllocateInfo-allocationSize-01743", device,
-                                     allocate_info_loc.dot(Field::memoryTypeIndex),
-                                     "memoryTypeIndex (%" PRIu32 ") does not match %s (0x%" PRIxPTR
-                                     ") of type %s memoryTypeIndex (%" PRIu32 ").",
-                                     pAllocateInfo->memoryTypeIndex, import_loc.Fields().c_str(),
-                                     reinterpret_cast<std::uintptr_t>(import_memory_win32_info->handle),
-                                     string_VkExternalMemoryHandleTypeFlagBits(import_memory_win32_info->handleType),
-                                     payload_info->memoryTypeIndex);
-                }
+    const auto import_memory_win32_info = vku::FindStructInPNextChain<VkImportMemoryWin32HandleInfoKHR>(pAllocateInfo->pNext);
+    const bool imported_win32 = import_memory_win32_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT ||
+                                import_memory_win32_info->handleType == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
+    if (imported_win32) {
+        if (const auto payload_info = GetAllocateInfoFromWin32Handle(import_memory_win32_info->handle)) {
+            const Location import_loc = allocate_info_loc.pNext(Struct::VkImportMemoryWin32HandleInfoKHR, Field::handle);
+            static_assert(sizeof(HANDLE) == sizeof(uintptr_t));  // to use PRIxPTR for HANDLE formatting
+            if (pAllocateInfo->allocationSize != payload_info->allocationSize) {
+                skip |= LogError(
+                    "VUID-VkMemoryAllocateInfo-allocationSize-01743", device, allocate_info_loc.dot(Field::allocationSize),
+                    "allocationSize (%" PRIu64 ") does not match %s (0x%" PRIxPTR ") of type %s allocationSize (%" PRIu64 ").",
+                    pAllocateInfo->allocationSize, import_loc.Fields().c_str(),
+                    reinterpret_cast<std::uintptr_t>(import_memory_win32_info->handle),
+                    string_VkExternalMemoryHandleTypeFlagBits(import_memory_win32_info->handleType), payload_info->allocationSize);
+            }
+            if (pAllocateInfo->memoryTypeIndex != payload_info->memoryTypeIndex) {
+                skip |= LogError(
+                    "VUID-VkMemoryAllocateInfo-allocationSize-01743", device, allocate_info_loc.dot(Field::memoryTypeIndex),
+                    "memoryTypeIndex (%" PRIu32 ") does not match %s (0x%" PRIxPTR ") of type %s memoryTypeIndex (%" PRIu32 ").",
+                    pAllocateInfo->memoryTypeIndex, import_loc.Fields().c_str(),
+                    reinterpret_cast<std::uintptr_t>(import_memory_win32_info->handle),
+                    string_VkExternalMemoryHandleTypeFlagBits(import_memory_win32_info->handleType), payload_info->memoryTypeIndex);
             }
         }
     }
@@ -582,15 +618,16 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
         }
 
         // Validate dedicated allocation
-        if (mem_info->IsDedicatedBuffer() && ((mem_info->dedicated->handle.Cast<VkBuffer>() != buffer) || (memoryOffset != 0))) {
+        VkBuffer dedicated_buffer = mem_info->GetDedicatedBuffer();
+        if (dedicated_buffer != VK_NULL_HANDLE && ((dedicated_buffer != buffer) || (memoryOffset != 0))) {
             const char *vuid =
                 bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-memory-01508" : "VUID-vkBindBufferMemory-memory-01508";
-            const LogObjectList objlist(buffer, memory, mem_info->dedicated->handle);
+            const LogObjectList objlist(buffer, memory, dedicated_buffer);
             skip |= LogError(vuid, objlist, loc.dot(Field::memory),
                              "(%s) is dedicated allocation, but VkMemoryDedicatedAllocateInfo::buffer %s must be equal "
                              "to %s and memoryOffset %" PRIu64 " must be zero.",
-                             FormatHandle(memory).c_str(), FormatHandle(mem_info->dedicated->handle).c_str(),
-                             FormatHandle(buffer).c_str(), memoryOffset);
+                             FormatHandle(memory).c_str(), FormatHandle(dedicated_buffer).c_str(), FormatHandle(buffer).c_str(),
+                             memoryOffset);
         }
 
         auto chained_flags_struct = vku::FindStructInPNextChain<VkMemoryAllocateFlagsInfo>(mem_info->alloc_info.pNext);
@@ -1188,7 +1225,8 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                 }
 
                 // Validate dedicated allocation
-                if (mem_info->IsDedicatedImage()) {
+                VkImage dedicated_image = mem_info->GetDedicatedImage();
+                if (dedicated_image != VK_NULL_HANDLE) {
                     if (enabled_features.dedicatedAllocationImageAliasing) {
                         auto current_image_state = Get<IMAGE_STATE>(bind_info.image);
                         if ((bind_info.memoryOffset != 0) || !current_image_state ||
@@ -1196,24 +1234,24 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                                 mem_info->dedicated->create_info.image)) {
                             const char *vuid = bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-memory-02629"
                                                                 : "VUID-vkBindImageMemory-memory-02629";
-                            const LogObjectList objlist(bind_info.image, bind_info.memory, mem_info->dedicated->handle);
+                            const LogObjectList objlist(bind_info.image, bind_info.memory, dedicated_image);
                             skip |= LogError(
                                 vuid, objlist, loc.dot(Field::memory),
                                 "(%s) is a dedicated memory allocation, but VkMemoryDedicatedAllocateInfo:: %s must compatible "
                                 "with %s and memoryOffset %" PRIu64 " must be zero.",
-                                FormatHandle(bind_info.memory).c_str(), FormatHandle(mem_info->dedicated->handle).c_str(),
+                                FormatHandle(bind_info.memory).c_str(), FormatHandle(dedicated_image).c_str(),
                                 FormatHandle(bind_info.image).c_str(), bind_info.memoryOffset);
                         }
                     } else {
-                        if ((bind_info.memoryOffset != 0) || (mem_info->dedicated->handle.Cast<VkImage>() != bind_info.image)) {
+                        if ((bind_info.memoryOffset != 0) || (dedicated_image != bind_info.image)) {
                             const char *vuid = bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-memory-02628"
                                                                 : "VUID-vkBindImageMemory-memory-02628";
-                            const LogObjectList objlist(bind_info.image, bind_info.memory, mem_info->dedicated->handle);
+                            const LogObjectList objlist(bind_info.image, bind_info.memory, dedicated_image);
                             skip |= LogError(
                                 vuid, objlist, loc.dot(Field::memory),
                                 "(%s) is a dedicated memory allocation, but VkMemoryDedicatedAllocateInfo:: %s must be equal "
                                 "to %s and memoryOffset %" PRIu64 " must be zero.",
-                                FormatHandle(bind_info.memory).c_str(), FormatHandle(mem_info->dedicated->handle).c_str(),
+                                FormatHandle(bind_info.memory).c_str(), FormatHandle(dedicated_image).c_str(),
                                 FormatHandle(bind_info.image).c_str(), bind_info.memoryOffset);
                         }
                     }

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -146,15 +146,17 @@ bool CoreChecks::PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetF
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
-bool CoreChecks::PreCallValidateImportSemaphoreWin32HandleKHR(VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR *info,
-                                                              const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateImportSemaphoreWin32HandleKHR(
+    VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR *pImportSemaphoreWin32HandleInfo,
+    const ErrorObject &error_obj) const {
     bool skip = false;
-    auto sem_state = Get<SEMAPHORE_STATE>(info->semaphore);
+    auto sem_state = Get<SEMAPHORE_STATE>(pImportSemaphoreWin32HandleInfo->semaphore);
     if (sem_state) {
         // Waiting for: https://gitlab.khronos.org/vulkan/vulkan/-/issues/3507
         skip |= ValidateObjectNotInUse(sem_state.get(), error_obj.location, kVUIDUndefined);
 
-        if ((info->flags & VK_SEMAPHORE_IMPORT_TEMPORARY_BIT) != 0 && sem_state->type == VK_SEMAPHORE_TYPE_TIMELINE) {
+        if ((pImportSemaphoreWin32HandleInfo->flags & VK_SEMAPHORE_IMPORT_TEMPORARY_BIT) != 0 &&
+            sem_state->type == VK_SEMAPHORE_TYPE_TIMELINE) {
             skip |= LogError("VUID-VkImportSemaphoreWin32HandleInfoKHR-flags-03322", sem_state->Handle(),
                              error_obj.location.dot(Field::pImportSemaphoreWin32HandleInfo).dot(Field::semaphore),
                              "includes VK_SEMAPHORE_IMPORT_TEMPORARY_BIT and semaphore is VK_SEMAPHORE_TYPE_TIMELINE.");
@@ -167,13 +169,13 @@ bool CoreChecks::PreCallValidateGetSemaphoreWin32HandleKHR(VkDevice device,
                                                            const VkSemaphoreGetWin32HandleInfoKHR *pGetWin32HandleInfo,
                                                            HANDLE *pHandle, const ErrorObject &error_obj) const {
     bool skip = false;
-    auto sem_state = Get<SEMAPHORE_STATE>(info->semaphore);
+    auto sem_state = Get<SEMAPHORE_STATE>(pGetWin32HandleInfo->semaphore);
     if (sem_state) {
-        if ((info->handleType & sem_state->exportHandleTypes) == 0) {
+        if ((pGetWin32HandleInfo->handleType & sem_state->exportHandleTypes) == 0) {
             skip |= LogError("VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01126", sem_state->Handle(),
                              error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::handleType),
                              "(%s) is different from VkExportSemaphoreCreateInfo::handleTypes (%s)",
-                             string_VkExternalSemaphoreHandleTypeFlagBits(info->handleType),
+                             string_VkExternalSemaphoreHandleTypeFlagBits(pGetWin32HandleInfo->handleType),
                              string_VkExternalSemaphoreHandleTypeFlags(sem_state->exportHandleTypes).c_str());
         }
     }
@@ -187,16 +189,16 @@ bool CoreChecks::PreCallValidateImportFenceWin32HandleKHR(VkDevice device,
                                error_obj.location.dot(Field::pImportFenceWin32HandleInfo));
 }
 
-bool CoreChecks::PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR *info, HANDLE *pHandle,
-                                                       const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR *pGetWin32HandleInfo,
+                                                       HANDLE *pHandle, const ErrorObject &error_obj) const {
     bool skip = false;
-    auto fence_state = Get<FENCE_STATE>(info->fence);
+    auto fence_state = Get<FENCE_STATE>(pGetWin32HandleInfo->fence);
     if (fence_state) {
-        if ((info->handleType & fence_state->exportHandleTypes) == 0) {
+        if ((pGetWin32HandleInfo->handleType & fence_state->exportHandleTypes) == 0) {
             skip |= LogError("VUID-VkFenceGetWin32HandleInfoKHR-handleType-01448", fence_state->Handle(),
                              error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::handleType),
                              "(%s) is different from VkExportFenceCreateInfo::handleTypes (%s)",
-                             string_VkExternalFenceHandleTypeFlagBits(info->handleType),
+                             string_VkExternalFenceHandleTypeFlagBits(pGetWin32HandleInfo->handleType),
                              string_VkExternalFenceHandleTypeFlags(fence_state->exportHandleTypes).c_str());
         }
     }
@@ -205,11 +207,11 @@ bool CoreChecks::PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const Vk
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 #ifdef VK_USE_PLATFORM_FUCHSIA
-bool CoreChecks::PreCallValidateImportSemaphoreZirconHandleFUCHSIA(VkDevice device,
-                                                                   const VkImportSemaphoreZirconHandleInfoFUCHSIA *info,
-                                                                   const ErrorObject &error_obj) const {
+bool CoreChecks::PreCallValidateImportSemaphoreZirconHandleFUCHSIA(
+    VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA *pImportSemaphoreZirconHandleInfo,
+    const ErrorObject &error_obj) const {
     bool skip = false;
-    auto sem_state = Get<SEMAPHORE_STATE>(info->semaphore);
+    auto sem_state = Get<SEMAPHORE_STATE>(pImportSemaphoreZirconHandleInfo->semaphore);
     if (sem_state) {
         skip |= ValidateObjectNotInUse(sem_state.get(), error_obj.location,
                                        "VUID-vkImportSemaphoreZirconHandleFUCHSIA-semaphore-04764");

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -69,9 +69,14 @@ class DEVICE_MEMORY_STATE : public BASE_NODE {
     }
     bool IsExport() const { return export_handle_types != 0; }
 
-    bool IsDedicatedBuffer() const { return dedicated && dedicated->handle.type == kVulkanObjectTypeBuffer; }
+    VkBuffer GetDedicatedBuffer() const {
+        return (dedicated && dedicated->handle.type == kVulkanObjectTypeBuffer) ? dedicated->handle.Cast<VkBuffer>()
+                                                                                : VK_NULL_HANDLE;
+    }
 
-    bool IsDedicatedImage() const { return dedicated && dedicated->handle.type == kVulkanObjectTypeImage; }
+    VkImage GetDedicatedImage() const {
+        return (dedicated && dedicated->handle.type == kVulkanObjectTypeImage) ? dedicated->handle.Cast<VkImage>() : VK_NULL_HANDLE;
+    }
 
     VkDeviceMemory deviceMemory() const { return handle_.Cast<VkDeviceMemory>(); }
 };

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -73,10 +73,12 @@ class DEVICE_MEMORY_STATE : public BASE_NODE {
         return (dedicated && dedicated->handle.type == kVulkanObjectTypeBuffer) ? dedicated->handle.Cast<VkBuffer>()
                                                                                 : VK_NULL_HANDLE;
     }
+    bool IsDedicatedBuffer() const { return GetDedicatedBuffer() != VK_NULL_HANDLE; }
 
     VkImage GetDedicatedImage() const {
         return (dedicated && dedicated->handle.type == kVulkanObjectTypeImage) ? dedicated->handle.Cast<VkImage>() : VK_NULL_HANDLE;
     }
+    bool IsDedicatedImage() const { return GetDedicatedImage() != VK_NULL_HANDLE; }
 
     VkDeviceMemory deviceMemory() const { return handle_.Cast<VkDeviceMemory>(); }
 };

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -191,6 +191,7 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
           metal_semaphore_export(GetMetalExport(pCreateInfo)),
 #endif  // VK_USE_PLATFORM_METAL_EXT
           type(type_create_info ? type_create_info->semaphoreType : VK_SEMAPHORE_TYPE_BINARY),
+          flags(pCreateInfo->flags),
           exportHandleTypes(GetExportHandleTypes(pCreateInfo)),
           completed_{type == VK_SEMAPHORE_TYPE_TIMELINE ? kSignal : kNone, nullptr, 0,
                      type_create_info ? type_create_info->initialValue : 0},
@@ -245,6 +246,7 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     const bool metal_semaphore_export;
 #endif  // VK_USE_PLATFORM_METAL_EXT
     const VkSemaphoreType type;
+    const VkSemaphoreCreateFlags flags;
     const VkExternalSemaphoreHandleTypeFlags exportHandleTypes;
 
   private:

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3404,15 +3404,17 @@ void ValidationStateTracker::PostCallRecordGetMemoryFdKHR(VkDevice device, const
     if (const auto memory_state = Get<DEVICE_MEMORY_STATE>(pGetFdInfo->memory)) {
         // For validation purposes we need to keep allocation size and memory type index.
         // There is no need to keep pNext chain.
-        VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
-        alloc_info.allocationSize = memory_state->alloc_info.allocationSize;
-        alloc_info.memoryTypeIndex = memory_state->alloc_info.memoryTypeIndex;
+        ExternalMemoryFdInfo fd_info = {};
+        fd_info.allocation_size = memory_state->alloc_info.allocationSize;
+        fd_info.memory_type_index = memory_state->alloc_info.memoryTypeIndex;
+        fd_info.dedicated_buffer = memory_state->GetDedicatedBuffer();
+        fd_info.dedicated_image = memory_state->GetDedicatedImage();
 
         WriteLockGuard guard(fd_handle_map_lock_);
         // `insert_or_assign` ensures that information is updated when the system decides to re-use
         // closed handle value for a new handle. The fd handle created inside Vulkan _can_ be closed
         // using the 'close' system call, which is not tracked by the validation layer.
-        fd_handle_map_.insert_or_assign(*pFd, alloc_info);
+        fd_handle_map_.insert_or_assign(*pFd, fd_info);
     }
 }
 

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1751,7 +1751,13 @@ class ValidationStateTracker : public ValidationObject {
         return {};
     }
 
-    inline std::optional<VkMemoryAllocateInfo> GetAllocateInfoFromFdHandle(int fd) const {
+    struct ExternalMemoryFdInfo {
+        VkDeviceSize allocation_size;
+        uint32_t memory_type_index;
+        VkBuffer dedicated_buffer;
+        VkImage dedicated_image;
+    };
+    inline std::optional<ExternalMemoryFdInfo> GetAllocateInfoFromFdHandle(int fd) const {
         ReadLockGuard guard(fd_handle_map_lock_);
         if (const auto itr = fd_handle_map_.find(fd); itr != fd_handle_map_.cend()) {
             return itr->second;
@@ -1891,7 +1897,7 @@ class ValidationStateTracker : public ValidationObject {
     mutable std::shared_mutex shader_identifier_map_lock_;
 
     // If vkGetMemoryFdKHR is called, keep track of fd handle -> allocation info
-    vvl::unordered_map<int, VkMemoryAllocateInfo> fd_handle_map_;
+    vvl::unordered_map<int, ExternalMemoryFdInfo> fd_handle_map_;
     mutable std::shared_mutex fd_handle_map_lock_;
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR

--- a/layers/stateless/sl_device_memory.cpp
+++ b/layers/stateless/sl_device_memory.cpp
@@ -18,56 +18,6 @@
 
 #include "stateless/stateless_validation.h"
 
-namespace {
-struct ImportOperationsInfo {
-    const VkImportMemoryHostPointerInfoEXT *host_pointer_info_ext;
-    uint32_t total_import_ops;
-};
-
-ImportOperationsInfo GetNumberOfImportInfo(const VkMemoryAllocateInfo *pAllocateInfo) {
-    uint32_t count = 0;
-
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    // VkImportMemoryWin32HandleInfoKHR with a non-zero handleType value
-    auto import_memory_win32_handle = vku::FindStructInPNextChain<VkImportMemoryWin32HandleInfoKHR>(pAllocateInfo->pNext);
-    count += (import_memory_win32_handle && import_memory_win32_handle->handleType);
-#endif
-
-    // VkImportMemoryFdInfoKHR with a non-zero handleType value
-    auto fd_info_khr = vku::FindStructInPNextChain<VkImportMemoryFdInfoKHR>(pAllocateInfo->pNext);
-    count += (fd_info_khr && fd_info_khr->handleType);
-
-    // VkImportMemoryHostPointerInfoEXT with a non-zero handleType value
-    auto host_pointer_info_ext = vku::FindStructInPNextChain<VkImportMemoryHostPointerInfoEXT>(pAllocateInfo->pNext);
-    count += (host_pointer_info_ext && host_pointer_info_ext->handleType);
-
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
-    // VkImportAndroidHardwareBufferInfoANDROID with a non-NULL buffer value
-    auto import_memory_ahb = vku::FindStructInPNextChain<VkImportAndroidHardwareBufferInfoANDROID>(pAllocateInfo->pNext);
-    count += (import_memory_ahb && import_memory_ahb->buffer);
-#endif
-
-#ifdef VK_USE_PLATFORM_FUCHSIA
-    // VkImportMemoryZirconHandleInfoFUCHSIA with a non-zero handleType value
-    auto import_zircon_fuchsia = vku::FindStructInPNextChain<VkImportMemoryZirconHandleInfoFUCHSIA>(pAllocateInfo->pNext);
-    count += (import_zircon_fuchsia && import_zircon_fuchsia->handleType);
-
-    // VkImportMemoryBufferCollectionFUCHSIA
-    auto import_buffer_collection_fuchsia = vku::FindStructInPNextChain<VkImportMemoryBufferCollectionFUCHSIA>(pAllocateInfo->pNext);
-    count += static_cast<bool>(
-        import_buffer_collection_fuchsia);  // NOTE: There's no handleType on VkImportMemoryBufferCollectionFUCHSIA, so we
-                                            // can't check that, and from the "Valid Usage (Implicit)" collection has to
-                                            // always be valid.
-#endif
-
-    ImportOperationsInfo info = {};
-    info.total_import_ops = count;
-    info.host_pointer_info_ext = host_pointer_info_ext;
-
-    return info;
-}
-}  // namespace
-
 bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
                                                                const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory,
                                                                const ErrorObject &error_obj) const {
@@ -84,86 +34,10 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
                          chained_prio_struct->priority);
     }
 
-    VkMemoryAllocateFlags flags = 0;
     auto flags_info = vku::FindStructInPNextChain<VkMemoryAllocateFlagsInfo>(pAllocateInfo->pNext);
-    if (flags_info) {
-        flags = flags_info->flags;
-    }
+    const VkMemoryAllocateFlags flags = flags_info ? flags_info->flags : 0;
 
-    const ImportOperationsInfo import_info = GetNumberOfImportInfo(pAllocateInfo);
-
-    auto opaque_alloc_info = vku::FindStructInPNextChain<VkMemoryOpaqueCaptureAddressAllocateInfo>(pAllocateInfo->pNext);
-    if (opaque_alloc_info && opaque_alloc_info->opaqueCaptureAddress != 0) {
-        const Location address_loc =
-            allocate_info_loc.pNext(Struct::VkMemoryOpaqueCaptureAddressAllocateInfo, Field::opaqueCaptureAddress);
-        if (!(flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT)) {
-            skip |= LogError("VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03329", device, address_loc,
-                             "is non-zero (%" PRIu64
-                             ") so VkMemoryAllocateFlagsInfo::flags must include "
-                             "VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT.",
-                             opaque_alloc_info->opaqueCaptureAddress);
-        }
-
-        if (import_info.host_pointer_info_ext) {
-            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-03332", device, address_loc,
-                             "is non-zero (%" PRIu64 ") but the pNext chain includes a VkImportMemoryHostPointerInfoEXT structure.",
-                             opaque_alloc_info->opaqueCaptureAddress);
-        }
-
-        if (import_info.total_import_ops > 0) {
-            skip |=
-                LogError("VUID-VkMemoryAllocateInfo-opaqueCaptureAddress-03333", device, address_loc,
-                         "is non-zero (%" PRIu64 ") but an import operation is defined.", opaque_alloc_info->opaqueCaptureAddress);
-        }
-    }
-
-    if (import_info.total_import_ops > 1) {
-        skip |= LogError("VUID-VkMemoryAllocateInfo-None-06657", device, allocate_info_loc,
-                         "%" PRIu32 " import operations are defined", import_info.total_import_ops);
-    }
-
-    auto export_memory = vku::FindStructInPNextChain<VkExportMemoryAllocateInfo>(pAllocateInfo->pNext);
-    if (export_memory) {
-        auto export_memory_nv = vku::FindStructInPNextChain<VkExportMemoryAllocateInfoNV>(pAllocateInfo->pNext);
-        if (export_memory_nv) {
-            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-00640", device, allocate_info_loc,
-                             "pNext chain includes both VkExportMemoryAllocateInfo and "
-                             "VkExportMemoryAllocateInfoNV");
-        }
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-        auto export_memory_win32_nv = vku::FindStructInPNextChain<VkExportMemoryWin32HandleInfoNV>(pAllocateInfo->pNext);
-        if (export_memory_win32_nv) {
-            skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-00640", device, allocate_info_loc,
-                             "pNext chain includes both VkExportMemoryAllocateInfo and "
-                             "VkExportMemoryWin32HandleInfoNV");
-        }
-#endif
-    }
-
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    if (vku::FindStructInPNextChain<VkImportMemoryWin32HandleInfoKHR>(pAllocateInfo->pNext) &&
-        vku::FindStructInPNextChain<VkImportMemoryWin32HandleInfoNV>(pAllocateInfo->pNext)) {
-        skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-00641", device, allocate_info_loc,
-                         "pNext chain includes both VkImportMemoryWin32HandleInfoKHR and "
-                         "VkImportMemoryWin32HandleInfoNV");
-    }
-#endif
-
-    if (auto fd_info = vku::FindStructInPNextChain<VkImportMemoryFdInfoKHR>(pAllocateInfo->pNext)) {
-        if (fd_info->handleType != 0) {
-            if (fd_info->fd < 0) {
-                skip |= LogError("VUID-VkImportMemoryFdInfoKHR-handleType-00670", device,
-                                 allocate_info_loc.pNext(Struct::VkImportMemoryFdInfoKHR, Field::fd),
-                                 "(%d) is not a valid POSIX file descriptor.", fd_info->fd);
-            }
-            if (fd_info->handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT &&
-                fd_info->handleType != VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT) {
-                skip |= LogError("VUID-VkImportMemoryFdInfoKHR-handleType-00669", device,
-                                 allocate_info_loc.pNext(Struct::VkImportMemoryFdInfoKHR, Field::handleType), "%s is not allowed.",
-                                 string_VkExternalMemoryHandleTypeFlagBits(fd_info->handleType));
-            }
-        }
-    }
+    skip |= ValidateAllocateMemoryExternal(device, pAllocateInfo, flags, allocate_info_loc);
 
     if (flags) {
         const Location flags_loc = allocate_info_loc.pNext(Struct::VkMemoryAllocateFlagsInfo, Field::flags);
@@ -190,11 +64,6 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
                              "has VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT set, but bufferDeviceAddress feature is not enabled.");
         }
     }
-#ifdef VK_USE_PLATFORM_METAL_EXT
-    skip |=
-        ExportMetalObjectsPNextUtil(VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT, "VUID-VkMemoryAllocateInfo-pNext-06780",
-                                    error_obj.location, "VK_EXPORT_METAL_OBJECT_TYPE_METAL_BUFFER_BIT_EXT", pAllocateInfo->pNext);
-#endif  // VK_USE_PLATFORM_METAL_EXT
     return skip;
 }
 

--- a/layers/stateless/sl_external_object.cpp
+++ b/layers/stateless/sl_external_object.cpp
@@ -75,26 +75,29 @@ bool StatelessValidation::ValidateExternalFenceHandleType(VkFence fence, const c
 static constexpr VkExternalSemaphoreHandleTypeFlags kSemFdHandleTypes =
     VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT | VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
 
-bool StatelessValidation::manual_PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR *info, int *pFd,
-                                                                  const ErrorObject &error_obj) const {
-    return ValidateExternalSemaphoreHandleType(info->semaphore, "VUID-VkSemaphoreGetFdInfoKHR-handleType-01136",
-                                               error_obj.location.dot(Field::info).dot(Field::handleType), info->handleType,
-                                               kSemFdHandleTypes);
+bool StatelessValidation::manual_PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR *pGetFdInfo,
+                                                                  int *pFd, const ErrorObject &error_obj) const {
+    return ValidateExternalSemaphoreHandleType(pGetFdInfo->semaphore, "VUID-VkSemaphoreGetFdInfoKHR-handleType-01136",
+                                               error_obj.location.dot(Field::pGetFdInfo).dot(Field::handleType),
+                                               pGetFdInfo->handleType, kSemFdHandleTypes);
 }
 
-bool StatelessValidation::manual_PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR *info,
+bool StatelessValidation::manual_PreCallValidateImportSemaphoreFdKHR(VkDevice device,
+                                                                     const VkImportSemaphoreFdInfoKHR *pImportSemaphoreFdInfo,
                                                                      const ErrorObject &error_obj) const {
     bool skip = false;
-    skip |= ValidateExternalSemaphoreHandleType(info->semaphore, "VUID-VkImportSemaphoreFdInfoKHR-handleType-01143",
-                                                error_obj.location.dot(Field::info).dot(Field::handleType), info->handleType,
-                                                kSemFdHandleTypes);
+    const Location info_loc = error_obj.location.dot(Field::pImportSemaphoreFdInfo);
+    skip |=
+        ValidateExternalSemaphoreHandleType(pImportSemaphoreFdInfo->semaphore, "VUID-VkImportSemaphoreFdInfoKHR-handleType-01143",
+                                            info_loc.dot(Field::handleType), pImportSemaphoreFdInfo->handleType, kSemFdHandleTypes);
 
-    if (info->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT &&
-        (info->flags & VK_SEMAPHORE_IMPORT_TEMPORARY_BIT) == 0) {
-        skip |= LogError("VUID-VkImportSemaphoreFdInfoKHR-handleType-07307", info->semaphore, error_obj.location.dot(Field::info),
-                         "handleType is VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT so"
+    if (pImportSemaphoreFdInfo->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT &&
+        (pImportSemaphoreFdInfo->flags & VK_SEMAPHORE_IMPORT_TEMPORARY_BIT) == 0) {
+        skip |= LogError("VUID-VkImportSemaphoreFdInfoKHR-handleType-07307", pImportSemaphoreFdInfo->semaphore,
+                         info_loc.dot(Field::handleType),
+                         "is VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT so"
                          " VK_SEMAPHORE_IMPORT_TEMPORARY_BIT must be set, but flags is 0x%x",
-                         info->flags);
+                         pImportSemaphoreFdInfo->flags);
     }
     return skip;
 }
@@ -102,25 +105,26 @@ bool StatelessValidation::manual_PreCallValidateImportSemaphoreFdKHR(VkDevice de
 static constexpr VkExternalFenceHandleTypeFlags kFenceFdHandleTypes =
     VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT | VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT;
 
-bool StatelessValidation::manual_PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR *info, int *pFd,
+bool StatelessValidation::manual_PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR *pGetFdInfo, int *pFd,
                                                               const ErrorObject &error_obj) const {
-    return ValidateExternalFenceHandleType(info->fence, "VUID-VkFenceGetFdInfoKHR-handleType-01456",
-                                           error_obj.location.dot(Field::info).dot(Field::handleType), info->handleType,
+    return ValidateExternalFenceHandleType(pGetFdInfo->fence, "VUID-VkFenceGetFdInfoKHR-handleType-01456",
+                                           error_obj.location.dot(Field::pGetFdInfo).dot(Field::handleType), pGetFdInfo->handleType,
                                            kFenceFdHandleTypes);
 }
 
-bool StatelessValidation::manual_PreCallValidateImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR *info,
+bool StatelessValidation::manual_PreCallValidateImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR *pImportFenceFdInfo,
                                                                  const ErrorObject &error_obj) const {
     bool skip = false;
-    skip |= ValidateExternalFenceHandleType(info->fence, "VUID-VkImportFenceFdInfoKHR-handleType-01464",
-                                            error_obj.location.dot(Field::info).dot(Field::handleType), info->handleType,
-                                            kFenceFdHandleTypes);
+    const Location info_loc = error_obj.location.dot(Field::pImportFenceFdInfo);
+    skip |= ValidateExternalFenceHandleType(pImportFenceFdInfo->fence, "VUID-VkImportFenceFdInfoKHR-handleType-01464",
+                                            info_loc.dot(Field::handleType), pImportFenceFdInfo->handleType, kFenceFdHandleTypes);
 
-    if (info->handleType == VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT && (info->flags & VK_FENCE_IMPORT_TEMPORARY_BIT) == 0) {
-        skip |= LogError("VUID-VkImportFenceFdInfoKHR-handleType-07306", info->fence, error_obj.location.dot(Field::info),
-                         "handleType is VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT so"
+    if (pImportFenceFdInfo->handleType == VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT &&
+        (pImportFenceFdInfo->flags & VK_FENCE_IMPORT_TEMPORARY_BIT) == 0) {
+        skip |= LogError("VUID-VkImportFenceFdInfoKHR-handleType-07306", pImportFenceFdInfo->fence, info_loc.dot(Field::handleType),
+                         "is VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT so"
                          " VK_FENCE_IMPORT_TEMPORARY_BIT must be set, but flags is 0x%x",
-                         info->flags);
+                         pImportFenceFdInfo->flags);
     }
     return skip;
 }
@@ -153,22 +157,23 @@ bool StatelessValidation::manual_PreCallValidateImportSemaphoreWin32HandleKHR(Vk
                                                                               const ErrorObject &error_obj) const {
     bool skip = false;
 
-    skip |= ValidateExternalSemaphoreHandleType(info->semaphore, "VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01140",
-                                                error_obj.location.dot(Field::info).dot(Field::handleType), info->handleType,
-                                                kSemWin32HandleTypes);
+    skip |=
+        ValidateExternalSemaphoreHandleType(info->semaphore, "VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01140",
+                                            error_obj.location.dot(Field::pImportSemaphoreWin32HandleInfo).dot(Field::handleType),
+                                            info->handleType, kSemWin32HandleTypes);
 
     static constexpr auto kNameAllowedTypes =
         VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT | VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE_BIT;
     if ((info->handleType & kNameAllowedTypes) == 0 && info->name) {
-        skip |=
-            LogError("VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01466", info->semaphore,
-                     error_obj.location.dot(Field::info).dot(Field::name), "(%p) must be NULL if handleType is %s",
-                     reinterpret_cast<const void *>(info->name), string_VkExternalSemaphoreHandleTypeFlagBits(info->handleType));
+        skip |= LogError("VUID-VkImportSemaphoreWin32HandleInfoKHR-handleType-01466", info->semaphore,
+                         error_obj.location.dot(Field::pImportSemaphoreWin32HandleInfo).dot(Field::name),
+                         "(%p) must be NULL if handleType is %s", reinterpret_cast<const void *>(info->name),
+                         string_VkExternalSemaphoreHandleTypeFlagBits(info->handleType));
     }
     if (info->handle && info->name) {
-        skip |=
-            LogError("VUID-VkImportSemaphoreWin32HandleInfoKHR-handle-01469", info->semaphore, error_obj.location.dot(Field::info),
-                     "both handle (%p) and name (%p) are non-NULL", info->handle, reinterpret_cast<const void *>(info->name));
+        skip |= LogError("VUID-VkImportSemaphoreWin32HandleInfoKHR-handle-01469", info->semaphore,
+                         error_obj.location.dot(Field::pImportSemaphoreWin32HandleInfo),
+                         "both handle (%p) and name (%p) are non-NULL", info->handle, reinterpret_cast<const void *>(info->name));
     }
     return skip;
 }
@@ -177,8 +182,8 @@ bool StatelessValidation::manual_PreCallValidateGetSemaphoreWin32HandleKHR(VkDev
                                                                            const VkSemaphoreGetWin32HandleInfoKHR *info,
                                                                            HANDLE *pHandle, const ErrorObject &error_obj) const {
     return ValidateExternalSemaphoreHandleType(info->semaphore, "VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01131",
-                                               error_obj.location.dot(Field::info).dot(Field::handleType), info->handleType,
-                                               kSemWin32HandleTypes);
+                                               error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::handleType),
+                                               info->handleType, kSemWin32HandleTypes);
 }
 
 static constexpr VkExternalFenceHandleTypeFlags kFenceWin32HandleTypes =
@@ -189,18 +194,20 @@ bool StatelessValidation::manual_PreCallValidateImportFenceWin32HandleKHR(VkDevi
                                                                           const ErrorObject &error_obj) const {
     bool skip = false;
     skip |= ValidateExternalFenceHandleType(info->fence, "VUID-VkImportFenceWin32HandleInfoKHR-handleType-01457",
-                                            error_obj.location.dot(Field::info).dot(Field::handleType), info->handleType,
-                                            kFenceWin32HandleTypes);
+                                            error_obj.location.dot(Field::pImportFenceWin32HandleInfo).dot(Field::handleType),
+                                            info->handleType, kFenceWin32HandleTypes);
 
     static constexpr auto kNameAllowedTypes = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
     if ((info->handleType & kNameAllowedTypes) == 0 && info->name) {
         skip |= LogError("VUID-VkImportFenceWin32HandleInfoKHR-handleType-01459", info->fence,
-                         error_obj.location.dot(Field::info).dot(Field::name), "(%p) must be NULL if handleType is %s",
-                         reinterpret_cast<const void *>(info->name), string_VkExternalFenceHandleTypeFlagBits(info->handleType));
+                         error_obj.location.dot(Field::pImportFenceWin32HandleInfo).dot(Field::name),
+                         "(%p) must be NULL if handleType is %s", reinterpret_cast<const void *>(info->name),
+                         string_VkExternalFenceHandleTypeFlagBits(info->handleType));
     }
     if (info->handle && info->name) {
-        skip |= LogError("VUID-VkImportFenceWin32HandleInfoKHR-handle-01462", info->fence, error_obj.location.dot(Field::info),
-                         "both handle (%p) and name (%p) are non-NULL", info->handle, reinterpret_cast<const void *>(info->name));
+        skip |= LogError("VUID-VkImportFenceWin32HandleInfoKHR-handle-01462", info->fence,
+                         error_obj.location.dot(Field::pImportFenceWin32HandleInfo), "both handle (%p) and name (%p) are non-NULL",
+                         info->handle, reinterpret_cast<const void *>(info->name));
     }
     return skip;
 }
@@ -208,8 +215,8 @@ bool StatelessValidation::manual_PreCallValidateImportFenceWin32HandleKHR(VkDevi
 bool StatelessValidation::manual_PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR *info,
                                                                        HANDLE *pHandle, const ErrorObject &error_obj) const {
     return ValidateExternalFenceHandleType(info->fence, "VUID-VkFenceGetWin32HandleInfoKHR-handleType-01452",
-                                           error_obj.location.dot(Field::info).dot(Field::handleType), info->handleType,
-                                           kFenceWin32HandleTypes);
+                                           error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::handleType),
+                                           info->handleType, kFenceWin32HandleTypes);
 }
 #endif
 
@@ -277,11 +284,11 @@ ExternalOperationsInfo GetExternalOperationsInfo(const void *pNext) {
     // VK_KHR_external_memory_win32
     auto import_info_win32 = vku::FindStructInPNextChain<VkImportMemoryWin32HandleInfoKHR>(pNext);
     ext.import_info_win32 = (import_info_win32 && import_info_win32->handleType);
-    ext.total_import_ops += import_info_win32;
+    ext.total_import_ops += ext.import_info_win32;
 
     auto import_info_win32_nv = vku::FindStructInPNextChain<VkImportMemoryWin32HandleInfoNV>(pNext);
     ext.import_info_win32_nv = (import_info_win32_nv && import_info_win32_nv->handleType);
-    ext.total_import_ops += import_info_win32_nv;
+    ext.total_import_ops += ext.import_info_win32_nv;
 
     ext.export_info_win32 = vku::FindStructInPNextChain<VkExportMemoryWin32HandleInfoKHR>(pNext) != nullptr;
 

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -370,6 +370,13 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         phys_dev_ext_props.depth_stencil_resolve_props = depth_stencil_resolve_props;
     }
 
+    if (IsExtEnabled(device_extensions.vk_ext_external_memory_host)) {
+        VkPhysicalDeviceExternalMemoryHostPropertiesEXT external_memory_host_props = vku::InitStructHelper();
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&external_memory_host_props);
+        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        phys_dev_ext_props.external_memory_host_props = external_memory_host_props;
+    }
+
     stateless_validation->phys_dev_ext_props = this->phys_dev_ext_props;
 
     // Save app-enabled features in this device's validation object

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1093,5 +1093,7 @@ class StatelessValidation : public ValidationObject {
                                                      const ErrorObject &error_obj) const;
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
+    bool ValidateAllocateMemoryExternal(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo, VkMemoryAllocateFlags flags,
+                                        const Location &allocate_info_loc) const;
 #include "generated/stateless_validation_helper.h"
 };  // Class StatelessValidation

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -69,6 +69,7 @@ class StatelessValidation : public ValidationObject {
         VkPhysicalDeviceMaintenance4PropertiesKHR maintenance4_props;
         VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_props;
         VkPhysicalDeviceDepthStencilResolveProperties depth_stencil_resolve_props;
+        VkPhysicalDeviceExternalMemoryHostPropertiesEXT external_memory_host_props;
     };
     DeviceExtensionProperties phys_dev_ext_props = {};
 
@@ -882,6 +883,11 @@ class StatelessValidation : public ValidationObject {
                                                 const ErrorObject &error_obj) const;
     bool manual_PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR *pGetFdInfo, int *pFd,
                                              const ErrorObject &error_obj) const;
+
+    bool manual_PreCallValidateGetMemoryHostPointerPropertiesEXT(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType,
+                                                                 const void *pHostPointer,
+                                                                 VkMemoryHostPointerPropertiesEXT *pMemoryHostPointerProperties,
+                                                                 const ErrorObject &error_obj) const;
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     bool manual_PreCallValidateGetMemoryWin32HandlePropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType,

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -23033,6 +23033,9 @@ bool StatelessValidation::PreCallValidateGetMemoryHostPointerPropertiesEXT(
                                     GeneratedVulkanHeaderVersion, "VUID-VkMemoryHostPointerPropertiesEXT-pNext-pNext",
                                     kVUIDUndefined, false, false);
     }
+    if (!skip)
+        skip |= manual_PreCallValidateGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer,
+                                                                        pMemoryHostPointerProperties, error_obj);
     return skip;
 }
 

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -119,6 +119,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'vkGetFenceWin32HandleKHR',
             'vkImportSemaphoreWin32HandleKHR',
             'vkGetSemaphoreWin32HandleKHR',
+            'vkGetMemoryHostPointerPropertiesEXT',
             'vkCmdBindVertexBuffers',
             'vkCreateImageView',
             'vkCopyAccelerationStructureToMemoryKHR',

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -1140,7 +1140,9 @@
                     "shaderRoundingModeRTZFloat32": true,
                     "shaderRoundingModeRTZFloat64": true
                 },
-                "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {},
+                "VkPhysicalDeviceExternalMemoryHostPropertiesEXT": {
+                    "minImportedHostPointerAlignment": 4096
+                },
                 "VkPhysicalDeviceConservativeRasterizationPropertiesEXT": {
                     "primitiveUnderestimation": true,
                     "conservativePointAndLineRasterization": true,

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -1745,3 +1745,88 @@ TEST_F(NegativeExternalMemorySync, FdMemoryHandleProperties) {
     vk::GetMemoryFdPropertiesKHR(*m_device, opaque_handle_type, valid_fd_handle, &properties);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferNoDedicated) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init())
+
+    VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
+    external_buffer_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+    auto buffer_info = vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
+    vkt::Buffer buffer;
+    buffer.init_no_mem(*m_device, buffer_info);
+
+    VkExportMemoryAllocateInfoKHR export_info = vku::InitStructHelper();
+    export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+    auto alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer.memory_requirements(), 0, &export_info);
+
+    vkt::DeviceMemory memory_export;
+    memory_export.init(*m_device, alloc_info);
+
+    VkMemoryGetFdInfoKHR mgfi = vku::InitStructHelper();
+    mgfi.memory = memory_export.handle();
+    mgfi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+    int fd;
+    vk::GetMemoryFdKHR(m_device->device(), &mgfi, &fd);
+
+    VkMemoryDedicatedAllocateInfoKHR dedicated_info = vku::InitStructHelper();
+    dedicated_info.image = VK_NULL_HANDLE;
+    dedicated_info.buffer = buffer.handle();
+
+    VkImportMemoryFdInfoKHR import_info = vku::InitStructHelper(&dedicated_info);
+    import_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+    import_info.fd = fd;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryDedicatedAllocateInfo-buffer-01879");
+    alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer.memory_requirements(), 0, &import_info);
+    vkt::DeviceMemory memory_import(*m_device, alloc_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferDifferentDedicated) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init())
+
+    VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
+    external_buffer_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+    auto buffer_info = vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
+    vkt::Buffer buffer;
+    buffer.init_no_mem(*m_device, buffer_info);
+
+    VkMemoryDedicatedAllocateInfoKHR dedicated_info = vku::InitStructHelper();
+    dedicated_info.image = VK_NULL_HANDLE;
+    dedicated_info.buffer = buffer.handle();
+
+    VkExportMemoryAllocateInfoKHR export_info = vku::InitStructHelper(&dedicated_info);
+    export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+    auto alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer.memory_requirements(), 0, &export_info);
+
+    vkt::DeviceMemory memory_export;
+    memory_export.init(*m_device, alloc_info);
+
+    VkMemoryGetFdInfoKHR mgfi = vku::InitStructHelper();
+    mgfi.memory = memory_export.handle();
+    mgfi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+
+    int fd;
+    vk::GetMemoryFdKHR(m_device->device(), &mgfi, &fd);
+
+    vkt::Buffer buffer2;
+    buffer2.init_no_mem(*m_device, buffer_info);
+
+    dedicated_info.buffer = buffer2.handle();
+
+    VkImportMemoryFdInfoKHR import_info = vku::InitStructHelper(&dedicated_info);
+    import_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+    import_info.fd = fd;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryDedicatedAllocateInfo-buffer-01879");
+    alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer2.memory_requirements(), 0, &import_info);
+    vkt::DeviceMemory memory_import(*m_device, alloc_info);
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -1830,3 +1830,43 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferDifferentDedicated) {
     vkt::DeviceMemory memory_import(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeExternalMemorySync, ImportMemoryFdBadFd) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init())
+
+    auto buffer_info = vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::Buffer buffer;
+    buffer.init_no_mem(*m_device, buffer_info);
+
+    VkImportMemoryFdInfoKHR import_info = vku::InitStructHelper();
+    import_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+    import_info.fd = -1;  // invalid
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImportMemoryFdInfoKHR-handleType-00670");
+    VkMemoryAllocateInfo alloc_info =
+        vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer.memory_requirements(), 0, &import_info);
+    vkt::DeviceMemory memory_import(*m_device, alloc_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeExternalMemorySync, ImportMemoryFdHandleType) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init())
+
+    auto buffer_info = vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::Buffer buffer;
+    buffer.init_no_mem(*m_device, buffer_info);
+
+    VkImportMemoryFdInfoKHR import_info = vku::InitStructHelper();
+    import_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+    import_info.fd = 1;
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImportMemoryFdInfoKHR-handleType-00669");
+    VkMemoryAllocateInfo alloc_info =
+        vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer.memory_requirements(), 0, &import_info);
+    vkt::DeviceMemory memory_import(*m_device, alloc_info);
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -262,8 +262,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithUnsupportedHandleType) {
 TEST_F(NegativeExternalMemorySync, BufferMemoryWithIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Bind buffer memory with incompatible external memory handle types.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init())
 
     VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     const auto buffer_info = vkt::Buffer::create_info(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
@@ -301,8 +300,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithIncompatibleHandleTypes) {
 TEST_F(NegativeExternalMemorySync, ImageMemoryWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Bind image memory with unsupported external memory handle type.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init())
 
     VkExternalMemoryImageCreateInfo external_image_info = vku::InitStructHelper();
     VkImageCreateInfo image_info = vku::InitStructHelper(&external_image_info);

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -22,8 +22,7 @@ TEST_F(NegativeExternalMemorySync, CreateBufferIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Creating buffer with incompatible external memory handle types");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     // Try all flags first. It's unlikely all of them are compatible.
     VkExternalMemoryBufferCreateInfo external_memory_info = vku::InitStructHelper();
@@ -61,8 +60,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Creating image with incompatible external memory handle types");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     // Try all flags first. It's unlikely all of them are compatible.
     VkExternalMemoryImageCreateInfo external_memory_info = vku::InitStructHelper();
@@ -117,8 +115,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypesNV) {
     TEST_DESCRIPTION("Creating image with incompatible external memory handle types from NVIDIA extension");
 
     AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     VkExternalMemoryImageCreateInfoNV external_memory_info = vku::InitStructHelper();
     VkImageCreateInfo image_create_info = vku::InitStructHelper(&external_memory_info);
@@ -161,8 +158,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypesNV) {
 TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
     TEST_DESCRIPTION("Test exporting memory with mismatching handleTypes.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     // Create export image
     VkExternalMemoryImageCreateInfo external_image_info = vku::InitStructHelper();
@@ -214,8 +210,7 @@ TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
 TEST_F(NegativeExternalMemorySync, BufferMemoryWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Bind buffer memory with unsupported external memory handle type.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     const auto buffer_info = vkt::Buffer::create_info(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
@@ -346,8 +341,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithUnsupportedHandleType) {
 TEST_F(NegativeExternalMemorySync, ImageMemoryWithIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Bind image memory with incompatible external memory handle types.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     // Create export image
     VkExternalMemoryImageCreateInfo external_image_info = vku::InitStructHelper();
@@ -399,8 +393,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithIncompatibleHandleTypes) {
 TEST_F(NegativeExternalMemorySync, ExportBufferHandleType) {
     TEST_DESCRIPTION("Test exporting memory with mismatching handleTypes.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     // Create export buffer
     VkExternalMemoryBufferCreateInfo external_info = vku::InitStructHelper();
@@ -608,8 +601,7 @@ TEST_F(NegativeExternalMemorySync, TemporaryFence) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME);
     AddRequiredExtensions(extension_name);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     // Check for external fence import and export capability
     VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
@@ -677,8 +669,7 @@ TEST_F(NegativeExternalMemorySync, Fence) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME);
     AddRequiredExtensions(extension_name);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     // Check for external fence import and export capability
     VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
@@ -751,8 +742,7 @@ TEST_F(NegativeExternalMemorySync, SyncFdFence) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     // Check for external fence import and export capability
     VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
@@ -808,10 +798,7 @@ TEST_F(NegativeExternalMemorySync, TemporarySemaphore) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(extension_name);
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME);
-
-    RETURN_IF_SKIP(InitFramework())
-
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     // Check for external semaphore import and export capability
     VkPhysicalDeviceExternalSemaphoreInfoKHR esi = vku::InitStructHelper();
@@ -902,10 +889,8 @@ TEST_F(NegativeExternalMemorySync, Semaphore) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(extension_name);
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
 
-    RETURN_IF_SKIP(InitFramework())
-
-    RETURN_IF_SKIP(InitState())
     // Check for external semaphore import and export capability
     VkPhysicalDeviceExternalSemaphoreInfoKHR esi = vku::InitStructHelper();
     esi.handleType = handle_type;
@@ -962,11 +947,10 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     const auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
 #endif
     AddRequiredExtensions(ext_mem_extension_name);
-    RETURN_IF_SKIP(InitFramework())
+    RETURN_IF_SKIP(Init());
     if (IsPlatformMockICD()) {
         GTEST_SKIP() << "External tests are not supported by MockICD, skipping tests";
     }
-    RETURN_IF_SKIP(InitState())
 
     // Check for import/export capability
     // export used to feed memory to test import
@@ -1175,8 +1159,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
 TEST_F(NegativeExternalMemorySync, FenceExportWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Create fence with unsupported external handle type in VkExportFenceCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     const auto exportable_types = FindSupportedExternalFenceHandleTypes(gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
@@ -1200,8 +1183,7 @@ TEST_F(NegativeExternalMemorySync, FenceExportWithUnsupportedHandleType) {
 TEST_F(NegativeExternalMemorySync, FenceExportWithIncompatibleHandleType) {
     TEST_DESCRIPTION("Create fence with incompatible external handle types in VkExportFenceCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     const auto exportable_types = FindSupportedExternalFenceHandleTypes(gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
@@ -1227,8 +1209,7 @@ TEST_F(NegativeExternalMemorySync, FenceExportWithIncompatibleHandleType) {
 TEST_F(NegativeExternalMemorySync, SemaphoreExportWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Create semaphore with unsupported external handle type in VkExportSemaphoreCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     const auto exportable_types = FindSupportedExternalSemaphoreHandleTypes(gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
@@ -1252,8 +1233,7 @@ TEST_F(NegativeExternalMemorySync, SemaphoreExportWithUnsupportedHandleType) {
 TEST_F(NegativeExternalMemorySync, SemaphoreExportWithIncompatibleHandleType) {
     TEST_DESCRIPTION("Create semaphore with incompatible external handle types in VkExportSemaphoreCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     const auto exportable_types = FindSupportedExternalSemaphoreHandleTypes(gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
@@ -1281,9 +1261,7 @@ TEST_F(NegativeExternalMemorySync, MemoryAndMemoryNV) {
 
     AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     VkExternalMemoryImageCreateInfoNV external_mem_nv = vku::InitStructHelper();
     VkExternalMemoryImageCreateInfo external_mem = vku::InitStructHelper(&external_mem_nv);
@@ -1349,8 +1327,7 @@ TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
 TEST_F(NegativeExternalMemorySync, D3D12FenceSubmitInfo) {
     TEST_DESCRIPTION("Test invalid D3D12FenceSubmitInfo");
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
     vkt::Semaphore semaphore(*m_device);
 
     // VkD3D12FenceSubmitInfoKHR::waitSemaphoreValuesCount == 1 is different from VkSubmitInfo::waitSemaphoreCount == 0
@@ -1383,8 +1360,7 @@ TEST_F(NegativeExternalMemorySync, GetMemoryFdHandle) {
     TEST_DESCRIPTION("Validate VkMemoryGetFdInfoKHR passed to vkGetMemoryFdKHR");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
     int fd = -1;
 
     // Allocate memory without VkExportMemoryAllocateInfo in the pNext chain
@@ -1447,8 +1423,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromFdHandle) {
     TEST_DESCRIPTION("POSIX fd handle memory import. Import parameters do not match payload's parameters");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
     constexpr auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
     VkExternalMemoryFeatureFlags external_features = 0;
@@ -1535,8 +1510,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
     TEST_DESCRIPTION("Win32 handle memory import. Import parameters do not match payload's parameters");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
     constexpr auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
 
     VkExternalMemoryFeatureFlags external_features = 0;
@@ -1628,8 +1602,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
 TEST_F(NegativeExternalMemorySync, BufferDedicatedAllocation) {
     TEST_DESCRIPTION("Bind external buffer that requires dedicated allocation to non-dedicated memory.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     const auto buffer_info = vkt::Buffer::create_info(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
@@ -1653,8 +1626,7 @@ TEST_F(NegativeExternalMemorySync, BufferDedicatedAllocation) {
 TEST_F(NegativeExternalMemorySync, ImageDedicatedAllocation) {
     TEST_DESCRIPTION("Bind external image that requires dedicated allocation to non-dedicated memory.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     VkExternalMemoryImageCreateInfo external_image_info = vku::InitStructHelper();
     VkImageCreateInfo image_info = vku::InitStructHelper(&external_image_info);
@@ -1692,8 +1664,7 @@ TEST_F(NegativeExternalMemorySync, ImageDedicatedAllocation) {
 TEST_F(NegativeExternalMemorySync, Win32MemoryHandleProperties) {
     TEST_DESCRIPTION("Call vkGetMemoryWin32HandlePropertiesKHR with invalid Win32 handle or with opaque handle type");
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init())
 
     constexpr auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
     constexpr auto opaque_handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
@@ -1724,8 +1695,7 @@ TEST_F(NegativeExternalMemorySync, Win32MemoryHandleProperties) {
 TEST_F(NegativeExternalMemorySync, FdMemoryHandleProperties) {
     TEST_DESCRIPTION("Call vkGetMemoryFdPropertiesKHR with invalid fd handle or with opaque handle type");
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-    RETURN_IF_SKIP(InitState())
+    RETURN_IF_SKIP(Init());
 
     constexpr auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT;
     constexpr auto opaque_handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
@@ -1753,6 +1723,17 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferNoDedicated) {
     external_buffer_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
     auto buffer_info = vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
+    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT)) {
+        GTEST_SKIP() << "Unable to find exportable handle type";
+    }
+    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+        GTEST_SKIP() << "Unable to find importable handle type";
+    }
+    const auto compatible_types = GetCompatibleHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
+    if ((VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT & compatible_types) == 0) {
+        GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
+    }
+
     vkt::Buffer buffer;
     buffer.init_no_mem(*m_device, buffer_info);
 
@@ -1769,6 +1750,9 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferNoDedicated) {
 
     int fd;
     vk::GetMemoryFdKHR(m_device->device(), &mgfi, &fd);
+    if (fd < 0) {
+        GTEST_SKIP() << "Cannot export FD memory";
+    }
 
     VkMemoryDedicatedAllocateInfoKHR dedicated_info = vku::InitStructHelper();
     dedicated_info.image = VK_NULL_HANDLE;
@@ -1793,6 +1777,17 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferDifferentDedicated) {
     external_buffer_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
     auto buffer_info = vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
+    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT)) {
+        GTEST_SKIP() << "Unable to find exportable handle type";
+    }
+    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+        GTEST_SKIP() << "Unable to find importable handle type";
+    }
+    const auto compatible_types = GetCompatibleHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
+    if ((VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT & compatible_types) == 0) {
+        GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
+    }
+
     vkt::Buffer buffer;
     buffer.init_no_mem(*m_device, buffer_info);
 
@@ -1835,6 +1830,14 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBadFd) {
     RETURN_IF_SKIP(Init())
 
     auto buffer_info = vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+        GTEST_SKIP() << "Unable to find importable handle type";
+    }
+    const auto compatible_types = GetCompatibleHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
+    if ((VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT & compatible_types) == 0) {
+        GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
+    }
+
     vkt::Buffer buffer;
     buffer.init_no_mem(*m_device, buffer_info);
 
@@ -1855,6 +1858,14 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdHandleType) {
     RETURN_IF_SKIP(Init())
 
     auto buffer_info = vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+        GTEST_SKIP() << "Unable to find importable handle type";
+    }
+    const auto compatible_types = GetCompatibleHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
+    if ((VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT & compatible_types) == 0) {
+        GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
+    }
+
     vkt::Buffer buffer;
     buffer.init_no_mem(*m_device, buffer_info);
 
@@ -1868,3 +1879,138 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdHandleType) {
     vkt::DeviceMemory memory_import(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 }
+
+// Because of aligned_alloc
+#if defined(__linux__) && !defined(__ANDROID__)
+TEST_F(NegativeExternalMemorySync, GetMemoryHostHandleType) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceExternalMemoryHostPropertiesEXT memory_host_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(memory_host_props);
+
+    VkDeviceSize alloc_size = memory_host_props.minImportedHostPointerAlignment;
+    void *host_memory = aligned_alloc(alloc_size, alloc_size);
+    if (!host_memory) {
+        GTEST_SKIP() << "Can't allocate host memory";
+    }
+
+    VkMemoryHostPointerPropertiesEXT host_pointer_props = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetMemoryHostPointerPropertiesEXT-handleType-01752");
+    vk::GetMemoryHostPointerPropertiesEXT(*m_device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT, host_memory,
+                                          &host_pointer_props);
+    m_errorMonitor->VerifyFound();
+    free(host_memory);
+}
+
+TEST_F(NegativeExternalMemorySync, GetMemoryHostAlignment) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceExternalMemoryHostPropertiesEXT memory_host_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(memory_host_props);
+
+    VkDeviceSize alloc_size = memory_host_props.minImportedHostPointerAlignment;
+    VkDeviceSize bad_alloc_size = alloc_size / 4;
+    void *host_memory = aligned_alloc(bad_alloc_size, alloc_size);
+    if (!host_memory) {
+        GTEST_SKIP() << "Can't allocate host memory";
+    }
+    const VkDeviceSize host_pointer = reinterpret_cast<VkDeviceSize>(host_memory);
+    if (host_pointer % alloc_size == 0) {
+        free(host_memory);
+        GTEST_SKIP() << "Can't create misaligned memory";  // when using ASAN
+    }
+    VkMemoryHostPointerPropertiesEXT host_pointer_props = vku::InitStructHelper();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetMemoryHostPointerPropertiesEXT-pHostPointer-01753");
+    vk::GetMemoryHostPointerPropertiesEXT(*m_device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT, host_memory,
+                                          &host_pointer_props);
+    m_errorMonitor->VerifyFound();
+    free(host_memory);
+}
+
+TEST_F(NegativeExternalMemorySync, ImportMemoryHostDedicated) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceExternalMemoryHostPropertiesEXT memory_host_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(memory_host_props);
+
+    VkDeviceSize alloc_size = memory_host_props.minImportedHostPointerAlignment;
+    void *host_memory = aligned_alloc(alloc_size, alloc_size);
+    if (!host_memory) {
+        GTEST_SKIP() << "Can't allocate host memory";
+    }
+
+    VkMemoryHostPointerPropertiesEXT host_pointer_props = vku::InitStructHelper();
+    vk::GetMemoryHostPointerPropertiesEXT(*m_device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT, host_memory,
+                                          &host_pointer_props);
+
+    const auto buffer_info = vkt::Buffer::create_info(alloc_size, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
+
+    VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
+    dedicated_info.buffer = buffer.handle();
+    dedicated_info.image = VK_NULL_HANDLE;
+
+    VkImportMemoryHostPointerInfoEXT import_info = vku::InitStructHelper(&dedicated_info);
+    import_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT;
+    import_info.pHostPointer = host_memory;
+
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&import_info);
+    alloc_info.allocationSize = alloc_size;
+    if (!m_device->phy().set_memory_type(host_pointer_props.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
+        free(host_memory);
+        GTEST_SKIP() << "Failed to set memory type.";
+    }
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-02806");
+    VkDeviceMemory device_memory;
+    vk::AllocateMemory(*m_device, &alloc_info, nullptr, &device_memory);
+    m_errorMonitor->VerifyFound();
+
+    free(host_memory);
+}
+
+TEST_F(NegativeExternalMemorySync, ImportMemoryHostMemoryIndex) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceExternalMemoryHostPropertiesEXT memory_host_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(memory_host_props);
+
+    VkDeviceSize alloc_size = memory_host_props.minImportedHostPointerAlignment;
+    void *host_memory = aligned_alloc(alloc_size, alloc_size);
+    if (!host_memory) {
+        GTEST_SKIP() << "Can't allocate host memory";
+    }
+
+    VkMemoryHostPointerPropertiesEXT host_pointer_props = vku::InitStructHelper();
+    vk::GetMemoryHostPointerPropertiesEXT(*m_device, VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT, host_memory,
+                                          &host_pointer_props);
+
+    VkImportMemoryHostPointerInfoEXT import_info = vku::InitStructHelper();
+    import_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT;
+    import_info.pHostPointer = host_memory;
+
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&import_info);
+    alloc_info.allocationSize = alloc_size;
+
+    uint32_t unsupported_mem_type =
+        ((1 << m_device->phy().memory_properties_.memoryTypeCount) - 1) & ~host_pointer_props.memoryTypeBits;
+    bool found_type = m_device->phy().set_memory_type(unsupported_mem_type, &alloc_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    if (unsupported_mem_type == 0 || !found_type) {
+        free(host_memory);
+        GTEST_SKIP() << "Failed to find unsupported memory type.";
+    }
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-memoryTypeIndex-01744");
+    vkt::DeviceMemory memory_import(*m_device, alloc_info);
+    m_errorMonitor->VerifyFound();
+
+    free(host_memory);
+}
+#endif

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -2107,6 +2107,7 @@ TEST_F(NegativeMemory, MemoryAllocatepNextChain) {
         VkImportMemoryWin32HandleInfoNV import_memory_info_win32_nv = vku::InitStructHelper(&import_memory_info_win32_khr);
         import_memory_info_win32_nv.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_NV;
 
+        m_errorMonitor->SetUnexpectedError("VUID-VkMemoryAllocateInfo-None-06657");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-00641");
         mem_alloc.pNext = &import_memory_info_win32_nv;
         vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);


### PR DESCRIPTION
for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5431

Does a lot of cleanup around the External Memory/Sync code

adds:

- VUID-VkMemoryDedicatedAllocateInfo-image-01878
- VUID-VkMemoryDedicatedAllocateInfo-buffer-01879
- VUID-VkImportMemoryFdInfoKHR-handleType-00669
- VUID-VkImportMemoryFdInfoKHR-handleType-00670
- VUID-VkMemoryAllocateInfo-allocationSize-07897
- VUID-VkMemoryAllocateInfo-allocationSize-01743
- VUID-VkImportSemaphoreFdInfoKHR-handleType-07307
- VUID-VkImportSemaphoreFdInfoKHR-handleType-03263
- VUID-vkGetMemoryHostPointerPropertiesEXT-handleType-01752
- VUID-vkGetMemoryHostPointerPropertiesEXT-pHostPointer-01753
- VUID-VkImportMemoryHostPointerInfoEXT-handleType-01748
- VUID-VkImportMemoryHostPointerInfoEXT-pHostPointer-01749
- VUID-VkMemoryAllocateInfo-allocationSize-01745
- VUID-VkMemoryAllocateInfo-memoryTypeIndex-01744
- VUID-VkMemoryAllocateInfo-pNext-02806