### PR TITLE
syncval: Add workaround to ensure monotonic rangegen

### DIFF
--- a/layers/containers/subresource_adapter.cpp
+++ b/layers/containers/subresource_adapter.cpp
@@ -293,6 +293,10 @@ ImageRangeEncoder::ImageRangeEncoder(const IMAGE_STATE& image, const AspectParam
         }
     }
 
+    // WORKAROUND for not being able to handle packed MIPS without resulting in a non-monotonically increasing range generation
+    // Need to clean this up to correctly detect aliasing conflicts between linear image(s) and buffers
+    if (limits_.mipLevel > 1) linear_image_ = false;
+
     is_compressed_ = vkuFormatIsCompressed(image.createInfo.format);
     texel_extent_ = vkuFormatTexelBlockExtent(image.createInfo.format);
 


### PR DESCRIPTION
Current ImageRangeGenerator doesn't emit monotonic ranges when the implementation packs MIP levels inside the "minimum stride" empty space.  The range map traversal engines require monotonic ranges.

This workaround forces the range generator encoder setup logic to use "idealized" memory organization for images with more than one mip level.

A better solution will be needed for full accurate aliasing support.