### PR TITLE
tests: Fix test case dependencies

### DIFF
--- a/docs/creating_tests.md
+++ b/docs/creating_tests.md
@@ -104,16 +104,24 @@ If a certain version of Vulkan is needed a test writer can call
 
 ```cpp
 SetTargetApiVersion(VK_API_VERSION_1_1);
-// Will skip if version is not high enough
+// Will skip if the supported instance version is not high enough, but actual device supported version may be lower
 RETURN_IF_SKIP(InitFramework());
 ```
 
-Later in the test it can also be checked
+Later in the test the actual Vulkan version supported by the device can be checked
+
 ```cpp
 if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
     // Only can be ran on Vulkan 1.0 or 1.1
 }
 ```
+
+### Promoted extensions
+
+The test framework now automatically handles extensions promoted to core versions by not enabling the extensions if the target instance Vulkan version (set through `SetTargetApiVersion`) or the Vulkan version supported by the device (queriable using `DeviceValidationVersion`) already includes the instance or device extension's functionality, respectively.
+This applies to both requirements requested using `AddRequiredExtensions` or `AddOptionalExtensions`, as well as optional requirements checked using `IsExtensionsEnabled`.
+
+In order to enforce enabling extensions even when they are included in the effective Vulkan version (which should only be necessary for very specific test cases), the test case can call the `AllowPromotedExtensions` function.
 
 ### Getting Function Pointers
 

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1284,14 +1284,11 @@ void RenderPass::init(const Device &dev, const VkRenderPassCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRenderPass, dev, &info);
 }
 
-void RenderPass::init(const Device &dev, const VkRenderPassCreateInfo2 &info, bool khr) {
-    if (!khr) {
-        NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRenderPass2, dev, &info);
+void RenderPass::init(const Device &dev, const VkRenderPassCreateInfo2 &info) {
+    if (vk::CreateRenderPass2KHR) {
+        NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRenderPass2KHR, dev, &info);
     } else {
-        auto vkCreateRenderPass2KHR =
-            reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(dev.handle(), "vkCreateRenderPass2KHR"));
-        ASSERT_NE(vkCreateRenderPass2KHR, nullptr);
-        NON_DISPATCHABLE_HANDLE_INIT(vkCreateRenderPass2KHR, dev, &info);
+        NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRenderPass2, dev, &info);
     }
 }
 
