### PR TITLE
layers: Have single way to get SpecConstant values

### DIFF
--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -803,7 +803,6 @@ SPIRV_MODULE_STATE::StaticData::StaticData(const SPIRV_MODULE_STATE& module_stat
                 if (insn.Word(2) == spv::DecorationBuiltIn) {
                     builtin_decoration_inst.push_back(&insn);
                 } else if (insn.Word(2) == spv::DecorationSpecId) {
-                    spec_const_map[insn.Word(3)] = target_id;
                     id_to_spec_id[target_id] = insn.Word(3);
                 }
             } break;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -472,10 +472,7 @@ struct SPIRV_MODULE_STATE {
         vvl::unordered_map<uint32_t, ExecutionModeSet> execution_modes;
         ExecutionModeSet empty_execution_mode;  // all zero values, allows use to return a reference and not a copy each time
 
-        // <Specialization constant ID -> target ID> mapping
-        vvl::unordered_map<uint32_t, uint32_t> spec_const_map;
-        // <target ID - > Specialization constant ID> mapping
-        // TODO - Remove having a second copy for the map in reverse
+        // [OpSpecConstant Result ID -> OpDecorate SpecID value] mapping
         vvl::unordered_map<uint32_t, uint32_t> id_to_spec_id;
         // Find all decoration instructions to prevent relooping module later - many checks need this info
         std::vector<const Instruction *> decoration_inst;

--- a/layers/utils/shader_utils.h
+++ b/layers/utils/shader_utils.h
@@ -99,6 +99,7 @@ struct SPIRV_MODULE_STATE;
 struct safe_VkPipelineShaderStageCreateInfo;
 struct safe_VkShaderCreateInfoEXT;
 struct safe_VkSpecializationInfo;
+class Instruction;
 
 struct PipelineStageState {
     // We use this over a SPIRV_MODULE_STATE because there are times we need to create empty objects
@@ -118,6 +119,7 @@ struct PipelineStageState {
     VkShaderStageFlagBits GetStage() const;
     safe_VkSpecializationInfo *GetSpecializationInfo() const;
     const void *GetPNext() const;
+    bool GetInt32ConstantValue(const Instruction &insn, uint32_t *value) const;
 };
 
 using StageStateVec = std::vector<PipelineStageState>;


### PR DESCRIPTION
- Move SpecConstant look up into a `PipelineStageState` helper function
- Only track a single set of SpecConstant mappings
- Adds more tests (most are just getting ready for a proper fix for #5911 )