### PR TITLE
tsan: Blacklist PositiveSyncObject.WaitEventThenSet

### DIFF
--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -237,6 +237,7 @@ def RunVVLTests(args):
     # NOTE: These test(s) fails sporadically.
     # These need extra care to prevent a regression in the future.
     failing_tsan_tests += ':PositiveSyncObject.WaitTimelineSemThreadRace'
+    failing_tsan_tests += ':PositiveSyncObject.WaitEventThenSet'
     failing_tsan_tests += ':PositiveQuery.ResetQueryPoolFromDifferentCB'
     failing_tsan_tests += ':PositiveQuery.PerformanceQueries'
 


### PR DESCRIPTION
See:
https://github.com/juan-lunarg/Vulkan-ValidationLayers/actions/runs/6670729791/job/18131209667

<details>

```
[ RUN      ] PositiveSyncObject.WaitEventThenSet
==================
WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=13639)
  Cycle in lock order graph: M4751765 (0x7b4c00002448) => M109066571313340336 (0x000000000000) => M4751690 (0x7bb00000b4c0) => M4751765

  Mutex M109066571313340336 acquired here while holding mutex M4751765 in thread T437:
    #0 pthread_rwlock_wrlock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1368 (libtsan.so.0+0x3f778)
    #1 __glibcxx_rwlock_wrlock /usr/include/c++/11/shared_mutex:80 (libVkLayer_khronos_validation.so+0x2f1f3c)
    #2 std::__shared_mutex_pthread::lock() /usr/include/c++/11/shared_mutex:193 (libVkLayer_khronos_validation.so+0x2f1fc4)
    #3 std::shared_mutex::lock() /usr/include/c++/11/shared_mutex:420 (libVkLayer_khronos_validation.so+0x2f20ee)
    #4 std::unique_lock<std::shared_mutex>::lock() /usr/include/c++/11/bits/unique_lock.h:139 (libVkLayer_khronos_validation.so+0x328ce9)
    #5 std::unique_lock<std::shared_mutex>::unique_lock(std::shared_mutex&) /usr/include/c++/11/bits/unique_lock.h:69 (libVkLayer_khronos_validation.so+0x328b2a)
    #6 CMD_BUFFER_STATE::WriteLock() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./state_tracker/cmd_buffer_state.h:470 (libVkLayer_khronos_validation.so+0x3f544c)
    #7 CMD_BUFFER_STATE::Destroy() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/state_tracker/cmd_buffer_state.cpp:252 (libVkLayer_khronos_validation.so+0x1e4cd19)
    #8 CMD_BUFFER_STATE::~CMD_BUFFER_STATE() <null> (libVkLayer_khronos_validation.so+0x31fdab)
    #9 CORE_CMD_BUFFER_STATE::~CORE_CMD_BUFFER_STATE() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./core_checks/core_validation.h:377 (libVkLayer_khronos_validation.so+0xee01e1)
    #10 void __gnu_cxx::new_allocator<CORE_CMD_BUFFER_STATE>::destroy<CORE_CMD_BUFFER_STATE>(CORE_CMD_BUFFER_STATE*) /usr/include/c++/11/ext/new_allocator.h:168 (libVkLayer_khronos_validation.so+0xee05e9)
    #11 void std::allocator_traits<std::allocator<CORE_CMD_BUFFER_STATE> >::destroy<CORE_CMD_BUFFER_STATE>(std::allocator<CORE_CMD_BUFFER_STATE>&, CORE_CMD_BUFFER_STATE*) /usr/include/c++/11/bits/alloc_traits.h:535 (libVkLayer_khronos_validation.so+0xee0583)
    #12 std::_Sp_counted_ptr_inplace<CORE_CMD_BUFFER_STATE, std::allocator<CORE_CMD_BUFFER_STATE>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/include/c++/11/bits/shared_ptr_base.h:528 (libVkLayer_khronos_validation.so+0xee03e4)
    #13 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/11/bits/shared_ptr_base.h:168 (libVkLayer_khronos_validation.so+0x334659)
    #14 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/11/bits/shared_ptr_base.h:705 (libVkLayer_khronos_validation.so+0x32953e)
    #15 std::__shared_ptr<CMD_BUFFER_STATE, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/11/bits/shared_ptr_base.h:1154 (libVkLayer_khronos_validation.so+0x31f643)
    #16 std::shared_ptr<CMD_BUFFER_STATE>::~shared_ptr() /usr/include/c++/11/bits/shared_ptr.h:122 (libVkLayer_khronos_validation.so+0x31f673)
    #17 void std::_Destroy<std::shared_ptr<CMD_BUFFER_STATE> >(std::shared_ptr<CMD_BUFFER_STATE>*) /usr/include/c++/11/bits/stl_construct.h:151 (libVkLayer_khronos_validation.so+0x1d0bd09)
    #18 void std::_Destroy_aux<false>::__destroy<std::shared_ptr<CMD_BUFFER_STATE>*>(std::shared_ptr<CMD_BUFFER_STATE>*, std::shared_ptr<CMD_BUFFER_STATE>*) /usr/include/c++/11/bits/stl_construct.h:163 (libVkLayer_khronos_validation.so+0x1d0770c)
    #19 void std::_Destroy<std::shared_ptr<CMD_BUFFER_STATE>*>(std::shared_ptr<CMD_BUFFER_STATE>*, std::shared_ptr<CMD_BUFFER_STATE>*) /usr/include/c++/11/bits/stl_construct.h:196 (libVkLayer_khronos_validation.so+0x1d02c79)
    #20 void std::_Destroy<std::shared_ptr<CMD_BUFFER_STATE>*, std::shared_ptr<CMD_BUFFER_STATE> >(std::shared_ptr<CMD_BUFFER_STATE>*, std::shared_ptr<CMD_BUFFER_STATE>*, std::allocator<std::shared_ptr<CMD_BUFFER_STATE> >&) /usr/include/c++/11/bits/alloc_traits.h:848 (libVkLayer_khronos_validation.so+0x1cfd555)
    #21 std::vector<std::shared_ptr<CMD_BUFFER_STATE>, std::allocator<std::shared_ptr<CMD_BUFFER_STATE> > >::~vector() /usr/include/c++/11/bits/stl_vector.h:680 (libVkLayer_khronos_validation.so+0x1cf540c)
    #22 CB_SUBMISSION::~CB_SUBMISSION() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./state_tracker/queue_state.h:268 (libVkLayer_khronos_validation.so+0x1d124f5)
    #23 void __gnu_cxx::new_allocator<CB_SUBMISSION>::destroy<CB_SUBMISSION>(CB_SUBMISSION*) /usr/include/c++/11/ext/new_allocator.h:168 (libVkLayer_khronos_validation.so+0x20ea9c7)
    #24 void std::allocator_traits<std::allocator<CB_SUBMISSION> >::destroy<CB_SUBMISSION>(std::allocator<CB_SUBMISSION>&, CB_SUBMISSION*) /usr/include/c++/11/bits/alloc_traits.h:535 (libVkLayer_khronos_validation.so+0x20e8b46)
    #25 std::deque<CB_SUBMISSION, std::allocator<CB_SUBMISSION> >::pop_front() /usr/include/c++/11/bits/stl_deque.h:1538 (libVkLayer_khronos_validation.so+0x20e660c)
    #26 QUEUE_STATE::ThreadFunc() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/state_tracker/queue_state.cpp:230 (libVkLayer_khronos_validation.so+0x20b0247)
    #27 void std::__invoke_impl<void, void (QUEUE_STATE::*)(), QUEUE_STATE*>(std::__invoke_memfun_deref, void (QUEUE_STATE::*&&)(), QUEUE_STATE*&&) <null> (libVkLayer_khronos_validation.so+0x20efcc7)
    #28 std::__invoke_result<void (QUEUE_STATE::*)(), QUEUE_STATE*>::type std::__invoke<void (QUEUE_STATE::*)(), QUEUE_STATE*>(void (QUEUE_STATE::*&&)(), QUEUE_STATE*&&) <null> (libVkLayer_khronos_validation.so+0x20efb96)
    #29 void std::thread::_Invoker<std::tuple<void (QUEUE_STATE::*)(), QUEUE_STATE*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) <null> (libVkLayer_khronos_validation.so+0x20efa92)
    #30 std::thread::_Invoker<std::tuple<void (QUEUE_STATE::*)(), QUEUE_STATE*> >::operator()() <null> (libVkLayer_khronos_validation.so+0x20ef9b4)
    #31 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (QUEUE_STATE::*)(), QUEUE_STATE*> > >::_M_run() /usr/include/c++/11/bits/std_thread.h:211 (libVkLayer_khronos_validation.so+0x20ef8f0)
    #32 <null> <null> (libstdc++.so.6+0xe62b2)

    Hint: use TSAN_OPTIONS=second_deadlock_stack=1 to get more informative warning message

  Mutex M4751690 acquired here while holding mutex M109066571313340336 in main thread:
    #0 pthread_rwlock_rdlock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1338 (libtsan.so.0+0x3cab8)
    #1 __glibcxx_rwlock_rdlock /usr/include/c++/11/shared_mutex:78 (libVkLayer_khronos_validation.so+0x2f1ef3)
    #2 std::__shared_mutex_pthread::lock_shared() /usr/include/c++/11/shared_mutex:229 (libVkLayer_khronos_validation.so+0x2f2058)
    #3 std::shared_mutex::lock_shared() /usr/include/c++/11/shared_mutex:426 (libVkLayer_khronos_validation.so+0x2f216c)
    #4 std::shared_lock<std::shared_mutex>::shared_lock(std::shared_mutex&) /usr/include/c++/11/shared_mutex:727 (libVkLayer_khronos_validation.so+0x328a42)
    #5 vl_concurrent_unordered_map<VkQueue_T*, std::shared_ptr<QUEUE_STATE>, 2, std::hash<VkQueue_T*> >::find(VkQueue_T* const&) const /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./utils/vk_layer_utils.h:677 (libVkLayer_khronos_validation.so+0x58b16e)
    #6 state_object::Traits<QUEUE_STATE>::ConstSharedType ValidationStateTracker::Get<QUEUE_STATE, state_object::Traits<QUEUE_STATE> >(state_object::Traits<QUEUE_STATE>::HandleType) const /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./state_tracker/state_tracker.h:421 (libVkLayer_khronos_validation.so+0x589ae4)
    #7 CoreChecks::ValidateQueueFamilyIndices(Location const&, CMD_BUFFER_STATE const&, VkQueue_T*) const /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/core_checks/cc_queue.cpp:432 (libVkLayer_khronos_validation.so+0xc8e07e)
    #8 CommandBufferSubmitState::Validate(Location const&, CMD_BUFFER_STATE const&, unsigned int) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/core_checks/cc_queue.cpp:53 (libVkLayer_khronos_validation.so+0xcc236c)
    #9 CoreChecks::PreCallValidateQueueSubmit(VkQueue_T*, unsigned int, VkSubmitInfo const*, VkFence_T*, ErrorObject const&) const /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/core_checks/cc_queue.cpp:146 (libVkLayer_khronos_validation.so+0xc8b364)
    #10 vulkan_layer_chassis::QueueSubmit(VkQueue_T*, unsigned int, VkSubmitInfo const*, VkFence_T*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/vulkan/generated/chassis.cpp:1278 (libVkLayer_khronos_validation.so+0x10757be)
    #11 vkQueueSubmit <null> (libvulkan.so+0x594a6)
    #12 PositiveSyncObject_WaitEventThenSet_Test::TestBody() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/unit/sync_object_positive.cpp:1607 (vk_layer_validation_tests+0x123310a)
    #13 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2612 (vk_layer_validation_tests+0x1b45ff4)
    #14 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2648 (vk_layer_validation_tests+0x1b3c253)
    #15 testing::Test::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2687 (vk_layer_validation_tests+0x1b0d8df)
    #16 testing::TestInfo::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2836 (vk_layer_validation_tests+0x1b0e712)
    #17 testing::TestSuite::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:3015 (vk_layer_validation_tests+0x1b0f519)
    #18 testing::internal::UnitTestImpl::RunAllTests() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:5920 (vk_layer_validation_tests+0x1b21e77)
    #19 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2612 (vk_layer_validation_tests+0x1b4783b)
    #20 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2648 (vk_layer_validation_tests+0x1b3dbb2)
    #21 testing::UnitTest::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:5484 (vk_layer_validation_tests+0x1b1fd6b)
    #22 RUN_ALL_TESTS() <null> (vk_layer_validation_tests+0x3ebb43)
    #23 main /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/framework/layer_validation_tests.cpp:1003 (vk_layer_validation_tests+0x3e1a26)

  Mutex M4751765 acquired here while holding mutex M4751690 in main thread:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4240 (libtsan.so.0+0x53908)
    #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/11/bits/gthr-default.h:749 (libVkLayer_khronos_validation.so+0x2f0841)
    #2 std::mutex::lock() /usr/include/c++/11/bits/std_mutex.h:100 (libVkLayer_khronos_validation.so+0x2f0d16)
    #3 std::unique_lock<std::mutex>::lock() /usr/include/c++/11/bits/unique_lock.h:139 (libVkLayer_khronos_validation.so+0x331471)
    #4 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/include/c++/11/bits/unique_lock.h:69 (libVkLayer_khronos_validation.so+0x32522c)
    #5 QUEUE_STATE::Lock() const /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./state_tracker/queue_state.h:334 (libVkLayer_khronos_validation.so+0x20e42ec)
    #6 QUEUE_STATE::Destroy() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/state_tracker/queue_state.cpp:145 (libVkLayer_khronos_validation.so+0x20af8b2)
    #7 QUEUE_STATE::~QUEUE_STATE() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./state_tracker/queue_state.h:311 (libVkLayer_khronos_validation.so+0x1cf4749)
    #8 void __gnu_cxx::new_allocator<QUEUE_STATE>::destroy<QUEUE_STATE>(QUEUE_STATE*) /usr/include/c++/11/ext/new_allocator.h:168 (libVkLayer_khronos_validation.so+0x22b6501)
    #9 void std::allocator_traits<std::allocator<QUEUE_STATE> >::destroy<QUEUE_STATE>(std::allocator<QUEUE_STATE>&, QUEUE_STATE*) /usr/include/c++/11/bits/alloc_traits.h:535 (libVkLayer_khronos_validation.so+0x22b5869)
    #10 std::_Sp_counted_ptr_inplace<QUEUE_STATE, std::allocator<QUEUE_STATE>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/include/c++/11/bits/shared_ptr_base.h:528 (libVkLayer_khronos_validation.so+0x22b42dc)
    #11 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/11/bits/shared_ptr_base.h:168 (libVkLayer_khronos_validation.so+0x334659)
    #12 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/11/bits/shared_ptr_base.h:705 (libVkLayer_khronos_validation.so+0x32953e)
    #13 std::__shared_ptr<QUEUE_STATE, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/11/bits/shared_ptr_base.h:1154 (libVkLayer_khronos_validation.so+0x374df1)
    #14 std::shared_ptr<QUEUE_STATE>::~shared_ptr() /usr/include/c++/11/bits/shared_ptr.h:122 (libVkLayer_khronos_validation.so+0x374e21)
    #15 std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >::~pair() /usr/include/c++/11/bits/stl_pair.h:211 (libVkLayer_khronos_validation.so+0x374e55)
    #16 void __gnu_cxx::new_allocator<std::__detail::_Hash_node<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >, false> >::destroy<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> > >(std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >*) /usr/include/c++/11/ext/new_allocator.h:168 (libVkLayer_khronos_validation.so+0x374e89)
    #17 void std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >, false> > >::destroy<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> > >(std::allocator<std::__detail::_Hash_node<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >, false> >&, std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >*) /usr/include/c++/11/bits/alloc_traits.h:535 (libVkLayer_khronos_validation.so+0x368ff7)
    #18 std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >, false> > >::_M_deallocate_node(std::__detail::_Hash_node<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >, false>*) /usr/include/c++/11/bits/hashtable_policy.h:1894 (libVkLayer_khronos_validation.so+0x3596ac)
    #19 std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >, false> > >::_M_deallocate_nodes(std::__detail::_Hash_node<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >, false>*) /usr/include/c++/11/bits/hashtable_policy.h:1916 (libVkLayer_khronos_validation.so+0x349905)
    #20 std::_Hashtable<VkQueue_T*, std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> >, std::allocator<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> > >, std::__detail::_Select1st, std::equal_to<VkQueue_T*>, std::hash<VkQueue_T*>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::clear() /usr/include/c++/11/bits/hashtable.h:2320 (libVkLayer_khronos_validation.so+0x33a934)
    #21 std::unordered_map<VkQueue_T*, std::shared_ptr<QUEUE_STATE>, std::hash<VkQueue_T*>, std::equal_to<VkQueue_T*>, std::allocator<std::pair<VkQueue_T* const, std::shared_ptr<QUEUE_STATE> > > >::clear() /usr/include/c++/11/bits/unordered_map.h:791 (libVkLayer_khronos_validation.so+0x2231d8f)
    #22 vl_concurrent_unordered_map<VkQueue_T*, std::shared_ptr<QUEUE_STATE>, 2, std::hash<VkQueue_T*> >::clear() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./utils/vk_layer_utils.h:721 (libVkLayer_khronos_validation.so+0x221f2d4)
    #23 ValidationStateTracker::PreCallRecordDestroyDevice(VkDevice_T*, VkAllocationCallbacks const*, RecordObject const&) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/state_tracker/state_tracker.cpp:1084 (libVkLayer_khronos_validation.so+0x21bfbd9)
    #24 CoreChecks::PreCallRecordDestroyDevice(VkDevice_T*, VkAllocationCallbacks const*, RecordObject const&) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/core_checks/cc_device.cpp:466 (libVkLayer_khronos_validation.so+0x944186)
    #25 vulkan_layer_chassis::DestroyDevice(VkDevice_T*, VkAllocationCallbacks const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/vulkan/generated/chassis.cpp:629 (libVkLayer_khronos_validation.so+0x106d128)
    #26 loader_layer_destroy_device <null> (libvulkan.so+0x41968)
    #27 vkDestroyDevice <null> (libvulkan.so+0x56f91)
    #28 vkt::Device::destroy() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/framework/binding.cpp:216 (vk_layer_validation_tests+0x496632)
    #29 vkt::Device::~Device() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/framework/binding.cpp:220 (vk_layer_validation_tests+0x496684)
    #30 VkRenderFramework::ShutdownFramework() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/framework/render.cpp:485 (vk_layer_validation_tests+0x441365)
    #31 VkRenderFramework::~VkRenderFramework() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/framework/render.cpp:69 (vk_layer_validation_tests+0x43d00f)
    #32 VkLayerTest::~VkLayerTest() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/unit/../framework/layer_validation_tests.h:151 (vk_layer_validation_tests+0x5442d9)
    #33 SyncObjectTest::~SyncObjectTest() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/unit/../framework/layer_validation_tests.h:547 (vk_layer_validation_tests+0x121beed)
    #34 PositiveSyncObject::~PositiveSyncObject() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/unit/../framework/layer_validation_tests.h:556 (vk_layer_validation_tests+0x124a49d)
    #35 PositiveSyncObject_WaitEventThenSet_Test::~PositiveSyncObject_WaitEventThenSet_Test() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/unit/sync_object_positive.cpp:1570 (vk_layer_validation_tests+0x124af73)
    #36 PositiveSyncObject_WaitEventThenSet_Test::~PositiveSyncObject_WaitEventThenSet_Test() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/unit/sync_object_positive.cpp:1570 (vk_layer_validation_tests+0x124afa7)
    #37 testing::Test::DeleteSelf_() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/include/gtest/gtest.h:336 (vk_layer_validation_tests+0x1b2e0a8)
    #38 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2612 (vk_layer_validation_tests+0x1b45ff4)
    #39 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2648 (vk_layer_validation_tests+0x1b3c253)
    #40 testing::TestInfo::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2842 (vk_layer_validation_tests+0x1b0e782)
    #41 testing::TestSuite::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:3015 (vk_layer_validation_tests+0x1b0f519)
    #42 testing::internal::UnitTestImpl::RunAllTests() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:5920 (vk_layer_validation_tests+0x1b21e77)
    #43 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2612 (vk_layer_validation_tests+0x1b4783b)
    #44 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2648 (vk_layer_validation_tests+0x1b3dbb2)
    #45 testing::UnitTest::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:5484 (vk_layer_validation_tests+0x1b1fd6b)
    #46 RUN_ALL_TESTS() <null> (vk_layer_validation_tests+0x3ebb43)
    #47 main /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/framework/layer_validation_tests.cpp:1003 (vk_layer_validation_tests+0x3e1a26)

  Thread T16 (tid=14142, finished) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:969 (libtsan.so.0+0x605b8)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xe6388)
    #2 std::_MakeUniq<std::thread>::__single_object std::make_unique<std::thread, void (QUEUE_STATE::*)(), QUEUE_STATE*>(void (QUEUE_STATE::*&&)(), QUEUE_STATE*&&) /usr/include/c++/11/bits/unique_ptr.h:962 (libVkLayer_khronos_validation.so+0x20e5ec4)
    #3 QUEUE_STATE::Submit(CB_SUBMISSION&&, Location const&) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/state_tracker/queue_state.cpp:94 (libVkLayer_khronos_validation.so+0x20af1a3)
    #4 ValidationStateTracker::PreCallRecordQueueSubmit(VkQueue_T*, unsigned int, VkSubmitInfo const*, VkFence_T*, RecordObject const&) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/state_tracker/state_tracker.cpp:1134 (libVkLayer_khronos_validation.so+0x21c02cd)
    #5 vulkan_layer_chassis::QueueSubmit(VkQueue_T*, unsigned int, VkSubmitInfo const*, VkFence_T*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/vulkan/generated/chassis.cpp:1284 (libVkLayer_khronos_validation.so+0x107595b)
    #6 vkQueueSubmit <null> (libvulkan.so+0x594a6)
    #7 PositiveSyncObject_WaitEventThenSet_Test::TestBody() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/unit/sync_object_positive.cpp:1607 (vk_layer_validation_tests+0x123310a)
    #8 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2612 (vk_layer_validation_tests+0x1b45ff4)
    #9 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2648 (vk_layer_validation_tests+0x1b3c253)
    #10 testing::Test::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2687 (vk_layer_validation_tests+0x1b0d8df)
    #11 testing::TestInfo::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2836 (vk_layer_validation_tests+0x1b0e712)
    #12 testing::TestSuite::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:3015 (vk_layer_validation_tests+0x1b0f519)
    #13 testing::internal::UnitTestImpl::RunAllTests() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:5920 (vk_layer_validation_tests+0x1b21e77)
    #14 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2612 (vk_layer_validation_tests+0x1b4783b)
    #15 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:2648 (vk_layer_validation_tests+0x1b3dbb2)
    #16 testing::UnitTest::Run() /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/googletest/googletest/src/gtest.cc:5484 (vk_layer_validation_tests+0x1b1fd6b)
    #17 RUN_ALL_TESTS() <null> (vk_layer_validation_tests+0x3ebb43)
    #18 main /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/tests/framework/layer_validation_tests.cpp:1003 (vk_layer_validation_tests+0x3e1a26)

SUMMARY: ThreadSanitizer: lock-order-inversion (potential deadlock) /usr/include/c++/11/shared_mutex:80 in __glibcxx_rwlock_wrlock
```

</details>
