### PR TITLE
layers: Add debug info for Instruction

### DIFF
--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -33,6 +33,14 @@ Instruction::Instruction(std::vector<uint32_t>::const_iterator it) {
     } else if (has_result) {
         result_id_index_ = 1;
     }
+
+#ifndef NDEBUG
+    opcode_ = std::string(string_SpvOpcode(Opcode()));
+    length_ = Length();
+    for (uint32_t i = 0; i < length_ && i < 12; i++) {
+        words_debug_[i] = words_[i];
+    }
+#endif
 }
 
 std::string Instruction::Describe() const {

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -87,4 +87,12 @@ class Instruction {
     small_vector<uint32_t, word_vector_length, uint32_t> words_;
     uint32_t result_id_index_ = 0;
     uint32_t type_id_index_ = 0;
+
+#ifndef NDEBUG
+    // Helping values to make debugging what is happening in a instruction easier
+    std::string opcode_;
+    // helps people new to using SPIR-V spec to understand Word()
+    uint32_t length_;
+    uint32_t words_debug_[12];
+#endif
 };


### PR DESCRIPTION
While debugging `Instruction` is can be hard to understand what is going on with a raw `uint32_t[]` of the words

When seeing code calling `insn->Word(2)` it can be hard to understand what that is grabbing without having to execute the helper member functions in a debugger