### PR TITLE
layers: Refactor how semaphore binary payload is tracked

### DIFF
--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -104,8 +104,7 @@ bool CoreChecks::PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemap
                     LogError("VUID-VkSemaphoreGetFdInfoKHR-handleType-03253", sem_state->Handle(), info_loc.dot(Field::handleType),
                              "is VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT, but semaphore type is %s.",
                              string_VkSemaphoreType(sem_state->type));
-            }
-            if (!sem_state->CanBeWaited()) {
+            } else if (!sem_state->CanBinaryBeWaited()) {
                 skip |= LogError("VUID-VkSemaphoreGetFdInfoKHR-handleType-03254", sem_state->Handle(),
                                  info_loc.dot(Field::semaphore), "must be signaled or have a pending signal operation.");
             }

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -1065,7 +1065,7 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, VkSwapchainKHR swapch
             // are completed. So it is possible to get in a condition where the semaphore is doing
             // acquire / wait / acquire and the first acquire (and thus the wait) have completed, but our state
             // isn't aware of it yet. This results in MANY false positives.
-            if (!semaphore_state->CanBeSignaled()) {
+            if (!semaphore_state->CanBinaryBeSignaled()) {
                 const char *vuid =
                     version_2 ? "VUID-VkAcquireNextImageInfoKHR-semaphore-01288" : "VUID-vkAcquireNextImageKHR-semaphore-01286";
                 skip |= LogError(vuid, semaphore, loc, "Semaphore must not be currently signaled.");

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -228,8 +228,8 @@ class SEMAPHORE_STATE : public REFCOUNTED_NODE {
     // look for most recent / highest payload operation that matches
     std::optional<SemOp> LastOp(const std::function<bool(const SemOp &, bool is_pending)> &filter = nullptr) const;
 
-    bool CanBeSignaled() const;
-    bool CanBeWaited() const;
+    bool CanBinaryBeSignaled() const;
+    bool CanBinaryBeWaited() const;
     bool HasPendingOps() const {
         auto guard = ReadLock();
         return !timeline_.empty();


### PR DESCRIPTION
It's enough to have a single map to track both binary payload value and the status of whether the payload was updated by this submission.

Adds comments that explain two stages of querying payload value (current submission, then other submissions).

Documents more places where we know that binary semaphore is used and not an arbitrary semaphore.

It has to be an equivalent transformation of code (until it's not).