### PR TITLE
gpu: Reorganise parts of the validation and error messages logic to simplify things

### DIFF
--- a/layers/gpu_validation/gpu_error_message.cpp
+++ b/layers/gpu_validation/gpu_error_message.cpp
@@ -16,6 +16,8 @@
  */
 
 #include "gpu_validation/gpu_error_message.h"
+#include "gpu_validation/gpu_validation.h"
+#include "gpu_validation/gpu_vuids.h"
 #include "spirv-tools/instrument.hpp"
 #include "state_tracker/shader_module.h"
 
@@ -335,4 +337,396 @@ void UtilGenerateSourceMessages(vvl::span<const uint32_t> pgm, const uint32_t *d
         }
     }
     source_msg = source_stream.str();
+}
+
+// Generate the part of the message describing the violation.
+bool gpuav::Validator::GenerateValidationMessage(const uint32_t *debug_record, const CommandResources &cmd_resources,
+                                                 const std::vector<DescSetState> &descriptor_sets, std::string &out_error_msg,
+                                                 std::string &out_vuid_msg, bool &out_oob_access) const {
+    using namespace spvtools;
+    using namespace glsl;
+    std::ostringstream strm;
+    bool error_found = false;
+    const GpuVuid vuid = GetGpuVuid(cmd_resources.command);
+    out_oob_access = false;
+    switch (debug_record[kInstValidationOutError]) {
+        case kInstErrorBindlessBounds: {
+            strm << "(set = " << debug_record[kInstBindlessBoundsOutDescSet]
+                 << ", binding = " << debug_record[kInstBindlessBoundsOutDescBinding] << ") Index of "
+                 << debug_record[kInstBindlessBoundsOutDescIndex] << " used to index descriptor array of length "
+                 << debug_record[kInstBindlessBoundsOutDescBound] << ".";
+            out_vuid_msg = "UNASSIGNED-Descriptor index out of bounds";
+            error_found = true;
+        } break;
+        case kInstErrorBindlessUninit: {
+            strm << "(set = " << debug_record[kInstBindlessUninitOutDescSet]
+                 << ", binding = " << debug_record[kInstBindlessUninitOutBinding] << ") Descriptor index "
+                 << debug_record[kInstBindlessUninitOutDescIndex] << " is uninitialized.";
+            out_vuid_msg = "UNASSIGNED-Descriptor uninitialized";
+            error_found = true;
+        } break;
+        case kInstErrorBindlessDestroyed: {
+            strm << "(set = " << debug_record[kInstBindlessUninitOutDescSet]
+                 << ", binding = " << debug_record[kInstBindlessUninitOutBinding] << ") Descriptor index "
+                 << debug_record[kInstBindlessUninitOutDescIndex] << " references a resource that was destroyed.";
+            out_vuid_msg = "UNASSIGNED-Descriptor destroyed";
+            error_found = true;
+        } break;
+        case kInstErrorBuffAddrUnallocRef: {
+            out_oob_access = true;
+            uint64_t *ptr = (uint64_t *)&debug_record[kInstBuffAddrUnallocOutDescPtrLo];
+            strm << "Device address 0x" << std::hex << *ptr << " access out of bounds. ";
+            out_vuid_msg = "UNASSIGNED-Device address out of bounds";
+            error_found = true;
+        } break;
+        case kInstErrorOOB: {
+            const uint32_t set_num = debug_record[kInstBindlessBuffOOBOutDescSet];
+            const uint32_t binding_num = debug_record[kInstBindlessBuffOOBOutDescBinding];
+            const uint32_t desc_index = debug_record[kInstBindlessBuffOOBOutDescIndex];
+            const uint32_t size = debug_record[kInstBindlessBuffOOBOutBuffSize];
+            const uint32_t offset = debug_record[kInstBindlessBuffOOBOutBuffOff];
+            const auto *binding_state = descriptor_sets[set_num].state->GetBinding(binding_num);
+            assert(binding_state);
+            if (size == 0) {
+                strm << "(set = " << set_num << ", binding = " << binding_num << ") Descriptor index " << desc_index
+                     << " is uninitialized.";
+                out_vuid_msg = "UNASSIGNED-Descriptor uninitialized";
+                error_found = true;
+                break;
+            }
+            out_oob_access = true;
+            auto desc_class = binding_state->descriptor_class;
+            if (desc_class == vvl::DescriptorClass::Mutable) {
+                desc_class = static_cast<const vvl::MutableBinding *>(binding_state)->descriptors[desc_index].ActiveClass();
+            }
+
+            switch (desc_class) {
+                case vvl::DescriptorClass::GeneralBuffer:
+                    strm << "(set = " << set_num << ", binding = " << binding_num << ") Descriptor index " << desc_index
+                         << " access out of bounds. Descriptor size is " << size << " and highest byte accessed was " << offset;
+                    if (binding_state->type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER ||
+                        binding_state->type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) {
+                        out_vuid_msg = vuid.uniform_access_oob;
+                    } else {
+                        out_vuid_msg = vuid.storage_access_oob;
+                    }
+                    error_found = true;
+                    break;
+                case vvl::DescriptorClass::TexelBuffer:
+                    strm << "(set = " << set_num << ", binding = " << binding_num << ") Descriptor index " << desc_index
+                         << " access out of bounds. Descriptor size is " << size << " texels and highest texel accessed was "
+                         << offset;
+                    if (binding_state->type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) {
+                        out_vuid_msg = vuid.uniform_access_oob;
+                    } else {
+                        out_vuid_msg = vuid.storage_access_oob;
+                    }
+                    error_found = true;
+                    break;
+                default:
+                    // other OOB checks are not implemented yet
+                    assert(false);
+            }
+        } break;
+#if 0
+        default: {
+            strm << "Internal Error (unexpected error type = " << debug_record[kInstValidationOutError] << "). ";
+            out_vuid_msg = "UNASSIGNED-Internal Error";
+            assert(false);
+        } break;
+#endif
+    }
+    out_error_msg = strm.str();
+    return error_found;
+}
+
+// Pull together all the information from the debug record to build the error message strings,
+// and then assemble them into a single message string.
+// Retrieve the shader program referenced by the unique shader ID provided in the debug record.
+// We had to keep a copy of the shader program with the same lifecycle as the pipeline to make
+// sure it is available when the pipeline is submitted.  (The ShaderModule tracking object also
+// keeps a copy, but it can be destroyed after the pipeline is created and before it is submitted.)
+//
+bool gpuav::Validator::AnalyzeAndGenerateMessages(VkCommandBuffer cmd_buffer, VkQueue queue, CommandResources &cmd_resources,
+                                                  uint32_t operation_index, uint32_t *const debug_output_buffer,
+                                                  const std::vector<DescSetState> &descriptor_sets, const Location &loc) {
+    const uint32_t total_words = debug_output_buffer[spvtools::kDebugOutputSizeOffset];
+    bool oob_access;
+    // A zero here means that the shader instrumentation didn't write anything.
+    // If you have nothing to say, don't say it here.
+    if (0 == total_words) {
+        return false;
+    }
+    // The second word in the debug output buffer is the number of words that would have
+    // been written by the shader instrumentation, if there was enough room in the buffer we provided.
+    // The number of words actually written by the shaders is determined by the size of the buffer
+    // we provide via the descriptor. So, we process only the number of words that can fit in the
+    // buffer.
+    // Each "report" written by the shader instrumentation is considered a "record". This function
+    // is hard-coded to process only one record because it expects the buffer to be large enough to
+    // hold only one record. If there is a desire to process more than one record, this function needs
+    // to be modified to loop over records and the buffer size increased.
+
+    VkShaderModule shader_module_handle = VK_NULL_HANDLE;
+    VkPipeline pipeline_handle = VK_NULL_HANDLE;
+    VkShaderEXT shader_object_handle = VK_NULL_HANDLE;
+    vvl::span<const uint32_t> pgm;
+    // The first record starts at this offset after the total_words.
+    const uint32_t *debug_record = &debug_output_buffer[spvtools::kDebugOutputDataOffset];
+    // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
+    // by the instrumented shader.
+    auto it = shader_map.find(debug_record[glsl::kInstCommonOutShaderId]);
+    if (it != shader_map.end()) {
+        shader_module_handle = it->second.shader_module;
+        pipeline_handle = it->second.pipeline;
+        shader_object_handle = it->second.shader_object;
+        pgm = it->second.pgm;
+    }
+
+    std::string error_msg;
+    std::string vuid_msg;
+    const bool error_found =
+        GenerateValidationMessage(debug_record, cmd_resources, descriptor_sets, error_msg, vuid_msg, oob_access);
+    if (error_found) {
+        std::string stage_message;
+        std::string common_message;
+        std::string filename_message;
+        std::string source_message;
+        UtilGenerateStageMessage(debug_record, stage_message);
+        UtilGenerateCommonMessage(report_data, cmd_buffer, debug_record, shader_module_handle, pipeline_handle,
+                                  shader_object_handle, cmd_resources.pipeline_bind_point, operation_index, common_message);
+        UtilGenerateSourceMessages(pgm, debug_record, false, filename_message, source_message);
+
+        if (cmd_resources.uses_robustness && oob_access) {
+            if (gpuav_settings.warn_on_robust_oob) {
+                LogWarning(vuid_msg.c_str(), queue, loc, "%s %s %s %s%s", error_msg.c_str(), common_message.c_str(),
+                           stage_message.c_str(), filename_message.c_str(), source_message.c_str());
+            }
+        } else {
+            LogError(vuid_msg.c_str(), queue, loc, "%s %s %s %s%s", error_msg.c_str(), common_message.c_str(),
+                     stage_message.c_str(), filename_message.c_str(), source_message.c_str());
+        }
+    }
+
+    if (error_found) {
+        // Clear the written size and any error messages. Note that this preserves the first word, which contains flags.
+        const uint32_t words_to_clear = std::min(total_words, output_buffer_size - spvtools::kDebugOutputDataOffset);
+        debug_output_buffer[spvtools::kDebugOutputSizeOffset] = 0;
+        memset(&debug_output_buffer[spvtools::kDebugOutputDataOffset], 0, sizeof(uint32_t) * words_to_clear);
+    }
+
+    return error_found;
+}
+
+void gpuav::CommandResources::LogErrorIfAny(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+                                            const uint32_t operation_index) {
+    uint32_t *debug_output_buffer = nullptr;
+    VkResult result =
+        vmaMapMemory(validator.vmaAllocator, output_mem_block.allocation, reinterpret_cast<void **>(&debug_output_buffer));
+    if (result == VK_SUCCESS) {
+        const uint32_t total_words = debug_output_buffer[spvtools::kDebugOutputSizeOffset];
+        // A zero here means that the shader instrumentation didn't write anything.
+        if (total_words != 0) {
+            uint32_t *debug_record = &debug_output_buffer[spvtools::kDebugOutputDataOffset];
+            const LogObjectList objlist(queue, cmd_buffer);
+            LogValidationMessage(validator, queue, cmd_buffer, debug_record, operation_index, objlist);
+        }
+        vmaUnmapMemory(validator.vmaAllocator, output_mem_block.allocation);
+    }
+}
+
+bool gpuav::CommandResources::LogValidationMessage(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+                                                   const uint32_t *debug_record, const uint32_t operation_index,
+                                                   const LogObjectList &objlist) {
+    bool error_logged = false;
+    uint32_t *data = nullptr;
+    VkResult result = vmaMapMemory(validator.vmaAllocator, output_mem_block.allocation, reinterpret_cast<void **>(&data));
+    if (result == VK_SUCCESS) {
+        const DescBindingInfo *di_info = desc_binding_index != vvl::kU32Max ? &(*desc_binding_list)[desc_binding_index] : nullptr;
+        const Location loc(command);
+        error_logged =
+            validator.AnalyzeAndGenerateMessages(cmd_buffer, queue, *this, operation_index, data,
+                                                 di_info ? di_info->descriptor_set_buffers : std::vector<DescSetState>(), loc);
+        vmaUnmapMemory(validator.vmaAllocator, output_mem_block.allocation);
+        return error_logged;
+    }
+
+    return error_logged;
+}
+
+bool gpuav::PreDrawResources::LogValidationMessage(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+                                               const uint32_t *debug_record, const uint32_t operation_index,
+                                               const LogObjectList &objlist) {
+    if (CommandResources::LogValidationMessage(validator, queue, cmd_buffer, debug_record, operation_index, objlist)) {
+        return true;
+    }
+
+    bool error_logged = false;
+    using namespace glsl;
+    switch (debug_record[kInstValidationOutError]) {
+        case kInstErrorPreDrawValidate: {
+            // Buffer size must be >= (stride * (drawCount - 1) + offset + sizeof(VkDrawIndexedIndirectCommand))
+            if (debug_record[kPreValidateSubError] == pre_draw_count_exceeds_bufsize_error) {
+                const uint32_t count = debug_record[kPreValidateSubError + 1];
+                const uint32_t stride = indirect_buffer_stride;
+                const uint32_t offset =
+                    static_cast<uint32_t>(indirect_buffer_offset);  // TODO: why cast to uin32_t? If it is changed, think about
+                                                                    // also doing it in the error message
+                const uint32_t draw_size = (stride * (count - 1) + offset + sizeof(VkDrawIndexedIndirectCommand));
+
+                // TODO: this is not an improvement
+                const char *vuid = nullptr;
+                if (command == vvl::Func::vkCmdDrawIndirectCount || command == vvl::Func::vkCmdDrawIndirectCountKHR) {
+                    if (count == 1) {
+                        vuid = "VUID-vkCmdDrawIndirectCount-countBuffer-03121";
+                    } else {
+                        vuid = "VUID-vkCmdDrawIndirectCount-countBuffer-03122";
+                    }
+                } else if (command == vvl::Func::vkCmdDrawIndexedIndirectCount ||
+                           command == vvl::Func::vkCmdDrawIndexedIndirectCountKHR) {
+                    if (count == 1) {
+                        vuid = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03153";
+                    } else {
+                        vuid = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154";
+                    }
+                }
+                assert(vuid);
+
+                validator.LogError(objlist, vuid,
+                                   "Indirect draw count of %" PRIu32 " would exceed buffer size %" PRIu64
+                                   " of buffer %s "
+                                   "stride = %" PRIu32 " offset = %" PRIu32
+                                   " (stride * (drawCount - 1) + offset + sizeof(VkDrawIndexedIndirectCommand)) = %" PRIu32 ".",
+                                   count, indirect_buffer_size, validator.FormatHandle(indirect_buffer).c_str(), stride, offset,
+                                   draw_size);
+                error_logged = true;
+            } else if (debug_record[kPreValidateSubError] == pre_draw_count_exceeds_limit_error) {
+                const uint32_t count = debug_record[kPreValidateSubError + 1];
+                const char *vuid = nullptr;
+                if (command == vvl::Func::vkCmdDrawIndirectCount || command == vvl::Func::vkCmdDrawIndirectCountKHR) {
+                    vuid = "VUID-vkCmdDrawIndirectCount-countBuffer-02717";
+                } else if (command == vvl::Func::vkCmdDrawIndexedIndirectCount ||
+                           command == vvl::Func::vkCmdDrawIndexedIndirectCountKHR) {
+                    vuid = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-02717";
+                }
+                assert(vuid);
+                validator.LogError(objlist, vuid,
+                                   "Indirect draw count of %" PRIu32 " would exceed maxDrawIndirectCount limit of %" PRIu32 ".",
+                                   count, validator.phys_dev_props.limits.maxDrawIndirectCount);
+                error_logged = true;
+            } else if (debug_record[kPreValidateSubError] == pre_draw_first_instance_error) {
+                const uint32_t index = debug_record[kPreValidateSubError + 1];
+                const char *vuid = nullptr;
+                if (command == vvl::Func::vkCmdDrawIndirect) {
+                    vuid = "VUID-VkDrawIndirectCommand-firstInstance-00501";
+                } else if (command == vvl::Func::vkCmdDrawIndexedIndirect) {
+                    vuid = "VUID-VkDrawIndexedIndirectCommand-firstInstance-00554";
+                } else {
+                    assert(false);
+                }
+                validator.LogError(
+                    objlist, vuid,
+                    "The drawIndirectFirstInstance feature is not enabled, but the firstInstance member of the %s structure at "
+                    "index %" PRIu32 " is not zero.",
+                    command == vvl::Func::vkCmdDrawIndirect ? "VkDrawIndirectCommand" : "VkDrawIndexedIndirectCommand", index);
+                error_logged = true;
+            }
+        } break;
+        default:
+            break;
+    }
+
+    return error_logged;
+}
+
+bool gpuav::PreDispatchResources::LogValidationMessage(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+                                                   const uint32_t *debug_record, const uint32_t operation_index,
+                                                   const LogObjectList &objlist) {
+    if (CommandResources::LogValidationMessage(validator, queue, cmd_buffer, debug_record, operation_index, objlist)) {
+        return true;
+    }
+
+    bool error_logged = false;
+    using namespace glsl;
+    switch (debug_record[kInstValidationOutError]) {
+        case kInstErrorPreDispatchValidate: {
+            if (debug_record[kPreValidateSubError] == pre_dispatch_count_exceeds_limit_x_error) {
+                uint32_t count = debug_record[kPreValidateSubError + 1];
+                validator.LogError(objlist, "VUID-VkDispatchIndirectCommand-x-00417",
+                                   "Indirect dispatch VkDispatchIndirectCommand::x of %" PRIu32
+                                   " would exceed maxComputeWorkGroupCount[0] limit of %" PRIu32 ".",
+                                   count, validator.phys_dev_props.limits.maxComputeWorkGroupCount[0]);
+                error_logged = true;
+            } else if (debug_record[kPreValidateSubError] == pre_dispatch_count_exceeds_limit_y_error) {
+                uint32_t count = debug_record[kPreValidateSubError + 1];
+                validator.LogError(objlist, "VUID-VkDispatchIndirectCommand-y-00418",
+                                   "Indirect dispatch VkDispatchIndirectCommand::y of %" PRIu32
+                                   " would exceed maxComputeWorkGroupCount[1] limit of %" PRIu32 ".",
+                                   count, validator.phys_dev_props.limits.maxComputeWorkGroupCount[1]);
+                error_logged = true;
+            } else if (debug_record[kPreValidateSubError] == pre_dispatch_count_exceeds_limit_z_error) {
+                uint32_t count = debug_record[kPreValidateSubError + 1];
+                validator.LogError(objlist, "VUID-VkDispatchIndirectCommand-z-00419",
+                                   "Indirect dispatch VkDispatchIndirectCommand::z of %" PRIu32
+                                   " would exceed maxComputeWorkGroupCount[2] limit of %" PRIu32 ".",
+                                   count, validator.phys_dev_props.limits.maxComputeWorkGroupCount[0]);
+                error_logged = true;
+            }
+        } break;
+        default:
+            break;
+    }
+
+    return error_logged;
+}
+
+bool gpuav::PreTraceRaysResources::LogValidationMessage(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+                                                    const uint32_t *debug_record, const uint32_t operation_index,
+                                                    const LogObjectList &objlist) {
+    if (CommandResources::LogValidationMessage(validator, queue, cmd_buffer, debug_record, operation_index, objlist)) {
+        return true;
+    }
+
+    bool error_logged = false;
+    using namespace glsl;
+    switch (debug_record[kInstValidationOutError]) {
+        case kInstErrorPreTraceRaysKhrValidate: {
+            if (debug_record[kPreValidateSubError] == pre_trace_rays_query_dimensions_exceeds_width_limit) {
+                const uint32_t width = debug_record[kPreValidateSubError + 1];
+                validator.LogError(objlist, "VUID-VkTraceRaysIndirectCommandKHR-width-03638",
+                                   "Indirect trace rays of VkTraceRaysIndirectCommandKHR::width of %" PRIu32
+                                   " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[0] * "
+                                   "VkPhysicalDeviceLimits::maxComputeWorkGroupSize[0] limit of %" PRIu64 ".",
+                                   width,
+                                   static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupCount[0]) *
+                                       static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupSize[0]));
+                error_logged = true;
+
+            } else if (debug_record[kPreValidateSubError] == pre_trace_rays_query_dimensions_exceeds_height_limit) {
+                uint32_t height = debug_record[kPreValidateSubError + 1];
+                validator.LogError(objlist, "VUID-VkTraceRaysIndirectCommandKHR-height-03639",
+                                   "Indirect trace rays of VkTraceRaysIndirectCommandKHR::height of %" PRIu32
+                                   " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[1] * "
+                                   "VkPhysicalDeviceLimits::maxComputeWorkGroupSize[1] limit of %" PRIu64 ".",
+                                   height,
+                                   static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupCount[1]) *
+                                       static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupSize[1]));
+                error_logged = true;
+            } else if (debug_record[kPreValidateSubError] == pre_trace_rays_query_dimensions_exceeds_depth_limit) {
+                uint32_t depth = debug_record[kPreValidateSubError + 1];
+                validator.LogError(objlist, "VUID-VkTraceRaysIndirectCommandKHR-depth-03640",
+                                   "Indirect trace rays of VkTraceRaysIndirectCommandKHR::height of %" PRIu32
+                                   " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[2] * "
+                                   "VkPhysicalDeviceLimits::maxComputeWorkGroupSize[2] limit of %" PRIu64 ".",
+                                   depth,
+                                   static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupCount[2]) *
+                                       static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupSize[2]));
+                error_logged = true;
+            }
+        } break;
+        default:
+            break;
+    }
+
+    return error_logged;
 }

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -441,104 +441,231 @@ VkPipeline gpuav::Validator::GetDrawValidationPipeline(VkRenderPass render_pass)
     return validation_pipeline;
 }
 
