### PR TITLE
layers: Clarify naming for binary semaphore cases

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -156,7 +156,7 @@ bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location &signal_semaph
             if ((semaphore_state->Scope() == kSyncScopeInternal || internal_semaphores.count(semaphore))) {
                 VkQueue other_queue = VK_NULL_HANDLE;
                 vvl::Func other_command = vvl::Func::Empty;
-                if (CannotSignal(*semaphore_state, other_queue, other_command)) {
+                if (CannotSignalBinarySemaphore(*semaphore_state, other_queue, other_command)) {
                     std::stringstream initiator;
                     if (other_command != vvl::Func::Empty) {
                         initiator << String(other_command);


### PR DESCRIPTION
Make sure it's more obvious when functions work with binary semaphores.
Clarify semantics of SemOp::CanBeWaited/CanBeSignaled. It checks if binary semaphore can be waited/signaled *after* this specific SemOp.