### PR TITLE
layers: Report when syncval reaches requested command

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -470,6 +470,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback([[maybe_unused]] VkDebugUt
                                                       [[maybe_unused]] VkDebugUtilsMessageTypeFlagsEXT message_type,
                                                       [[maybe_unused]] const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
                                                       [[maybe_unused]] void *user_data) {
+    // TODO: Consider to use https://github.com/scottt/debugbreak
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     DebugBreak();
 #else

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -337,6 +337,8 @@ class CommandBufferAccessContext : public CommandExecutionContext {
     bool ValidateClearAttachment(const Location &loc, const ClearAttachmentInfo &info) const;
     void RecordClearAttachment(ResourceUsageTag tag, const ClearAttachmentInfo &clear_info);
 
+    void CheckCommandTagDebugCheckpoint();
+
     // Note: since every CommandBufferAccessContext is encapsulated in its CommandBuffer object,
     // a reference count is not needed here.
     CMD_BUFFER_STATE *cb_state_;

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -535,6 +535,17 @@ void SyncValidator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
             std::make_shared<QueueSyncState>(queue_state, queue_flags, queue_id_limit_++);
         queue_sync_states_.emplace(std::make_pair(queue_state->VkHandle(), std::move(queue_sync_state)));
     });
+
+    const auto env_debug_command_number = GetEnvironment("VK_SYNCVAL_DEBUG_COMMAND_NUMBER");
+    if (!env_debug_command_number.empty()) {
+        debug_command_number = static_cast<uint32_t>(std::stoul(env_debug_command_number));
+    }
+    const auto env_debug_reset_count = GetEnvironment("VK_SYNCVAL_DEBUG_RESET_COUNT");
+    if (!env_debug_reset_count.empty()) {
+        debug_reset_count = static_cast<uint32_t>(std::stoul(env_debug_reset_count));
+    }
+    debug_cmdbuf_pattern = GetEnvironment("VK_SYNCVAL_DEBUG_CMDBUF_PATTERN");
+    vvl::ToLower(debug_cmdbuf_pattern);
 }
 
 bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -61,6 +61,10 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
     using SignaledFence = SignaledFences::value_type;
     SignaledFences waitable_fences_;
 
+    uint32_t debug_command_number = vvl::kU32Max;
+    uint32_t debug_reset_count = 1;
+    std::string debug_cmdbuf_pattern;
+
     void ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag);
     void ApplyAcquireWait(const AcquiredImage &acquired);
     template <typename BatchOp>


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6698

Allows to trigger a breakpoint when a command stream reaches the location identified by the `command number`/`reset count` from the syncval error message. 

The implementation is experimental and can be replaced by a better debugging mechanism in the future. It assumes deterministic application behavior which is often not the case, but still can be useful for simpler scenarios.

In order to trigger a breakpoint for specific `command number`/`reset count` (*prior access* location):
1. Specify command to track by setting environment variables:
`VK_SYNCVAL_DEBUG_COMMAND_NUMBER` (mandatory, can be extracted from existing error message),
`VK_SYNCVAL_DEBUG_RESET_COUNT` (optional, default value is 1, can be extracted from existing error message),
`VK_SYNCVAL_DEBUG_CMDBUF_PATTERN` (optional, default is an empty string). Allows to filter command buffers by substring matching command buffer debug name (`vkSetDebugUtilsObjectNameEXT`).
2. In Vulkan Configuration set debug action as **Break** and **Info** message level. Disable other message levels to minimize spam, since each message will trigger a breakpoint.
3. When SyncVal validation reaches the requested command it will report a message that will trigger a breakpoint.
4. One limitation that any informational message will trigger a breakpoint and such false-positives should be ignored.

<img src="https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/121836235/553d8f86-a632-4c14-864b-f75c150161c2" width=50% height=50%>
