### PR TITLE
Syncval: Perf:  Additional (up to 25%) performance gains for certain traces

### DIFF
--- a/layers/containers/subresource_adapter.h
+++ b/layers/containers/subresource_adapter.h
@@ -405,6 +405,7 @@ class ImageRangeEncoder : public RangeEncoder {
 
 class ImageRangeGenerator {
   public:
+    using RangeType = IndexRange;
     ImageRangeGenerator(const ImageRangeGenerator&) = default;
     ImageRangeGenerator() : encoder_(nullptr), subres_range_(), offset_(), extent_(), base_address_(), pos_() {}
     ImageRangeGenerator(const ImageRangeEncoder& encoder, const VkImageSubresourceRange& subres_range, const VkOffset3D& offset,

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -801,11 +801,23 @@ AccessContext::AccessContext(uint32_t subpass, VkQueueFlags queue_flags,
     }
 }
 
+template <typename NormalizeOp>
+void AccessContext::Trim(NormalizeOp &&normalize) {
+    ForAll(std::forward<NormalizeOp>(normalize));
+    sparse_container::consolidate(access_state_map_);
+}
+
 void AccessContext::Trim() {
     auto normalize = [](ResourceAccessRangeMap::value_type &access) { access.second.Normalize(); };
-    ForAll(normalize);
-    // Consolidate map after normalization, combines directly adjacent ranges with common values.
-    sparse_container::consolidate(access_state_map_);
+    Trim(normalize);
+}
+
+void AccessContext::TrimAndClearFirstAccess() {
+    auto normalize = [](ResourceAccessRangeMap::value_type &access) {
+        access.second.Normalize();
+        access.second.ClearFirstUse();
+    };
+    Trim(normalize);
 }
 
 void AccessContext::AddReferencedTags(ResourceUsageTagSet &used) const {
@@ -3917,17 +3929,7 @@ bool operator<(const ResourceAccessState::ReadState &lhs, const ResourceAccessSt
 }
 
 void ResourceAccessState::Normalize() {
-    if (!last_reads.size()) {
-        ClearRead();
-    } else {
-        // Sort the reads in stage order for consistent comparisons
-        std::sort(last_reads.begin(), last_reads.end());
-        for (auto &read_access : last_reads) {
-            read_access.Normalize();
-        }
-    }
-
-    ClearPending();
+    std::sort(last_reads.begin(), last_reads.end());
     ClearFirstUse();
 }
 
@@ -7404,7 +7406,7 @@ void SyncOpSetEvent::ReplayRecord(CommandExecutionContext &exec_context, Resourc
     // Note: merged_context is a copy of the access_context, combined with the recorded context
     auto merged_context = std::make_shared<AccessContext>(*access_context);
     merged_context->ResolveFromContext(QueueTagOffsetBarrierAction(queue_id, exec_tag), *recorded_context_);
-    merged_context->Trim();  // Ensure the copy is minimal and normalized
+    merged_context->TrimAndClearFirstAccess();  // Ensure the copy is minimal and normalized
     DoRecord(queue_id, exec_tag, merged_context, events_context);
 }
 
@@ -8117,7 +8119,7 @@ QueueBatchContext::QueueBatchContext(const SyncValidator &sync_state)
 
 void QueueBatchContext::Trim() {
     // Clean up unneeded access context contents and log information
-    access_context_.Trim();
+    access_context_.TrimAndClearFirstAccess();
 
     ResourceUsageTagSet used_tags;
     access_context_.AddReferencedTags(used_tags);

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1715,9 +1715,7 @@ struct ActionToOpsAdapter {
 template <typename Action, typename RangeGen>
 void UpdateMemoryAccessState(ResourceAccessRangeMap &accesses, const Action &action, RangeGen &range_gen) {
     ActionToOpsAdapter<Action> ops{action};
-    for (; range_gen->non_empty(); ++range_gen) {
-        infill_update_range(accesses, *range_gen, ops);
-    }
+    infill_update_rangegen(accesses, range_gen, ops);
 }
 
 template <typename Action>

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -419,6 +419,7 @@ static ResourceAccessRange MakeRange(const BufferBinding &binding, uint32_t firs
 template <typename KeyType>
 class SingleRangeGenerator {
   public:
+    using RangeType = KeyType;
     SingleRangeGenerator(const KeyType &range) : current_(range) {}
     const KeyType &operator*() const { return current_; }
     const KeyType *operator->() const { return &current_; }
@@ -857,34 +858,106 @@ void AccessContext::EraseIf(Predicate &&pred) {
     vvl::EraseIf(access_state_map_, pred);
 }
 
-template <typename Detector, typename RangeGen>
-HazardResult AccessContext::DetectHazard(Detector &detector, RangeGen &range_gen, DetectOptions options) const {
-    for (; range_gen->non_empty(); ++range_gen) {
-        HazardResult hazard = DetectHazard(detector, *range_gen, options);
-        if (hazard.IsHazard()) return hazard;
+template <typename Detector>
+HazardResult AccessContext::DetectHazardRange(Detector &detector, const ResourceAccessRange &range, DetectOptions options) const {
+    SingleRangeGenerator range_gen(range);
+    return DetectHazardGeneratedRanges(detector, range_gen, options);
+}
+
+// ForEachEntryInRangesUntil -- Execute Action for each map entry in the generated ranges until it returns true
+//
+// Action is const w.r.t. map
+// Action is allowed (assumed) to modify pos
+// Action must not advance pos for ranges strictly < pos->first
+// Action must handle range strictly less than pos->first correctly
+// Action must handle pos == end correctly
+// Action is assumed to only require invocation once per map entry
+// RangeGen must be strictly monotonic
+// Note: If Action invocations are heavyweight and inter-entry (gap) calls are not needed
+//       add a template or function parameter to skip them. TBD.
+template <typename RangeMap, typename RangeGen, typename Action>
+bool ForEachEntryInRangesUntil(const RangeMap &map, RangeGen &range_gen, Action &action) {
+    using RangeType = typename RangeGen::RangeType;
+    using IndexType = typename RangeType::index_type;
+    auto pos = map.lower_bound(*range_gen);
+    const auto end = map.end();
+    IndexType skip_limit = 0;
+    for (; range_gen->non_empty() && pos != end; ++range_gen) {
+        RangeType range = *range_gen;
+        // See if a prev pos has covered this range
+        if (range.end <= skip_limit) {
+            // Since the map is const, we needn't call action on the same pos again
+            continue;
+        }
+
+        //  If the current range was *partially* covered be a previous pos, trim, such that Action is only
+        //  called once for a given range (and pos)
+        if (range.begin < skip_limit) {
+            range.begin = skip_limit;
+        }
+
+        // Now advance pos as needed to match range
+        if (pos->first.strictly_less(range)) {
+            ++pos;
+            if (pos->first.strictly_less(range)) {
+                pos = map.lower_bound(range);
+                if (pos == end) break;
+            }
+        }
+        assert(pos == map.lower_bound(range));
+
+        // If the range intersects pos->first, consider Action performed for that map entry, and
+        // make sure not to call Action for this pos for any subsequent ranges
+        skip_limit = range.end > pos->first.begin ? pos->first.end : 0U;
+
+        // Action is allowed to alter pos but shouldn't do so if range is strictly < pos->first
+        if (action(range, end, pos)) return true;
     }
-    return HazardResult();
+
+    // Action needs to handle the "at end " condition (and can be useful for recursive actions)
+    for (; range_gen->non_empty(); ++range_gen) {
+        if (action(*range_gen, end, pos)) return true;
+    }
+
+    return false;
 }
 
 // A recursive range walker for hazard detection, first for the current context and the (DetectHazardRecur) to walk
 // the DAG of the contexts (for example subpasses)
-template <typename Detector>
-HazardResult AccessContext::DetectHazard(Detector &detector, const ResourceAccessRange &range, DetectOptions options) const {
+template <typename Detector, typename RangeGen>
+HazardResult AccessContext::DetectHazardGeneratedRanges(Detector &detector, RangeGen &range_gen, DetectOptions options) const {
     HazardResult hazard;
 
+    // Do this before range_gen is incremented s.t. the copies used will be correct
     if (static_cast<uint32_t>(options) & DetectOptions::kDetectAsync) {
         // Async checks don't require recursive lookups, as the async lists are exhaustive for the top-level context
         // so we'll check these first
         for (const auto &async_ref : async_) {
-            hazard = async_ref.Context().DetectAsyncHazard(detector, range, async_ref.StartTag());
+            hazard = async_ref.Context().DetectAsyncHazard(detector, range_gen, async_ref.StartTag());
             if (hazard.IsHazard()) return hazard;
         }
     }
 
     const bool detect_prev = (static_cast<uint32_t>(options) & DetectOptions::kDetectPrevious) != 0;
 
-    const auto the_end = access_state_map_.cend();  // End is not invalidated
-    auto pos = access_state_map_.lower_bound(range);
+    using RangeType = typename RangeGen::RangeType;
+    using ConstIterator = ResourceAccessRangeMap::const_iterator;
+    auto do_detect_hazard_range = [this, &detector, &hazard, detect_prev](const RangeType &range, const ConstIterator &end,
+                                                                          ConstIterator &pos) {
+        hazard = DetectHazardOneRange(detector, detect_prev, pos, end, range);
+        return hazard.IsHazard();
+    };
+
+    ForEachEntryInRangesUntil(access_state_map_, range_gen, do_detect_hazard_range);
+
+    return hazard;
+}
+
+template <typename Detector>
+HazardResult AccessContext::DetectHazardOneRange(Detector &detector, bool detect_prev, ResourceAccessRangeMap::const_iterator &pos,
+                                                 const ResourceAccessRangeMap::const_iterator &the_end,
+                                                 const ResourceAccessRange &range) const {
+    HazardResult hazard;
     ResourceAccessRange gap = {range.begin, range.begin};
 
     while (pos != the_end && pos->first.begin < range.end) {
@@ -919,18 +992,26 @@ HazardResult AccessContext::DetectHazard(Detector &detector, const ResourceAcces
 }
 
 // A non recursive range walker for the asynchronous contexts (those we have no barriers with)
-template <typename Detector>
-HazardResult AccessContext::DetectAsyncHazard(const Detector &detector, const ResourceAccessRange &range,
+template <typename Detector, typename RangeGen>
+HazardResult AccessContext::DetectAsyncHazard(const Detector &detector, const RangeGen &const_range_gen,
                                               ResourceUsageTag async_tag) const {
-    auto pos = access_state_map_.lower_bound(range);
-    const auto the_end = access_state_map_.end();
+    using RangeType = typename RangeGen::RangeType;
+    using ConstIterator = ResourceAccessRangeMap::const_iterator;
+    RangeGen range_gen(const_range_gen);
 
     HazardResult hazard;
-    while (pos != the_end && pos->first.begin < range.end) {
-        hazard = detector.DetectAsync(pos, async_tag);
-        if (hazard.IsHazard()) break;
-        ++pos;
-    }
+
+    auto do_async_hazard_check = [&detector, async_tag, &hazard](const RangeType &range, const ConstIterator &end,
+                                                                 ConstIterator &pos) {
+        while (pos != end && pos->first.begin < range.end) {
+            hazard = detector.DetectAsync(pos, async_tag);
+            if (hazard.IsHazard()) return true;
+            ++pos;
+        }
+        return false;
+    };
+
+    ForEachEntryInRangesUntil(access_state_map_, range_gen, do_async_hazard_check);
 
     return hazard;
 }
@@ -1365,7 +1446,7 @@ HazardResult AccessContext::DetectHazard(const BUFFER_STATE &buffer, SyncStageAc
     if (!SimpleBinding(buffer)) return HazardResult();
     const auto base_address = ResourceBaseAddress(buffer);
     HazardDetector detector(usage_index);
-    return DetectHazard(detector, (range + base_address), DetectOptions::kDetectAll);
+    return DetectHazardRange(detector, (range + base_address), DetectOptions::kDetectAll);
 }
 
 template <typename Detector>
@@ -1375,7 +1456,7 @@ HazardResult AccessContext::DetectHazard(Detector &detector, const AttachmentVie
     if (!attachment_gen) return HazardResult();
 
     subresource_adapter::ImageRangeGenerator range_gen(*attachment_gen);
-    return DetectHazard(detector, range_gen, options);
+    return DetectHazardGeneratedRanges(detector, range_gen, options);
 }
 
 template <typename Detector>
@@ -1384,7 +1465,7 @@ HazardResult AccessContext::DetectHazard(Detector &detector, const ImageState &i
                                          const VkExtent3D &extent, bool is_depth_sliced, DetectOptions options) const {
     // range_gen is non-temporary to avoid additional copy
     ImageRangeGen range_gen = image.MakeImageRangeGen(subresource_range, offset, extent, is_depth_sliced);
-    return DetectHazard(detector, range_gen, options);
+    return DetectHazardGeneratedRanges(detector, range_gen, options);
 }
 
 template <typename Detector>
@@ -1393,7 +1474,7 @@ HazardResult AccessContext::DetectHazard(Detector &detector, const ImageState &i
                                          DetectOptions options) const {
     // range_gen is non-temporary to avoid additional copy
     ImageRangeGen range_gen = image.MakeImageRangeGen(subresource_range, is_depth_sliced);
-    return DetectHazard(detector, range_gen, options);
+    return DetectHazardGeneratedRanges(detector, range_gen, options);
 }
 
 HazardResult AccessContext::DetectHazard(const ImageState &image, SyncStageAccessIndex current_usage,
@@ -1414,7 +1495,7 @@ HazardResult AccessContext::DetectHazard(const ImageState &image, SyncStageAcces
 HazardResult AccessContext::DetectHazard(const ImageViewState &image_view, SyncStageAccessIndex current_usage) const {
     // Get is const, but callee will copy
     HazardDetector detector(current_usage);
-    return DetectHazard(detector, image_view.GetFullViewImageRangeGen(), DetectOptions::kDetectAll);
+    return DetectHazardGeneratedRanges(detector, image_view.GetFullViewImageRangeGen(), DetectOptions::kDetectAll);
 }
 
 HazardResult AccessContext::DetectHazard(const ImageViewState &image_view, SyncStageAccessIndex current_usage,
@@ -1422,7 +1503,7 @@ HazardResult AccessContext::DetectHazard(const ImageViewState &image_view, SyncS
     // range_gen is non-temporary to avoid an additional copy
     ImageRangeGen range_gen(image_view.MakeImageRangeGen(offset, extent));
     HazardDetectorWithOrdering detector(current_usage, ordering_rule);
-    return DetectHazard(detector, range_gen, DetectOptions::kDetectAll);
+    return DetectHazardGeneratedRanges(detector, range_gen, DetectOptions::kDetectAll);
 }
 
 HazardResult AccessContext::DetectHazard(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type,
@@ -2520,7 +2601,7 @@ HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const Resourc
         // Cull any entries not in the current tag range
         if (!recorded_access.second.FirstAccessInTagRange(tag_range)) continue;
         HazardDetectFirstUse detector(recorded_access.second, queue_id, tag_range);
-        hazard = access_context.DetectHazard(detector, recorded_access.first, DetectOptions::kDetectAll);
+        hazard = access_context.DetectHazardRange(detector, recorded_access.first, DetectOptions::kDetectAll);
         if (hazard.IsHazard()) break;
     }
 
@@ -8398,7 +8479,8 @@ bool QueueBatchContext::DoQueuePresentValidate(const Location &loc, const Presen
         const PresentedImage &presented = presented_images[index];
 
         // Need a copy that can be used as the pseudo-iterator...
-        HazardResult hazard = access_context_.DetectHazard(detector, presented.range_gen, AccessContext::DetectOptions::kDetectAll);
+        HazardResult hazard =
+            access_context_.DetectHazardGeneratedRanges(detector, presented.range_gen, AccessContext::DetectOptions::kDetectAll);
         if (hazard.IsHazard()) {
             const auto queue_handle = queue_state_->Handle();
             const auto swap_handle = BASE_NODE::Handle(presented.swapchain_state.lock());

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -1145,12 +1145,14 @@ class AccessContext {
 
     using TrackBack = SubpassBarrierTrackback<AccessContext>;
 
+    template <typename Detector>
+    HazardResult DetectHazardRange(Detector &detector, const ResourceAccessRange &range, DetectOptions options) const;
     template <typename Detector, typename RangeGen>
-    HazardResult DetectHazard(Detector &detector, RangeGen &range_gen, DetectOptions options) const;
+    HazardResult DetectHazardGeneratedRanges(Detector &detector, RangeGen &range_gen, DetectOptions options) const;
     template <typename Detector, typename RangeGen>
-    HazardResult DetectHazard(Detector &detector, const RangeGen &range_gen, DetectOptions options) const {
+    HazardResult DetectHazardGeneratedRanges(Detector &detector, const RangeGen &range_gen, DetectOptions options) const {
         RangeGen mutable_gen(range_gen);
-        return DetectHazard<Detector, RangeGen>(detector, mutable_gen, options);
+        return DetectHazardGeneratedRanges<Detector, RangeGen>(detector, mutable_gen, options);
     }
 
     HazardResult DetectHazard(const BUFFER_STATE &buffer, SyncStageAccessIndex usage_index, const ResourceAccessRange &range) const;
@@ -1326,9 +1328,12 @@ class AccessContext {
 
   private:
     template <typename Detector>
-    HazardResult DetectHazard(Detector &detector, const ResourceAccessRange &range, DetectOptions options) const;
-    template <typename Detector>
-    HazardResult DetectAsyncHazard(const Detector &detector, const ResourceAccessRange &range, ResourceUsageTag async_tag) const;
+    HazardResult DetectHazardOneRange(Detector &detector, bool detect_prev, ResourceAccessRangeMap::const_iterator &pos,
+                                      const ResourceAccessRangeMap::const_iterator &the_end,
+                                      const ResourceAccessRange &range) const;
+
+    template <typename Detector, typename RangeGen>
+    HazardResult DetectAsyncHazard(const Detector &detector, const RangeGen &const_range_gen, ResourceUsageTag async_tag) const;
 
     template <typename NormalizeOp>
     void Trim(NormalizeOp &&normalize);

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -1270,6 +1270,7 @@ class AccessContext {
     AccessContext() { Reset(); }
     AccessContext(const AccessContext &copy_from) = default;
     void Trim();
+    void TrimAndClearFirstAccess();
     void AddReferencedTags(ResourceUsageTagSet &referenced) const;
 
     ResourceAccessRangeMap &GetAccessStateMap() { return access_state_map_; }
@@ -1328,6 +1329,10 @@ class AccessContext {
     HazardResult DetectHazard(Detector &detector, const ResourceAccessRange &range, DetectOptions options) const;
     template <typename Detector>
     HazardResult DetectAsyncHazard(const Detector &detector, const ResourceAccessRange &range, ResourceUsageTag async_tag) const;
+
+    template <typename NormalizeOp>
+    void Trim(NormalizeOp &&normalize);
+
     template <typename Detector>
     HazardResult DetectPreviousHazard(Detector &detector, const ResourceAccessRange &range) const;
 


### PR DESCRIPTION
Targeted optimizations that help some traces, but don't hurt any.

1)  Use range/iterator combined walk to avoid pre-range lower_bound calls
2)  DetectHazard with range_gen/iterator walk

Benefits traces where resource access state ranges well match range generated one
