### PR TITLE
tests: Fix MatchingAttachmentFormats2

### DIFF
--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -1086,7 +1086,8 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
         m_commandBuffer->EndRendering();
 
         // Matching depth format
-        depth_stencil_attachment.imageView = depthStencilImage.targetView(depthStencilFormat, VK_IMAGE_ASPECT_DEPTH_BIT);
+        const vkt::ImageView depth_view(*m_device, depthStencilImage.BasicViewCreatInfo(VK_IMAGE_ASPECT_DEPTH_BIT));
+        depth_stencil_attachment.imageView = depth_view.handle();
         m_commandBuffer->BeginRendering(begin_rendering_info);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_depth.Handle());
         vk::CmdDraw(m_commandBuffer->handle(), 1, 1, 0, 0);
@@ -1106,7 +1107,8 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
         m_commandBuffer->EndRendering();
 
         // Matching stencil format
-        depth_stencil_attachment.imageView = depthStencilImage.targetView(depthStencilFormat, VK_IMAGE_ASPECT_STENCIL_BIT);
+        const vkt::ImageView stencil_view(*m_device, depthStencilImage.BasicViewCreatInfo(VK_IMAGE_ASPECT_STENCIL_BIT));
+        depth_stencil_attachment.imageView = stencil_view.handle();
         m_commandBuffer->BeginRendering(begin_rendering_info);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_stencil.Handle());
         vk::CmdDraw(m_commandBuffer->handle(), 1, 1, 0, 0);


### PR DESCRIPTION
`VkImageObj::targetView()` is an error-prone design. The method suggests it will return target view based on provided parameters but it does this only for the first call. For subsequent calls it ignores provided parameters and returns cached value. When reading code it's not clear what the result of `targetView` will be without checking previous context. 

The plan for the future change. Get rid of targetView. Use vkt::ImageView directly. VkImageObj currently provides BasicViewCreateInfo() to initialize VkImageViewCreateInfo parameterized by aspect - that's convenient and can be kept. Additional constructor can be added to vkt::ImageView that creates image view based on provided image (and also parameterize by aspect).

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7002