### PR TITLE
Fix possible null pointer dereference

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -390,7 +390,7 @@ bool CoreChecks::ValidateDrawDynamicState(const LAST_BOUND_STATE& last_bound_sta
                                      string_VkSampleCountFlagBits(rasterizationSamples), gridSize.height);
                 }
             }
-            if (frag_spirv_state->static_data_.uses_interpolate_at_sample) {
+            if (frag_spirv_state && frag_spirv_state->static_data_.uses_interpolate_at_sample) {
                 const LogObjectList objlist(cb_state.commandBuffer(), frag_spirv_state->handle());
                 skip |= LogError(vuid.sample_locations_enable_07487, objlist, loc,
                                  "sampleLocationsEnable set with vkCmdSetSampleLocationsEnableEXT() was VK_TRUE, but fragment "


### PR DESCRIPTION
Fixes crashes in:
dEQP-VK.pipeline.shader_object_unlinked_binary.multisample.sample_locations_ext.draw.color.samples_2.separate_renderpass_no_clear_same_pattern
dEQP-VK.pipeline.shader_object_unlinked_binary.multisample.sample_locations_ext.draw.color.samples_4.separate_renderpass_no_clear_same_pattern
dEQP-VK.pipeline.shader_object_unlinked_binary.multisample.sample_locations_ext.verify_location.samples_2
dEQP-VK.pipeline.shader_object_unlinked_binary.multisample.sample_locations_ext.verify_interpolation.samples_2