### PR TITLE
tests: Draft for redundant core and extension dependencies

### DIFF
--- a/layers/vulkan/generated/vk_function_pointers.cpp
+++ b/layers/vulkan/generated/vk_function_pointers.cpp
@@ -1035,6 +1035,201 @@ void InitCore(const char *api_name) {
     GetDeviceImageMemoryRequirements = reinterpret_cast<PFN_vkGetDeviceImageMemoryRequirements>(get_proc_address(lib_handle, "vkGetDeviceImageMemoryRequirements"));
     GetDeviceImageSparseMemoryRequirements = reinterpret_cast<PFN_vkGetDeviceImageSparseMemoryRequirements>(get_proc_address(lib_handle, "vkGetDeviceImageSparseMemoryRequirements"));
 }
+void InitExtensionFromCore(const char* extension_name) {
+    static const vvl::unordered_map<std::string, std::function<void()>> initializers = {
+        {
+            "VK_KHR_dynamic_rendering", []() {
+                CmdBeginRenderingKHR = CmdBeginRendering;
+                CmdEndRenderingKHR = CmdEndRendering;
+            }
+        },
+        {
+            "VK_KHR_get_physical_device_properties2", []() {
+                GetPhysicalDeviceFeatures2KHR = GetPhysicalDeviceFeatures2;
+                GetPhysicalDeviceProperties2KHR = GetPhysicalDeviceProperties2;
+                GetPhysicalDeviceFormatProperties2KHR = GetPhysicalDeviceFormatProperties2;
+                GetPhysicalDeviceImageFormatProperties2KHR = GetPhysicalDeviceImageFormatProperties2;
+                GetPhysicalDeviceQueueFamilyProperties2KHR = GetPhysicalDeviceQueueFamilyProperties2;
+                GetPhysicalDeviceMemoryProperties2KHR = GetPhysicalDeviceMemoryProperties2;
+                GetPhysicalDeviceSparseImageFormatProperties2KHR = GetPhysicalDeviceSparseImageFormatProperties2;
+            }
+        },
+        {
+            "VK_KHR_device_group", []() {
+                GetDeviceGroupPeerMemoryFeaturesKHR = GetDeviceGroupPeerMemoryFeatures;
+                CmdSetDeviceMaskKHR = CmdSetDeviceMask;
+                CmdDispatchBaseKHR = CmdDispatchBase;
+            }
+        },
+        {
+            "VK_KHR_maintenance1", []() {
+                TrimCommandPoolKHR = TrimCommandPool;
+            }
+        },
+        {
+            "VK_KHR_device_group_creation", []() {
+                EnumeratePhysicalDeviceGroupsKHR = EnumeratePhysicalDeviceGroups;
+            }
+        },
+        {
+            "VK_KHR_external_memory_capabilities", []() {
+                GetPhysicalDeviceExternalBufferPropertiesKHR = GetPhysicalDeviceExternalBufferProperties;
+            }
+        },
+        {
+            "VK_KHR_external_semaphore_capabilities", []() {
+                GetPhysicalDeviceExternalSemaphorePropertiesKHR = GetPhysicalDeviceExternalSemaphoreProperties;
+            }
+        },
+        {
+            "VK_KHR_descriptor_update_template", []() {
+                CreateDescriptorUpdateTemplateKHR = CreateDescriptorUpdateTemplate;
+                DestroyDescriptorUpdateTemplateKHR = DestroyDescriptorUpdateTemplate;
+                UpdateDescriptorSetWithTemplateKHR = UpdateDescriptorSetWithTemplate;
+            }
+        },
+        {
+            "VK_KHR_create_renderpass2", []() {
+                CreateRenderPass2KHR = CreateRenderPass2;
+                CmdBeginRenderPass2KHR = CmdBeginRenderPass2;
+                CmdNextSubpass2KHR = CmdNextSubpass2;
+                CmdEndRenderPass2KHR = CmdEndRenderPass2;
+            }
+        },
+        {
+            "VK_KHR_external_fence_capabilities", []() {
+                GetPhysicalDeviceExternalFencePropertiesKHR = GetPhysicalDeviceExternalFenceProperties;
+            }
+        },
+        {
+            "VK_KHR_get_memory_requirements2", []() {
+                GetImageMemoryRequirements2KHR = GetImageMemoryRequirements2;
+                GetBufferMemoryRequirements2KHR = GetBufferMemoryRequirements2;
+                GetImageSparseMemoryRequirements2KHR = GetImageSparseMemoryRequirements2;
+            }
+        },
+        {
+            "VK_KHR_sampler_ycbcr_conversion", []() {
+                CreateSamplerYcbcrConversionKHR = CreateSamplerYcbcrConversion;
+                DestroySamplerYcbcrConversionKHR = DestroySamplerYcbcrConversion;
+            }
+        },
+        {
+            "VK_KHR_bind_memory2", []() {
+                BindBufferMemory2KHR = BindBufferMemory2;
+                BindImageMemory2KHR = BindImageMemory2;
+            }
+        },
+        {
+            "VK_KHR_maintenance3", []() {
+                GetDescriptorSetLayoutSupportKHR = GetDescriptorSetLayoutSupport;
+            }
+        },
+        {
+            "VK_KHR_draw_indirect_count", []() {
+                CmdDrawIndirectCountKHR = CmdDrawIndirectCount;
+                CmdDrawIndexedIndirectCountKHR = CmdDrawIndexedIndirectCount;
+            }
+        },
+        {
+            "VK_KHR_timeline_semaphore", []() {
+                GetSemaphoreCounterValueKHR = GetSemaphoreCounterValue;
+                WaitSemaphoresKHR = WaitSemaphores;
+                SignalSemaphoreKHR = SignalSemaphore;
+            }
+        },
+        {
+            "VK_KHR_buffer_device_address", []() {
+                GetBufferDeviceAddressKHR = GetBufferDeviceAddress;
+                GetBufferOpaqueCaptureAddressKHR = GetBufferOpaqueCaptureAddress;
+                GetDeviceMemoryOpaqueCaptureAddressKHR = GetDeviceMemoryOpaqueCaptureAddress;
+            }
+        },
+        {
+            "VK_KHR_synchronization2", []() {
+                CmdSetEvent2KHR = CmdSetEvent2;
+                CmdResetEvent2KHR = CmdResetEvent2;
+                CmdWaitEvents2KHR = CmdWaitEvents2;
+                CmdPipelineBarrier2KHR = CmdPipelineBarrier2;
+                CmdWriteTimestamp2KHR = CmdWriteTimestamp2;
+                QueueSubmit2KHR = QueueSubmit2;
+            }
+        },
+        {
+            "VK_KHR_copy_commands2", []() {
+                CmdCopyBuffer2KHR = CmdCopyBuffer2;
+                CmdCopyImage2KHR = CmdCopyImage2;
+                CmdCopyBufferToImage2KHR = CmdCopyBufferToImage2;
+                CmdCopyImageToBuffer2KHR = CmdCopyImageToBuffer2;
+                CmdBlitImage2KHR = CmdBlitImage2;
+                CmdResolveImage2KHR = CmdResolveImage2;
+            }
+        },
+        {
+            "VK_KHR_maintenance4", []() {
+                GetDeviceBufferMemoryRequirementsKHR = GetDeviceBufferMemoryRequirements;
+                GetDeviceImageMemoryRequirementsKHR = GetDeviceImageMemoryRequirements;
+                GetDeviceImageSparseMemoryRequirementsKHR = GetDeviceImageSparseMemoryRequirements;
+            }
+        },
+        {
+            "VK_EXT_debug_marker", []() {
+            }
+        },
+        {
+            "VK_AMD_draw_indirect_count", []() {
+                CmdDrawIndirectCountAMD = CmdDrawIndirectCount;
+                CmdDrawIndexedIndirectCountAMD = CmdDrawIndexedIndirectCount;
+            }
+        },
+        {
+            "VK_EXT_tooling_info", []() {
+                GetPhysicalDeviceToolPropertiesEXT = GetPhysicalDeviceToolProperties;
+            }
+        },
+        {
+            "VK_EXT_host_query_reset", []() {
+                ResetQueryPoolEXT = ResetQueryPool;
+            }
+        },
+        {
+            "VK_EXT_extended_dynamic_state", []() {
+                CmdSetCullModeEXT = CmdSetCullMode;
+                CmdSetFrontFaceEXT = CmdSetFrontFace;
+                CmdSetPrimitiveTopologyEXT = CmdSetPrimitiveTopology;
+                CmdSetViewportWithCountEXT = CmdSetViewportWithCount;
+                CmdSetScissorWithCountEXT = CmdSetScissorWithCount;
+                CmdBindVertexBuffers2EXT = CmdBindVertexBuffers2;
+                CmdSetDepthTestEnableEXT = CmdSetDepthTestEnable;
+                CmdSetDepthWriteEnableEXT = CmdSetDepthWriteEnable;
+                CmdSetDepthCompareOpEXT = CmdSetDepthCompareOp;
+                CmdSetDepthBoundsTestEnableEXT = CmdSetDepthBoundsTestEnable;
+                CmdSetStencilTestEnableEXT = CmdSetStencilTestEnable;
+                CmdSetStencilOpEXT = CmdSetStencilOp;
+            }
+        },
+        {
+            "VK_EXT_private_data", []() {
+                CreatePrivateDataSlotEXT = CreatePrivateDataSlot;
+                DestroyPrivateDataSlotEXT = DestroyPrivateDataSlot;
+                SetPrivateDataEXT = SetPrivateData;
+                GetPrivateDataEXT = GetPrivateData;
+            }
+        },
+        {
+            "VK_EXT_extended_dynamic_state2", []() {
+                CmdSetRasterizerDiscardEnableEXT = CmdSetRasterizerDiscardEnable;
+                CmdSetDepthBiasEnableEXT = CmdSetDepthBiasEnable;
+                CmdSetPrimitiveRestartEnableEXT = CmdSetPrimitiveRestartEnable;
+            }
+        },
+
+    };
+
+    if (auto it = initializers.find(extension_name); it != initializers.end())
+        (it->second)();
+}
+
 void InitInstanceExtension(VkInstance instance, const char* extension_name) {
     assert(instance);
     static const vvl::unordered_map<std::string, std::function<void(VkInstance)>> initializers = {

--- a/layers/vulkan/generated/vk_function_pointers.h
+++ b/layers/vulkan/generated/vk_function_pointers.h
@@ -762,6 +762,7 @@ extern PFN_vkCmdDrawMeshTasksIndirectEXT CmdDrawMeshTasksIndirectEXT;
 extern PFN_vkCmdDrawMeshTasksIndirectCountEXT CmdDrawMeshTasksIndirectCountEXT;
 
 void InitCore(const char *api_name);
+void InitExtensionFromCore(const char* extension_name);
 void InitInstanceExtension(VkInstance instance, const char* extension_name);
 void InitDeviceExtension(VkInstance instance, VkDevice device, const char* extension_name);
 void ResetAllExtensions();

--- a/scripts/generators/extension_helper_generator.py
+++ b/scripts/generators/extension_helper_generator.py
@@ -67,44 +67,29 @@ def exprToCpp(pr: ParseResults, opt = lambda x: x) -> str:
     dependCheck(pr, printExt, printOp, openParen, closeParen)
     return ''.join(r)
 
-# This class is a container for any source code, data, or other behavior that is necessary to
-# customize the generator script for a specific target API variant (e.g. Vulkan SC). As such,
-# all of these API-specific interfaces and their use in the generator script are part of the
-# contract between this repository and its downstream users. Changing or removing any of these
-# interfaces or their use in the generator script will have downstream effects and thus
-# should be avoided unless absolutely necessary.
-class APISpecific:
-    # Returns dictionary of version field names
-    @staticmethod
-    def getVersionFieldNameDict(targetApiName: str) -> dict[str, str]:
-        match targetApiName:
-
-            # Vulkan specific version field names
-            case 'vulkan':
-                return {
-                    'VK_VERSION_1_1': 'vk_feature_version_1_1',
-                    'VK_VERSION_1_2': 'vk_feature_version_1_2',
-                    'VK_VERSION_1_3': 'vk_feature_version_1_3'
-                }
-
-
-    # Returns dictionary of promoted extension array variable names
-    @staticmethod
-    def getPromotedExtensionArrayName(targetApiName: str, scope: str) -> dict[str, str]:
-        match targetApiName:
-
-            # Vulkan specific promoted extension array variable names
-            case 'vulkan':
-                return {
-                    'VK_VERSION_1_1': f'V_1_1_promoted_{scope}_apis',
-                    'VK_VERSION_1_2': f'V_1_2_promoted_{scope}_apis',
-                    'VK_VERSION_1_3': f'V_1_3_promoted_{scope}_apis'
-                }
-
 
 class ExtensionHelperOutputGenerator(BaseGenerator):
     def __init__(self):
         BaseGenerator.__init__(self)
+
+    def generatePromotedExtensionMap(self, out: list[str], type: str):
+        out.append('''
+            static const PromotedExtensionInfoMap &get_promotion_info_map() {
+                static const PromotedExtensionInfoMap promoted_map = {
+            ''')
+
+        for version in self.vk.versions.keys():
+            promoted_ext_list = [x for x in self.vk.extensions.values() if x.promotedTo == version and getattr(x, type)]
+            if len(promoted_ext_list) > 0:
+                out.append(f'{{{version.replace("VERSION", "API_VERSION")},{{"{version}",{{')
+                out.extend(['    %s,\n' % ext.nameString for ext in promoted_ext_list])
+                out.append('}}},\n')
+
+        out.append('''
+                };
+                return promoted_map;
+            }
+            ''')
 
     def generate(self):
         # [ Feature name | name in struct InstanceExtensions ]
@@ -121,8 +106,8 @@ class ExtensionHelperOutputGenerator(BaseGenerator):
                 for reqs in exprValues(parseExpr(temp)):
                     feature = self.vk.extensions[reqs] if reqs in self.vk.extensions else self.vk.versions[reqs]
                     requiredExpression[extension.name].append(feature)
-        for version, field in APISpecific.getVersionFieldNameDict(self.targetApiName).items():
-            fieldName[version] = field
+        for version in self.vk.versions.keys():
+            fieldName[version] = version.lower().replace('version', 'feature_version')
 
         out = []
         out.append(f'''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
@@ -170,6 +155,11 @@ class ExtensionHelperOutputGenerator(BaseGenerator):
                 kEnabledByInteraction,
             };
 
+            // Map of promoted extension information per version (a separate map exists for instance and device extensions).
+            // The map is keyed by the version number (e.g. VK_API_VERSION_1_1) and each value is a pair consisting of the
+            // version string (e.g. "VK_VERSION_1_1") and the set of name of the promoted extensions.
+            typedef vvl::unordered_map<uint32_t, std::pair<const char*, vvl::unordered_set<std::string>>> PromotedExtensionInfoMap;
+
             /*
             This function is a helper to know if the extension is enabled.
 
@@ -197,10 +187,12 @@ class ExtensionHelperOutputGenerator(BaseGenerator):
             ''')
 
         out.append('\nstruct InstanceExtensions {\n')
-        for name in APISpecific.getVersionFieldNameDict(self.targetApiName).values():
-            out.append(f'    ExtEnabled {name}{{kNotEnabled}};\n')
+        for version in self.vk.versions.keys():
+            out.append(f'    ExtEnabled {fieldName[version]}{{kNotEnabled}};\n')
 
         out.extend([f'    ExtEnabled {ext.name.lower()}{{kNotEnabled}};\n' for ext in self.vk.extensions.values() if ext.instance])
+
+        self.generatePromotedExtensionMap(out, 'instance')
 
         out.append('''
             struct InstanceReq {
@@ -219,8 +211,8 @@ class ExtensionHelperOutputGenerator(BaseGenerator):
             static const InstanceInfoMap &get_info_map() {
                 static const InstanceInfoMap info_map = {
             ''')
-        for version, name in APISpecific.getVersionFieldNameDict(self.targetApiName).items():
-            out.append(f'{{"{version}", InstanceInfo(&InstanceExtensions::{name}, {{}})}},\n')
+        for version in self.vk.versions.keys():
+            out.append(f'{{"{version}", InstanceInfo(&InstanceExtensions::{fieldName[version]}, {{}})}},\n')
 
         for extension in [x for x in self.vk.extensions.values() if x.instance]:
             out.extend(guard_helper.add_guard(extension.protect))
@@ -249,39 +241,32 @@ class ExtensionHelperOutputGenerator(BaseGenerator):
             }
 
             APIVersion InitFromInstanceCreateInfo(APIVersion requested_api_version, const VkInstanceCreateInfo *pCreateInfo) {
-            ''')
-        promoted_var_names = APISpecific.getPromotedExtensionArrayName(self.targetApiName, 'instance')
-        for version_name, promoted_var_name in promoted_var_names.items():
-            promoted_ext_list = [x for x in self.vk.extensions.values() if x.promotedTo == version_name and x.instance]
-            out.append(f'constexpr std::array<const char*, {len(promoted_ext_list)}> {promoted_var_name} = {{\n')
-            out.extend(['    %s,\n' % ext.nameString for ext in promoted_ext_list])
-            out.append('};\n')
+                // Initialize struct data, robust to invalid pCreateInfo
+                auto api_version = NormalizeApiVersion(requested_api_version);
+                if (!api_version.Valid()) return api_version;
 
-        out.append('''
-            // Initialize struct data, robust to invalid pCreateInfo
-            auto api_version = NormalizeApiVersion(requested_api_version);''')
-        for version_name, promoted_var_name in promoted_var_names.items():
-            out.append(f'''
-                if (api_version >= {version_name.replace('_VERSION_', '_API_VERSION_')}) {{
-                    auto info = get_info("{version_name}");
-                    if (info.state) this->*(info.state) = kEnabledByCreateinfo;
-                    for (auto promoted_ext : {promoted_var_name}) {{
-                        info = get_info(promoted_ext);
-                        assert(info.state);
-                        if (info.state) this->*(info.state) = kEnabledByApiLevel;
-                    }}
-                }}''')
-
-        out.append('''
-            // CreateInfo takes precedence over promoted
-            if (pCreateInfo && pCreateInfo->ppEnabledExtensionNames) {
-                for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
-                    if (!pCreateInfo->ppEnabledExtensionNames[i]) continue;
-                    auto info = get_info(pCreateInfo->ppEnabledExtensionNames[i]);
-                    if (info.state) this->*(info.state) = kEnabledByCreateinfo;
+                const auto promotion_info_map = get_promotion_info_map();
+                for (const auto& version_it : promotion_info_map) {
+                    auto info = get_info(version_it.second.first);
+                    if (api_version >= version_it.first) {
+                        if (info.state) this->*(info.state) = kEnabledByCreateinfo;
+                        for (const auto& ext_name : version_it.second.second) {
+                            info = get_info(ext_name.c_str());
+                            assert(info.state);
+                            if (info.state) this->*(info.state) = kEnabledByApiLevel;
+                        }
+                    }
                 }
-            }
-            return api_version;
+
+                // CreateInfo takes precedence over promoted
+                if (pCreateInfo && pCreateInfo->ppEnabledExtensionNames) {
+                    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
+                        if (!pCreateInfo->ppEnabledExtensionNames[i]) continue;
+                        auto info = get_info(pCreateInfo->ppEnabledExtensionNames[i]);
+                        if (info.state) this->*(info.state) = kEnabledByCreateinfo;
+                    }
+                }
+                return api_version;
             }
             };
             ''')
@@ -294,9 +279,12 @@ class ExtensionHelperOutputGenerator(BaseGenerator):
         out.append('};\n')
 
         out.append('\nstruct DeviceExtensions : public InstanceExtensions {\n')
-        out.extend([f'    ExtEnabled {feature_field}{{kNotEnabled}};\n' for feature_field in APISpecific.getVersionFieldNameDict(self.targetApiName).values()])
+        for version in self.vk.versions.keys():
+            out.append(f'    ExtEnabled {fieldName[version]}{{kNotEnabled}};\n')
 
         out.extend([f'    ExtEnabled {ext.name.lower()}{{kNotEnabled}};\n' for ext in self.vk.extensions.values() if ext.device])
+
+        self.generatePromotedExtensionMap(out, 'device')
 
         out.append('''
             struct DeviceReq {
@@ -315,8 +303,8 @@ class ExtensionHelperOutputGenerator(BaseGenerator):
             static const DeviceInfoMap &get_info_map() {
                 static const DeviceInfoMap info_map = {
             ''')
-        for version, field in APISpecific.getVersionFieldNameDict(self.targetApiName).items():
-            out.append(f'{{"{version}", DeviceInfo(&DeviceExtensions::{field}, {{}})}},\n')
+        for version in self.vk.versions.keys():
+            out.append(f'{{"{version}", DeviceInfo(&DeviceExtensions::{fieldName[version]}, {{}})}},\n')
 
         for extension in [x for x in self.vk.extensions.values() if x.device]:
             out.extend(guard_helper.add_guard(extension.protect))
@@ -353,61 +341,56 @@ class ExtensionHelperOutputGenerator(BaseGenerator):
                 // Initialize: this to defaults,  base class fields to input.
                 assert(instance_extensions);
                 *this = DeviceExtensions(*instance_extensions);
-            ''')
-        promoted_var_names = APISpecific.getPromotedExtensionArrayName(self.targetApiName, 'device')
-        for version_name, promoted_var_name in promoted_var_names.items():
-            promoted_ext_list = [x for x in self.vk.extensions.values() if x.promotedTo == version_name and x.device]
-            out.append(f'constexpr std::array<const char*, {len(promoted_ext_list)}> {promoted_var_name} = {{\n')
-            out.extend(['    %s,\n' % ext.nameString for ext in promoted_ext_list])
-            out.append('};\n')
 
-        out.append('''
-            // Initialize struct data, robust to invalid pCreateInfo
-            auto api_version = NormalizeApiVersion(requested_api_version);''')
-        for version_name, promoted_var_name in promoted_var_names.items():
-            out.append(f'''
-                if (api_version >= {version_name.replace('_VERSION_', '_API_VERSION_')}) {{
-                    auto info = get_info("{version_name}");
-                    if (info.state) this->*(info.state) = kEnabledByCreateinfo;
-                    for (auto promoted_ext : {promoted_var_name}) {{
-                        info = get_info(promoted_ext);
-                        assert(info.state);
-                        if (info.state) this->*(info.state) = kEnabledByApiLevel;
-                    }}
-                }}''')
+                // Initialize struct data, robust to invalid pCreateInfo
+                auto api_version = NormalizeApiVersion(requested_api_version);
+                if (!api_version.Valid()) return api_version;
 
-        out.append('''
-            // CreateInfo takes precedence over promoted
-            if (pCreateInfo && pCreateInfo->ppEnabledExtensionNames) {
-                for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
-                    if (!pCreateInfo->ppEnabledExtensionNames[i]) continue;
-                    auto info = get_info(pCreateInfo->ppEnabledExtensionNames[i]);
-                    if (info.state) this->*(info.state) = kEnabledByCreateinfo;
-                }
-            }
-            // Workaround for functions being introduced by multiple extensions, until the layer is fixed to handle this correctly
-            // See https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5579 and https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5600
-            {
-                constexpr std::array shader_object_interactions = {
-                    VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME,
-                    VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME,
-                    VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME,
-                    VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME,
-                };
-                auto info = get_info(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
-                if (info.state) {
-                    if (this->*(info.state) != kNotEnabled) {
-                        for (auto interaction_ext : shader_object_interactions) {
-                            info = get_info(interaction_ext);
+                const auto promotion_info_map = get_promotion_info_map();
+                for (const auto& version_it : promotion_info_map) {
+                    auto info = get_info(version_it.second.first);
+                    if (api_version >= version_it.first) {
+                        if (info.state) this->*(info.state) = kEnabledByCreateinfo;
+                        for (const auto& ext_name : version_it.second.second) {
+                            info = get_info(ext_name.c_str());
                             assert(info.state);
-                            if (this->*(info.state) != kEnabledByCreateinfo) {
-                                this->*(info.state) = kEnabledByInteraction;
+                            if (info.state) this->*(info.state) = kEnabledByApiLevel;
+                        }
+                    }
+                }
+
+                // CreateInfo takes precedence over promoted
+                if (pCreateInfo && pCreateInfo->ppEnabledExtensionNames) {
+                    for (uint32_t i = 0; i < pCreateInfo->enabledExtensionCount; i++) {
+                        if (!pCreateInfo->ppEnabledExtensionNames[i]) continue;
+                        auto info = get_info(pCreateInfo->ppEnabledExtensionNames[i]);
+                        if (info.state) this->*(info.state) = kEnabledByCreateinfo;
+                    }
+                }
+
+                // Workaround for functions being introduced by multiple extensions, until the layer is fixed to handle this correctly
+                // See https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5579 and https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5600
+                {
+                    constexpr std::array shader_object_interactions = {
+                        VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME,
+                        VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME,
+                        VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME,
+                        VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME,
+                    };
+                    auto info = get_info(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
+                    if (info.state) {
+                        if (this->*(info.state) != kNotEnabled) {
+                            for (auto interaction_ext : shader_object_interactions) {
+                                info = get_info(interaction_ext);
+                                assert(info.state);
+                                if (this->*(info.state) != kEnabledByCreateinfo) {
+                                    this->*(info.state) = kEnabledByInteraction;
+                                }
                             }
                         }
                     }
                 }
-            }
-            return api_version;
+                return api_version;
             }
             };
 

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -134,6 +134,10 @@ class VkRenderFramework : public VkTestFramework {
     // if requested extensions are not supported, helper function to get string to print out
     std::string RequiredExtensionsNotSupported() const;
 
+    // By default, requested extensions that are promoted to the effective API version (and thus are redundant)
+    // are not enabled, but this can be overridden for individual test cases that explicitly test such use cases.
+    void AllowPromotedExtensions() { allow_promoted_extensions_ = true; }
+
     void *SetupValidationSettings(void *first_pnext);
 
     template <typename GLSLContainer>
@@ -169,6 +173,8 @@ class VkRenderFramework : public VkTestFramework {
 
     ErrorMonitor monitor_ = ErrorMonitor(m_print_vu);
     ErrorMonitor *m_errorMonitor = &monitor_;  // TODO: Removing this properly is it's own PR. It's a big change.
+
+    bool allow_promoted_extensions_ = false;
 
     VkApplicationInfo app_info_;
     std::vector<const char *> instance_layers_;

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -94,6 +94,9 @@ TEST_F(VkBestPracticesLayerTest, ReturnCodes) {
 TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
     TEST_DESCRIPTION("Create an instance with a deprecated extension.");
 
+    // We need to explicitly allow promoted extensions to be enabled as this test relies on this behavior
+    AllowPromotedExtensions();
+
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework())

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -371,6 +371,9 @@ TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature) {
 TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature12) {
     TEST_DESCRIPTION("Use VK_KHR_draw_indirect_count in 1.2 using the extension");
 
+    // We need to explicitly allow promoted extensions to be enabled as this test relies on this behavior
+    AllowPromotedExtensions();
+
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
     RETURN_IF_SKIP(Init())

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -4874,6 +4874,7 @@ TEST_F(NegativeDescriptors, InvalidDescriptorSetLayoutFlags) {
 TEST_F(NegativeDescriptors, SampledImageDepthComparisonForFormat) {
     TEST_DESCRIPTION("Verify that OpImage*Dref* operations are supported for given format ");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init())
     InitRenderTarget();

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -1473,6 +1473,9 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromFdHandle) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "External tests are not supported by MockICD, skipping tests";
+    }
     constexpr auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
     VkExternalMemoryFeatureFlags external_features = 0;

--- a/tests/unit/image_drm.cpp
+++ b/tests/unit/image_drm.cpp
@@ -122,13 +122,13 @@ TEST_F(NegativeImageDrm, ImageFormatInfo) {
 
     VkImageFormatProperties2 image_format_properties = vku::InitStructHelper();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249");
-    vk::GetPhysicalDeviceImageFormatProperties2KHR(gpu(), &image_format_info, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
     m_errorMonitor->VerifyFound();
 
     image_format_info.pNext = nullptr;
     image_format_info.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249");
-    vk::GetPhysicalDeviceImageFormatProperties2KHR(gpu(), &image_format_info, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
     m_errorMonitor->VerifyFound();
 
     VkImageFormatListCreateInfo format_list = vku::InitStructHelper(&image_drm_format_modifier);
@@ -136,7 +136,7 @@ TEST_F(NegativeImageDrm, ImageFormatInfo) {
     image_format_info.pNext = &format_list;
     image_format_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02313");
-    vk::GetPhysicalDeviceImageFormatProperties2KHR(gpu(), &image_format_info, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/instance_positive.cpp
+++ b/tests/unit/instance_positive.cpp
@@ -40,22 +40,6 @@ TEST_F(PositiveInstance, TwoInstances) {
     ASSERT_NO_FATAL_FAILURE(vk::DestroyInstance(i1, nullptr));
 }
 
-TEST_F(PositiveInstance, NullFunctionPointer) {
-    TEST_DESCRIPTION("On 1_0 instance , call GetDeviceProcAddr on promoted 1_1 device-level entrypoint");
-    SetTargetApiVersion(VK_API_VERSION_1_0);
-
-    AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
-
-    RETURN_IF_SKIP(InitState())
-
-    auto fpGetBufferMemoryRequirements =
-        (PFN_vkGetBufferMemoryRequirements2)vk::GetDeviceProcAddr(m_device->device(), "vkGetBufferMemoryRequirements2");
-    if (fpGetBufferMemoryRequirements) {
-        m_errorMonitor->SetError("Null was expected!");
-    }
-}
-
 TEST_F(PositiveInstance, ValidationInstanceExtensions) {
     RETURN_IF_SKIP(Init())
 

--- a/tests/unit/sampler_positive.cpp
+++ b/tests/unit/sampler_positive.cpp
@@ -34,6 +34,9 @@ TEST_F(PositiveSampler, SamplerMirrorClampToEdgeWithoutFeature) {
 TEST_F(PositiveSampler, SamplerMirrorClampToEdgeWithoutFeature12) {
     TEST_DESCRIPTION("Use VK_KHR_sampler_mirror_clamp_to_edge in 1.2 using the extension");
 
+    // We need to explicitly allow promoted extensions to be enabled as this test relies on this behavior
+    AllowPromotedExtensions();
+
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -268,6 +268,9 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithoutFeature) {
 TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithoutFeature11) {
     TEST_DESCRIPTION("Use VK_KHR_shader_draw_parameters in 1.1 using the extension");
 
+    // We need to explicitly allow promoted extensions to be enabled as this test relies on this behavior
+    AllowPromotedExtensions();
+
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework())


### PR DESCRIPTION
This is just a draft to see whether this approach looks fine. This, as is, currently will fail CI, so we'll have to add some mechanisms to deal with extensions that intentionally depend on the old behavior.

What this does is that if the test requests both a core API version (target, not necessarily required) and an extension that's part of the effective core version, then it does not enable the extension, only the core version.

Maybe we should relax this and just remove the requirement, so this is for discussion for now based on our offline conversations with @spencer-lunarg.