### PR TITLE
tests: Remove usage of unused glslang libraries

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -95,7 +95,7 @@
             "sub_dir": "glslang",
             "build_dir": "glslang/build",
             "install_dir": "glslang/build/install",
-            "commit": "845e5d5a28561a25f85d23ef779c828e535bd56f",
+            "commit": "719b6b7debbfe75bd427daa0e39c347fce16cf9a",
             "cmake_options": [
                 "-DENABLE_OPT=OFF"
             ],

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -223,12 +223,6 @@ find_package(glslang CONFIG)
 
 target_link_libraries(vk_layer_validation_tests PRIVATE
     VkLayer_utils
-    glslang::glslang
-    glslang::OGLCompiler
-    glslang::OSDependent
-    glslang::MachineIndependent
-    glslang::GenericCodeGen
-    glslang::HLSL
     glslang::SPIRV
     glslang::SPVRemapper
     SPIRV-Headers::SPIRV-Headers


### PR DESCRIPTION
KhronosGroup/glslang/pull/3426 removed the OGLCompiler and HLSL stub libraries.

Furthermore there was no reason for us to link OSDependent, MachineIndependent, GenericCodeGen, and glslang.