-void gpuav::Validator::AllocatePreDrawValidationResources(const DeviceMemoryBlock &output_block, const VkRenderPass render_pass,
-                                                          const bool use_shader_objects, VkPipeline *pPipeline,
-                                                          const CmdIndirectState *indirect_state,
-                                                          PreDrawResources &out_draw_resources) {
+gpuav::CommandResources gpuav::Validator::AllocateCommandResources(const VkCommandBuffer cmd_buffer,
+                                                                   const VkPipelineBindPoint bind_point, vvl::Func command,
+                                                                   const CmdIndirectState *indirect_state) {
+    if (bind_point != VK_PIPELINE_BIND_POINT_GRAPHICS && bind_point != VK_PIPELINE_BIND_POINT_COMPUTE &&
+        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
+        return CommandResources();
+    }
     VkResult result;
-    if (!common_draw_resources.initialized) {
-        std::vector<VkDescriptorSetLayoutBinding> bindings = {
-            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},  // output buffer
-            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},  // count/draws buffer
-        };
 
-        VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
-        ds_layout_ci.bindingCount = static_cast<uint32_t>(bindings.size());
-        ds_layout_ci.pBindings = bindings.data();
-        result = DispatchCreateDescriptorSetLayout(device, &ds_layout_ci, nullptr, &common_draw_resources.ds_layout);
-        if (result != VK_SUCCESS) {
-            ReportSetupProblem(device, "Unable to create descriptor set layout. Aborting GPU-AV");
-            aborted = true;
-            return;
-        }
+    if (aborted) return CommandResources();
 
-        VkPushConstantRange push_constant_range = {};
-        push_constant_range.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-        push_constant_range.offset = 0;
-        push_constant_range.size = out_draw_resources.push_constant_words * sizeof(uint32_t);
-        VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
-        pipeline_layout_ci.pushConstantRangeCount = 1;
-        pipeline_layout_ci.pPushConstantRanges = &push_constant_range;
-        pipeline_layout_ci.setLayoutCount = 1;
-        pipeline_layout_ci.pSetLayouts = &common_draw_resources.ds_layout;
-        result = DispatchCreatePipelineLayout(device, &pipeline_layout_ci, nullptr, &common_draw_resources.pipeline_layout);
-        if (result != VK_SUCCESS) {
-            ReportSetupProblem(device, "Unable to create pipeline layout. Aborting GPU-AV");
-            aborted = true;
-            return;
-        }
+    auto cb_node = GetWrite<CommandBuffer>(cmd_buffer);
+    if (!cb_node) {
+        ReportSetupProblem(device, "Unrecognized command buffer");
+        aborted = true;
+        return CommandResources();
+    }
+    const auto lv_bind_point = ConvertToLvlBindPoint(bind_point);
+    auto const &last_bound = cb_node->lastBound[lv_bind_point];
+    const auto *pipeline_state = last_bound.pipeline_state;
 
-        if (use_shader_objects) {
-            VkShaderCreateInfoEXT shader_ci = vku::InitStructHelper();
-            shader_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
-            shader_ci.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
-            shader_ci.codeSize = sizeof(gpu_pre_draw_vert);
-            shader_ci.pCode = gpu_pre_draw_vert;
-            shader_ci.pName = "main";
-            shader_ci.setLayoutCount = 1u;
-            shader_ci.pSetLayouts = &common_draw_resources.ds_layout;
-            shader_ci.pushConstantRangeCount = 1u;
-            shader_ci.pPushConstantRanges = &push_constant_range;
-            result = DispatchCreateShadersEXT(device, 1u, &shader_ci, nullptr, &common_draw_resources.shader_object);
-            if (result != VK_SUCCESS) {
-                ReportSetupProblem(device, "Unable to create shader object. Aborting GPU-AV");
-                aborted = true;
-                return;
-            }
-        } else {
-            VkShaderModuleCreateInfo shader_module_ci = vku::InitStructHelper();
-            shader_module_ci.codeSize = sizeof(gpu_pre_draw_vert);
-            shader_module_ci.pCode = gpu_pre_draw_vert;
-            result = DispatchCreateShaderModule(device, &shader_module_ci, nullptr, &common_draw_resources.shader_module);
-            if (result != VK_SUCCESS) {
-                ReportSetupProblem(device, "Unable to create shader module. Aborting GPU-AV");
-                aborted = true;
-                return;
-            }
-        }
-
-        common_draw_resources.initialized = true;
+    if (!pipeline_state && !last_bound.HasShaderObjects()) {
+        ReportSetupProblem(device, "Neither pipeline state nor shader object states were found, aborting GPU-AV");
+        aborted = true;
+        return CommandResources();
     }
 
+    std::vector<VkDescriptorSet> output_buffer_desc_set;
+    VkDescriptorPool output_buffer_desc_pool = VK_NULL_HANDLE;
+    result = desc_set_manager->GetDescriptorSets(1, &output_buffer_desc_pool, debug_desc_layout, &output_buffer_desc_set);
+    assert(result == VK_SUCCESS);
+    if (result != VK_SUCCESS) {
+        ReportSetupProblem(device, "Unable to allocate descriptor sets. Device could become unstable.");
+        aborted = true;
+        return CommandResources();
+    }
+
+    // Allocate memory for the output block that the gpu will use to return any error information
+    DeviceMemoryBlock output_block = {};
+    VkBufferCreateInfo buffer_info = vku::InitStructHelper();
+    buffer_info.size = output_buffer_size;
+    buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    VmaAllocationCreateInfo alloc_info = {};
+    alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    alloc_info.pool = output_buffer_pool;
+    result = vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &output_block.buffer, &output_block.allocation, nullptr);
+    if (result != VK_SUCCESS) {
+        ReportSetupProblem(device, "Unable to allocate device memory. Device could become unstable.", true);
+        aborted = true;
+        return CommandResources();
+    }
+
+    uint32_t *output_buffer_ptr;
+    result = vmaMapMemory(vmaAllocator, output_block.allocation, reinterpret_cast<void **>(&output_buffer_ptr));
+    bool uses_robustness = false;
+    if (result == VK_SUCCESS) {
+        memset(output_buffer_ptr, 0, output_buffer_size);
+        if (gpuav_settings.validate_descriptors) {
+            uses_robustness = (enabled_features.robustBufferAccess || enabled_features.robustBufferAccess2 ||
+                               (pipeline_state && pipeline_state->uses_pipeline_robustness));
+            output_buffer_ptr[spvtools::kDebugOutputFlagsOffset] = spvtools::kInstBufferOOBEnable;
+        }
+        vmaUnmapMemory(vmaAllocator, output_block.allocation);
+    } else {
+        ReportSetupProblem(device, "Unable to map device memory allocated for output buffer. Device could become unstable.", true);
+        aborted = true;
+        return CommandResources();
+    }
+
+    // Write the descriptor that will be used to check for OOB accesses
+    {
+        VkDescriptorBufferInfo output_desc_buffer_info = {};
+        output_desc_buffer_info.range = output_buffer_size;
+        output_desc_buffer_info.buffer = output_block.buffer;
+        output_desc_buffer_info.offset = 0;
+
+        std::array<VkWriteDescriptorSet, 3> desc_writes = {};
+        VkDescriptorBufferInfo di_input_desc_buffer_info = {};
+        VkDescriptorBufferInfo bda_input_desc_buffer_info = {};
+
+        desc_writes[0] = vku::InitStructHelper();
+        desc_writes[0].descriptorCount = 1;
+        desc_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        desc_writes[0].pBufferInfo = &output_desc_buffer_info;
+        desc_writes[0].dstSet = output_buffer_desc_set[0];
+
+        uint32_t desc_count = 1;
+
+        if (cb_node->current_bindless_buffer != VK_NULL_HANDLE) {
+            di_input_desc_buffer_info.range = VK_WHOLE_SIZE;
+            di_input_desc_buffer_info.buffer = cb_node->current_bindless_buffer;
+            di_input_desc_buffer_info.offset = 0;
+
+            desc_writes[desc_count] = vku::InitStructHelper();
+            desc_writes[desc_count].dstBinding = 1;
+            desc_writes[desc_count].descriptorCount = 1;
+            desc_writes[desc_count].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            desc_writes[desc_count].pBufferInfo = &di_input_desc_buffer_info;
+            desc_writes[desc_count].dstSet = output_buffer_desc_set[0];
+            desc_count++;
+        }
+
+        if (buffer_device_address_enabled) {
+            bda_input_desc_buffer_info.range = app_bda_buffer_size;
+            bda_input_desc_buffer_info.buffer = app_buffer_device_addresses.buffer;
+            bda_input_desc_buffer_info.offset = 0;
+
+            desc_writes[desc_count] = vku::InitStructHelper();
+            desc_writes[desc_count].dstBinding = 2;
+            desc_writes[desc_count].descriptorCount = 1;
+            desc_writes[desc_count].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            desc_writes[desc_count].pBufferInfo = &bda_input_desc_buffer_info;
+            desc_writes[desc_count].dstSet = output_buffer_desc_set[0];
+            desc_count++;
+        }
+
+        DispatchUpdateDescriptorSets(device, desc_count, desc_writes.data(), 0, NULL);
+    }
+
+    const auto pipeline_layout =
+        pipeline_state ? pipeline_state->PipelineLayoutState() : Get<PIPELINE_LAYOUT_STATE>(last_bound.pipeline_layout);
+    // If GPL is used, it's possible the pipeline layout used at pipeline creation time is null. If CmdBindDescriptorSets has
+    // not been called yet (i.e., state.pipeline_null), then fall back to the layout associated with pre-raster state.
+    // PipelineLayoutState should be used for the purposes of determining the number of sets in the layout, but this layout
+    // may be a "pseudo layout" used to represent the union of pre-raster and fragment shader layouts, and therefore have a
+    // null handle.
+    VkPipelineLayout pipeline_layout_handle = VK_NULL_HANDLE;
+    if (last_bound.pipeline_layout) {
+        pipeline_layout_handle = last_bound.pipeline_layout;
+    } else if (pipeline_state && !pipeline_state->PreRasterPipelineLayoutState()->Destroyed()) {
+        pipeline_layout_handle = pipeline_state->PreRasterPipelineLayoutState()->layout();
+    }
+    if ((pipeline_layout && pipeline_layout->set_layouts.size() <= desc_set_bind_index) &&
+        pipeline_layout_handle != VK_NULL_HANDLE) {
+        DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_layout_handle, desc_set_bind_index, 1,
+                                      output_buffer_desc_set.data(), 0, nullptr);
+    } else {
+        // If no pipeline layout was bound when using shader objects that don't use any descriptor set, bind the debug pipeline
+        // layout
+        DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, debug_pipeline_layout, desc_set_bind_index, 1,
+                                      output_buffer_desc_set.data(), 0, nullptr);
+    }
+
+    if (pipeline_state && pipeline_layout_handle == VK_NULL_HANDLE) {
+        ReportSetupProblem(device, "Unable to find pipeline layout to bind debug descriptor set. Aborting GPU-AV");
+        aborted = true;
+        vmaDestroyBuffer(vmaAllocator, output_block.buffer, output_block.allocation);
+    }
+
+    // It is possible to have no descriptor sets bound, for example if using push constants.
+    uint32_t di_buf_index =
+        cb_node->di_input_buffer_list.size() > 0 ? uint32_t(cb_node->di_input_buffer_list.size()) - 1 : vvl::kU32Max;
+
+    CommandResources cmd_resources;
+    cmd_resources.output_mem_block = output_block;
+    cmd_resources.output_buffer_desc_set = output_buffer_desc_set[0];
+    cmd_resources.output_buffer_desc_pool = output_buffer_desc_pool;
+    cmd_resources.pipeline_bind_point = bind_point;
+    cmd_resources.uses_robustness = uses_robustness;
+    cmd_resources.command = command;
+    cmd_resources.desc_binding_index = di_buf_index;
+    cmd_resources.desc_binding_list = &cb_node->di_input_buffer_list;
+    return cmd_resources;
+}
+
+std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreDrawIndirectValidationResources(
+    vvl::Func command, VkCommandBuffer cmd_buffer, VkBuffer indirect_buffer, VkDeviceSize indirect_offset, uint32_t draw_count,
+    VkBuffer count_buffer, VkDeviceSize count_buffer_offset, uint32_t stride) {
+    CommandResources cmd_resources = AllocateCommandResources(cmd_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, command);
+    if (!gpuav_settings.validate_indirect_buffer) {
+        auto cmd_resources_ptr = std::make_unique<CommandResources>(cmd_resources);
+        return cmd_resources_ptr;
+    }
+
+    auto cb_node = GetWrite<CommandBuffer>(cmd_buffer);
+    if (!cb_node) {
+        ReportSetupProblem(device, "Unrecognized command buffer");
+        aborted = true;
+        return std::make_unique<PreDispatchResources>();
+    }
+
+    const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
+    auto const &last_bound = cb_node->lastBound[lv_bind_point];
+    const auto *pipeline_state = last_bound.pipeline_state;
+    const bool use_shader_objects = pipeline_state == nullptr;
+
+    AllocateSharedDrawIndirectValidationResources(use_shader_objects);
+
+    auto draw_resources = std::make_unique<PreDrawResources>();
+    CommandResources &base = *draw_resources;
+    base = cmd_resources;
+    draw_resources->indirect_buffer = indirect_buffer;
+    draw_resources->indirect_buffer_offset = indirect_offset;
+    draw_resources->indirect_buffer_stride = stride;
+
+    VkPipeline validation_pipeline = VK_NULL_HANDLE;
     if (!use_shader_objects) {
-        *pPipeline = GetDrawValidationPipeline(render_pass);
-        if (*pPipeline == VK_NULL_HANDLE) {
+        validation_pipeline = GetDrawValidationPipeline(cb_node->activeRenderPass.get()->renderPass());
+        if (validation_pipeline == VK_NULL_HANDLE) {
             ReportSetupProblem(device, "Could not find or create a pipeline. Aborting GPU-AV");
             aborted = true;
-            return;
+            return std::make_unique<PreDrawResources>();
         }
     }
-
-    result = desc_set_manager->GetDescriptorSet(&out_draw_resources.desc_pool, common_draw_resources.ds_layout,
-                                                &out_draw_resources.desc_set);
+    VkResult result = VK_SUCCESS;
+    result = desc_set_manager->GetDescriptorSet(&draw_resources->desc_pool, common_draw_resources.ds_layout,
+                                                &draw_resources->buffer_desc_set);
     if (result != VK_SUCCESS) {
         ReportSetupProblem(device, "Unable to allocate descriptor set. Aborting GPU-AV");
         aborted = true;
-        return;
+        return std::make_unique<PreDrawResources>();
     }
 
     const uint32_t buffer_count = 2;
     VkDescriptorBufferInfo buffer_infos[buffer_count] = {};
     // Error output buffer
-    buffer_infos[0].buffer = output_block.buffer;
+    buffer_infos[0].buffer = draw_resources->output_mem_block.buffer;
     buffer_infos[0].offset = 0;
     buffer_infos[0].range = VK_WHOLE_SIZE;
-    if (indirect_state->count_buffer) {
+    if (count_buffer) {
         // Count buffer
-        buffer_infos[1].buffer = indirect_state->count_buffer;
+        buffer_infos[1].buffer = count_buffer;
     } else {
         // Draw Buffer
-        buffer_infos[1].buffer = indirect_state->buffer;
+        buffer_infos[1].buffer = indirect_buffer;
     }
     buffer_infos[1].offset = 0;
     buffer_infos[1].range = VK_WHOLE_SIZE;
@@ -550,110 +677,134 @@ void gpuav::Validator::AllocatePreDrawValidationResources(const DeviceMemoryBloc
         desc_writes[i].descriptorCount = 1;
         desc_writes[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         desc_writes[i].pBufferInfo = &buffer_infos[i];
-        desc_writes[i].dstSet = out_draw_resources.desc_set;
+        desc_writes[i].dstSet = draw_resources->buffer_desc_set;
     }
     DispatchUpdateDescriptorSets(device, buffer_count, desc_writes, 0, NULL);
-}
 
-void gpuav::Validator::AllocatePreDispatchValidationResources(const DeviceMemoryBlock &output_block,
-                                                              const CmdIndirectState *indirect_state, const bool use_shader_objects,
-                                                              PreDispatchResources &out_dispatch_resources) {
-    VkResult result;
-    if (!common_dispatch_resources.initialized) {
-        std::vector<VkDescriptorSetLayoutBinding> bindings = {
-            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // output buffer
-            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // indirect buffer
-        };
+    // Insert a draw that can examine some device memory right before the draw we're validating (Pre Draw Validation)
+    //
+    // NOTE that this validation does not attempt to abort invalid api calls as most other validation does. A crash
+    // or DEVICE_LOST resulting from the invalid call will prevent preceeding validation errors from being reported.
 
-        VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
-        ds_layout_ci.bindingCount = static_cast<uint32_t>(bindings.size());
-        ds_layout_ci.pBindings = bindings.data();
-        result = DispatchCreateDescriptorSetLayout(device, &ds_layout_ci, nullptr, &common_dispatch_resources.ds_layout);
-        if (result != VK_SUCCESS) {
-            ReportSetupProblem(device, "Unable to create descriptor set layout. Aborting GPU-AV");
+    // Save current graphics pipeline state
+    RestorablePipelineState restorable_state(cb_node.get(), VK_PIPELINE_BIND_POINT_GRAPHICS);
+
+    uint32_t push_constants[PreDrawResources::push_constant_words] = {};
+    if (command == Func::vkCmdDrawIndirectCount || command == Func::vkCmdDrawIndirectCountKHR ||
+        command == Func::vkCmdDrawIndexedIndirectCount || command == Func::vkCmdDrawIndexedIndirectCountKHR) {
+        // Validate count buffer
+        if (count_buffer_offset > std::numeric_limits<uint32_t>::max()) {
+            ReportSetupProblem(device, "Count buffer offset is larger than can be contained in an unsigned int. Aborting GPU-AV");
             aborted = true;
-            return;
+            return std::make_unique<PreDrawResources>();
         }
 
-        VkPushConstantRange push_constant_range = {};
-        push_constant_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-        push_constant_range.offset = 0;
-        push_constant_range.size = out_dispatch_resources.push_constant_words * sizeof(uint32_t);
-        VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
-        pipeline_layout_ci.pushConstantRangeCount = 1;
-        pipeline_layout_ci.pPushConstantRanges = &push_constant_range;
-        pipeline_layout_ci.setLayoutCount = 1;
-        pipeline_layout_ci.pSetLayouts = &common_dispatch_resources.ds_layout;
-        result = DispatchCreatePipelineLayout(device, &pipeline_layout_ci, nullptr, &common_dispatch_resources.pipeline_layout);
-        if (result != VK_SUCCESS) {
-            ReportSetupProblem(device, "Unable to create pipeline layout. Aborting GPU-AV");
-            aborted = true;
-            return;
-        }
-
-        if (use_shader_objects) {
-            VkShaderCreateInfoEXT shader_ci = vku::InitStructHelper();
-            shader_ci.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-            shader_ci.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
-            shader_ci.codeSize = sizeof(gpu_pre_dispatch_comp);
-            shader_ci.pCode = gpu_pre_dispatch_comp;
-            shader_ci.pName = "main";
-            shader_ci.setLayoutCount = 1u;
-            shader_ci.pSetLayouts = &common_dispatch_resources.ds_layout;
-            shader_ci.pushConstantRangeCount = 1u;
-            shader_ci.pPushConstantRanges = &push_constant_range;
-            result = DispatchCreateShadersEXT(device, 1u, &shader_ci, nullptr, &common_dispatch_resources.shader_object);
-            if (result != VK_SUCCESS) {
-                ReportSetupProblem(device, "Unable to create shader object. Aborting GPU-AV");
-                aborted = true;
-                return;
-            }
+        // Buffer size must be >= (stride * (drawCount - 1) + offset + sizeof(VkDrawIndirectCommand))
+        uint32_t struct_size;
+        if (command == Func::vkCmdDrawIndirectCount || command == Func::vkCmdDrawIndirectCountKHR) {
+            struct_size = sizeof(VkDrawIndirectCommand);
         } else {
-            VkShaderModuleCreateInfo shader_module_ci = vku::InitStructHelper();
-            shader_module_ci.codeSize = sizeof(gpu_pre_dispatch_comp);
-            shader_module_ci.pCode = gpu_pre_dispatch_comp;
-            result = DispatchCreateShaderModule(device, &shader_module_ci, nullptr, &common_dispatch_resources.shader_module);
-            if (result != VK_SUCCESS) {
-                ReportSetupProblem(device, "Unable to create shader module. Aborting GPU-AV");
-                aborted = true;
-                return;
-            }
-
-            // Create pipeline
-            VkPipelineShaderStageCreateInfo pipeline_stage_ci = vku::InitStructHelper();
-            pipeline_stage_ci.stage = VK_SHADER_STAGE_COMPUTE_BIT;
-            pipeline_stage_ci.module = common_dispatch_resources.shader_module;
-            pipeline_stage_ci.pName = "main";
-
-            VkComputePipelineCreateInfo pipeline_ci = vku::InitStructHelper();
-            pipeline_ci.stage = pipeline_stage_ci;
-            pipeline_ci.layout = common_dispatch_resources.pipeline_layout;
-
-            result = DispatchCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr,
-                                                    &common_dispatch_resources.pipeline);
-            if (result != VK_SUCCESS) {
-                ReportSetupProblem(device, "Failed to create compute pipeline for pre dispatch validation.");
-            }
+            assert(command == Func::vkCmdDrawIndexedIndirectCount || command == Func::vkCmdDrawIndexedIndirectCountKHR);
+            struct_size = sizeof(VkDrawIndexedIndirectCommand);
         }
+        auto buffer_state = Get<BUFFER_STATE>(indirect_buffer);
+        uint32_t max_count;
+        uint64_t bufsize = buffer_state->createInfo.size;
+        uint64_t first_command_bytes = struct_size + indirect_offset;
+        if (first_command_bytes > bufsize) {
+            max_count = 0;
+        } else {
+            max_count = 1 + static_cast<uint32_t>(std::floor(((bufsize - first_command_bytes) / stride)));
+        }
+        draw_resources->indirect_buffer_size = bufsize;
 
-        common_dispatch_resources.initialized = true;
+        assert(phys_dev_props.limits.maxDrawIndirectCount > 0);
+        push_constants[0] = phys_dev_props.limits.maxDrawIndirectCount;
+        push_constants[1] = max_count;
+        push_constants[2] = static_cast<uint32_t>((count_buffer_offset / sizeof(uint32_t)));
+    } else {
+        // Validate buffer for firstInstance check instead of count buffer check
+        push_constants[0] = 0;
+        push_constants[1] = draw_count;
+        if (command == Func::vkCmdDrawIndirect) {
+            push_constants[2] =
+                static_cast<uint32_t>((indirect_offset + offsetof(struct VkDrawIndirectCommand, firstInstance)) / sizeof(uint32_t));
+        } else {
+            assert(command == Func::vkCmdDrawIndexedIndirect);
+            push_constants[2] = static_cast<uint32_t>(
+                (indirect_offset + offsetof(struct VkDrawIndexedIndirectCommand, firstInstance)) / sizeof(uint32_t));
+        }
+        push_constants[3] = stride / sizeof(uint32_t);
     }
 
-    result = desc_set_manager->GetDescriptorSet(&out_dispatch_resources.desc_pool, common_dispatch_resources.ds_layout,
-                                                &out_dispatch_resources.desc_set);
+    // Insert diagnostic draw
+    if (use_shader_objects) {
+        VkShaderStageFlagBits stage = VK_SHADER_STAGE_VERTEX_BIT;
+        DispatchCmdBindShadersEXT(cmd_buffer, 1u, &stage, &common_draw_resources.shader_object);
+    } else {
+        DispatchCmdBindPipeline(cmd_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, validation_pipeline);
+    }
+    DispatchCmdPushConstants(cmd_buffer, common_draw_resources.pipeline_layout, VK_SHADER_STAGE_VERTEX_BIT, 0,
+                             sizeof(push_constants), push_constants);
+    DispatchCmdBindDescriptorSets(cmd_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, common_draw_resources.pipeline_layout, 0, 1,
+                                  &draw_resources->buffer_desc_set, 0, nullptr);
+    DispatchCmdDraw(cmd_buffer, 3, 1, 0, 0);
+
+    // Restore the previous graphics pipeline state.
+    restorable_state.Restore(cmd_buffer);
+
+    return draw_resources;
+}
+
+std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreDispatchIndirectValidationResources(
+    vvl::Func command, VkCommandBuffer cmd_buffer, VkBuffer indirect_buffer, VkDeviceSize indirect_offset) {
+    CommandResources cmd_resources = AllocateCommandResources(cmd_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, command);
+    if (!gpuav_settings.validate_indirect_buffer) {
+        auto cmd_resources_ptr = std::make_unique<CommandResources>(cmd_resources);
+        return cmd_resources_ptr;
+    }
+
+    // Insert a dispatch that can examine some device memory right before the dispatch we're validating
+    //
+    // NOTE that this validation does not attempt to abort invalid api calls as most other validation does. A crash
+    // or DEVICE_LOST resulting from the invalid call will prevent preceding validation errors from being reported.
+
+    auto cb_node = GetWrite<CommandBuffer>(cmd_buffer);
+    if (!cb_node) {
+        ReportSetupProblem(device, "Unrecognized command buffer");
+        aborted = true;
+        return std::make_unique<PreDispatchResources>();
+    }
+
+    const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_COMPUTE);
+    auto const &last_bound = cb_node->lastBound[lv_bind_point];
+    const auto *pipeline_state = last_bound.pipeline_state;
+    const bool use_shader_objects = pipeline_state == nullptr;
+
+    AllocateSharedDispatchIndirectValidationResources(use_shader_objects);
+
+    auto dispatch_resources = std::make_unique<PreDispatchResources>();
+    CommandResources &base = *dispatch_resources;
+    base = cmd_resources;
+    dispatch_resources->indirect_buffer = indirect_buffer;
+    dispatch_resources->indirect_buffer_offset = indirect_offset;
+
+    VkResult result = VK_SUCCESS;
+    result = desc_set_manager->GetDescriptorSet(&dispatch_resources->desc_pool, common_dispatch_resources.ds_layout,
+                                                &dispatch_resources->indirect_buffer_desc_set);
     if (result != VK_SUCCESS) {
         ReportSetupProblem(device, "Unable to allocate descriptor set. Aborting GPU-AV");
         aborted = true;
-        return;
+        return std::make_unique<PreDispatchResources>();
     }
 
     const uint32_t buffer_count = 2;
     VkDescriptorBufferInfo buffer_infos[buffer_count] = {};
     // Error output buffer
-    buffer_infos[0].buffer = output_block.buffer;
+    buffer_infos[0].buffer = dispatch_resources->output_mem_block.buffer;
     buffer_infos[0].offset = 0;
     buffer_infos[0].range = VK_WHOLE_SIZE;
-    buffer_infos[1].buffer = indirect_state->buffer;
+    buffer_infos[1].buffer = indirect_buffer;
     buffer_infos[1].offset = 0;
     buffer_infos[1].range = VK_WHOLE_SIZE;
 
@@ -664,20 +815,133 @@ void gpuav::Validator::AllocatePreDispatchValidationResources(const DeviceMemory
         desc_writes[i].descriptorCount = 1;
         desc_writes[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         desc_writes[i].pBufferInfo = &buffer_infos[i];
-        desc_writes[i].dstSet = out_dispatch_resources.desc_set;
+        desc_writes[i].dstSet = dispatch_resources->indirect_buffer_desc_set;
     }
     DispatchUpdateDescriptorSets(device, buffer_count, desc_writes, 0, nullptr);
+
+    // Save current graphics pipeline state
+    RestorablePipelineState restorable_state(cb_node.get(), VK_PIPELINE_BIND_POINT_COMPUTE);
+
+    uint32_t push_constants[PreDispatchResources::push_constant_words] = {};
+    push_constants[0] = phys_dev_props.limits.maxComputeWorkGroupCount[0];
+    push_constants[1] = phys_dev_props.limits.maxComputeWorkGroupCount[1];
+    push_constants[2] = phys_dev_props.limits.maxComputeWorkGroupCount[2];
+    push_constants[3] = static_cast<uint32_t>((indirect_offset / sizeof(uint32_t)));
+
+    // Insert diagnostic dispatch
+    if (use_shader_objects) {
+        VkShaderStageFlagBits stage = VK_SHADER_STAGE_COMPUTE_BIT;
+        DispatchCmdBindShadersEXT(cmd_buffer, 1u, &stage, &common_dispatch_resources.shader_object);
+    } else {
+        DispatchCmdBindPipeline(cmd_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, common_dispatch_resources.pipeline);
+    }
+    DispatchCmdPushConstants(cmd_buffer, common_dispatch_resources.pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0,
+                             sizeof(push_constants), push_constants);
+    DispatchCmdBindDescriptorSets(cmd_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, common_dispatch_resources.pipeline_layout, 0, 1,
+                                  &dispatch_resources->indirect_buffer_desc_set, 0, nullptr);
+    DispatchCmdDispatch(cmd_buffer, 1, 1, 1);
+
+    // Restore the previous compute pipeline state.
+    restorable_state.Restore(cmd_buffer);
+
+    return dispatch_resources;
 }
 
-void gpuav::Validator::AllocatePreTraceRaysValidationResources(const DeviceMemoryBlock &output_block,
-                                                               const CmdIndirectState *indirect_state,
-                                                               PreTraceRaysResources &out_trace_rays_resources) {
-    // Create Shader(s), only ray gen for now ?
-    // In the context of validating the indirect command buffer, it seems that a dispatch could be enough
+std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreTraceRaysValidationResources(
+    vvl::Func command, VkCommandBuffer cmd_buffer, VkDeviceAddress indirect_data_address) {
+    CommandResources cmd_resources = AllocateCommandResources(cmd_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, command);
+    if (!gpuav_settings.validate_indirect_buffer) {
+        auto cmd_resources_ptr = std::make_unique<CommandResources>(cmd_resources);
+        return cmd_resources_ptr;
+    }
+
+    AllocateSharedTraceRaysValidationResources();
 
     // Allocate descriptor set. Can I assume VK_EXT_descriptor_indexing is supported?
+    auto trace_rays_resources = std::make_unique<PreTraceRaysResources>();
+    CommandResources &base = *trace_rays_resources;
+    base = cmd_resources;
+    trace_rays_resources->indirect_data_address = indirect_data_address;
     VkResult result = VK_SUCCESS;
+
+    // Create descriptor set for validation pipeline
+    result = desc_set_manager->GetDescriptorSet(&trace_rays_resources->desc_pool, common_trace_rays_resources.ds_layout,
+                                                &trace_rays_resources->desc_set);
+    if (result != VK_SUCCESS) {
+        ReportSetupProblem(device, "Unable to allocate descriptor set for ray tracing validation pipeline. Aborting GPU-AV");
+        aborted = true;
+        return std::make_unique<PreTraceRaysResources>();
+    }
+
+    constexpr uint32_t buffer_count = 1;
+    VkDescriptorBufferInfo buffer_infos[buffer_count] = {};
+    // Error output buffer
+    buffer_infos[0].buffer = trace_rays_resources->output_mem_block.buffer;
+    buffer_infos[0].offset = 0;
+    buffer_infos[0].range = VK_WHOLE_SIZE;
+
+    VkWriteDescriptorSet desc_writes[buffer_count] = {};
+    for (uint32_t i = 0; i < buffer_count; i++) {
+        desc_writes[i] = vku::InitStructHelper();
+        desc_writes[i].dstBinding = i;
+        desc_writes[i].descriptorCount = 1;
+        desc_writes[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        desc_writes[i].pBufferInfo = &buffer_infos[i];
+        desc_writes[i].dstSet = trace_rays_resources->desc_set;
+    }
+    DispatchUpdateDescriptorSets(device, buffer_count, desc_writes, 0, nullptr);
+
+    auto cb_node = GetWrite<CommandBuffer>(cmd_buffer);
+    if (!cb_node) {
+        ReportSetupProblem(device, "Unrecognized command buffer");
+        aborted = true;
+        return std::make_unique<PreTraceRaysResources>();
+    }
+
+    // Save current ray tracing pipeline state
+    RestorablePipelineState restorable_state(cb_node.get(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
+
+    // Push info needed for validation:
+    // - the device address indirect data is read from
+    // - the limits to check against
+    uint32_t push_constants[PreTraceRaysResources::push_constant_words] = {};
+    const uint64_t ray_query_dimension_max_width = static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[0]) *
+                                                   static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[0]);
+    const uint64_t ray_query_dimension_max_height = static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[1]) *
+                                                    static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[1]);
+    const uint64_t ray_query_dimension_max_depth = static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[2]) *
+                                                   static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[2]);
+    // Need to put the buffer reference first otherwise it is incorrect, probably an alignment issue
+    push_constants[0] = static_cast<uint32_t>(trace_rays_resources->indirect_data_address) & vvl::kU32Max;
+    push_constants[1] = static_cast<uint32_t>(trace_rays_resources->indirect_data_address >> 32) & vvl::kU32Max;
+    push_constants[2] = static_cast<uint32_t>(std::min<uint64_t>(ray_query_dimension_max_width, vvl::kU32Max));
+    push_constants[3] = static_cast<uint32_t>(std::min<uint64_t>(ray_query_dimension_max_height, vvl::kU32Max));
+    push_constants[4] = static_cast<uint32_t>(std::min<uint64_t>(ray_query_dimension_max_depth, vvl::kU32Max));
+
+    DispatchCmdBindPipeline(cmd_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, common_trace_rays_resources.pipeline);
+    DispatchCmdPushConstants(cmd_buffer, common_trace_rays_resources.pipeline_layout, VK_SHADER_STAGE_RAYGEN_BIT_KHR, 0,
+                             sizeof(push_constants), push_constants);
+    DispatchCmdBindDescriptorSets(cmd_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, common_trace_rays_resources.pipeline_layout,
+                                  0, 1, &trace_rays_resources->desc_set, 0, nullptr);
+    VkStridedDeviceAddressRegionKHR ray_gen_sbt{};
+    assert(common_trace_rays_resources.sbt_address != 0);
+    ray_gen_sbt.deviceAddress = common_trace_rays_resources.sbt_address;
+    ray_gen_sbt.stride = common_trace_rays_resources.shader_group_handle_size_aligned;
+    ray_gen_sbt.size = common_trace_rays_resources.shader_group_handle_size_aligned;
+
+    VkStridedDeviceAddressRegionKHR empty_sbt{};
+    DispatchCmdTraceRaysKHR(cmd_buffer, &ray_gen_sbt, &empty_sbt, &empty_sbt, &empty_sbt, 1, 1, 1);
+
+    // Restore the previous ray tracing pipeline state.
+    restorable_state.Restore(cmd_buffer);
+
+    return trace_rays_resources;
+}
+
+void gpuav::Validator::AllocateSharedTraceRaysValidationResources() {
     if (!common_trace_rays_resources.initialized) {
+        VkResult result = VK_SUCCESS;
+
         std::vector<VkDescriptorSetLayoutBinding> bindings = {
             {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_RAYGEN_BIT_KHR, nullptr}  // output buffer
         };
@@ -695,7 +959,7 @@ void gpuav::Validator::AllocatePreTraceRaysValidationResources(const DeviceMemor
         VkPushConstantRange push_constant_range = {};
         push_constant_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
         push_constant_range.offset = 0;
-        push_constant_range.size = out_trace_rays_resources.push_constant_words * sizeof(uint32_t);
+        push_constant_range.size = PreTraceRaysResources::push_constant_words * sizeof(uint32_t);
         VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
         pipeline_layout_ci.pushConstantRangeCount = 1;
         pipeline_layout_ci.pPushConstantRanges = &push_constant_range;
@@ -786,7 +1050,7 @@ void gpuav::Validator::AllocatePreTraceRaysValidationResources(const DeviceMemor
             return;
         }
 
-        alloc_info.pool = common_trace_rays_resources.sbt_pool;  // #ARNO_TODO create dedicated pool
+        alloc_info.pool = common_trace_rays_resources.sbt_pool;
         result = vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &common_trace_rays_resources.sbt_buffer,
                                  &common_trace_rays_resources.sbt_allocation, nullptr);
         if (result != VK_SUCCESS) {
@@ -823,45 +1087,160 @@ void gpuav::Validator::AllocatePreTraceRaysValidationResources(const DeviceMemor
 
         common_trace_rays_resources.initialized = true;
     }
-
-    result = desc_set_manager->GetDescriptorSet(&out_trace_rays_resources.desc_pool, common_trace_rays_resources.ds_layout,
-                                                &out_trace_rays_resources.desc_set);
-    if (result != VK_SUCCESS) {
-        ReportSetupProblem(device, "Unable to allocate descriptor set. Aborting GPU-AV");
-        aborted = true;
-        return;
-    }
-
-    constexpr uint32_t buffer_count = 1;
-    VkDescriptorBufferInfo buffer_infos[buffer_count] = {};
-    // Error output buffer
-    buffer_infos[0].buffer = output_block.buffer;
-    buffer_infos[0].offset = 0;
-    buffer_infos[0].range = VK_WHOLE_SIZE;
-
-    VkWriteDescriptorSet desc_writes[buffer_count] = {};
-    for (uint32_t i = 0; i < buffer_count; i++) {
-        desc_writes[i] = vku::InitStructHelper();
-        desc_writes[i].dstBinding = i;
-        desc_writes[i].descriptorCount = 1;
-        desc_writes[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        desc_writes[i].pBufferInfo = &buffer_infos[i];
-        desc_writes[i].dstSet = out_trace_rays_resources.desc_set;
-    }
-    DispatchUpdateDescriptorSets(device, buffer_count, desc_writes, 0, nullptr);
-
-    // Save parameters for error message
-    out_trace_rays_resources.indirect_device_address = indirect_state->indirectDeviceAddress;
 }
 
-void gpuav::Validator::AllocateValidationResources(const VkCommandBuffer cmd_buffer, const VkPipelineBindPoint bind_point,
-                                                   vvl::Func command, const CmdIndirectState *indirect_state) {
-    if (bind_point != VK_PIPELINE_BIND_POINT_GRAPHICS && bind_point != VK_PIPELINE_BIND_POINT_COMPUTE &&
-        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
-        return;
-    }
+void gpuav::Validator::AllocateSharedDrawIndirectValidationResources(bool use_shader_objects) {
     VkResult result;
+    if (!common_draw_resources.initialized) {
+        std::vector<VkDescriptorSetLayoutBinding> bindings = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},  // output buffer
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},  // count/draws buffer
+        };
 
+        VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
+        ds_layout_ci.bindingCount = static_cast<uint32_t>(bindings.size());
+        ds_layout_ci.pBindings = bindings.data();
+        result = DispatchCreateDescriptorSetLayout(device, &ds_layout_ci, nullptr, &common_draw_resources.ds_layout);
+        if (result != VK_SUCCESS) {
+            ReportSetupProblem(device, "Unable to create descriptor set layout. Aborting GPU-AV");
+            aborted = true;
+            return;
+        }
+
+        VkPushConstantRange push_constant_range = {};
+        push_constant_range.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+        push_constant_range.offset = 0;
+        push_constant_range.size = PreDrawResources::push_constant_words * sizeof(uint32_t);
+        VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
+        pipeline_layout_ci.pushConstantRangeCount = 1;
+        pipeline_layout_ci.pPushConstantRanges = &push_constant_range;
+        pipeline_layout_ci.setLayoutCount = 1;
+        pipeline_layout_ci.pSetLayouts = &common_draw_resources.ds_layout;
+        result = DispatchCreatePipelineLayout(device, &pipeline_layout_ci, nullptr, &common_draw_resources.pipeline_layout);
+        if (result != VK_SUCCESS) {
+            ReportSetupProblem(device, "Unable to create pipeline layout. Aborting GPU-AV");
+            aborted = true;
+            return;
+        }
+
+        if (use_shader_objects) {
+            VkShaderCreateInfoEXT shader_ci = vku::InitStructHelper();
+            shader_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
+            shader_ci.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
+            shader_ci.codeSize = sizeof(gpu_pre_draw_vert);
+            shader_ci.pCode = gpu_pre_draw_vert;
+            shader_ci.pName = "main";
+            shader_ci.setLayoutCount = 1u;
+            shader_ci.pSetLayouts = &common_draw_resources.ds_layout;
+            shader_ci.pushConstantRangeCount = 1u;
+            shader_ci.pPushConstantRanges = &push_constant_range;
+            result = DispatchCreateShadersEXT(device, 1u, &shader_ci, nullptr, &common_draw_resources.shader_object);
+            if (result != VK_SUCCESS) {
+                ReportSetupProblem(device, "Unable to create shader object. Aborting GPU-AV");
+                aborted = true;
+                return;
+            }
+        } else {
+            VkShaderModuleCreateInfo shader_module_ci = vku::InitStructHelper();
+            shader_module_ci.codeSize = sizeof(gpu_pre_draw_vert);
+            shader_module_ci.pCode = gpu_pre_draw_vert;
+            result = DispatchCreateShaderModule(device, &shader_module_ci, nullptr, &common_draw_resources.shader_module);
+            if (result != VK_SUCCESS) {
+                ReportSetupProblem(device, "Unable to create shader module. Aborting GPU-AV");
+                aborted = true;
+                return;
+            }
+        }
+
+        common_draw_resources.initialized = true;
+    }
+}
+
+void gpuav::Validator::AllocateSharedDispatchIndirectValidationResources(bool use_shader_objects) {
+    if (!common_dispatch_resources.initialized) {
+        VkResult result = VK_SUCCESS;
+        std::vector<VkDescriptorSetLayoutBinding> bindings = {
+            {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // output buffer
+            {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},  // indirect buffer
+        };
+
+        VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
+        ds_layout_ci.bindingCount = static_cast<uint32_t>(bindings.size());
+        ds_layout_ci.pBindings = bindings.data();
+        result = DispatchCreateDescriptorSetLayout(device, &ds_layout_ci, nullptr, &common_dispatch_resources.ds_layout);
+        if (result != VK_SUCCESS) {
+            ReportSetupProblem(device, "Unable to create descriptor set layout. Aborting GPU-AV");
+            aborted = true;
+            return;
+        }
+
+        VkPushConstantRange push_constant_range = {};
+        push_constant_range.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+        push_constant_range.offset = 0;
+        push_constant_range.size = PreDispatchResources::push_constant_words * sizeof(uint32_t);
+        VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
+        pipeline_layout_ci.pushConstantRangeCount = 1;
+        pipeline_layout_ci.pPushConstantRanges = &push_constant_range;
+        pipeline_layout_ci.setLayoutCount = 1;
+        pipeline_layout_ci.pSetLayouts = &common_dispatch_resources.ds_layout;
+        result = DispatchCreatePipelineLayout(device, &pipeline_layout_ci, nullptr, &common_dispatch_resources.pipeline_layout);
+        if (result != VK_SUCCESS) {
+            ReportSetupProblem(device, "Unable to create pipeline layout. Aborting GPU-AV");
+            aborted = true;
+            return;
+        }
+
+        if (use_shader_objects) {
+            VkShaderCreateInfoEXT shader_ci = vku::InitStructHelper();
+            shader_ci.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+            shader_ci.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
+            shader_ci.codeSize = sizeof(gpu_pre_dispatch_comp);
+            shader_ci.pCode = gpu_pre_dispatch_comp;
+            shader_ci.pName = "main";
+            shader_ci.setLayoutCount = 1u;
+            shader_ci.pSetLayouts = &common_dispatch_resources.ds_layout;
+            shader_ci.pushConstantRangeCount = 1u;
+            shader_ci.pPushConstantRanges = &push_constant_range;
+            result = DispatchCreateShadersEXT(device, 1u, &shader_ci, nullptr, &common_dispatch_resources.shader_object);
+            if (result != VK_SUCCESS) {
+                ReportSetupProblem(device, "Unable to create shader object. Aborting GPU-AV");
+                aborted = true;
+                return;
+            }
+        } else {
+            VkShaderModuleCreateInfo shader_module_ci = vku::InitStructHelper();
+            shader_module_ci.codeSize = sizeof(gpu_pre_dispatch_comp);
+            shader_module_ci.pCode = gpu_pre_dispatch_comp;
+            result = DispatchCreateShaderModule(device, &shader_module_ci, nullptr, &common_dispatch_resources.shader_module);
+            if (result != VK_SUCCESS) {
+                ReportSetupProblem(device, "Unable to create shader module. Aborting GPU-AV");
+                aborted = true;
+                return;
+            }
+
+            // Create pipeline
+            VkPipelineShaderStageCreateInfo pipeline_stage_ci = vku::InitStructHelper();
+            pipeline_stage_ci.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+            pipeline_stage_ci.module = common_dispatch_resources.shader_module;
+            pipeline_stage_ci.pName = "main";
+
+            VkComputePipelineCreateInfo pipeline_ci = vku::InitStructHelper();
+            pipeline_ci.stage = pipeline_stage_ci;
+            pipeline_ci.layout = common_dispatch_resources.pipeline_layout;
+
+            result = DispatchCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr,
+                                                    &common_dispatch_resources.pipeline);
+            if (result != VK_SUCCESS) {
+                ReportSetupProblem(device, "Failed to create compute pipeline for pre dispatch validation.");
+            }
+        }
+
+        common_dispatch_resources.initialized = true;
+    }
+}
+
+void gpuav::Validator::StoreCommandResources(const VkCommandBuffer cmd_buffer,
+                                             std::unique_ptr<CommandResources> command_resources) {
     if (aborted) return;
 
     auto cb_node = GetWrite<CommandBuffer>(cmd_buffer);
@@ -870,561 +1249,6 @@ void gpuav::Validator::AllocateValidationResources(const VkCommandBuffer cmd_buf
         aborted = true;
         return;
     }
-    const auto lv_bind_point = ConvertToLvlBindPoint(bind_point);
-    auto const &last_bound = cb_node->lastBound[lv_bind_point];
-    const auto *pipeline_state = last_bound.pipeline_state;
-    bool uses_robustness = false;
-    const bool use_shader_objects = pipeline_state == nullptr;
 
-    if (!pipeline_state && !last_bound.HasShaderObjects()) {
-        ReportSetupProblem(device, "Neither pipeline state nor shader object states were found, aborting GPU-AV");
-        aborted = true;
-        return;
-    }
-
-    std::vector<VkDescriptorSet> desc_sets;
-    VkDescriptorPool desc_pool = VK_NULL_HANDLE;
-    result = desc_set_manager->GetDescriptorSets(1, &desc_pool, debug_desc_layout, &desc_sets);
-    assert(result == VK_SUCCESS);
-    if (result != VK_SUCCESS) {
-        ReportSetupProblem(device, "Unable to allocate descriptor sets. Device could become unstable.");
-        aborted = true;
-        return;
-    }
-
-    // Allocate memory for the output block that the gpu will use to return any error information
-    DeviceMemoryBlock output_block = {};
-    VkBufferCreateInfo buffer_info = vku::InitStructHelper();
-    buffer_info.size = output_buffer_size;
-    buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-    VmaAllocationCreateInfo alloc_info = {};
-    alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    alloc_info.pool = output_buffer_pool;
-    result = vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &output_block.buffer, &output_block.allocation, nullptr);
-    if (result != VK_SUCCESS) {
-        ReportSetupProblem(device, "Unable to allocate device memory. Device could become unstable.", true);
-        aborted = true;
-        return;
-    }
-
-    uint32_t *output_buffer_ptr;
-    result = vmaMapMemory(vmaAllocator, output_block.allocation, reinterpret_cast<void **>(&output_buffer_ptr));
-    if (result == VK_SUCCESS) {
-        memset(output_buffer_ptr, 0, output_buffer_size);
-        if (gpuav_settings.validate_descriptors) {
-            uses_robustness = (enabled_features.robustBufferAccess || enabled_features.robustBufferAccess2 ||
-                               (pipeline_state && pipeline_state->uses_pipeline_robustness));
-            output_buffer_ptr[spvtools::kDebugOutputFlagsOffset] = spvtools::kInstBufferOOBEnable;
-        }
-        vmaUnmapMemory(vmaAllocator, output_block.allocation);
-    } else {
-        ReportSetupProblem(device, "Unable to map device memory allocated for output buffer. Device could become unstable.", true);
-        aborted = true;
-        return;
-    }
-
-    PreDrawResources draw_resources = {};
-    PreDispatchResources dispatch_resources = {};
-    PreTraceRaysResources trace_rays_resources = {};
-
-    if (gpuav_settings.validate_indirect_buffer &&
-        ((command == Func::vkCmdDrawIndirectCount || command == Func::vkCmdDrawIndirectCountKHR ||
-          command == Func::vkCmdDrawIndexedIndirectCount || command == Func::vkCmdDrawIndexedIndirectCountKHR) ||
-         ((command == Func::vkCmdDrawIndirect || command == Func::vkCmdDrawIndexedIndirect) &&
-          !(enabled_features.drawIndirectFirstInstance)))) {
-        // Insert a draw that can examine some device memory right before the draw we're validating (Pre Draw Validation)
-        //
-        // NOTE that this validation does not attempt to abort invalid api calls as most other validation does. A crash
-        // or DEVICE_LOST resulting from the invalid call will prevent preceeding validation errors from being reported.
-
-        assert(bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS);
-        assert(indirect_state != NULL);
-        VkPipeline validation_pipeline = VK_NULL_HANDLE;
-        AllocatePreDrawValidationResources(output_block, cb_node->activeRenderPass.get()->renderPass(), use_shader_objects,
-                                           &validation_pipeline, indirect_state, draw_resources);
-        if (aborted) return;
-
-        // Save current graphics pipeline state
-        RestorablePipelineState restorable_state(cb_node.get(), VK_PIPELINE_BIND_POINT_GRAPHICS);
-
-        // Save parameters for error message
-        draw_resources.indirect_buffer = indirect_state->buffer;
-        draw_resources.indirect_buffer_offset = indirect_state->offset;
-        draw_resources.indirect_buffer_stride = indirect_state->stride;
-
-        uint32_t push_constants[draw_resources.push_constant_words] = {};
-        if (command == Func::vkCmdDrawIndirectCount || command == Func::vkCmdDrawIndirectCountKHR ||
-            command == Func::vkCmdDrawIndexedIndirectCount || command == Func::vkCmdDrawIndexedIndirectCountKHR) {
-            // Validate count buffer
-            if (indirect_state->count_buffer_offset > std::numeric_limits<uint32_t>::max()) {
-                ReportSetupProblem(device,
-                                   "Count buffer offset is larger than can be contained in an unsigned int. Aborting GPU-AV");
-                aborted = true;
-                return;
-            }
-
-            // Buffer size must be >= (stride * (drawCount - 1) + offset + sizeof(VkDrawIndirectCommand))
-            uint32_t struct_size;
-            if (command == Func::vkCmdDrawIndirectCount || command == Func::vkCmdDrawIndirectCountKHR) {
-                struct_size = sizeof(VkDrawIndirectCommand);
-            } else {
-                assert(command == Func::vkCmdDrawIndexedIndirectCount || command == Func::vkCmdDrawIndexedIndirectCountKHR);
-                struct_size = sizeof(VkDrawIndexedIndirectCommand);
-            }
-            auto buffer_state = Get<BUFFER_STATE>(indirect_state->buffer);
-            uint32_t max_count;
-            uint64_t bufsize = buffer_state->createInfo.size;
-            uint64_t first_command_bytes = struct_size + indirect_state->offset;
-            if (first_command_bytes > bufsize) {
-                max_count = 0;
-            } else {
-                max_count = 1 + static_cast<uint32_t>(std::floor(((bufsize - first_command_bytes) / indirect_state->stride)));
-            }
-            draw_resources.indirect_buffer_size = buffer_state->createInfo.size;
-
-            assert(phys_dev_props.limits.maxDrawIndirectCount > 0);
-            push_constants[0] = phys_dev_props.limits.maxDrawIndirectCount;
-            push_constants[1] = max_count;
-            push_constants[2] = static_cast<uint32_t>((indirect_state->count_buffer_offset / sizeof(uint32_t)));
-        } else {
-            // Validate buffer for firstInstance check instead of count buffer check
-            push_constants[0] = 0;
-            push_constants[1] = indirect_state->draw_count;
-            if (command == Func::vkCmdDrawIndirect) {
-                push_constants[2] = static_cast<uint32_t>(
-                    ((indirect_state->offset + offsetof(struct VkDrawIndirectCommand, firstInstance)) / sizeof(uint32_t)));
-            } else {
-                assert(command == Func::vkCmdDrawIndexedIndirect);
-                push_constants[2] = static_cast<uint32_t>(
-                    ((indirect_state->offset + offsetof(struct VkDrawIndexedIndirectCommand, firstInstance)) / sizeof(uint32_t)));
-            }
-            push_constants[3] = (indirect_state->stride / sizeof(uint32_t));
-        }
-
-        // Insert diagnostic draw
-        if (use_shader_objects) {
-            VkShaderStageFlagBits stage = VK_SHADER_STAGE_VERTEX_BIT;
-            DispatchCmdBindShadersEXT(cmd_buffer, 1u, &stage, &common_draw_resources.shader_object);
-        } else {
-            DispatchCmdBindPipeline(cmd_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, validation_pipeline);
-        }
-        DispatchCmdPushConstants(cmd_buffer, common_draw_resources.pipeline_layout, VK_SHADER_STAGE_VERTEX_BIT, 0,
-                                 sizeof(push_constants), push_constants);
-        DispatchCmdBindDescriptorSets(cmd_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, common_draw_resources.pipeline_layout, 0, 1,
-                                      &draw_resources.desc_set, 0, nullptr);
-        DispatchCmdDraw(cmd_buffer, 3, 1, 0, 0);
-
-        // Restore the previous graphics pipeline state.
-        restorable_state.Restore(cmd_buffer);
-    } else if (gpuav_settings.validate_indirect_buffer && command == Func::vkCmdDispatchIndirect) {
-        // Insert a dispatch that can examine some device memory right before the dispatch we're validating
-        //
-        // NOTE that this validation does not attempt to abort invalid api calls as most other validation does. A crash
-        // or DEVICE_LOST resulting from the invalid call will prevent preceding validation errors from being reported.
-
-        AllocatePreDispatchValidationResources(output_block, indirect_state, use_shader_objects, dispatch_resources);
-        if (aborted) return;
-
-        // Save current graphics pipeline state
-        RestorablePipelineState restorable_state(cb_node.get(), VK_PIPELINE_BIND_POINT_COMPUTE);
-
-        // Save parameters for error message
-        dispatch_resources.indirect_buffer = indirect_state->buffer;
-        dispatch_resources.indirect_buffer_offset = indirect_state->offset;
-
-        uint32_t push_constants[dispatch_resources.push_constant_words] = {};
-        push_constants[0] = phys_dev_props.limits.maxComputeWorkGroupCount[0];
-        push_constants[1] = phys_dev_props.limits.maxComputeWorkGroupCount[1];
-        push_constants[2] = phys_dev_props.limits.maxComputeWorkGroupCount[2];
-        push_constants[3] = static_cast<uint32_t>((indirect_state->offset / sizeof(uint32_t)));
-
-        // Insert diagnostic dispatch
-        if (use_shader_objects) {
-            VkShaderStageFlagBits stage = VK_SHADER_STAGE_COMPUTE_BIT;
-            DispatchCmdBindShadersEXT(cmd_buffer, 1u, &stage, &common_dispatch_resources.shader_object);
-        } else {
-            DispatchCmdBindPipeline(cmd_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, common_dispatch_resources.pipeline);
-        }
-        DispatchCmdPushConstants(cmd_buffer, common_dispatch_resources.pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0,
-                                 sizeof(push_constants), push_constants);
-        DispatchCmdBindDescriptorSets(cmd_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, common_dispatch_resources.pipeline_layout, 0, 1,
-                                      &dispatch_resources.desc_set, 0, nullptr);
-        DispatchCmdDispatch(cmd_buffer, 1, 1, 1);
-
-        // Restore the previous compute pipeline state.
-        restorable_state.Restore(cmd_buffer);
-    } else if (gpuav_settings.validate_indirect_buffer &&
-               (command == Func::vkCmdTraceRaysIndirectKHR /*|| command == Func::vkCmdTraceRaysIndirect2KHR */)) {
-        AllocatePreTraceRaysValidationResources(output_block, indirect_state, trace_rays_resources);
-        if (aborted) return;
-
-        // Save current ray tracing pipeline state
-        RestorablePipelineState restorable_state(cb_node.get(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
-
-        // Push info needed for validation:
-        // - the device address indirect data is read from
-        // - the limits to check against
-        uint32_t push_constants[trace_rays_resources.push_constant_words] = {};
-        const uint64_t ray_query_dimension_max_width = static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[0]) *
-                                                       static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[0]);
-        const uint64_t ray_query_dimension_max_height = static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[1]) *
-                                                        static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[1]);
-        const uint64_t ray_query_dimension_max_depth = static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[2]) *
-                                                       static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[2]);
-        // Need to put the buffer reference first otherwise it is incorrect, probably an alignment issue
-        push_constants[0] = static_cast<uint32_t>(trace_rays_resources.indirect_device_address) & vvl::kU32Max;
-        push_constants[1] = static_cast<uint32_t>(trace_rays_resources.indirect_device_address >> 32) & vvl::kU32Max;
-        push_constants[2] = static_cast<uint32_t>(std::min<uint64_t>(ray_query_dimension_max_width, vvl::kU32Max));
-        push_constants[3] = static_cast<uint32_t>(std::min<uint64_t>(ray_query_dimension_max_height, vvl::kU32Max));
-        push_constants[4] = static_cast<uint32_t>(std::min<uint64_t>(ray_query_dimension_max_depth, vvl::kU32Max));
-
-        DispatchCmdBindPipeline(cmd_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, common_trace_rays_resources.pipeline);
-        DispatchCmdPushConstants(cmd_buffer, common_trace_rays_resources.pipeline_layout, VK_SHADER_STAGE_RAYGEN_BIT_KHR, 0,
-                                 sizeof(push_constants), push_constants);
-        DispatchCmdBindDescriptorSets(cmd_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR,
-                                      common_trace_rays_resources.pipeline_layout, 0, 1, &trace_rays_resources.desc_set, 0,
-                                      nullptr);
-        VkStridedDeviceAddressRegionKHR ray_gen_sbt{};
-        assert(common_trace_rays_resources.sbt_address != 0);
-        ray_gen_sbt.deviceAddress = common_trace_rays_resources.sbt_address;
-        ray_gen_sbt.stride = common_trace_rays_resources.shader_group_handle_size_aligned;
-        ray_gen_sbt.size = common_trace_rays_resources.shader_group_handle_size_aligned;
-
-        VkStridedDeviceAddressRegionKHR empty_sbt{};
-        DispatchCmdTraceRaysKHR(cmd_buffer, &ray_gen_sbt, &empty_sbt, &empty_sbt, &empty_sbt, 1, 1, 1);
-
-        // Restore the previous ray tracing pipeline state.
-        restorable_state.Restore(cmd_buffer);
-    }
-
-    // Write the descriptor that will be used to check for OOB accesses
-    {
-        VkDescriptorBufferInfo output_desc_buffer_info = {};
-        output_desc_buffer_info.range = output_buffer_size;
-        output_desc_buffer_info.buffer = output_block.buffer;
-        output_desc_buffer_info.offset = 0;
-
-        std::array<VkWriteDescriptorSet, 3> desc_writes = {};
-        VkDescriptorBufferInfo di_input_desc_buffer_info = {};
-        VkDescriptorBufferInfo bda_input_desc_buffer_info = {};
-
-        desc_writes[0] = vku::InitStructHelper();
-        desc_writes[0].descriptorCount = 1;
-        desc_writes[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        desc_writes[0].pBufferInfo = &output_desc_buffer_info;
-        desc_writes[0].dstSet = desc_sets[0];
-
-        uint32_t desc_count = 1;
-
-        if (cb_node->current_bindless_buffer != VK_NULL_HANDLE) {
-            di_input_desc_buffer_info.range = VK_WHOLE_SIZE;
-            di_input_desc_buffer_info.buffer = cb_node->current_bindless_buffer;
-            di_input_desc_buffer_info.offset = 0;
-
-            desc_writes[desc_count] = vku::InitStructHelper();
-            desc_writes[desc_count].dstBinding = 1;
-            desc_writes[desc_count].descriptorCount = 1;
-            desc_writes[desc_count].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            desc_writes[desc_count].pBufferInfo = &di_input_desc_buffer_info;
-            desc_writes[desc_count].dstSet = desc_sets[0];
-            desc_count++;
-        }
-
-        if (buffer_device_address_enabled) {
-            bda_input_desc_buffer_info.range = app_bda_buffer_size;
-            bda_input_desc_buffer_info.buffer = app_buffer_device_addresses.buffer;
-            bda_input_desc_buffer_info.offset = 0;
-
-            desc_writes[desc_count] = vku::InitStructHelper();
-            desc_writes[desc_count].dstBinding = 2;
-            desc_writes[desc_count].descriptorCount = 1;
-            desc_writes[desc_count].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            desc_writes[desc_count].pBufferInfo = &bda_input_desc_buffer_info;
-            desc_writes[desc_count].dstSet = desc_sets[0];
-            desc_count++;
-        }
-
-        DispatchUpdateDescriptorSets(device, desc_count, desc_writes.data(), 0, NULL);
-    }
-
-    const auto pipeline_layout =
-        pipeline_state ? pipeline_state->PipelineLayoutState() : Get<PIPELINE_LAYOUT_STATE>(last_bound.pipeline_layout);
-    // If GPL is used, it's possible the pipeline layout used at pipeline creation time is null. If CmdBindDescriptorSets has
-    // not been called yet (i.e., state.pipeline_null), then fall back to the layout associated with pre-raster state.
-    // PipelineLayoutState should be used for the purposes of determining the number of sets in the layout, but this layout
-    // may be a "pseudo layout" used to represent the union of pre-raster and fragment shader layouts, and therefore have a
-    // null handle.
-    VkPipelineLayout pipeline_layout_handle = VK_NULL_HANDLE;
-    if (last_bound.pipeline_layout) {
-        pipeline_layout_handle = last_bound.pipeline_layout;
-    } else if (pipeline_state && !pipeline_state->PreRasterPipelineLayoutState()->Destroyed()) {
-        pipeline_layout_handle = pipeline_state->PreRasterPipelineLayoutState()->layout();
-    }
-    if ((pipeline_layout && pipeline_layout->set_layouts.size() <= desc_set_bind_index) &&
-        pipeline_layout_handle != VK_NULL_HANDLE) {
-        DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_layout_handle, desc_set_bind_index, 1, desc_sets.data(), 0,
-                                      nullptr);
-    } else {
-        // If no pipeline layout was bound when using shader objects that don't use any descriptor set, bind the debug pipeline
-        // layout
-        DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, debug_pipeline_layout, desc_set_bind_index, 1, desc_sets.data(), 0,
-                                      nullptr);
-    }
-
-    if (pipeline_state && pipeline_layout_handle == VK_NULL_HANDLE) {
-        ReportSetupProblem(device, "Unable to find pipeline layout to bind debug descriptor set. Aborting GPU-AV");
-        aborted = true;
-        vmaDestroyBuffer(vmaAllocator, output_block.buffer, output_block.allocation);
-    } else {
-        // It is possible to have no descriptor sets bound, for example if using push constants.
-        uint32_t di_buf_index =
-            cb_node->di_input_buffer_list.size() > 0 ? uint32_t(cb_node->di_input_buffer_list.size()) - 1 : vvl::kU32Max;
-        // Record buffer and memory info in CB state tracking
-        cb_node->per_draw_command_infos.emplace_back(output_block, draw_resources, dispatch_resources, trace_rays_resources,
-                                                     desc_sets[0], desc_pool, bind_point, uses_robustness, command, di_buf_index);
-    }
-}
-
-// Generate the part of the message describing the violation.
-bool gpuav::Validator::GenerateValidationMessage(const uint32_t *debug_record, const CommandInfo &cmd_info,
-                                                 const std::vector<DescSetState> &descriptor_sets, std::string &out_error_msg,
-                                                 std::string &out_vuid_msg, bool &out_oob_access) const {
-    using namespace spvtools;
-    using namespace glsl;
-    std::ostringstream strm;
-    bool return_code = true;
-    const GpuVuid vuid = GetGpuVuid(cmd_info.command);
-    out_oob_access = false;
-    switch (debug_record[kInstValidationOutError]) {
-        case kInstErrorBindlessBounds: {
-            strm << "(set = " << debug_record[kInstBindlessBoundsOutDescSet]
-                 << ", binding = " << debug_record[kInstBindlessBoundsOutDescBinding] << ") Index of "
-                 << debug_record[kInstBindlessBoundsOutDescIndex] << " used to index descriptor array of length "
-                 << debug_record[kInstBindlessBoundsOutDescBound] << ".";
-            out_vuid_msg = "UNASSIGNED-Descriptor index out of bounds";
-        } break;
-        case kInstErrorBindlessUninit: {
-            strm << "(set = " << debug_record[kInstBindlessUninitOutDescSet]
-                 << ", binding = " << debug_record[kInstBindlessUninitOutBinding] << ") Descriptor index "
-                 << debug_record[kInstBindlessUninitOutDescIndex] << " is uninitialized.";
-            out_vuid_msg = "UNASSIGNED-Descriptor uninitialized";
-        } break;
-        case kInstErrorBindlessDestroyed: {
-            strm << "(set = " << debug_record[kInstBindlessUninitOutDescSet]
-                 << ", binding = " << debug_record[kInstBindlessUninitOutBinding] << ") Descriptor index "
-                 << debug_record[kInstBindlessUninitOutDescIndex] << " references a resource that was destroyed.";
-            out_vuid_msg = "UNASSIGNED-Descriptor destroyed";
-        } break;
-        case kInstErrorBuffAddrUnallocRef: {
-            out_oob_access = true;
-            uint64_t *ptr = (uint64_t *)&debug_record[kInstBuffAddrUnallocOutDescPtrLo];
-            strm << "Device address 0x" << std::hex << *ptr << " access out of bounds. ";
-            out_vuid_msg = "UNASSIGNED-Device address out of bounds";
-        } break;
-        case kInstErrorOOB: {
-            const uint32_t set_num = debug_record[kInstBindlessBuffOOBOutDescSet];
-            const uint32_t binding_num = debug_record[kInstBindlessBuffOOBOutDescBinding];
-            const uint32_t desc_index = debug_record[kInstBindlessBuffOOBOutDescIndex];
-            const uint32_t size = debug_record[kInstBindlessBuffOOBOutBuffSize];
-            const uint32_t offset = debug_record[kInstBindlessBuffOOBOutBuffOff];
-            const auto *binding_state = descriptor_sets[set_num].state->GetBinding(binding_num);
-            assert(binding_state);
-            if (size == 0) {
-                strm << "(set = " << set_num << ", binding = " << binding_num << ") Descriptor index " << desc_index
-                     << " is uninitialized.";
-                out_vuid_msg = "UNASSIGNED-Descriptor uninitialized";
-                break;
-            }
-            out_oob_access = true;
-            auto desc_class = binding_state->descriptor_class;
-            if (desc_class == vvl::DescriptorClass::Mutable) {
-                desc_class = static_cast<const vvl::MutableBinding *>(binding_state)->descriptors[desc_index].ActiveClass();
-            }
-
-            switch (desc_class) {
-                case vvl::DescriptorClass::GeneralBuffer:
-                    strm << "(set = " << set_num << ", binding = " << binding_num << ") Descriptor index " << desc_index
-                         << " access out of bounds. Descriptor size is " << size << " and highest byte accessed was " << offset;
-                    if (binding_state->type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER ||
-                        binding_state->type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) {
-                        out_vuid_msg = vuid.uniform_access_oob;
-                    } else {
-                        out_vuid_msg = vuid.storage_access_oob;
-                    }
-                    break;
-                case vvl::DescriptorClass::TexelBuffer:
-                    strm << "(set = " << set_num << ", binding = " << binding_num << ") Descriptor index " << desc_index
-                         << " access out of bounds. Descriptor size is " << size << " texels and highest texel accessed was "
-                         << offset;
-                    if (binding_state->type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) {
-                        out_vuid_msg = vuid.uniform_access_oob;
-                    } else {
-                        out_vuid_msg = vuid.storage_access_oob;
-                    }
-                    break;
-                default:
-                    // other OOB checks are not implemented yet
-                    assert(false);
-            }
-        } break;
-        case kInstErrorPreDrawValidate: {
-            // Buffer size must be >= (stride * (drawCount - 1) + offset + sizeof(VkDrawIndexedIndirectCommand))
-            if (debug_record[kPreValidateSubError] == pre_draw_count_exceeds_bufsize_error) {
-                uint32_t count = debug_record[kPreValidateSubError + 1];
-                uint32_t stride = cmd_info.draw_resources.indirect_buffer_stride;
-                uint32_t offset = static_cast<uint32_t>(cmd_info.draw_resources.indirect_buffer_offset);
-                uint32_t draw_size = (stride * (count - 1) + offset + sizeof(VkDrawIndexedIndirectCommand));
-                strm << "Indirect draw count of " << count << " would exceed buffer size "
-                     << cmd_info.draw_resources.indirect_buffer_size << " of buffer " << cmd_info.draw_resources.indirect_buffer
-                     << " stride = " << stride << " offset = " << offset
-                     << " (stride * (drawCount - 1) + offset + sizeof(VkDrawIndexedIndirectCommand)) = " << draw_size;
-                if (count == 1) {
-                    out_vuid_msg = vuid.count_exceeds_bufsize_1;
-                } else {
-                    out_vuid_msg = vuid.count_exceeds_bufsize;
-                }
-            } else if (debug_record[kPreValidateSubError] == pre_draw_count_exceeds_limit_error) {
-                uint32_t count = debug_record[kPreValidateSubError + 1];
-                strm << "Indirect draw count of " << count << " would exceed maxDrawIndirectCount limit of "
-                     << phys_dev_props.limits.maxDrawIndirectCount;
-                out_vuid_msg = vuid.count_exceeds_device_limit;
-            } else if (debug_record[kPreValidateSubError] == pre_draw_first_instance_error) {
-                uint32_t index = debug_record[kPreValidateSubError + 1];
-                strm << "The drawIndirectFirstInstance feature is not enabled, but the firstInstance member of the "
-                     << ((cmd_info.command == vvl::Func::vkCmdDrawIndirect) ? "VkDrawIndirectCommand"
-                                                                            : "VkDrawIndexedIndirectCommand")
-                     << " structure at index " << index << " is not zero";
-                out_vuid_msg = vuid.first_instance_not_zero;
-            }
-            return_code = false;
-        } break;
-        case kInstErrorPreDispatchValidate: {
-            if (debug_record[kPreValidateSubError] == pre_dispatch_count_exceeds_limit_x_error) {
-                uint32_t count = debug_record[kPreValidateSubError + 1];
-                strm << "Indirect dispatch VkDispatchIndirectCommand::x of " << count
-                     << " would exceed maxComputeWorkGroupCount[0] limit of " << phys_dev_props.limits.maxComputeWorkGroupCount[0];
-                out_vuid_msg = vuid.group_exceeds_device_limit_x;
-            } else if (debug_record[kPreValidateSubError] == pre_dispatch_count_exceeds_limit_y_error) {
-                uint32_t count = debug_record[kPreValidateSubError + 1];
-                strm << "Indirect dispatch VkDispatchIndirectCommand:y of " << count
-                     << " would exceed maxComputeWorkGroupCount[1] limit of " << phys_dev_props.limits.maxComputeWorkGroupCount[1];
-                out_vuid_msg = vuid.group_exceeds_device_limit_y;
-            } else if (debug_record[kPreValidateSubError] == pre_dispatch_count_exceeds_limit_z_error) {
-                uint32_t count = debug_record[kPreValidateSubError + 1];
-                strm << "Indirect dispatch VkDispatchIndirectCommand::z of " << count
-                     << " would exceed maxComputeWorkGroupCount[2] limit of " << phys_dev_props.limits.maxComputeWorkGroupCount[2];
-                out_vuid_msg = vuid.group_exceeds_device_limit_z;
-            }
-            return_code = false;
-        } break;
-
-        case kInstErrorPreTraceRaysKhrValidate: {
-            if (debug_record[kPreValidateSubError] == pre_trace_rays_query_dimensions_exceeds_width_limit) {
-                uint32_t width = debug_record[kPreValidateSubError + 1];
-                strm << "Indirect trace rays of VkTraceRaysIndirectCommandKHR::width of " << width
-                     << " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[0] * "
-                        "VkPhysicalDeviceLimits::maxComputeWorkGroupSize[0] limit of "
-                     << static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[0]) *
-                            static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[0]);
-                out_vuid_msg = vuid.trace_rays_width_exceeds_device_limit;
-            } else if (debug_record[kPreValidateSubError] == pre_trace_rays_query_dimensions_exceeds_height_limit) {
-                uint32_t height = debug_record[kPreValidateSubError + 1];
-                strm << "Indirect trace rays of VkTraceRaysIndirectCommandKHR::height of " << height
-                     << " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[1] * "
-                        "VkPhysicalDeviceLimits::maxComputeWorkGroupSize[1] limit of "
-                     << static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[1]) *
-                            static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[1]);
-                out_vuid_msg = vuid.trace_rays_height_exceeds_device_limit;
-            } else if (debug_record[kPreValidateSubError] == pre_trace_rays_query_dimensions_exceeds_depth_limit) {
-                uint32_t depth = debug_record[kPreValidateSubError + 1];
-                strm << "Indirect trace rays of VkTraceRaysIndirectCommandKHR::depth of " << depth
-                     << " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[2] * "
-                        "VkPhysicalDeviceLimits::maxComputeWorkGroupSize[2] limit of "
-                     << static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[2]) *
-                            static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[2]);
-                out_vuid_msg = vuid.trace_rays_depth_exceeds_device_limit;
-            }
-            return_code = false;
-        } break;
-        default: {
-            strm << "Internal Error (unexpected error type = " << debug_record[kInstValidationOutError] << "). ";
-            out_vuid_msg = "UNASSIGNED-Internal Error";
-            assert(false);
-        } break;
-    }
-    out_error_msg = strm.str();
-    return return_code;
-}
-
-// Pull together all the information from the debug record to build the error message strings,
-// and then assemble them into a single message string.
-// Retrieve the shader program referenced by the unique shader ID provided in the debug record.
-// We had to keep a copy of the shader program with the same lifecycle as the pipeline to make
-// sure it is available when the pipeline is submitted.  (The ShaderModule tracking object also
-// keeps a copy, but it can be destroyed after the pipeline is created and before it is submitted.)
-//
-void gpuav::Validator::AnalyzeAndGenerateMessages(CommandBuffer &command_buffer, VkQueue queue, CommandInfo &cmd_info,
-                                                  uint32_t operation_index, uint32_t *const debug_output_buffer,
-                                                  const std::vector<DescSetState> &descriptor_sets, const Location &loc) {
-    const uint32_t total_words = debug_output_buffer[spvtools::kDebugOutputSizeOffset];
-    bool oob_access;
-    // A zero here means that the shader instrumentation didn't write anything.
-    // If you have nothing to say, don't say it here.
-    if (0 == total_words) {
-        return;
-    }
-    // The second word in the debug output buffer is the number of words that would have
-    // been written by the shader instrumentation, if there was enough room in the buffer we provided.
-    // The number of words actually written by the shaders is determined by the size of the buffer
-    // we provide via the descriptor.  So, we process only the number of words that can fit in the
-    // buffer.
-    // Each "report" written by the shader instrumentation is considered a "record".  This function
-    // is hard-coded to process only one record because it expects the buffer to be large enough to
-    // hold only one record.  If there is a desire to process more than one record, this function needs
-    // to be modified to loop over records and the buffer size increased.
-    std::string error_msg;
-    std::string stage_message;
-    std::string common_message;
-    std::string filename_message;
-    std::string source_message;
-    std::string vuid_msg;
-    VkShaderModule shader_module_handle = VK_NULL_HANDLE;
-    VkPipeline pipeline_handle = VK_NULL_HANDLE;
-    VkShaderEXT shader_object_handle = VK_NULL_HANDLE;
-    vvl::span<const uint32_t> pgm;
-    // The first record starts at this offset after the total_words.
-    const uint32_t *debug_record = &debug_output_buffer[spvtools::kDebugOutputDataOffset];
-    // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
-    // by the instrumented shader.
-    auto it = shader_map.find(debug_record[glsl::kInstCommonOutShaderId]);
-    if (it != shader_map.end()) {
-        shader_module_handle = it->second.shader_module;
-        pipeline_handle = it->second.pipeline;
-        shader_object_handle = it->second.shader_object;
-        pgm = it->second.pgm;
-    }
-    const bool gen_full_message =
-        GenerateValidationMessage(debug_record, cmd_info, descriptor_sets, error_msg, vuid_msg, oob_access);
-    if (gen_full_message) {
-        UtilGenerateStageMessage(debug_record, stage_message);
-        UtilGenerateCommonMessage(report_data, command_buffer.commandBuffer(), debug_record, shader_module_handle, pipeline_handle,
-                                  shader_object_handle, cmd_info.pipeline_bind_point, operation_index, common_message);
-        UtilGenerateSourceMessages(pgm, debug_record, false, filename_message, source_message);
-        if (cmd_info.uses_robustness && oob_access) {
-            if (gpuav_settings.warn_on_robust_oob) {
-                LogWarning(vuid_msg.c_str(), queue, loc, "%s %s %s %s%s", error_msg.c_str(), common_message.c_str(),
-                           stage_message.c_str(), filename_message.c_str(), source_message.c_str());
-            }
-        } else {
-            LogError(vuid_msg.c_str(), queue, loc, "%s %s %s %s%s", error_msg.c_str(), common_message.c_str(),
-                     stage_message.c_str(), filename_message.c_str(), source_message.c_str());
-        }
-    } else {
-        LogError(vuid_msg.c_str(), queue, loc, "%s", error_msg.c_str());
-    }
-
-    // Clear the written size and any error messages. Note that this preserves the first word, which contains flags.
-    const uint32_t words_to_clear = std::min(total_words, output_buffer_size - spvtools::kDebugOutputDataOffset);
-    debug_output_buffer[spvtools::kDebugOutputSizeOffset] = 0;
-    memset(&debug_output_buffer[spvtools::kDebugOutputDataOffset], 0, sizeof(uint32_t) * words_to_clear);
+    cb_node->per_command_resources.emplace_back(std::move(command_resources));
 }


