### PR TITLE
tests: Add option --gpuav-enable-core

### DIFF
--- a/tests/framework/gpu_av_helper.h
+++ b/tests/framework/gpu_av_helper.h
@@ -31,23 +31,3 @@ bool CanEnableGpuAV(Test &test) {
     }
     return true;
 }
-
-static const std::array gpu_av_enables = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT,
-                                          VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT};
-static const std::array gpu_av_disables = {VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT,
-                                           VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
-
-// All VkGpuAssistedLayerTest should use this for setup as a single access point to more easily toggle which validation features are
-// enabled/disabled
-template <typename Test>
-VkValidationFeaturesEXT GetGpuAvValidationFeatures(Test &test) {
-    test.AddRequiredExtensions(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
-    VkValidationFeaturesEXT features = vku::InitStructHelper();
-    features.enabledValidationFeatureCount = size32(gpu_av_enables);
-    // TODO - Add command line flag or env var or another system for setting this to 'zero' to allow for someone writting a new
-    // GPU-AV test to easily check the test is valid
-    features.disabledValidationFeatureCount = size32(gpu_av_disables);
-    features.pEnabledValidationFeatures = gpu_av_enables.data();
-    features.pDisabledValidationFeatures = gpu_av_disables.data();
-    return features;
-}

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -250,12 +250,14 @@ class VkGpuAssistedLayerTest : public virtual VkLayerTest {
   public:
     void InitGpuAvFramework(void *p_next = nullptr);
 
-    VkValidationFeaturesEXT GetValidationFeatures();
+    VkValidationFeaturesEXT GetGpuAvValidationFeatures();
     void ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDeviceSize binding_offset, VkDeviceSize binding_range,
                               VkDescriptorType descriptor_type, const char *fragment_shader, const char *expected_error, bool shader_objects = false);
 
   protected:
 };
+
+class PositiveGpuAssistedLayer : public VkGpuAssistedLayerTest {};
 
 class NegativeDebugPrintf : public VkLayerTest {
   public:
@@ -488,7 +490,7 @@ class ShaderComputeTest : public VkLayerTest {};
 class NegativeShaderCompute : public ShaderComputeTest {};
 class PositiveShaderCompute : public ShaderComputeTest {};
 
-class ShaderObjectTest : public VkLayerTest {
+class ShaderObjectTest : public virtual VkLayerTest {
     vkt::Buffer vertexBuffer;
 
   public:

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -164,6 +164,8 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
             m_print_vu = true;
         } else if (current_argument == "--syncval-enable-core") {
             m_syncval_enable_core = true;
+        } else if (current_argument == "--gpuav-enable-core") {
+            m_gpuav_enable_core = true;
         } else if (current_argument == "--device-index" && ((i + 1) < *argc)) {
             m_phys_device_index = std::atoi(argv[++i]);
         } else if ((current_argument == "--help") || (current_argument == "-h")) {
@@ -175,6 +177,10 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
                 "\t--syncval-enable-core\n"
                 "\t\tEnable both syncval and core validation when running syncval tests.\n"
                 "\t\tBy default only syncval validation is enabled.\n");
+            printf(
+                "\t--gpuav-enable-core\n"
+                "\t\tEnable both gpu-av and core validation when running gpu-av tests.\n"
+                "\t\tBy default only gpu-av is enabled.\n");
             printf(
                 "\t--strip-SPV\n"
                 "\t\tStrip SPIR-V debug information (line numbers, names, etc).\n");

--- a/tests/framework/test_framework.h
+++ b/tests/framework/test_framework.h
@@ -56,6 +56,7 @@ class VkTestFramework : public ::testing::Test {
     static inline bool m_do_everything_spv = false;
     static inline bool m_print_vu = false;
     static inline bool m_syncval_enable_core = false;
+    static inline bool m_gpuav_enable_core = false;
     static inline int m_phys_device_index = -1;
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -21,7 +21,24 @@
 #include "../framework/gpu_av_helper.h"
 #include "../../layers/gpu_shaders/gpu_shaders_constants.h"
 
-class PositiveGpuAssistedLayer : public VkGpuAssistedLayerTest {};
+static const std::array gpu_av_enables = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT,
+                                          VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT};
+static const std::array gpu_av_disables = {VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT,
+                                           VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
+
+// All VkGpuAssistedLayerTest should use this for setup as a single access point to more easily toggle which validation features are
+// enabled/disabled
+VkValidationFeaturesEXT VkGpuAssistedLayerTest::GetGpuAvValidationFeatures() {
+    AddRequiredExtensions(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME);
+    VkValidationFeaturesEXT features = vku::InitStructHelper();
+    features.enabledValidationFeatureCount = size32(gpu_av_enables);
+    features.pEnabledValidationFeatures = gpu_av_enables.data();
+    if (!m_gpuav_enable_core) {
+        features.disabledValidationFeatureCount = size32(gpu_av_disables);
+        features.pDisabledValidationFeatures = gpu_av_disables.data();
+    }
+    return features;
+}
 
 TEST_F(PositiveGpuAssistedLayer, SetSSBOBindDescriptor) {
     TEST_DESCRIPTION("Makes sure we can use vkCmdBindDescriptorSets()");

--- a/tests/unit/ray_tracing_gpu_nv.cpp
+++ b/tests/unit/ray_tracing_gpu_nv.cpp
@@ -24,7 +24,7 @@ TEST_F(NegativeGpuAssistedRayTracingNV, BuildAccelerationStructureValidationInva
         "acceleration structure with an invalid handle for a bottom level acceleration structure.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures(*this);
+    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false, nullptr, &validation_features))
 
     if (!CanEnableGpuAV(*this)) {
@@ -104,7 +104,7 @@ TEST_F(NegativeGpuAssistedRayTracingNV, BuildAccelerationStructureValidationBott
         "acceleration structure with a handle for a bottom level acceleration structure that has not yet been built.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures(*this);
+    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false, nullptr, &validation_features))
 
     if (!CanEnableGpuAV(*this)) {
@@ -193,7 +193,7 @@ TEST_F(NegativeGpuAssistedRayTracingNV, BuildAccelerationStructureValidationBott
         "acceleration structure with a handle for a destroyed bottom level acceleration structure.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures(*this);
+    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false, nullptr, &validation_features))
 
     if (!CanEnableGpuAV(*this)) {
@@ -302,7 +302,7 @@ TEST_F(NegativeGpuAssistedRayTracingNV, BuildAccelerationStructureValidationRest
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
-    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures(*this);
+    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false, nullptr, &validation_features))
 
     if (!CanEnableGpuAV(*this)) {

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -1171,7 +1171,9 @@ TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
     m_commandBuffer->end();
 }
 
-TEST_F(PositiveShaderObject, SelectInstrumentedShaders) {
+class PositiveGpuAssistedShaderObject : public PositiveShaderObject, public PositiveGpuAssistedLayer {};
+
+TEST_F(PositiveGpuAssistedShaderObject, SelectInstrumentedShaders) {
     TEST_DESCRIPTION("GPU validation: Validate selection of which shaders get instrumented for GPU-AV");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1180,7 +1182,7 @@ TEST_F(PositiveShaderObject, SelectInstrumentedShaders) {
                                        &value};
     VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
                                                                &setting};
-    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures(*this);
+    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
     validation_features.pNext = &layer_settings_create_info;
     AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);


### PR DESCRIPTION
Add option --gpuav-enable-core to enable core validation when running gpu-av tests

With that option enabled, locally the only failing test is `VkGpuAssistedLayerTest.UnnormalizedCoordinatesSeparateSamplerSharedSampler`, the expected VUID `VUID-vkCmdDraw-None-08609` is not received.
I updated this test so that it works with core validation enabled, and added a comment describing the situation