### PR TITLE
layers: Move cvdescriptorset namespace contents to vvl::

### DIFF
--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -189,7 +189,7 @@ The following objects have already been updated to meet the above construction r
 * VkBufferView / BUFFER_VIEW_STATE
 * VkImageView / IMAGE_VIEW_STATE
 * VkPipelineLayout / PIPELINE_LAYOUT_STATE
-* VkDescriptorSetLayout / cvdescriptorset::DescriptorSetLayout
+* VkDescriptorSetLayout / vvl::DescriptorSetLayout
 * VkQueryPool / QUERY_POOL_STATE
 * VkShaderModule / SPIRV_MODULE_STATE
 * VkPipeline / Pipeline state
@@ -402,7 +402,7 @@ The only dynamic data in `COMMAND_POOL_STATE` is a set of all the command buffer
 ```
 
 
-This state is only changed in Vulkan functions that require external synchronization of the `VkCommandPool` handle. TODO: currently this object is not lock guarded but it could be converted to work like `DESCRIPTOR_POOL_STATE`, which is.
+This state is only changed in Vulkan functions that require external synchronization of the `VkCommandPool` handle. TODO: currently this object is not lock guarded but it could be converted to work like `vvl::DescriptorPool`, which is.
 
 
 ### VkCommandBuffer / CMD_BUFFER_STATE
@@ -740,7 +740,7 @@ Also, surfaces are instance level objects but they hold a reference on the curre
 
 ###### PRs:
 
-[layers: Make SURFACE_STATE, DESCRIPTOR_POOL_STATE, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
+[layers: Make SURFACE_STATE, vvl::DescriptorPool, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
 
 [layers: Don't pre-query surface attributes during creation](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3452)
 
@@ -750,16 +750,16 @@ Also, surfaces are instance level objects but they hold a reference on the curre
 ## Descriptor sets
 
 
-### VkDescriptorPool / DESCRIPTOR_POOL_STATE
+### VkDescriptorPool / vvl::DescriptorPool
 
-All of the dynamic data in `DESCRIPTOR_POOL_STATE` is associated with tracking the currently allocated descriptor sets and the remaining resources available for allocating new ones:
+All of the dynamic data in `vvl::DescriptorPool` is associated with tracking the currently allocated descriptor sets and the remaining resources available for allocating new ones:
 
 
 
 
 ```
    // Collection of all sets in this pool`
-    vvl::unordered_set<cvdescriptorset::DescriptorSet *> sets;
+    vvl::unordered_set<vvl::DescriptorSet *> sets;
     // Available descriptor sets in this pool
     uint32_t availableSets;
     // Available # of descriptors of each type in this pool
@@ -770,10 +770,10 @@ This data is fully encapsulated by accessor methods that manage the locking.
 
 ###### PRs:
 
