### PR TITLE
tests: Fix UnknownWriteComponentA8Unorm

### DIFF
--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -858,7 +858,7 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteComponentA8Unorm) {
        %main = OpFunction %void None %func
       %label = OpLabel
        %load = OpLoad %image %var
-               OpImageWrite %load %coord %texelU3 ZeroExtend
+               OpImageWrite %load %coord %texelU3
                OpReturn
                OpFunctionEnd
         )";


### PR DESCRIPTION
`NegativeShaderStorageImage.UnknownWriteComponentA8Unorm` was crashing in mesa because of an uncaught check in `spirv-val` (now added https://github.com/KhronosGroup/SPIRV-Tools/pull/5458)

You can't use `ZeroExtend` on a float image (`A8_UNORM`)