### PR TITLE
tests: Replace targetView with CreateView (part 1)

### DIFF
--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -336,7 +336,15 @@ class VkImageObj : public vkt::Image {
         if (!m_targetView.initialized()) {
             ci.image = handle();
             m_targetView.init(*m_device, ci);
+            m_createInfo = ci;
         }
+        assert(m_createInfo.viewType == ci.viewType);
+        assert(m_createInfo.format == ci.format);
+        assert(m_createInfo.subresourceRange.aspectMask == ci.subresourceRange.aspectMask);
+        assert(m_createInfo.subresourceRange.baseMipLevel == ci.subresourceRange.baseMipLevel);
+        assert(m_createInfo.subresourceRange.levelCount == ci.subresourceRange.levelCount);
+        assert(m_createInfo.subresourceRange.baseArrayLayer == ci.subresourceRange.baseArrayLayer);
+        assert(m_createInfo.subresourceRange.layerCount == ci.subresourceRange.layerCount);
         return m_targetView.handle();
     }
 
@@ -355,7 +363,15 @@ class VkImageObj : public vkt::Image {
             createView.subresourceRange = {aspect, baseMipLevel, levelCount, baseArrayLayer, layerCount};
             createView.flags = 0;
             m_targetView.init(*m_device, createView);
+            m_createInfo = createView;
         }
+        assert(m_createInfo.viewType == type);
+        assert(m_createInfo.format == format);
+        assert(m_createInfo.subresourceRange.aspectMask == aspect);
+        assert(m_createInfo.subresourceRange.baseMipLevel == baseMipLevel);
+        assert(m_createInfo.subresourceRange.levelCount == levelCount);
+        assert(m_createInfo.subresourceRange.baseArrayLayer == baseArrayLayer);
+        assert(m_createInfo.subresourceRange.layerCount == layerCount);
         return m_targetView.handle();
     }
 