@@ -1303,14 +1300,11 @@ void Framebuffer::init(const Device &dev, const VkFramebufferCreateInfo &info) {
 
 NON_DISPATCHABLE_HANDLE_DTOR(Framebuffer, vk::DestroyFramebuffer)
 
-void SamplerYcbcrConversion::init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info, bool khr) {
-    if (!khr) {
-        NON_DISPATCHABLE_HANDLE_INIT(vk::CreateSamplerYcbcrConversion, dev, &info);
+void SamplerYcbcrConversion::init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info) {
+    if (vk::CreateSamplerYcbcrConversionKHR) {
+        NON_DISPATCHABLE_HANDLE_INIT(vk::CreateSamplerYcbcrConversionKHR, dev, &info);
     } else {
-        auto vkCreateSamplerYcbcrConversionKHR = reinterpret_cast<PFN_vkCreateSamplerYcbcrConversionKHR>(
-            vk::GetDeviceProcAddr(dev.handle(), "vkCreateSamplerYcbcrConversionKHR"));
-        ASSERT_NE(vkCreateSamplerYcbcrConversionKHR, nullptr);
-        NON_DISPATCHABLE_HANDLE_INIT(vkCreateSamplerYcbcrConversionKHR, dev, &info);
+        NON_DISPATCHABLE_HANDLE_INIT(vk::CreateSamplerYcbcrConversion, dev, &info);
     }
 }
 
@@ -1339,15 +1333,13 @@ void SamplerYcbcrConversion::destroy() noexcept {
     if (!initialized()) {
         return;
     }
-    if (!khr_) {
-        vk::DestroySamplerYcbcrConversion(device(), handle(), nullptr);
+    if (vk::DestroySamplerYcbcrConversionKHR) {
+        vk::DestroySamplerYcbcrConversionKHR(device(), handle(), nullptr);
     } else {
-        auto vkDestroySamplerYcbcrConversionKHR = reinterpret_cast<PFN_vkDestroySamplerYcbcrConversionKHR>(
-            vk::GetDeviceProcAddr(device(), "vkDestroySamplerYcbcrConversionKHR"));
-        assert(vkDestroySamplerYcbcrConversionKHR != nullptr);
-        vkDestroySamplerYcbcrConversionKHR(device(), handle(), nullptr);
+        vk::DestroySamplerYcbcrConversion(device(), handle(), nullptr);
     }
     handle_ = VK_NULL_HANDLE;
+    internal::NonDispHandle<decltype(handle_)>::destroy();
 }
 
 SamplerYcbcrConversion::~SamplerYcbcrConversion() noexcept { destroy(); }

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1003,14 +1003,14 @@ class RenderPass : public internal::NonDispHandle<VkRenderPass> {
     // vkCreateRenderPass()
     RenderPass(const Device &dev, const VkRenderPassCreateInfo &info) { init(dev, info); }
     // vkCreateRenderPass2()
-    RenderPass(const Device &dev, const VkRenderPassCreateInfo2 &info, bool khr = false) { init(dev, info, khr); }
+    RenderPass(const Device &dev, const VkRenderPassCreateInfo2 &info) { init(dev, info); }
     ~RenderPass() noexcept;
     void destroy() noexcept;
 
     // vkCreateRenderPass()
     void init(const Device &dev, const VkRenderPassCreateInfo &info);
     // vkCreateRenderPass2()
-    void init(const Device &dev, const VkRenderPassCreateInfo2 &info, bool khr = false);
+    void init(const Device &dev, const VkRenderPassCreateInfo2 &info);
 };
 
 
@@ -1028,21 +1028,19 @@ class Framebuffer : public internal::NonDispHandle<VkFramebuffer> {
 class SamplerYcbcrConversion : public internal::NonDispHandle<VkSamplerYcbcrConversion> {
   public:
     SamplerYcbcrConversion() = default;
-    SamplerYcbcrConversion(const Device &dev, VkFormat format, bool khr = false) : khr_(khr) {
-        init(dev, DefaultConversionInfo(format), khr);
+    SamplerYcbcrConversion(const Device &dev, VkFormat format) {
+        init(dev, DefaultConversionInfo(format));
     }
-    SamplerYcbcrConversion(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info, bool khr = false) : khr_(khr) {
-        init(dev, info, khr);
+    SamplerYcbcrConversion(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info) {
+        init(dev, info);
     }
     ~SamplerYcbcrConversion() noexcept;
     void destroy() noexcept;
 
-    void init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info, bool khr);
+    void init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info);
     VkSamplerYcbcrConversionInfo ConversionInfo();
 
     static VkSamplerYcbcrConversionCreateInfo DefaultConversionInfo(VkFormat format);
-
-    bool khr_ = false;
 };
 
 inline VkBufferCreateInfo Buffer::create_info(VkDeviceSize size, VkFlags usage, const std::vector<uint32_t> *queue_families,

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -209,24 +209,9 @@ void TestRenderPassCreate(ErrorMonitor *error_monitor, const vkt::Device &device
 
     if (rp2_supported && rp2_vuid) {
         safe_VkRenderPassCreateInfo2 create_info2 = ConvertVkRenderPassCreateInfoToV2KHR(create_info);
-
-        const auto vkCreateRenderPass2KHR =
-            reinterpret_cast<PFN_vkCreateRenderPass2KHR>(vk::GetDeviceProcAddr(device, "vkCreateRenderPass2KHR"));
-        // For API version < 1.2 where the extension was not enabled
-        if (vkCreateRenderPass2KHR) {
-            error_monitor->SetDesiredFailureMsg(kErrorBit, rp2_vuid);
-            vkt::RenderPass rp2_khr(device, *create_info2.ptr(), true);
-            error_monitor->VerifyFound();
-        }
-
-        const auto vkCreateRenderPass2 =
-            reinterpret_cast<PFN_vkCreateRenderPass2>(vk::GetDeviceProcAddr(device, "vkCreateRenderPass2"));
-        // For API version >= 1.2, try core entrypoint
-        if (vkCreateRenderPass2) {
-            error_monitor->SetDesiredFailureMsg(kErrorBit, rp2_vuid);
-            vkt::RenderPass rp2_core(device, *create_info2.ptr(), false);
-            error_monitor->VerifyFound();
-        }
+        error_monitor->SetDesiredFailureMsg(kErrorBit, rp2_vuid);
+        vkt::RenderPass rp2(device, *create_info2.ptr());
+        error_monitor->VerifyFound();
     }
 }
 
@@ -234,12 +219,12 @@ void PositiveTestRenderPassCreate(ErrorMonitor *error_monitor, const vkt::Device
                                   bool rp2_supported) {
     vkt::RenderPass rp(device, create_info);
     if (rp2_supported) {
-        vkt::RenderPass rp2(device, *ConvertVkRenderPassCreateInfoToV2KHR(create_info).ptr(), true);
+        vkt::RenderPass rp2(device, *ConvertVkRenderPassCreateInfoToV2KHR(create_info).ptr());
     }
 }
 
 void PositiveTestRenderPass2KHRCreate(const vkt::Device &device, const VkRenderPassCreateInfo2KHR &create_info) {
-    vkt::RenderPass rp(device, create_info, true);
+    vkt::RenderPass rp(device, create_info);
 }
 
 void TestRenderPass2KHRCreate(ErrorMonitor &error_monitor, const vkt::Device &device, const VkRenderPassCreateInfo2KHR &create_info,
@@ -247,7 +232,7 @@ void TestRenderPass2KHRCreate(ErrorMonitor &error_monitor, const vkt::Device &de
     for (auto vuid : vuids) {
         error_monitor.SetDesiredFailureMsg(kErrorBit, vuid);
     }
-    vkt::RenderPass rp(device, create_info, true);
+    vkt::RenderPass rp(device, create_info);
     error_monitor.VerifyFound();
 }
 

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -248,17 +248,25 @@ class VkRenderFramework : public VkTestFramework {
     // extension is not supported, no extension names are added for instance creation. `ext_name` can refer to a device or instance
     // extension.
     bool AddRequestedInstanceExtensions(const char *ext_name);
+    // Returns true if the instance extension is promoted to core in the target API version requested using SetTargetApiVersion().
+    bool IsPromotedInstanceExtension(const char *inst_ext_name) const;
     // Returns true if the instance extension inst_ext_name is enabled. This call is only valid _after_ previous
     // `AddRequired*Extensions` calls and InitFramework has been called. `inst_ext_name` must be an instance extension name; false
     // is returned for all device extension names.
+    // This function also returns true if the instance extension is implicitly supported in the target API version
+    // requested using SetTargetApiVersion().
     bool CanEnableInstanceExtension(const std::string &inst_ext_name) const;
     // Add dev_ext_name, then names of _device_ extensions required by dev_ext_name, and return true if dev_ext_name is supported.
     // If the extension is not supported, no extension names are added for device creation. This function has no effect if
     // dev_ext_name refers to an instance extension.
     bool AddRequestedDeviceExtensions(const char *dev_ext_name);
+    // Returns true if the device extension is promoted to core in the API version supported by the device.
+    bool IsPromotedDeviceExtension(const char *dev_ext_name) const;
     // Returns true if the device extension is enabled. This call is only valid _after_ previous `AddRequired*Extensions` calls and
     // InitFramework has been called.
     // `dev_ext_name` must be an instance extension name; false is returned for all instance extension names.
+    // This function also returns true if the device extension is implicitly supported by the API version supported
+    // by the device, as queriable using DeviceValidationVersion().
     bool CanEnableDeviceExtension(const std::string &dev_ext_name) const;
 };
 

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -136,6 +136,9 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
 TEST_F(VkBestPracticesLayerTest, UseDeprecatedDeviceExtensions) {
     TEST_DESCRIPTION("Create a device with a deprecated extension.");
 
+    // We need to explicitly allow promoted extensions to be enabled as this test relies on this behavior
+    AllowPromotedExtensions();
+
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework());
@@ -2377,7 +2380,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetMiddle) {
     TEST_DESCRIPTION("Set only a part of push constants in middle of as struct");
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_8BIT_STORAGE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework());
     VkPhysicalDevice8BitStorageFeatures storage_8_bit_features = vku::InitStructHelper();

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -409,7 +409,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapLayerCount) {
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attach_desc;
 
-    vkt::RenderPass rp(*m_device, rpci, true /*khr*/);
+    vkt::RenderPass rp(*m_device, rpci);
 
     VkImageObj image(m_device);
     image.InitNoLayout(image.ImageCreateInfo2D(32, 32, 1, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
@@ -433,7 +433,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapLayerCount) {
 
     // Set viewMask to non-zero - requires multiview
     subpass.viewMask = 0x10;
-    vkt::RenderPass rp_mv(*m_device, rpci, true /*khr*/);
+    vkt::RenderPass rp_mv(*m_device, rpci);
 
     fb_info.renderPass = rp_mv.handle();
 
@@ -905,7 +905,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferUsage) {
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attach_desc;
 
-    vkt::RenderPass rp(*m_device, rpci, true);
+    vkt::RenderPass rp(*m_device, rpci);
     ASSERT_TRUE(rp.initialized());
 
     VkImageObj image(m_device);
@@ -977,7 +977,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attach_desc;
 
-    vkt::RenderPass rp(*m_device, rpci, true);
+    vkt::RenderPass rp(*m_device, rpci);
     ASSERT_TRUE(rp.initialized());
 
     VkImageObj image(m_device);
@@ -1022,7 +1022,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
         m_errorMonitor->VerifyFound();
 
         subpass.viewMask = 0x4;
-        vkt::RenderPass rp2(*m_device, rpci, true);
+        vkt::RenderPass rp2(*m_device, rpci);
         ASSERT_TRUE(rp2.initialized());
         subpass.viewMask = 0;
 
@@ -1189,7 +1189,7 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
     rcpi_no_fsr.subpassCount = 1;
     rcpi_no_fsr.pSubpasses = &subpass_no_fsr;
 
-    vkt::RenderPass rp_no_fsr(*m_device, rcpi_no_fsr, true);
+    vkt::RenderPass rp_no_fsr(*m_device, rcpi_no_fsr);
 
     // Create 2 render passes with fragment shading rate attachments with
     // differing shadingRateAttachmentTexelSize values
@@ -1228,7 +1228,7 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
     rpci_fsr_1.attachmentCount = 1;
     rpci_fsr_1.pAttachments = &attach_desc;
 
-    vkt::RenderPass rp_fsr_1(*m_device, rpci_fsr_1, true);
+    vkt::RenderPass rp_fsr_1(*m_device, rpci_fsr_1);
     ASSERT_TRUE(rp_fsr_1.initialized());
 
     VkRenderPassCreateInfo2KHR rpci_fsr_2 = vku::InitStructHelper();
@@ -1237,7 +1237,7 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
     rpci_fsr_2.attachmentCount = 1;
     rpci_fsr_2.pAttachments = &attach_desc;
 
-    vkt::RenderPass rp_fsr_2(*m_device, rpci_fsr_2, true);
+    vkt::RenderPass rp_fsr_2(*m_device, rpci_fsr_2);
     ASSERT_TRUE(rp_fsr_2.initialized());
 
     VkImageObj image(m_device);
@@ -1930,10 +1930,10 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
 
     // Create rp2[0] without Multiview (zero viewMask), rp2[1] with Multiview
     vkt::RenderPass rp2[2];
-    rp2[0].init(*m_device, rpci, true);
+    rp2[0].init(*m_device, rpci);
 
     subpass.viewMask = 0x3u;
-    rp2[1].init(*m_device, rpci, true);
+    rp2[1].init(*m_device, rpci);
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -133,7 +133,7 @@ TEST_F(PositiveFragmentShadingRate, Attachments) {
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attach_desc;
 
-    vkt::RenderPass rp(*m_device, rpci, true);
+    vkt::RenderPass rp(*m_device, rpci);
     ASSERT_TRUE(rp.initialized());
 
     VkImageObj image(m_device);

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -202,7 +202,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     image_format_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_format_info.usage = VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT;
     image_format_info.flags = 0;
-    vk::GetPhysicalDeviceImageFormatProperties2KHR(gpu(), &image_format_info, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
 }
 
 TEST_F(PositiveHostImageCopy, CopyImageToMemoryMipLevel) {

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -2828,6 +2828,8 @@ TEST_F(NegativeImage, ImageViewDifferentClass) {
 
 TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
     TEST_DESCRIPTION("Passing bad image subrange to CreateImageView");
+
+    AddOptionalExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     const bool maintenance1 = IsExtensionsEnabled(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
 
@@ -3170,6 +3172,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
             if (device_features.sparseBinding) {
                 VkImageObj sparse_image(m_device);
                 image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
+                m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-flags-09403");
                 sparse_image.Init(image_ci, 0, false);
                 sparse_image_view_ci.image = sparse_image.handle();
 
@@ -3185,6 +3188,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
                 VkImageObj sparse_image(m_device);
                 image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
                 m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-flags-00987");
+                m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-flags-09403");
                 sparse_image.Init(image_ci, 0, false);
                 sparse_image_view_ci.image = sparse_image.handle();
 
@@ -3200,6 +3204,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
                 VkImageObj sparse_image(m_device);
                 image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR | VK_IMAGE_CREATE_SPARSE_ALIASED_BIT |
                                  VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
+                m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-flags-09403");
                 sparse_image.Init(image_ci, 0, false);
                 sparse_image_view_ci.image = sparse_image.handle();
 
@@ -4202,7 +4207,7 @@ TEST_F(NegativeImage, ImageFormatListSizeCompatible) {
     TEST_DESCRIPTION("Tests for VK_KHR_image_format_list with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT");
 
     AddRequiredExtensions(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
-    AddRequiredExtensions(VK_KHR_MAINTENANCE2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
 
     RETURN_IF_SKIP(InitFramework());
 
@@ -4245,7 +4250,7 @@ TEST_F(NegativeImage, ImageFormatListSizeCompatible) {
 
 TEST_F(NegativeImage, BlockTextImageViewCompatibleFormat) {
     TEST_DESCRIPTION("VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT without VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT");
-    AddRequiredExtensions(VK_KHR_MAINTENANCE2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     RETURN_IF_SKIP(InitState());
 
@@ -4265,7 +4270,7 @@ TEST_F(NegativeImage, BlockTextImageViewCompatibleFormat) {
 
 TEST_F(NegativeImage, BlockTextImageViewCompatibleFlag) {
     TEST_DESCRIPTION("VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT without VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT");
-    AddRequiredExtensions(VK_KHR_MAINTENANCE2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     RETURN_IF_SKIP(InitState());
 
@@ -4716,11 +4721,12 @@ TEST_F(NegativeImage, ImageSubresourceRangeAspectMask) {
     TEST_DESCRIPTION("Test creating Image with invalid VkImageSubresourceRange aspectMask.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
-    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(features11);
-    if (features11.samplerYcbcrConversion != VK_TRUE) {
+    VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcrFeatures = vku::InitStructHelper();
+    auto features2 = GetPhysicalDeviceFeatures2(ycbcrFeatures);
+    if (ycbcrFeatures.samplerYcbcrConversion != VK_TRUE) {
         printf("samplerYcbcrConversion not supported, skipping test\n");
         return;
     }

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -859,7 +859,7 @@ TEST_F(NegativeImagelessFramebuffer, DepthStencilResolveAttachment) {
     renderPassCreateInfo.subpassCount = 1;
     renderPassCreateInfo.pSubpasses = &subpassDescription;
     renderPassCreateInfo.pAttachments = attachmentDescriptions;
-    vkt::RenderPass render_pass(*m_device, renderPassCreateInfo, true);
+    vkt::RenderPass render_pass(*m_device, renderPassCreateInfo);
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfos[2] = {};
     // Depth/stencil attachment
@@ -956,7 +956,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateUsage) {
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attach_desc;
 
-    vkt::RenderPass rp(*m_device, rpci, true);
+    vkt::RenderPass rp(*m_device, rpci);
     ASSERT_TRUE(rp.initialized());
 
     VkFormat viewFormat = VK_FORMAT_R8_UINT;
@@ -1035,7 +1035,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensions) {
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attach_desc;
 
-    vkt::RenderPass rp(*m_device, rpci, true);
+    vkt::RenderPass rp(*m_device, rpci);
 
     VkFormat viewFormat = VK_FORMAT_R8_UINT;
     VkFramebufferAttachmentImageInfo fbai_info = vku::InitStructHelper();
@@ -1087,7 +1087,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensions) {
 
     if (fsr_properties.layeredShadingRateAttachments && mv_features.multiview) {
         subpass.viewMask = 0x4;
-        vkt::RenderPass rp2(*m_device, rpci, true);
+        vkt::RenderPass rp2(*m_device, rpci);
         ASSERT_TRUE(rp2.initialized());
         subpass.viewMask = 0;
 

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -746,11 +746,14 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
 TEST_F(NegativeMultiview, Features) {
     TEST_DESCRIPTION("Checks VK_KHR_multiview features.");
 
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     std::vector<const char *> device_extensions;
-    device_extensions.push_back(VK_KHR_MULTIVIEW_EXTENSION_NAME);
+    if (DeviceValidationVersion() < VK_API_VERSION_1_1) {
+        device_extensions.push_back(VK_KHR_MULTIVIEW_EXTENSION_NAME);
+    }
 
     VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
@@ -972,13 +975,13 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
     // Create rp2[0] with Multiview, rp2[1] without Multiview (zero viewMask), rp2[2] with Multiview but another viewMask
     std::array<vkt::RenderPass, 3> rp2;
     if (rp2Supported) {
-        rp2[0].init(*m_device, rpci2, true);
+        rp2[0].init(*m_device, rpci2);
         subpass2.viewMask = 0x0u;
         rpci2.pSubpasses = &subpass2;
-        rp2[1].init(*m_device, rpci2, true);
+        rp2[1].init(*m_device, rpci2);
         subpass2.viewMask = 0x1u;
         rpci2.pSubpasses = &subpass2;
-        rp2[2].init(*m_device, rpci2, true);
+        rp2[2].init(*m_device, rpci2);
     }
 
     // Create image view

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -3768,7 +3768,7 @@ TEST_F(NegativePipeline, PipelineCreationFlags2CacheControl) {
     AddRequiredExtensions(VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework())
+    RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT cache_control_features = vku::InitStructHelper();
     cache_control_features.pipelineCreationCacheControl = VK_FALSE;  // Tests all assume feature is off

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -465,7 +465,7 @@ TEST_F(PositivePipeline, TessellationDomainOrigin) {
         "VkPipelineTessellationDomainOriginStateCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
-    AddRequiredExtensions(VK_KHR_MAINTENANCE2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1519,7 +1519,7 @@ TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
-    AddRequiredExtensions(VK_KHR_MAINTENANCE3_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true));
 
     VkPhysicalDeviceAccelerationStructureFeaturesKHR as_features = vku::InitStructHelper();

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -1257,7 +1257,7 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
         "Test no false overlap is reported with multi attachment framebuffer (attachments are slices of a 3D image). Multiple "
         "subpasses that draw to a single slice of a 3D image");
 
-    AddRequiredExtensions(VK_KHR_MAINTENANCE1_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     constexpr unsigned depth_count = 2u;
@@ -1353,7 +1353,7 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
         "Test that transitioning the layout of a mip level of a 3D image using a view of one of its slice applies to the entire 3D "
         "image: all views referencing different slices of the same mip level should also see their layout transitioned");
 
-    AddRequiredExtensions(VK_KHR_MAINTENANCE1_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
@@ -1667,7 +1667,7 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
     rp2.pSubpasses = &sub;
     rp2.attachmentCount = 1;
     rp2.pAttachments = &desc;
-    vkt::RenderPass render_pass_separate(*m_device, rp2, true);
+    vkt::RenderPass render_pass_separate(*m_device, rp2);
 
     desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
     desc.finalLayout = desc.initialLayout;
@@ -1675,7 +1675,7 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
     desc.pNext = nullptr;
     att.layout = desc.initialLayout;
     att.pNext = nullptr;
-    vkt::RenderPass render_pass_combined(*m_device, rp2, true);
+    vkt::RenderPass render_pass_combined(*m_device, rp2);
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
     fb_info.renderPass = render_pass_separate.handle();

--- a/tests/unit/renderpass.cpp
+++ b/tests/unit/renderpass.cpp
@@ -979,7 +979,7 @@ TEST_F(NegativeRenderPass, AttachmentReferenceSync2Layout) {
         safe_VkRenderPassCreateInfo2 rpci2 = ConvertVkRenderPassCreateInfoToV2KHR(rpci);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAttachmentReference2-synchronization2-06910");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSubpassDescription2-attachment-06922");
-        vkt::RenderPass rp2_core(*m_device, *rpci2.ptr(), false);
+        vkt::RenderPass rp2_core(*m_device, *rpci2.ptr());
         m_errorMonitor->VerifyFound();
     }
 
@@ -1712,7 +1712,7 @@ TEST_F(NegativeRenderPass, FramebufferDepthStencilResolveAttachment) {
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpassDescription;
     rpci.pAttachments = attachmentDescriptions;
-    vkt::RenderPass rp(*m_device, rpci, true);
+    vkt::RenderPass rp(*m_device, rpci);
     ASSERT_TRUE(rp.initialized());
 
     // Depth resolve attachment, mismatched image usage
@@ -3900,7 +3900,7 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayout) {
 TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutMaintenance2) {
     TEST_DESCRIPTION("Invalid attachment reference layout, Maintenance2 enabled");
 
-    AddRequiredExtensions(VK_KHR_MAINTENANCE2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     const bool rp2_supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
@@ -4155,14 +4155,14 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSeparateDepthStencil) {
         {
             depth_stencil_ref.layout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSubpassDescription2-attachment-06251");
-            vkt::RenderPass rp2(*m_device, rpci2, true);
+            vkt::RenderPass rp2(*m_device, rpci2);
             m_errorMonitor->VerifyFound();
         }
 
         {
             depth_stencil_ref.layout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSubpassDescription2-attachment-06251");
-            vkt::RenderPass rp2(*m_device, rpci2, true);
+            vkt::RenderPass rp2(*m_device, rpci2);
             m_errorMonitor->VerifyFound();
         }
     }
@@ -4319,7 +4319,7 @@ TEST_F(NegativeRenderPass, InvalidAttachmentDescriptionDSLayout) {
 TEST_F(NegativeRenderPass, InvalidAttachmentDescriptionColorLayout) {
     TEST_DESCRIPTION("Invalid final layout for color attachment");
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    AddRequiredExtensions(VK_KHR_MAINTENANCE2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     RETURN_IF_SKIP(InitState());
 

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -554,9 +554,9 @@ TEST_F(NegativeSampler, MultiplaneImageSamplerConversionMismatch) {
     ycbcr_create_info.chromaFilter = VK_FILTER_NEAREST;
     ycbcr_create_info.forceExplicitReconstruction = false;
     vkt::SamplerYcbcrConversion conversions[2];
-    conversions[0].init(*m_device, ycbcr_create_info, false);
+    conversions[0].init(*m_device, ycbcr_create_info);
     ycbcr_create_info.components.a = VK_COMPONENT_SWIZZLE_ZERO;  // Just anything different than above
-    conversions[1].init(*m_device, ycbcr_create_info, false);
+    conversions[1].init(*m_device, ycbcr_create_info);
 
     VkSamplerYcbcrConversionInfo ycbcr_info = vku::InitStructHelper();
     ycbcr_info.conversion = conversions[0].handle();

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -185,7 +185,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatReadForFormat) {
         VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
         VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
-        vk::GetPhysicalDeviceFormatProperties2KHR(gpu(), (VkFormat)fmt, &fmt_props);
+        vk::GetPhysicalDeviceFormatProperties2(gpu(), (VkFormat)fmt, &fmt_props);
 
         const bool has_storage = (fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR) != 0;
         const bool has_read_without_format =
@@ -342,7 +342,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWriteForFormat) {
         VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
         VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
-        vk::GetPhysicalDeviceFormatProperties2KHR(gpu(), (VkFormat)fmt, &fmt_props);
+        vk::GetPhysicalDeviceFormatProperties2(gpu(), (VkFormat)fmt, &fmt_props);
 
         const bool has_storage = (fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR) != 0;
         const bool has_write_without_format =

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -229,6 +229,8 @@ TEST_F(NegativeSyncObject, Barriers) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
     // Make sure extensions for multi-planar and separate depth stencil images are enabled if possible
     AddOptionalExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -1656,10 +1656,8 @@ TEST_F(NegativeSyncVal, CmdDispatchDrawHazards) {
     RETURN_IF_SKIP(InitSyncValFramework());
     const bool has_khr_indirect = IsExtensionsEnabled(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
     VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
-    if (has_khr_indirect) {
-        if (DeviceValidationVersion() >= VK_API_VERSION_1_2) {
-            features12.drawIndirectCount = VK_TRUE;
-        }
+    if (DeviceValidationVersion() >= VK_API_VERSION_1_2) {
+        features12.drawIndirectCount = VK_TRUE;
     }
     RETURN_IF_SKIP(InitState(nullptr, &features12));
     InitRenderTarget();

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -254,7 +254,7 @@ TEST_F(NegativeYcbcr, Swizzle) {
     // Create a valid conversion with guaranteed support
     sycci.format = mp_format;
     sycci.components = identity;
-    vkt::SamplerYcbcrConversion conversion(*m_device, sycci, false);
+    vkt::SamplerYcbcrConversion conversion(*m_device, sycci);
 
     VkImageObj image(m_device);
     image.Init(128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
@@ -652,8 +652,7 @@ TEST_F(NegativeYcbcr, WriteDescriptorSet) {
         VkComponentMapping{VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
                            VK_COMPONENT_SWIZZLE_IDENTITY},
         VK_CHROMA_LOCATION_COSITED_EVEN, VK_CHROMA_LOCATION_COSITED_EVEN, VK_FILTER_NEAREST, VK_FALSE);
-    bool khr = (DeviceValidationVersion() < VK_API_VERSION_1_1);
-    vkt::SamplerYcbcrConversion conversion(*m_device, ycbcr_create_info, khr);
+    vkt::SamplerYcbcrConversion conversion(*m_device, ycbcr_create_info);
 
     OneOffDescriptorSet descriptor_set(m_device, {
                                                      {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -1272,7 +1271,7 @@ TEST_F(NegativeYcbcr, MismatchedImageViewAndSamplerFormat) {
     sampler_conversion_ci.chromaFilter = VK_FILTER_NEAREST;
     sampler_conversion_ci.forceExplicitReconstruction = false;
 
-    vkt::SamplerYcbcrConversion sampler_conversion(*m_device, sampler_conversion_ci, false);
+    vkt::SamplerYcbcrConversion sampler_conversion(*m_device, sampler_conversion_ci);
 
     VkSamplerYcbcrConversionInfo sampler_ycbcr_conversion_info = vku::InitStructHelper();
     sampler_ycbcr_conversion_info.conversion = sampler_conversion.handle();
@@ -1519,7 +1518,7 @@ TEST_F(NegativeYcbcr, MultiplaneAspectBits) {
     ycbcr_create_info.chromaFilter = VK_FILTER_NEAREST;
     ycbcr_create_info.forceExplicitReconstruction = false;
 
-    vkt::SamplerYcbcrConversion conversion(*m_device, ycbcr_create_info, DeviceValidationVersion() < VK_API_VERSION_1_1);
+    vkt::SamplerYcbcrConversion conversion(*m_device, ycbcr_create_info);
 
     VkSamplerYcbcrConversionInfo ycbcr_info = vku::InitStructHelper();
     ycbcr_info.conversion = conversion.handle();

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -17,26 +17,17 @@
 #include "generated/vk_extension_helper.h"
 
 void YcbcrTest::InitBasicYcbcr(void *pNextFeatures) {
-    // VK_KHR_sampler_ycbcr_conversion was added in 1.2
-    const bool use_12 = m_attempted_api_version >= VK_API_VERSION_1_2;
-    if (!use_12) {
-        AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
-    }
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
-    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper(pNextFeatures);
     VkPhysicalDeviceSamplerYcbcrConversionFeatures ycbcr_features = vku::InitStructHelper(pNextFeatures);
     VkPhysicalDeviceFeatures2 features2;
-    if (use_12) {
-        features2 = GetPhysicalDeviceFeatures2(features11);
-        if (features11.samplerYcbcrConversion != VK_TRUE) {
-            GTEST_SKIP() << "samplerYcbcrConversion not supported, skipping test";
-        }
-    } else {
-        features2 = GetPhysicalDeviceFeatures2(ycbcr_features);
-        if (ycbcr_features.samplerYcbcrConversion != VK_TRUE) {
-            GTEST_SKIP() << "samplerYcbcrConversion feature not supported";
-        }
+    features2 = GetPhysicalDeviceFeatures2(ycbcr_features);
+    if (ycbcr_features.samplerYcbcrConversion != VK_TRUE) {
+        GTEST_SKIP() << "samplerYcbcrConversion feature not supported";
     }
 
     RETURN_IF_SKIP(InitState(nullptr, &features2));


### PR DESCRIPTION
This is a follow-up on https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6923 with the following additions:

  * Improved handling of promoted extensions
  * Documentation updates regarding the suggested way to handle dependencies in test cases
  * Fixes to various test cases with incorrect dependencies
 