### PR TITLE
android: Update SPIRV-Tools

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -369,6 +369,9 @@ if (ANDROID)
     # Required for __android_log_print. Marking as PUBLIC since the tests use __android_log_print as well.
     target_link_libraries(VkLayer_utils PUBLIC log)
 
+    # Required for AHardwareBuffer_describe. Marking as PUBLIC since the tests use AHardwareBuffer_describe as well.
+    target_link_libraries(VkLayer_utils PUBLIC android)
+
     install(TARGETS vvl DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
     return()

--- a/layers/vulkan/generated/spirv_tools_commit_id.h
+++ b/layers/vulkan/generated/spirv_tools_commit_id.h
@@ -23,4 +23,4 @@
 
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "360d469b9eac54d6c6e20f609f9ec35e3a5380ad"
+#define SPIRV_TOOLS_COMMIT_ID "f4a73dd7a0cadfa9a9ea384b609e0e6a2cb71f5b"

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -43,7 +43,7 @@
                 "-DSPIRV_SKIP_TESTS=ON",
                 "-DSPIRV_SKIP_EXECUTABLES=ON"
             ],
-            "commit": "360d469b9eac54d6c6e20f609f9ec35e3a5380ad"
+            "commit": "f4a73dd7a0cadfa9a9ea384b609e0e6a2cb71f5b"
         },
         {
             "name": "robin-hood-hashing",


### PR DESCRIPTION
SPIRV-Tools no longer links against android libraries it doesn't use. See https://github.com/KhronosGroup/SPIRV-Tools/pull/5482

Now VVL must explicitly link against `android`