### PR TITLE
tests: Fix API dependent includes

### DIFF
--- a/tests/framework/external_memory_sync.cpp
+++ b/tests/framework/external_memory_sync.cpp
@@ -12,7 +12,7 @@
 #include "external_memory_sync.h"
 
 #include <vulkan/utility/vk_struct_helper.hpp>
-#include <vulkan/generated/enum_flag_bits.h>
+#include <generated/enum_flag_bits.h>
 
 #include "utils/vk_layer_utils.h"
 

--- a/tests/framework/external_memory_sync.h
+++ b/tests/framework/external_memory_sync.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <vulkan/generated/vk_function_pointers.h>
+#include <generated/vk_function_pointers.h>
 
 VkExternalMemoryHandleTypeFlags GetCompatibleHandleTypes(VkPhysicalDevice gpu, const VkBufferCreateInfo &buffer_create_info,
                                                          VkExternalMemoryHandleTypeFlagBits handle_type);


### PR DESCRIPTION
This change fixes hard-coded API-specific include paths replacing them with the expected way to refer to generated files, i.e. `<generated/...>`.