### PR TITLE
layers: Check resolve attachment usage before access

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1017,8 +1017,10 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                         if (subpass_desc->pResolveAttachments) {
                             const uint32_t resolve_attachment =
                                 subpass_desc->pResolveAttachments[clear_desc->colorAttachment].attachment;
-                            external_format_resolve =
-                                GetExternalFormat(renderpass_create_info->pAttachments[resolve_attachment].pNext) != 0;
+                            if (resolve_attachment != VK_ATTACHMENT_UNUSED) {
+                                external_format_resolve =
+                                    GetExternalFormat(renderpass_create_info->pAttachments[resolve_attachment].pNext) != 0;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixes crash seen in CTS tests in:
dEQP-VK.pipeline.monolithic.multisample.multisampled_render_to_single_sampled.clear_attachments.*

Somewhat related to the PR, it would be nice if I didn't have to break the CTS test name for the commit description into multiple lines.