### PR TITLE
tests: Fix some more test case dependency issues

### DIFF
--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -4974,6 +4974,7 @@ TEST_F(NegativeDescriptors, InvalidImageInfoDescriptorType) {
     TEST_DESCRIPTION("Try to copy a descriptor set where the src and dst have different update after bind flags.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_IMAGE_2D_VIEW_OF_3D_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDevicePortabilitySubsetFeaturesKHR portability_subset_features = vku::InitStructHelper();

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -5084,6 +5084,7 @@ TEST_F(NegativeImage, ImageViewMinLod) {
 
 TEST_F(NegativeImage, ImageViewMinLodFeature) {
     TEST_DESCRIPTION("Checks for image view minimum level of detail feature enabled.");
+    AddRequiredExtensions(VK_EXT_IMAGE_VIEW_MIN_LOD_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     VkImageObj image(m_device);
     // Initialize image with transfer source usage

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -2270,13 +2270,13 @@ TEST_F(VkLayerTest, InvalidCombinationOfDeviceFeatures) {
     device_create_info.queueCreateInfoCount = queue_info.size();
     device_create_info.pQueueCreateInfos = queue_info.data();
 
-    {
+    if (DeviceExtensionSupported(VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME)) {
         VkDevice testDevice;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDeviceCreateInfo-None-04896");
         vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
         m_errorMonitor->VerifyFound();
     }
-    {
+    if (DeviceExtensionSupported(VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME)) {
         pd_features2.pNext = &shader_atomic_float_feature;
 
         VkDevice testDevice;
@@ -2285,7 +2285,7 @@ TEST_F(VkLayerTest, InvalidCombinationOfDeviceFeatures) {
         vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
         m_errorMonitor->VerifyFound();
     }
-    {
+    if (DeviceExtensionSupported(VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME)) {
         pd_features2.pNext = &shader_atomic_float_feature2;
 
         VkDevice testDevice;

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -1440,6 +1440,7 @@ TEST_F(NegativeSampler, NonSeamlessCubeMapNotEnabled) {
 TEST_F(NegativeSampler, BorderColorSwizzle) {
     TEST_DESCRIPTION("Validate vkCreateSampler with VkSamplerBorderColorComponentMappingCreateInfoEXT");
 
+    AddRequiredExtensions(VK_EXT_BORDER_COLOR_SWIZZLE_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     RETURN_IF_SKIP(InitState());
 

--- a/tests/unit/shader_storage_image_positive.cpp
+++ b/tests/unit/shader_storage_image_positive.cpp
@@ -100,6 +100,7 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteMoreComponent) {
     TEST_DESCRIPTION("Test writing to image with less components for Unknown for OpTypeImage.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     if (m_device->phy().features().shaderStorageImageExtendedFormats == VK_FALSE) {
         GTEST_SKIP() << "shaderStorageImageExtendedFormats feature is not supported";

--- a/tests/unit/viewport_inheritance.cpp
+++ b/tests/unit/viewport_inheritance.cpp
@@ -402,7 +402,7 @@ class ViewportInheritanceTestData {
 
 TEST_F(NegativeViewportInheritance, BasicUsage) {
     TEST_DESCRIPTION("Simple correct and incorrect usage of VK_NV_inherited_viewport_scissor");
-    m_instance_extension_names.push_back("VK_KHR_get_physical_device_properties2");
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     bool has_features = false;
     const char* missing_feature_string = nullptr;
@@ -636,7 +636,7 @@ TEST_F(NegativeViewportInheritance, BasicUsage) {
 
 TEST_F(NegativeViewportInheritance, MissingFeature) {
     TEST_DESCRIPTION("Error using VK_NV_inherited_viewport_scissor without enabling feature.");
-    m_instance_extension_names.push_back("VK_KHR_get_physical_device_properties2");
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     bool has_features = false;
     const char* missing_feature_string = nullptr;
@@ -663,7 +663,7 @@ TEST_F(NegativeViewportInheritance, MissingFeature) {
 
 TEST_F(NegativeViewportInheritance, MultiViewport) {
     TEST_DESCRIPTION("VK_NV_inherited_viewport_scissor tests with multiple viewports/scissors");
-    m_instance_extension_names.push_back("VK_KHR_get_physical_device_properties2");
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     bool has_features = false;
     const char* missing_feature_string = nullptr;
@@ -893,7 +893,7 @@ TEST_F(NegativeViewportInheritance, MultiViewport) {
 
 TEST_F(NegativeViewportInheritance, ScissorMissingFeature) {
     TEST_DESCRIPTION("Error using VK_NV_inherited_viewport_scissor without enabling multiViewport feature.");
-    m_instance_extension_names.push_back("VK_KHR_get_physical_device_properties2");
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     bool has_features = false;
     const char* missing_feature_string = nullptr;


### PR DESCRIPTION
I found some more test cases that had broken dependency code in my temporary change for the Vulkan SC Validation Layers.