### PR TITLE
layers: Fix tessellation point mode output

### DIFF
--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -224,7 +224,11 @@ bool CoreChecks::ValidatePrimitiveTopology(const SPIRV_MODULE_STATE &module_stat
         if (stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT || stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) {
             has_tess = true;
             if (stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) {
-                topology = stage_state.entrypoint->execution_mode.primitive_topology;
+                if (stage_state.entrypoint->execution_mode.Has(ExecutionModeSet::point_mode_bit)) {
+                    topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+                } else {
+                    topology = stage_state.entrypoint->execution_mode.primitive_topology;
+                }
             }
         }
     }


### PR DESCRIPTION
If tessellation evaluation shader uses point mode, the output primitive will be points