### PR TITLE
layers: Add VkDeviceImageSubresourceInfoKHR

### DIFF
--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -581,6 +581,10 @@ class StatelessValidation : public ValidationObject {
                                                const VkAllocationCallbacks *pAllocator, VkImageView *pView,
                                                const ErrorObject &error_obj) const;
 
+    bool manual_PreCallValidateGetDeviceImageSubresourceLayoutKHR(VkDevice device, const VkDeviceImageSubresourceInfoKHR *pInfo,
+                                                                  VkSubresourceLayout2KHR *pLayout,
+                                                                  const ErrorObject &error_obj) const;
+
     bool ValidateViewport(const VkViewport &viewport, VkCommandBuffer object, const Location &loc) const;
 
     bool manual_PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -20390,6 +20390,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSubresourceLayoutKHR(VkDe
                                     "VUID-VkSubresourceLayout2KHR-pNext-pNext", "VUID-VkSubresourceLayout2KHR-sType-unique", false,
                                     false);
     }
+    if (!skip) skip |= manual_PreCallValidateGetDeviceImageSubresourceLayoutKHR(device, pInfo, pLayout, error_obj);
     return skip;
 }
 

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -181,6 +181,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'vkCreateShadersEXT',
             'vkGetShaderBinaryDataEXT',
             'vkSetDeviceMemoryPriorityEXT',
+            'vkGetDeviceImageSubresourceLayoutKHR',
             'vkQueueBindSparse'
             ]
 

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -2603,6 +2603,75 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
     }
 }
 
+TEST_F(NegativeImage, DeviceImageSubresourceInfoKHR) {
+    TEST_DESCRIPTION("Test VkDeviceImageSubresourceInfoKHR which just like vkGetImageSubresourceLayout");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitFramework())
+    VkPhysicalDeviceMaintenance5FeaturesKHR maintenance5_features = vku::InitStructHelper();
+    GetPhysicalDeviceFeatures2(maintenance5_features);
+    RETURN_IF_SKIP(InitState(nullptr, &maintenance5_features));
+
+    VkImageSubresource2KHR subresource = vku::InitStructHelper();
+    VkImageCreateInfo image_ci = DefaultImageInfo();
+    VkDeviceImageSubresourceInfoKHR image_sub_info = vku::InitStructHelper();
+    image_sub_info.pCreateInfo = &image_ci;
+    image_sub_info.pSubresource = &subresource;
+
+    VkSubresourceLayout2KHR out_layout = vku::InitStructHelper();
+
+    {
+        subresource.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_METADATA_BIT;
+
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageSubresourceInfoKHR-aspectMask-00997");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageSubresourceInfoKHR-format-08886");
+        vk::GetDeviceImageSubresourceLayoutKHR(device(), &image_sub_info, &out_layout);
+        m_errorMonitor->VerifyFound();
+    }
+
+    {
+        subresource.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        subresource.imageSubresource.mipLevel = 1;
+        subresource.imageSubresource.arrayLayer = 0;
+
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageSubresourceInfoKHR-mipLevel-01716");
+        vk::GetDeviceImageSubresourceLayoutKHR(device(), &image_sub_info, &out_layout);
+        m_errorMonitor->VerifyFound();
+    }
+
+    {
+        subresource.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        subresource.imageSubresource.mipLevel = 0;
+        subresource.imageSubresource.arrayLayer = 1;
+
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageSubresourceInfoKHR-arrayLayer-01717");
+        vk::GetDeviceImageSubresourceLayoutKHR(device(), &image_sub_info, &out_layout);
+        m_errorMonitor->VerifyFound();
+    }
+
+    {
+        subresource.imageSubresource.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+        subresource.imageSubresource.mipLevel = 0;
+        subresource.imageSubresource.arrayLayer = 0;
+
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageSubresourceInfoKHR-format-08886");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageSubresourceInfoKHR-format-04464");
+        vk::GetDeviceImageSubresourceLayoutKHR(device(), &image_sub_info, &out_layout);
+        m_errorMonitor->VerifyFound();
+    }
+
+    {
+        subresource.imageSubresource.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
+        subresource.imageSubresource.mipLevel = 0;
+        subresource.imageSubresource.arrayLayer = 0;
+
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageSubresourceInfoKHR-format-08886");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceImageSubresourceInfoKHR-format-04464");
+        vk::GetDeviceImageSubresourceLayoutKHR(device(), &image_sub_info, &out_layout);
+        m_errorMonitor->VerifyFound();
+    }
+}
+
 TEST_F(NegativeImage, UndefinedFormat) {
     TEST_DESCRIPTION("Create image with undefined format");
 


### PR DESCRIPTION
I have https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6264 which will fix the VUs as they were referring to a "created image" but this struct was designed to query prior to the image creation