### PR DESCRIPTION
Adding validation for a command that needs to track the lifetime of its specific validation resources is a bit painful, as you need to update "Uber" functions, and classes, mainly `AllocateValidationResources`, `GenerateValidationMessage`, and the `gpuav::CommandBuffer` class. 
This design does not scale well, this PR is the starting point I propose for an improved organisation. 
One of the root problem is how `AllocateValidationResources` is used. Every recorded command that needs to allocate validation resources and need them to survive until an eventual error message is generated uses `AllocateValidationResources`.
But not all of them want the same thing, right now this is handled with a big `if` block that allocates some resources or not depending on the command being validated. If you want to add your own stuff for some new command, you have to update that block, 
update the `CommandInfo` class with your new struct, think about making sure destruction of this struct is handled correctly, etc...

The new flow I propose starts in "record" calls. Most of them do not need specific resources, and just look like what they use to:
```cpp
void gpuav::Validator::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                                            uint32_t firstVertex, uint32_t firstInstance, const RecordObject &record_obj) {
    BaseClass::PreCallRecordCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, record_obj);

    CommandResources cmd_resources =
        AllocateCommandResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location.function);
    auto cmd_resources_ptr = std::make_unique<CommandResources>(cmd_resources);
    StoreCommandResources(commandBuffer, std::move(cmd_resources_ptr));
}
```

