### PR TITLE
layers: Check Ycbcr sampling instructions

### DIFF
--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -325,6 +325,27 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                         FormatHandle(set).c_str(), binding, index);
     }
 
+    if (image_view_state->samplerConversion) {
+        if (variable.info.is_not_sampler_sampled) {
+            auto set = descriptor_set.GetSet();
+            const LogObjectList objlist(set, image_view);
+            return dev_state.LogError(
+                vuids.image_ycbcr_sampled_06550, set, loc,
+                "the image descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                ") was created with a sampler Ycbcr conversion, but was accessed with a non OpImage*Sample* command.",
+                FormatHandle(set).c_str(), binding, index);
+        }
+        if (variable.info.is_sampler_offset) {
+            auto set = descriptor_set.GetSet();
+            const LogObjectList objlist(set, image_view);
+            return dev_state.LogError(
+                vuids.image_ycbcr_offset_06551, set, loc,
+                "the image descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                ") was created with a sampler Ycbcr conversion, but was accessed with ConstOffset/Offset image operands.",
+                FormatHandle(set).c_str(), binding, index);
+        }
+    }
+
     // Verify VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT
     if (variable.info.is_atomic_operation && (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) &&
         !(image_view_state->format_features & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
@@ -725,6 +746,27 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                 ") Image View %s is used by %s that uses invalid bias or offset operator.",
                                 FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
                                 FormatHandle(sampler_state->sampler()).c_str());
+            }
+        }
+
+        if (sampler_state->samplerConversion) {
+            if (variable.info.is_not_sampler_sampled) {
+                auto set = descriptor_set.GetSet();
+                const LogObjectList objlist(set, image_view, sampler_state->sampler());
+                return dev_state.LogError(
+                    vuids.image_ycbcr_sampled_06550, set, loc,
+                    "the sampler descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                    ") was created with a sampler Ycbcr conversion, but was accessed with a non OpImage*Sample* command.",
+                    FormatHandle(set).c_str(), binding, index);
+            }
+            if (variable.info.is_sampler_offset) {
+                auto set = descriptor_set.GetSet();
+                const LogObjectList objlist(set, image_view, sampler_state->sampler());
+                return dev_state.LogError(
+                    vuids.image_ycbcr_offset_06551, set, loc,
+                    "the sampler descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                    ") was created with a sampler Ycbcr conversion, but was accessed with ConstOffset/Offset image operands.",
+                    FormatHandle(set).c_str(), binding, index);
             }
         }
     }

--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -172,6 +172,8 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDraw-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDraw-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDraw-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDraw-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDraw-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDraw-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDraw-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDraw-stippledLineEnable-07495";
@@ -465,6 +467,8 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMultiEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMultiEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMultiEXT-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMultiEXT-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMultiEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMultiEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMultiEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMultiEXT-stippledLineEnable-07495";
@@ -759,6 +763,8 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndexed-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndexed-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndexed-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndexed-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndexed-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndexed-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndexed-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndexed-stippledLineEnable-07495";
@@ -1053,6 +1059,8 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMultiIndexedEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMultiIndexedEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMultiIndexedEXT-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMultiIndexedEXT-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMultiIndexedEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMultiIndexedEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMultiIndexedEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMultiIndexedEXT-stippledLineEnable-07495";
@@ -1348,6 +1356,8 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndirect-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndirect-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndirect-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndirect-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndirect-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndirect-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndirect-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndirect-stippledLineEnable-07495";
@@ -1644,6 +1654,8 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndexedIndirect-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndexedIndirect-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndexedIndirect-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndexedIndirect-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndexedIndirect-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndexedIndirect-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndexedIndirect-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndexedIndirect-stippledLineEnable-07495";
@@ -1823,6 +1835,8 @@ struct DispatchVuidsCmdDispatch : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDispatch-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDispatch-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDispatch-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDispatch-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDispatch-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDispatch-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDispatch-format-07753";
     }
