### PR TITLE
gpuav: Combine Indirect Buffer settings

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -890,49 +890,9 @@
                                             ]
                                         },
                                         {
-                                            "key": "validate_draw_indirect",
-                                            "label": "Check Draw Indirect Count Buffers and firstInstance values",
-                                            "description": "Enable draw indirect checking",
-                                            "type": "BOOL",
-                                            "default": true,
-                                            "platforms": [
-                                                "WINDOWS",
-                                                "LINUX"
-                                            ],
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    {
-                                                        "key": "validate_gpu_based",
-                                                        "value": "GPU_BASED_GPU_ASSISTED"
-                                                    }
-                                                ]
-                                            }
-                                        },
-                                        {
-                                            "key": "validate_dispatch_indirect",
-                                            "label": "Check Dispatch Indirect group count values",
-                                            "description": "Enable dispatch indirect checking",
-                                            "type": "BOOL",
-                                            "default": true,
-                                            "platforms": [
-                                                "WINDOWS",
-                                                "LINUX"
-                                            ],
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    {
-                                                        "key": "validate_gpu_based",
-                                                        "value": "GPU_BASED_GPU_ASSISTED"
-                                                    }
-                                                ]
-                                            }
-                                        },
-                                        {
-                                            "key": "validate_trace_rays_indirect",
-                                            "label": "Check Trace Rays Indirect group count values",
-                                            "description": "Enable trace rays indirect checking",
+                                            "key": "validate_indirect_buffer",
+                                            "label": "Check Draw/Dispatch/TraceRays Indirect buffers",
+                                            "description": "Enable draw/dispatch/traceRays indirect checking",
                                             "type": "BOOL",
                                             "default": true,
                                             "platforms": [

--- a/layers/gpu_validation/gpu_record.cpp
+++ b/layers/gpu_validation/gpu_record.cpp
@@ -44,8 +44,7 @@ void gpuav::Validator::PreCallRecordCreateBuffer(VkDevice device, const VkBuffer
         }
 
         // Indirect buffers will require validation shader to bind the indirect buffers as a storage buffer.
-        if ((gpuav_settings.validate_draw_indirect || gpuav_settings.validate_dispatch_indirect ||
-             gpuav_settings.validate_trace_rays_indirect) &&
+        if (gpuav_settings.validate_indirect_buffer &&
             cb_state->modified_create_info.usage & VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT) {
             cb_state->modified_create_info.usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
         }

--- a/layers/gpu_validation/gpu_settings.h
+++ b/layers/gpu_validation/gpu_settings.h
@@ -14,13 +14,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ 
+ */
 #pragma once
 typedef struct {
     bool validate_descriptors;
-    bool validate_draw_indirect;
-    bool validate_dispatch_indirect;
-    bool validate_trace_rays_indirect;
+    bool validate_indirect_buffer;
     bool vma_linear_output;
     bool warn_on_robust_oob;
     bool cache_instrumented_shaders;

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -927,7 +927,7 @@ void gpuav::Validator::AllocateValidationResources(const VkCommandBuffer cmd_buf
     PreDispatchResources dispatch_resources = {};
     PreTraceRaysResources trace_rays_resources = {};
 
-    if (gpuav_settings.validate_draw_indirect &&
+    if (gpuav_settings.validate_indirect_buffer &&
         ((command == Func::vkCmdDrawIndirectCount || command == Func::vkCmdDrawIndirectCountKHR ||
           command == Func::vkCmdDrawIndexedIndirectCount || command == Func::vkCmdDrawIndexedIndirectCountKHR) ||
          ((command == Func::vkCmdDrawIndirect || command == Func::vkCmdDrawIndexedIndirect) &&
@@ -1016,7 +1016,7 @@ void gpuav::Validator::AllocateValidationResources(const VkCommandBuffer cmd_buf
 
         // Restore the previous graphics pipeline state.
         restorable_state.Restore(cmd_buffer);
-    } else if (gpuav_settings.validate_dispatch_indirect && command == Func::vkCmdDispatchIndirect) {
+    } else if (gpuav_settings.validate_indirect_buffer && command == Func::vkCmdDispatchIndirect) {
         // Insert a dispatch that can examine some device memory right before the dispatch we're validating
         //
         // NOTE that this validation does not attempt to abort invalid api calls as most other validation does. A crash
@@ -1053,7 +1053,7 @@ void gpuav::Validator::AllocateValidationResources(const VkCommandBuffer cmd_buf
 
         // Restore the previous compute pipeline state.
         restorable_state.Restore(cmd_buffer);
-    } else if (gpuav_settings.validate_trace_rays_indirect &&
+    } else if (gpuav_settings.validate_indirect_buffer &&
                (command == Func::vkCmdTraceRaysIndirectKHR /*|| command == Func::vkCmdTraceRaysIndirect2KHR */)) {
         AllocatePreTraceRaysValidationResources(output_block, indirect_state, trace_rays_resources);
         if (aborted) return;

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -56,8 +56,7 @@ const char *SETTING_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
 const char *SETTING_FINE_GRAINED_LOCKING = "fine_grained_locking";
 
 const char *SETTING_GPUAV_VALIDATE_DESCRIPTORS = "gpuav_descriptor_checks";
-const char *SETTING_GPUAV_VALIDATE_DRAW_INDIRECT = "validate_draw_indirect";
-const char *SETTING_GPUAV_VALIDATE_DISPATCH_INDIRECT = "validate_dispatch_indirect";
+const char *SETTING_GPUAV_VALIDATE_INDIRECT_BUFFER = "validate_indirect_buffer";
 const char *SETTING_GPUAV_VMA_LINEAR_OUTPUT = "vma_linear_output";
 const char *SETTING_GPUAV_WARN_ON_ROBUST_OOB = "warn_on_robust_oob";
 const char *SETTING_GPUAV_USE_INSTRUMENTED_SHADER_CACHE = "use_instrumented_shader_cache";
@@ -399,14 +398,9 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
                                 settings_data->gpuav_settings->validate_descriptors);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VALIDATE_DRAW_INDIRECT)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VALIDATE_DRAW_INDIRECT,
-                                settings_data->gpuav_settings->validate_draw_indirect);
-    }
-
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VALIDATE_DISPATCH_INDIRECT)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VALIDATE_DISPATCH_INDIRECT,
-                                settings_data->gpuav_settings->validate_dispatch_indirect);
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VALIDATE_INDIRECT_BUFFER)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VALIDATE_INDIRECT_BUFFER,
+                                settings_data->gpuav_settings->validate_indirect_buffer);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VMA_LINEAR_OUTPUT)) {

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -80,23 +80,11 @@ khronos_validation.enables =
 # Enable descriptor indexing and buffer out of bounds checking
 #khronos_validation.gpuav_descriptor_checks = true
 
-# Check Draw Indirect Count Buffers and firstInstance values
+# Check Draw/Dispatch/TraceRays Indirect Buffers
 # =====================
-# <LayerIdentifier>.validate_draw_indirect
-# Enable draw indirect checking
-#khronos_validation.validate_draw_indirect = true
-
-# Check Dispatch Indirect group count values
-# =====================
-# <LayerIdentifier>.validate_dispatch_indirect
-# Enable dispatch indirect checking
-#khronos_validation.validate_dispatch_indirect = true
-
-# Check Dispatch Indirect group count values
-# =====================
-# <LayerIdentifier>.validate_trace_rays_indirect
-# Enable trace rays indirect checking
-#khronos_validation.validate_trace_rays_indirect = true
+# <LayerIdentifier>.validate_indirect_buffer
+# Enable draw/dispatch/traceRays indirect checking
+#khronos_validation.validate_indirect_buffer = true
 
 # Cache instrumented shaders rather than instrumenting them on every run
 # =====================

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -377,7 +377,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     CHECK_DISABLED local_disables{};
     bool lock_setting;
     // select_instrumented_shaders is the only gpu-av setting that is off by default
-    GpuAVSettings local_gpuav_settings = {true, true, true, true, true, true, true, false, 10000};
+    GpuAVSettings local_gpuav_settings = {true, true, true, true, true, false, 10000};
     ConfigAndEnvSettings config_and_env_settings_data{OBJECT_LAYER_DESCRIPTION,
                                                       pCreateInfo,
                                                       local_enables,

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1096,7 +1096,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 CHECK_DISABLED local_disables{};
                 bool lock_setting;
                 // select_instrumented_shaders is the only gpu-av setting that is off by default
-                GpuAVSettings local_gpuav_settings = {true, true, true, true, true, true, true, false, 10000};
+                GpuAVSettings local_gpuav_settings = {true, true, true, true, true, false, 10000};
                 ConfigAndEnvSettings config_and_env_settings_data{OBJECT_LAYER_DESCRIPTION,
                                                                 pCreateInfo,
                                                                 local_enables,


### PR DESCRIPTION
Create a single `validate_indirect_buffer` to bundle all the GPU-AV settings together related to checking the indirect buffers

I find it not practical where someone would want to validate just the `Dispatch` but not the `Draws` indirect buffers