### PR TITLE
layers: Validate dynamic rendering with VK_RENDERING_CONTENTS_INLINE_BIT_EXT flag

### DIFF
--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -3126,6 +3126,11 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
     }
 
     const Location rendering_info = error_obj.location.dot(Field::pRenderingInfo);
+    if ((pRenderingInfo->flags & VK_RENDERING_CONTENTS_INLINE_BIT_EXT) != 0 && !enabled_features.nestedCommandBuffer) {
+        skip |= LogError("VUID-VkRenderingInfo-flags-09381", commandBuffer, rendering_info.dot(Field::flags),
+                         "are %s, but nestedCommandBuffer feature is not enabled.",
+                         string_VkRenderingFlags(pRenderingInfo->flags).c_str());
+    }
     if (pRenderingInfo->layerCount > phys_dev_props.limits.maxFramebufferLayers) {
         skip |= LogError("VUID-VkRenderingInfo-layerCount-07817", commandBuffer, rendering_info.dot(Field::layerCount),
                          "(%" PRIu32 ") is greater than maxFramebufferLayers (%" PRIu32 ").", pRenderingInfo->layerCount,

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -6660,3 +6660,20 @@ TEST_F(NegativeDynamicRendering, MissingImageCreateSubsampled) {
     m_errorMonitor->VerifyFound();
     m_commandBuffer->end();
 }
+
+TEST_F(NegativeDynamicRendering, DynamicRenderingInlineContents) {
+    TEST_DESCRIPTION("Use dynamic rendering with VK_RENDERING_CONTENTS_INLINE_BIT_EXT");
+
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.flags = VK_RENDERING_CONTENTS_INLINE_BIT_EXT;
+    rendering_info.renderArea = {{0, 0}, {32u, 32u}};
+    rendering_info.layerCount = 1u;
+
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingInfo-flags-09381");
+    vk::CmdBeginRenderingKHR(m_commandBuffer->handle(), &rendering_info);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}


### PR DESCRIPTION
VUID from https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6702