### PR TITLE
gpu: Put GPUAV and DebugPrintf in namespaces

### DIFF
--- a/layers/gpu_shaders/gpu_shaders_constants.h
+++ b/layers/gpu_shaders/gpu_shaders_constants.h
@@ -20,7 +20,8 @@
 #define GPU_SHADERS_CONSTANTS_H
 
 #ifdef __cplusplus
-namespace gpuav_glsl {
+namespace gpuav {
+namespace glsl {
 using uint = unsigned int;
 
 // Upper bound for maxUpdateAfterBindDescriptorsInAllPools. This value needs to
@@ -231,6 +232,7 @@ const int pre_dispatch_count_exceeds_limit_y_error = 2;
 const int pre_dispatch_count_exceeds_limit_z_error = 3;
 
 #ifdef __cplusplus
-} // namespace gpuav_glsl
+}  // namespace glsl
+}  // namespace gpuav
 #endif
 #endif

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -22,7 +22,7 @@
 #include "utils/shader_utils.h"
 
 // Perform initializations that can be done at Create Device time.
-void DebugPrintf::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
+void debug_printf::Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
     if (enabled[gpu_validation]) {
         ReportSetupProblem(device,
                            "Debug Printf cannot be enabled when gpu assisted validation is enabled.  "
@@ -46,11 +46,11 @@ void DebugPrintf::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
     VkDescriptorSetLayoutBinding binding = {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1,
                                             VK_SHADER_STAGE_ALL_GRAPHICS | VK_SHADER_STAGE_MESH_BIT_EXT |
                                                 VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_COMPUTE_BIT |
-                                                kShaderStageAllRayTracing,
+                                                gpu_tracker::kShaderStageAllRayTracing,
                                             NULL};
     bindings_.push_back(binding);
 
-    GpuAssistedBase::CreateDevice(pCreateInfo);
+    BaseClass::CreateDevice(pCreateInfo);
 
     if (phys_dev_props.apiVersion < VK_API_VERSION_1_1) {
         ReportSetupProblem(device, "Debug Printf requires Vulkan 1.1 or later.  Debug Printf disabled.");
@@ -69,7 +69,7 @@ void DebugPrintf::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
 }
 
 // Free the device memory and descriptor set associated with a command buffer.
-void DebugPrintf::DestroyBuffer(DPFBufferInfo &buffer_info) {
+void debug_printf::Validator::DestroyBuffer(BufferInfo &buffer_info) {
     vmaDestroyBuffer(vmaAllocator, buffer_info.output_mem_block.buffer, buffer_info.output_mem_block.allocation);
     if (buffer_info.desc_set != VK_NULL_HANDLE) {
         desc_set_manager->PutBackDescriptorSet(buffer_info.desc_pool, buffer_info.desc_set);
@@ -77,8 +77,8 @@ void DebugPrintf::DestroyBuffer(DPFBufferInfo &buffer_info) {
 }
 
 // Call the SPIR-V Optimizer to run the instrumentation pass on the shader.
-bool DebugPrintf::InstrumentShader(const vvl::span<const uint32_t> &input, std::vector<uint32_t> &new_pgm,
-                                   uint32_t unique_shader_id, const Location &loc) {
+bool debug_printf::Validator::InstrumentShader(const vvl::span<const uint32_t> &input, std::vector<uint32_t> &new_pgm,
+                                               uint32_t unique_shader_id, const Location &loc) {
     if (aborted) return false;
     if (input[0] != spv::MagicNumber) return false;
 
@@ -120,9 +120,10 @@ bool DebugPrintf::InstrumentShader(const vvl::span<const uint32_t> &input, std::
     return pass;
 }
 // Create the instrumented shader data to provide to the driver.
-void DebugPrintf::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
-                                                  const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
-                                                  const RecordObject &record_obj, void *csm_state_data) {
+void debug_printf::Validator::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
+                                                              const VkAllocationCallbacks *pAllocator,
+                                                              VkShaderModule *pShaderModule, const RecordObject &record_obj,
+                                                              void *csm_state_data) {
     ValidationStateTracker::PreCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, record_obj,
                                                             csm_state_data);
     create_shader_module_api_state *csm_state = static_cast<create_shader_module_api_state *>(csm_state_data);
@@ -135,13 +136,14 @@ void DebugPrintf::PreCallRecordCreateShaderModule(VkDevice device, const VkShade
     }
 }
 
-void DebugPrintf::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
-                                                const VkShaderCreateInfoEXT *pCreateInfos, const VkAllocationCallbacks *pAllocator,
-                                                VkShaderEXT *pShaders, const RecordObject &record_obj, void *csm_state_data) {
+void debug_printf::Validator::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
+                                                            const VkShaderCreateInfoEXT *pCreateInfos,
+                                                            const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
+                                                            const RecordObject &record_obj, void *csm_state_data) {
     ValidationStateTracker::PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, record_obj,
                                                           csm_state_data);
-    GpuAssistedBase::PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, record_obj,
-                                                   csm_state_data);
+    BaseClass::PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, record_obj,
+                                             csm_state_data);
     create_shader_object_api_state *csm_state = static_cast<create_shader_object_api_state *>(csm_state_data);
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         csm_state->unique_shader_ids[i] = unique_shader_module_id++;
@@ -155,11 +157,11 @@ void DebugPrintf::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t create
     }
 }
 
