### PR TITLE
cmake: Remove VVL_CLANG_TIDY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,15 +116,6 @@ if (VVL_ENABLE_ASAN)
     endif()
 endif()
 
-option(VVL_CLANG_TIDY "Use clang-tidy")
-if (VVL_CLANG_TIDY)
-    find_program(CLANG_TIDY NAMES clang-tidy)
-    if(NOT CLANG_TIDY)
-        message(FATAL_ERROR "clang-tidy not found!")
-    endif()
-    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY}")
-endif()
-
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
     add_compile_options(
         -Wall


### PR DESCRIPTION
Isn't used in CI, no plans to work on this at the moment.