### PR TITLE
GitHub actions cleanup linux CI runs

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -76,13 +76,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ matrix.config }}-${{ matrix.sanitize }}-${{matrix.robin_hood}}
-      - run: python3 -m pip install jsonschema pyparsing
       - run: sudo apt-get -qq update && sudo apt-get install -y libwayland-dev xorg-dev
       - run: python scripts/tests.py --build --config ${{ matrix.config }} --cmake='-DUSE_ROBIN_HOOD_HASHING=${{matrix.robin_hood}}'
         env:

--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -60,6 +60,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-22.04
+    name: "linux (${{matrix.sanitize}} sanitizer, ${{matrix.config}}, robinhood ${{matrix.robin_hood}} )"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -67,13 +67,9 @@ jobs:
         config: [debug, release]
         robin_hood: [ "ON" ]
         include:
-          # Test clang support
-          - compiler: {cc: clang, cxx: clang++}
-            config: release
           # Test with Robin Hood disabled
           # Chromium build, and some package managers don't use it.
-          - compiler: {cc: clang, cxx: clang++}
-            config: release
+          - config: release
             robin_hood: "OFF"
             sanitize: address
     steps:
@@ -84,13 +80,11 @@ jobs:
           python-version: '3.10'
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ matrix.config }}-${{ matrix.compiler.cc }}-${{ matrix.compiler.cxx }}-${{ matrix.sanitize }}-${{matrix.robin_hood}}
+          key: ${{ matrix.config }}-${{ matrix.sanitize }}-${{matrix.robin_hood}}
       - run: python3 -m pip install jsonschema pyparsing
       - run: sudo apt-get -qq update && sudo apt-get install -y libwayland-dev xorg-dev
       - run: python scripts/tests.py --build --config ${{ matrix.config }} --cmake='-DUSE_ROBIN_HOOD_HASHING=${{matrix.robin_hood}}'
         env:
-          CC: ${{ matrix.compiler.cc }}
-          CXX: ${{ matrix.compiler.cxx }}
           CFLAGS: -fsanitize=${{ matrix.sanitize }}
           CXXFLAGS: -fsanitize=${{ matrix.sanitize }}
           LDFLAGS: -fsanitize=${{ matrix.sanitize }}

--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -63,20 +63,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flags: [{c: "-fsanitize=address", ld: "-fsanitize=address"}, {c: "-fsanitize=thread", ld: "-fsanitize=thread"}]
+        sanitize: [ address, thread ]
         config: [debug, release]
+        robin_hood: [ "ON" ]
         include:
           # Test clang support
           - compiler: {cc: clang, cxx: clang++}
             config: release
-            robin_hood: "ON"
           # Test with Robin Hood disabled
           # Chromium build, and some package managers don't use it.
           - compiler: {cc: clang, cxx: clang++}
             config: release
             robin_hood: "OFF"
-            flags: [{c: "-fsanitize=address", ld: "-fsanitize=address"}]
-
+            sanitize: address
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
@@ -85,17 +84,16 @@ jobs:
           python-version: '3.10'
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ matrix.config }}-${{ matrix.compiler.cc }}-${{ matrix.compiler.cxx }}-${{ matrix.flags.c }}-${{ matrix.flags.ld }}-${{matrix.robin_hood}}
+          key: ${{ matrix.config }}-${{ matrix.compiler.cc }}-${{ matrix.compiler.cxx }}-${{ matrix.sanitize }}-${{matrix.robin_hood}}
       - run: python3 -m pip install jsonschema pyparsing
       - run: sudo apt-get -qq update && sudo apt-get install -y libwayland-dev xorg-dev
-      - name: Build
-        run: python scripts/tests.py --build --config ${{ matrix.config }} --cmake='-DUSE_ROBIN_HOOD_HASHING=${{matrix.robin_hood}}'
+      - run: python scripts/tests.py --build --config ${{ matrix.config }} --cmake='-DUSE_ROBIN_HOOD_HASHING=${{matrix.robin_hood}}'
         env:
           CC: ${{ matrix.compiler.cc }}
           CXX: ${{ matrix.compiler.cxx }}
-          CFLAGS: ${{ matrix.flags.c }}
-          CXXFLAGS: ${{ matrix.flags.c }}
-          LDFLAGS: ${{ matrix.flags.ld }}
+          CFLAGS: -fsanitize=${{ matrix.sanitize }}
+          CXXFLAGS: -fsanitize=${{ matrix.sanitize }}
+          LDFLAGS: -fsanitize=${{ matrix.sanitize }}
           CMAKE_C_COMPILER_LAUNCHER: ccache
           CMAKE_CXX_COMPILER_LAUNCHER: ccache
       - name: Test Max Profile


### PR DESCRIPTION
1. Sets address/thread sanitizer in a much clearer fashion
1. Removes clang testing, we test clang for Android/Apple/Chromium/etc extensively already
1. Improves the naming of the runs
1. Removes unnecessary python usage from the linux runs