### PR TITLE
tests: Cleanup tests and help Thread Sanitizer

### DIFF
--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -336,8 +336,6 @@ TEST_F(PositiveQuery, QueryAndCopyMultipleCommandBuffers) {
     }
 
     vk::QueueWaitIdle(queue);
-
-    vk::FreeCommandBuffers(m_device->device(), command_pool.handle(), 2, command_buffer);
 }
 
 TEST_F(PositiveQuery, DestroyQueryPoolAfterGetQueryPoolResults) {

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1859,8 +1859,6 @@ TEST_F(PositiveSyncObject, ResetQueryPoolFromDifferentCBWithFenceAfter) {
     }
 
     vk::QueueWaitIdle(m_default_queue);
-
-    vk::FreeCommandBuffers(m_device->device(), m_commandPool->handle(), 2, command_buffer);
 }
 
 struct FenceSemRaceData {


### PR DESCRIPTION
The (not)hidden agenda behind this change is to simplify life for the Thread Sanitizer (TS). It can't recognize that queue mutex is private to each `QUEUE_STATE` object and produces false-positive.

If I'm wrong in any of the following considerations lets assume it's just a test cleanup (command pools owns command buffers and `FreeCommandBuffers` is optional).

TS reports possible deadlock due to inverted pair of locks:
(**Q**-mutex -> CmdBuf-mutex) and (CmdBuf->mutex -> **Q**-mutex)
but in our situation we can only have:
(**Q1**-mutex -> CmdBuf-mutex) and (CmdBuf->mutex -> **Q2**-mutex)
which can't lead to deadlock.

Also TS made the above analysis based only a single queue thread (the tests of interest run only single queue thread), which could not lead to a deadlock by definition.

The presense of `vk::FreeCommandBuffers` at the end of the test in rare cases (not sure why on CI it became more often) leads to a situation that command buffer is destroyed by the `Queue Thread` instead of by the `VkRenderFramework`. In the case of  `Queue Thread` command buffer destruction we have QueueLock->CmdBufLock that confuses TS. When we move CB destruction to `VkRenderFramework` then it guarantees that QueueLock is released and only CmdBufLock is active. This should make TS happy.

This changes the following tests.:
`PositiveSyncObject.ResetQueryPoolFromDifferentCBWithFenceAfter` (used mostly this test during investigation)
`PositiveQuery.QueryAndCopyMultipleCommandBuffers`
Other tests if reported by the TS should be considered separately.

Call stacks for the first and the second lock (enabled by `TSAN_OPTIONS=second_deadlock_stack=1`):
[err_ResetQueryPoolFromDifferentCBWithFenceAfter.txt](https://github.com/KhronosGroup/Vulkan-ValidationLayers/files/13208801/err_ResetQueryPoolFromDifferentCBWithFenceAfter.txt)
