### PR TITLE
tests: Cleanup MSVC c-runtime tweaks and add support for breakpoint on assert

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -965,10 +965,22 @@ int main(int argc, char **argv) {
     int result;
 
 #if defined(_WIN32)
-    // Disable message box for: "Errors, unrecoverable problems, and issues that require immediate attention."
-    // This does not include asserts. GTest does similar configuration for asserts.
-    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    // --gtest_break_on_failure disables gtest suppression of debug message boxes.
+    // If this flag is set, then limit the VVL test framework in how it configures CRT
+    // in order not to change expected gtest behavior (with regard to --gtest_break_on_failure).
+    bool break_on_failure = false;
+    for (int i = 1; i < argc; i++) {
+        if (std::string_view(argv[i]) == "--gtest_break_on_failure") {
+            break_on_failure = true;
+            break;
+        }
+    }
+    if (!break_on_failure) {
+        // Disable message box for: "Errors, unrecoverable problems, and issues that require immediate attention."
+        // This does not include asserts. GTest does similar configuration for asserts.
+        _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
+        _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    }
 #endif
 
     ::testing::InitGoogleTest(&argc, argv);

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -965,16 +965,8 @@ int main(int argc, char **argv) {
     int result;
 
 #if defined(_WIN32)
-#if !defined(NDEBUG)
-    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
-    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE);
-    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
-#endif
-    // Avoid "Abort, Retry, Ignore" dialog boxes
-    _set_error_mode(_OUT_TO_STDERR);
-    _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
-    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    // Disable message box for: "Errors, unrecoverable problems, and issues that require immediate attention."
+    // This does not include asserts. GTest does similar configuration for asserts.
     _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE);
     _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
 #endif


### PR DESCRIPTION
A) Removes c-runtime configuration that is already handled by gtest.

gtest internally disables MSVC **assert** message boxes and tweaks confirugation of c-runtime. Check `UnitTest::Run()` in gtest.cc.

`_CRT_WARN` - is not handled by gtest, but `_CRT_WARN` does not create message boxes in case of warnings (it logs debug messages), that's why it was removed too.

One part that has to be explicitly disabled by the VVL code is `_CRT_ERROR`, to not show message boxes in case of crashes.

B) Allows to use gtest's `--gtest_break_on_failure` command line option to enable breakpoint on assert in windows debug builds.
