### PR TITLE
scripts: Robustness improvements and cleanup

### DIFF
--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -60,12 +60,12 @@ bool wrap_handles = true;
 #include "chassis_dispatch_helper.h"
 
 // Extension exposed by the validation layer
-static constexpr std::array kInstanceExtensions = {
+static constexpr std::array<VkExtensionProperties, 3> kInstanceExtensions = {
     VkExtensionProperties{VK_EXT_DEBUG_REPORT_EXTENSION_NAME, VK_EXT_DEBUG_REPORT_SPEC_VERSION},
     VkExtensionProperties{VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_UTILS_SPEC_VERSION},
     VkExtensionProperties{VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME, VK_EXT_VALIDATION_FEATURES_SPEC_VERSION},
 };
-static constexpr std::array kDeviceExtensions = {
+static constexpr std::array<VkExtensionProperties, 3> kDeviceExtensions = {
     VkExtensionProperties{VK_EXT_VALIDATION_CACHE_EXTENSION_NAME, VK_EXT_VALIDATION_CACHE_SPEC_VERSION},
     VkExtensionProperties{VK_EXT_DEBUG_MARKER_EXTENSION_NAME, VK_EXT_DEBUG_MARKER_SPEC_VERSION},
     VkExtensionProperties{VK_EXT_TOOLING_INFO_EXTENSION_NAME, VK_EXT_TOOLING_INFO_SPEC_VERSION},

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -808,12 +808,16 @@ class LayerChassisOutputGenerator(BaseGenerator):
         out.append('\n')
 
         out.append('// Extension exposed by the validation layer\n')
-        out.append('static constexpr std::array kInstanceExtensions = {\n')
-        for ext in [x.upper() for x in APISpecific.getInstanceExtensionList(self.targetApiName)]:
+
+        instance_exts = APISpecific.getInstanceExtensionList(self.targetApiName)
+        out.append(f'static constexpr std::array<VkExtensionProperties, {len(instance_exts)}> kInstanceExtensions = {{\n')
+        for ext in [x.upper() for x in instance_exts]:
             out.append(f'    VkExtensionProperties{{{ext}_EXTENSION_NAME, {ext}_SPEC_VERSION}},\n')
         out.append('};\n')
-        out.append('static constexpr std::array kDeviceExtensions = {\n')
-        for ext in [x.upper() for x in APISpecific.getDeviceExtensionList(self.targetApiName)]:
+
+        device_exts = APISpecific.getDeviceExtensionList(self.targetApiName)
+        out.append(f'static constexpr std::array<VkExtensionProperties, {len(device_exts)}> kDeviceExtensions = {{\n')
+        for ext in [x.upper() for x in device_exts]:
             out.append(f'    VkExtensionProperties{{{ext}_EXTENSION_NAME, {ext}_SPEC_VERSION}},\n')
         out.append('};\n')
 

--- a/scripts/generators/object_tracker_generator.py
+++ b/scripts/generators/object_tracker_generator.py
@@ -30,21 +30,6 @@ from generators.base_generator import BaseGenerator
 # interfaces or their use in the generator script will have downstream effects and thus
 # should be avoided unless absolutely necessary.
 class APISpecific:
-    # Returns VUIDs to report when detecting undestroyed objects
-    @staticmethod
-    def getUndestroyedObjectVUID(targetApiName: str, scope: str) -> str:
-        match targetApiName:
-
-            # Vulkan specific undestroyed object VUIDs
-            case 'vulkan':
-                per_scope = {
-                    'instance': 'VUID-vkDestroyInstance-instance-00629',
-                    'device': 'VUID-vkDestroyDevice-device-05137'
-                }
-
-        return per_scope[scope]
-
-
     # Tells whether an object handle type is implicitly destroyed because it does not have
     # destroy APIs or its parent object type does not have destroy APIs
     @staticmethod
@@ -418,8 +403,8 @@ WriteLockGuard ObjectLifetimes::WriteLock() { return WriteLockGuard(validation_o
 // ObjectTracker undestroyed objects validation function
 bool ObjectLifetimes::ReportUndestroyedInstanceObjects(VkInstance instance, const Location& loc) const {
     bool skip = false;
-    const std::string error_code = "%s";
-''' % APISpecific.getUndestroyedObjectVUID(self.targetApiName, 'instance'))
+    const std::string error_code = "VUID-vkDestroyInstance-instance-00629";
+''')
         for handle in [x for x in self.vk.handles.values() if not x.dispatchable and not self.isParentDevice(x)]:
             comment_prefix = ''
             if APISpecific.IsImplicitlyDestroyed(self.targetApiName, handle.name):
@@ -431,8 +416,8 @@ bool ObjectLifetimes::ReportUndestroyedInstanceObjects(VkInstance instance, cons
         out.append('''
 bool ObjectLifetimes::ReportUndestroyedDeviceObjects(VkDevice device, const Location& loc) const {
     bool skip = false;
-    const std::string error_code = "%s";
-''' % APISpecific.getUndestroyedObjectVUID(self.targetApiName, 'device'))
+    const std::string error_code = "VUID-vkDestroyDevice-device-05137";
+''')
 
         comment_prefix = ''
         if APISpecific.IsImplicitlyDestroyed(self.targetApiName, 'VkCommandBuffer'):


### PR DESCRIPTION
This changes the following:

  * Makes it possible for the validation layers to expose zero instance and/or device extensions (changes in `layer_chassis_generator.py`)
  * Removes the need for API-specific undestroyed object VUIDs thanks to ifdef'd VUID support and related cleanup