-[layers: Make SURFACE_STATE, DESCRIPTOR_POOL_STATE, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
+[layers: Make SURFACE_STATE, vvl::DescriptorPool, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
 
 
-### VkDescriptorSet / cvdescriptorset::DescriptorSet
+### VkDescriptorSet / vvl::DescriptorSet
 
 Descriptor set validation, especially of image descriptors, is currently the most CPU intensive part of validation. The state for descriptor sets consists mostly of an efficient way to store descriptors of various types in a single vector:
 
@@ -816,7 +816,7 @@ This data is fully encapsulated by accessor methods that manage the locking.
 
 [layers: remove global queryToStateMap](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3586)
 
-[layers: Make SURFACE_STATE, DESCRIPTOR_POOL_STATE, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
+[layers: Make SURFACE_STATE, vvl::DescriptorPool, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
 
 
 

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -337,10 +337,10 @@ class CommandBuffer : public CMD_BUFFER_STATE {
     void UnbindResources() { push_constant_data_set.clear(); }
 };
 
-class DescriptorPool : public DESCRIPTOR_POOL_STATE {
+class DescriptorPool : public vvl::DescriptorPool {
   public:
     DescriptorPool(ValidationStateTracker* dev, const VkDescriptorPool pool, const VkDescriptorPoolCreateInfo* pCreateInfo)
-        : DESCRIPTOR_POOL_STATE(dev, pool, pCreateInfo) {}
+        : vvl::DescriptorPool(dev, pool, pCreateInfo) {}
 
     uint32_t freed_count{0};
 };
@@ -359,7 +359,7 @@ VALSTATETRACK_DERIVED_STATE_OBJECT(VkPhysicalDevice, bp_state::PhysicalDevice, P
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, bp_state::CommandBuffer, CMD_BUFFER_STATE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkSwapchainKHR, bp_state::Swapchain, SWAPCHAIN_NODE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkImage, bp_state::Image, IMAGE_STATE)
-VALSTATETRACK_DERIVED_STATE_OBJECT(VkDescriptorPool, bp_state::DescriptorPool, DESCRIPTOR_POOL_STATE)
+VALSTATETRACK_DERIVED_STATE_OBJECT(VkDescriptorPool, bp_state::DescriptorPool, vvl::DescriptorPool)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkPipeline, bp_state::Pipeline, PIPELINE_STATE)
 
 class BestPractices : public ValidationStateTracker {
@@ -1014,9 +1014,9 @@ class BestPractices : public ValidationStateTracker {
         return std::make_shared<bp_state::Image>(this, img, pCreateInfo, swapchain, swapchain_index, features);
     }
 
-    std::shared_ptr<DESCRIPTOR_POOL_STATE> CreateDescriptorPoolState(VkDescriptorPool pool,
+    std::shared_ptr<vvl::DescriptorPool> CreateDescriptorPoolState(VkDescriptorPool pool,
                                                                      const VkDescriptorPoolCreateInfo* pCreateInfo) final {
-        return std::static_pointer_cast<DESCRIPTOR_POOL_STATE>(std::make_shared<bp_state::DescriptorPool>(this, pool, pCreateInfo));
+        return std::static_pointer_cast<vvl::DescriptorPool>(std::make_shared<bp_state::DescriptorPool>(this, pool, pCreateInfo));
     }
 
     std::shared_ptr<DEVICE_MEMORY_STATE> CreateDeviceMemoryState(VkDeviceMemory mem, const VkMemoryAllocateInfo* p_alloc_info,

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -637,15 +637,15 @@ void BestPractices::ValidateBoundDescriptorSets(bp_state::CommandBuffer& cb_stat
                     continue;
                 }
                 switch (descriptor->GetClass()) {
-                    case cvdescriptorset::DescriptorClass::Image: {
-                        if (const auto image_descriptor = static_cast<const cvdescriptorset::ImageDescriptor*>(descriptor)) {
+                    case vvl::DescriptorClass::Image: {
+                        if (const auto image_descriptor = static_cast<const vvl::ImageDescriptor*>(descriptor)) {
                             image_view = image_descriptor->GetImageView();
                         }
                         break;
                     }
-                    case cvdescriptorset::DescriptorClass::ImageSampler: {
+                    case vvl::DescriptorClass::ImageSampler: {
                         if (const auto image_sampler_descriptor =
-                                static_cast<const cvdescriptorset::ImageSamplerDescriptor*>(descriptor)) {
+                                static_cast<const vvl::ImageSamplerDescriptor*>(descriptor)) {
                             image_view = image_sampler_descriptor->GetImageView();
                         }
                         break;

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -549,7 +549,7 @@ bool BestPractices::PreCallValidateCreatePipelineLayout(VkDevice device, const V
         // Push constants cost 1 DWORD per 4 bytes in the Push constant range.
         uint32_t pipeline_size = pCreateInfo->setLayoutCount;  // in DWORDS
         for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; i++) {
-            auto descriptor_set_layout_state = Get<cvdescriptorset::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
+            auto descriptor_set_layout_state = Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
             pipeline_size += descriptor_set_layout_state->GetDynamicDescriptorCount() * descriptor_size;
         }
 
@@ -574,7 +574,7 @@ bool BestPractices::PreCallValidateCreatePipelineLayout(VkDevice device, const V
         size_t fast_space_usage = 0;
 
         for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-            auto descriptor_set_layout_state = Get<cvdescriptorset::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
+            auto descriptor_set_layout_state = Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
             for (const auto& binding : descriptor_set_layout_state->GetBindings()) {
                 if (binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER) {
                     has_separate_sampler = true;

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1531,7 +1531,7 @@ bool CoreChecks::ValidateActionState(const CMD_BUFFER_STATE &cb_state, const VkP
                     } else if (!VerifySetLayoutCompatibility(*set_info.bound_descriptor_set, pipeline_layout->set_layouts,
                                                              pipeline_layout->Handle(), set_index, error_string)) {
                         // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
-                        VkDescriptorSet set_handle = set_info.bound_descriptor_set->GetSet();
+                        VkDescriptorSet set_handle = set_info.bound_descriptor_set->VkHandle();
                         LogObjectList objlist = cb_state.GetObjectList(bind_point);
                         objlist.add(set_handle);
                         objlist.add(pipeline_layout->layout());
@@ -1601,7 +1601,7 @@ bool CoreChecks::ValidateActionState(const CMD_BUFFER_STATE &cb_state, const VkP
                     } else if (!VerifySetLayoutCompatibility(*set_info.bound_descriptor_set, shader_state->set_layouts,
                                                              shader_state->Handle(), set_index, error_string)) {
                         // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
-                        VkDescriptorSet set_handle = set_info.bound_descriptor_set->GetSet();
+                        VkDescriptorSet set_handle = set_info.bound_descriptor_set->VkHandle();
                         const LogObjectList objlist(cb_state.commandBuffer(), set_handle, shader_state->shader());
                         skip |= LogError(vuid.compatible_pipeline_08600, objlist, loc,
                                          "%s bound as set #%" PRIu32 " is not compatible with overlapping %s due to: %s",

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -596,22 +596,22 @@ class CoreChecks : public ValidationStateTracker {
     VkResult CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize,
                                                 void* pData) override;
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
-    bool ValidateDrawState(const cvdescriptorset::DescriptorSet& descriptor_set, const BindingVariableMap& bindings,
+    bool ValidateDrawState(const vvl::DescriptorSet& descriptor_set, const BindingVariableMap& bindings,
                            const std::vector<uint32_t>& dynamic_offsets, const CMD_BUFFER_STATE& cb_state, const Location& loc,
                            const vvl::DrawDispatchVuid& vuids) const;
 
-    bool VerifySetLayoutCompatibility(const cvdescriptorset::DescriptorSetLayout& layout_dsl,
-                                      const cvdescriptorset::DescriptorSetLayout& bound_dsl, std::string& error_msg) const;
+    bool VerifySetLayoutCompatibility(const vvl::DescriptorSetLayout& layout_dsl,
+                                      const vvl::DescriptorSetLayout& bound_dsl, std::string& error_msg) const;
 
-    bool VerifySetLayoutCompatibility(const cvdescriptorset::DescriptorSet& descriptor_set,
-                                      const std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>>& set_layouts,
+    bool VerifySetLayoutCompatibility(const vvl::DescriptorSet& descriptor_set,
+                                      const std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>>& set_layouts,
                                       const VulkanTypedHandle& handle, const uint32_t layoutIndex, std::string& errorMsg) const;
 
     bool VerifySetLayoutCompatibility(const PIPELINE_LAYOUT_STATE& layout_a, const PIPELINE_LAYOUT_STATE& layout_b,
                                       std::string& errorMsg) const;
 
     // Validate contents of a CopyUpdate
-    using DescriptorSet = cvdescriptorset::DescriptorSet;
+    using DescriptorSet = vvl::DescriptorSet;
     bool ValidateCopyUpdate(const VkCopyDescriptorSet& update, const Location& copy_loc) const;
     bool VerifyCopyUpdateContents(const VkCopyDescriptorSet& update, const DescriptorSet& src_set, VkDescriptorType src_type,
                                   uint32_t src_index, const DescriptorSet& dst_set, VkDescriptorType dst_type, uint32_t dst_index,

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -9,7 +9,7 @@ bool vvl::DescriptorValidator::ValidateDescriptors(const DescriptorBindingInfo &
         const auto &descriptor = binding.descriptors[index];
 
         if (!binding.updated[index]) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                             "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                             ") is being used in draw but has never been updated via vkUpdateDescriptorSets() or a similar call.",
@@ -20,31 +20,31 @@ bool vvl::DescriptorValidator::ValidateDescriptors(const DescriptorBindingInfo &
     return skip;
 }
 
-bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &binding_info, const cvdescriptorset::DescriptorBinding &binding) const {
-    using DescriptorClass = cvdescriptorset::DescriptorClass;
+bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &binding_info, const vvl::DescriptorBinding &binding) const {
+    using DescriptorClass = vvl::DescriptorClass;
     bool skip = false;
     switch (binding.descriptor_class) {
         case DescriptorClass::InlineUniform:
             // Can't validate the descriptor because it may not have been updated.
             break;
         case DescriptorClass::GeneralBuffer:
-            skip = ValidateDescriptors(binding_info, static_cast<const cvdescriptorset::BufferBinding &>(binding));
+            skip = ValidateDescriptors(binding_info, static_cast<const vvl::BufferBinding &>(binding));
             break;
         case DescriptorClass::ImageSampler:
-            skip = ValidateDescriptors(binding_info, static_cast<const cvdescriptorset::ImageSamplerBinding &>(binding));
+            skip = ValidateDescriptors(binding_info, static_cast<const vvl::ImageSamplerBinding &>(binding));
             break;
         case DescriptorClass::Image:
-            skip = ValidateDescriptors(binding_info, static_cast<const cvdescriptorset::ImageBinding &>(binding));
+            skip = ValidateDescriptors(binding_info, static_cast<const vvl::ImageBinding &>(binding));
             break;
         case DescriptorClass::PlainSampler:
-            skip = ValidateDescriptors(binding_info, static_cast<const cvdescriptorset::SamplerBinding &>(binding));
+            skip = ValidateDescriptors(binding_info, static_cast<const vvl::SamplerBinding &>(binding));
             break;
         case DescriptorClass::TexelBuffer:
-            skip = ValidateDescriptors(binding_info, static_cast<const cvdescriptorset::TexelBinding &>(binding));
+            skip = ValidateDescriptors(binding_info, static_cast<const vvl::TexelBinding &>(binding));
             break;
         case DescriptorClass::AccelerationStructure:
             skip = ValidateDescriptors(binding_info,
-                                       static_cast<const cvdescriptorset::AccelerationStructureBinding &>(binding));
+                                       static_cast<const vvl::AccelerationStructureBinding &>(binding));
             break;
         default:
             break;
@@ -60,7 +60,7 @@ bool vvl::DescriptorValidator::ValidateDescriptors(const DescriptorBindingInfo &
         const auto &descriptor = binding.descriptors[index];
 
         if (!binding.updated[index]) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                             "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                             ") is being used in draw but has never been updated via vkUpdateDescriptorSets() or a similar call.",
@@ -72,7 +72,7 @@ bool vvl::DescriptorValidator::ValidateDescriptors(const DescriptorBindingInfo &
 }
 
 bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &binding_info, const std::vector<uint32_t> &indices) {
-    using DescriptorClass = cvdescriptorset::DescriptorClass;
+    using DescriptorClass = vvl::DescriptorClass;
     auto &binding = *descriptor_set.GetBinding(binding_info.first);
     bool skip = false;
     switch (binding.descriptor_class) {
@@ -80,10 +80,10 @@ bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &bind
             // Can't validate the descriptor because it may not have been updated.
             break;
         case DescriptorClass::GeneralBuffer:
-            skip = ValidateDescriptors(binding_info, static_cast<const cvdescriptorset::BufferBinding &>(binding), indices);
+            skip = ValidateDescriptors(binding_info, static_cast<const vvl::BufferBinding &>(binding), indices);
             break;
         case DescriptorClass::ImageSampler: {
-            auto &imgs_binding = static_cast<cvdescriptorset::ImageSamplerBinding &>(binding);
+            auto &imgs_binding = static_cast<vvl::ImageSamplerBinding &>(binding);
             for (auto index : indices) {
                 auto &descriptor = imgs_binding.descriptors[index];
                 descriptor.UpdateDrawState(&dev_state, &cb_state);
@@ -92,7 +92,7 @@ bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &bind
             break;
         }
         case DescriptorClass::Image: {
-            auto &img_binding = static_cast<cvdescriptorset::ImageBinding &>(binding);
+            auto &img_binding = static_cast<vvl::ImageBinding &>(binding);
             for (auto index : indices) {
                 auto &descriptor = img_binding.descriptors[index];
                 descriptor.UpdateDrawState(&dev_state, &cb_state);
@@ -101,14 +101,14 @@ bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &bind
             break;
         }
         case DescriptorClass::PlainSampler:
-            skip = ValidateDescriptors(binding_info, static_cast<const cvdescriptorset::SamplerBinding &>(binding), indices);
+            skip = ValidateDescriptors(binding_info, static_cast<const vvl::SamplerBinding &>(binding), indices);
             break;
         case DescriptorClass::TexelBuffer:
-            skip = ValidateDescriptors(binding_info, static_cast<const cvdescriptorset::TexelBinding &>(binding), indices);
+            skip = ValidateDescriptors(binding_info, static_cast<const vvl::TexelBinding &>(binding), indices);
             break;
         case DescriptorClass::AccelerationStructure:
             skip = ValidateDescriptors(binding_info,
-                                       static_cast<const cvdescriptorset::AccelerationStructureBinding &>(binding), indices);
+                                       static_cast<const vvl::AccelerationStructureBinding &>(binding), indices);
             break;
         default:
             break;
@@ -117,12 +117,12 @@ bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &bind
 }
 
 bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index,
-                                    VkDescriptorType descriptor_type, const cvdescriptorset::BufferDescriptor &descriptor) const {
+                                    VkDescriptorType descriptor_type, const vvl::BufferDescriptor &descriptor) const {
     // Verify that buffers are valid
     const VkBuffer buffer = descriptor.GetBuffer();
     auto buffer_node = descriptor.GetBufferState();
     if ((!buffer_node && !dev_state.enabled_features.nullDescriptor) || (buffer_node && buffer_node->Destroyed())) {
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                         "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                         ") is using buffer %s that is invalid or has been destroyed.",
@@ -134,7 +134,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     }
     if (buffer_node /* && !buffer_node->sparse*/) {
         for (const auto &binding : buffer_node->GetInvalidMemory()) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                             "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                             ") is using buffer %s that references invalid memory %s.",
@@ -158,22 +158,22 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
 bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index,
                                     VkDescriptorType descriptor_type,
-                                    const cvdescriptorset::ImageDescriptor &image_descriptor) const {
+                                    const vvl::ImageDescriptor &image_descriptor) const {
     std::vector<const SAMPLER_STATE *> sampler_states;
     const VkImageView image_view = image_descriptor.GetImageView();
     const IMAGE_VIEW_STATE *image_view_state = image_descriptor.GetImageViewState();
     const auto binding = binding_info.first;
 
-    if (image_descriptor.GetClass() == cvdescriptorset::DescriptorClass::ImageSampler) {
+    if (image_descriptor.GetClass() == vvl::DescriptorClass::ImageSampler) {
         sampler_states.emplace_back(
-            static_cast<const cvdescriptorset::ImageSamplerDescriptor &>(image_descriptor).GetSamplerState());
+            static_cast<const vvl::ImageSamplerDescriptor &>(image_descriptor).GetSamplerState());
     } else if (binding_info.second.variable && binding_info.second.variable->samplers_used_by_image.size() > index) {
         for (const auto &desc_index : binding_info.second.variable->samplers_used_by_image[index]) {
             const auto *desc = descriptor_set.GetDescriptorFromBinding(desc_index.sampler_slot.binding, desc_index.sampler_index);
             // TODO: This check _shouldn't_ be necessary due to the checks made in ResourceInterfaceVariable() in
             //       shader_validation.cpp. However, without this check some traces still crash.
-            if (desc && (desc->GetClass() == cvdescriptorset::DescriptorClass::PlainSampler)) {
-                const auto *sampler_state = static_cast<const cvdescriptorset::SamplerDescriptor *>(desc)->GetSamplerState();
+            if (desc && (desc->GetClass() == vvl::DescriptorClass::PlainSampler)) {
+                const auto *sampler_state = static_cast<const vvl::SamplerDescriptor *>(desc)->GetSamplerState();
                 if (sampler_state) sampler_states.emplace_back(sampler_state);
             }
         }
@@ -183,7 +183,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         // Image view must have been destroyed since initial update. Could potentially flag the descriptor
         //  as "invalid" (updated = false) at DestroyImageView() time and detect this error at bind time
 
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                         "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                         ") is using imageView %s that is invalid or has been destroyed.",
@@ -236,7 +236,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 break;  // incase a new VkImageViewType is added, let it be valid by default
         }
         if (!valid_dim) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
             return dev_state.LogError(vuids.image_view_dim_07752, objlist, loc,
                             "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -249,7 +249,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             const bool signed_override = ((variable.info.image_format_type & NumericTypeUint) && variable.info.is_sign_extended);
             const bool unsigned_override = ((variable.info.image_format_type & NumericTypeSint) && variable.info.is_zero_extended);
             if (!signed_override && !unsigned_override) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view);
                 return dev_state.LogError(vuids.image_view_numeric_format_07753, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -262,7 +262,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         const bool image_format_width_64 = vkuFormatHasComponentSize(image_view_ci.format, 64);
         if (image_format_width_64) {
             if (binding_info.second.variable->image_sampled_type_width != 64) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view);
                 return dev_state.LogError(
                     vuids.image_view_access_64_04470, objlist, loc,
@@ -271,7 +271,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     FormatHandle(set).c_str(), binding, index, string_VkFormat(image_view_ci.format),
                     binding_info.second.variable->image_sampled_type_width);
             } else if (!dev_state.enabled_features.sparseImageInt64Atomics && image_view_state->image_state->sparse_residency) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, image_view_state->image_state->image());
                 return dev_state.LogError(vuids.image_view_sparse_64_04474, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -280,7 +280,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                 FormatHandle(set).c_str(), binding, index);
             }
         } else if (!image_format_width_64 && binding_info.second.variable->image_sampled_type_width != 32) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
             return dev_state.LogError(
                 vuids.image_view_access_32_04471, objlist, loc,
@@ -299,7 +299,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         dev_state.VerifyImageLayout(cb_state, *image_view_state, image_layout, loc,
                           "VUID-VkDescriptorImageInfo-imageLayout-00344", &hit_error);
         if (hit_error) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             std::stringstream msg;
             if (!descriptor_set.IsPushDescriptor()) {
                 msg << "Descriptor set " << FormatHandle(set)
@@ -316,13 +316,13 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
     // Verify Sample counts
     if (variable.IsImage() && !variable.info.is_multisampled && image_view_state->samples != VK_SAMPLE_COUNT_1_BIT) {
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         return dev_state.LogError("VUID-RuntimeSpirv-samples-08725", set, loc,
                         "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32 ") has image created with %s.",
                         FormatHandle(set).c_str(), binding, index, string_VkSampleCountFlagBits(image_view_state->samples));
     }
     if (variable.IsImage() && variable.info.is_multisampled && image_view_state->samples == VK_SAMPLE_COUNT_1_BIT) {
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         return dev_state.LogError("VUID-RuntimeSpirv-samples-08726", set, loc,
                         "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32 ") has image created with VK_SAMPLE_COUNT_1_BIT.",
                         FormatHandle(set).c_str(), binding, index);
@@ -330,7 +330,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
     if (image_view_state->samplerConversion) {
         if (variable.info.is_not_sampler_sampled) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
             return dev_state.LogError(
                 vuids.image_ycbcr_sampled_06550, set, loc,
@@ -339,7 +339,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 FormatHandle(set).c_str(), binding, index);
         }
         if (variable.info.is_sampler_offset) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
             return dev_state.LogError(
                 vuids.image_ycbcr_offset_06551, set, loc,
@@ -352,7 +352,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     // Verify VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT
     if (variable.info.is_atomic_operation && (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) &&
         !(image_view_state->format_features & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         const LogObjectList objlist(set, image_view);
         return dev_state.LogError(
             vuids.imageview_atomic_02691, objlist, loc,
@@ -371,7 +371,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         if (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
             if ((variable.info.is_read_without_format) &&
                 !(format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT)) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view);
                 return dev_state.LogError(vuids.storage_image_read_without_format_07028, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -383,7 +383,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
             if ((variable.info.is_write_without_format) &&
                 !(format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT)) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view);
                 return dev_state.LogError(vuids.storage_image_write_without_format_07027, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -395,7 +395,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         }
 
         if ((variable.info.is_dref) && !(format_features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT)) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
             return dev_state.LogError(vuids.depth_compare_sample_06479, objlist, loc,
                             "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -500,7 +500,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                   : !depth_write_attachment ? vuids.attachment_access_09001
                                                             : vuids.attachment_access_09002;
                 if (same_view) {
-                    auto set = descriptor_set.GetSet();
+                    auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer);
                     return dev_state.LogError(vuid, objlist, loc,
                                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -508,7 +508,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                     FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
                                     FormatHandle(framebuffer).c_str(), att_index);
                 } else if (overlapping_view) {
-                    auto set = descriptor_set.GetSet();
+                    auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer, view_state->image_view());
                     return dev_state.LogError(vuid, objlist, loc,
                                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -521,7 +521,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             const bool read_attachment = (subpass.usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) > 0;
             if (read_attachment && descriptor_written_to) {
                 if (same_view) {
-                    auto set = descriptor_set.GetSet();
+                    auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer);
                     return dev_state.LogError(vuids.image_subresources_subpass_write_06539, objlist, loc,
                                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -529,7 +529,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                     FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
                                     FormatHandle(framebuffer).c_str(), att_index);
                 } else if (overlapping_view) {
-                    auto set = descriptor_set.GetSet();
+                    auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer, view_state->image_view());
                     return dev_state.LogError(vuids.image_subresources_subpass_write_06539, objlist, loc,
                                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -542,7 +542,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
             if (descriptor_written_to && !layout_read_only) {
                 if (same_view) {
-                    auto set = descriptor_set.GetSet();
+                    auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer);
                     return dev_state.LogError(vuids.image_subresources_render_pass_write_06537, objlist, loc,
                                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -550,7 +550,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                     FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
                                     FormatHandle(framebuffer).c_str(), att_index);
                 } else if (overlapping_view) {
-                    auto set = descriptor_set.GetSet();
+                    auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer, view_state->image_view());
                     return dev_state.LogError(vuids.image_subresources_render_pass_write_06537, objlist, loc,
                                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -586,7 +586,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             (sampler_state->customCreateInfo.format == VK_FORMAT_UNDEFINED)) {
             if (image_view_format == VK_FORMAT_B4G4R4A4_UNORM_PACK16 || image_view_format == VK_FORMAT_B5G6R5_UNORM_PACK16 ||
                 image_view_format == VK_FORMAT_B5G5R5A1_UNORM_PACK16 || image_view_format == VK_FORMAT_A1B5G5R5_UNORM_PACK16_KHR) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
                 return dev_state.LogError(
                     "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04015", objlist, loc,
@@ -603,7 +603,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         if ((sampler_compare_enable == VK_FALSE) &&
             !(image_view_state->format_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)) {
             if (sampler_mag_filter == VK_FILTER_LINEAR || sampler_min_filter == VK_FILTER_LINEAR) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
                 return dev_state.LogError(vuids.linear_filter_sampler_04553, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -614,7 +614,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                 FormatHandle(image_view_state->image_view()).c_str(), string_VkFormat(image_view_format));
             }
             if (sampler_state->createInfo.mipmapMode == VK_SAMPLER_MIPMAP_MODE_LINEAR) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
                 return dev_state.LogError(vuids.linear_mipmap_sampler_04770, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -628,7 +628,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
         if (sampler_mag_filter == VK_FILTER_CUBIC_EXT || sampler_min_filter == VK_FILTER_CUBIC_EXT) {
             if (!(image_view_state->format_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT)) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
                 return dev_state.LogError(vuids.cubic_sampler_02692, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -645,7 +645,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     (reduction_mode_info->reductionMode == VK_SAMPLER_REDUCTION_MODE_MIN ||
                      reduction_mode_info->reductionMode == VK_SAMPLER_REDUCTION_MODE_MAX) &&
                     !image_view_state->filter_cubic_props.filterCubicMinmax) {
-                    auto set = descriptor_set.GetSet();
+                    auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
                     return dev_state.LogError(vuids.filter_cubic_min_max_02695, objlist, loc,
                                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -657,7 +657,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 }
 
                 if (!image_view_state->filter_cubic_props.filterCubic) {
-                    auto set = descriptor_set.GetSet();
+                    auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
                     return dev_state.LogError(vuids.filter_cubic_02694, objlist, loc,
                                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -672,7 +672,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 if (image_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_3D ||
                     image_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_CUBE ||
                     image_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
-                    auto set = descriptor_set.GetSet();
+                    auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
                     return dev_state.LogError(vuids.img_filter_cubic_02693, objlist, loc,
                                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -698,7 +698,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                                 : (sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
                                                     ? sampler_state->createInfo.addressModeV
                                                     : sampler_state->createInfo.addressModeW;
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, sampler_state->sampler(), image_state->image(), image_view_state->image_view());
             return dev_state.LogError(vuids.corner_sampled_address_mode_02696, objlist, loc,
                             "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -718,7 +718,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             if (image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_3D || image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_CUBE ||
                 image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_1D_ARRAY || image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY ||
                 image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, sampler_state->sampler());
                 return dev_state.LogError(vuids.sampler_imageview_type_08609, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -730,7 +730,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample*
             // instructions with ImplicitLod, Dref or Proj in their name
             if (variable.info.is_sampler_implicitLod_dref_proj) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, sampler_state->sampler());
                 return dev_state.LogError(vuids.sampler_implicitLod_dref_proj_08610, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -742,7 +742,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample*
             // instructions that includes a LOD bias or any offset values
             if (variable.info.is_sampler_bias_offset) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, sampler_state->sampler());
                 return dev_state.LogError(vuids.sampler_bias_offset_08611, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -754,7 +754,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
         if (sampler_state->samplerConversion) {
             if (variable.info.is_not_sampler_sampled) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, sampler_state->sampler());
                 return dev_state.LogError(
                     vuids.image_ycbcr_sampled_06550, set, loc,
@@ -763,7 +763,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     FormatHandle(set).c_str(), binding, index);
             }
             if (variable.info.is_sampler_offset) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, sampler_state->sampler());
                 return dev_state.LogError(
                     vuids.image_ycbcr_offset_06551, set, loc,
@@ -778,7 +778,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         const uint32_t format_component_count = vkuFormatComponentCount(image_view_format);
         if (image_view_format == VK_FORMAT_A8_UNORM_KHR) {
             if (texel_component_count != 4) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view);
                 return dev_state.LogError(vuids.storage_image_write_texel_count_08796, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -787,7 +787,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                 FormatHandle(set).c_str(), binding, index, texel_component_count);
             }
         } else if (texel_component_count < format_component_count) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
             return dev_state.LogError(vuids.storage_image_write_texel_count_08795, objlist, loc,
                             "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -803,9 +803,9 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
 bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index,
                                     VkDescriptorType descriptor_type,
-                                    const cvdescriptorset::ImageSamplerDescriptor &descriptor) const {
+                                    const vvl::ImageSamplerDescriptor &descriptor) const {
     bool skip = ValidateDescriptor(binding_info, index, descriptor_type,
-                                   static_cast<const cvdescriptorset::ImageDescriptor &>(descriptor));
+                                   static_cast<const vvl::ImageDescriptor &>(descriptor));
     if (!skip) {
         skip = ValidateSamplerDescriptor(binding_info, index, descriptor.GetSampler(),
                                          descriptor.IsImmutableSampler(), descriptor.GetSamplerState());
@@ -815,12 +815,12 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
 bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index,
                                     VkDescriptorType descriptor_type,
-                                    const cvdescriptorset::TexelDescriptor &texel_descriptor) const {
+                                    const vvl::TexelDescriptor &texel_descriptor) const {
     const VkBufferView buffer_view = texel_descriptor.GetBufferView();
     auto buffer_view_state = texel_descriptor.GetBufferViewState();
     const auto binding = binding_info.first;
     if ((!buffer_view_state && !dev_state.enabled_features.nullDescriptor) || (buffer_view_state && buffer_view_state->Destroyed())) {
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                         "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                         ") is using bufferView %s that is invalid or has been destroyed.",
@@ -842,7 +842,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     const auto *buffer_state = buffer_view_state->buffer_state.get();
     const VkFormat buffer_view_format = buffer_view_state->create_info.format;
     if (buffer_state->Destroyed()) {
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                         "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32 ") is using buffer %s that has been destroyed.",
                         FormatHandle(set).c_str(), binding, index, FormatHandle(buffer).c_str());
@@ -853,7 +853,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         const bool signed_override = ((variable.info.image_format_type & NumericTypeUint) && variable.info.is_sign_extended);
         const bool unsigned_override = ((variable.info.image_format_type & NumericTypeSint) && variable.info.is_zero_extended);
         if (!signed_override && !unsigned_override) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                             "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                             ") requires %s component type, but bound descriptor format is %s.",
@@ -864,7 +864,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
     const bool buffer_format_width_64 = vkuFormatHasComponentSize(buffer_view_format, 64);
     if (buffer_format_width_64 && binding_info.second.variable->image_sampled_type_width != 64) {
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         const LogObjectList objlist(set, buffer_view);
         return dev_state.LogError(vuids.buffer_view_access_64_04472, objlist, loc,
                         "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -873,7 +873,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                         FormatHandle(set).c_str(), binding, index, string_VkFormat(buffer_view_format),
                         binding_info.second.variable->image_sampled_type_width);
     } else if (!buffer_format_width_64 && binding_info.second.variable->image_sampled_type_width != 32) {
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         const LogObjectList objlist(set, buffer_view);
         return dev_state.LogError(vuids.buffer_view_access_32_04473, objlist, loc,
                         "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -888,7 +888,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     // Verify VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT
     if ((variable.info.is_atomic_operation) && (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) &&
         !(buf_format_features & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)) {
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         const LogObjectList objlist(set, buffer_view);
         return dev_state.LogError(
             vuids.bufferview_atomic_07888, objlist, loc,
@@ -905,7 +905,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         if (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
             if ((variable.info.is_read_without_format) &&
                 !(buf_format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR)) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, buffer_view);
                 return dev_state.LogError(vuids.storage_texel_buffer_read_without_format_07030, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -917,7 +917,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
             if ((variable.info.is_write_without_format) &&
                 !(buf_format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR)) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, buffer_view);
                 return dev_state.LogError(vuids.storage_texel_buffer_write_without_format_07029, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -944,7 +944,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     for (const uint32_t texel_component_count : binding_info.second.variable->write_without_formats_component_count_list) {
         const uint32_t format_component_count = vkuFormatComponentCount(buffer_view_format);
         if (texel_component_count < format_component_count) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, buffer_view);
             return dev_state.LogError(vuids.storage_texel_buffer_write_texel_count_04469, objlist, loc,
                             "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -960,7 +960,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
 bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index,
                                     VkDescriptorType descriptor_type,
-                                    const cvdescriptorset::AccelerationStructureDescriptor &descriptor) const {
+                                    const vvl::AccelerationStructureDescriptor &descriptor) const {
     // Verify that acceleration structures are valid
     const auto binding = binding_info.first;
     if (descriptor.is_khr()) {
@@ -968,7 +968,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         auto acc_node = descriptor.GetAccelerationStructureStateKHR();
         if (!acc_node || acc_node->Destroyed()) {
             if (acc != VK_NULL_HANDLE || !dev_state.enabled_features.nullDescriptor) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                 ") is using acceleration structure %s that is invalid or has been destroyed.",
@@ -976,7 +976,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             }
         } else {
             for (const auto &mem_binding : acc_node->buffer_state->GetInvalidMemory()) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                 ") is using acceleration structure %s that references invalid memory %s.",
@@ -989,7 +989,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         auto acc_node = descriptor.GetAccelerationStructureStateNV();
         if (!acc_node || acc_node->Destroyed()) {
             if (acc != VK_NULL_HANDLE || !dev_state.enabled_features.nullDescriptor) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                 ") is using acceleration structure %s that is invalid or has been destroyed.",
@@ -997,7 +997,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             }
         } else {
             for (const auto &mem_binding : acc_node->GetInvalidMemory()) {
-                auto set = descriptor_set.GetSet();
+                auto set = descriptor_set.Handle();
                 return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                 ") is using acceleration structure %s that references invalid memory %s.",
@@ -1016,14 +1016,14 @@ bool vvl::DescriptorValidator::ValidateSamplerDescriptor(const DescriptorBinding
                                                          bool is_immutable, const SAMPLER_STATE *sampler_state) const {
     // Verify Sampler still valid
     if (!sampler_state || sampler_state->Destroyed()) {
-        auto set = descriptor_set.GetSet();
+        auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                         "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                         ") is using sampler %s that is invalid or has been destroyed.",
                         FormatHandle(set).c_str(), binding_info.first, index, FormatHandle(sampler).c_str());
     } else {
         if (sampler_state->samplerConversion && !is_immutable) {
-            auto set = descriptor_set.GetSet();
+            auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                             "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                             ") sampler (%s) contains a YCBCR conversion (%s), but the sampler is not an "
@@ -1036,7 +1036,7 @@ bool vvl::DescriptorValidator::ValidateSamplerDescriptor(const DescriptorBinding
 }
 
 bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index,
-                                    VkDescriptorType descriptor_type, const cvdescriptorset::SamplerDescriptor &descriptor) const {
+                                    VkDescriptorType descriptor_type, const vvl::SamplerDescriptor &descriptor) const {
     return ValidateSamplerDescriptor(binding_info, index, descriptor.GetSampler(), descriptor.IsImmutableSampler(), descriptor.GetSamplerState());
 }
 

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -11,7 +11,7 @@ using DescriptorBindingInfo = vvl::map_entry<uint32_t, DescriptorRequirement>;
 class DescriptorValidator {
  public:
 
-    DescriptorValidator(ValidationStateTracker &dev, CMD_BUFFER_STATE &cb, cvdescriptorset::DescriptorSet& set,
+    DescriptorValidator(ValidationStateTracker &dev, CMD_BUFFER_STATE &cb, vvl::DescriptorSet& set,
                         VkFramebuffer fb, const Location &l) : dev_state(dev), cb_state(cb), descriptor_set(set),
                         framebuffer(fb), loc(l), vuids(GetDrawDispatchVuid(loc.function))  {}
 
@@ -20,7 +20,7 @@ class DescriptorValidator {
         return dev_state.FormatHandle(std::forward<T>(h));
     }
 
-    bool ValidateBinding(const DescriptorBindingInfo& binding_info, const cvdescriptorset::DescriptorBinding& binding) const;
+    bool ValidateBinding(const DescriptorBindingInfo& binding_info, const vvl::DescriptorBinding& binding) const;
     bool ValidateBinding(const DescriptorBindingInfo& binding_info, const std::vector<uint32_t> &indices);
 
  private:
@@ -32,18 +32,18 @@ class DescriptorValidator {
 
 
     bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type, const cvdescriptorset::BufferDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const vvl::BufferDescriptor& descriptor) const;
     bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type, const cvdescriptorset::ImageDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const vvl::ImageDescriptor& descriptor) const;
     bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type, const cvdescriptorset::ImageSamplerDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const vvl::ImageSamplerDescriptor& descriptor) const;
     bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type, const cvdescriptorset::TexelDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const vvl::TexelDescriptor& descriptor) const;
     bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
                             VkDescriptorType descriptor_type,
-                            const cvdescriptorset::AccelerationStructureDescriptor& descriptor) const;
+                            const vvl::AccelerationStructureDescriptor& descriptor) const;
     bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type, const cvdescriptorset::SamplerDescriptor& descriptor) const;
+                            VkDescriptorType descriptor_type, const vvl::SamplerDescriptor& descriptor) const;
 
     // helper for the common parts of ImageSamplerDescriptor and SamplerDescriptor validation
     bool ValidateSamplerDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkSampler sampler, bool is_immutable,
@@ -51,7 +51,7 @@ class DescriptorValidator {
 
     ValidationStateTracker& dev_state;
     CMD_BUFFER_STATE& cb_state;
-    cvdescriptorset::DescriptorSet& descriptor_set;
+    vvl::DescriptorSet& descriptor_set;
     const VkFramebuffer framebuffer;
     const Location& loc;
     const DrawDispatchVuid& vuids;

--- a/layers/gpu_validation/gpu_descriptor_set.h
+++ b/layers/gpu_validation/gpu_descriptor_set.h
@@ -26,10 +26,10 @@ class GpuAssisted;
 
 namespace gpuav_state {
 
-class DescriptorSet : public cvdescriptorset::DescriptorSet {
+class DescriptorSet : public vvl::DescriptorSet {
   public:
-    DescriptorSet(const VkDescriptorSet set, DESCRIPTOR_POOL_STATE *pool,
-                  const std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> &layout, uint32_t variable_count,
+    DescriptorSet(const VkDescriptorSet set, vvl::DescriptorPool *pool,
+                  const std::shared_ptr<vvl::DescriptorSetLayout const> &layout, uint32_t variable_count,
                   ValidationStateTracker *state_data);
     virtual ~DescriptorSet();
     void Destroy() override { last_used_state_.reset(); };
@@ -47,14 +47,14 @@ class DescriptorSet : public cvdescriptorset::DescriptorSet {
     };
     void PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet *write_descs) override;
     void PerformWriteUpdate(const VkWriteDescriptorSet &) override;
-    void PerformCopyUpdate(const VkCopyDescriptorSet &, const cvdescriptorset::DescriptorSet &) override;
+    void PerformCopyUpdate(const VkCopyDescriptorSet &, const vvl::DescriptorSet &) override;
 
     VkDeviceAddress GetLayoutState();
     std::shared_ptr<State> GetCurrentState();
     std::shared_ptr<State> GetOutputState();
 
   protected:
-    bool SkipBinding(const cvdescriptorset::DescriptorBinding &binding) const override { return true; }
+    bool SkipBinding(const vvl::DescriptorBinding &binding) const override { return true; }
   private:
     struct Layout {
         VmaAllocation allocation{nullptr};

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -198,10 +198,10 @@ void gpuav_state::CommandBuffer::Process(VkQueue queue, const Location &loc) {
             Location draw_loc(vvl::Func::vkCmdDraw);
             // For each descriptor set ...
             for (auto &set : di_info.descriptor_set_buffers) {
-                if (validated_desc_sets.count(set.state->GetSet()) > 0) {
+                if (validated_desc_sets.count(set.state->VkHandle()) > 0) {
                     continue;
                 }
-                validated_desc_sets.emplace(set.state->GetSet());
+                validated_desc_sets.emplace(set.state->VkHandle());
                 assert(set.output_state);
 
                 vvl::DescriptorValidator context(*device_state, *this, *set.state, VK_NULL_HANDLE /*framebuffer*/, draw_loc);

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -727,7 +727,7 @@ struct RestorablePipelineState {
             for (std::size_t i = 0; i < last_bound.per_set.size(); i++) {
                 const auto &bound_descriptor_set = last_bound.per_set[i].bound_descriptor_set;
                 if (bound_descriptor_set) {
-                    descriptor_sets.push_back(std::make_pair(bound_descriptor_set->GetSet(), static_cast<uint32_t>(i)));
+                    descriptor_sets.push_back(std::make_pair(bound_descriptor_set->VkHandle(), static_cast<uint32_t>(i)));
                     if (bound_descriptor_set->IsPushDescriptor()) {
                         push_descriptor_set_index = static_cast<uint32_t>(i);
                     }
@@ -1301,13 +1301,13 @@ bool GenerateValidationMessage(const uint32_t *debug_record, std::string &msg, s
             }
             oob_access = true;
             auto desc_class = binding_state->descriptor_class;
-            if (desc_class == cvdescriptorset::DescriptorClass::Mutable) {
+            if (desc_class == vvl::DescriptorClass::Mutable) {
                 desc_class =
-                    static_cast<const cvdescriptorset::MutableBinding *>(binding_state)->descriptors[desc_index].ActiveClass();
+                    static_cast<const vvl::MutableBinding *>(binding_state)->descriptors[desc_index].ActiveClass();
             }
 
             switch (desc_class) {
-                case cvdescriptorset::DescriptorClass::GeneralBuffer:
+                case vvl::DescriptorClass::GeneralBuffer:
                     strm << "(set = " << set_num << ", binding = " << binding_num << ") Descriptor index " << desc_index
                          << " access out of bounds. Descriptor size is " << size << " and highest byte accessed was " << offset;
                     if (binding_state->type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER ||
@@ -1317,7 +1317,7 @@ bool GenerateValidationMessage(const uint32_t *debug_record, std::string &msg, s
                         vuid_msg = vuid.storage_access_oob;
                     }
                     break;
-                case cvdescriptorset::DescriptorClass::TexelBuffer:
+                case vvl::DescriptorClass::TexelBuffer:
                     strm << "(set = " << set_num << ", binding = " << binding_num << ") Descriptor index " << desc_index
                          << " access out of bounds. Descriptor size is " << size << " texels and highest texel accessed was "
                          << offset;
@@ -2578,10 +2578,10 @@ void GpuAssisted::AllocateValidationResources(const VkCommandBuffer cmd_buffer, 
     // push the command id
 }
 
-std::shared_ptr<cvdescriptorset::DescriptorSet> GpuAssisted::CreateDescriptorSet(
-    VkDescriptorSet set, DESCRIPTOR_POOL_STATE *pool, const std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> &layout,
+std::shared_ptr<vvl::DescriptorSet> GpuAssisted::CreateDescriptorSet(
+    VkDescriptorSet set, vvl::DescriptorPool *pool, const std::shared_ptr<vvl::DescriptorSetLayout const> &layout,
     uint32_t variable_count) {
-    return std::static_pointer_cast<cvdescriptorset::DescriptorSet>(
+    return std::static_pointer_cast<vvl::DescriptorSet>(
         std::make_shared<gpuav_state::DescriptorSet>(set, pool, layout, variable_count, this));
 }
 

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -97,7 +97,7 @@ VALSTATETRACK_DERIVED_STATE_OBJECT(VkAccelerationStructureNV, gpuav_state::Accel
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkBuffer, gpuav_state::Buffer, BUFFER_STATE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkBufferView, gpuav_state::BufferView, BUFFER_VIEW_STATE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, gpuav_state::CommandBuffer, CMD_BUFFER_STATE)
-VALSTATETRACK_DERIVED_STATE_OBJECT(VkDescriptorSet, gpuav_state::DescriptorSet, cvdescriptorset::DescriptorSet)
+VALSTATETRACK_DERIVED_STATE_OBJECT(VkDescriptorSet, gpuav_state::DescriptorSet, vvl::DescriptorSet)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkImageView, gpuav_state::ImageView, IMAGE_VIEW_STATE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkSampler, gpuav_state::Sampler, SAMPLER_STATE)
 
@@ -404,8 +404,8 @@ class GpuAssisted : public GpuAssistedBase {
 
     std::shared_ptr<CMD_BUFFER_STATE> CreateCmdBufferState(VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info,
                                                            const COMMAND_POOL_STATE* pool) final;
-    std::shared_ptr<cvdescriptorset::DescriptorSet> CreateDescriptorSet(
-        VkDescriptorSet, DESCRIPTOR_POOL_STATE*, const std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>& layout,
+    std::shared_ptr<vvl::DescriptorSet> CreateDescriptorSet(
+        VkDescriptorSet, vvl::DescriptorPool*, const std::shared_ptr<vvl::DescriptorSetLayout const>& layout,
         uint32_t variable_count) final;
 
     void DestroyBuffer(gpuav_state::CommandInfo& cmd_info);

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1112,7 +1112,7 @@ static bool PushDescriptorCleanup(LAST_BOUND_STATE &last_bound, uint32_t set_idx
 void CMD_BUFFER_STATE::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_bind_point,
                                                      const PIPELINE_LAYOUT_STATE &pipeline_layout, uint32_t first_set,
                                                      uint32_t set_count, const VkDescriptorSet *pDescriptorSets,
-                                                     std::shared_ptr<cvdescriptorset::DescriptorSet> &push_descriptor_set,
+                                                     std::shared_ptr<vvl::DescriptorSet> &push_descriptor_set,
                                                      uint32_t dynamic_offset_count, const uint32_t *p_dynamic_offsets) {
     assert((pDescriptorSets == nullptr) ^ (push_descriptor_set == nullptr));
 
@@ -1167,7 +1167,7 @@ void CMD_BUFFER_STATE::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipelin
         auto set_idx = input_idx + first_set;  // set_idx is index within layout, input_idx is index within input descriptor sets
         auto &set_info = last_bound.per_set[set_idx];
         auto descriptor_set =
-            push_descriptor_set ? push_descriptor_set : dev_data->Get<cvdescriptorset::DescriptorSet>(pDescriptorSets[input_idx]);
+            push_descriptor_set ? push_descriptor_set : dev_data->Get<vvl::DescriptorSet>(pDescriptorSets[input_idx]);
 
         set_info.Reset();
         // Record binding (or push)

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -548,7 +548,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
 
     void UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_bind_point, const PIPELINE_LAYOUT_STATE &pipeline_layout,
                                        uint32_t first_set, uint32_t set_count, const VkDescriptorSet *pDescriptorSets,
-                                       std::shared_ptr<cvdescriptorset::DescriptorSet> &push_descriptor_set,
+                                       std::shared_ptr<vvl::DescriptorSet> &push_descriptor_set,
                                        uint32_t dynamic_offset_count, const uint32_t *p_dynamic_offsets);
 
     void UpdateLastBoundDescriptorBuffers(VkPipelineBindPoint pipeline_bind_point, const PIPELINE_LAYOUT_STATE &pipeline_layout,

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -122,7 +122,7 @@ static PIPELINE_LAYOUT_STATE::SetLayoutVector GetSetLayouts(ValidationStateTrack
     PIPELINE_LAYOUT_STATE::SetLayoutVector set_layouts(pCreateInfo->setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-        set_layouts[i] = dev_data->Get<cvdescriptorset::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
+        set_layouts[i] = dev_data->Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
     }
     return set_layouts;
 }
@@ -164,7 +164,7 @@ static PIPELINE_LAYOUT_STATE::SetLayoutVector GetSetLayouts(const vvl::span<cons
 }
 
 std::vector<PipelineLayoutCompatId> GetCompatForSet(
-    const std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>> &set_layouts,
+    const std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>> &set_layouts,
     const PushConstantRangesId &push_constant_ranges) {
     PipelineLayoutSetLayoutsDef set_layout_ids(set_layouts.size());
     for (size_t i = 0; i < set_layouts.size(); i++) {

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -27,15 +27,15 @@
 #include "state_tracker/state_tracker.h"
 
 // Fwd declarations -- including descriptor_set.h creates an ugly include loop
-namespace cvdescriptorset {
+namespace vvl {
 class DescriptorSetLayout;
 class DescriptorSetLayoutDef;
-}  // namespace cvdescriptorset
+}  // namespace vvl
 
 class ValidationStateTracker;
 
 // Canonical dictionary for the pipeline layout's layout of descriptorsetlayouts
-using DescriptorSetLayoutDef = cvdescriptorset::DescriptorSetLayoutDef;
+using DescriptorSetLayoutDef = vvl::DescriptorSetLayoutDef;
 using DescriptorSetLayoutId = std::shared_ptr<const DescriptorSetLayoutDef>;
 using PipelineLayoutSetLayoutsDef = std::vector<DescriptorSetLayoutId>;
 using PipelineLayoutSetLayoutsDict =
@@ -69,7 +69,7 @@ PushConstantRangesId GetCanonicalId(uint32_t pushConstantRangeCount, const VkPus
 // Store layouts and pushconstants for PipelineLayout
 class PIPELINE_LAYOUT_STATE : public BASE_NODE {
   public:
-    using SetLayoutVector = std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>>;
+    using SetLayoutVector = std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>>;
     const SetLayoutVector set_layouts;
     // canonical form IDs for the "compatible for set" contents
     const PushConstantRangesId push_constant_ranges;
@@ -86,8 +86,8 @@ class PIPELINE_LAYOUT_STATE : public BASE_NODE {
 
     VkPipelineLayout layout() const { return handle_.Cast<VkPipelineLayout>(); }
 
-    std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> GetDsl(uint32_t set) const {
-        std::shared_ptr<cvdescriptorset::DescriptorSetLayout const> dsl = nullptr;
+    std::shared_ptr<vvl::DescriptorSetLayout const> GetDsl(uint32_t set) const {
+        std::shared_ptr<vvl::DescriptorSetLayout const> dsl = nullptr;
         if (set < set_layouts.size()) {
             dsl = set_layouts[set];
         }
@@ -98,5 +98,5 @@ class PIPELINE_LAYOUT_STATE : public BASE_NODE {
 };
 
 std::vector<PipelineLayoutCompatId> GetCompatForSet(
-    const std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>> &set_layouts,
+    const std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>> &set_layouts,
     const PushConstantRangesId &push_constant_ranges);

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -716,7 +716,7 @@ PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const V
                    VK_SHADER_STAGE_MISS_BIT_KHR | VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR)));
 }
 
-void LAST_BOUND_STATE::UnbindAndResetPushDescriptorSet(std::shared_ptr<cvdescriptorset::DescriptorSet> &&ds) {
+void LAST_BOUND_STATE::UnbindAndResetPushDescriptorSet(std::shared_ptr<vvl::DescriptorSet> &&ds) {
     if (push_descriptor_set) {
         for (auto &ps : per_set) {
             if (ps.bound_descriptor_set == push_descriptor_set) {

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -29,13 +29,13 @@
 #include "utils/shader_utils.h"
 
 // Fwd declarations -- including descriptor_set.h creates an ugly include loop
-namespace cvdescriptorset {
+namespace vvl {
 class DescriptorSetLayoutDef;
 class DescriptorSetLayout;
 class DescriptorSet;
 class Descriptor;
 
-}  // namespace cvdescriptorset
+}  // namespace vvl
 
 class ValidationStateTracker;
 class CMD_BUFFER_STATE;
@@ -704,7 +704,7 @@ struct LAST_BOUND_STATE {
     bool shader_object_bound[SHADER_OBJECT_STAGE_COUNT]{false};
     SHADER_OBJECT_STATE *shader_object_states[SHADER_OBJECT_STAGE_COUNT]{nullptr};
     VkPipelineLayout pipeline_layout{VK_NULL_HANDLE};
-    std::shared_ptr<cvdescriptorset::DescriptorSet> push_descriptor_set;
+    std::shared_ptr<vvl::DescriptorSet> push_descriptor_set;
 
     struct DescriptorBufferBinding {
         uint32_t index{0};
@@ -712,7 +712,7 @@ struct LAST_BOUND_STATE {
     };
     // Ordered bound set tracking where index is set# that given set is bound to
     struct PER_SET {
-        std::shared_ptr<cvdescriptorset::DescriptorSet> bound_descriptor_set;
+        std::shared_ptr<vvl::DescriptorSet> bound_descriptor_set;
         std::optional<DescriptorBufferBinding> bound_descriptor_buffer;
 
         // one dynamic offset per dynamic descriptor bound to this CB
@@ -720,7 +720,7 @@ struct LAST_BOUND_STATE {
         PipelineLayoutCompatId compat_id_for_set{0};
 
         // Cache most recently validated descriptor state for ValidateActionState/UpdateDrawState
-        const cvdescriptorset::DescriptorSet *validated_set{nullptr};
+        const vvl::DescriptorSet *validated_set{nullptr};
         uint64_t validated_set_change_count{~0ULL};
         uint64_t validated_set_image_layout_change_count{~0ULL};
         BindingVariableMap validated_set_binding_req_map;
@@ -736,7 +736,7 @@ struct LAST_BOUND_STATE {
 
     void Reset();
 
-    void UnbindAndResetPushDescriptorSet(std::shared_ptr<cvdescriptorset::DescriptorSet> &&ds);
+    void UnbindAndResetPushDescriptorSet(std::shared_ptr<vvl::DescriptorSet> &&ds);
 
     inline bool IsUsing() const { return pipeline_state != nullptr; }
 

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -22,7 +22,7 @@ static SHADER_OBJECT_STATE::SetLayoutVector GetSetLayouts(ValidationStateTracker
     SHADER_OBJECT_STATE::SetLayoutVector set_layouts(pCreateInfo.setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo.setLayoutCount; ++i) {
-        set_layouts[i] = dev_data->Get<cvdescriptorset::DescriptorSetLayout>(pCreateInfo.pSetLayouts[i]);
+        set_layouts[i] = dev_data->Get<vvl::DescriptorSetLayout>(pCreateInfo.pSetLayouts[i]);
     }
     return set_layouts;
 }

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -46,7 +46,7 @@ struct SHADER_OBJECT_STATE : public BASE_NODE {
     const ActiveSlotMap active_slots;
     const uint32_t max_active_slot = 0;  // the highest set number in active_slots for pipeline layout compatibility checks
 
-    using SetLayoutVector = std::vector<std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>>;
+    using SetLayoutVector = std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>>;
     const SetLayoutVector set_layouts;
     const PushConstantRangesId push_constant_ranges;
     const std::vector<PipelineLayoutCompatId> set_compat_ids;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -39,14 +39,15 @@
 #include <memory>
 #include <vector>
 
-namespace cvdescriptorset {
+namespace vvl {
+struct AllocateDescriptorSetsData;
+class DescriptorPool;
 class DescriptorSet;
 class DescriptorSetLayout;
-struct AllocateDescriptorSetsData;
-}  // namespace cvdescriptorset
+class DescriptorUpdateTemplate;
+}  // namespace vvl
 
 class CMD_BUFFER_STATE;
-class DESCRIPTOR_POOL_STATE;
 class FRAMEBUFFER_STATE;
 class PIPELINE_CACHE_STATE;
 class PIPELINE_STATE;
@@ -65,7 +66,6 @@ class SAMPLER_YCBCR_CONVERSION_STATE;
 class EVENT_STATE;
 class SWAPCHAIN_NODE;
 class SURFACE_STATE;
-class UPDATE_TEMPLATE_STATE;
 struct SHADER_MODULE_STATE;
 struct SHADER_OBJECT_STATE;
 struct SPIRV_MODULE_STATE;
@@ -285,7 +285,7 @@ static inline VkDeviceSize GetBufferSizeFromCopyImage(const RegionType& region, 
 VALSTATETRACK_STATE_OBJECT(VkQueue, QUEUE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE_NV)
 VALSTATETRACK_STATE_OBJECT(VkRenderPass, RENDER_PASS_STATE)
-VALSTATETRACK_STATE_OBJECT(VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout)
+VALSTATETRACK_STATE_OBJECT(VkDescriptorSetLayout, vvl::DescriptorSetLayout)
 VALSTATETRACK_STATE_OBJECT(VkSampler, SAMPLER_STATE)
 VALSTATETRACK_STATE_OBJECT(VkImageView, IMAGE_VIEW_STATE)
 VALSTATETRACK_STATE_OBJECT(VkImage, IMAGE_STATE)
@@ -297,10 +297,10 @@ VALSTATETRACK_STATE_OBJECT(VkShaderEXT, SHADER_OBJECT_STATE)
 VALSTATETRACK_STATE_OBJECT(VkDeviceMemory, DEVICE_MEMORY_STATE)
 VALSTATETRACK_STATE_OBJECT(VkFramebuffer, FRAMEBUFFER_STATE)
 VALSTATETRACK_STATE_OBJECT(VkShaderModule, SHADER_MODULE_STATE)
-VALSTATETRACK_STATE_OBJECT(VkDescriptorUpdateTemplate, UPDATE_TEMPLATE_STATE)
+VALSTATETRACK_STATE_OBJECT(VkDescriptorUpdateTemplate, vvl::DescriptorUpdateTemplate)
 VALSTATETRACK_STATE_OBJECT(VkSwapchainKHR, SWAPCHAIN_NODE)
-VALSTATETRACK_STATE_OBJECT(VkDescriptorPool, DESCRIPTOR_POOL_STATE)
-VALSTATETRACK_STATE_OBJECT(VkDescriptorSet, cvdescriptorset::DescriptorSet)
+VALSTATETRACK_STATE_OBJECT(VkDescriptorPool, vvl::DescriptorPool)
+VALSTATETRACK_STATE_OBJECT(VkDescriptorSet, vvl::DescriptorSet)
 VALSTATETRACK_STATE_OBJECT(VkCommandBuffer, CMD_BUFFER_STATE)
 VALSTATETRACK_STATE_OBJECT(VkCommandPool, COMMAND_POOL_STATE)
 VALSTATETRACK_STATE_OBJECT(VkPipelineLayout, PIPELINE_LAYOUT_STATE)
@@ -740,10 +740,10 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator,
                                    const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<DESCRIPTOR_POOL_STATE> CreateDescriptorPoolState(VkDescriptorPool pool,
+    virtual std::shared_ptr<vvl::DescriptorPool> CreateDescriptorPoolState(VkDescriptorPool pool,
                                                                              const VkDescriptorPoolCreateInfo* pCreateInfo);
-    virtual std::shared_ptr<cvdescriptorset::DescriptorSet> CreateDescriptorSet(
-        VkDescriptorSet, DESCRIPTOR_POOL_STATE*, const std::shared_ptr<cvdescriptorset::DescriptorSetLayout const>& layout,
+    virtual std::shared_ptr<vvl::DescriptorSet> CreateDescriptorSet(
+        VkDescriptorSet, vvl::DescriptorPool*, const std::shared_ptr<vvl::DescriptorSetLayout const>& layout,
         uint32_t variable_count);
 
     void PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo* pCreateInfo,
@@ -1478,8 +1478,8 @@ class ValidationStateTracker : public ValidationObject {
                                                                             const FRAMEBUFFER_STATE& fb_state) const;
 
     VkFormatFeatureFlags2KHR GetPotentialFormatFeatures(VkFormat format) const;
-    void PerformUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet, const UPDATE_TEMPLATE_STATE* template_state,
-                                                    const void* pData);
+    void PerformUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet,
+                                                    const vvl::DescriptorUpdateTemplate* template_state, const void* pData);
     void RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
                                      VkFence fence, uint32_t* pImageIndex, vvl::Func command);
     virtual std::shared_ptr<SWAPCHAIN_NODE> CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info,
@@ -1502,7 +1502,7 @@ class ValidationStateTracker : public ValidationObject {
     void RecordVulkanSurface(VkSurfaceKHR* pSurface);
     void UpdateBindBufferMemoryState(VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset);
     void UpdateBindImageMemoryState(const VkBindImageMemoryInfo& bindInfo);
-    void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, cvdescriptorset::AllocateDescriptorSetsData*) const;
+    void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, vvl::AllocateDescriptorSetsData*) const;
 
     void PostCallRecordCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                     const VkCopyAccelerationStructureInfoKHR* pInfo,
@@ -1897,7 +1897,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkQueue, QUEUE_STATE, queue_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE_NV, acceleration_structure_nv_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkRenderPass, RENDER_PASS_STATE, render_pass_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorSetLayout, cvdescriptorset::DescriptorSetLayout, descriptor_set_layout_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorSetLayout, vvl::DescriptorSetLayout, descriptor_set_layout_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkSampler, SAMPLER_STATE, sampler_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkImageView, IMAGE_VIEW_STATE, image_view_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkImage, IMAGE_STATE, image_map_)
@@ -1909,10 +1909,10 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkDeviceMemory, DEVICE_MEMORY_STATE, mem_obj_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkFramebuffer, FRAMEBUFFER_STATE, frame_buffer_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkShaderModule, SHADER_MODULE_STATE, shader_module_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorUpdateTemplate, UPDATE_TEMPLATE_STATE, desc_template_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorUpdateTemplate, vvl::DescriptorUpdateTemplate, desc_template_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkSwapchainKHR, SWAPCHAIN_NODE, swapchain_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorPool, DESCRIPTOR_POOL_STATE, descriptor_pool_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorSet, cvdescriptorset::DescriptorSet, descriptor_set_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorPool, vvl::DescriptorPool, descriptor_pool_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorSet, vvl::DescriptorSet, descriptor_set_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkCommandBuffer, CMD_BUFFER_STATE, command_buffer_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkCommandPool, COMMAND_POOL_STATE, command_pool_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkPipelineLayout, PIPELINE_LAYOUT_STATE, pipeline_layout_map_)

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2218,10 +2218,10 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
         return skip;
     }
 
-    using DescriptorClass = cvdescriptorset::DescriptorClass;
-    using BufferDescriptor = cvdescriptorset::BufferDescriptor;
-    using ImageDescriptor = cvdescriptorset::ImageDescriptor;
-    using TexelDescriptor = cvdescriptorset::TexelDescriptor;
+    using DescriptorClass = vvl::DescriptorClass;
+    using BufferDescriptor = vvl::BufferDescriptor;
+    using ImageDescriptor = vvl::ImageDescriptor;
+    using TexelDescriptor = vvl::TexelDescriptor;
 
     for (const auto &stage_state : pipe->stage_states) {
         const auto raster_state = pipe->RasterizationState();
@@ -2294,7 +2294,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                                 string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(img_view_state->image_view()).c_str(),
                                 sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
                                 sync_state_->FormatHandle(pipe->pipeline()).c_str(),
-                                sync_state_->FormatHandle(descriptor_set->GetSet()).c_str(),
+                                sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
                                 string_VkDescriptorType(descriptor_type), string_VkImageLayout(image_layout),
                                 variable.decorations.binding, index, FormatHazard(hazard).c_str());
                         }
@@ -2317,7 +2317,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                                 sync_state_->FormatHandle(buf_view_state->buffer_view()).c_str(),
                                 sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
                                 sync_state_->FormatHandle(pipe->pipeline()).c_str(),
-                                sync_state_->FormatHandle(descriptor_set->GetSet()).c_str(),
+                                sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
                                 string_VkDescriptorType(descriptor_type), variable.decorations.binding, index,
                                 FormatHazard(hazard).c_str());
                         }
@@ -2339,7 +2339,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                                 string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(buf_state->buffer()).c_str(),
                                 sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
                                 sync_state_->FormatHandle(pipe->pipeline()).c_str(),
-                                sync_state_->FormatHandle(descriptor_set->GetSet()).c_str(),
+                                sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
                                 string_VkDescriptorType(descriptor_type), variable.decorations.binding, index,
                                 FormatHazard(hazard).c_str());
                         }
@@ -2364,10 +2364,10 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
         return;
     }
 
-    using DescriptorClass = cvdescriptorset::DescriptorClass;
-    using BufferDescriptor = cvdescriptorset::BufferDescriptor;
-    using ImageDescriptor = cvdescriptorset::ImageDescriptor;
-    using TexelDescriptor = cvdescriptorset::TexelDescriptor;
+    using DescriptorClass = vvl::DescriptorClass;
+    using BufferDescriptor = vvl::BufferDescriptor;
+    using ImageDescriptor = vvl::ImageDescriptor;
+    using TexelDescriptor = vvl::TexelDescriptor;
 
     for (const auto &stage_state : pipe->stage_states) {
         const auto raster_state = pipe->RasterizationState();

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -924,7 +924,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(VkDevice device, const VkD
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkAllocateDescriptorSets, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-    cvdescriptorset::AllocateDescriptorSetsData ads_state[LayerObjectTypeMaxEnum];
+    vvl::AllocateDescriptorSetsData ads_state[LayerObjectTypeMaxEnum];
 
     for (const ValidationObject* intercept : layer_data->object_dispatch) {
         ads_state[intercept->container_type].Init(pAllocateInfo->descriptorSetCount);

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1642,7 +1642,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 bool skip = false;
                 ErrorObject error_obj(vvl::Func::vkAllocateDescriptorSets, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-                cvdescriptorset::AllocateDescriptorSetsData ads_state[LayerObjectTypeMaxEnum];
+                vvl::AllocateDescriptorSetsData ads_state[LayerObjectTypeMaxEnum];
 
                 for (const ValidationObject* intercept : layer_data->object_dispatch) {
                     ads_state[intercept->container_type].Init(pAllocateInfo->descriptorSetCount);


### PR DESCRIPTION
cvdescriptorset stood for Core Validation DescriptorSet, which is not a useful grouping of things. Start to move state tracker objects into the common namespace by renaming this one to include them.

Rename all vulkan handle accessors to VkHandle(), which makes it easier to remember than the old inconsistent names that violate coding standards in some cases. (eg. GetSet(), queue(), commandBuffer()).

Note that the VulkanTypedHandle accessor, Handle(), should be used with error logging functionality, such as FormatHandle(), LogObjectList(), and LogError().  The handle type is lost when passing raw non-Dispatchable handles to these functions on 32 bit systems.