### PR TITLE
layers: Invert parameters order in vvl::enumerate

### DIFF
--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -898,12 +898,10 @@ class enumeration {
 template <typename T, typename IndexType = size_t>
 class IndexedIterator {
   public:
-    IndexedIterator(T *data, IndexType index = 0) : data_(data), index_(index) {}
+    IndexedIterator(T *data, IndexType index = 0) : index_(index), data_(data) {}
 
-    IndexedIterator<T, IndexType> &operator*() { return *this /*IndexedIterator<T, IndexType>(data_ + index_, index_)*/; }
-    const IndexedIterator<T, IndexType> &operator*() const {
-        return *this /*IndexedIterator<T, IndexType>(data_ + index_, index_)*/;
-    }
+    IndexedIterator<T, IndexType> &operator*() { return *this; }
+    const IndexedIterator<T, IndexType> &operator*() const { return *this; }
 
     // prefix increment
     IndexedIterator<T, IndexType> &operator++() {
@@ -929,8 +927,8 @@ class IndexedIterator {
     bool operator!=(const IndexedIterator<T, IndexType> &rhs) const { return data_ != rhs.data_; }
 
   public:
-    T *data_;
     IndexType index_ = 0;
+    T *data_;
 };
 
 template <typename T>

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -203,7 +203,7 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(VkCommandBuffer c
         }
     }
 
-    for (auto [other_info, other_info_j] : vvl::enumerate(pInfos + info_i, infoCount - info_i)) {
+    for (auto [other_info_j, other_info] : vvl::enumerate(pInfos + info_i, infoCount - info_i)) {
         // Validate that scratch buffer's memory does not overlap destination acceleration structure's memory, or source
         // acceleration structure's memory if build mode is update, or other scratch buffers' memory.
         // Here validation is pessimistic: if one buffer associated to pInfos[other_info_j].scratchData.deviceAddress has an
@@ -596,7 +596,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
         return skip;
     }
 
-    for (const auto [info, info_i] : vvl::enumerate(pInfos, infoCount)) {
+    for (const auto [info_i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
 
         const auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(info->srcAccelerationStructure);

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -1139,7 +1139,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBuildAccelerationStructuresKH
     const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const ErrorObject &error_obj) const {
     bool skip = false;
     skip |= ValidateAccelerationStructureBuildGeometryInfoKHR(pInfos, infoCount, 0, error_obj.handle, error_obj.location);
-    for (const auto [info, info_i] : vvl::enumerate(pInfos, infoCount)) {
+    for (const auto [info_i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
         if (SafeModulo(info->scratchData.deviceAddress,
                        phys_dev_ext_props.acc_structure_props.minAccelerationStructureScratchOffsetAlignment) != 0) {
@@ -1151,7 +1151,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBuildAccelerationStructuresKH
         }
         skip |= ValidateRangedEnum(info_loc.dot(Field::mode), "VkBuildAccelerationStructureModeKHR", info->mode,
                                    "VUID-vkCmdBuildAccelerationStructuresKHR-mode-04628");
-        for (const auto [other_info, other_info_j] : vvl::enumerate(pInfos, infoCount)) {
+        for (const auto [other_info_j, other_info] : vvl::enumerate(pInfos, infoCount)) {
             if (info_i == other_info_j) continue;
             if (info->dstAccelerationStructure == other_info->dstAccelerationStructure) {
                 const LogObjectList objlist(commandBuffer, info->dstAccelerationStructure);

--- a/tests/vvl_utils/small_vector.cpp
+++ b/tests/vvl_utils/small_vector.cpp
@@ -419,7 +419,7 @@ TEST(CustomContainer, Enumerate) {
     small_vector<int, 2, size_t> sv = {1, 2, 3, 4};
     std::array ref_elements = {1, 2, 3, 4};
     size_t indices_i = 0;
-    for (auto [x, i] : vvl::enumerate(sv.data(), sv.size())) {
+    for (auto [i, x] : vvl::enumerate(sv.data(), sv.size())) {
         ASSERT_TRUE(i == indices_i);
         ASSERT_TRUE(*x == ref_elements[indices_i]);
         ++indices_i;


### PR DESCRIPTION
The structured binding now becomes [index, element_ptr]