### PR TITLE
layers: VK_KHR_pipeline_executable_properties Device parent

### DIFF
--- a/layers/vulkan/generated/object_tracker.cpp
+++ b/layers/vulkan/generated/object_tracker.cpp
@@ -3947,8 +3947,9 @@ bool ObjectLifetimes::PreCallValidateGetPipelineExecutablePropertiesKHR(VkDevice
     // Checked by chassis: device: "VUID-vkGetPipelineExecutablePropertiesKHR-device-parameter"
     if (pPipelineInfo) {
         [[maybe_unused]] const Location pPipelineInfo_loc = error_obj.location.dot(Field::pPipelineInfo);
-        skip |= ValidateObject(pPipelineInfo->pipeline, kVulkanObjectTypePipeline, false,
-                               "VUID-VkPipelineInfoKHR-pipeline-parameter", kVUIDUndefined, pPipelineInfo_loc.dot(Field::pipeline));
+        skip |=
+            ValidateObject(pPipelineInfo->pipeline, kVulkanObjectTypePipeline, false, "VUID-VkPipelineInfoKHR-pipeline-parameter",
+                           "VUID-vkGetPipelineExecutablePropertiesKHR-pipeline-03271", pPipelineInfo_loc.dot(Field::pipeline));
     }
 
     return skip;
@@ -3963,9 +3964,9 @@ bool ObjectLifetimes::PreCallValidateGetPipelineExecutableStatisticsKHR(VkDevice
     // Checked by chassis: device: "VUID-vkGetPipelineExecutableStatisticsKHR-device-parameter"
     if (pExecutableInfo) {
         [[maybe_unused]] const Location pExecutableInfo_loc = error_obj.location.dot(Field::pExecutableInfo);
-        skip |= ValidateObject(pExecutableInfo->pipeline, kVulkanObjectTypePipeline, false,
-                               "VUID-VkPipelineExecutableInfoKHR-pipeline-parameter", kVUIDUndefined,
-                               pExecutableInfo_loc.dot(Field::pipeline));
+        skip |= ValidateObject(
+            pExecutableInfo->pipeline, kVulkanObjectTypePipeline, false, "VUID-VkPipelineExecutableInfoKHR-pipeline-parameter",
+            "VUID-vkGetPipelineExecutableStatisticsKHR-pipeline-03273", pExecutableInfo_loc.dot(Field::pipeline));
     }
 
     return skip;
@@ -3978,9 +3979,9 @@ bool ObjectLifetimes::PreCallValidateGetPipelineExecutableInternalRepresentation
     // Checked by chassis: device: "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-device-parameter"
     if (pExecutableInfo) {
         [[maybe_unused]] const Location pExecutableInfo_loc = error_obj.location.dot(Field::pExecutableInfo);
-        skip |= ValidateObject(pExecutableInfo->pipeline, kVulkanObjectTypePipeline, false,
-                               "VUID-VkPipelineExecutableInfoKHR-pipeline-parameter", kVUIDUndefined,
-                               pExecutableInfo_loc.dot(Field::pipeline));
+        skip |= ValidateObject(
+            pExecutableInfo->pipeline, kVulkanObjectTypePipeline, false, "VUID-VkPipelineExecutableInfoKHR-pipeline-parameter",
+            "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipeline-03277", pExecutableInfo_loc.dot(Field::pipeline));
     }
 
     return skip;

--- a/scripts/generators/object_tracker_generator.py
+++ b/scripts/generators/object_tracker_generator.py
@@ -210,8 +210,6 @@ class ObjectTrackerOutputGenerator(BaseGenerator):
             'VkImportFenceFdInfoKHR',
             'VkFenceGetFdInfoKHR',
             'VkPhysicalDeviceSurfaceInfo2KHR',
-            'VkPipelineInfoKHR',
-            'VkPipelineExecutableInfoKHR',
             'VkMemoryMapInfoKHR',
             'VkMemoryUnmapInfoKHR',
             'VkVideoEncodeSessionParametersGetInfoKHR',
@@ -610,6 +608,13 @@ bool ObjectLifetimes::ReportUndestroyedDeviceObjects(VkDevice device, const Loca
             return "\"VUID-vkCreateImageView-image-09179\""
         if 'vkCmdBeginRenderPass' in commandName and member.name == 'pAttachments':
             return "\"VUID-VkRenderPassBeginInfo-framebuffer-02780\""
+        if 'vkGetPipelineExecutablePropertiesKHR' in commandName and member.name == 'pipeline':
+                return "\"VUID-vkGetPipelineExecutablePropertiesKHR-pipeline-03271\""
+        if 'VkPipelineExecutableInfoKHR' in structName and member.name == 'pipeline':
+            if commandName == 'vkGetPipelineExecutableStatisticsKHR':
+                return "\"VUID-vkGetPipelineExecutableStatisticsKHR-pipeline-03273\""
+            elif commandName == 'vkGetPipelineExecutableInternalRepresentationsKHR':
+                return "\"VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipeline-03277\""
 
         if singleParentVuid:
             return getVUID(self.valid_vuids, f'VUID-{structName}-{member.name}-parent')


### PR DESCRIPTION
(slightly) overdue revision of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/1855

adds 

- VUID-vkGetPipelineExecutableStatisticsKHR-pipeline-03273
- VUID-vkGetPipelineExecutablePropertiesKHR-pipeline-03271
- VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipeline-03277