### PR TITLE
gpu: Fix handling of maximum descriptor records

### DIFF
--- a/layers/gpu_shaders/gpu_shaders_constants.h
+++ b/layers/gpu_shaders/gpu_shaders_constants.h
@@ -27,7 +27,7 @@ using uint = unsigned int;
 // be small enough to allow for a table in memory, but some devices set it to 2^32.
 // This value only matters for host code, but it is defined here so it can be used
 // in unit tests.
-const uint kDebugInputBindlessMaxDescriptors = 1024u*1024u;
+const uint kDebugInputBindlessMaxDescriptors = 1024u*1024u*4u;
 
 #endif
 


### PR DESCRIPTION
gpuav_state::DescriptorHeap has to keep track of all resources that could be used in a descriptor, in gpu-accessible memory. Avoid an infinite loop if this limit is hit and raise the limit.