### PR TITLE
layers: Unconfuse thread sanitizer

### DIFF
--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -225,9 +225,13 @@ void QUEUE_STATE::ThreadFunc() {
         }
         // wake up anyone waiting for this submission to be retired
         {
-            auto guard = Lock();
-            submission->completed.set_value();
-            submissions_.pop_front();
+            std::promise<void> completed;
+            {
+                auto guard = Lock();
+                completed = std::move(submission->completed);
+                submissions_.pop_front();
+            }
+            completed.set_value();
         }
     }
 }


### PR DESCRIPTION
Gets rid of the code pass with two locked mutexes (queue and cmdbuf mutex) which causes false positive from TS (lock inversion). These mutexes can't cause deadlock due to lock inversion because queue mutex is per-thread state.