### PR TITLE
layers: Validate image acquire wait

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1818,6 +1818,8 @@ class CoreChecks : public ValidationStateTracker {
                                              VkImage* pSwapchainImages, const RecordObject& record_obj) override;
     bool PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
                                         const ErrorObject& error_obj) const override;
+    bool ValidateImageAcquireWait(const SWAPCHAIN_IMAGE& swapchain_image, uint32_t image_index,
+                                  const VkPresentInfoKHR& present_info, const Location present_info_loc) const;
     bool PreCallValidateReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo,
                                                   const ErrorObject& error_obj) const override;
     bool PreCallValidateCreateSharedSwapchainsKHR(VkDevice device, uint32_t swapchainCount,

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -535,6 +535,8 @@ void SWAPCHAIN_NODE::PresentImage(uint32_t image_index, uint64_t present_id) {
     if (!shared_presentable) {
         acquired_images--;
         images[image_index].acquired = false;
+        images[image_index].acquire_semaphore.reset();
+        images[image_index].acquire_fence.reset();
     } else {
         IMAGE_STATE *image_state = images[image_index].image_state;
         if (image_state) {
@@ -546,12 +548,15 @@ void SWAPCHAIN_NODE::PresentImage(uint32_t image_index, uint64_t present_id) {
     }
 }
 
-void SWAPCHAIN_NODE::AcquireImage(uint32_t image_index) {
+void SWAPCHAIN_NODE::AcquireImage(uint32_t image_index, const std::shared_ptr<SEMAPHORE_STATE> &semaphore_state,
+                                  const std::shared_ptr<FENCE_STATE> &fence_state) {
     if (image_index >= images.size()) return;
 
     assert(acquired_images < std::numeric_limits<uint32_t>::max());
     acquired_images++;
     images[image_index].acquired = true;
+    images[image_index].acquire_semaphore = semaphore_state;
+    images[image_index].acquire_fence = fence_state;
     if (shared_presentable) {
         IMAGE_STATE *image_state = images[image_index].image_state;
         if (image_state) {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -30,6 +30,8 @@
 
 class ValidationStateTracker;
 class VideoProfileDesc;
+class FENCE_STATE;
+class SEMAPHORE_STATE;
 class SURFACE_STATE;
 class SWAPCHAIN_NODE;
 
@@ -318,6 +320,8 @@ class IMAGE_VIEW_STATE : public BASE_NODE {
 struct SWAPCHAIN_IMAGE {
     IMAGE_STATE *image_state = nullptr;
     bool acquired = false;
+    std::shared_ptr<SEMAPHORE_STATE> acquire_semaphore;
+    std::shared_ptr<FENCE_STATE> acquire_fence;
 };
 
 // State for VkSwapchainKHR objects.
@@ -352,7 +356,8 @@ class SWAPCHAIN_NODE : public BASE_NODE {
 
     void PresentImage(uint32_t image_index, uint64_t present_id);
 
-    void AcquireImage(uint32_t image_index);
+    void AcquireImage(uint32_t image_index, const std::shared_ptr<SEMAPHORE_STATE> &semaphore_state,
+                      const std::shared_ptr<FENCE_STATE> &fence_state);
 
     void Destroy() override;
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3538,7 +3538,7 @@ void ValidationStateTracker::RecordAcquireNextImageState(VkDevice device, VkSwap
     // Mark the image as acquired.
     auto swapchain_data = Get<SWAPCHAIN_NODE>(swapchain);
     if (swapchain_data) {
-        swapchain_data->AcquireImage(*pImageIndex);
+        swapchain_data->AcquireImage(*pImageIndex, semaphore_state, fence_state);
     }
 }
 


### PR DESCRIPTION
Validates that semaphore or fence from `vkAcquireNextImageKHR` has been waited on.
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4593
