### PR TITLE
syncval: Remove bad assert/Avoid bad access

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -899,12 +899,13 @@ bool ForEachEntryInRangesUntil(const RangeMap &map, RangeGen &range_gen, Action 
         // Now advance pos as needed to match range
         if (pos->first.strictly_less(range)) {
             ++pos;
+            if (pos == end) break;
             if (pos->first.strictly_less(range)) {
                 pos = map.lower_bound(range);
                 if (pos == end) break;
             }
+            assert(pos == map.lower_bound(range));
         }
-        assert(pos == map.lower_bound(range));
 
         // If the range intersects pos->first, consider Action performed for that map entry, and
         // make sure not to call Action for this pos for any subsequent ranges


### PR DESCRIPTION
An assert was too broadly applied and could trigger in the valid condition that the lower_bound of a range also overlaps and early range (and thus been processed/advanced past).

Also added a missing check vs. end that could have resulted in an invalid access when `pos == map.end()`.

Addresses #6926 .