@@ -1867,6 +1881,8 @@ struct DispatchVuidsCmdDispatchIndirect : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDispatchIndirect-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDispatchIndirect-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDispatchIndirect-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDispatchIndirect-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDispatchIndirect-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDispatchIndirect-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDispatchIndirect-format-07753";
     }
@@ -2028,6 +2044,8 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndirectCount-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndirectCount-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndirectCount-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndirectCount-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndirectCount-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndirectCount-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndirectCount-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndirectCount-stippledLineEnable-07495";
@@ -2327,6 +2345,8 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndexedIndirectCount-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndexedIndirectCount-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndexedIndirectCount-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndexedIndirectCount-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndexedIndirectCount-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndexedIndirectCount-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndexedIndirectCount-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndexedIndirectCount-stippledLineEnable-07495";
@@ -2506,6 +2526,8 @@ struct DispatchVuidsCmdTraceRaysNV: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdTraceRaysNV-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdTraceRaysNV-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdTraceRaysNV-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdTraceRaysNV-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdTraceRaysNV-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdTraceRaysNV-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdTraceRaysNV-format-07753";
     }
@@ -2548,6 +2570,8 @@ struct DispatchVuidsCmdTraceRaysKHR: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdTraceRaysKHR-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdTraceRaysKHR-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdTraceRaysKHR-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdTraceRaysKHR-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdTraceRaysKHR-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdTraceRaysKHR-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdTraceRaysKHR-format-07753";
     }
@@ -2592,6 +2616,8 @@ struct DispatchVuidsCmdTraceRaysIndirectKHR: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdTraceRaysIndirectKHR-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdTraceRaysIndirectKHR-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdTraceRaysIndirectKHR-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdTraceRaysIndirectKHR-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdTraceRaysIndirectKHR-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdTraceRaysIndirectKHR-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdTraceRaysIndirectKHR-format-07753";
     }
@@ -2636,6 +2662,8 @@ struct DispatchVuidsCmdTraceRaysIndirect2KHR: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdTraceRaysIndirect2KHR-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdTraceRaysIndirect2KHR-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdTraceRaysIndirect2KHR-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdTraceRaysIndirect2KHR-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdTraceRaysIndirect2KHR-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdTraceRaysIndirect2KHR-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdTraceRaysIndirect2KHR-format-07753";
     }
@@ -2782,6 +2810,8 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksNV-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksNV-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksNV-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksNV-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksNV-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksNV-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksNV-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksNV-stippledLineEnable-07495";
@@ -3065,6 +3095,8 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksIndirectNV-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksIndirectNV-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksIndirectNV-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksIndirectNV-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksIndirectNV-stippledLineEnable-07495";
@@ -3351,6 +3383,8 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksIndirectCountNV-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksIndirectCountNV-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksIndirectCountNV-stippledLineEnable-07495";
@@ -3631,6 +3665,8 @@ struct DispatchVuidsCmdDrawMeshTasksEXT: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksEXT-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksEXT-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksEXT-stippledLineEnable-07495";
@@ -3914,6 +3950,8 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectEXT: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksIndirectEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksIndirectEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksIndirectEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksIndirectEXT-stippledLineEnable-07495";
@@ -4200,6 +4238,8 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountEXT : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-stippledLineEnable-07495";
@@ -4492,6 +4532,8 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndirectByteCountEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndirectByteCountEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndirectByteCountEXT-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndirectByteCountEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndirectByteCountEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndirectByteCountEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndirectByteCountEXT-stippledLineEnable-07495";
@@ -4671,6 +4713,8 @@ struct DispatchVuidsCmdDispatchBase: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDispatchBase-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDispatchBase-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDispatchBase-None-08117";
+        image_ycbcr_sampled_06550                = "VUID-vkCmdDispatchBase-None-06550";
+        image_ycbcr_offset_06551                 = "VUID-vkCmdDispatchBase-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDispatchBase-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDispatchBase-format-07753";
     }

