### PR TITLE
scripts: Limit installation time precision to 3 decimal places

### DIFF
--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -556,7 +556,7 @@ class GoodRepo(object):
 
         total_time = time.time() - start
 
-        print(f"Installed {self.name} ({self.commit}) in {total_time} seconds", flush=True)
+        print(f"Installed {self.name} ({self.commit}) in {total_time:.3f} seconds", flush=True)
 
     def IsOptional(self, opts):
         return len(self.optional.intersection(opts)) > 0


### PR DESCRIPTION
Full floating point precision is not very practical for installation times and adds some noise to the output (in the scenarios when nanosecond precision is needed ints are preferable because that's how it is reported by the hardware, e.g. rdtsc).

Having the number of digits after decimal point multiple of 3 has a benefit of representing standard sub-second units like milliseconds, microseconds, nanoseconds. 3 digits can be read directly as milliseconds. For installation tasks (and build tasks in general) this should be enough.

Old output: Installed Vulkan-Headers (v1.3.271) in 2.8966236114501953 seconds

New output: Installed Vulkan-Headers (v1.3.271) in 2.663 seconds

In the new version it's 2 seconds and 663 milliseconds which is nice to read.