### PR TITLE
tests: Add Positive Parent test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/other_positive.cpp
     unit/others.cpp
     unit/parent.cpp
+    unit/parent_positive.cpp
     unit/pipeline.cpp
     unit/pipeline_advanced_blend.cpp
     unit/pipeline_layout.cpp

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -589,6 +589,7 @@ class ParentTest : public VkLayerTest {
     vkt::Device *m_second_device = nullptr;
 };
 class NegativeParent : public ParentTest {};
+class PositiveParent : public ParentTest {};
 
 // Thread safety tests and other tests that implement non-trivial threading scenarios
 class ThreadingTest : public VkLayerTest {};

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 
 #include "utils/cast_utils.h"
 #include "generated/enum_flag_bits.h"
@@ -31,13 +41,6 @@ struct Surface {
     operator VkSurfaceKHR() const { return handle; }
 };
 }  // namespace
-
-ParentTest::~ParentTest() {
-    if (m_second_device) {
-        delete m_second_device;
-        m_second_device = nullptr;
-    }
-}
 
 TEST_F(NegativeParent, FillBuffer) {
     TEST_DESCRIPTION("Test VUID-*-commonparent checks not sharing the same Device");

--- a/tests/unit/parent_positive.cpp
+++ b/tests/unit/parent_positive.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+
+ParentTest::~ParentTest() {
+    if (m_second_device) {
+        delete m_second_device;
+        m_second_device = nullptr;
+    }
+}
+
+TEST_F(PositiveParent, ImagelessFramebuffer) {
+    TEST_DESCRIPTION("pAttachments is ignored even for common parent");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    RETURN_IF_SKIP(InitFramework())
+    VkPhysicalDeviceImagelessFramebufferFeatures imageless_framebuffer = vku::InitStructHelper();
+    GetPhysicalDeviceFeatures2(imageless_framebuffer);
+    RETURN_IF_SKIP(InitState(nullptr, &imageless_framebuffer));
+    InitRenderTarget();  // Renderpass created on first device
+    auto features = m_device->phy().features();
+    m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
+
+    VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
+    VkImageObj image(m_second_device);
+    auto image_ci =
+        VkImageObj::ImageCreateInfo2D(256, 256, 1, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
+    image.Init(image_ci);
+    VkImageView image_view = image.targetView(format);
+
+    VkFramebufferAttachmentImageInfo framebuffer_attachment_image_info = vku::InitStructHelper();
+    framebuffer_attachment_image_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    framebuffer_attachment_image_info.width = 256;
+    framebuffer_attachment_image_info.height = 256;
+    framebuffer_attachment_image_info.layerCount = 1;
+    framebuffer_attachment_image_info.viewFormatCount = 1;
+    framebuffer_attachment_image_info.pViewFormats = &format;
+
+    VkFramebufferAttachmentsCreateInfo framebuffer_attachments = vku::InitStructHelper();
+    framebuffer_attachments.attachmentImageInfoCount = 1;
+    framebuffer_attachments.pAttachmentImageInfos = &framebuffer_attachment_image_info;
+
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper(&framebuffer_attachments);
+    fb_info.renderPass = m_renderPass;
+    fb_info.attachmentCount = 1;
+    fb_info.pAttachments = &image_view;
+    fb_info.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
+    fb_info.width = m_width;
+    fb_info.height = m_height;
+    fb_info.layers = 1;
+
+    vkt::Framebuffer fb(*m_device, fb_info);
+}


### PR DESCRIPTION
Adds test making sure imageless framebuffer is ignored in generated Object Tracker