### PR TITLE
syncval: Correct hazard report for submit and exec

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -127,10 +127,10 @@ std::string CommandBufferAccessContext::FormatUsage(const ResourceUsageTag tag) 
     return out.str();
 }
 
-std::string CommandBufferAccessContext::FormatUsage(const ResourceFirstAccess &access) const {
+std::string CommandBufferAccessContext::FormatUsage(const char *usage_string, const ResourceFirstAccess &access) const {
     std::stringstream out;
     assert(access.usage_info);
-    out << "(recorded_usage: " << access.usage_info->name;
+    out << "(" << usage_string << ": " << access.usage_info->name;
     out << ", " << FormatUsage(access.tag) << ")";
     return out.str();
 }
@@ -1040,13 +1040,13 @@ std::ostream &operator<<(std::ostream &out, const ResourceUsageRecord::Formatter
         out << record.alt_usage.Formatter(formatter.sync_state);
     } else {
         out << "command: " << vvl::String(record.command);
-        out << ", seq_no: " << record.seq_num;
-        if (record.sub_command != 0) {
-            out << ", subcmd: " << record.sub_command;
-        }
         // Note: ex_cb_state set to null forces output of record.cb_state
         if (!formatter.ex_cb_state || (formatter.ex_cb_state != record.cb_state)) {
             out << ", " << SyncNodeFormatter(formatter.sync_state, record.cb_state);
+        }
+        out << ", seq_no: " << record.seq_num;
+        if (record.sub_command != 0) {
+            out << ", subcmd: " << record.sub_command;
         }
         for (const auto &named_handle : record.handles) {
             out << "," << named_handle.Formatter(formatter.sync_state);

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1218,11 +1218,12 @@ bool ReplayState::DetectFirstUseHazard(const ResourceUsageRange &first_use_range
             const SyncValidator &sync_state = exec_context_.GetSyncState();
             const auto handle = exec_context_.Handle();
             const auto recorded_handle = recorded_context_.GetCBState().commandBuffer();
-            skip = sync_state.LogError(string_SyncHazardVUID(hazard.Hazard()), handle, error_obj_.location,
-                                       "Hazard %s for entry %" PRIu32 ", %s, Recorded access info %s. Access info %s.",
-                                       string_SyncHazard(hazard.Hazard()), index_, sync_state.FormatHandle(recorded_handle).c_str(),
-                                       recorded_context_.FormatUsage(*hazard.RecordedAccess()).c_str(),
-                                       recorded_context_.FormatHazard(hazard).c_str());
+            skip = sync_state.LogError(
+                string_SyncHazardVUID(hazard.Hazard()), handle, error_obj_.location,
+                "Hazard %s for entry %" PRIu32 ", %s, %s access info %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
+                index_, sync_state.FormatHandle(recorded_handle).c_str(), exec_context_.ExecutionTypeString(),
+                recorded_context_.FormatUsage(exec_context_.ExecutionUsageString(), *hazard.RecordedAccess()).c_str(),
+                exec_context_.FormatHazard(hazard).c_str());
         }
     }
     return skip;

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -254,6 +254,7 @@ class QueueBatchContext : public CommandExecutionContext {
     const SyncEventsContext *GetCurrentEventsContext() const override { return &events_context_; }
     VkQueueFlags GetQueueFlags() const;
     QueueId GetQueueId() const override;
+    ExecutionType Type() const override { return kSubmitted; }
 
     void SetupBatchTags(const ResourceUsageRange &tag_range);
     void SetupBatchTags();


### PR DESCRIPTION
Correct and clarify hazard messages at exec and submit command buffer time.