### PR TITLE
chassis: Use vulkan_layer_chassis instead of globals

### DIFF
--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -17568,9 +17568,9 @@ VVL_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkNegotiateLoaderLayerInterfaceVersion
 
     // Fill in the function pointers if our version is at least capable of having the structure contain them.
     if (pVersionStruct->loaderLayerInterfaceVersion >= 2) {
-        pVersionStruct->pfnGetInstanceProcAddr = vkGetInstanceProcAddr;
-        pVersionStruct->pfnGetDeviceProcAddr = vkGetDeviceProcAddr;
-        pVersionStruct->pfnGetPhysicalDeviceProcAddr = vk_layerGetPhysicalDeviceProcAddr;
+        pVersionStruct->pfnGetInstanceProcAddr = vulkan_layer_chassis::GetInstanceProcAddr;
+        pVersionStruct->pfnGetDeviceProcAddr = vulkan_layer_chassis::GetDeviceProcAddr;
+        pVersionStruct->pfnGetPhysicalDeviceProcAddr = vulkan_layer_chassis::GetPhysicalDeviceProcAddr;
     }
 
     return VK_SUCCESS;

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1968,9 +1968,9 @@ const vvl::unordered_map<std::string, function_data> name_to_funcptr_map = {
 
                 // Fill in the function pointers if our version is at least capable of having the structure contain them.
                 if (pVersionStruct->loaderLayerInterfaceVersion >= 2) {
-                    pVersionStruct->pfnGetInstanceProcAddr = vkGetInstanceProcAddr;
-                    pVersionStruct->pfnGetDeviceProcAddr = vkGetDeviceProcAddr;
-                    pVersionStruct->pfnGetPhysicalDeviceProcAddr = vk_layerGetPhysicalDeviceProcAddr;
+                    pVersionStruct->pfnGetInstanceProcAddr = vulkan_layer_chassis::GetInstanceProcAddr;
+                    pVersionStruct->pfnGetDeviceProcAddr = vulkan_layer_chassis::GetDeviceProcAddr;
+                    pVersionStruct->pfnGetPhysicalDeviceProcAddr = vulkan_layer_chassis::GetPhysicalDeviceProcAddr;
                 }
 
                 return VK_SUCCESS;


### PR DESCRIPTION
vkGetInstanceProcAddr and vkGetDeviceProcAddr were occassionally linking to the libvulkan.so's functions rather than the validation layers own symbols. While the root cause of this is unclear, it is very easy to prevent, by directly using the vulkan_layer_chassis::Get<Instance|Device>ProcAddr.

Fixes #6890 