### PR TITLE
layers: Add vkSetDeviceMemoryPriorityEXT support

### DIFF
--- a/layers/stateless/sl_device_memory.cpp
+++ b/layers/stateless/sl_device_memory.cpp
@@ -188,3 +188,13 @@ bool StatelessValidation::manual_PreCallValidateQueueBindSparse(VkQueue queue, u
 
     return skip;
 }
+
+bool StatelessValidation::manual_PreCallValidateSetDeviceMemoryPriorityEXT(VkDevice device, VkDeviceMemory memory, float priority,
+                                                                           const ErrorObject &error_obj) const {
+    bool skip = false;
+    if (!IsBetweenInclusive(priority, 0.0F, 1.0F)) {
+        skip |= LogError("VUID-vkSetDeviceMemoryPriorityEXT-priority-06258", device, error_obj.location.dot(Field::priority),
+                         "is %f.", priority);
+    }
+    return skip;
+}

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1069,6 +1069,9 @@ class StatelessValidation : public ValidationObject {
                                                               const VkBool32 *pExclusiveScissorEnables,
                                                               const ErrorObject &error_obj) const;
 
+    bool manual_PreCallValidateSetDeviceMemoryPriorityEXT(VkDevice device, VkDeviceMemory memory, float priority,
+                                                          const ErrorObject &error_obj) const;
+
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     bool manual_PreCallValidateGetPhysicalDeviceSurfacePresentModes2EXT(VkPhysicalDevice physicalDevice,
                                                                         const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo,

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -26174,6 +26174,7 @@ bool StatelessValidation::PreCallValidateSetDeviceMemoryPriorityEXT(VkDevice dev
     if (!IsExtEnabled(device_extensions.vk_ext_pageable_device_local_memory))
         skip |= OutputExtensionError(loc, "VK_EXT_pageable_device_local_memory");
     skip |= ValidateRequiredHandle(loc.dot(Field::memory), memory);
+    if (!skip) skip |= manual_PreCallValidateSetDeviceMemoryPriorityEXT(device, memory, priority, error_obj);
     return skip;
 }
 

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -180,6 +180,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'vkGetMemoryFdPropertiesKHR',
             'vkCreateShadersEXT',
             'vkGetShaderBinaryDataEXT',
+            'vkSetDeviceMemoryPriorityEXT',
             'vkQueueBindSparse'
             ]
 

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -2315,3 +2315,24 @@ TEST_F(NegativeMemory, MemoryPriorityOutOfRange) {
     vk::AllocateMemory(*m_device, &memory_ai, nullptr, &memory);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeMemory, SetDeviceMemoryPriority) {
+    AddRequiredExtensions(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Buffer buffer;
+    buffer.init_no_mem(*m_device, vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT));
+
+    vkt::DeviceMemory buffer_memory;
+    buffer_memory.init(*m_device, vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer.memory_requirements(), 0));
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkSetDeviceMemoryPriorityEXT-priority-06258");
+    vk::SetDeviceMemoryPriorityEXT(*m_device, buffer_memory.handle(), -0.01f);
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkSetDeviceMemoryPriorityEXT-priority-06258");
+    vk::SetDeviceMemoryPriorityEXT(*m_device, buffer_memory.handle(), 1.01f);
+    m_errorMonitor->VerifyFound();
+
+    vk::SetDeviceMemoryPriorityEXT(*m_device, buffer_memory.handle(), 1.0f);
+}


### PR DESCRIPTION
adds `VUID-vkSetDeviceMemoryPriorityEXT-priority-06258` (which seems to be the only VU for `VK_EXT_pageable_device_local_memory`)