### PR TITLE
ObjectTracker cleanup

### DIFF
--- a/layers/object_tracker/object_lifetime_validation.h
+++ b/layers/object_tracker/object_lifetime_validation.h
@@ -65,7 +65,7 @@ class ObjectLifetimes : public ValidationObject {
     // Vector of unordered_maps per object type to hold ObjTrackState info
     object_map_type object_map[kVulkanObjectTypeMax + 1];
     // Special-case map for swapchain images
-    object_map_type swapchainImageMap;
+    object_map_type swapchain_image_map;
 
     void *device_createinfo_pnext;
     bool null_descriptor_enabled;
@@ -123,70 +123,9 @@ class ObjectLifetimes : public ValidationObject {
     bool ValidateAccelerationStructures(const char *dst_handle_vuid, uint32_t count,
                                         const VkAccelerationStructureBuildGeometryInfoKHR *infos, const Location &loc) const;
 
-    bool TracksObject(uint64_t object_handle, VulkanObjectType object_type) const {
-        // Look for object in object map
-        if (object_map[object_type].contains(object_handle)) {
-            return true;
-        }
-        // If object is an image, also look for it in the swapchain image map
-        if (object_type == kVulkanObjectTypeImage && swapchainImageMap.find(object_handle) != swapchainImageMap.end()) {
-            return true;
-        }
-        return false;
-    }
-
+    bool TracksObject(uint64_t object_handle, VulkanObjectType object_type) const;
     bool CheckObjectValidity(uint64_t object_handle, VulkanObjectType object_type, const char *invalid_handle_vuid,
-                             const char *wrong_parent_vuid, const Location &loc, VulkanObjectType parent_type) const {
-        constexpr bool skip = false;
-
-        // If this instance of lifetime validation tracks the object, report success
-        if (TracksObject(object_handle, object_type)) {
-            return skip;
-        }
-        // Object not found, look for it in other device object maps
-        const ObjectLifetimes *other_lifetimes = nullptr;
-        for (const auto &other_device_data : layer_data_map) {
-            const auto lifetimes = other_device_data.second->GetValidationObject<ObjectLifetimes>();
-            if (lifetimes && lifetimes != this && lifetimes->TracksObject(object_handle, object_type)) {
-                other_lifetimes = lifetimes;
-                break;
-            }
-        }
-        // Object was not found anywhere
-        if (!other_lifetimes) {
-            return LogError(invalid_handle_vuid, instance, loc, "Invalid %s Object 0x%" PRIxLEAST64 ".", object_string[object_type],
-                            object_handle);
-        }
-        // Anonymous object validation does not check parent, only that the object exists
-        if (wrong_parent_vuid == kVUIDUndefined) {
-            return skip;
-        }
-        // Object found on another device
-        LogObjectList objlist;
-        std::string handle_str;
-        std::string other_handle_str;
-        if (parent_type == kVulkanObjectTypeDevice) {
-            objlist = LogObjectList(instance, device, other_lifetimes->device);
-            handle_str = FormatHandle(device);
-            other_handle_str = FormatHandle(other_lifetimes->device);
-        } else if (parent_type == kVulkanObjectTypeInstance) {
-            objlist = LogObjectList(instance, other_lifetimes->instance);
-            handle_str = FormatHandle(instance);
-            other_handle_str = FormatHandle(other_lifetimes->instance);
-        } else if (parent_type == kVulkanObjectTypePhysicalDevice) {
-            objlist = LogObjectList(instance, physical_device, other_lifetimes->physical_device);
-            handle_str = FormatHandle(physical_device);
-            other_handle_str = FormatHandle(other_lifetimes->physical_device);
-        } else {
-            assert(false);
-            return skip;
-        }
-        return LogError(wrong_parent_vuid, objlist, loc,
-                        "(%s 0x%" PRIxLEAST64
-                        ") was created, allocated or retrieved from %s, but command is using (or its dispatchable parameter is "
-                        "associated with) %s",
-                        object_string[object_type], object_handle, other_handle_str.c_str(), handle_str.c_str());
-    }
+                             const char *wrong_parent_vuid, const Location &loc, VulkanObjectType parent_type) const;
 
     template <typename T1>
     bool ValidateObject(T1 object, VulkanObjectType object_type, bool null_allowed, const char *invalid_handle_vuid,
@@ -218,28 +157,7 @@ class ObjectLifetimes : public ValidationObject {
         }
     }
 
-    void DestroyObjectSilently(uint64_t object, VulkanObjectType object_type) {
-        assert(object != HandleToUint64(VK_NULL_HANDLE));
-
-        auto item = object_map[object_type].pop(object);
-        if (item == object_map[object_type].end()) {
-            // We've already checked that the object exists. If we couldn't find and atomically remove it
-            // from the map, there must have been a race condition in the app. Report an error and move on.
-            const Location loc(Func::vkDestroyDevice);
-            (void)LogError(kVUID_ObjectTracker_Info, device, loc,
-                           "Couldn't destroy %s Object 0x%" PRIxLEAST64
-                           ", not found. This should not happen and may indicate a race condition in the application.",
-                           object_string[object_type], object);
-
-            return;
-        }
-        assert(num_total_objects > 0);
-
-        num_total_objects--;
-        assert(num_objects[item->second->object_type] > 0);
-
-        num_objects[item->second->object_type]--;
-    }
+    void DestroyObjectSilently(uint64_t object, VulkanObjectType object_type);
 
     template <typename T1>
     void RecordDestroyObject(T1 object_handle, VulkanObjectType object_type) {

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -31,6 +31,94 @@ VulkanTypedHandle ObjTrackStateTypedHandle(const ObjTrackState &track_state) {
     return typed_handle;
 }
 
+bool ObjectLifetimes::TracksObject(uint64_t object_handle, VulkanObjectType object_type) const {
+    // Look for object in object map
+    if (object_map[object_type].contains(object_handle)) {
+        return true;
+    }
+    // If object is an image, also look for it in the swapchain image map
+    if (object_type == kVulkanObjectTypeImage && swapchain_image_map.find(object_handle) != swapchain_image_map.end()) {
+        return true;
+    }
+    return false;
+}
+
+bool ObjectLifetimes::CheckObjectValidity(uint64_t object_handle, VulkanObjectType object_type, const char *invalid_handle_vuid,
+                                          const char *wrong_parent_vuid, const Location &loc, VulkanObjectType parent_type) const {
+    constexpr bool skip = false;
+
+    // If this instance of lifetime validation tracks the object, report success
+    if (TracksObject(object_handle, object_type)) {
+        return skip;
+    }
+    // Object not found, look for it in other device object maps
+    const ObjectLifetimes *other_lifetimes = nullptr;
+    for (const auto &other_device_data : layer_data_map) {
+        const auto lifetimes = other_device_data.second->GetValidationObject<ObjectLifetimes>();
+        if (lifetimes && lifetimes != this && lifetimes->TracksObject(object_handle, object_type)) {
+            other_lifetimes = lifetimes;
+            break;
+        }
+    }
+    // Object was not found anywhere
+    if (!other_lifetimes) {
+        return LogError(invalid_handle_vuid, instance, loc, "Invalid %s Object 0x%" PRIxLEAST64 ".", object_string[object_type],
+                        object_handle);
+    }
+    // Anonymous object validation does not check parent, only that the object exists
+    if (wrong_parent_vuid == kVUIDUndefined) {
+        return skip;
+    }
+    // Object found on another device
+    LogObjectList objlist;
+    std::string handle_str;
+    std::string other_handle_str;
+    if (parent_type == kVulkanObjectTypeDevice) {
+        objlist = LogObjectList(instance, device, other_lifetimes->device);
+        handle_str = FormatHandle(device);
+        other_handle_str = FormatHandle(other_lifetimes->device);
+    } else if (parent_type == kVulkanObjectTypeInstance) {
+        objlist = LogObjectList(instance, other_lifetimes->instance);
+        handle_str = FormatHandle(instance);
+        other_handle_str = FormatHandle(other_lifetimes->instance);
+    } else if (parent_type == kVulkanObjectTypePhysicalDevice) {
+        objlist = LogObjectList(instance, physical_device, other_lifetimes->physical_device);
+        handle_str = FormatHandle(physical_device);
+        other_handle_str = FormatHandle(other_lifetimes->physical_device);
+    } else {
+        assert(false);
+        return skip;
+    }
+    return LogError(wrong_parent_vuid, objlist, loc,
+                    "(%s 0x%" PRIxLEAST64
+                    ") was created, allocated or retrieved from %s, but command is using (or its dispatchable parameter is "
+                    "associated with) %s",
+                    object_string[object_type], object_handle, other_handle_str.c_str(), handle_str.c_str());
+}
+
+void ObjectLifetimes::DestroyObjectSilently(uint64_t object, VulkanObjectType object_type) {
+    assert(object != HandleToUint64(VK_NULL_HANDLE));
+
+    auto item = object_map[object_type].pop(object);
+    if (item == object_map[object_type].end()) {
+        // We've already checked that the object exists. If we couldn't find and atomically remove it
+        // from the map, there must have been a race condition in the app. Report an error and move on.
+        const Location loc(Func::vkDestroyDevice);
+        (void)LogError(kVUID_ObjectTracker_Info, device, loc,
+                       "Couldn't destroy %s Object 0x%" PRIxLEAST64
+                       ", not found. This should not happen and may indicate a race condition in the application.",
+                       object_string[object_type], object);
+
+        return;
+    }
+    assert(num_total_objects > 0);
+
+    num_total_objects--;
+    assert(num_objects[item->second->object_type] > 0);
+
+    num_objects[item->second->object_type]--;
+}
+
 // Destroy memRef lists and free all memory
 void ObjectLifetimes::DestroyQueueDataStructures() {
     // Destroy the items in the queue map
@@ -264,13 +352,13 @@ void ObjectLifetimes::CreateQueue(VkQueue vkObj, const Location &loc) {
 }
 
 void ObjectLifetimes::CreateSwapchainImageObject(VkImage swapchain_image, VkSwapchainKHR swapchain, const Location &loc) {
-    if (!swapchainImageMap.contains(HandleToUint64(swapchain_image))) {
+    if (!swapchain_image_map.contains(HandleToUint64(swapchain_image))) {
         auto new_obj_node = std::make_shared<ObjTrackState>();
         new_obj_node->object_type = kVulkanObjectTypeImage;
         new_obj_node->status = OBJSTATUS_NONE;
         new_obj_node->handle = HandleToUint64(swapchain_image);
         new_obj_node->parent_object = HandleToUint64(swapchain);
-        InsertObject(swapchainImageMap, swapchain_image, kVulkanObjectTypeImage, loc, new_obj_node);
+        InsertObject(swapchain_image_map, swapchain_image, kVulkanObjectTypeImage, loc, new_obj_node);
     }
 }
 
@@ -749,10 +837,10 @@ void ObjectLifetimes::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapch
                                                        const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
     RecordDestroyObject(swapchain, kVulkanObjectTypeSwapchainKHR);
 
-    auto snapshot = swapchainImageMap.snapshot(
+    auto snapshot = swapchain_image_map.snapshot(
         [swapchain](const std::shared_ptr<ObjTrackState> &pNode) { return pNode->parent_object == HandleToUint64(swapchain); });
     for (const auto &itr : snapshot) {
-        swapchainImageMap.erase(itr.first);
+        swapchain_image_map.erase(itr.first);
     }
 }
 

--- a/layers/vulkan/generated/object_tracker.cpp
+++ b/layers/vulkan/generated/object_tracker.cpp
@@ -2284,8 +2284,9 @@ bool ObjectLifetimes::PreCallValidateDestroyPrivateDataSlot(VkDevice device, VkP
     skip |= ValidateObject(privateDataSlot, kVulkanObjectTypePrivateDataSlot, true,
                            "VUID-vkDestroyPrivateDataSlot-privateDataSlot-parameter",
                            "VUID-vkDestroyPrivateDataSlot-privateDataSlot-parent", error_obj.location.dot(Field::privateDataSlot));
-    skip |= ValidateDestroyObject(privateDataSlot, kVulkanObjectTypePrivateDataSlot, pAllocator, kVUIDUndefined, kVUIDUndefined,
-                                  error_obj.location);
+    skip |= ValidateDestroyObject(privateDataSlot, kVulkanObjectTypePrivateDataSlot, pAllocator,
+                                  "VUID-vkDestroyPrivateDataSlot-privateDataSlot-04062",
+                                  "VUID-vkDestroyPrivateDataSlot-privateDataSlot-04063", error_obj.location);
 
     return skip;
 }
@@ -3894,8 +3895,9 @@ bool ObjectLifetimes::PreCallValidateDestroyDeferredOperationKHR(VkDevice device
     skip |= ValidateObject(operation, kVulkanObjectTypeDeferredOperationKHR, true,
                            "VUID-vkDestroyDeferredOperationKHR-operation-parameter",
                            "VUID-vkDestroyDeferredOperationKHR-operation-parent", error_obj.location.dot(Field::operation));
-    skip |= ValidateDestroyObject(operation, kVulkanObjectTypeDeferredOperationKHR, pAllocator, kVUIDUndefined, kVUIDUndefined,
-                                  error_obj.location);
+    skip |= ValidateDestroyObject(operation, kVulkanObjectTypeDeferredOperationKHR, pAllocator,
+                                  "VUID-vkDestroyDeferredOperationKHR-operation-03434",
+                                  "VUID-vkDestroyDeferredOperationKHR-operation-03435", error_obj.location);
 
     return skip;
 }
@@ -4221,8 +4223,9 @@ bool ObjectLifetimes::PreCallValidateDestroyDebugReportCallbackEXT(VkInstance in
     skip |= ValidateObject(
         callback, kVulkanObjectTypeDebugReportCallbackEXT, true, "VUID-vkDestroyDebugReportCallbackEXT-callback-parameter",
         "VUID-vkDestroyDebugReportCallbackEXT-callback-parent", error_obj.location.dot(Field::callback), kVulkanObjectTypeInstance);
-    skip |= ValidateDestroyObject(callback, kVulkanObjectTypeDebugReportCallbackEXT, pAllocator, kVUIDUndefined, kVUIDUndefined,
-                                  error_obj.location);
+    skip |= ValidateDestroyObject(callback, kVulkanObjectTypeDebugReportCallbackEXT, pAllocator,
+                                  "VUID-vkDestroyDebugReportCallbackEXT-instance-01242",
+                                  "VUID-vkDestroyDebugReportCallbackEXT-instance-01243", error_obj.location);
 
     return skip;
 }
@@ -4759,8 +4762,9 @@ bool ObjectLifetimes::PreCallValidateDestroyDebugUtilsMessengerEXT(VkInstance in
                            "VUID-vkDestroyDebugUtilsMessengerEXT-messenger-parameter",
                            "VUID-vkDestroyDebugUtilsMessengerEXT-messenger-parent", error_obj.location.dot(Field::messenger),
                            kVulkanObjectTypeInstance);
-    skip |= ValidateDestroyObject(messenger, kVulkanObjectTypeDebugUtilsMessengerEXT, pAllocator, kVUIDUndefined, kVUIDUndefined,
-                                  error_obj.location);
+    skip |= ValidateDestroyObject(messenger, kVulkanObjectTypeDebugUtilsMessengerEXT, pAllocator,
+                                  "VUID-vkDestroyDebugUtilsMessengerEXT-messenger-01915",
+                                  "VUID-vkDestroyDebugUtilsMessengerEXT-messenger-01916", error_obj.location);
 
     return skip;
 }
@@ -4937,8 +4941,9 @@ bool ObjectLifetimes::PreCallValidateDestroyValidationCacheEXT(VkDevice device, 
     skip |= ValidateObject(
         validationCache, kVulkanObjectTypeValidationCacheEXT, true, "VUID-vkDestroyValidationCacheEXT-validationCache-parameter",
         "VUID-vkDestroyValidationCacheEXT-validationCache-parent", error_obj.location.dot(Field::validationCache));
-    skip |= ValidateDestroyObject(validationCache, kVulkanObjectTypeValidationCacheEXT, pAllocator, kVUIDUndefined, kVUIDUndefined,
-                                  error_obj.location);
+    skip |= ValidateDestroyObject(validationCache, kVulkanObjectTypeValidationCacheEXT, pAllocator,
+                                  "VUID-vkDestroyValidationCacheEXT-validationCache-01537",
+                                  "VUID-vkDestroyValidationCacheEXT-validationCache-01538", error_obj.location);
 
     return skip;
 }
@@ -6436,8 +6441,8 @@ bool ObjectLifetimes::PreCallValidateDestroyMicromapEXT(VkDevice device, VkMicro
     // Checked by chassis: device: "VUID-vkDestroyMicromapEXT-device-parameter"
     skip |= ValidateObject(micromap, kVulkanObjectTypeMicromapEXT, true, "VUID-vkDestroyMicromapEXT-micromap-parameter",
                            "VUID-vkDestroyMicromapEXT-micromap-parent", error_obj.location.dot(Field::micromap));
-    skip |= ValidateDestroyObject(micromap, kVulkanObjectTypeMicromapEXT, pAllocator, kVUIDUndefined, kVUIDUndefined,
-                                  error_obj.location);
+    skip |= ValidateDestroyObject(micromap, kVulkanObjectTypeMicromapEXT, pAllocator, "VUID-vkDestroyMicromapEXT-micromap-07442",
+                                  "VUID-vkDestroyMicromapEXT-micromap-07443", error_obj.location);
 
     return skip;
 }

--- a/scripts/generators/object_tracker_generator.py
+++ b/scripts/generators/object_tracker_generator.py
@@ -174,6 +174,18 @@ class ObjectTrackerOutputGenerator(BaseGenerator):
             "VkAccelerationStructureNV-accelerationStructure-nullalloc": "\"VUID-vkDestroyAccelerationStructureNV-accelerationStructure-03754\"",
             "shader-compatalloc": "\"VUID-vkDestroyShaderEXT-pAllocator-08483\"",
             "shader-nullalloc": "\"VUID-vkDestroyShaderEXT-pAllocator-08484\"",
+            "callback-compatalloc": "\"VUID-vkDestroyDebugReportCallbackEXT-instance-01242\"",
+            "callback-nullalloc": "\"VUID-vkDestroyDebugReportCallbackEXT-instance-01243\"",
+            "messenger-compatalloc": "\"VUID-vkDestroyDebugUtilsMessengerEXT-messenger-01915\"",
+            "messenger-nullalloc": "\"VUID-vkDestroyDebugUtilsMessengerEXT-messenger-01916\"",
+            "operation-compatalloc": "\"VUID-vkDestroyDeferredOperationKHR-operation-03434\"",
+            "operation-nullalloc": "\"VUID-vkDestroyDeferredOperationKHR-operation-03435\"",
+            "micromap-compatalloc": "\"VUID-vkDestroyMicromapEXT-micromap-07442\"",
+            "micromap-nullalloc": "\"VUID-vkDestroyMicromapEXT-micromap-07443\"",
+            "privateDataSlot-compatalloc": "\"VUID-vkDestroyPrivateDataSlot-privateDataSlot-04062\"",
+            "privateDataSlot-nullalloc": "\"VUID-vkDestroyPrivateDataSlot-privateDataSlot-04063\"",
+            "validationCache-compatalloc": "\"VUID-vkDestroyValidationCacheEXT-validationCache-01537\"",
+            "validationCache-nullalloc": "\"VUID-vkDestroyValidationCacheEXT-validationCache-01538\"",
            }
 
         # Structures that do not define parent/commonparent VUIDs for vulkan handles.


### PR DESCRIPTION
1. Moves logic from headers to source (it seems it use to be small but now grown my larger then code in a header file should be)

2. Add missing VUs for `VkAllocationCallbacks` when destroyed

3. `swapchainImageMap` -> `swapchain_image_map`