### PR TITLE
layers: Revert ImageBufferCopyMemoryOverlap

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -2573,9 +2573,11 @@ bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkI
                                              region.imageSubresource.layerCount, subresource_loc, vuid);
     }
 
-    if (!skip && !dst_buffer_state->sparse && !src_image_state->sparse) {
-        skip |= ValidateImageBufferCopyMemoryOverlap(*cb_state_ptr, regionCount, pRegions, *src_image_state, *dst_buffer_state, loc, true, is_2);
-    }
+    // TODO 6898 - ValidateImageBufferCopyMemoryOverlap logic has issues
+    // if (!skip && !dst_buffer_state->sparse && !src_image_state->sparse) {
+    //     skip |= ValidateImageBufferCopyMemoryOverlap(*cb_state_ptr, regionCount, pRegions, *src_image_state, *dst_buffer_state,
+    //     loc, true, is_2);
+    // }
     return skip;
 }
 
@@ -2726,9 +2728,11 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
         }
     }
 
-    if (!skip && !src_buffer_state->sparse && !dst_image_state->sparse){
-        skip |= ValidateImageBufferCopyMemoryOverlap(*cb_state_ptr, regionCount, pRegions, *dst_image_state, *src_buffer_state, loc, false, is_2);
-    }
+    // TODO 6898 - ValidateImageBufferCopyMemoryOverlap logic has issues
+    // if (!skip && !src_buffer_state->sparse && !dst_image_state->sparse){
+    //     skip |= ValidateImageBufferCopyMemoryOverlap(*cb_state_ptr, regionCount, pRegions, *dst_image_state, *src_buffer_state,
+    //     loc, false, is_2);
+    // }
 
     return skip;
 }

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -6267,7 +6267,8 @@ TEST_F(NegativeCommand, CopyCommands2V13) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeCommand, CopyImageOverlappingMemory) {
+// TODO 6898
+TEST_F(NegativeCommand, DISABLED_CopyImageOverlappingMemory) {
     TEST_DESCRIPTION("Validate Copy Image from/to Buffer with overlapping memory");
     SetTargetApiVersion(VK_API_VERSION_1_3);
 


### PR DESCRIPTION
This was added in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6843/ and seems there are some issues being tracked in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6898

For now just removing the logic from running until proper testing can be added to confirm we have correctly added support