### PR TITLE
layers: Fix new VU for vkCmdExecuteCommands secondary

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -794,6 +794,11 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
         skip |= viewport_scissor_inheritance.VisitPrimary(cb_state);
     }
 
+    if (!cb_state.IsPrimary() && !enabled_features.nestedCommandBuffer) {
+        skip |= LogError("VUID-vkCmdExecuteCommands-commandBuffer-09375", commandBuffer,
+                         error_obj.location.dot(Field::commandBuffer), "is a secondary command buffer.");
+    }
+
     const QueryObject *active_occlusion_query = nullptr;
     for (const auto &active_query : cb_state.activeQueries) {
         auto query_pool_state = Get<QUERY_POOL_STATE>(active_query.pool);

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -921,7 +921,7 @@ TEST_F(NegativeCommand, ExecuteCommandsPrimaryCB) {
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeCommand, DISABLED_ExecuteCommandsToSecondaryCB) {
+TEST_F(NegativeCommand, ExecuteCommandsToSecondaryCB) {
     TEST_DESCRIPTION("Attempt vkCmdExecuteCommands to a Secondary command buffer");
 
     RETURN_IF_SKIP(Init())
@@ -932,7 +932,7 @@ TEST_F(NegativeCommand, DISABLED_ExecuteCommandsToSecondaryCB) {
     secondary_cb.end();
 
     main_cb.begin();
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdExecuteCommands-bufferlevel");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdExecuteCommands-commandBuffer-09375");
     vk::CmdExecuteCommands(main_cb.handle(), 1, &secondary_cb.handle());
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
adds `VUID-vkCmdExecuteCommands-commandBuffer-09375` (for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6702)

This was just an implicit VU that was converted to a explicit VU with a feature bit to disable it