--- a/layers/drawdispatch/drawdispatch_vuids.h
+++ b/layers/drawdispatch/drawdispatch_vuids.h
@@ -166,6 +166,8 @@ struct DrawDispatchVuid {
     const char* descriptor_buffer_bit_set_08114 = kVUIDUndefined;
     const char* descriptor_buffer_bit_not_set_08115 = kVUIDUndefined;
     const char* descriptor_buffer_set_offset_missing_08117 = kVUIDUndefined;
+    const char* image_ycbcr_sampled_06550 = kVUIDUndefined;
+    const char* image_ycbcr_offset_06551 = kVUIDUndefined;
     const char* image_view_dim_07752 = kVUIDUndefined;
     const char* image_view_numeric_format_07753 = kVUIDUndefined;
     const char* stippled_rectangular_lines_07495 = kVUIDUndefined;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -573,13 +573,20 @@ ImageAccess::ImageAccess(const SPIRV_MODULE_STATE& module_state, const Instructi
             break;
     }
 
+    is_not_sampler_sampled = !is_sampler_sampled;
+
     // Find any optional Image Operands
     const uint32_t image_operand_position = OpcodeImageOperandsPosition(image_opcode);
     if (image_insn.Length() > image_operand_position) {
         const uint32_t image_operand_word = image_insn.Word(image_operand_position);
 
-        if (is_sampler_sampled && IsImageOperandsBiasOffset(image_operand_word)) {
-            is_sampler_bias_offset = true;
+        if (is_sampler_sampled) {
+            if (IsImageOperandsBiasOffset(image_operand_word)) {
+                is_sampler_bias_offset = true;
+            }
+            if ((image_operand_word & (spv::ImageOperandsConstOffsetMask | spv::ImageOperandsOffsetMask)) != 0) {
+                is_sampler_offset = true;
+            }
         }
 
         if ((image_operand_word & spv::ImageOperandsSignExtendMask) != 0) {
@@ -1825,7 +1832,9 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const SPIRV_MODULE_STATE& m
                 info.is_dref |= image_access.is_dref;
                 info.is_sampler_implicitLod_dref_proj |= image_access.is_sampler_implicitLod_dref_proj;
                 info.is_sampler_sampled |= image_access.is_sampler_sampled;
+                info.is_not_sampler_sampled |= image_access.is_not_sampler_sampled;
                 info.is_sampler_bias_offset |= image_access.is_sampler_bias_offset;
+                info.is_sampler_offset |= image_access.is_sampler_offset;
                 info.is_sign_extended |= image_access.is_sign_extended;
                 info.is_zero_extended |= image_access.is_zero_extended;
                 is_written_to |= image_access.is_written_to;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -184,8 +184,10 @@ struct ImageAccess {
 
     bool is_dref = false;
     bool is_sampler_implicitLod_dref_proj = false;
-    bool is_sampler_sampled = false;
+    bool is_sampler_sampled = false;  // OpImageSample* or OpImageSparseSample*
+    bool is_not_sampler_sampled = false;
     bool is_sampler_bias_offset = false;
+    bool is_sampler_offset = false;  // ConstOffset or Offset (not ConstOffsets)
     bool is_written_to = false;
     bool is_read_from = false;
     bool is_sign_extended = false;
@@ -335,9 +337,11 @@ struct ResourceInterfaceVariable : public VariableBase {
         bool is_multisampled;
         bool is_atomic_operation;
 
-        bool is_sampler_sampled{false};
+        bool is_sampler_sampled{false};  // OpImageSample* or OpImageSparseSample*
+        bool is_not_sampler_sampled{false};
         bool is_sampler_implicitLod_dref_proj{false};
         bool is_sampler_bias_offset{false};
+        bool is_sampler_offset{false};        // ConstOffset or Offset (not ConstOffsets)
         bool is_read_without_format{false};   // For storage images
         bool is_write_without_format{false};  // For storage images
         bool is_dref{false};

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -3605,6 +3605,102 @@ TEST_F(VkGpuAssistedLayerTest, UnnormalizedCoordinatesSeparateSamplerSharedSampl
     m_errorMonitor->VerifyFound();
 }
 
+// TODO - Indexing is not being recognized by GPU-AV
+TEST_F(VkGpuAssistedLayerTest, DISABLED_YcbcrDrawFetchIndexed) {
+    TEST_DESCRIPTION("Do OpImageFetch on a Ycbcr COMBINED_IMAGE_SAMPLER.");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper();
+    GetPhysicalDeviceFeatures2(features11);
+    if (!features11.samplerYcbcrConversion) {
+        GTEST_SKIP() << "samplerYcbcrConversion not supported, skipping test";
+    }
+    RETURN_IF_SKIP(InitState(nullptr, &features11));
+    InitRenderTarget();
+    const VkFormat format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR;
+
+    auto ci = vku::InitStruct<VkImageCreateInfo>();
+    ci.flags = 0;
+    ci.imageType = VK_IMAGE_TYPE_2D;
+    ci.format = format;
+    ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    ci.extent = {256, 256, 1};
+    ci.mipLevels = 1;
+    ci.arrayLayers = 1;
+    ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    if (!ImageFormatIsSupported(instance(), gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        // Assume there's low ROI on searching for different mp formats
+        GTEST_SKIP() << "Multiplane image format not supported";
+    }
+
+    VkImageObj image(m_device);
+    image.Init(ci);
+
+    vkt::SamplerYcbcrConversion conversion(*m_device, format);
+    auto conversion_info = conversion.ConversionInfo();
+    auto ivci = vku::InitStruct<VkImageViewCreateInfo>(&conversion_info);
+    ivci.image = image.handle();
+    ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    ivci.format = format;
+    ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    vkt::ImageView view(*m_device, ivci);
+
+    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
+    sampler_ci.pNext = &conversion_info;
+    vkt::Sampler sampler(*m_device, sampler_ci);
+    VkSampler immutable_samplers[2] = {sampler.handle(), sampler.handle()};
+
+    OneOffDescriptorSet descriptor_set(
+        m_device, {
+                      {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, immutable_samplers},
+                  });
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
+
+    VkDescriptorImageInfo image_infos[2] = {};
+    image_infos[0] = {sampler.handle(), view.handle(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+    image_infos[1] = {sampler.handle(), view.handle(), VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
+
+    VkWriteDescriptorSet descriptor_writes = vku::InitStruct<VkWriteDescriptorSet>();
+    descriptor_writes.dstSet = descriptor_set.set_;
+    descriptor_writes.dstBinding = 0;
+    descriptor_writes.descriptorCount = 2;
+    descriptor_writes.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    descriptor_writes.pImageInfo = image_infos;
+    vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_writes, 0, nullptr);
+
+    const char fsSource[] = R"glsl(
+        #version 450
+        layout (set = 0, binding = 0) uniform sampler2D ycbcr[2];
+        layout(location=0) out vec4 out_color;
+        void main() {
+            int index = 0;
+            if (gl_FragCoord.x > 0.5) {
+                index = 1;
+            }
+            out_color = texelFetch(ycbcr[index], ivec2(0), 0);
+        }
+    )glsl";
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    pipe.gp_ci_.layout = pipeline_layout.handle();
+    pipe.CreateGraphicsPipeline();
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
+                              &descriptor_set.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-06550");
+    vk::CmdDraw(m_commandBuffer->handle(), 1, 0, 0, 0);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->EndRenderPass();
+    m_commandBuffer->end();
+}
+
 TEST_F(VkGpuAssistedLayerTest, UpdateAfterBind) {
     TEST_DESCRIPTION("Exercise errors for updating a descriptor set after it is bound.");
 


### PR DESCRIPTION
adds `VUID-vkCmdDraw-None-06550` and `VUID-vkCmdDraw-ConstOffset-06551`

Checks the ImageAccesses of any Ycbcr sampled descriptor