### PR TITLE
tests: Cleanup wsi tests

### DIFF
--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -769,6 +769,52 @@ VkImageAspectFlags Image::aspect_mask(VkFormat format) {
     return image_aspect;
 }
 
+VkImageMemoryBarrier Image::transition_to_present(VkImage swapchain_image, VkImageLayout old_layout,
+                                                  VkAccessFlags src_access_mask) {
+    VkImageMemoryBarrier transition = vku::InitStructHelper();
+    transition.srcAccessMask = src_access_mask;
+
+    // No need to make writes visible. Available writes are automatically become visible to the presentation engine
+    transition.dstAccessMask = 0;
+
+    transition.oldLayout = old_layout;
+    transition.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    transition.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    transition.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    transition.image = swapchain_image;
+    transition.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    transition.subresourceRange.baseMipLevel = 0;
+    transition.subresourceRange.levelCount = 1;
+    transition.subresourceRange.baseArrayLayer = 0;
+    transition.subresourceRange.layerCount = 1;
+    return transition;
+}
+
+VkImageMemoryBarrier2 Image::transition_to_present_2(VkImage swapchain_image, VkImageLayout old_layout,
+                                                     VkPipelineStageFlags2 src_stage_mask, VkAccessFlags2 src_access_mask) {
+    VkImageMemoryBarrier2 transition = vku::InitStructHelper();
+    transition.srcStageMask = src_stage_mask;
+    transition.srcAccessMask = src_access_mask;
+
+    // Spec advice: when transitioning to "present" there is no need to delay subsequent processing
+    transition.dstStageMask = VK_PIPELINE_STAGE_2_NONE;
+
+    // No need to make writes visible. Available writes are automatically become visible to the presentation engine
+    transition.dstAccessMask = 0;
+
+    transition.oldLayout = old_layout;
+    transition.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    transition.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    transition.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    transition.image = swapchain_image;
+    transition.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    transition.subresourceRange.baseMipLevel = 0;
+    transition.subresourceRange.levelCount = 1;
+    transition.subresourceRange.baseArrayLayer = 0;
+    transition.subresourceRange.layerCount = 1;
+    return transition;
+}
+
 NON_DISPATCHABLE_HANDLE_DTOR(ImageView, vk::DestroyImageView)
 
 void ImageView::init(const Device &dev, const VkImageViewCreateInfo &info) {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -668,6 +668,12 @@ class Image : public internal::NonDispHandle<VkImage> {
 
     static VkExtent3D extent(int32_t width, int32_t height, int32_t depth);
 
+    static VkImageMemoryBarrier transition_to_present(VkImage swapchain_image, VkImageLayout old_layout = VK_IMAGE_LAYOUT_UNDEFINED,
+                                                      VkAccessFlags src_access_mask = 0);
+    static VkImageMemoryBarrier2 transition_to_present_2(
+        VkImage swapchain_image, VkImageLayout old_layout = VK_IMAGE_LAYOUT_UNDEFINED,
+        VkPipelineStageFlags2 src_stage_mask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT, VkAccessFlags2 src_access_mask = 0);
+
   private:
     void init_info(const Device &dev, const VkImageCreateInfo &info);
 

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -2443,24 +2443,10 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionRelease) {
     uint32_t image_index = 0;
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore.handle(), VK_NULL_HANDLE, &image_index);
 
+    const VkImageMemoryBarrier present_transition = vkt::Image::transition_to_present(swapchain_images[image_index]);
     m_commandBuffer->begin();
-
-    VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
-    img_barrier.srcAccessMask = 0;
-    img_barrier.dstAccessMask = 0;
-    img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    img_barrier.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-    img_barrier.image = swapchain_images[image_index];
-    img_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    img_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    img_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    img_barrier.subresourceRange.baseArrayLayer = 0;
-    img_barrier.subresourceRange.baseMipLevel = 0;
-    img_barrier.subresourceRange.layerCount = 1;
-    img_barrier.subresourceRange.levelCount = 1;
-
-    vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, 0,
-                           nullptr, 0, nullptr, 1, &img_barrier);
+    vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
+                           0, nullptr, 0, nullptr, 1, &present_transition);
     m_commandBuffer->end();
 
     VkPipelineStageFlags stage_mask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;


### PR DESCRIPTION
- Adds helper to create transition barriers (there are some subtleties there, and the tests often did that in a different ways).
- Rename  `NegativeWsi.UseSwapchainImageBeforeWait` -> `NegativeWsi.PresentImageWithWrongLayout` to show what the test actually does. It made attempt to create a "missing semaphore wait" scenario, but the actual validation was about image layout. At the moment we don't have the missing semaphore wait validation but it will be added in the future PR.