### PR TITLE
Fix acceleration structure type when copied to mutable descriptor

### DIFF
--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -1052,7 +1052,7 @@ void cvdescriptorset::MutableDescriptor::CopyUpdate(DescriptorSet &set_state, co
                 ReplaceStatePtr(set_state, buffer_view_state_, mutable_src.GetSharedBufferViewState(), is_bindless);
             } break;
             case AccelerationStructure: {
-                if (is_khr_) {
+                if (mutable_src.is_khr()) {
                     acc_ = mutable_src.GetAccelerationStructureKHR();
                     ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_KHR>(acc_),
                                     is_bindless);

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -695,6 +695,7 @@ class MutableDescriptor : public Descriptor {
     bool AddParent(BASE_NODE *base_node) override;
     void RemoveParent(BASE_NODE *base_node) override;
 
+    bool is_khr() const { return is_khr_; }
     bool Invalid() const override;
 
     VkDescriptorType ActiveType() const { return active_descriptor_type_; }


### PR DESCRIPTION
Fixes a crash in dEQP-VK.binding_model.mutable_descriptor.single.acceleration_structure_khr.update_copy.mutable_source.normal_source.pool_same_types.update_after_bind.no_array.comp
with GPU-AV