### PR TITLE
glslang: Remove usage of non-public header file

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -95,7 +95,7 @@
             "sub_dir": "glslang",
             "build_dir": "glslang/build",
             "install_dir": "glslang/build/install",
-            "commit": "be564292f00c5bf0d7251c11f1c9618eb1117762",
+            "commit": "845e5d5a28561a25f85d23ef779c828e535bd56f",
             "cmake_options": [
                 "-DENABLE_OPT=OFF"
             ],

--- a/tests/framework/shader_helper.h
+++ b/tests/framework/shader_helper.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include "glslang/SPIRV/GLSL.std.450.h"
 #include "spirv-tools/libspirv.h"
 #include "glslang/Public/ShaderLang.h"
 


### PR DESCRIPTION
KhronosGroup/glslang/pull/3397 cleans up the header files glslang was installing.

Now only the intended files are being installed.

FYI @arcady-lunarg 