Some functions like `CmdDrawIndirect` need specific resources, and the record call looks like this now:

```cpp
void gpuav::Validator::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                    uint32_t count, uint32_t stride, const RecordObject &record_obj) {
    BaseClass::PreCallRecordCmdDrawIndirect(commandBuffer, buffer, offset, count, stride, record_obj);

    CommandResources cmd_resources =
        AllocateCommandResources(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location.function);
    if (!gpuav_settings.validate_indirect_buffer) {// no need to allocate specific resources 
        auto cmd_resources_ptr = std::make_unique<CommandResources>(cmd_resources);
        StoreCommandResources(commandBuffer, std::move(cmd_resources_ptr));
        return;
    }
    auto draw_resources = AllocatePreDrawIndirectValidationResources(record_obj.location.function, commandBuffer, cmd_resources,
                                                                     buffer, offset, count, VK_NULL_HANDLE, 0, stride);
    StoreCommandResources(commandBuffer, std::move(draw_resources));
}
```

So the `if command is draw indirect then allocate those validation resources` logic that used to live in `AllocateValidationResources` is now sort of baked in the correct record command.

I added a base `CommandResources` class that stores the resources every command needs, like the error output buffer, and new classes (right now`PreDrawResources`, `PreDispatchResources` and `PreTraceRaysResources`) that also need specific stuff just inherit from this class. The objects instanced from those classes are stored as pointers to this `CommandResources` class and virtual `Destroy` calls are done when cleaning resources, no need to update some random functions by hand. You just need to provide a `Destroy` function.

Class inheriting from `CommandResources` will also typically define a new error logging function, that again gets called "automatically" with a virtual call, helping to reduce reliance on Uber `GenerateValidationMessage`. 

The `AnalyzeAndGenerateMessages` and `GenerateValidationMessage` are still there, I trimmed them down a bit, but I think we need to go further. 
Error messages need to be updated to, the way they are created seems clunky and out of date when compared to how we do things in Core validation.

Again I see those changes as a starting point, a basis for a "how the validation flow in GPU-AV could be improved" discussion

**PR review note**: I tried to keep changes separated with different commits, progressively moving command validation away from the current flow, but over time rebasing become to tedious and the first commits are not clean, some classes things have been renamed in the final commit. They still have value for review purposes, but I will squash the commits together before merging anything.