### PR TITLE
layers: Fix shader module identifier check

### DIFF
--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -633,18 +633,18 @@ bool CoreChecks::ValidateShaderModuleId(const PIPELINE_STATE &pipeline, const Lo
                                  module_identifier->identifierSize, VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT,
                                  string_VkShaderStageFlagBits(stage_ci.stage));
                 }
+                if (stage_ci.module != VK_NULL_HANDLE) {
+                    skip |= LogError("VUID-VkPipelineShaderStageCreateInfo-stage-06848", device, loc,
+                                     "has a VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
+                                     "struct in the pNext chain, but module is not VK_NULL_HANDLE. (stage %s).",
+                                     string_VkShaderStageFlagBits(stage_ci.stage));
+                }
             }
             if (module_create_info) {
                 skip |= LogError("VUID-VkPipelineShaderStageCreateInfo-stage-06844", device, loc,
                                  "has both a "
                                  "VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
                                  "struct and a VkShaderModuleCreateInfo struct in the pNext chain. (stage %s).",
-                                 string_VkShaderStageFlagBits(stage_ci.stage));
-            }
-            if (stage_ci.module != VK_NULL_HANDLE) {
-                skip |= LogError("VUID-VkPipelineShaderStageCreateInfo-stage-06848", device, loc,
-                                 "has a VkPipelineShaderStageModuleIdentifierCreateInfoEXT "
-                                 "struct in the pNext chain, but module is not VK_NULL_HANDLE. (stage %s).",
                                  string_VkShaderStageFlagBits(stage_ci.stage));
             }
         } else {

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -1513,6 +1513,11 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
+    VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
+    vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
+    sm_id_create_info.identifierSize = get_identifier.identifierSize;
+    sm_id_create_info.pIdentifier = get_identifier.identifier;
+
     // shader module id ci and module not VK_NULL_HANDLE
     stage_ci.pNext = &sm_id_create_info;
     stage_ci.module = vs.handle();
@@ -1520,10 +1525,6 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
-    vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
-    sm_id_create_info.identifierSize = get_identifier.identifierSize;
-    sm_id_create_info.pIdentifier = get_identifier.identifier;
     stage_ci.module = VK_NULL_HANDLE;
     pipe.gp_ci_.flags = 0;
     // shader module id ci and no VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -1804,3 +1804,17 @@ TEST_F(PositivePipeline, InterpolateAtSample) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 }
+
+TEST_F(PositivePipeline, ShaderModuleIdentifierZeroLength) {
+    TEST_DESCRIPTION("Use shader module identifier with zero size and provide a shader module");
+
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT moduleIdentifier = vku::InitStructHelper();
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.shader_stages_[0].pNext = &moduleIdentifier;
+    pipe.CreateGraphicsPipeline();
+}


### PR DESCRIPTION
The spec says:

> If the shaderModuleIdentifier feature is enabled, applications can omit shader code for stage and instead provide a module identifier. This is done by including a VkPipelineShaderStageModuleIdentifierCreateInfoEXT struct with identifierSize not equal to 0 in the pNext chain

So this should only be validated if size is greater than 0