### PR TITLE
tests: Make syncval to pass core validation

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -326,8 +326,6 @@ bool CoreChecks::PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer, 
     const CMD_BUFFER_STATE &cb_state = *cb_state_ptr;
     if ((VK_COMMAND_BUFFER_LEVEL_PRIMARY == cb_state.createInfo.level) ||
         !(cb_state.beginInfo.flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)) {
-        // This needs spec clarification to update valid usage, see comments in PR:
-        // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/165
         skip |= InsideRenderPass(cb_state, error_obj.location, "VUID-vkEndCommandBuffer-commandBuffer-00060");
     }
 

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -248,6 +248,9 @@ def RunVVLTests(args):
 
     RunShellCmd(lvt_cmd + f" --gtest_filter={failing_tsan_tests}", env=lvt_env)
 
+    print("Re-Running syncval tests with core validation enabled")
+    RunShellCmd(lvt_cmd + f' --gtest_filter=*SyncVal*:{failing_tsan_tests} --syncval-enable-core', env=lvt_env)
+
     print("Re-Running multithreaded tests with VK_LAYER_FINE_GRAINED_LOCKING disabled")
     lvt_env['VK_LAYER_FINE_GRAINED_LOCKING'] = '0'
     RunShellCmd(lvt_cmd + f' --gtest_filter=*Thread*:{failing_tsan_tests}', env=lvt_env)

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -270,11 +270,11 @@ class VkSyncValTest : public VkLayerTest {
     void InitSyncValFramework(bool enable_queue_submit_validation = false);
 
   protected:
-    VkValidationFeatureEnableEXT enables_[1] = {VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
-    VkValidationFeatureDisableEXT disables_[4] = {
+    const VkValidationFeatureEnableEXT enables_[1] = {VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
+    const VkValidationFeatureDisableEXT disables_[4] = {
         VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT, VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT,
         VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT, VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
-    VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1, enables_, 4, disables_};
+    VkValidationFeaturesEXT features_ = {};
 };
 
 class AndroidHardwareBufferTest : public VkLayerTest {};

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -162,6 +162,8 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
             m_canonicalize_spv = true;
         } else if (current_argument == "--print-vu") {
             m_print_vu = true;
+        } else if (current_argument == "--syncval-enable-core") {
+            m_syncval_enable_core = true;
         } else if (current_argument == "--device-index" && ((i + 1) < *argc)) {
             m_phys_device_index = std::atoi(argv[++i]);
         } else if ((current_argument == "--help") || (current_argument == "-h")) {
@@ -169,6 +171,10 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
             printf(
                 "\t--print-vu\n"
                 "\t\tPrints all VUs - help see what new VU will look like.\n");
+            printf(
+                "\t--syncval-enable-core\n"
+                "\t\tEnable both syncval and core validation when running syncval tests.\n"
+                "\t\tBy default only syncval validation is enabled.\n");
             printf(
                 "\t--strip-SPV\n"
                 "\t\tStrip SPIR-V debug information (line numbers, names, etc).\n");

--- a/tests/framework/test_framework.h
+++ b/tests/framework/test_framework.h
@@ -52,9 +52,10 @@ class VkTestFramework : public ::testing::Test {
     void FreeFileData(char **data);
 
     static inline bool m_canonicalize_spv = false;
-    static inline bool m_print_vu = false;
     static inline bool m_strip_spv = false;
     static inline bool m_do_everything_spv = false;
+    static inline bool m_print_vu = false;
+    static inline bool m_syncval_enable_core = false;
     static inline int m_phys_device_index = -1;
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -20,14 +20,22 @@ class PositiveSyncVal : public VkSyncValTest {};
 
 void VkSyncValTest::InitSyncValFramework(bool enable_queue_submit_validation) {
     // Enable synchronization validation
+    features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1u, enables_, 4, disables_};
 
-    // Optional feature definition, add if requested (but they can't be defined at the conditional scope)
-    const char *kEnableQueuSubmitSyncValidation[] = {"VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT"};
-    const VkLayerSettingEXT settings[] = {
+    // Optionally enable core validation (by disabling nothing)
+    if (m_syncval_enable_core) {
+        features_.disabledValidationFeatureCount = 0;
+    }
+
+    // Optionally enable syncval submit validation
+    static const char *kEnableQueuSubmitSyncValidation[] = {"VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT"};
+    static const VkLayerSettingEXT settings[] = {
         {OBJECT_LAYER_NAME, "enables", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, kEnableQueuSubmitSyncValidation}};
-    const VkLayerSettingsCreateInfoEXT qs_settings{VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr,
-                                                   static_cast<uint32_t>(std::size(settings)), settings};
-
+    // The pNext of qs_settings is modified by InitFramework that's why it can't
+    // be static (should be separate instance per stack frame). Also we show
+    // explicitly that it's not const (InitFramework casts const pNext to non-const).
+    VkLayerSettingsCreateInfoEXT qs_settings{VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr,
+                                             static_cast<uint32_t>(std::size(settings)), settings};
     if (enable_queue_submit_validation) {
         features_.pNext = &qs_settings;
     }

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -149,7 +149,7 @@ TEST_F(PositiveSyncVal, WriteToImageAfterTransition) {
     constexpr uint32_t height = 128;
     constexpr VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
 
-    vkt::Buffer buffer(*m_device, width * height * 4, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::Buffer buffer(*m_device, width * height * 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     VkImageObj image(m_device);
     image.InitNoLayout(width, height, 1, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_OPTIMAL);
 
@@ -722,7 +722,13 @@ TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
 
 TEST_F(PositiveSyncVal, ImageArrayConstantIndexing) {
     TEST_DESCRIPTION("Access different elements of the image array using constant indices. There should be no hazards");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitSyncValFramework());
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper();
+    GetPhysicalDeviceFeatures2(features2);
+    if (!features2.features.fragmentStoresAndAtomics) {
+        GTEST_SKIP() << "Test requires (unsupported) fragmentStoresAndAtomics";
+    }
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
@@ -792,7 +798,13 @@ TEST_F(PositiveSyncVal, ImageArrayConstantIndexing) {
 
 TEST_F(PositiveSyncVal, TexelBufferArrayConstantIndexing) {
     TEST_DESCRIPTION("Access different elements of the texel buffer array using constant indices. There should be no hazards");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitSyncValFramework());
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper();
+    GetPhysicalDeviceFeatures2(features2);
+    if (!features2.features.fragmentStoresAndAtomics) {
+        GTEST_SKIP() << "Test requires (unsupported) fragmentStoresAndAtomics";
+    }
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 


### PR DESCRIPTION
* Fix syncval tests to work with core validation
* `--syncval-enable-core` command line option to conveniently test syncval+core during development
* Add pass to CI  (thanks Spencer for the guide) to run syncval with core validation enabled (in addition to regular syncval only)