-vartype vartype_lookup(char intype) {
+static debug_printf::vartype vartype_lookup(char intype) {
     switch (intype) {
         case 'd':
         case 'i':
-            return varsigned;
+            return debug_printf::varsigned;
             break;
 
         case 'f':
@@ -170,27 +172,27 @@ vartype vartype_lookup(char intype) {
         case 'E':
         case 'g':
         case 'G':
-            return varfloat;
+            return debug_printf::varfloat;
             break;
 
         case 'u':
         case 'x':
         case 'o':
         default:
-            return varunsigned;
+            return debug_printf::varunsigned;
             break;
     }
 }
 
-std::vector<DPFSubstring> DebugPrintf::ParseFormatString(const std::string &format_string) {
+std::vector<debug_printf::Substring> debug_printf::Validator::ParseFormatString(const std::string &format_string) {
     const char types[] = {'d', 'i', 'o', 'u', 'x', 'X', 'a', 'A', 'e', 'E', 'f', 'F', 'g', 'G', 'v', '\0'};
-    std::vector<DPFSubstring> parsed_strings;
+    std::vector<Substring> parsed_strings;
     size_t pos = 0;
     size_t begin = 0;
     size_t percent = 0;
 
     while (begin < format_string.length()) {
-        DPFSubstring substring;
+        Substring substring;
 
         // Find a percent sign
         pos = percent = format_string.find_first_of('%', pos);
@@ -257,7 +259,7 @@ std::vector<DPFSubstring> DebugPrintf::ParseFormatString(const std::string &form
     return parsed_strings;
 }
 
-std::string DebugPrintf::FindFormatString(vvl::span<const uint32_t> pgm, uint32_t string_id) {
+std::string debug_printf::Validator::FindFormatString(vvl::span<const uint32_t> pgm, uint32_t string_id) {
     std::string format_string;
     SPIRV_MODULE_STATE module_state(pgm);
     if (module_state.words_.empty()) {
@@ -281,8 +283,8 @@ std::string DebugPrintf::FindFormatString(vvl::span<const uint32_t> pgm, uint32_
 #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
 
-void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, DPFBufferInfo &buffer_info,
-                                             uint32_t operation_index, uint32_t *const debug_output_buffer) {
+void debug_printf::Validator::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQueue queue, BufferInfo &buffer_info,
+                                                         uint32_t operation_index, uint32_t *const debug_output_buffer) {
     // Word         Content
     //    0         Must be zero
     //    1         Size of output record, including this word
@@ -309,7 +311,7 @@ void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
         VkShaderEXT shader_object_handle = VK_NULL_HANDLE;
         vvl::span<const uint32_t> pgm;
 
-        DPFOutputRecord *debug_record = reinterpret_cast<DPFOutputRecord *>(&debug_output_buffer[index]);
+        OutputRecord *debug_record = reinterpret_cast<OutputRecord *>(&debug_output_buffer[index]);
         // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
         // by the instrumented shader.
         auto it = shader_map.find(debug_record->shader_id);
@@ -418,8 +420,8 @@ void DebugPrintf::AnalyzeAndGenerateMessages(VkCommandBuffer command_buffer, VkQ
 }
 
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
-void debug_printf_state::CommandBuffer::Process(VkQueue queue, const Location &loc) {
-    auto *device_state = static_cast<DebugPrintf *>(dev_data);
+void debug_printf::CommandBuffer::Process(VkQueue queue, const Location &loc) {
+    auto *device_state = static_cast<debug_printf::Validator *>(dev_data);
     if (has_draw_cmd || has_trace_rays_cmd || has_dispatch_cmd) {
         auto &gpu_buffer_list = buffer_infos;
         uint32_t draw_index = 0;
@@ -456,183 +458,192 @@ void debug_printf_state::CommandBuffer::Process(VkQueue queue, const Location &l
 #pragma GCC diagnostic pop
 #endif
 
-void DebugPrintf::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
-                                       uint32_t firstVertex, uint32_t firstInstance, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
+                                                   uint32_t firstVertex, uint32_t firstInstance, const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                               const VkMultiDrawInfoEXT *pVertexInfo, uint32_t instanceCount,
-                                               uint32_t firstInstance, uint32_t stride, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
+                                                           const VkMultiDrawInfoEXT *pVertexInfo, uint32_t instanceCount,
+                                                           uint32_t firstInstance, uint32_t stride,
+                                                           const RecordObject &record_obj) {
     for (uint32_t i = 0; i < drawCount; i++) {
         AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
     }
 }
 
-void DebugPrintf::PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
-                                              uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
-                                              const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount,
+                                                          uint32_t instanceCount, uint32_t firstIndex, int32_t vertexOffset,
+                                                          uint32_t firstInstance, const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
-                                                      const VkMultiDrawIndexedInfoEXT *pIndexInfo, uint32_t instanceCount,
-                                                      uint32_t firstInstance, uint32_t stride, const int32_t *pVertexOffset,
-                                                      const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
+                                                                  const VkMultiDrawIndexedInfoEXT *pIndexInfo,
+                                                                  uint32_t instanceCount, uint32_t firstInstance, uint32_t stride,
+                                                                  const int32_t *pVertexOffset, const RecordObject &record_obj) {
     for (uint32_t i = 0; i < drawCount; i++) {
         AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
     }
 }
 
-void DebugPrintf::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
-                                               uint32_t stride, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
+                                                           uint32_t count, uint32_t stride, const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                      uint32_t count, uint32_t stride, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                  VkDeviceSize offset, uint32_t count, uint32_t stride,
+                                                                  const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
-                                           const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
+                                                       const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE);
 }
 
-void DebugPrintf::PreCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                   const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
+                                                               const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE);
 }
 
-void DebugPrintf::PreCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
-                                               uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                               uint32_t groupCountZ, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
+                                                           uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
+                                                           uint32_t groupCountZ, const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE);
 }
 
-void DebugPrintf::PreCallRecordCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
-                                                  uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY,
-                                                  uint32_t groupCountZ, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGroupX,
+                                                              uint32_t baseGroupY, uint32_t baseGroupZ, uint32_t groupCountX,
+                                                              uint32_t groupCountY, uint32_t groupCountZ,
+                                                              const RecordObject &record_obj) {
     PreCallRecordCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ,
                                  record_obj);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                       VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                       uint32_t stride, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                   VkDeviceSize offset, VkBuffer countBuffer,
+                                                                   VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
+                                                                   uint32_t stride, const RecordObject &record_obj) {
     PreCallRecordCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                       record_obj);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                    VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
-                                                    uint32_t stride, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
+                                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset,
+                                                                uint32_t maxDrawCount, uint32_t stride,
+                                                                const RecordObject &record_obj) {
     ValidationStateTracker::PreCallRecordCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
                                                               maxDrawCount, stride, record_obj);
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                              VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                              uint32_t maxDrawCount, uint32_t stride,
-                                                              const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                          VkDeviceSize offset, VkBuffer countBuffer,
+                                                                          VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
+                                                                          uint32_t stride, const RecordObject &record_obj) {
     PreCallRecordCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride,
                                              record_obj);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                           VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                           uint32_t maxDrawCount, uint32_t stride, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                       VkDeviceSize offset, VkBuffer countBuffer,
+                                                                       VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
+                                                                       uint32_t stride, const RecordObject &record_obj) {
     ValidationStateTracker::PreCallRecordCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
                                                                      maxDrawCount, stride, record_obj);
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
-                                                           uint32_t firstInstance, VkBuffer counterBuffer,
-                                                           VkDeviceSize counterBufferOffset, uint32_t counterOffset,
-                                                           uint32_t vertexStride, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
+                                                                       uint32_t firstInstance, VkBuffer counterBuffer,
+                                                                       VkDeviceSize counterBufferOffset, uint32_t counterOffset,
+                                                                       uint32_t vertexStride, const RecordObject &record_obj) {
     ValidationStateTracker::PreCallRecordCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer,
                                                                      counterBufferOffset, counterOffset, vertexStride, record_obj);
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
-                                                  const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
+                                                              const RecordObject &record_obj) {
     ValidationStateTracker::PreCallRecordCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, record_obj);
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                          uint32_t drawCount, uint32_t stride, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                      VkDeviceSize offset, uint32_t drawCount, uint32_t stride,
+                                                                      const RecordObject &record_obj) {
     ValidationStateTracker::PreCallRecordCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, record_obj);
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                               uint32_t maxDrawCount, uint32_t stride,
-                                                               const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                           VkDeviceSize offset, VkBuffer countBuffer,
+                                                                           VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
+                                                                           uint32_t stride, const RecordObject &record_obj) {
     ValidationStateTracker::PreCallRecordCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer,
                                                                          countBufferOffset, maxDrawCount, stride, record_obj);
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
-                                                   uint32_t groupCountZ, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX,
+                                                               uint32_t groupCountY, uint32_t groupCountZ,
+                                                               const RecordObject &record_obj) {
     ValidationStateTracker::PreCallRecordCmdDrawMeshTasksEXT(commandBuffer, groupCountX, groupCountY, groupCountZ, record_obj);
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                           uint32_t drawCount, uint32_t stride, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                       VkDeviceSize offset, uint32_t drawCount, uint32_t stride,
+                                                                       const RecordObject &record_obj) {
     ValidationStateTracker::PreCallRecordCmdDrawMeshTasksIndirectEXT(commandBuffer, buffer, offset, drawCount, stride, record_obj);
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
-                                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset,
-                                                                uint32_t maxDrawCount, uint32_t stride,
-                                                                const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer commandBuffer, VkBuffer buffer,
+                                                                            VkDeviceSize offset, VkBuffer countBuffer,
+                                                                            VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
+                                                                            uint32_t stride, const RecordObject &record_obj) {
     ValidationStateTracker::PreCallRecordCmdDrawMeshTasksIndirectCountEXT(commandBuffer, buffer, offset, countBuffer,
                                                                           countBufferOffset, maxDrawCount, stride, record_obj);
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS);
 }
 
-void DebugPrintf::PreCallRecordCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer,
-                                              VkDeviceSize raygenShaderBindingOffset, VkBuffer missShaderBindingTableBuffer,
-                                              VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride,
-                                              VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset,
-                                              VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
-                                              VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
-                                              uint32_t width, uint32_t height, uint32_t depth, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdTraceRaysNV(
+    VkCommandBuffer commandBuffer, VkBuffer raygenShaderBindingTableBuffer, VkDeviceSize raygenShaderBindingOffset,
+    VkBuffer missShaderBindingTableBuffer, VkDeviceSize missShaderBindingOffset, VkDeviceSize missShaderBindingStride,
+    VkBuffer hitShaderBindingTableBuffer, VkDeviceSize hitShaderBindingOffset, VkDeviceSize hitShaderBindingStride,
+    VkBuffer callableShaderBindingTableBuffer, VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
+    uint32_t width, uint32_t height, uint32_t depth, const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_NV);
 }
 
-void DebugPrintf::PreCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
-                                               const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                               const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                               const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                               const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable, uint32_t width,
-                                               uint32_t height, uint32_t depth, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
+                                                           const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
+                                                           const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
+                                                           const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
+                                                           const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
+                                                           uint32_t width, uint32_t height, uint32_t depth,
+                                                           const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
 }
 
-void DebugPrintf::PreCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
-                                                       const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
-                                                       const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable,
-                                                       const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
-                                                       const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
-                                                       VkDeviceAddress indirectDeviceAddress, const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdTraceRaysIndirectKHR(
+    VkCommandBuffer commandBuffer, const VkStridedDeviceAddressRegionKHR *pRaygenShaderBindingTable,
+    const VkStridedDeviceAddressRegionKHR *pMissShaderBindingTable, const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
+    const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable, VkDeviceAddress indirectDeviceAddress,
+    const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
 }
 