@@ -372,6 +388,8 @@ class VkImageObj : public vkt::Image {
     vkt::Device *m_device;
 
     vkt::ImageView m_targetView;
+    VkImageViewCreateInfo m_createInfo;  // To validate that cached view matches requested parameters
+
     VkDescriptorImageInfo m_descriptorImageInfo;
     uint32_t m_mipLevels;
     uint32_t m_arrayLayers;

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -332,20 +332,9 @@ class VkImageObj : public vkt::Image {
         return ci;
     }
 
-    const VkImageView &targetView(VkImageViewCreateInfo ci) {
-        if (!m_targetView.initialized()) {
-            ci.image = handle();
-            m_targetView.init(*m_device, ci);
-            m_createInfo = ci;
-        }
-        assert(m_createInfo.viewType == ci.viewType);
-        assert(m_createInfo.format == ci.format);
-        assert(m_createInfo.subresourceRange.aspectMask == ci.subresourceRange.aspectMask);
-        assert(m_createInfo.subresourceRange.baseMipLevel == ci.subresourceRange.baseMipLevel);
-        assert(m_createInfo.subresourceRange.levelCount == ci.subresourceRange.levelCount);
-        assert(m_createInfo.subresourceRange.baseArrayLayer == ci.subresourceRange.baseArrayLayer);
-        assert(m_createInfo.subresourceRange.layerCount == ci.subresourceRange.layerCount);
-        return m_targetView.handle();
+    vkt::ImageView CreateView(VkImageViewCreateInfo ci) const {
+        ci.image = handle();
+        return vkt::ImageView(*m_device, ci);
     }
 
     const VkImageView &targetView(VkFormat format, VkImageAspectFlags aspect = VK_IMAGE_ASPECT_COLOR_BIT, uint32_t baseMipLevel = 0,

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -465,10 +465,11 @@ TEST_F(NegativeAndroidExternalResolve, Framebuffer) {
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view = resolve_image.CreateView(ivci);
 
     VkImageView attachments[2];
     attachments[0] = color_image.targetView(format_resolve_prop.colorAttachmentFormat);
-    attachments[1] = resolve_image.targetView(ivci);
+    attachments[1] = resolve_view.handle();
 
     VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
     fb_ci.width = 32;
@@ -578,10 +579,11 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebuffer) {
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view = resolve_image.CreateView(ivci);
 
     VkImageView attachments[2];
     attachments[0] = color_image.targetView(format_resolve_prop.colorAttachmentFormat);
-    attachments[1] = resolve_image.targetView(ivci);
+    attachments[1] = resolve_view.handle();
 
     VkFramebufferAttachmentImageInfo framebuffer_attachment_image_info[2];
     framebuffer_attachment_image_info[0] = vku::InitStructHelper();
@@ -688,12 +690,13 @@ TEST_F(NegativeAndroidExternalResolve, DynamicRendering) {
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view = resolve_image.CreateView(ivci);
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageView = color_image.targetView(format_resolve_prop.colorAttachmentFormat);
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
-    color_attachment.resolveImageView = resolve_image.targetView(ivci);
+    color_attachment.resolveImageView = resolve_view.handle();
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingAttachmentInfoKHR ds_attachment = vku::InitStructHelper();
@@ -788,6 +791,7 @@ TEST_F(NegativeAndroidExternalResolve, DynamicRenderingResolveModeNonNullColor) 
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view = resolve_image.CreateView(ivci);
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageView = color_image.targetView(format_resolve_prop.colorAttachmentFormat);
@@ -803,7 +807,7 @@ TEST_F(NegativeAndroidExternalResolve, DynamicRenderingResolveModeNonNullColor) 
 
     m_commandBuffer->begin();
 
-    color_attachment.resolveImageView = resolve_image.targetView(ivci);
+    color_attachment.resolveImageView = resolve_view.handle();
     color_attachment.imageView = VK_NULL_HANDLE;
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06129");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderingAttachmentInfo-resolveMode-09329");
@@ -977,12 +981,13 @@ TEST_F(NegativeAndroidExternalResolve, ClearAttachment) {
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view = resolve_image.CreateView(ivci);
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageView = color_image.targetView(format_resolve_prop.colorAttachmentFormat);
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID;
-    color_attachment.resolveImageView = resolve_image.targetView(ivci);
+    color_attachment.resolveImageView = resolve_view.handle();
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
@@ -1070,12 +1075,13 @@ TEST_F(NegativeAndroidExternalResolve, DrawDynamicRasterizationSamples) {
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view = resolve_image.CreateView(ivci);
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageView = color_image.targetView(format_resolve_prop.colorAttachmentFormat);
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID;
-    color_attachment.resolveImageView = resolve_image.targetView(ivci);
+    color_attachment.resolveImageView = resolve_view.handle();
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -141,10 +141,11 @@ TEST_F(PositiveAndroidExternalResolve, RenderPassAndFramebuffer) {
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view = resolve_image.CreateView(ivci);
 
     VkImageView attachments[2];
     attachments[0] = color_image.targetView(format_resolve_prop.colorAttachmentFormat);
-    attachments[1] = resolve_image.targetView(ivci);
+    attachments[1] = resolve_view.handle();
 
     VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
     fb_ci.width = 32;
@@ -256,10 +257,11 @@ TEST_F(PositiveAndroidExternalResolve, ImagelessFramebuffer) {
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view = resolve_image.CreateView(ivci);
 
     VkImageView attachments[2];
     attachments[0] = color_image.targetView(format_resolve_prop.colorAttachmentFormat);
-    attachments[1] = resolve_image.targetView(ivci);
+    attachments[1] = resolve_view.handle();
 
     VkFramebufferAttachmentImageInfo framebuffer_attachment_image_info[2];
     framebuffer_attachment_image_info[0] = vku::InitStructHelper();
@@ -365,12 +367,14 @@ TEST_F(PositiveAndroidExternalResolve, DynamicRendering) {
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    const vkt::ImageView resolve_view = resolve_image.CreateView(ivci);
+
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageView = color_image.targetView(format_resolve_prop.colorAttachmentFormat);
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID;
-    color_attachment.resolveImageView = resolve_image.targetView(ivci);
+    color_attachment.resolveImageView = resolve_view.handle();
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -1745,10 +1745,10 @@ TEST_F(NegativeDynamicRendering, AttachmentInfo) {
                                    VK_COMPONENT_SWIZZLE_IDENTITY},
                                   {VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, 0, 1, 0, 1}};
 
-    VkImageView depth_image_view = image.targetView(ivci);
-    VkImageView depth_image_view_fragment = image_fragment.targetView(ivci);
-    ASSERT_NE(depth_image_view, VK_NULL_HANDLE);
-    ASSERT_NE(depth_image_view_fragment, VK_NULL_HANDLE);
+    const vkt::ImageView depth_image_view = image.CreateView(ivci);
+    const vkt::ImageView depth_image_view_fragment = image_fragment.CreateView(ivci);
+    ASSERT_NE(depth_image_view.handle(), VK_NULL_HANDLE);
+    ASSERT_NE(depth_image_view_fragment.handle(), VK_NULL_HANDLE);
 
     VkRenderingAttachmentInfoKHR depth_attachment = vku::InitStructHelper();
     depth_attachment.imageLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -1009,8 +1009,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
     m_errorMonitor->VerifyFound();
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
 
-    VkImageView imageViewLayered = image.targetView(VK_FORMAT_R8_UINT, VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 2);
-    fb_info.pAttachments = &imageViewLayered;
+    fb_info.pAttachments = &imageView;
     fb_info.layers = 3;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04538");
     fb.init(*m_device, fb_info);

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -987,12 +987,12 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
     auto image_view_ci = image.BasicViewCreatInfo();
     image_view_ci.subresourceRange.layerCount = 2;
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-    const auto imageView = image.targetView(image_view_ci);
+    const auto imageView = image.CreateView(image_view_ci);
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
     fb_info.renderPass = rp.handle();
     fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &imageView;
+    fb_info.pAttachments = &imageView.handle();
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width * 2;
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
     fb_info.layers = 1;
@@ -1009,7 +1009,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
     m_errorMonitor->VerifyFound();
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
 
-    fb_info.pAttachments = &imageView;
+    fb_info.pAttachments = &imageView.handle();
     fb_info.layers = 3;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04538");
     fb.init(*m_device, fb_info);

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -1158,7 +1158,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     imageViewCreateInfo.subresourceRange.levelCount = 1;
     imageViewCreateInfo.subresourceRange.baseArrayLayer = 0;
     imageViewCreateInfo.subresourceRange.layerCount = 1;
-    VkImageView imageView3D = image3D.targetView(imageViewCreateInfo);
+    const vkt::ImageView imageView3D = image3D.CreateView(imageViewCreateInfo);
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfo = vku::InitStructHelper();
     framebufferAttachmentImageInfo.flags = 0;
@@ -1183,7 +1183,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     {
         framebufferCreateInfo.pNext = nullptr;
         framebufferCreateInfo.flags = 0;
-        framebufferCreateInfo.pAttachments = &imageView3D;
+        framebufferCreateInfo.pAttachments = &imageView3D.handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04113");
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         m_errorMonitor->VerifyFound();
@@ -1197,7 +1197,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
 
     VkRenderPassAttachmentBeginInfoKHR renderPassAttachmentBeginInfo = vku::InitStructHelper();
     renderPassAttachmentBeginInfo.attachmentCount = 1;
-    renderPassAttachmentBeginInfo.pAttachments = &imageView3D;
+    renderPassAttachmentBeginInfo.pAttachments = &imageView3D.handle();
     VkRenderPassBeginInfo renderPassBeginInfo = vku::InitStructHelper(&renderPassAttachmentBeginInfo);
     renderPassBeginInfo.renderPass = renderPass.handle();
     renderPassBeginInfo.renderArea.extent.width = attachmentWidth;

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -708,7 +708,7 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
     image.Init(image_create_info);
     auto image_view_ci = image.BasicViewCreatInfo();
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-    VkImageView imageView = image.targetView(image_view_ci);
+    const vkt::ImageView imageView = image.CreateView(image_view_ci);
 
     VkFramebufferCreateInfo framebufferCreateInfo = vku::InitStructHelper();
     framebufferCreateInfo.width = 32;
@@ -716,7 +716,7 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
     framebufferCreateInfo.layers = 1;
     framebufferCreateInfo.renderPass = render_pass.handle();
     framebufferCreateInfo.attachmentCount = 1;
-    framebufferCreateInfo.pAttachments = &imageView;
+    framebufferCreateInfo.pAttachments = &imageView.handle();
 
     vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
 

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -1784,8 +1784,8 @@ TEST_F(PositiveRenderPass, TestDepthStencilRenderPassTransition) {
     depthImage.Init(32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
 
     for (size_t i = 0; i < 2; i++) {
-        const VkImageView depthView =
-            depthImage.targetView(ds_format, i == 0 ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_STENCIL_BIT);
+        const vkt::ImageView depth_or_stencil_view(
+            *m_device, depthImage.BasicViewCreatInfo(i == 0 ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_STENCIL_BIT));
 
         VkAttachmentReference depthAttachment = {};
         depthAttachment.attachment = 0;
@@ -1812,7 +1812,7 @@ TEST_F(PositiveRenderPass, TestDepthStencilRenderPassTransition) {
         VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
         fb_ci.renderPass = render_pass.handle();
         fb_ci.attachmentCount = 1;
-        fb_ci.pAttachments = &depthView;
+        fb_ci.pAttachments = &depth_or_stencil_view.handle();
         fb_ci.width = 32;
         fb_ci.height = 32;
         fb_ci.layers = 1;

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -1525,7 +1525,7 @@ TEST_F(NegativeYcbcr, MultiplaneAspectBits) {
 
     auto image_view_ci = image_obj.BasicViewCreatInfo();
     image_view_ci.pNext = &ycbcr_info;
-    auto image_view = image_obj.targetView(image_view_ci);
+    const auto image_view = image_obj.CreateView(image_view_ci);
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     sampler_ci.pNext = &ycbcr_info;


### PR DESCRIPTION
Part one of replacing `targetView` due to the issue mentioned here https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7013

While targetView is still here this PR adds asserts when it is used incorrectly. A couple of tests triggered that asserts and were fixed. `targetView` has two overloads. This PR starts with a simpler one (called only in a few places) and replaces it with `CreateView` that returns uncached `vkt::ImageView`. 