-void DebugPrintf::PreCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
-                                                        const RecordObject &record_obj) {
+void debug_printf::Validator::PreCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer,
+                                                                    VkDeviceAddress indirectDeviceAddress,
+                                                                    const RecordObject &record_obj) {
     AllocateDebugPrintfResources(commandBuffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
 }
 
-void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer, const VkPipelineBindPoint bind_point) {
+void debug_printf::Validator::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer, const VkPipelineBindPoint bind_point) {
     if (bind_point != VK_PIPELINE_BIND_POINT_GRAPHICS && bind_point != VK_PIPELINE_BIND_POINT_COMPUTE &&
         bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
         return;
@@ -654,7 +665,7 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
     VkDescriptorBufferInfo output_desc_buffer_info = {};
     output_desc_buffer_info.range = output_buffer_size;
 
-    auto cb_node = GetWrite<debug_printf_state::CommandBuffer>(cmd_buffer);
+    auto cb_node = GetWrite<debug_printf::CommandBuffer>(cmd_buffer);
     if (!cb_node) {
         ReportSetupProblem(device, "Unrecognized command buffer");
         aborted = true;
@@ -672,7 +683,7 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
     }
 
     // Allocate memory for the output block that the gpu will use to return values for printf
-    DPFDeviceMemoryBlock output_block = {};
+    DeviceMemoryBlock output_block = {};
     VkBufferCreateInfo buffer_info = vku::InitStructHelper();
     buffer_info.size = output_buffer_size;
     buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
@@ -731,31 +742,30 @@ void DebugPrintf::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer,
     cb_node->buffer_infos.emplace_back(output_block, desc_sets[0], desc_pool, bind_point);
 }
 
-std::shared_ptr<CMD_BUFFER_STATE> DebugPrintf::CreateCmdBufferState(VkCommandBuffer cb,
-                                                                    const VkCommandBufferAllocateInfo *pCreateInfo,
-                                                                    const COMMAND_POOL_STATE *pool) {
-    return std::static_pointer_cast<CMD_BUFFER_STATE>(
-        std::make_shared<debug_printf_state::CommandBuffer>(this, cb, pCreateInfo, pool));
+std::shared_ptr<CMD_BUFFER_STATE> debug_printf::Validator::CreateCmdBufferState(VkCommandBuffer cb,
+                                                                                const VkCommandBufferAllocateInfo *pCreateInfo,
+                                                                                const COMMAND_POOL_STATE *pool) {
+    return std::static_pointer_cast<CMD_BUFFER_STATE>(std::make_shared<debug_printf::CommandBuffer>(this, cb, pCreateInfo, pool));
 }
 
-debug_printf_state::CommandBuffer::CommandBuffer(DebugPrintf *dp, VkCommandBuffer cb,
-                                                 const VkCommandBufferAllocateInfo *pCreateInfo, const COMMAND_POOL_STATE *pool)
-    : gpu_utils_state::CommandBuffer(dp, cb, pCreateInfo, pool) {}
+debug_printf::CommandBuffer::CommandBuffer(debug_printf::Validator *dp, VkCommandBuffer cb,
+                                           const VkCommandBufferAllocateInfo *pCreateInfo, const COMMAND_POOL_STATE *pool)
+    : gpu_tracker::CommandBuffer(dp, cb, pCreateInfo, pool) {}
 
-debug_printf_state::CommandBuffer::~CommandBuffer() { Destroy(); }
+debug_printf::CommandBuffer::~CommandBuffer() { Destroy(); }
 
-void debug_printf_state::CommandBuffer::Destroy() {
+void debug_printf::CommandBuffer::Destroy() {
     ResetCBState();
     CMD_BUFFER_STATE::Destroy();
 }
 
-void debug_printf_state::CommandBuffer::Reset() {
+void debug_printf::CommandBuffer::Reset() {
     CMD_BUFFER_STATE::Reset();
     ResetCBState();
 }
 
-void debug_printf_state::CommandBuffer::ResetCBState() {
-    auto debug_printf = static_cast<DebugPrintf *>(dev_data);
+void debug_printf::CommandBuffer::ResetCBState() {
+    auto debug_printf = static_cast<debug_printf::Validator *>(dev_data);
     // Free the device memory and descriptor set(s) associated with a command buffer.
     if (debug_printf->aborted) {
         return;

--- a/layers/gpu_validation/gpu_descriptor_set.cpp
+++ b/layers/gpu_validation/gpu_descriptor_set.cpp
@@ -21,7 +21,8 @@
 
 using vvl::DescriptorClass;
 
-namespace gpuav_glsl {
+namespace gpuav {
+namespace glsl {
 
 struct BindingLayout {
     uint32_t count;
@@ -36,7 +37,6 @@ struct DescriptorState {
     uint32_t extra_data;
 
     static uint32_t ClassToShaderBits(DescriptorClass dc) {
-        using namespace gpuav_glsl;
         switch (dc) {
             case DescriptorClass::PlainSampler:
                 return (kSamplerDesc << kDescBitShift);
@@ -59,7 +59,8 @@ struct DescriptorState {
     }
 };
 
-} // namespace gpuav_glsl
+}  // namespace glsl
+}  // namespace gpuav
 
 // Returns the number of bytes to hold 32 bit aligned array of bits.
 static uint32_t BitBufferSize(uint32_t num_bits) {
@@ -67,27 +68,27 @@ static uint32_t BitBufferSize(uint32_t num_bits) {
     return (((num_bits + (kBitsPerWord - 1)) & ~(kBitsPerWord - 1))/kBitsPerWord) * sizeof(uint32_t);
 }
 
-gpuav_state::DescriptorSet::DescriptorSet(const VkDescriptorSet set, vvl::DescriptorPool *pool,
-                                          const std::shared_ptr<vvl::DescriptorSetLayout const> &layout,
-                                          uint32_t variable_count, ValidationStateTracker *state_data)
+gpuav::DescriptorSet::DescriptorSet(const VkDescriptorSet set, vvl::DescriptorPool *pool,
+                                    const std::shared_ptr<vvl::DescriptorSetLayout const> &layout, uint32_t variable_count,
+                                    ValidationStateTracker *state_data)
     : vvl::DescriptorSet(set, pool, layout, variable_count, state_data) {}
 
-gpuav_state::DescriptorSet::~DescriptorSet() {
+gpuav::DescriptorSet::~DescriptorSet() {
     Destroy();
-    GpuAssisted *gv_dev = static_cast<GpuAssisted *>(state_data_);
+    Validator *gv_dev = static_cast<Validator *>(state_data_);
     vmaDestroyBuffer(gv_dev->vmaAllocator, layout_.buffer, layout_.allocation);
 }
 
-VkDeviceAddress gpuav_state::DescriptorSet::GetLayoutState() {
+VkDeviceAddress gpuav::DescriptorSet::GetLayoutState() {
     auto guard = Lock();
     if (layout_.device_addr != 0) {
         return layout_.device_addr;
     }
     uint32_t num_bindings = (GetBindingCount() > 0) ? GetLayout()->GetMaxBinding() + 1 : 0;
-    GpuAssisted *gv_dev = static_cast<GpuAssisted *>(state_data_);
+    Validator *gv_dev = static_cast<Validator *>(state_data_);
     VkBufferCreateInfo buffer_info = vku::InitStruct<VkBufferCreateInfo>();
     // 1 uvec2 to store num_bindings and 1 for each binding's data
-    buffer_info.size = (1 + num_bindings) * sizeof(gpuav_glsl::BindingLayout);
+    buffer_info.size = (1 + num_bindings) * sizeof(glsl::BindingLayout);
     buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
     VmaAllocationCreateInfo alloc_info{};
@@ -97,7 +98,7 @@ VkDeviceAddress gpuav_state::DescriptorSet::GetLayoutState() {
     if (result != VK_SUCCESS) {
         return 0;
     }
-    gpuav_glsl::BindingLayout *layout_data;
+    glsl::BindingLayout *layout_data;
     result = vmaMapMemory(gv_dev->vmaAllocator, layout_.allocation, reinterpret_cast<void **>(&layout_data));
     assert(result == VK_SUCCESS);
     memset(layout_data, 0, static_cast<size_t>(buffer_info.size));
@@ -155,113 +156,112 @@ VkDeviceAddress gpuav_state::DescriptorSet::GetLayoutState() {
     return layout_.device_addr;
 }
 
-static gpuav_glsl::DescriptorState GetInData(const vvl::BufferDescriptor &desc) {
-    auto buffer_state = static_cast<const gpuav_state::Buffer *>(desc.GetBufferState());
+namespace gpuav {
+static glsl::DescriptorState GetInData(const vvl::BufferDescriptor &desc) {
+    auto buffer_state = static_cast<const Buffer *>(desc.GetBufferState());
     if (!buffer_state) {
-        return gpuav_glsl::DescriptorState(DescriptorClass::GeneralBuffer, gpuav_glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
+        return glsl::DescriptorState(DescriptorClass::GeneralBuffer, glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
     }
-    return gpuav_glsl::DescriptorState(DescriptorClass::GeneralBuffer, buffer_state->id, static_cast<uint32_t>(buffer_state->createInfo.size));
+    return glsl::DescriptorState(DescriptorClass::GeneralBuffer, buffer_state->id,
+                                 static_cast<uint32_t>(buffer_state->createInfo.size));
 }
 
-static gpuav_glsl::DescriptorState GetInData(const vvl::TexelDescriptor &desc) {
-    auto buffer_view_state = static_cast<const gpuav_state::BufferView *>(desc.GetBufferViewState());
+static glsl::DescriptorState GetInData(const vvl::TexelDescriptor &desc) {
+    auto buffer_view_state = static_cast<const BufferView *>(desc.GetBufferViewState());
     if (!buffer_view_state) {
-        return gpuav_glsl::DescriptorState(DescriptorClass::TexelBuffer, gpuav_glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
+        return glsl::DescriptorState(DescriptorClass::TexelBuffer, glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
     }
     auto view_size = buffer_view_state->Size();
     uint32_t res_size = static_cast<uint32_t>(view_size / vkuFormatElementSize(buffer_view_state->create_info.format));
-    return gpuav_glsl::DescriptorState(DescriptorClass::TexelBuffer, buffer_view_state->id, res_size);
+    return glsl::DescriptorState(DescriptorClass::TexelBuffer, buffer_view_state->id, res_size);
 }
 
-static gpuav_glsl::DescriptorState GetInData(const vvl::ImageDescriptor &desc) {
-    auto image_state = static_cast<const gpuav_state::ImageView *>(desc.GetImageViewState());
-    return gpuav_glsl::DescriptorState(DescriptorClass::Image,
-                                       image_state ? image_state->id : gpuav_glsl::kDebugInputBindlessSkipId);
+static glsl::DescriptorState GetInData(const vvl::ImageDescriptor &desc) {
+    auto image_state = static_cast<const ImageView *>(desc.GetImageViewState());
+    return glsl::DescriptorState(DescriptorClass::Image, image_state ? image_state->id : glsl::kDebugInputBindlessSkipId);
 }
 
-static gpuav_glsl::DescriptorState GetInData(const vvl::SamplerDescriptor &desc) {
-    auto sampler_state = static_cast<const gpuav_state::Sampler *>(desc.GetSamplerState());
-    return gpuav_glsl::DescriptorState(DescriptorClass::PlainSampler, sampler_state->id);
+static glsl::DescriptorState GetInData(const vvl::SamplerDescriptor &desc) {
+    auto sampler_state = static_cast<const Sampler *>(desc.GetSamplerState());
+    return glsl::DescriptorState(DescriptorClass::PlainSampler, sampler_state->id);
 }
 
-static gpuav_glsl::DescriptorState GetInData(const vvl::ImageSamplerDescriptor &desc) {
-    auto image_state = static_cast<const gpuav_state::ImageView *>(desc.GetImageViewState());
-    auto sampler_state = static_cast<const gpuav_state::Sampler *>(desc.GetSamplerState());
-    return gpuav_glsl::DescriptorState(DescriptorClass::ImageSampler,
-                                       image_state ? image_state->id : gpuav_glsl::kDebugInputBindlessSkipId,
-                                       sampler_state ? sampler_state->id : 0);
+static glsl::DescriptorState GetInData(const vvl::ImageSamplerDescriptor &desc) {
+    auto image_state = static_cast<const ImageView *>(desc.GetImageViewState());
+    auto sampler_state = static_cast<const Sampler *>(desc.GetSamplerState());
+    return glsl::DescriptorState(DescriptorClass::ImageSampler, image_state ? image_state->id : glsl::kDebugInputBindlessSkipId,
+                                 sampler_state ? sampler_state->id : 0);
 }
 
-static gpuav_glsl::DescriptorState GetInData(const vvl::AccelerationStructureDescriptor &ac) {
+static glsl::DescriptorState GetInData(const vvl::AccelerationStructureDescriptor &ac) {
     uint32_t id;
     if (ac.is_khr()) {
-        auto ac_state = static_cast<const gpuav_state::AccelerationStructureKHR *>(ac.GetAccelerationStructureStateKHR());
-        id = ac_state ? ac_state->id : gpuav_glsl::kDebugInputBindlessSkipId;
+        auto ac_state = static_cast<const AccelerationStructureKHR *>(ac.GetAccelerationStructureStateKHR());
+        id = ac_state ? ac_state->id : glsl::kDebugInputBindlessSkipId;
     } else {
-        auto ac_state = static_cast<const gpuav_state::AccelerationStructureNV *>(ac.GetAccelerationStructureStateNV());
-        id = ac_state ? ac_state->id : gpuav_glsl::kDebugInputBindlessSkipId;
+        auto ac_state = static_cast<const AccelerationStructureNV *>(ac.GetAccelerationStructureStateNV());
+        id = ac_state ? ac_state->id : glsl::kDebugInputBindlessSkipId;
     }
-    return gpuav_glsl::DescriptorState(DescriptorClass::AccelerationStructure, id);
+    return glsl::DescriptorState(DescriptorClass::AccelerationStructure, id);
 }
 
-static gpuav_glsl::DescriptorState GetInData(const vvl::MutableDescriptor &desc) {
-
+static glsl::DescriptorState GetInData(const vvl::MutableDescriptor &desc) {
     auto desc_class = desc.ActiveClass();
     switch (desc_class) {
         case DescriptorClass::GeneralBuffer: {
-            auto buffer_state = std::static_pointer_cast<const gpuav_state::Buffer>(desc.GetSharedBufferState());
+            auto buffer_state = std::static_pointer_cast<const Buffer>(desc.GetSharedBufferState());
             if (!buffer_state) {
-                return gpuav_glsl::DescriptorState(desc_class, gpuav_glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
+                return glsl::DescriptorState(desc_class, glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
             }
-            return gpuav_glsl::DescriptorState(desc_class, buffer_state->id, static_cast<uint32_t>(buffer_state->createInfo.size));
+            return glsl::DescriptorState(desc_class, buffer_state->id, static_cast<uint32_t>(buffer_state->createInfo.size));
         }
         case DescriptorClass::TexelBuffer: {
-            auto buffer_view_state = std::static_pointer_cast<const gpuav_state::BufferView>(desc.GetSharedBufferViewState());
+            auto buffer_view_state = std::static_pointer_cast<const BufferView>(desc.GetSharedBufferViewState());
             if (!buffer_view_state) {
-                return gpuav_glsl::DescriptorState(desc_class, gpuav_glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
+                return glsl::DescriptorState(desc_class, glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
             }
             auto view_size = buffer_view_state->Size();
             uint32_t res_size = static_cast<uint32_t>(view_size / vkuFormatElementSize(buffer_view_state->create_info.format));
-            return gpuav_glsl::DescriptorState(desc_class, buffer_view_state->id, res_size);
+            return glsl::DescriptorState(desc_class, buffer_view_state->id, res_size);
         }
         case DescriptorClass::PlainSampler: {
-            auto sampler_state = std::static_pointer_cast<const gpuav_state::Sampler>(desc.GetSharedSamplerState());
-            return gpuav_glsl::DescriptorState(desc_class, sampler_state->id);
+            auto sampler_state = std::static_pointer_cast<const Sampler>(desc.GetSharedSamplerState());
+            return glsl::DescriptorState(desc_class, sampler_state->id);
         }
         case DescriptorClass::ImageSampler: {
-            auto image_state = std::static_pointer_cast<const gpuav_state::ImageView>(desc.GetSharedImageViewState());
-            auto sampler_state = std::static_pointer_cast<const gpuav_state::Sampler>(desc.GetSharedSamplerState());
+            auto image_state = std::static_pointer_cast<const ImageView>(desc.GetSharedImageViewState());
+            auto sampler_state = std::static_pointer_cast<const Sampler>(desc.GetSharedSamplerState());
             // image can be null in some cases, but the sampler can't
-            return gpuav_glsl::DescriptorState(desc_class, image_state ? image_state->id : gpuav_glsl::kDebugInputBindlessSkipId,
-                                               sampler_state ? sampler_state->id : 0);
+            return glsl::DescriptorState(desc_class, image_state ? image_state->id : glsl::kDebugInputBindlessSkipId,
+                                         sampler_state ? sampler_state->id : 0);
         }
         case DescriptorClass::Image: {
-            auto image_state = std::static_pointer_cast<const gpuav_state::ImageView>(desc.GetSharedImageViewState());
-            return gpuav_glsl::DescriptorState(desc_class, image_state ? image_state->id : gpuav_glsl::kDebugInputBindlessSkipId);
+            auto image_state = std::static_pointer_cast<const ImageView>(desc.GetSharedImageViewState());
+            return glsl::DescriptorState(desc_class, image_state ? image_state->id : glsl::kDebugInputBindlessSkipId);
         }
         case DescriptorClass::AccelerationStructure: {
             uint32_t id;
             if (desc.IsAccelerationStructureKHR()) {
-                auto ac_state = static_cast<const gpuav_state::AccelerationStructureKHR *>(desc.GetAccelerationStructureStateKHR());
-                id = ac_state ? ac_state->id : gpuav_glsl::kDebugInputBindlessSkipId;
+                auto ac_state = static_cast<const AccelerationStructureKHR *>(desc.GetAccelerationStructureStateKHR());
+                id = ac_state ? ac_state->id : glsl::kDebugInputBindlessSkipId;
             } else {
-                auto ac_state = static_cast<const gpuav_state::AccelerationStructureNV *>(desc.GetAccelerationStructureStateNV());
-                id = ac_state ? ac_state->id : gpuav_glsl::kDebugInputBindlessSkipId;
+                auto ac_state = static_cast<const AccelerationStructureNV *>(desc.GetAccelerationStructureStateNV());
+                id = ac_state ? ac_state->id : glsl::kDebugInputBindlessSkipId;
             }
-            return gpuav_glsl::DescriptorState(desc_class, id);
+            return glsl::DescriptorState(desc_class, id);
         }
         default:
             assert(false);
             break;
     }
-    return gpuav_glsl::DescriptorState(desc_class, gpuav_glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
+    return glsl::DescriptorState(desc_class, glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
 }
 
 template <typename Binding>
-void FillBindingInData(const Binding &binding, gpuav_glsl::DescriptorState *data, uint32_t &index) {
+void FillBindingInData(const Binding &binding, glsl::DescriptorState *data, uint32_t &index) {
     for (uint32_t di = 0; di < binding.count; di++) {
         if (!binding.updated[di]) {
-            data[index++] = gpuav_glsl::DescriptorState();
+            data[index++] = glsl::DescriptorState();
         } else {
             data[index++] = GetInData(binding.descriptors[di]);
         }
@@ -270,14 +270,14 @@ void FillBindingInData(const Binding &binding, gpuav_glsl::DescriptorState *data
 
 // Inline Uniforms are currently treated as a single descriptor. Writes to any offsets cause the whole range to be valid.
 template <>
-void FillBindingInData(const vvl::InlineUniformBinding &binding, gpuav_glsl::DescriptorState *data, uint32_t &index) {
-    data[index++] = gpuav_glsl::DescriptorState(DescriptorClass::InlineUniform, gpuav_glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
+void FillBindingInData(const vvl::InlineUniformBinding &binding, glsl::DescriptorState *data, uint32_t &index) {
+    data[index++] = glsl::DescriptorState(DescriptorClass::InlineUniform, glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
 }
+}  // namespace gpuav
 
-std::shared_ptr<gpuav_state::DescriptorSet::State> gpuav_state::DescriptorSet::GetCurrentState() {
-    using namespace vvl;
+std::shared_ptr<gpuav::DescriptorSet::State> gpuav::DescriptorSet::GetCurrentState() {
     auto guard = Lock();
-    GpuAssisted *gv_dev = static_cast<GpuAssisted *>(state_data_);
+    Validator *gv_dev = static_cast<Validator *>(state_data_);
     uint32_t cur_version = current_version_.load();
     if (last_used_state_ && last_used_state_->version == cur_version) {
         return last_used_state_;
@@ -306,7 +306,7 @@ std::shared_ptr<gpuav_state::DescriptorSet::State> gpuav_state::DescriptorSet::G
     }
 
     VkBufferCreateInfo buffer_info = vku::InitStruct<VkBufferCreateInfo>();
-    buffer_info.size = descriptor_count  * sizeof(gpuav_glsl::DescriptorState);
+    buffer_info.size = descriptor_count * sizeof(glsl::DescriptorState);
     buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
     // The descriptor state buffer can be very large (4mb+ in some games). Allocating it as HOST_CACHED
@@ -318,7 +318,7 @@ std::shared_ptr<gpuav_state::DescriptorSet::State> gpuav_state::DescriptorSet::G
     if (result != VK_SUCCESS) {
         return nullptr;
     }
-    gpuav_glsl::DescriptorState *data{nullptr};
+    glsl::DescriptorState *data{nullptr};
     result = vmaMapMemory(next_state->allocator, next_state->allocation, reinterpret_cast<void **>(&data));
     assert(result == VK_SUCCESS);
     uint32_t index = 0;
@@ -326,28 +326,28 @@ std::shared_ptr<gpuav_state::DescriptorSet::State> gpuav_state::DescriptorSet::G
         const auto &binding = *bindings_[i];
         switch (binding.descriptor_class) {
             case DescriptorClass::InlineUniform:
-                FillBindingInData(static_cast<const InlineUniformBinding &>(binding), data, index);
+                FillBindingInData(static_cast<const vvl::InlineUniformBinding &>(binding), data, index);
                 break;
             case DescriptorClass::GeneralBuffer:
                 FillBindingInData(static_cast<const vvl::BufferBinding &>(binding), data, index);
                 break;
             case DescriptorClass::TexelBuffer:
-                FillBindingInData(static_cast<const TexelBinding &>(binding), data, index);
+                FillBindingInData(static_cast<const vvl::TexelBinding &>(binding), data, index);
                 break;
             case DescriptorClass::Mutable:
-                FillBindingInData(static_cast<const MutableBinding &>(binding), data, index);
+                FillBindingInData(static_cast<const vvl::MutableBinding &>(binding), data, index);
                 break;
-            case PlainSampler:
-                FillBindingInData(static_cast<const SamplerBinding &>(binding), data, index);
+            case DescriptorClass::PlainSampler:
+                FillBindingInData(static_cast<const vvl::SamplerBinding &>(binding), data, index);
                 break;
-            case ImageSampler:
-                FillBindingInData(static_cast<const ImageSamplerBinding &>(binding), data, index);
+            case DescriptorClass::ImageSampler:
+                FillBindingInData(static_cast<const vvl::ImageSamplerBinding &>(binding), data, index);
                 break;
-            case Image:
-                FillBindingInData(static_cast<const ImageBinding &>(binding), data, index);
+            case DescriptorClass::Image:
+                FillBindingInData(static_cast<const vvl::ImageBinding &>(binding), data, index);
                 break;
-            case AccelerationStructure:
-                FillBindingInData(static_cast<const AccelerationStructureBinding &>(binding), data, index);
+            case DescriptorClass::AccelerationStructure:
+                FillBindingInData(static_cast<const vvl::AccelerationStructureBinding &>(binding), data, index);
                 break;
             default:
                 assert(false);
@@ -375,9 +375,9 @@ std::shared_ptr<gpuav_state::DescriptorSet::State> gpuav_state::DescriptorSet::G
     return next_state;
 }
 
-std::shared_ptr<gpuav_state::DescriptorSet::State> gpuav_state::DescriptorSet::GetOutputState() {
+std::shared_ptr<gpuav::DescriptorSet::State> gpuav::DescriptorSet::GetOutputState() {
     auto guard = Lock();
-    GpuAssisted *gv_dev = static_cast<GpuAssisted *>(state_data_);
+    Validator *gv_dev = static_cast<Validator *>(state_data_);
     uint32_t cur_version = current_version_.load();
     if (output_state_) {
         return output_state_;
@@ -443,13 +443,13 @@ std::shared_ptr<gpuav_state::DescriptorSet::State> gpuav_state::DescriptorSet::G
     return next_state;
 }
 
-std::map<uint32_t, std::vector<uint32_t>> gpuav_state::DescriptorSet::State::UsedDescriptors(const gpuav_state::DescriptorSet &set) const {
+std::map<uint32_t, std::vector<uint32_t>> gpuav::DescriptorSet::State::UsedDescriptors(const gpuav::DescriptorSet &set) const {
     std::map<uint32_t, std::vector<uint32_t>> used_descs;
     if (!allocation) {
         return used_descs;
     }
 
-    gpuav_glsl::BindingLayout *layout_data;
+    glsl::BindingLayout *layout_data;
     [[maybe_unused]] auto result = vmaMapMemory(allocator, set.layout_.allocation, reinterpret_cast<void **>(&layout_data));
 
     uint32_t *data{nullptr};
@@ -474,32 +474,30 @@ std::map<uint32_t, std::vector<uint32_t>> gpuav_state::DescriptorSet::State::Use
     return used_descs;
 }
 
-gpuav_state::DescriptorSet::State::~State() { vmaDestroyBuffer(allocator, buffer, allocation); }
+gpuav::DescriptorSet::State::~State() { vmaDestroyBuffer(allocator, buffer, allocation); }
 
-void gpuav_state::DescriptorSet::PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet *write_descs) {
+void gpuav::DescriptorSet::PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet *write_descs) {
     vvl::DescriptorSet::PerformPushDescriptorsUpdate(write_count, write_descs);
     current_version_++;
 }
 
-void gpuav_state::DescriptorSet::PerformWriteUpdate(const VkWriteDescriptorSet &write_desc) {
+void gpuav::DescriptorSet::PerformWriteUpdate(const VkWriteDescriptorSet &write_desc) {
     vvl::DescriptorSet::PerformWriteUpdate(write_desc);
     current_version_++;
 }
 
-void gpuav_state::DescriptorSet::PerformCopyUpdate(const VkCopyDescriptorSet &copy_desc,
-                                                   const vvl::DescriptorSet &src_set) {
+void gpuav::DescriptorSet::PerformCopyUpdate(const VkCopyDescriptorSet &copy_desc, const vvl::DescriptorSet &src_set) {
     vvl::DescriptorSet::PerformCopyUpdate(copy_desc, src_set);
     current_version_++;
 }
 
-gpuav_state::DescriptorHeap::DescriptorHeap(GpuAssisted &gpu_dev, uint32_t max_descriptors)
+gpuav::DescriptorHeap::DescriptorHeap(gpuav::Validator &gpu_dev, uint32_t max_descriptors)
     : max_descriptors_(max_descriptors), allocator_(gpu_dev.vmaAllocator) {
-
-     // If max_descriptors_ is 0, GPU-AV aborted during vkCreateDevice(). We still need to
-     // support calls into this class as no-ops if this happens.
-     if (max_descriptors_ == 0) {
-         return;
-     }
+    // If max_descriptors_ is 0, GPU-AV aborted during vkCreateDevice(). We still need to
+    // support calls into this class as no-ops if this happens.
+    if (max_descriptors_ == 0) {
+        return;
+    }
 
     VkBufferCreateInfo buffer_info = vku::InitStruct<VkBufferCreateInfo>();
     buffer_info.size = BitBufferSize(max_descriptors_ + 1); // add extra entry since 0 is the invalid id.
@@ -527,7 +525,7 @@ gpuav_state::DescriptorHeap::DescriptorHeap(GpuAssisted &gpu_dev, uint32_t max_d
     assert(device_address_ != 0);
 }
 
-gpuav_state::DescriptorHeap::~DescriptorHeap() {
+gpuav::DescriptorHeap::~DescriptorHeap() {
     if (max_descriptors_ > 0) {
         vmaUnmapMemory(allocator_, allocation_);
         gpu_heap_state_ = nullptr;
@@ -535,11 +533,11 @@ gpuav_state::DescriptorHeap::~DescriptorHeap() {
     }
 }
 
-gpuav_state::DescriptorId gpuav_state::DescriptorHeap::NextId(const VulkanTypedHandle &handle) {
+gpuav::DescriptorId gpuav::DescriptorHeap::NextId(const VulkanTypedHandle &handle) {
     if (max_descriptors_ == 0) {
         return 0;
     }
-    gpuav_state::DescriptorId result;
+    DescriptorId result;
 
     // NOTE: valid ids are in the range [1, max_descriptors_] (inclusive)
     // 0 is the invalid id.
@@ -558,7 +556,7 @@ gpuav_state::DescriptorId gpuav_state::DescriptorHeap::NextId(const VulkanTypedH
     return result;
 }
 
-void gpuav_state::DescriptorHeap::DeleteId(gpuav_state::DescriptorId id) {
+void gpuav::DescriptorHeap::DeleteId(gpuav::DescriptorId id) {
     if (max_descriptors_ > 0) {
         auto guard = Lock();
         // Note: We don't mess with next_id_ here because ids should be signed in LRU order.
@@ -566,4 +564,3 @@ void gpuav_state::DescriptorHeap::DeleteId(gpuav_state::DescriptorId id) {
         alloc_map_.erase(id);
     }
 }
-

--- a/layers/gpu_validation/gpu_descriptor_set.h
+++ b/layers/gpu_validation/gpu_descriptor_set.h
@@ -22,9 +22,9 @@
 #include "state_tracker/descriptor_sets.h"
 #include "vma/vma.h"
 
-class GpuAssisted;
+namespace gpuav {
 
-namespace gpuav_state {
+class Validator;
 
 class DescriptorSet : public vvl::DescriptorSet {
   public:
@@ -42,8 +42,8 @@ class DescriptorSet : public vvl::DescriptorSet {
         VmaAllocation allocation{nullptr};
         VkBuffer buffer{VK_NULL_HANDLE};
         VkDeviceAddress device_addr{0};
-    
-        std::map<uint32_t, std::vector<uint32_t>> UsedDescriptors(const gpuav_state::DescriptorSet &set) const;
+
+        std::map<uint32_t, std::vector<uint32_t>> UsedDescriptors(const DescriptorSet &set) const;
     };
     void PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet *write_descs) override;
     void PerformWriteUpdate(const VkWriteDescriptorSet &) override;
@@ -71,10 +71,9 @@ class DescriptorSet : public vvl::DescriptorSet {
 };
 
 typedef uint32_t DescriptorId;
-
 class DescriptorHeap {
   public:
-    DescriptorHeap(GpuAssisted &, uint32_t max_descriptors);
+    DescriptorHeap(Validator &, uint32_t max_descriptors);
     ~DescriptorHeap();
     DescriptorId NextId(const VulkanTypedHandle &handle);
     void DeleteId(DescriptorId id);
@@ -89,8 +88,8 @@ class DescriptorHeap {
     mutable std::mutex lock_;
 
     const uint32_t max_descriptors_;
-    gpuav_state::DescriptorId next_id_{1};
-    vvl::unordered_map<gpuav_state::DescriptorId, VulkanTypedHandle> alloc_map_;
+    DescriptorId next_id_{1};
+    vvl::unordered_map<DescriptorId, VulkanTypedHandle> alloc_map_;
 
     VmaAllocator allocator_{nullptr};
     VmaAllocation allocation_{nullptr};
@@ -99,5 +98,4 @@ class DescriptorHeap {
     VkDeviceAddress device_address_{0};
 };
 
-
-}  // namespace gpuav_state
+}  // namespace gpuav

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -20,121 +20,120 @@
 #include "gpu_vuids.h"
 #include "drawdispatch/descriptor_validator.h"
 
-gpuav_state::Buffer::Buffer(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo,
-                            DescriptorHeap &desc_heap_)
+gpuav::Buffer::Buffer(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo,
+                      DescriptorHeap &desc_heap_)
     : BUFFER_STATE(dev_data, buff, pCreateInfo),
       desc_heap(desc_heap_),
       id(desc_heap.NextId(VulkanTypedHandle(buff, kVulkanObjectTypeBuffer))) {}
 
-void gpuav_state::Buffer::Destroy() {
+void gpuav::Buffer::Destroy() {
     desc_heap.DeleteId(id);
     BUFFER_STATE::Destroy();
 }
 
-void gpuav_state::Buffer::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::Buffer::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     desc_heap.DeleteId(id);
     BUFFER_STATE::NotifyInvalidate(invalid_nodes, unlink);
 }
 
-gpuav_state::BufferView::BufferView(const std::shared_ptr<BUFFER_STATE> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
-                                    VkFormatFeatureFlags2KHR buf_ff, DescriptorHeap &desc_heap_)
+gpuav::BufferView::BufferView(const std::shared_ptr<BUFFER_STATE> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
+                              VkFormatFeatureFlags2KHR buf_ff, DescriptorHeap &desc_heap_)
     : BUFFER_VIEW_STATE(bf, bv, ci, buf_ff),
       desc_heap(desc_heap_),
       id(desc_heap.NextId(VulkanTypedHandle(bv, kVulkanObjectTypeBufferView))) {}
 
-void gpuav_state::BufferView::Destroy() {
+void gpuav::BufferView::Destroy() {
     desc_heap.DeleteId(id);
     BUFFER_VIEW_STATE::Destroy();
 }
 
-void gpuav_state::BufferView::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::BufferView::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     desc_heap.DeleteId(id);
     BUFFER_VIEW_STATE::NotifyInvalidate(invalid_nodes, unlink);
 }
 
-gpuav_state::ImageView::ImageView(const std::shared_ptr<IMAGE_STATE> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci,
-                                  VkFormatFeatureFlags2KHR ff, const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props,
-                                  DescriptorHeap &desc_heap_)
+gpuav::ImageView::ImageView(const std::shared_ptr<IMAGE_STATE> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci,
+                            VkFormatFeatureFlags2KHR ff, const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props,
+                            DescriptorHeap &desc_heap_)
     : IMAGE_VIEW_STATE(image_state, iv, ci, ff, cubic_props),
       desc_heap(desc_heap_),
       id(desc_heap.NextId(VulkanTypedHandle(iv, kVulkanObjectTypeImageView))) {}
 
-void gpuav_state::ImageView::Destroy() {
+void gpuav::ImageView::Destroy() {
     desc_heap.DeleteId(id);
     IMAGE_VIEW_STATE::Destroy();
 }
 
-void gpuav_state::ImageView::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::ImageView::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     desc_heap.DeleteId(id);
     IMAGE_VIEW_STATE::NotifyInvalidate(invalid_nodes, unlink);
 }
 
-gpuav_state::Sampler::Sampler(const VkSampler s, const VkSamplerCreateInfo *pci, DescriptorHeap &desc_heap_)
+gpuav::Sampler::Sampler(const VkSampler s, const VkSamplerCreateInfo *pci, DescriptorHeap &desc_heap_)
     : SAMPLER_STATE(s, pci), desc_heap(desc_heap_), id(desc_heap.NextId(VulkanTypedHandle(s, kVulkanObjectTypeSampler))) {}
 
-void gpuav_state::Sampler::Destroy() {
+void gpuav::Sampler::Destroy() {
     desc_heap.DeleteId(id);
     SAMPLER_STATE::Destroy();
 }
 
-void gpuav_state::Sampler::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::Sampler::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     desc_heap.DeleteId(id);
     SAMPLER_STATE::NotifyInvalidate(invalid_nodes, unlink);
 }
 
-gpuav_state::AccelerationStructureKHR::AccelerationStructureKHR(VkAccelerationStructureKHR as,
-                                                                const VkAccelerationStructureCreateInfoKHR *ci,
-                                                                std::shared_ptr<BUFFER_STATE> &&buf_state, VkDeviceAddress address,
-                                                                DescriptorHeap &desc_heap_)
+gpuav::AccelerationStructureKHR::AccelerationStructureKHR(VkAccelerationStructureKHR as,
+                                                          const VkAccelerationStructureCreateInfoKHR *ci,
+                                                          std::shared_ptr<BUFFER_STATE> &&buf_state, VkDeviceAddress address,
+                                                          DescriptorHeap &desc_heap_)
     : ACCELERATION_STRUCTURE_STATE_KHR(as, ci, std::move(buf_state), address),
       desc_heap(desc_heap_),
       id(desc_heap.NextId(VulkanTypedHandle(as, kVulkanObjectTypeAccelerationStructureKHR))) {}
 
-void gpuav_state::AccelerationStructureKHR::Destroy() {
+void gpuav::AccelerationStructureKHR::Destroy() {
     desc_heap.DeleteId(id);
     ACCELERATION_STRUCTURE_STATE_KHR::Destroy();
 }
 
-void gpuav_state::AccelerationStructureKHR::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::AccelerationStructureKHR::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     desc_heap.DeleteId(id);
     ACCELERATION_STRUCTURE_STATE_KHR::NotifyInvalidate(invalid_nodes, unlink);
 }
 
-gpuav_state::AccelerationStructureNV::AccelerationStructureNV(VkDevice device, VkAccelerationStructureNV as,
-                                                              const VkAccelerationStructureCreateInfoNV *ci,
-                                                              DescriptorHeap &desc_heap_)
+gpuav::AccelerationStructureNV::AccelerationStructureNV(VkDevice device, VkAccelerationStructureNV as,
+                                                        const VkAccelerationStructureCreateInfoNV *ci, DescriptorHeap &desc_heap_)
     : ACCELERATION_STRUCTURE_STATE_NV(device, as, ci),
       desc_heap(desc_heap_),
       id(desc_heap.NextId(VulkanTypedHandle(as, kVulkanObjectTypeAccelerationStructureNV))) {}
 
-void gpuav_state::AccelerationStructureNV::Destroy() {
+void gpuav::AccelerationStructureNV::Destroy() {
     desc_heap.DeleteId(id);
     ACCELERATION_STRUCTURE_STATE_NV::Destroy();
 }
 
-void gpuav_state::AccelerationStructureNV::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::AccelerationStructureNV::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     desc_heap.DeleteId(id);
     ACCELERATION_STRUCTURE_STATE_NV::NotifyInvalidate(invalid_nodes, unlink);
 }
 
-gpuav_state::CommandBuffer::CommandBuffer(GpuAssisted *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
-                                          const COMMAND_POOL_STATE *pool)
-    : gpu_utils_state::CommandBuffer(ga, cb, pCreateInfo, pool) {}
+gpuav::CommandBuffer::CommandBuffer(gpuav::Validator *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
+                                    const COMMAND_POOL_STATE *pool)
+    : gpu_tracker::CommandBuffer(ga, cb, pCreateInfo, pool) {}
 
-gpuav_state::CommandBuffer::~CommandBuffer() { Destroy(); }
+gpuav::CommandBuffer::~CommandBuffer() { Destroy(); }
 
-void gpuav_state::CommandBuffer::Destroy() {
+void gpuav::CommandBuffer::Destroy() {
     ResetCBState();
     CMD_BUFFER_STATE::Destroy();
 }
 
-void gpuav_state::CommandBuffer::Reset() {
+void gpuav::CommandBuffer::Reset() {
     CMD_BUFFER_STATE::Reset();
     ResetCBState();
 }
 
-void gpuav_state::CommandBuffer::ResetCBState() {
-    auto gpuav = static_cast<GpuAssisted *>(dev_data);
+void gpuav::CommandBuffer::ResetCBState() {
+    auto gpuav = static_cast<Validator *>(dev_data);
     // Free the device memory and descriptor set(s) associated with a command buffer.
     for (auto &cmd_info : per_draw_buffer_list) {
         gpuav->DestroyBuffer(cmd_info);
@@ -154,8 +153,8 @@ void gpuav_state::CommandBuffer::ResetCBState() {
 }
 
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
-void gpuav_state::CommandBuffer::Process(VkQueue queue, const Location &loc) {
-    auto *device_state = static_cast<GpuAssisted *>(dev_data);
+void gpuav::CommandBuffer::Process(VkQueue queue, const Location &loc) {
+    auto *device_state = static_cast<Validator *>(dev_data);
     if (has_draw_cmd || has_trace_rays_cmd || has_dispatch_cmd) {
         uint32_t draw_index = 0;
         uint32_t compute_index = 0;
@@ -163,11 +162,11 @@ void gpuav_state::CommandBuffer::Process(VkQueue queue, const Location &loc) {
 
         for (auto &cmd_info : per_draw_buffer_list) {
             char *data;
-            gpuav_state::DescBindingInfo *di_info = nullptr;
+            DescBindingInfo *di_info = nullptr;
             if (cmd_info.desc_binding_index != vvl::kU32Max) {
                 di_info = &di_input_buffer_list[cmd_info.desc_binding_index];
             }
-            std::vector<gpuav_state::DescSetState> empty;
+            std::vector<DescSetState> empty;
 
             uint32_t operation_index = 0;
             if (cmd_info.pipeline_bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS) {
@@ -209,7 +208,8 @@ void gpuav_state::CommandBuffer::Process(VkQueue queue, const Location &loc) {
                 // For each used binding ...
                 for (const auto &u : used_descs) {
                     auto iter = set.binding_req.find(u.first);
-                    vvl::DescriptorBindingInfo binding_info{u.first, (iter != set.binding_req.end()) ? iter->second : DescriptorRequirement()};
+                    vvl::DescriptorBindingInfo binding_info{
+                        u.first, (iter != set.binding_req.end()) ? iter->second : DescriptorRequirement()};
                     context.ValidateBinding(binding_info, u.second);
                 }
             }
@@ -218,13 +218,13 @@ void gpuav_state::CommandBuffer::Process(VkQueue queue, const Location &loc) {
     ProcessAccelerationStructure(queue);
 }
 
-void gpuav_state::CommandBuffer::ProcessAccelerationStructure(VkQueue queue) {
+void gpuav::CommandBuffer::ProcessAccelerationStructure(VkQueue queue) {
     if (!has_build_as_cmd) {
         return;
     }
-    auto *device_state = static_cast<GpuAssisted *>(dev_data);
+    auto *device_state = static_cast<Validator *>(dev_data);
     for (const auto &as_validation_buffer_info : as_validation_buffers) {
-        gpuav_glsl::AccelerationStructureBuildValidationBuffer *mapped_validation_buffer = nullptr;
+        glsl::AccelerationStructureBuildValidationBuffer *mapped_validation_buffer = nullptr;
 
         VkResult result = vmaMapMemory(device_state->vmaAllocator, as_validation_buffer_info.buffer_allocation,
                                        reinterpret_cast<void **>(&mapped_validation_buffer));
@@ -246,4 +246,3 @@ void gpuav_state::CommandBuffer::ProcessAccelerationStructure(VkQueue queue) {
         }
     }
 }
-

--- a/layers/gpu_validation/gpu_subclasses.h
+++ b/layers/gpu_validation/gpu_subclasses.h
@@ -25,9 +25,9 @@
 #include "generated/vk_object_types.h"
 #include "gpu_shaders/gpu_shaders_constants.h"
 
-class GpuAssisted;
+namespace gpuav {
 
-namespace gpuav_state {
+class Validator;
 
 struct DescSetState {
     uint32_t num;
@@ -107,7 +107,7 @@ struct AccelerationStructureBuildValidationBufferInfo {
     VmaAllocation buffer_allocation = VK_NULL_HANDLE;
 };
 
-class CommandBuffer : public gpu_utils_state::CommandBuffer {
+class CommandBuffer : public gpu_tracker::CommandBuffer {
   public:
     // per draw/dispatch command state
     std::vector<CommandInfo> per_draw_buffer_list;
@@ -116,7 +116,7 @@ class CommandBuffer : public gpu_utils_state::CommandBuffer {
     std::vector<AccelerationStructureBuildValidationBufferInfo> as_validation_buffers;
     VkBuffer current_bindless_buffer = VK_NULL_HANDLE;
 
-    CommandBuffer(GpuAssisted *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
+    CommandBuffer(Validator *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
                   const COMMAND_POOL_STATE *pool);
     ~CommandBuffer();
 
@@ -202,9 +202,7 @@ class AccelerationStructureNV : public ACCELERATION_STRUCTURE_STATE_NV {
     const DescriptorId id;
 };
 
-}  // namespace gpuav_state
-
-namespace gpuav_glsl {
+namespace glsl {
 
 struct AccelerationStructureBuildValidationBuffer {
     uint32_t instances_to_validate;
@@ -224,6 +222,9 @@ struct DescriptorSetRecord {
 
 struct BindlessStateBuffer {
     VkDeviceAddress global_state;
-    DescriptorSetRecord desc_sets[gpuav_glsl::kDebugInputBindlessMaxDescSets];
+    DescriptorSetRecord desc_sets[kDebugInputBindlessMaxDescSets];
 };
-} // namespace gpuav_glsl
+
+}  // namespace glsl
+
+}  // namespace gpuav

--- a/layers/gpu_validation/gpu_vuids.cpp
+++ b/layers/gpu_validation/gpu_vuids.cpp
@@ -17,35 +17,35 @@
 #include "gpu_vuids.h"
 
 // clang-format off
-struct GpuVuidsCmdDraw : GpuVuid {
+struct GpuVuidsCmdDraw : gpuav::GpuVuid {
     GpuVuidsCmdDraw() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDraw-None-08612";
         storage_access_oob = "VUID-vkCmdDraw-None-08613";
     }
 };
 
-struct GpuVuidsCmdDrawMultiEXT : GpuVuid {
+struct GpuVuidsCmdDrawMultiEXT : gpuav::GpuVuid {
     GpuVuidsCmdDrawMultiEXT() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawMultiEXT-None-08612";
         storage_access_oob = "VUID-vkCmdDrawMultiEXT-None-08613";
     }
 };
 
-struct GpuVuidsCmdDrawIndexed : GpuVuid {
+struct GpuVuidsCmdDrawIndexed : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndexed() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawIndexed-None-08612";
         storage_access_oob = "VUID-vkCmdDrawIndexed-None-08613";
     }
 };
 
-struct GpuVuidsCmdDrawMultiIndexedEXT : GpuVuid {
+struct GpuVuidsCmdDrawMultiIndexedEXT : gpuav::GpuVuid {
     GpuVuidsCmdDrawMultiIndexedEXT() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawMultiIndexedEXT-None-08612";
         storage_access_oob = "VUID-vkCmdDrawMultiIndexedEXT-None-08613";
     }
 };
 
-struct GpuVuidsCmdDrawIndirect : GpuVuid {
+struct GpuVuidsCmdDrawIndirect : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndirect() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawIndirect-None-08612";
         storage_access_oob = "VUID-vkCmdDrawIndirect-None-08613";
@@ -53,7 +53,7 @@ struct GpuVuidsCmdDrawIndirect : GpuVuid {
     }
 };
 
-struct GpuVuidsCmdDrawIndexedIndirect : GpuVuid {
+struct GpuVuidsCmdDrawIndexedIndirect : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndexedIndirect() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawIndexedIndirect-None-08612";
         storage_access_oob = "VUID-vkCmdDrawIndexedIndirect-None-08613";
@@ -61,14 +61,14 @@ struct GpuVuidsCmdDrawIndexedIndirect : GpuVuid {
     }
 };
 
-struct GpuVuidsCmdDispatch : GpuVuid {
+struct GpuVuidsCmdDispatch : gpuav::GpuVuid {
     GpuVuidsCmdDispatch() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDispatch-None-08612";
         storage_access_oob = "VUID-vkCmdDispatch-None-08613";
     }
 };
 
-struct GpuVuidsCmdDispatchIndirect : GpuVuid {
+struct GpuVuidsCmdDispatchIndirect : gpuav::GpuVuid {
     GpuVuidsCmdDispatchIndirect() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDispatchIndirect-None-08612";
         storage_access_oob = "VUID-vkCmdDispatchIndirect-None-08613";
@@ -79,7 +79,7 @@ struct GpuVuidsCmdDispatchIndirect : GpuVuid {
     }
 };
 
-struct GpuVuidsCmdDrawIndirectCount : GpuVuid {
+struct GpuVuidsCmdDrawIndirectCount : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndirectCount() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawIndirectCount-None-08612";
         storage_access_oob = "VUID-vkCmdDrawIndirectCount-None-08613";
@@ -89,7 +89,7 @@ struct GpuVuidsCmdDrawIndirectCount : GpuVuid {
     }
 };
 
-struct GpuVuidsCmdDrawIndexedIndirectCount : GpuVuid {
+struct GpuVuidsCmdDrawIndexedIndirectCount : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndexedIndirectCount() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawIndexedIndirectCount-None-08612";
         storage_access_oob = "VUID-vkCmdDrawIndexedIndirectCount-None-08613";
@@ -99,63 +99,63 @@ struct GpuVuidsCmdDrawIndexedIndirectCount : GpuVuid {
     }
 };
 
-struct GpuVuidsCmdTraceRaysNV : GpuVuid {
+struct GpuVuidsCmdTraceRaysNV : gpuav::GpuVuid {
     GpuVuidsCmdTraceRaysNV() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdTraceRaysNV-None-08612";
         storage_access_oob = "VUID-vkCmdTraceRaysNV-None-08613";
     }
 };
 
-struct GpuVuidsCmdTraceRaysKHR : GpuVuid {
+struct GpuVuidsCmdTraceRaysKHR : gpuav::GpuVuid {
     GpuVuidsCmdTraceRaysKHR() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdTraceRaysKHR-None-08612";
         storage_access_oob = "VUID-vkCmdTraceRaysKHR-None-08613";
     }
 };
 
-struct GpuVuidsCmdTraceRaysIndirectKHR : GpuVuid {
+struct GpuVuidsCmdTraceRaysIndirectKHR : gpuav::GpuVuid {
     GpuVuidsCmdTraceRaysIndirectKHR() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdTraceRaysIndirectKHR-None-08612";
         storage_access_oob = "VUID-vkCmdTraceRaysIndirectKHR-None-08613";
     }
 };
 
-struct GpuVuidsCmdTraceRaysIndirect2KHR : GpuVuid {
+struct GpuVuidsCmdTraceRaysIndirect2KHR : gpuav::GpuVuid {
     GpuVuidsCmdTraceRaysIndirect2KHR() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdTraceRaysIndirect2KHR-None-08612";
         storage_access_oob = "VUID-vkCmdTraceRaysIndirect2KHR-None-08613";
     }
 };
 
-struct GpuVuidsCmdDrawMeshTasksNV : GpuVuid {
+struct GpuVuidsCmdDrawMeshTasksNV : gpuav::GpuVuid {
     GpuVuidsCmdDrawMeshTasksNV() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawMeshTasksNV-None-08612";
         storage_access_oob = "VUID-vkCmdDrawMeshTasksNV-None-08613";
     }
 };
 
-struct GpuVuidsCmdDrawMeshTasksIndirectNV : GpuVuid {
+struct GpuVuidsCmdDrawMeshTasksIndirectNV : gpuav::GpuVuid {
     GpuVuidsCmdDrawMeshTasksIndirectNV() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08612";
         storage_access_oob = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08613";
     }
 };
 
-struct GpuVuidsCmdDrawMeshTasksIndirectCountNV : GpuVuid {
+struct GpuVuidsCmdDrawMeshTasksIndirectCountNV : gpuav::GpuVuid {
     GpuVuidsCmdDrawMeshTasksIndirectCountNV() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08612";
         storage_access_oob = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08613";
     }
 };
 
-struct GpuVuidsCmdDrawIndirectByteCountEXT : GpuVuid {
+struct GpuVuidsCmdDrawIndirectByteCountEXT : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndirectByteCountEXT() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDrawIndirectByteCountEXT-None-08612";
         storage_access_oob = "VUID-vkCmdDrawIndirectByteCountEXT-None-08613";
     }
 };
 
-struct GpuVuidsCmdDispatchBase : GpuVuid {
+struct GpuVuidsCmdDispatchBase : gpuav::GpuVuid {
     GpuVuidsCmdDispatchBase() : GpuVuid() {
         uniform_access_oob = "VUID-vkCmdDispatchBase-None-08612";
         storage_access_oob = "VUID-vkCmdDispatchBase-None-08613";
@@ -164,7 +164,7 @@ struct GpuVuidsCmdDispatchBase : GpuVuid {
 
 using Func = vvl::Func;
 // This LUT is created to allow a static listing of each VUID that is covered by drawdispatch commands
-static const std::map<Func, GpuVuid> gpu_vuid = {
+static const std::map<Func, gpuav::GpuVuid> gpu_vuid = {
     {Func::vkCmdDraw, GpuVuidsCmdDraw()},
     {Func::vkCmdDrawMultiEXT, GpuVuidsCmdDrawMultiEXT()},
     {Func::vkCmdDrawIndexed, GpuVuidsCmdDrawIndexed()},
@@ -188,10 +188,10 @@ static const std::map<Func, GpuVuid> gpu_vuid = {
     {Func::vkCmdDispatchBase, GpuVuidsCmdDispatchBase()},
     {Func::vkCmdDispatchBaseKHR, GpuVuidsCmdDispatchBase()},
     // Used if invalid function is used
-    {Func::Empty, GpuVuid()}
+    {Func::Empty, gpuav::GpuVuid()}
 };
 
-const GpuVuid &GetGpuVuid(Func command) {
+const gpuav::GpuVuid &gpuav::GetGpuVuid(Func command) {
     if (gpu_vuid.find(command) != gpu_vuid.cend()) {
         return gpu_vuid.at(command);
     }

--- a/layers/gpu_validation/gpu_vuids.h
+++ b/layers/gpu_validation/gpu_vuids.h
@@ -19,4 +19,6 @@
 
 #pragma once
 // Getter function to provide kVUIDUndefined in case an invalid function is passed in
+namespace gpuav {
 const GpuVuid &GetGpuVuid(vvl::Func command);
+}  // namespace gpuav

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -159,7 +159,7 @@ void SetValidationFeatureEnable(CHECK_ENABLED &enable_data, const VkValidationFe
             enable_data[best_practices] = true;
             break;
         case VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT:
-            enable_data[debug_printf] = true;
+            enable_data[debug_printf_validation] = true;
             break;
         case VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT:
             enable_data[sync_validation] = true;
@@ -462,7 +462,7 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
             std::string setting_value;
             vkuGetLayerSettingValue(layer_setting_set, SETTING_VALIDATE_GPU_BASED, setting_value);
             settings_data->enables[gpu_validation] = setting_value == "GPU_BASED_GPU_ASSISTED";
-            settings_data->enables[debug_printf] = setting_value == "GPU_BASED_DEBUG_PRINTF";
+            settings_data->enables[debug_printf_validation] = setting_value == "GPU_BASED_DEBUG_PRINTF";
         }
 
         SetValidationSetting(layer_setting_set, settings_data->enables, gpu_validation_reserve_binding_slot,

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -93,10 +93,10 @@ static std::vector<ValidationObject*> CreateObjectDispatch(const CHECK_ENABLED& 
         object_dispatch.emplace_back(new BestPractices);
     }
     if (enables[gpu_validation]) {
-        object_dispatch.emplace_back(new GpuAssisted);
+        object_dispatch.emplace_back(new gpuav::Validator);
     }
-    if (enables[debug_printf]) {
-        object_dispatch.emplace_back(new DebugPrintf);
+    if (enables[debug_printf_validation]) {
+        object_dispatch.emplace_back(new debug_printf::Validator);
     }
     if (enables[sync_validation]) {
         object_dispatch.emplace_back(new SyncValidator);
@@ -127,10 +127,10 @@ static void InitDeviceObjectDispatch(ValidationObject* instance_interceptor, Val
         device_interceptor->object_dispatch.emplace_back(new BestPractices);
     }
     if (enables[gpu_validation]) {
-        device_interceptor->object_dispatch.emplace_back(new GpuAssisted);
+        device_interceptor->object_dispatch.emplace_back(new gpuav::Validator);
     }
-    if (enables[debug_printf]) {
-        device_interceptor->object_dispatch.emplace_back(new DebugPrintf);
+    if (enables[debug_printf_validation]) {
+        device_interceptor->object_dispatch.emplace_back(new debug_printf::Validator);
     }
     if (enables[sync_validation]) {
         device_interceptor->object_dispatch.emplace_back(new SyncValidator);

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2191,7 +2191,7 @@ typedef enum EnableFlags {
     vendor_specific_amd,
     vendor_specific_img,
     vendor_specific_nvidia,
-    debug_printf,
+    debug_printf_validation,
     sync_validation,
     sync_validation_queue_submit,
     // Insert new enables above this line

--- a/layers/vulkan/generated/chassis_dispatch_helper.h
+++ b/layers/vulkan/generated/chassis_dispatch_helper.h
@@ -1685,8 +1685,8 @@ void ValidationObject::InitObjectDispatchVectors() {
                                 typeid(&ObjectLifetimes::name), \
                                 typeid(&CoreChecks::name), \
                                 typeid(&BestPractices::name), \
-                                typeid(&GpuAssisted::name), \
-                                typeid(&DebugPrintf::name), \
+                                typeid(&gpuav::Validator::name), \
+                                typeid(&debug_printf::Validator::name), \
                                 typeid(&SyncValidator::name));
 
     auto init_object_dispatch_vector = [this](InterceptId id,

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -68,13 +68,13 @@ class APISpecific:
                     },
                     {
                         'include': 'gpu_validation/gpu_validation.h',
-                        'class': 'GpuAssisted',
+                        'class': 'gpuav::Validator',
                         'enabled': 'enables[gpu_validation]'
                     },
                     {
                         'include': 'gpu_validation/debug_printf.h',
-                        'class': 'DebugPrintf',
-                        'enabled': 'enables[debug_printf]'
+                        'class': 'debug_printf::Validator',
+                        'enabled': 'enables[debug_printf_validation]'
                     },
                     {
                         'include': 'sync/sync_validation.h',
@@ -131,8 +131,8 @@ void ValidationObject::InitObjectDispatchVectors() {
                                 typeid(&ObjectLifetimes::name), \\
                                 typeid(&CoreChecks::name), \\
                                 typeid(&BestPractices::name), \\
-                                typeid(&GpuAssisted::name), \\
-                                typeid(&DebugPrintf::name), \\
+                                typeid(&gpuav::Validator::name), \\
+                                typeid(&debug_printf::Validator::name), \\
                                 typeid(&SyncValidator::name));
 
     auto init_object_dispatch_vector = [this](InterceptId id,
@@ -416,7 +416,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 vendor_specific_amd,
                 vendor_specific_img,
                 vendor_specific_nvidia,
-                debug_printf,
+                debug_printf_validation,
                 sync_validation,
                 sync_validation_queue_submit,
                 // Insert new enables above this line

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -495,7 +495,7 @@ TEST_F(PositiveGpuAssistedLayer, MaxDescriptorsClamp) {
 
     vk::GetPhysicalDeviceProperties2(gpu(), &props2);
 
-    ASSERT_GE(gpuav_glsl::kDebugInputBindlessMaxDescriptors, desc_indexing_props.maxUpdateAfterBindDescriptorsInAllPools);
+    ASSERT_GE(gpuav::glsl::kDebugInputBindlessMaxDescriptors, desc_indexing_props.maxUpdateAfterBindDescriptorsInAllPools);
 }
 
 TEST_F(PositiveGpuAssistedLayer, MaxDescriptorsClamp13) {
@@ -509,7 +509,7 @@ TEST_F(PositiveGpuAssistedLayer, MaxDescriptorsClamp13) {
 
     vk::GetPhysicalDeviceProperties2(gpu(), &props2);
 
-    ASSERT_GE(gpuav_glsl::kDebugInputBindlessMaxDescriptors, vk12_props.maxUpdateAfterBindDescriptorsInAllPools);
+    ASSERT_GE(gpuav::glsl::kDebugInputBindlessMaxDescriptors, vk12_props.maxUpdateAfterBindDescriptorsInAllPools);
 }
 
 TEST_F(PositiveGpuAssistedLayer, GpuValidationUnInitImage) {


### PR DESCRIPTION
Convert `gpuav_state::` to `gpuav::`, `debug_printf_state::` to `debug_printf::` and `gpu_utils_state::` to `gpu_tracker::`. Move all definitions for each validation area into these namespaces. Having a separate `_state` namespace isn't very helpful.

Note that the 'main' objects are now called `namespace::Validator`. At some point these very large classes should be split up into at least `namespace::Instance` and `namespace::Device`, but possibly there should be a separate class for every dispatchable handle type. But this is not going to happen soon.

Add a `BaseClass` alias in each `Validator` class so that upcalls are easier to do. In the past, people have forgotten about `gpu_tracker::Validator()` and called directly into `ValidationStateTracker`, which lead to bugs.

Unfortunately, uses of the `VALTRACK_*_STATE_OBJECT()` macros must occur outside of all namespaces.