### PR TITLE
Remove more shouty state names

### DIFF
--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -668,7 +668,7 @@ And `vvl::Buffer::deviceAddress` field is used for lookups in a separate map use
 The `deviceAddress` field can only be set after memory is bound to the buffer, so it cannot be const. But once it is set it is not modified.
 
 
-### VkAccelerationStructureKHR / ACCELERATION_STRUCTURE_STATE_KHR
+### VkAccelerationStructureKHR / vvl::AccelerationStructureKHR
 
 There are separate state objects for the KHR and NV versions of the extensions. Unfortunately, due to differences in how memory is bound in the 2 extensions, these objects cannot be easily combined.
 

--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -186,7 +186,7 @@ The following objects have already been updated to meet the above construction r
 * VkSamplerYcbcrConversion / SAMPLER_YCBCR_CONVERSION_STATE
 * VkRenderPass / RENDER_PASS_STATE
 * VkFramebuffer / FRAMEBUFFER_STATE
-* VkBufferView / BUFFER_VIEW_STATE
+* VkBufferView / vvl::BufferView
 * VkImageView / IMAGE_VIEW_STATE
 * VkPipelineLayout / PIPELINE_LAYOUT_STATE
 * VkDescriptorSetLayout / vvl::DescriptorSetLayout

--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -225,17 +225,17 @@ The following sections cover state objects with non-const data and describe how 
 There it not any instance member data in `ValidationStateTracker` other than state object maps. It would be nice if there were separate classes for `VkInstance` and `VkDevice` state but that is beyond the scope of this project.
 
 
-### VkPhysicalDevice / PHYSICAL_DEVICE_STATE
+### VkPhysicalDevice / vvl::PhysicalDevice
 
 Since VkPhysicalDevice handles persist until the VkInstance is destroyed, it is not necessary to hold shared_ptr reference counts on them.
 
 The `queue_family_known_count` field is an uint32_t storing the maximum property count used in a call to `vkGetPhysicalDeviceQueueFamilyProperties2()`. The `vkGetPhysicalDeviceDisplayPlanePropertiesKHR_called` field and `display_plane_property_count uint32_t` field are similar but for display plane properties.
 
-The `perf_counters` map is a per-queue family map of the results of calls to `vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCounters()` which are not otherwise modified. These could be made const by adding query code to `PHYSICAL_DEVICE_STATE` construction.
+The `perf_counters` map is a per-queue family map of the results of calls to `vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCounters()` which are not otherwise modified. These could be made const by adding query code to `vvl::PhysicalDevice` construction.
 
 ###### PRs:
 
-[layers: Set up vvl::Queue and PHYSICAL_DEVICE_STATE at create time](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3370)
+[layers: Set up vvl::Queue and vvl::PhysicalDevice at create time](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3370)
 
 
 ## Device Data

--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -185,7 +185,7 @@ The following objects have already been updated to meet the above construction r
 * VkSampler / vvl::Sampler
 * VkSamplerYcbcrConversion / vvl::SamplerYcbcrConversion
 * VkRenderPass / RENDER_PASS_STATE
-* VkFramebuffer / FRAMEBUFFER_STATE
+* VkFramebuffer / vvl::Framebuffer
 * VkBufferView / vvl::BufferView
 * VkImageView / IMAGE_VIEW_STATE
 * VkPipelineLayout / PIPELINE_LAYOUT_STATE

--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -182,7 +182,7 @@ It is very common for state objects to contain data that is set up at creation t
 
 The following objects have already been updated to meet the above construction requirements and now only have `const` data members. They do not require any additional locking. This is the best way to make a state object thread safe and should be used whenever possible!
 
-* VkSampler / SAMPLER_STATE
+* VkSampler / vvl::Sampler
 * VkSamplerYcbcrConversion / SAMPLER_YCBCR_CONVERSION_STATE
 * VkRenderPass / RENDER_PASS_STATE
 * VkFramebuffer / FRAMEBUFFER_STATE

--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -184,7 +184,7 @@ The following objects have already been updated to meet the above construction r
 
 * VkSampler / vvl::Sampler
 * VkSamplerYcbcrConversion / vvl::SamplerYcbcrConversion
-* VkRenderPass / RENDER_PASS_STATE
+* VkRenderPass / vvl::RenderPass
 * VkFramebuffer / vvl::Framebuffer
 * VkBufferView / vvl::BufferView
 * VkImageView / IMAGE_VIEW_STATE

--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -183,7 +183,7 @@ It is very common for state objects to contain data that is set up at creation t
 The following objects have already been updated to meet the above construction requirements and now only have `const` data members. They do not require any additional locking. This is the best way to make a state object thread safe and should be used whenever possible!
 
 * VkSampler / vvl::Sampler
-* VkSamplerYcbcrConversion / SAMPLER_YCBCR_CONVERSION_STATE
+* VkSamplerYcbcrConversion / vvl::SamplerYcbcrConversion
 * VkRenderPass / RENDER_PASS_STATE
 * VkFramebuffer / FRAMEBUFFER_STATE
 * VkBufferView / vvl::BufferView

--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -202,7 +202,7 @@ For data that must change after object creation, the next best strategy is to ma
 
 Thread safe accessors are very important for complex data structures such as vectors, sets, and maps. It may be possible in some cases to make simple counters or flags thread safe using `std::atomic` instead.
 
-`SURFACE_STATE` is an example of a state object with fully encapsulated non-const data members.
+`vvl::Surface` is an example of a state object with fully encapsulated non-const data members.
 
 #### Encapsulated with limited interactions with other state objects
 
@@ -716,9 +716,9 @@ Some of this data is set in `vkGetSwapchainImagesKHR()` and `vkBindImageMemory2K
 TODO: Accesses to most of these fields will need to be atomic or lock guarded.
 
 
-### VkSurfaceState / SURFACE_STATE
+### VkSurfaceState / vvl::Surface
 
-`SURFACE_STATE` tracks the results of several calls that involve both `VkPhysicalDevice` and `VkSurface`:
+`vvl::Surface` tracks the results of several calls that involve both `VkPhysicalDevice` and `VkSurface`:
 
 
 ```
@@ -740,7 +740,7 @@ Also, surfaces are instance level objects but they hold a reference on the curre
 
 ###### PRs:
 
-[layers: Make SURFACE_STATE, vvl::DescriptorPool, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
+[layers: Make vvl::Surface, vvl::DescriptorPool, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
 
 [layers: Don't pre-query surface attributes during creation](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3452)
 
@@ -770,7 +770,7 @@ This data is fully encapsulated by accessor methods that manage the locking.
 
 ###### PRs:
 
-[layers: Make SURFACE_STATE, vvl::DescriptorPool, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
+[layers: Make vvl::Surface, vvl::DescriptorPool, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
 
 
 ### VkDescriptorSet / vvl::DescriptorSet
@@ -816,7 +816,7 @@ This data is fully encapsulated by accessor methods that manage the locking.
 
 [layers: remove global queryToStateMap](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3586)
 
-[layers: Make SURFACE_STATE, vvl::DescriptorPool, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
+[layers: Make vvl::Surface, vvl::DescriptorPool, QUERY_POOL_STATE and ValidationCache threadsafe](https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/3649)
 
 
 

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -211,9 +211,9 @@ class Image : public IMAGE_STATE {
     std::vector<std::vector<Usage>> usages_;
 };
 
-class PhysicalDevice : public PHYSICAL_DEVICE_STATE {
+class PhysicalDevice : public vvl::PhysicalDevice {
   public:
-    PhysicalDevice(VkPhysicalDevice phys_dev) : PHYSICAL_DEVICE_STATE(phys_dev) {}
+    PhysicalDevice(VkPhysicalDevice phys_dev) : vvl::PhysicalDevice(phys_dev) {}
 
     // Track the call state and array sizes for various query functions
     CALL_STATE vkGetPhysicalDeviceQueueFamilyPropertiesState = UNCALLED;
@@ -355,7 +355,7 @@ class Pipeline : public PIPELINE_STATE {
 };
 }  // namespace bp_state
 
-VALSTATETRACK_DERIVED_STATE_OBJECT(VkPhysicalDevice, bp_state::PhysicalDevice, PHYSICAL_DEVICE_STATE)
+VALSTATETRACK_DERIVED_STATE_OBJECT(VkPhysicalDevice, bp_state::PhysicalDevice, vvl::PhysicalDevice)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, bp_state::CommandBuffer, CMD_BUFFER_STATE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkSwapchainKHR, bp_state::Swapchain, SWAPCHAIN_NODE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkImage, bp_state::Image, IMAGE_STATE)
@@ -756,7 +756,7 @@ class BestPractices : public ValidationStateTracker {
     bool PreCallValidateGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                            uint32_t* pSurfaceFormatCount, VkSurfaceFormatKHR* pSurfaceFormats,
                                                            const ErrorObject& error_obj) const override;
-    bool ValidateCommonGetPhysicalDeviceQueueFamilyProperties(const PHYSICAL_DEVICE_STATE* pd_state,
+    bool ValidateCommonGetPhysicalDeviceQueueFamilyProperties(const vvl::PhysicalDevice* pd_state,
                                                               uint32_t requested_queue_family_property_count,
                                                               const CALL_STATE call_state, const Location& loc) const;
     bool PreCallValidateBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,
@@ -1001,8 +1001,8 @@ class BestPractices : public ValidationStateTracker {
         return std::static_pointer_cast<SWAPCHAIN_NODE>(std::make_shared<bp_state::Swapchain>(this, create_info, swapchain));
     }
 
-    std::shared_ptr<PHYSICAL_DEVICE_STATE> CreatePhysicalDeviceState(VkPhysicalDevice phys_dev) final {
-        return std::static_pointer_cast<PHYSICAL_DEVICE_STATE>(std::make_shared<bp_state::PhysicalDevice>(phys_dev));
+    std::shared_ptr<vvl::PhysicalDevice> CreatePhysicalDeviceState(VkPhysicalDevice phys_dev) final {
+        return std::static_pointer_cast<vvl::PhysicalDevice>(std::make_shared<bp_state::PhysicalDevice>(phys_dev));
     }
     std::shared_ptr<IMAGE_STATE> CreateImageState(VkImage img, const VkImageCreateInfo* pCreateInfo,
                                                   VkFormatFeatureFlags2KHR features) final {

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -348,7 +348,7 @@ class DescriptorPool : public vvl::DescriptorPool {
 class Pipeline : public PIPELINE_STATE {
   public:
     Pipeline(const ValidationStateTracker* state_data, const VkGraphicsPipelineCreateInfo* pCreateInfo,
-             std::shared_ptr<const RENDER_PASS_STATE>&& rpstate, std::shared_ptr<const PIPELINE_LAYOUT_STATE>&& layout,
+             std::shared_ptr<const vvl::RenderPass>&& rpstate, std::shared_ptr<const PIPELINE_LAYOUT_STATE>&& layout,
              CreateShaderModuleStates* csm_states);
 
     const std::vector<AttachmentInfo> access_framebuffer_attachments;
@@ -1029,7 +1029,7 @@ class BestPractices : public ValidationStateTracker {
     }
 
     std::shared_ptr<PIPELINE_STATE> CreateGraphicsPipelineState(const VkGraphicsPipelineCreateInfo* pCreateInfo,
-                                                                std::shared_ptr<const RENDER_PASS_STATE>&& render_pass,
+                                                                std::shared_ptr<const vvl::RenderPass>&& render_pass,
                                                                 std::shared_ptr<const PIPELINE_LAYOUT_STATE>&& layout,
                                                                 CreateShaderModuleStates* csm_states) const final;
 

--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -124,7 +124,7 @@ bool BestPractices::ClearAttachmentsIsFullClear(const bp_state::CommandBuffer& c
 
 bool BestPractices::ValidateClearAttachment(const bp_state::CommandBuffer& cmd, uint32_t fb_attachment, uint32_t color_attachment,
                                             VkImageAspectFlags aspects, const Location& loc) const {
-    const RENDER_PASS_STATE* rp = cmd.activeRenderPass.get();
+    const vvl::RenderPass* rp = cmd.activeRenderPass.get();
     bool skip = false;
 
     if (!rp || fb_attachment == VK_ATTACHMENT_UNUSED) {
@@ -207,7 +207,7 @@ bool BestPractices::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
 
     // Check for uses of ClearAttachments along with LOAD_OP_LOAD,
     // as it can be more efficient to just use LOAD_OP_CLEAR
-    const RENDER_PASS_STATE* rp = cb_node->activeRenderPass.get();
+    const vvl::RenderPass* rp = cb_node->activeRenderPass.get();
     if (rp) {
         if (rp->use_dynamic_rendering || rp->use_dynamic_rendering_inherited) {
             const auto pColorAttachments = rp->dynamic_rendering_begin_rendering_info.pColorAttachments;

--- a/layers/best_practices/bp_framebuffer.cpp
+++ b/layers/best_practices/bp_framebuffer.cpp
@@ -78,7 +78,7 @@ bool BestPractices::PreCallValidateCreateFramebuffer(VkDevice device, const VkFr
                                                      const ErrorObject& error_obj) const {
     bool skip = false;
 
-    auto rp_state = Get<RENDER_PASS_STATE>(pCreateInfo->renderPass);
+    auto rp_state = Get<vvl::RenderPass>(pCreateInfo->renderPass);
     if (rp_state && !(pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT)) {
         skip = ValidateAttachments(rp_state->createInfo.ptr(), pCreateInfo->attachmentCount, pCreateInfo->pAttachments,
                                    error_obj.location);

--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -221,7 +221,7 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
 }
 
 // Common function to handle validation for GetPhysicalDeviceQueueFamilyProperties & 2KHR version
-bool BestPractices::ValidateCommonGetPhysicalDeviceQueueFamilyProperties(const PHYSICAL_DEVICE_STATE* bp_pd_state,
+bool BestPractices::ValidateCommonGetPhysicalDeviceQueueFamilyProperties(const vvl::PhysicalDevice* bp_pd_state,
                                                                          uint32_t requested_queue_family_property_count,
                                                                          const CALL_STATE call_state, const Location& loc) const {
     bool skip = false;

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -51,7 +51,7 @@ bool BestPractices::ValidateMultisampledBlendingArm(uint32_t createInfoCount, co
             return skip;
         }
 
-        auto rp_state = Get<RENDER_PASS_STATE>(create_info->renderPass);
+        auto rp_state = Get<vvl::RenderPass>(create_info->renderPass);
         if (!rp_state) {
             continue;
         }
@@ -253,13 +253,13 @@ static std::vector<bp_state::AttachmentInfo> GetAttachmentAccess(bp_state::Pipel
 }
 
 bp_state::Pipeline::Pipeline(const ValidationStateTracker* state_data, const VkGraphicsPipelineCreateInfo* pCreateInfo,
-                             std::shared_ptr<const RENDER_PASS_STATE>&& rpstate,
+                             std::shared_ptr<const vvl::RenderPass>&& rpstate,
                              std::shared_ptr<const PIPELINE_LAYOUT_STATE>&& layout, CreateShaderModuleStates* csm_states)
     : PIPELINE_STATE(state_data, pCreateInfo, std::move(rpstate), std::move(layout), csm_states),
       access_framebuffer_attachments(GetAttachmentAccess(*this)) {}
 
 std::shared_ptr<PIPELINE_STATE> BestPractices::CreateGraphicsPipelineState(const VkGraphicsPipelineCreateInfo* pCreateInfo,
-                                                                           std::shared_ptr<const RENDER_PASS_STATE>&& render_pass,
+                                                                           std::shared_ptr<const vvl::RenderPass>&& render_pass,
                                                                            std::shared_ptr<const PIPELINE_LAYOUT_STATE>&& layout,
                                                                            CreateShaderModuleStates* csm_states) const {
     return std::static_pointer_cast<PIPELINE_STATE>(

--- a/layers/best_practices/bp_ray_tracing.cpp
+++ b/layers/best_practices/bp_ray_tracing.cpp
@@ -65,7 +65,7 @@ bool BestPractices::PreCallValidateBindAccelerationStructureMemoryNV(VkDevice de
     bool skip = false;
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(pBindInfos[i].accelerationStructure);
+        auto as_state = Get<vvl::AccelerationStructureNV>(pBindInfos[i].accelerationStructure);
         if (!as_state->memory_requirements_checked) {
             // There's not an explicit requirement in the spec to call vkGetImageMemoryRequirements() prior to calling
             // BindAccelerationStructureMemoryNV but it's implied in that memory being bound must conform with

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -171,7 +171,7 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, co
                            "and can only be used for side effects such as layout transitions.");
     }
 
-    auto rp_state = Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
+    auto rp_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     if (rp_state) {
         if (rp_state->createInfo.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
             const VkRenderPassAttachmentBeginInfo* rpabi = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(pRenderPassBegin->pNext);
@@ -387,7 +387,7 @@ void BestPractices::RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, cons
 
     auto cb = GetWrite<bp_state::CommandBuffer>(commandBuffer);
 
-    auto rp_state = Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
+    auto rp_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     if (rp_state) {
         // Check load ops
         for (uint32_t att = 0; att < rp_state->createInfo.attachmentCount; att++) {
@@ -681,7 +681,7 @@ void BestPractices::PostRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, 
     // Reset NV state
     cb->nv = {};
 
-    auto rp_state = Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
+    auto rp_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     if (rp_state) {
         // track depth / color attachment usage within the renderpass
         for (size_t i = 0; i < rp_state->createInfo.subpassCount; i++) {
@@ -791,7 +791,7 @@ bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, cons
             VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG));
     }
 
-    RENDER_PASS_STATE* rp = cmd->activeRenderPass.get();
+    vvl::RenderPass* rp = cmd->activeRenderPass.get();
 
     if ((VendorCheckEnabled(kBPVendorArm) || VendorCheckEnabled(kBPVendorIMG)) && rp) {
         // If we use an attachment on-tile, we should access it in some way. Otherwise,

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -416,7 +416,7 @@ void BestPractices::RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, cons
                 usage = IMAGE_SUBRESOURCE_USAGE_BP::DESCRIPTOR_ACCESS;
             }
 
-            auto framebuffer = Get<FRAMEBUFFER_STATE>(pRenderPassBegin->framebuffer);
+            auto framebuffer = Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
             std::shared_ptr<IMAGE_VIEW_STATE> image_view = nullptr;
 
             if (framebuffer->createInfo.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
@@ -453,7 +453,7 @@ void BestPractices::RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, cons
                 usage = IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_STORED;
             }
 
-            auto framebuffer = Get<FRAMEBUFFER_STATE>(pRenderPassBegin->framebuffer);
+            auto framebuffer = Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
 
             std::shared_ptr<IMAGE_VIEW_STATE> image_view;
             if (framebuffer->createInfo.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -564,7 +564,7 @@ bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo *cre
         uint64_t external_format = 0;
         const VkSamplerYcbcrConversionInfo *ycbcr_conv_info = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(create_info->pNext);
         if (ycbcr_conv_info != nullptr) {
-            auto ycbcr_state = Get<SAMPLER_YCBCR_CONVERSION_STATE>(ycbcr_conv_info->conversion);
+            auto ycbcr_state = Get<vvl::SamplerYcbcrConversion>(ycbcr_conv_info->conversion);
             if (ycbcr_state) {
                 conv_found = true;
                 external_format = ycbcr_state->external_format;

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -424,7 +424,7 @@ bool CoreChecks::PreCallValidateDestroyBuffer(VkDevice device, VkBuffer buffer, 
 
 bool CoreChecks::PreCallValidateDestroyBufferView(VkDevice device, VkBufferView bufferView, const VkAllocationCallbacks *pAllocator,
                                                   const ErrorObject &error_obj) const {
-    auto buffer_view_state = Get<BUFFER_VIEW_STATE>(bufferView);
+    auto buffer_view_state = Get<vvl::BufferView>(bufferView);
     bool skip = false;
     if (buffer_view_state) {
         skip |= ValidateObjectNotInUse(buffer_view_state.get(), error_obj.location, "VUID-vkDestroyBufferView-bufferView-00936");

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -92,7 +92,7 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                 auto framebuffer = Get<vvl::Framebuffer>(info->framebuffer);
                 if (framebuffer) {
                     if (framebuffer->createInfo.renderPass != info->renderPass) {
-                        auto render_pass = Get<RENDER_PASS_STATE>(info->renderPass);
+                        auto render_pass = Get<vvl::RenderPass>(info->renderPass);
                         // renderPass that framebuffer was created with must be compatible with local renderPass
                         skip |= ValidateRenderPassCompatibility("framebuffer", *framebuffer->rp_state.get(), "command buffer",
                                                                 *render_pass.get(), inheritance_loc,
@@ -101,7 +101,7 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                 }
 
                 if (info->renderPass != VK_NULL_HANDLE) {
-                    auto render_pass = Get<RENDER_PASS_STATE>(info->renderPass);
+                    auto render_pass = Get<vvl::RenderPass>(info->renderPass);
                     if (!render_pass) {
                         skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-06000", commandBuffer,
                                          inheritance_loc.dot(Field::renderPass), "is not a valid VkRenderPass.");
@@ -866,7 +866,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
             } else if (sub_cb_state.beginInfo.pInheritanceInfo != nullptr) {
                 const uint32_t inheritance_subpass = sub_cb_state.beginInfo.pInheritanceInfo->subpass;
                 const VkRenderPass inheritance_render_pass = sub_cb_state.beginInfo.pInheritanceInfo->renderPass;
-                auto secondary_rp_state = Get<RENDER_PASS_STATE>(inheritance_render_pass);
+                auto secondary_rp_state = Get<vvl::RenderPass>(inheritance_render_pass);
                 if (!(sub_cb_state.beginInfo.flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)) {
                     const LogObjectList objlist(pCommandBuffers[i], cb_state.activeRenderPass->renderPass());
                     skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-00096", objlist, cb_loc,

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -89,7 +89,7 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
             auto p_inherited_rendering_info = vku::FindStructInPNextChain<VkCommandBufferInheritanceRenderingInfo>(info->pNext);
 
             if (pBeginInfo->flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT) {
-                auto framebuffer = Get<FRAMEBUFFER_STATE>(info->framebuffer);
+                auto framebuffer = Get<vvl::Framebuffer>(info->framebuffer);
                 if (framebuffer) {
                     if (framebuffer->createInfo.renderPass != info->renderPass) {
                         auto render_pass = Get<RENDER_PASS_STATE>(info->renderPass);

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -4161,7 +4161,7 @@ bool CoreChecks::PreCallValidateCreateSampler(VkDevice device, const VkSamplerCr
         const auto *conversion_info = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
         if (conversion_info) {
             const VkSamplerYcbcrConversion sampler_ycbcr_conversion = conversion_info->conversion;
-            auto ycbcr_state = Get<SAMPLER_YCBCR_CONVERSION_STATE>(sampler_ycbcr_conversion);
+            auto ycbcr_state = Get<vvl::SamplerYcbcrConversion>(sampler_ycbcr_conversion);
             if ((ycbcr_state->format_features &
                  VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT_KHR) == 0) {
                 const VkFilter chroma_filter = ycbcr_state->chromaFilter;

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -1257,7 +1257,7 @@ bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t descriptorWriteCount, con
         const auto *acceleration_structure_khr = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureKHR>(pDescriptorWrites[i].pNext);
         if (acceleration_structure_khr) {
             for (uint32_t j = 0; j < acceleration_structure_khr->accelerationStructureCount; ++j) {
-                auto as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(acceleration_structure_khr->pAccelerationStructures[j]);
+                auto as_state = Get<vvl::AccelerationStructureKHR>(acceleration_structure_khr->pAccelerationStructures[j]);
                 if (as_state && (as_state->create_infoKHR.sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR &&
                                     (as_state->create_infoKHR.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
                                     as_state->create_infoKHR.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR))) {
@@ -1273,7 +1273,7 @@ bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t descriptorWriteCount, con
         const auto *acceleration_structure_nv = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(pDescriptorWrites[i].pNext);
         if (acceleration_structure_nv) {
             for (uint32_t j = 0; j < acceleration_structure_nv->accelerationStructureCount; ++j) {
-                auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(acceleration_structure_nv->pAccelerationStructures[j]);
+                auto as_state = Get<vvl::AccelerationStructureNV>(acceleration_structure_nv->pAccelerationStructures[j]);
                 if (as_state && (as_state->create_infoNV.sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV &&
                                     as_state->create_infoNV.info.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV)) {
                     const LogObjectList objlist(dst_set, as_state->Handle());
@@ -1948,7 +1948,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet &dst_set, const V
             const auto *acc_info = vku::FindStructInPNextChain<VkWriteDescriptorSetAccelerationStructureNV>(update.pNext);
             for (uint32_t di = 0; di < update.descriptorCount; ++di) {
                 VkAccelerationStructureNV as = acc_info->pAccelerationStructures[di];
-                auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(as);
+                auto as_state = Get<vvl::AccelerationStructureNV>(as);
                 // nullDescriptor feature allows this to be VK_NULL_HANDLE
                 if (as_state) {
                     skip |= VerifyBoundMemoryIsValid(
@@ -2517,7 +2517,7 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureOpaqueCaptureDescriptorD
     }
 
     if (pInfo->accelerationStructure != VK_NULL_HANDLE) {
-        auto acceleration_structure_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->accelerationStructure);
+        auto acceleration_structure_state = Get<vvl::AccelerationStructureKHR>(pInfo->accelerationStructure);
 
         if (acceleration_structure_state) {
             if (!(acceleration_structure_state->create_infoKHR.createFlags &
@@ -2537,7 +2537,7 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureOpaqueCaptureDescriptorD
     }
 
     if (pInfo->accelerationStructureNV != VK_NULL_HANDLE) {
-        auto acceleration_structure_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(pInfo->accelerationStructureNV);
+        auto acceleration_structure_state = Get<vvl::AccelerationStructureNV>(pInfo->accelerationStructureNV);
 
         if (acceleration_structure_state) {
             if (!(acceleration_structure_state->create_infoNV.info.flags &
@@ -2709,7 +2709,7 @@ bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescri
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
             if (pDescriptorInfo->data.accelerationStructure) {
                 const VkAccelerationStructureNV as = (VkAccelerationStructureNV)pDescriptorInfo->data.accelerationStructure;
-                auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(as);
+                auto as_state = Get<vvl::AccelerationStructureNV>(as);
 
                 if (!as_state) {
                     skip |= LogError("VUID-VkDescriptorGetInfoEXT-type-08029", device, descriptor_info_loc.dot(Field::type),

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -1602,7 +1602,7 @@ bool CoreChecks::VerifyCopyUpdateContents(const VkCopyDescriptorSet &update, con
                 if (!src_iter.updated()) continue;
                 auto buffer_view = static_cast<const TexelDescriptor &>(*src_iter).GetBufferView();
                 if (buffer_view) {
-                    auto bv_state = device_data->Get<BUFFER_VIEW_STATE>(buffer_view);
+                    auto bv_state = device_data->Get<vvl::BufferView>(buffer_view);
                     if (!bv_state) {
                         const LogObjectList objlist(update.srcSet);
                         skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-02994", objlist, copy_loc,
@@ -1909,7 +1909,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet &dst_set, const V
                 if (buffer_view == VK_NULL_HANDLE) {
                     continue;
                 }
-                auto bv_state = Get<BUFFER_VIEW_STATE>(buffer_view);
+                auto bv_state = Get<vvl::BufferView>(buffer_view);
                 if (!bv_state) {
                     skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-02994", device, write_loc,
                                      "Attempted write update to texel buffer descriptor with invalid buffer view (%s).",

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -157,7 +157,7 @@ bool CoreChecks::ValidateDeviceMaskToRenderPass(const CMD_BUFFER_STATE &cb_state
     return skip;
 }
 
-bool CoreChecks::ValidateQueueFamilyIndex(const PHYSICAL_DEVICE_STATE *pd_state, uint32_t requested_queue_family, const char *vuid,
+bool CoreChecks::ValidateQueueFamilyIndex(const vvl::PhysicalDevice *pd_state, uint32_t requested_queue_family, const char *vuid,
                                           const Location &loc) const {
     bool skip = false;
 
@@ -174,7 +174,7 @@ bool CoreChecks::ValidateQueueFamilyIndex(const PHYSICAL_DEVICE_STATE *pd_state,
     return skip;
 }
 
-bool CoreChecks::ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE *pd_state, uint32_t info_count,
+bool CoreChecks::ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice *pd_state, uint32_t info_count,
                                                 const VkDeviceQueueCreateInfo *infos, const Location &loc) const {
     bool skip = false;
 
@@ -322,7 +322,7 @@ bool CoreChecks::PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkDevic
                                              const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
                                              const ErrorObject &error_obj) const {
     bool skip = false;
-    auto pd_state = Get<PHYSICAL_DEVICE_STATE>(gpu);
+    auto pd_state = Get<vvl::PhysicalDevice>(gpu);
 
     // TODO: object_tracker should perhaps do this instead
     //       and it does not seem to currently work anyway -- the loader just crashes before this point

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -389,7 +389,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                     }
                 }
                 if (metal_texture_ptr->bufferView) {
-                    auto buffer_view_info = Get<BUFFER_VIEW_STATE>(metal_texture_ptr->bufferView);
+                    auto buffer_view_info = Get<vvl::BufferView>(metal_texture_ptr->bufferView);
                     if (buffer_view_info) {
                         if (!buffer_view_info->metal_bufferview_export) {
                             skip |= LogError(

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -2173,7 +2173,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
 
     const auto ycbcr_conversion = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
     if (ycbcr_conversion && ycbcr_conversion->conversion != VK_NULL_HANDLE) {
-        auto ycbcr_state = Get<SAMPLER_YCBCR_CONVERSION_STATE>(ycbcr_conversion->conversion);
+        auto ycbcr_state = Get<vvl::SamplerYcbcrConversion>(ycbcr_conversion->conversion);
         if (pCreateInfo->format != ycbcr_state->format) {
             skip |= LogError("VUID-VkImageViewCreateInfo-pNext-06658", pCreateInfo->image,
                              create_info_loc.pNext(Struct::VkSamplerYcbcrConversionInfo, Field::conversion),

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1235,7 +1235,7 @@ void CoreChecks::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
                 // if a secondary level command buffer inherits the framebuffer from the primary command buffer
                 // (see VkCommandBufferInheritanceInfo), this validation must be deferred until queue submit time
                 auto val_fn = [this, rectCount, clear_rect_copy, record_obj](
-                                  const CMD_BUFFER_STATE &secondary, const CMD_BUFFER_STATE *prim_cb, const FRAMEBUFFER_STATE *) {
+                                  const CMD_BUFFER_STATE &secondary, const CMD_BUFFER_STATE *prim_cb, const vvl::Framebuffer *) {
                     assert(rectCount == clear_rect_copy->size());
                     bool skip = false;
                     skip = ValidateClearAttachmentExtent(
@@ -1270,7 +1270,7 @@ void CoreChecks::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
                 // if a secondary level command buffer inherits the framebuffer from the primary command buffer
                 // (see VkCommandBufferInheritanceInfo), this validation must be deferred until queue submit time
                 auto val_fn = [this, rectCount, clear_rect_copy, record_obj](
-                                  const CMD_BUFFER_STATE &secondary, const CMD_BUFFER_STATE *prim_cb, const FRAMEBUFFER_STATE *fb) {
+                                  const CMD_BUFFER_STATE &secondary, const CMD_BUFFER_STATE *prim_cb, const vvl::Framebuffer *fb) {
                     assert(rectCount == clear_rect_copy->size());
                     const auto &render_area = prim_cb->active_render_pass_begin_info.renderArea;
                     bool skip = false;

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -495,7 +495,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const CMD_BUFFER_STATE &c
                                                        const vvl::Framebuffer &framebuffer_state,
                                                        const Location &rp_begin_loc) const {
     bool skip = false;
-    auto render_pass_state = Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
+    auto render_pass_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     const auto *render_pass_info = render_pass_state->createInfo.ptr();
     auto render_pass = render_pass_state->renderPass();
     auto const &framebuffer_info = framebuffer_state.createInfo;
@@ -741,7 +741,7 @@ void CoreChecks::TransitionAttachmentRefLayout(CMD_BUFFER_STATE *cb_state, const
     }
 }
 
-void CoreChecks::TransitionSubpassLayouts(CMD_BUFFER_STATE *cb_state, const RENDER_PASS_STATE &render_pass_state,
+void CoreChecks::TransitionSubpassLayouts(CMD_BUFFER_STATE *cb_state, const vvl::RenderPass &render_pass_state,
                                           const int subpass_index) {
     auto const &subpass = render_pass_state.createInfo.pSubpasses[subpass_index];
     for (uint32_t j = 0; j < subpass.inputAttachmentCount; ++j) {
@@ -758,7 +758,7 @@ void CoreChecks::TransitionSubpassLayouts(CMD_BUFFER_STATE *cb_state, const REND
 // Transition the layout state for renderpass attachments based on the BeginRenderPass() call. This includes:
 // 1. Transition into initialLayout state
 // 2. Transition from initialLayout to layout used in subpass 0
-void CoreChecks::TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE *cb_state, const RENDER_PASS_STATE &render_pass_state) {
+void CoreChecks::TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE *cb_state, const vvl::RenderPass &render_pass_state) {
     // First record expected initialLayout as a potential initial layout usage.
     auto const rpci = render_pass_state.createInfo.ptr();
     for (uint32_t i = 0; i < rpci->attachmentCount; ++i) {

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -492,7 +492,7 @@ bool CoreChecks::ValidateRenderPassStencilLayoutAgainstFramebufferImageUsage(VkI
 
 bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const CMD_BUFFER_STATE &cb_state,
                                                        const VkRenderPassBeginInfo *pRenderPassBegin,
-                                                       const FRAMEBUFFER_STATE &framebuffer_state,
+                                                       const vvl::Framebuffer &framebuffer_state,
                                                        const Location &rp_begin_loc) const {
     bool skip = false;
     auto render_pass_state = Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -227,7 +227,7 @@ bool CoreChecks::ValidateGraphicsPipelinePortability(const PIPELINE_STATE &pipel
 
         // Validate color attachments
         const uint32_t subpass = pipeline.Subpass();
-        auto render_pass = Get<RENDER_PASS_STATE>(pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass);
+        auto render_pass = Get<vvl::RenderPass>(pipeline.GetCreateInfo<VkGraphicsPipelineCreateInfo>().renderPass);
         const bool ignore_color_blend_state =
             raster_state_ci->rasterizerDiscardEnable ||
             (pipeline.rendering_create_info ? (pipeline.rendering_create_info->colorAttachmentCount == 0)

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -88,7 +88,7 @@ bool CoreChecks::PreCallValidateBindAccelerationStructureMemoryNV(VkDevice devic
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         const Location bind_info_loc = error_obj.location.dot(Field::pBindInfos, i);
         const VkBindAccelerationStructureMemoryInfoNV &info = pBindInfos[i];
-        auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(info.accelerationStructure);
+        auto as_state = Get<vvl::AccelerationStructureNV>(info.accelerationStructure);
         if (!as_state) {
             continue;
         }
@@ -141,7 +141,7 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureHandleNV(VkDevice device
                                                                  size_t dataSize, void *pData, const ErrorObject &error_obj) const {
     bool skip = false;
 
-    auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(accelerationStructure);
+    auto as_state = Get<vvl::AccelerationStructureNV>(accelerationStructure);
     if (as_state != nullptr) {
         skip = VerifyBoundMemoryIsValid(as_state->MemState(), LogObjectList(accelerationStructure), as_state->Handle(),
                                         error_obj.location.dot(Field::accelerationStructure),
@@ -159,14 +159,14 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(VkCommandBuffer c
     bool skip = false;
     const VkAccelerationStructureBuildGeometryInfoKHR &info = pInfos[info_i];
     const Location info_i_loc = error_obj.location.dot(Field::pInfos, info_i);
-    const auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(info.srcAccelerationStructure);
-    const auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(info.dstAccelerationStructure);
+    const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure);
+    const auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure);
 
     auto validate_no_as_buffer_memory_overlap =
-        [this, commandBuffer, error_obj](const ACCELERATION_STRUCTURE_STATE_KHR &accel_struct_a, const Location &location_a,
+        [this, commandBuffer, error_obj](const vvl::AccelerationStructureKHR &accel_struct_a, const Location &location_a,
                                          const vvl::Buffer &buffer_a, const sparse_container::range<VkDeviceSize> &range_a,
 
-                                         const ACCELERATION_STRUCTURE_STATE_KHR &accel_struct_b, const Location &location_b,
+                                         const vvl::AccelerationStructureKHR &accel_struct_b, const Location &location_b,
                                          const vvl::Buffer &buffer_b, const sparse_container::range<VkDeviceSize> &range_b,
 
                                          const char *vuid) {
@@ -444,8 +444,8 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(VkCommandBuffer c
 #endif
         // skip comparing to self info
         if (other_info_j != info_i) {
-            const auto other_dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfos[other_info_j].dstAccelerationStructure);
-            const auto other_src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfos[other_info_j].srcAccelerationStructure);
+            const auto other_dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfos[other_info_j].dstAccelerationStructure);
+            const auto other_src_as_state = Get<vvl::AccelerationStructureKHR>(pInfos[other_info_j].srcAccelerationStructure);
 
             // Validate destination acceleration structure's memory is not overlapped by another source acceleration structure's
             // memory that is going to be updated by this cmd
@@ -599,8 +599,8 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
     for (const auto [info_i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
 
-        const auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(info->srcAccelerationStructure);
-        const auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(info->dstAccelerationStructure);
+        const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info->srcAccelerationStructure);
+        const auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info->dstAccelerationStructure);
 
         if (dst_as_state != nullptr) {
             skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_state->buffer_state,
@@ -782,8 +782,8 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
     bool skip = false;
     for (uint32_t i = 0; i < infoCount; ++i) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, i);
-        auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfos[i].srcAccelerationStructure);
-        auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfos[i].dstAccelerationStructure);
+        auto src_as_state = Get<vvl::AccelerationStructureKHR>(pInfos[i].srcAccelerationStructure);
+        auto dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfos[i].dstAccelerationStructure);
         if (dst_as_state) {
             skip |=
                 ValidateHostVisibleMemoryIsBoundToBuffer(*dst_as_state->buffer_state, info_loc.dot(Field::dstAccelerationStructure),
@@ -881,8 +881,8 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructureNV(VkCommandBuffer 
                          pInfo->geometryCount);
     }
 
-    auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(dst);
-    auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(src);
+    auto dst_as_state = Get<vvl::AccelerationStructureNV>(dst);
+    auto src_as_state = Get<vvl::AccelerationStructureNV>(src);
     auto scratch_buffer_state = Get<vvl::Buffer>(scratch);
 
     if (dst_as_state != nullptr && pInfo != nullptr) {
@@ -1031,8 +1031,8 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureNV(VkCommandBuffer c
     bool skip = false;
 
     skip |= ValidateCmd(*cb_state, error_obj.location);
-    auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(dst);
-    auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(src);
+    auto dst_as_state = Get<vvl::AccelerationStructureNV>(dst);
+    auto src_as_state = Get<vvl::AccelerationStructureNV>(src);
 
     if (dst_as_state != nullptr) {
         const LogObjectList objlist(commandBuffer, dst);
@@ -1073,7 +1073,7 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureNV(VkCommandBuffer c
 bool CoreChecks::PreCallValidateDestroyAccelerationStructureNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
                                                                const VkAllocationCallbacks *pAllocator,
                                                                const ErrorObject &error_obj) const {
-    auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(accelerationStructure);
+    auto as_state = Get<vvl::AccelerationStructureNV>(accelerationStructure);
     bool skip = false;
     if (as_state) {
         skip |= ValidateObjectNotInUse(as_state.get(), error_obj.location,
@@ -1085,7 +1085,7 @@ bool CoreChecks::PreCallValidateDestroyAccelerationStructureNV(VkDevice device, 
 bool CoreChecks::PreCallValidateDestroyAccelerationStructureKHR(VkDevice device, VkAccelerationStructureKHR accelerationStructure,
                                                                 const VkAllocationCallbacks *pAllocator,
                                                                 const ErrorObject &error_obj) const {
-    auto as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(accelerationStructure);
+    auto as_state = Get<vvl::AccelerationStructureKHR>(accelerationStructure);
     bool skip = false;
     if (as_state) {
         skip |= ValidateObjectNotInUse(as_state.get(), error_obj.location,
@@ -1123,7 +1123,7 @@ bool CoreChecks::PreCallValidateWriteAccelerationStructuresPropertiesKHR(VkDevic
     bool skip = false;
     for (uint32_t i = 0; i < accelerationStructureCount; ++i) {
         const Location as_loc = error_obj.location.dot(Field::pAccelerationStructures, i);
-        auto as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pAccelerationStructures[i]);
+        auto as_state = Get<vvl::AccelerationStructureKHR>(pAccelerationStructures[i]);
         const auto &as_info = as_state->build_info_khr;
         if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR) {
             if (!(as_info.flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
@@ -1156,7 +1156,7 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
     }
     for (uint32_t i = 0; i < accelerationStructureCount; ++i) {
         if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR) {
-            auto as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pAccelerationStructures[i]);
+            auto as_state = Get<vvl::AccelerationStructureKHR>(pAccelerationStructures[i]);
             if (!(as_state->build_info_khr.flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
                 skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-accelerationStructures-03431", commandBuffer,
                                  error_obj.location.dot(Field::pAccelerationStructures, i),
@@ -1184,7 +1184,7 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesNV(
     }
     for (uint32_t i = 0; i < accelerationStructureCount; ++i) {
         if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV) {
-            auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(pAccelerationStructures[i]);
+            auto as_state = Get<vvl::AccelerationStructureNV>(pAccelerationStructures[i]);
             if (!(as_state->build_info.flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
                 skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesNV-pAccelerationStructures-06215", commandBuffer,
                                  error_obj.location.dot(Field::pAccelerationStructures, i),
@@ -1210,8 +1210,8 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkComm
     skip |= ValidateCmdRayQueryState(*cb_state, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
     for (uint32_t i = 0; i < infoCount; ++i) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, i);
-        auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfos[i].srcAccelerationStructure);
-        auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfos[i].dstAccelerationStructure);
+        auto src_as_state = Get<vvl::AccelerationStructureKHR>(pInfos[i].srcAccelerationStructure);
+        auto dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfos[i].dstAccelerationStructure);
         skip |=
             ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_state->buffer_state, info_loc.dot(Field::dstAccelerationStructure),
                                           "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03707");
@@ -1282,7 +1282,7 @@ bool CoreChecks::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerati
                                                           const VulkanTypedHandle &handle, const Location &info_loc) const {
     bool skip = false;
     if (pInfo->mode == VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_KHR) {
-        auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->src);
+        auto src_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->src);
         if (!(src_as_state->build_info_khr.flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
             const LogObjectList objlist(handle, pInfo->src);
             skip |= LogError("VUID-VkCopyAccelerationStructureInfoKHR-src-03411", objlist, info_loc.dot(Field::src),
@@ -1291,13 +1291,13 @@ bool CoreChecks::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerati
                              FormatHandle(pInfo->src).c_str());
         }
     }
-    auto src_accel_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->src);
+    auto src_accel_state = Get<vvl::AccelerationStructureKHR>(pInfo->src);
     if (src_accel_state) {
         auto buffer_state = Get<vvl::Buffer>(src_accel_state->create_infoKHR.buffer);
         skip |= ValidateMemoryIsBoundToBuffer(device, *buffer_state, info_loc.dot(Field::src),
                                               "VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
     }
-    auto dst_accel_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->dst);
+    auto dst_accel_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst);
     if (dst_accel_state) {
         auto buffer_state = Get<vvl::Buffer>(dst_accel_state->create_infoKHR.buffer);
         skip |= ValidateMemoryIsBoundToBuffer(device, *buffer_state, info_loc.dot(Field::dst),
@@ -1316,12 +1316,12 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuffer 
     if (pInfo) {
         const Location info_loc = error_obj.location.dot(Field::pInfo);
         skip |= ValidateCopyAccelerationStructureInfoKHR(pInfo, error_obj.handle, info_loc);
-        auto src_accel_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->src);
+        auto src_accel_state = Get<vvl::AccelerationStructureKHR>(pInfo->src);
         if (src_accel_state) {
             skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_accel_state->buffer_state, info_loc.dot(Field::src),
                                                   "VUID-vkCmdCopyAccelerationStructureKHR-buffer-03737");
         }
-        auto dst_accel_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->dst);
+        auto dst_accel_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst);
         if (dst_accel_state) {
             skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_accel_state->buffer_state, info_loc.dot(Field::dst),
                                                   "VUID-vkCmdCopyAccelerationStructureKHR-buffer-03738");
@@ -1337,12 +1337,12 @@ bool CoreChecks::PreCallValidateCopyAccelerationStructureKHR(VkDevice device, Vk
     if (pInfo) {
         const Location info_loc = error_obj.location.dot(Field::pInfo);
         skip |= ValidateCopyAccelerationStructureInfoKHR(pInfo, error_obj.handle, error_obj.location.dot(Field::pInfo));
-        auto src_accel_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->src);
+        auto src_accel_state = Get<vvl::AccelerationStructureKHR>(pInfo->src);
         if (src_accel_state) {
             skip |= ValidateHostVisibleMemoryIsBoundToBuffer(*src_accel_state->buffer_state, info_loc.dot(Field::src),
                                                              "VUID-vkCopyAccelerationStructureKHR-buffer-03727");
         }
-        auto dst_accel_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->dst);
+        auto dst_accel_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst);
         if (dst_accel_state) {
             skip |= ValidateHostVisibleMemoryIsBoundToBuffer(*dst_accel_state->buffer_state, info_loc.dot(Field::dst),
                                                              "VUID-vkCopyAccelerationStructureKHR-buffer-03728");
@@ -1358,7 +1358,7 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkComman
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
-    auto accel_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->src);
+    auto accel_state = Get<vvl::AccelerationStructureKHR>(pInfo->src);
     if (accel_state) {
         auto buffer_state = Get<vvl::Buffer>(accel_state->create_infoKHR.buffer);
         skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *buffer_state, error_obj.location.dot(Field::pInfo).dot(Field::src),
@@ -1372,7 +1372,7 @@ bool CoreChecks::PreCallValidateCopyMemoryToAccelerationStructureKHR(VkDevice de
                                                                      const ErrorObject &error_obj) const {
     bool skip = false;
 
-    auto accel_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->dst);
+    auto accel_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst);
     if (accel_state) {
         skip |= ValidateHostVisibleMemoryIsBoundToBuffer(*accel_state->buffer_state,
                                                          error_obj.location.dot(Field::pInfo).dot(Field::dst),
@@ -1390,7 +1390,7 @@ bool CoreChecks::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkComman
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
-    auto accel_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->dst);
+    auto accel_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst);
     if (accel_state) {
         skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *accel_state->buffer_state,
                                               error_obj.location.dot(Field::pInfo).dot(Field::dst),

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -28,8 +28,8 @@
 #include "sync/sync_utils.h"
 #include "utils/convert_utils.h"
 
-bool CoreChecks::LogInvalidAttachmentMessage(const char *type1_string, const RENDER_PASS_STATE &rp1_state, const char *type2_string,
-                                             const RENDER_PASS_STATE &rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
+bool CoreChecks::LogInvalidAttachmentMessage(const char *type1_string, const vvl::RenderPass &rp1_state, const char *type2_string,
+                                             const vvl::RenderPass &rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
                                              const char *msg, const Location &loc, const char *error_code) const {
     const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
     return LogError(error_code, objlist, loc,
@@ -40,8 +40,8 @@ bool CoreChecks::LogInvalidAttachmentMessage(const char *type1_string, const REN
                     secondary_attach, msg);
 }
 
-bool CoreChecks::ValidateAttachmentCompatibility(const char *type1_string, const RENDER_PASS_STATE &rp1_state,
-                                                 const char *type2_string, const RENDER_PASS_STATE &rp2_state,
+bool CoreChecks::ValidateAttachmentCompatibility(const char *type1_string, const vvl::RenderPass &rp1_state,
+                                                 const char *type2_string, const vvl::RenderPass &rp2_state,
                                                  uint32_t primary_attach, uint32_t secondary_attach, const Location &loc,
                                                  const char *error_code) const {
     bool skip = false;
@@ -82,9 +82,9 @@ bool CoreChecks::ValidateAttachmentCompatibility(const char *type1_string, const
     return skip;
 }
 
-bool CoreChecks::ValidateSubpassCompatibility(const char *type1_string, const RENDER_PASS_STATE &rp1_state,
-                                              const char *type2_string, const RENDER_PASS_STATE &rp2_state, const int subpass,
-                                              const Location &loc, const char *error_code) const {
+bool CoreChecks::ValidateSubpassCompatibility(const char *type1_string, const vvl::RenderPass &rp1_state, const char *type2_string,
+                                              const vvl::RenderPass &rp2_state, const int subpass, const Location &loc,
+                                              const char *error_code) const {
     bool skip = false;
     const auto &primary_desc = rp1_state.createInfo.pSubpasses[subpass];
     const auto &secondary_desc = rp2_state.createInfo.pSubpasses[subpass];
@@ -190,8 +190,8 @@ bool CoreChecks::ValidateSubpassCompatibility(const char *type1_string, const RE
     return skip;
 }
 
-bool CoreChecks::ValidateDependencyCompatibility(const char *type1_string, const RENDER_PASS_STATE &rp1_state,
-                                                 const char *type2_string, const RENDER_PASS_STATE &rp2_state,
+bool CoreChecks::ValidateDependencyCompatibility(const char *type1_string, const vvl::RenderPass &rp1_state,
+                                                 const char *type2_string, const vvl::RenderPass &rp2_state,
                                                  const uint32_t dependency, const Location &loc, const char *error_code) const {
     bool skip = false;
 
@@ -270,16 +270,16 @@ bool CoreChecks::ValidateDependencyCompatibility(const char *type1_string, const
     return skip;
 }
 
-bool CoreChecks::LogInvalidPnextMessage(const char *type1_string, const RENDER_PASS_STATE &rp1_state, const char *type2_string,
-                                        const RENDER_PASS_STATE &rp2_state, const char *msg, const Location &loc,
+bool CoreChecks::LogInvalidPnextMessage(const char *type1_string, const vvl::RenderPass &rp1_state, const char *type2_string,
+                                        const vvl::RenderPass &rp2_state, const char *msg, const Location &loc,
                                         const char *error_code) const {
     const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
     return LogError(error_code, objlist, loc, "RenderPasses incompatible between %s w/ %s and %s w/ %s: %s", type1_string,
                     FormatHandle(rp1_state).c_str(), type2_string, FormatHandle(rp2_state).c_str(), msg);
 }
 
-bool CoreChecks::LogInvalidDependencyMessage(const char *type1_string, const RENDER_PASS_STATE &rp1_state, const char *type2_string,
-                                             const RENDER_PASS_STATE &rp2_state, const char *msg, const Location &loc,
+bool CoreChecks::LogInvalidDependencyMessage(const char *type1_string, const vvl::RenderPass &rp1_state, const char *type2_string,
+                                             const vvl::RenderPass &rp2_state, const char *msg, const Location &loc,
                                              const char *error_code) const {
     const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
     return LogError(error_code, objlist, loc, "RenderPasses incompatible between %s w/ %s and %s w/ %s: %s", type1_string,
@@ -289,8 +289,8 @@ bool CoreChecks::LogInvalidDependencyMessage(const char *type1_string, const REN
 // Verify that given renderPass CreateInfo for primary and secondary command buffers are compatible.
 //  This function deals directly with the CreateInfo, there are overloaded versions below that can take the renderPass handle and
 //  will then feed into this function
-bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const RENDER_PASS_STATE &rp1_state,
-                                                 const char *type2_string, const RENDER_PASS_STATE &rp2_state, const Location &loc,
+bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const vvl::RenderPass &rp1_state,
+                                                 const char *type2_string, const vvl::RenderPass &rp2_state, const Location &loc,
                                                  const char *vuid) const {
     bool skip = false;
 
@@ -374,7 +374,7 @@ bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const
 
 bool CoreChecks::PreCallValidateDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator,
                                                   const ErrorObject &error_obj) const {
-    auto rp_state = Get<RENDER_PASS_STATE>(renderPass);
+    auto rp_state = Get<vvl::RenderPass>(renderPass);
     bool skip = false;
     if (rp_state) {
         skip |= ValidateObjectNotInUse(rp_state.get(), error_obj.location, "VUID-vkDestroyRenderPass-renderPass-00873");
@@ -400,7 +400,7 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
                                             const ErrorObject &error_obj) const {
     bool skip = false;
     const auto &cb_state = *GetRead<CMD_BUFFER_STATE>(commandBuffer);
-    const auto &rp_state = *Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
+    const auto &rp_state = *Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     const auto &fb_state = *Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
     const Location rp_begin_loc = error_obj.location.dot(Field::pRenderPassBegin);
 
@@ -540,7 +540,7 @@ void CoreChecks::RecordCmdBeginRenderPassLayouts(VkCommandBuffer commandBuffer, 
         return;
     }
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
-    auto render_pass_state = Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
+    auto render_pass_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     if (cb_state && render_pass_state) {
         // transition attachments to the correct layouts for beginning of renderPass and first subpass
         TransitionBeginRenderPassLayouts(cb_state.get(), *render_pass_state);
@@ -920,7 +920,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
                 ", but VkFramebuffer was created with VkFramebufferAttachmentsCreateInfo::attachmentImageInfoCount = %" PRIu32 ".",
                 render_pass_attachment_begin_info->attachmentCount, framebuffer_attachments_create_info->attachmentImageInfoCount);
         } else {
-            auto render_pass_state = Get<RENDER_PASS_STATE>(pRenderPassBeginInfo->renderPass);
+            auto render_pass_state = Get<vvl::RenderPass>(pRenderPassBeginInfo->renderPass);
             const auto *render_pass_create_info = &render_pass_state->createInfo;
             for (uint32_t i = 0; i < render_pass_attachment_begin_info->attachmentCount; ++i) {
                 const Location attachment_loc = loc.pNext(Struct::VkRenderPassAttachmentBeginInfo, Field::pAttachments, i);
@@ -2049,7 +2049,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
     return skip;
 }
 
-bool CoreChecks::ValidateDependencies(const vvl::Framebuffer &framebuffer_state, const RENDER_PASS_STATE &render_pass_state,
+bool CoreChecks::ValidateDependencies(const vvl::Framebuffer &framebuffer_state, const vvl::RenderPass &render_pass_state,
                                       const ErrorObject &error_obj) const {
     bool skip = false;
     auto const framebuffer_info = framebuffer_state.createInfo.ptr();
@@ -4146,7 +4146,7 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
                          phys_dev_props.limits.maxFramebufferLayers);
     }
 
-    auto rp_state = Get<RENDER_PASS_STATE>(pCreateInfo->renderPass);
+    auto rp_state = Get<vvl::RenderPass>(pCreateInfo->renderPass);
     if (!rp_state) {
         return skip;
     }

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -401,7 +401,7 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
     bool skip = false;
     const auto &cb_state = *GetRead<CMD_BUFFER_STATE>(commandBuffer);
     const auto &rp_state = *Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
-    const auto &fb_state = *Get<FRAMEBUFFER_STATE>(pRenderPassBegin->framebuffer);
+    const auto &fb_state = *Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
     const Location rp_begin_loc = error_obj.location.dot(Field::pRenderPassBegin);
 
     skip |= ValidateCmd(cb_state, error_obj.location);
@@ -823,7 +823,7 @@ bool CoreChecks::VerifyRenderAreaBounds(const VkRenderPassBeginInfo *pRenderPass
     const uint32_t device_group_area_count =
         device_group_render_pass_begin_info ? device_group_render_pass_begin_info->deviceRenderAreaCount : 0;
 
-    auto framebuffer_state = Get<FRAMEBUFFER_STATE>(pRenderPassBegin->framebuffer);
+    auto framebuffer_state = Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
     const auto *framebuffer_info = &framebuffer_state->createInfo;
     // These VUs depend on count being non-zero, or else acts like struct is not there
     if (device_group_area_count > 0) {
@@ -899,7 +899,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
         return false;
     }
 
-    const auto &framebuffer_state = *Get<FRAMEBUFFER_STATE>(pRenderPassBeginInfo->framebuffer);
+    const auto &framebuffer_state = *Get<vvl::Framebuffer>(pRenderPassBeginInfo->framebuffer);
     const auto &framebuffer_create_info = framebuffer_state.createInfo;
     const auto *framebuffer_attachments_create_info =
         vku::FindStructInPNextChain<VkFramebufferAttachmentsCreateInfo>(framebuffer_create_info.pNext);
@@ -2049,7 +2049,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
     return skip;
 }
 
-bool CoreChecks::ValidateDependencies(const FRAMEBUFFER_STATE &framebuffer_state, const RENDER_PASS_STATE &render_pass_state,
+bool CoreChecks::ValidateDependencies(const vvl::Framebuffer &framebuffer_state, const RENDER_PASS_STATE &render_pass_state,
                                       const ErrorObject &error_obj) const {
     bool skip = false;
     auto const framebuffer_info = framebuffer_state.createInfo.ptr();
@@ -4777,7 +4777,7 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
 
 bool CoreChecks::PreCallValidateDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer,
                                                    const VkAllocationCallbacks *pAllocator, const ErrorObject &error_obj) const {
-    auto framebuffer_state = Get<FRAMEBUFFER_STATE>(framebuffer);
+    auto framebuffer_state = Get<vvl::Framebuffer>(framebuffer);
     bool skip = false;
     if (framebuffer_state) {
         skip |= ValidateObjectNotInUse(framebuffer_state.get(), error_obj.location, "VUID-vkDestroyFramebuffer-framebuffer-00892");

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -577,7 +577,7 @@ bool CoreChecks::PreCallValidateDestroyEvent(VkDevice device, VkEvent event, con
 
 bool CoreChecks::PreCallValidateDestroySampler(VkDevice device, VkSampler sampler, const VkAllocationCallbacks *pAllocator,
                                                const ErrorObject &error_obj) const {
-    auto sampler_state = Get<SAMPLER_STATE>(sampler);
+    auto sampler_state = Get<vvl::Sampler>(sampler);
     bool skip = false;
     if (sampler_state) {
         skip |= ValidateObjectNotInUse(sampler_state.get(), error_obj.location.dot(Field::sampler),

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1625,7 +1625,7 @@ bool CoreChecks::ValidateBarriersToImages(const Location &barrier_loc, const CMD
 
 // Verify image barrier image state and that the image is consistent with FB image
 bool CoreChecks::ValidateImageBarrierAttachment(const Location &barrier_loc, CMD_BUFFER_STATE const *cb_state,
-                                                const FRAMEBUFFER_STATE *framebuffer, uint32_t active_subpass,
+                                                const vvl::Framebuffer *framebuffer, uint32_t active_subpass,
                                                 const safe_VkSubpassDescription2 &sub_desc, const VkRenderPass rp_handle,
                                                 const ImageBarrier &img_barrier, const CMD_BUFFER_STATE *primary_cb_state) const {
     using sync_vuid_maps::GetImageBarrierVUID;
@@ -1732,7 +1732,7 @@ void CoreChecks::EnqueueSubmitTimeValidateImageBarrierAttachment(const Location 
         const auto render_pass = rp_state->renderPass();
         cb_state->cmd_execute_commands_functions.emplace_back(
             [this_ptr, loc_capture, active_subpass, sub_desc, render_pass, barrier](
-                const CMD_BUFFER_STATE &secondary_cb, const CMD_BUFFER_STATE *primary_cb, const FRAMEBUFFER_STATE *fb) {
+                const CMD_BUFFER_STATE &secondary_cb, const CMD_BUFFER_STATE *primary_cb, const vvl::Framebuffer *fb) {
                 return this_ptr->ValidateImageBarrierAttachment(loc_capture.Get(), &secondary_cb, fb, active_subpass, sub_desc,
                                                                 render_pass, barrier, primary_cb);
             });

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -1360,7 +1360,7 @@ bool CoreChecks::PreCallValidateCreateDisplayPlaneSurfaceKHR(VkInstance instance
         }
     }
 
-    auto dm_state = Get<DISPLAY_MODE_STATE>(display_mode);
+    auto dm_state = Get<vvl::DisplayMode>(display_mode);
     if (dm_state != nullptr) {
         // Get physical device from VkDisplayModeKHR state tracking
         const VkPhysicalDevice physical_device = dm_state->physical_device;

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -1254,7 +1254,7 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceWaylandPresentationSupportKHR(V
                                                                                uint32_t queueFamilyIndex,
                                                                                struct wl_display *display,
                                                                                const ErrorObject &error_obj) const {
-    auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
+    auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(pd_state.get(), queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceWaylandPresentationSupportKHR-queueFamilyIndex-01306",
                                     error_obj.location.dot(Field::queueFamilyIndex));
@@ -1265,7 +1265,7 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceWaylandPresentationSupportKHR(V
 bool CoreChecks::PreCallValidateGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice physicalDevice,
                                                                              uint32_t queueFamilyIndex,
                                                                              const ErrorObject &error_obj) const {
-    auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
+    auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(pd_state.get(), queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceWin32PresentationSupportKHR-queueFamilyIndex-01309",
                                     error_obj.location.dot(Field::queueFamilyIndex));
@@ -1277,7 +1277,7 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceXcbPresentationSupportKHR(VkPhy
                                                                            uint32_t queueFamilyIndex, xcb_connection_t *connection,
                                                                            xcb_visualid_t visual_id,
                                                                            const ErrorObject &error_obj) const {
-    auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
+    auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(pd_state.get(), queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceXcbPresentationSupportKHR-queueFamilyIndex-01312",
                                     error_obj.location.dot(Field::queueFamilyIndex));
@@ -1288,7 +1288,7 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceXcbPresentationSupportKHR(VkPhy
 bool CoreChecks::PreCallValidateGetPhysicalDeviceXlibPresentationSupportKHR(VkPhysicalDevice physicalDevice,
                                                                             uint32_t queueFamilyIndex, Display *dpy,
                                                                             VisualID visualID, const ErrorObject &error_obj) const {
-    auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
+    auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(pd_state.get(), queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceXlibPresentationSupportKHR-queueFamilyIndex-01315",
                                     error_obj.location.dot(Field::queueFamilyIndex));
@@ -1300,7 +1300,7 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceScreenPresentationSupportQNX(Vk
                                                                               uint32_t queueFamilyIndex,
                                                                               struct _screen_window *window,
                                                                               const ErrorObject &error_obj) const {
-    auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
+    auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(pd_state.get(), queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceScreenPresentationSupportQNX-queueFamilyIndex-04743",
                                     error_obj.location.dot(Field::queueFamilyIndex));
@@ -1310,7 +1310,7 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceScreenPresentationSupportQNX(Vk
 bool CoreChecks::PreCallValidateGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex,
                                                                    VkSurfaceKHR surface, VkBool32 *pSupported,
                                                                    const ErrorObject &error_obj) const {
-    auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
+    auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     return ValidateQueueFamilyIndex(pd_state.get(), queueFamilyIndex,
                                     "VUID-vkGetPhysicalDeviceSurfaceSupportKHR-queueFamilyIndex-01269",
                                     error_obj.location.dot(Field::queueFamilyIndex));
@@ -1364,7 +1364,7 @@ bool CoreChecks::PreCallValidateCreateDisplayPlaneSurfaceKHR(VkInstance instance
     if (dm_state != nullptr) {
         // Get physical device from VkDisplayModeKHR state tracking
         const VkPhysicalDevice physical_device = dm_state->physical_device;
-        auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physical_device);
+        auto pd_state = Get<vvl::PhysicalDevice>(physical_device);
         VkPhysicalDeviceProperties device_properties = {};
         DispatchGetPhysicalDeviceProperties(physical_device, &device_properties);
 
@@ -1472,7 +1472,7 @@ bool CoreChecks::ValidatePhysicalDeviceSurfaceSupport(VkPhysicalDevice physicalD
                                                       const Location &loc) const {
     bool skip = false;
 
-    auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
+    auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     auto surface_state = Get<vvl::Surface>(surface);
     if (pd_state && surface_state) {
         bool is_supported = false;
@@ -1680,7 +1680,7 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceSurfacePresentModesKHR(VkPhysic
 bool CoreChecks::ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
                                                                          const Location &loc) const {
     bool skip = false;
-    auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physicalDevice);
+    auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
     if (pd_state->vkGetPhysicalDeviceDisplayPlanePropertiesKHR_called) {
         if (planeIndex >= pd_state->display_plane_property_count) {
             skip |= LogError("VUID-vkGetDisplayPlaneSupportedDisplaysKHR-planeIndex-01249", physicalDevice, loc,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -375,12 +375,12 @@ class CoreChecks : public ValidationStateTracker {
                                       VkSharingMode sharing_mode) const;
     bool ValidateSwapchainPresentModesCreateInfo(VkPresentModeKHR present_mode, const Location& create_info_loc,
                                                  VkSwapchainCreateInfoKHR const* create_info,
-                                                 const SURFACE_STATE* surface_state) const;
+                                                 const vvl::Surface* surface_state) const;
     bool ValidateSwapchainPresentScalingCreateInfo(VkPresentModeKHR present_mode, const Location& create_info_loc,
                                                    const VkSurfaceCapabilitiesKHR* capabilities,
                                                    VkSwapchainCreateInfoKHR const* create_info,
-                                                   const SURFACE_STATE* surface_state) const;
-    bool ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const* pCreateInfo, const SURFACE_STATE* surface_state,
+                                                   const vvl::Surface* surface_state) const;
+    bool ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const* pCreateInfo, const vvl::Surface* surface_state,
                                  const SWAPCHAIN_NODE* old_swapchain_state, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineBindPoint(const CMD_BUFFER_STATE* cb_state, const PIPELINE_STATE& pipeline,
                                            const Location& loc) const;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -290,9 +290,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateRenderPassCompatibility(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
                                          const vvl::RenderPass& rp2_state, const Location& loc, const char* vuid) const;
     bool ReportInvalidCommandBuffer(const CMD_BUFFER_STATE& cb_state, const Location& loc, const char* vuid) const;
-    bool ValidateQueueFamilyIndex(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t requested_queue_family, const char* vuid,
+    bool ValidateQueueFamilyIndex(const vvl::PhysicalDevice* pd_state, uint32_t requested_queue_family, const char* vuid,
                                   const Location& loc) const;
-    bool ValidateDeviceQueueCreateInfos(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t info_count,
+    bool ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice* pd_state, uint32_t info_count,
                                         const VkDeviceQueueCreateInfo* infos, const Location& loc) const;
 
     bool ValidateProtectedImage(const CMD_BUFFER_STATE& cb_state, const IMAGE_STATE& image_state, const Location& image_loc,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -265,30 +265,30 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDrawDynamicState(const LAST_BOUND_STATE& last_bound_state, const Location& loc) const;
     bool ValidateDrawDynamicStatePipeline(const LAST_BOUND_STATE& last_bound_state, const Location& loc) const;
     bool ValidateDrawDynamicStateShaderObject(const LAST_BOUND_STATE& last_bound_state, const Location& loc) const;
-    bool LogInvalidAttachmentMessage(const char* type1_string, const RENDER_PASS_STATE& rp1_state, const char* type2_string,
-                                     const RENDER_PASS_STATE& rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
+    bool LogInvalidAttachmentMessage(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
+                                     const vvl::RenderPass& rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
                                      const char* msg, const Location& loc, const char* error_code) const;
-    bool LogInvalidPnextMessage(const char* type1_string, const RENDER_PASS_STATE& rp1_state, const char* type2_string,
-                                const RENDER_PASS_STATE& rp2_state, const char* msg, const Location& loc,
+    bool LogInvalidPnextMessage(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
+                                const vvl::RenderPass& rp2_state, const char* msg, const Location& loc,
                                 const char* error_code) const;
-    bool LogInvalidDependencyMessage(const char* type1_string, const RENDER_PASS_STATE& rp1_state, const char* type2_string,
-                                     const RENDER_PASS_STATE& rp2_state, const char* msg, const Location& loc,
+    bool LogInvalidDependencyMessage(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
+                                     const vvl::RenderPass& rp2_state, const char* msg, const Location& loc,
                                      const char* error_code) const;
     bool ValidateStageMaskHost(const Location& stage_mask_loc, VkPipelineStageFlags2KHR stageMask) const;
     bool ValidateMapMemory(const DEVICE_MEMORY_STATE& mem_info, VkDeviceSize offset, VkDeviceSize size, const Location& offset_loc,
                            const Location& size_loc) const;
     bool ValidateRenderPassDAG(const VkRenderPassCreateInfo2* pCreateInfo, const ErrorObject& error_obj) const;
-    bool ValidateAttachmentCompatibility(const char* type1_string, const RENDER_PASS_STATE& rp1_state, const char* type2_string,
-                                         const RENDER_PASS_STATE& rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
+    bool ValidateAttachmentCompatibility(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
+                                         const vvl::RenderPass& rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
                                          const Location& loc, const char* error_code) const;
-    bool ValidateSubpassCompatibility(const char* type1_string, const RENDER_PASS_STATE& rp1_state, const char* type2_string,
-                                      const RENDER_PASS_STATE& rp2_state, const int subpass, const Location& loc,
+    bool ValidateSubpassCompatibility(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
+                                      const vvl::RenderPass& rp2_state, const int subpass, const Location& loc,
                                       const char* error_code) const;
-    bool ValidateDependencyCompatibility(const char* type1_string, const RENDER_PASS_STATE& rp1_state, const char* type2_string,
-                                         const RENDER_PASS_STATE& rp2_state, const uint32_t dependency, const Location& loc,
+    bool ValidateDependencyCompatibility(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
+                                         const vvl::RenderPass& rp2_state, const uint32_t dependency, const Location& loc,
                                          const char* error_code) const;
-    bool ValidateRenderPassCompatibility(const char* type1_string, const RENDER_PASS_STATE& rp1_state, const char* type2_string,
-                                         const RENDER_PASS_STATE& rp2_state, const Location& loc, const char* vuid) const;
+    bool ValidateRenderPassCompatibility(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
+                                         const vvl::RenderPass& rp2_state, const Location& loc, const char* vuid) const;
     bool ReportInvalidCommandBuffer(const CMD_BUFFER_STATE& cb_state, const Location& loc, const char* vuid) const;
     bool ValidateQueueFamilyIndex(const PHYSICAL_DEVICE_STATE* pd_state, uint32_t requested_queue_family, const char* vuid,
                                   const Location& loc) const;
@@ -326,7 +326,7 @@ class CoreChecks : public ValidationStateTracker {
                                                   uint32_t dst_queue_family);
     bool ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                     const ErrorObject& error_obj) const;
-    bool ValidateDependencies(const vvl::Framebuffer& framebuffer_state, const RENDER_PASS_STATE& render_pass_state,
+    bool ValidateDependencies(const vvl::Framebuffer& framebuffer_state, const vvl::RenderPass& render_pass_state,
                               const ErrorObject& error_obj) const;
     bool ValidateBufferBarrier(const LogObjectList& objlist, const Location& barrier_loc, const CMD_BUFFER_STATE* cb_state,
                                const BufferBarrier& barrier) const;
@@ -888,9 +888,9 @@ class CoreChecks : public ValidationStateTracker {
                                          const VkSubpassContents contents);
     void TransitionAttachmentRefLayout(CMD_BUFFER_STATE* cb_state, const safe_VkAttachmentReference2& ref);
 
-    void TransitionSubpassLayouts(CMD_BUFFER_STATE* cb_state, const RENDER_PASS_STATE& render_pass_state, const int);
+    void TransitionSubpassLayouts(CMD_BUFFER_STATE* cb_state, const vvl::RenderPass& render_pass_state, const int);
 
-    void TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE* cb_state, const RENDER_PASS_STATE& render_pass_state);
+    void TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE* cb_state, const vvl::RenderPass& render_pass_state);
 
     bool UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE* cb_state, const Location& image_loc,
                                            const ImageBarrier& img_barrier, const CommandBufferImageLayoutMap& current_map,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -316,7 +316,7 @@ class CoreChecks : public ValidationStateTracker {
     void EnqueueSubmitTimeValidateImageBarrierAttachment(const Location& loc, CMD_BUFFER_STATE* cb_state,
                                                           const ImageBarrier& barrier);
     bool ValidateImageBarrierAttachment(const Location& barrier_loc, CMD_BUFFER_STATE const* cb_state,
-                                        const FRAMEBUFFER_STATE* framebuffer, uint32_t active_subpass,
+                                        const vvl::Framebuffer* framebuffer, uint32_t active_subpass,
                                         const safe_VkSubpassDescription2& sub_desc, const VkRenderPass rp_handle,
                                         const ImageBarrier& img_barrier, const CMD_BUFFER_STATE* primary_cb_state = nullptr) const;
 
@@ -326,7 +326,7 @@ class CoreChecks : public ValidationStateTracker {
                                                   uint32_t dst_queue_family);
     bool ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                     const ErrorObject& error_obj) const;
-    bool ValidateDependencies(const FRAMEBUFFER_STATE& framebuffer_state, const RENDER_PASS_STATE& render_pass_state,
+    bool ValidateDependencies(const vvl::Framebuffer& framebuffer_state, const RENDER_PASS_STATE& render_pass_state,
                               const ErrorObject& error_obj) const;
     bool ValidateBufferBarrier(const LogObjectList& objlist, const Location& barrier_loc, const CMD_BUFFER_STATE* cb_state,
                                const BufferBarrier& barrier) const;
@@ -883,7 +883,7 @@ class CoreChecks : public ValidationStateTracker {
     bool FindLayouts(const IMAGE_STATE& image_state, std::vector<VkImageLayout>& layouts) const;
 
     bool VerifyFramebufferAndRenderPassLayouts(const CMD_BUFFER_STATE& cb_state, const VkRenderPassBeginInfo* pRenderPassBegin,
-                                               const FRAMEBUFFER_STATE& framebuffer_state, const Location& rp_begin_loc) const;
+                                               const vvl::Framebuffer& framebuffer_state, const Location& rp_begin_loc) const;
     void RecordCmdBeginRenderPassLayouts(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                          const VkSubpassContents contents);
     void TransitionAttachmentRefLayout(CMD_BUFFER_STATE* cb_state, const safe_VkAttachmentReference2& ref);

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -159,7 +159,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index,
                                     VkDescriptorType descriptor_type,
                                     const vvl::ImageDescriptor &image_descriptor) const {
-    std::vector<const SAMPLER_STATE *> sampler_states;
+    std::vector<const vvl::Sampler *> sampler_states;
     const VkImageView image_view = image_descriptor.GetImageView();
     const IMAGE_VIEW_STATE *image_view_state = image_descriptor.GetImageViewState();
     const auto binding = binding_info.first;
@@ -1012,8 +1012,9 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 // If the validation is related to both of image and sampler,
 // please leave it in (descriptor_class == DescriptorClass::ImageSampler || descriptor_class ==
 // DescriptorClass::Image) Here is to validate for only sampler.
-bool vvl::DescriptorValidator::ValidateSamplerDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index, VkSampler sampler,
-                                                         bool is_immutable, const SAMPLER_STATE *sampler_state) const {
+bool vvl::DescriptorValidator::ValidateSamplerDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index,
+                                                         VkSampler sampler, bool is_immutable,
+                                                         const vvl::Sampler *sampler_state) const {
     // Verify Sampler still valid
     if (!sampler_state || sampler_state->Destroyed()) {
         auto set = descriptor_set.Handle();

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -47,7 +47,7 @@ class DescriptorValidator {
 
     // helper for the common parts of ImageSamplerDescriptor and SamplerDescriptor validation
     bool ValidateSamplerDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkSampler sampler, bool is_immutable,
-                                   const SAMPLER_STATE* sampler_state) const;
+                                   const vvl::Sampler* sampler_state) const;
 
     ValidationStateTracker& dev_state;
     CMD_BUFFER_STATE& cb_state;

--- a/layers/gpu_validation/gpu_image_layout.cpp
+++ b/layers/gpu_validation/gpu_image_layout.cpp
@@ -543,7 +543,7 @@ void gpuav::Validator::TransitionAttachmentRefLayout(CMD_BUFFER_STATE *cb_state,
     }
 }
 
-void gpuav::Validator::TransitionSubpassLayouts(CMD_BUFFER_STATE *cb_state, const RENDER_PASS_STATE &render_pass_state,
+void gpuav::Validator::TransitionSubpassLayouts(CMD_BUFFER_STATE *cb_state, const vvl::RenderPass &render_pass_state,
                                                 const int subpass_index) {
     auto const &subpass = render_pass_state.createInfo.pSubpasses[subpass_index];
     for (uint32_t j = 0; j < subpass.inputAttachmentCount; ++j) {
@@ -560,7 +560,7 @@ void gpuav::Validator::TransitionSubpassLayouts(CMD_BUFFER_STATE *cb_state, cons
 // Transition the layout state for renderpass attachments based on the BeginRenderPass() call. This includes:
 // 1. Transition into initialLayout state
 // 2. Transition from initialLayout to layout used in subpass 0
-void gpuav::Validator::TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE *cb_state, const RENDER_PASS_STATE &render_pass_state) {
+void gpuav::Validator::TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE *cb_state, const vvl::RenderPass &render_pass_state) {
     // First record expected initialLayout as a potential initial layout usage.
     auto const rpci = render_pass_state.createInfo.ptr();
     for (uint32_t i = 0; i < rpci->attachmentCount; ++i) {

--- a/layers/gpu_validation/gpu_record.cpp
+++ b/layers/gpu_validation/gpu_record.cpp
@@ -387,7 +387,7 @@ void gpuav::Validator::RecordCmdBeginRenderPassLayouts(VkCommandBuffer commandBu
         return;
     }
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
-    auto render_pass_state = Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
+    auto render_pass_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     if (cb_state && render_pass_state) {
         // transition attachments to the correct layouts for beginning of renderPass and first subpass
         TransitionBeginRenderPassLayouts(cb_state.get(), *render_pass_state);

--- a/layers/gpu_validation/gpu_record.cpp
+++ b/layers/gpu_validation/gpu_record.cpp
@@ -79,7 +79,7 @@ void gpuav::Validator::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuf
     assert(cb_state != nullptr);
 
     std::vector<uint64_t> current_valid_handles;
-    ForEach<ACCELERATION_STRUCTURE_STATE_NV>([&current_valid_handles](const ACCELERATION_STRUCTURE_STATE_NV &as_state) {
+    ForEach<vvl::AccelerationStructureNV>([&current_valid_handles](const vvl::AccelerationStructureNV &as_state) {
         if (as_state.built && as_state.create_infoNV.info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV) {
             current_valid_handles.push_back(as_state.opaque_handle);
         }
@@ -227,7 +227,7 @@ void gpuav::Validator::PostCallRecordBindAccelerationStructureMemoryNV(VkDevice 
     BaseClass::PostCallRecordBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, record_obj);
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         const VkBindAccelerationStructureMemoryInfoNV &info = pBindInfos[i];
-        auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(info.accelerationStructure);
+        auto as_state = Get<vvl::AccelerationStructureNV>(info.accelerationStructure);
         if (as_state) {
             DispatchGetAccelerationStructureHandleNV(device, info.accelerationStructure, 8, &as_state->opaque_handle);
         }

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -64,7 +64,7 @@ std::shared_ptr<ACCELERATION_STRUCTURE_STATE_KHR> gpuav::Validator::CreateAccele
     return std::make_shared<AccelerationStructureKHR>(as, ci, std::move(buf_state), address, *desc_heap);
 }
 
-std::shared_ptr<SAMPLER_STATE> gpuav::Validator::CreateSamplerState(VkSampler s, const VkSamplerCreateInfo *ci) {
+std::shared_ptr<vvl::Sampler> gpuav::Validator::CreateSamplerState(VkSampler s, const VkSamplerCreateInfo *ci) {
     return std::make_shared<Sampler>(s, ci, *desc_heap);
 }
 

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -53,12 +53,12 @@ std::shared_ptr<IMAGE_VIEW_STATE> gpuav::Validator::CreateImageViewState(
     return std::make_shared<ImageView>(image_state, iv, ci, ff, cubic_props, *desc_heap);
 }
 
-std::shared_ptr<ACCELERATION_STRUCTURE_STATE_NV> gpuav::Validator::CreateAccelerationStructureState(
+std::shared_ptr<vvl::AccelerationStructureNV> gpuav::Validator::CreateAccelerationStructureState(
     VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV *ci) {
     return std::make_shared<AccelerationStructureNV>(device, as, ci, *desc_heap);
 }
 
-std::shared_ptr<ACCELERATION_STRUCTURE_STATE_KHR> gpuav::Validator::CreateAccelerationStructureState(
+std::shared_ptr<vvl::AccelerationStructureKHR> gpuav::Validator::CreateAccelerationStructureState(
     VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci, std::shared_ptr<vvl::Buffer> &&buf_state,
     VkDeviceAddress address) {
     return std::make_shared<AccelerationStructureKHR>(as, ci, std::move(buf_state), address, *desc_heap);

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -41,9 +41,9 @@ std::shared_ptr<vvl::Buffer> gpuav::Validator::CreateBufferState(VkBuffer buf, c
     return std::make_shared<Buffer>(this, buf, pCreateInfo, *desc_heap);
 }
 
-std::shared_ptr<BUFFER_VIEW_STATE> gpuav::Validator::CreateBufferViewState(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView bv,
-                                                                           const VkBufferViewCreateInfo *ci,
-                                                                           VkFormatFeatureFlags2KHR buf_ff) {
+std::shared_ptr<vvl::BufferView> gpuav::Validator::CreateBufferViewState(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView bv,
+                                                                         const VkBufferViewCreateInfo *ci,
+                                                                         VkFormatFeatureFlags2KHR buf_ff) {
     return std::make_shared<BufferView>(bf, bv, ci, buf_ff, *desc_heap);
 }
 

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -251,7 +251,7 @@ void gpuav::Validator::CreateAccelerationStructureBuildValidationState(const VkD
     Location loc(vvl::Func::vkCreateDevice);
 
     // Cannot use this validation without a queue that supports graphics
-    auto pd_state = Get<PHYSICAL_DEVICE_STATE>(physical_device);
+    auto pd_state = Get<vvl::PhysicalDevice>(physical_device);
     bool graphics_queue_exists = false;
     uint32_t graphics_queue_family = 0;
     for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; i++) {

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -86,34 +86,34 @@ gpuav::AccelerationStructureKHR::AccelerationStructureKHR(VkAccelerationStructur
                                                           const VkAccelerationStructureCreateInfoKHR *ci,
                                                           std::shared_ptr<vvl::Buffer> &&buf_state, VkDeviceAddress address,
                                                           DescriptorHeap &desc_heap_)
-    : ACCELERATION_STRUCTURE_STATE_KHR(as, ci, std::move(buf_state), address),
+    : vvl::AccelerationStructureKHR(as, ci, std::move(buf_state), address),
       desc_heap(desc_heap_),
       id(desc_heap.NextId(VulkanTypedHandle(as, kVulkanObjectTypeAccelerationStructureKHR))) {}
 
 void gpuav::AccelerationStructureKHR::Destroy() {
     desc_heap.DeleteId(id);
-    ACCELERATION_STRUCTURE_STATE_KHR::Destroy();
+    vvl::AccelerationStructureKHR::Destroy();
 }
 
 void gpuav::AccelerationStructureKHR::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     desc_heap.DeleteId(id);
-    ACCELERATION_STRUCTURE_STATE_KHR::NotifyInvalidate(invalid_nodes, unlink);
+    vvl::AccelerationStructureKHR::NotifyInvalidate(invalid_nodes, unlink);
 }
 
 gpuav::AccelerationStructureNV::AccelerationStructureNV(VkDevice device, VkAccelerationStructureNV as,
                                                         const VkAccelerationStructureCreateInfoNV *ci, DescriptorHeap &desc_heap_)
-    : ACCELERATION_STRUCTURE_STATE_NV(device, as, ci),
+    : vvl::AccelerationStructureNV(device, as, ci),
       desc_heap(desc_heap_),
       id(desc_heap.NextId(VulkanTypedHandle(as, kVulkanObjectTypeAccelerationStructureNV))) {}
 
 void gpuav::AccelerationStructureNV::Destroy() {
     desc_heap.DeleteId(id);
-    ACCELERATION_STRUCTURE_STATE_NV::Destroy();
+    vvl::AccelerationStructureNV::Destroy();
 }
 
 void gpuav::AccelerationStructureNV::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     desc_heap.DeleteId(id);
-    ACCELERATION_STRUCTURE_STATE_NV::NotifyInvalidate(invalid_nodes, unlink);
+    vvl::AccelerationStructureNV::NotifyInvalidate(invalid_nodes, unlink);
 }
 
 gpuav::CommandBuffer::CommandBuffer(gpuav::Validator *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -38,18 +38,18 @@ void gpuav::Buffer::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink)
 
 gpuav::BufferView::BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
                               VkFormatFeatureFlags2KHR buf_ff, DescriptorHeap &desc_heap_)
-    : BUFFER_VIEW_STATE(bf, bv, ci, buf_ff),
+    : vvl::BufferView(bf, bv, ci, buf_ff),
       desc_heap(desc_heap_),
       id(desc_heap.NextId(VulkanTypedHandle(bv, kVulkanObjectTypeBufferView))) {}
 
 void gpuav::BufferView::Destroy() {
     desc_heap.DeleteId(id);
-    BUFFER_VIEW_STATE::Destroy();
+    vvl::BufferView::Destroy();
 }
 
 void gpuav::BufferView::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     desc_heap.DeleteId(id);
-    BUFFER_VIEW_STATE::NotifyInvalidate(invalid_nodes, unlink);
+    vvl::BufferView::NotifyInvalidate(invalid_nodes, unlink);
 }
 
 gpuav::ImageView::ImageView(const std::shared_ptr<IMAGE_STATE> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci,

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -70,16 +70,16 @@ void gpuav::ImageView::NotifyInvalidate(const NodeList &invalid_nodes, bool unli
 }
 
 gpuav::Sampler::Sampler(const VkSampler s, const VkSamplerCreateInfo *pci, DescriptorHeap &desc_heap_)
-    : SAMPLER_STATE(s, pci), desc_heap(desc_heap_), id(desc_heap.NextId(VulkanTypedHandle(s, kVulkanObjectTypeSampler))) {}
+    : vvl::Sampler(s, pci), desc_heap(desc_heap_), id(desc_heap.NextId(VulkanTypedHandle(s, kVulkanObjectTypeSampler))) {}
 
 void gpuav::Sampler::Destroy() {
     desc_heap.DeleteId(id);
-    SAMPLER_STATE::Destroy();
+    vvl::Sampler::Destroy();
 }
 
 void gpuav::Sampler::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     desc_heap.DeleteId(id);
-    SAMPLER_STATE::NotifyInvalidate(invalid_nodes, unlink);
+    vvl::Sampler::NotifyInvalidate(invalid_nodes, unlink);
 }
 
 gpuav::AccelerationStructureKHR::AccelerationStructureKHR(VkAccelerationStructureKHR as,

--- a/layers/gpu_validation/gpu_subclasses.h
+++ b/layers/gpu_validation/gpu_subclasses.h
@@ -269,7 +269,7 @@ class ImageView : public IMAGE_VIEW_STATE {
     const DescriptorId id;
 };
 
-class Sampler : public SAMPLER_STATE {
+class Sampler : public vvl::Sampler {
   public:
     Sampler(const VkSampler s, const VkSamplerCreateInfo *pci, DescriptorHeap &desc_heap_);
 

--- a/layers/gpu_validation/gpu_subclasses.h
+++ b/layers/gpu_validation/gpu_subclasses.h
@@ -244,7 +244,7 @@ class Buffer : public vvl::Buffer {
     const DescriptorId id;
 };
 
-class BufferView : public BUFFER_VIEW_STATE {
+class BufferView : public vvl::BufferView {
   public:
     BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
                VkFormatFeatureFlags2KHR buf_ff, DescriptorHeap &desc_heap_);

--- a/layers/gpu_validation/gpu_subclasses.h
+++ b/layers/gpu_validation/gpu_subclasses.h
@@ -280,7 +280,7 @@ class Sampler : public vvl::Sampler {
     const DescriptorId id;
 };
 
-class AccelerationStructureKHR : public ACCELERATION_STRUCTURE_STATE_KHR {
+class AccelerationStructureKHR : public vvl::AccelerationStructureKHR {
   public:
     AccelerationStructureKHR(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci,
                              std::shared_ptr<vvl::Buffer> &&buf_state, VkDeviceAddress address, DescriptorHeap &desc_heap_);
@@ -292,7 +292,7 @@ class AccelerationStructureKHR : public ACCELERATION_STRUCTURE_STATE_KHR {
     const DescriptorId id;
 };
 
-class AccelerationStructureNV : public ACCELERATION_STRUCTURE_STATE_NV {
+class AccelerationStructureNV : public vvl::AccelerationStructureNV {
   public:
     AccelerationStructureNV(VkDevice device, VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV *ci,
                             DescriptorHeap &desc_heap_);

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -43,8 +43,8 @@ struct GpuVuid {
 };
 }  // namespace gpuav
 
-VALSTATETRACK_DERIVED_STATE_OBJECT(VkAccelerationStructureKHR, gpuav::AccelerationStructureKHR, ACCELERATION_STRUCTURE_STATE_KHR)
-VALSTATETRACK_DERIVED_STATE_OBJECT(VkAccelerationStructureNV, gpuav::AccelerationStructureNV, ACCELERATION_STRUCTURE_STATE_NV)
+VALSTATETRACK_DERIVED_STATE_OBJECT(VkAccelerationStructureKHR, gpuav::AccelerationStructureKHR, vvl::AccelerationStructureKHR)
+VALSTATETRACK_DERIVED_STATE_OBJECT(VkAccelerationStructureNV, gpuav::AccelerationStructureNV, vvl::AccelerationStructureNV)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkBuffer, gpuav::Buffer, vvl::Buffer)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkBufferView, gpuav::BufferView, vvl::BufferView)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, gpuav::CommandBuffer, CMD_BUFFER_STATE)
@@ -129,9 +129,9 @@ class Validator : public gpu_tracker::Validator {
     std::shared_ptr<IMAGE_VIEW_STATE> CreateImageViewState(const std::shared_ptr<IMAGE_STATE>& image_state, VkImageView iv,
                                                            const VkImageViewCreateInfo* ci, VkFormatFeatureFlags2KHR ff,
                                                            const VkFilterCubicImageViewImageFormatPropertiesEXT& cubic_props) final;
-    std::shared_ptr<ACCELERATION_STRUCTURE_STATE_NV> CreateAccelerationStructureState(
+    std::shared_ptr<vvl::AccelerationStructureNV> CreateAccelerationStructureState(
         VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV* pCreateInfo) final;
-    std::shared_ptr<ACCELERATION_STRUCTURE_STATE_KHR> CreateAccelerationStructureState(
+    std::shared_ptr<vvl::AccelerationStructureKHR> CreateAccelerationStructureState(
         VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
         std::shared_ptr<vvl::Buffer>&& buf_state, VkDeviceAddress address) final;
     std::shared_ptr<vvl::Sampler> CreateSamplerState(VkSampler s, const VkSamplerCreateInfo* ci) final;

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -50,7 +50,7 @@ VALSTATETRACK_DERIVED_STATE_OBJECT(VkBufferView, gpuav::BufferView, vvl::BufferV
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, gpuav::CommandBuffer, CMD_BUFFER_STATE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkDescriptorSet, gpuav::DescriptorSet, vvl::DescriptorSet)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkImageView, gpuav::ImageView, IMAGE_VIEW_STATE)
-VALSTATETRACK_DERIVED_STATE_OBJECT(VkSampler, gpuav::Sampler, SAMPLER_STATE)
+VALSTATETRACK_DERIVED_STATE_OBJECT(VkSampler, gpuav::Sampler, vvl::Sampler)
 
 namespace gpuav {
 
@@ -134,7 +134,7 @@ class Validator : public gpu_tracker::Validator {
     std::shared_ptr<ACCELERATION_STRUCTURE_STATE_KHR> CreateAccelerationStructureState(
         VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
         std::shared_ptr<vvl::Buffer>&& buf_state, VkDeviceAddress address) final;
-    std::shared_ptr<SAMPLER_STATE> CreateSamplerState(VkSampler s, const VkSamplerCreateInfo* ci) final;
+    std::shared_ptr<vvl::Sampler> CreateSamplerState(VkSampler s, const VkSamplerCreateInfo* ci) final;
     std::shared_ptr<CMD_BUFFER_STATE> CreateCmdBufferState(VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info,
                                                            const COMMAND_POOL_STATE* pool) final;
     std::shared_ptr<vvl::DescriptorSet> CreateDescriptorSet(VkDescriptorSet, vvl::DescriptorPool*,

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -46,7 +46,7 @@ struct GpuVuid {
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkAccelerationStructureKHR, gpuav::AccelerationStructureKHR, ACCELERATION_STRUCTURE_STATE_KHR)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkAccelerationStructureNV, gpuav::AccelerationStructureNV, ACCELERATION_STRUCTURE_STATE_NV)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkBuffer, gpuav::Buffer, vvl::Buffer)
-VALSTATETRACK_DERIVED_STATE_OBJECT(VkBufferView, gpuav::BufferView, BUFFER_VIEW_STATE)
+VALSTATETRACK_DERIVED_STATE_OBJECT(VkBufferView, gpuav::BufferView, vvl::BufferView)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, gpuav::CommandBuffer, CMD_BUFFER_STATE)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkDescriptorSet, gpuav::DescriptorSet, vvl::DescriptorSet)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkImageView, gpuav::ImageView, IMAGE_VIEW_STATE)
@@ -124,9 +124,8 @@ class Validator : public gpu_tracker::Validator {
     // -------------
   public:
     std::shared_ptr<vvl::Buffer> CreateBufferState(VkBuffer buf, const VkBufferCreateInfo* pCreateInfo) final;
-    std::shared_ptr<BUFFER_VIEW_STATE> CreateBufferViewState(const std::shared_ptr<vvl::Buffer>& bf, VkBufferView bv,
-                                                             const VkBufferViewCreateInfo* ci,
-                                                             VkFormatFeatureFlags2KHR buf_ff) final;
+    std::shared_ptr<vvl::BufferView> CreateBufferViewState(const std::shared_ptr<vvl::Buffer>& bf, VkBufferView bv,
+                                                           const VkBufferViewCreateInfo* ci, VkFormatFeatureFlags2KHR buf_ff) final;
     std::shared_ptr<IMAGE_VIEW_STATE> CreateImageViewState(const std::shared_ptr<IMAGE_STATE>& image_state, VkImageView iv,
                                                            const VkImageViewCreateInfo* ci, VkFormatFeatureFlags2KHR ff,
                                                            const VkFilterCubicImageViewImageFormatPropertiesEXT& cubic_props) final;

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -310,10 +310,10 @@ class Validator : public gpu_tracker::Validator {
 
     void TransitionAttachmentRefLayout(CMD_BUFFER_STATE* cb_state, const safe_VkAttachmentReference2& ref);
 
-    void TransitionSubpassLayouts(CMD_BUFFER_STATE* cb_state, const RENDER_PASS_STATE& render_pass_state, const int);
+    void TransitionSubpassLayouts(CMD_BUFFER_STATE* cb_state, const vvl::RenderPass& render_pass_state, const int);
     void TransitionFinalSubpassLayouts(CMD_BUFFER_STATE* cb_state);
 
-    void TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE* cb_state, const RENDER_PASS_STATE& render_pass_state);
+    void TransitionBeginRenderPassLayouts(CMD_BUFFER_STATE* cb_state, const vvl::RenderPass& render_pass_state);
 
     bool UpdateCommandBufferImageLayoutMap(const CMD_BUFFER_STATE* cb_state, const Location& image_loc,
                                            const ImageBarrier& img_barrier, const CommandBufferImageLayoutMap& current_map,

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -69,9 +69,7 @@ class Buffer : public BINDABLE {
     std::variant<std::monostate, BindableLinearMemoryTracker, BindableSparseMemoryTracker> tracker_;
 };
 
-}  // namespace vvl
-
-class BUFFER_VIEW_STATE : public BASE_NODE {
+class BufferView : public BASE_NODE {
   public:
     const VkBufferViewCreateInfo create_info;
     std::shared_ptr<vvl::Buffer> buffer_state;
@@ -82,20 +80,20 @@ class BUFFER_VIEW_STATE : public BASE_NODE {
     // both as a buffer (ex OpLoad) or image (ex OpImageWrite)
     const VkFormatFeatureFlags2KHR buf_format_features;
 
-    BUFFER_VIEW_STATE(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
-                      VkFormatFeatureFlags2KHR buf_ff);
+    BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
+               VkFormatFeatureFlags2KHR buf_ff);
 
     void LinkChildNodes() override {
         // Connect child node(s), which cannot safely be done in the constructor.
         buffer_state->AddParent(this);
     }
-    virtual ~BUFFER_VIEW_STATE() {
+    virtual ~BufferView() {
         if (!Destroyed()) {
             Destroy();
         }
     }
 
-    BUFFER_VIEW_STATE(const BUFFER_VIEW_STATE &rh_obj) = delete;
+    BufferView(const BufferView &rh_obj) = delete;
 
     VkBufferView buffer_view() const { return handle_.Cast<VkBufferView>(); }
 
@@ -116,3 +114,5 @@ class BUFFER_VIEW_STATE : public BASE_NODE {
         return size;
     }
 };
+
+}  // namespace vvl

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -482,7 +482,7 @@ void CMD_BUFFER_STATE::BeginRenderPass(Func command, const VkRenderPassBeginInfo
                                        const VkSubpassContents contents) {
     RecordCmd(command);
     activeFramebuffer = dev_data->Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
-    activeRenderPass = dev_data->Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
+    activeRenderPass = dev_data->Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     active_render_pass_begin_info = safe_VkRenderPassBeginInfo(pRenderPassBegin);
     SetActiveSubpass(0);
     activeSubpassContents = contents;
@@ -556,7 +556,7 @@ void CMD_BUFFER_STATE::EndRenderPass(Func command) {
 
 void CMD_BUFFER_STATE::BeginRendering(Func command, const VkRenderingInfo *pRenderingInfo) {
     RecordCmd(command);
-    activeRenderPass = std::make_shared<RENDER_PASS_STATE>(pRenderingInfo, true);
+    activeRenderPass = std::make_shared<vvl::RenderPass>(pRenderingInfo, true);
 
     auto chained_device_group_struct = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(pRenderingInfo->pNext);
     if (chained_device_group_struct) {
@@ -845,7 +845,7 @@ void CMD_BUFFER_STATE::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
         if ((createInfo.level != VK_COMMAND_BUFFER_LEVEL_PRIMARY) &&
             (beginInfo.flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)) {
             if (beginInfo.pInheritanceInfo->renderPass) {
-                activeRenderPass = dev_data->Get<RENDER_PASS_STATE>(beginInfo.pInheritanceInfo->renderPass);
+                activeRenderPass = dev_data->Get<vvl::RenderPass>(beginInfo.pInheritanceInfo->renderPass);
                 SetActiveSubpass(beginInfo.pInheritanceInfo->subpass);
 
                 if (beginInfo.pInheritanceInfo->framebuffer) {
@@ -875,7 +875,7 @@ void CMD_BUFFER_STATE::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
                 auto inheritance_rendering_info =
                     vku::FindStructInPNextChain<VkCommandBufferInheritanceRenderingInfo>(beginInfo.pInheritanceInfo->pNext);
                 if (inheritance_rendering_info) {
-                    activeRenderPass = std::make_shared<RENDER_PASS_STATE>(inheritance_rendering_info);
+                    activeRenderPass = std::make_shared<vvl::RenderPass>(inheritance_rendering_info);
                 }
             }
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -481,7 +481,7 @@ void CMD_BUFFER_STATE::UpdateAttachmentsView(const VkRenderPassBeginInfo *pRende
 void CMD_BUFFER_STATE::BeginRenderPass(Func command, const VkRenderPassBeginInfo *pRenderPassBegin,
                                        const VkSubpassContents contents) {
     RecordCmd(command);
-    activeFramebuffer = dev_data->Get<FRAMEBUFFER_STATE>(pRenderPassBegin->framebuffer);
+    activeFramebuffer = dev_data->Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
     activeRenderPass = dev_data->Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
     active_render_pass_begin_info = safe_VkRenderPassBeginInfo(pRenderPassBegin);
     SetActiveSubpass(0);
@@ -849,7 +849,7 @@ void CMD_BUFFER_STATE::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
                 SetActiveSubpass(beginInfo.pInheritanceInfo->subpass);
 
                 if (beginInfo.pInheritanceInfo->framebuffer) {
-                    activeFramebuffer = dev_data->Get<FRAMEBUFFER_STATE>(beginInfo.pInheritanceInfo->framebuffer);
+                    activeFramebuffer = dev_data->Get<vvl::Framebuffer>(beginInfo.pInheritanceInfo->framebuffer);
                     active_subpasses = nullptr;
                     active_attachments = nullptr;
 

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -32,7 +32,6 @@
 #include "containers/custom_containers.h"
 
 struct SUBPASS_INFO;
-class RENDER_PASS_STATE;
 class VIDEO_SESSION_STATE;
 class VIDEO_SESSION_PARAMETERS_STATE;
 class CoreChecks;
@@ -40,6 +39,7 @@ class ValidationStateTracker;
 
 namespace vvl {
 class Framebuffer;
+class RenderPass;
 }  // namespace vvl
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
@@ -375,7 +375,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     uint32_t initial_device_mask;
 
     // The RenderPass created from vkCmdBeginRenderPass or vkCmdBeginRendering
-    std::shared_ptr<RENDER_PASS_STATE> activeRenderPass;
+    std::shared_ptr<vvl::RenderPass> activeRenderPass;
     // Used for both type of renderPass
     vvl::unordered_set<uint32_t> active_color_attachments_index;
     uint32_t active_render_pass_device_mask;

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -32,12 +32,15 @@
 #include "containers/custom_containers.h"
 
 struct SUBPASS_INFO;
-class FRAMEBUFFER_STATE;
 class RENDER_PASS_STATE;
 class VIDEO_SESSION_STATE;
 class VIDEO_SESSION_PARAMETERS_STATE;
 class CoreChecks;
 class ValidationStateTracker;
+
+namespace vvl {
+class Framebuffer;
+}  // namespace vvl
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
 static bool GetMetalExport(const VkEventCreateInfo *info) {
@@ -389,7 +392,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     void SetActiveSubpassRasterizationSampleCount(VkSampleCountFlagBits rasterization_sample_count) {
         active_subpass_sample_count_ = rasterization_sample_count;
     }
-    std::shared_ptr<FRAMEBUFFER_STATE> activeFramebuffer;
+    std::shared_ptr<vvl::Framebuffer> activeFramebuffer;
     // Unified data structs to track objects bound to this command buffer as well as object
     //  dependencies that have been broken : either destroyed objects, or updated descriptor sets
     vvl::unordered_set<std::shared_ptr<BASE_NODE>> object_bindings;
@@ -421,7 +424,7 @@ class CMD_BUFFER_STATE : public REFCOUNTED_NODE {
     // Layers using this are responsible for inserting the callbacks into queue_submit_functions.
     std::vector<QueueCallback> queue_submit_functions_after_render_pass;
     // Validation functions run when secondary CB is executed in primary
-    std::vector<std::function<bool(const CMD_BUFFER_STATE &secondary, const CMD_BUFFER_STATE *primary, const FRAMEBUFFER_STATE *)>>
+    std::vector<std::function<bool(const CMD_BUFFER_STATE &secondary, const CMD_BUFFER_STATE *primary, const vvl::Framebuffer *)>>
         cmd_execute_commands_functions;
 
     using EventCallback = std::function<bool(CMD_BUFFER_STATE &cb_state, bool do_validate, EventToStageMap &local_event_signal_info,

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -738,7 +738,7 @@ void vvl::BufferDescriptor::CopyUpdate(DescriptorSet &set_state, const Validatio
 
 void vvl::TexelDescriptor::WriteUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data,
                                                    const VkWriteDescriptorSet &update, const uint32_t index, bool is_bindless) {
-    auto buffer_view = dev_data.GetConstCastShared<BUFFER_VIEW_STATE>(update.pTexelBufferView[index]);
+    auto buffer_view = dev_data.GetConstCastShared<vvl::BufferView>(update.pTexelBufferView[index]);
     ReplaceStatePtr(set_state, buffer_view_state_, buffer_view, is_bindless);
 }
 
@@ -849,7 +849,7 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const Validat
             break;
         }
         case DescriptorClass::TexelBuffer: {
-            const auto buffer_view = dev_data.GetConstCastShared<BUFFER_VIEW_STATE>(update.pTexelBufferView[index]);
+            const auto buffer_view = dev_data.GetConstCastShared<vvl::BufferView>(update.pTexelBufferView[index]);
             if (buffer_view) {
                 buffer_size = buffer_view->buffer_state->createInfo.size;
             }

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -403,7 +403,7 @@ vvl::DescriptorSet::DescriptorSet(const VkDescriptorSet set, vvl::DescriptorPool
                 auto immut = layout_->GetImmutableSamplerPtrFromIndex(i);
                 if (immut) {
                     for (uint32_t di = 0; di < descriptor_count; ++di) {
-                        auto sampler = state_data->GetConstCastShared<SAMPLER_STATE>(immut[di]);
+                        auto sampler = state_data->GetConstCastShared<vvl::Sampler>(immut[di]);
                         if (sampler) {
                             some_update_ = true;  // Immutable samplers are updated at creation
                             binding->updated[di] = true;
@@ -419,7 +419,7 @@ vvl::DescriptorSet::DescriptorSet(const VkDescriptorSet set, vvl::DescriptorPool
                 auto immut = layout_->GetImmutableSamplerPtrFromIndex(i);
                 if (immut) {
                     for (uint32_t di = 0; di < descriptor_count; ++di) {
-                        auto sampler = state_data->GetConstCastShared<SAMPLER_STATE>(immut[di]);
+                        auto sampler = state_data->GetConstCastShared<vvl::Sampler>(immut[di]);
                         if (sampler) {
                             some_update_ = true;  // Immutable samplers are updated at creation
                             binding->updated[di] = true;
@@ -630,7 +630,7 @@ static void ReplaceStatePtr(DescriptorSet &set_state, T &dst, const T &src, bool
 void vvl::SamplerDescriptor::WriteUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data,
                                                      const VkWriteDescriptorSet &update, const uint32_t index, bool is_bindless) {
     if (!immutable_) {
-        ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<SAMPLER_STATE>(update.pImageInfo[index].sampler),
+        ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<vvl::Sampler>(update.pImageInfo[index].sampler),
                         is_bindless);
     }
 }
@@ -655,7 +655,7 @@ void vvl::ImageSamplerDescriptor::WriteUpdate(DescriptorSet &set_state, const Va
                                                           bool is_bindless) {
     const auto &image_info = update.pImageInfo[index];
     if (!immutable_) {
-        ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<SAMPLER_STATE>(image_info.sampler), is_bindless);
+        ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<vvl::Sampler>(image_info.sampler), is_bindless);
     }
     image_layout_ = image_info.imageLayout;
     ReplaceStatePtr(set_state, image_view_state_, dev_data.GetConstCastShared<IMAGE_VIEW_STATE>(image_info.imageView), is_bindless);
@@ -816,13 +816,13 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const Validat
         case DescriptorClass::PlainSampler:
             if (!immutable_) {
                 ReplaceStatePtr(set_state, sampler_state_,
-                                dev_data.GetConstCastShared<SAMPLER_STATE>(update.pImageInfo[index].sampler), is_bindless);
+                                dev_data.GetConstCastShared<vvl::Sampler>(update.pImageInfo[index].sampler), is_bindless);
             }
             break;
         case DescriptorClass::ImageSampler: {
             const auto &image_info = update.pImageInfo[index];
             if (!immutable_) {
-                ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<SAMPLER_STATE>(image_info.sampler),
+                ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<vvl::Sampler>(image_info.sampler),
                                 is_bindless);
             }
             image_layout_ = image_info.imageLayout;

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -761,11 +761,10 @@ void vvl::AccelerationStructureDescriptor::WriteUpdate(DescriptorSet &set_state,
     is_khr_ = (acc_info != NULL);
     if (is_khr_) {
         acc_ = acc_info->pAccelerationStructures[index];
-        ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_KHR>(acc_), is_bindless);
+        ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<vvl::AccelerationStructureKHR>(acc_), is_bindless);
     } else {
         acc_nv_ = acc_info_nv->pAccelerationStructures[index];
-        ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_NV>(acc_nv_),
-                        is_bindless);
+        ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<vvl::AccelerationStructureNV>(acc_nv_), is_bindless);
     }
 }
 
@@ -777,11 +776,10 @@ void vvl::AccelerationStructureDescriptor::CopyUpdate(DescriptorSet &set_state, 
         is_khr_ = acc_desc.IsAccelerationStructureKHR();
         if (is_khr_) {
             acc_ = acc_desc.GetAccelerationStructureKHR();
-            ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_KHR>(acc_),
-                            is_bindless);
+            ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<vvl::AccelerationStructureKHR>(acc_), is_bindless);
         } else {
             acc_nv_ = acc_desc.GetAccelerationStructureNV();
-            ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_NV>(acc_nv_),
+            ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<vvl::AccelerationStructureNV>(acc_nv_),
                             is_bindless);
         }
         return;
@@ -790,11 +788,10 @@ void vvl::AccelerationStructureDescriptor::CopyUpdate(DescriptorSet &set_state, 
     is_khr_ = acc_desc.is_khr_;
     if (is_khr_) {
         acc_ = acc_desc.acc_;
-        ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_KHR>(acc_), is_bindless);
+        ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<vvl::AccelerationStructureKHR>(acc_), is_bindless);
     } else {
         acc_nv_ = acc_desc.acc_nv_;
-        ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_NV>(acc_nv_),
-                        is_bindless);
+        ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<vvl::AccelerationStructureNV>(acc_nv_), is_bindless);
     }
 }
 
@@ -863,11 +860,11 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const Validat
             is_khr_ = (acc_info != NULL);
             if (is_khr_) {
                 acc_ = acc_info->pAccelerationStructures[index];
-                ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_KHR>(acc_),
+                ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<vvl::AccelerationStructureKHR>(acc_),
                                 is_bindless);
             } else {
                 acc_nv_ = acc_info_nv->pAccelerationStructures[index];
-                ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_NV>(acc_nv_),
+                ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<vvl::AccelerationStructureNV>(acc_nv_),
                                 is_bindless);
             }
             break;
@@ -913,11 +910,10 @@ void vvl::MutableDescriptor::CopyUpdate(DescriptorSet &set_state, const Validati
         auto &acc_desc = static_cast<const AccelerationStructureDescriptor &>(src);
         if (is_khr_) {
             acc_ = acc_desc.GetAccelerationStructure();
-            ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_KHR>(acc_),
-                            is_bindless);
+            ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<vvl::AccelerationStructureKHR>(acc_), is_bindless);
         } else {
             acc_nv_ = acc_desc.GetAccelerationStructureNV();
-            ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_NV>(acc_nv_),
+            ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<vvl::AccelerationStructureNV>(acc_nv_),
                             is_bindless);
         }
     } else if (src.GetClass() == DescriptorClass::Mutable) {
@@ -952,11 +948,11 @@ void vvl::MutableDescriptor::CopyUpdate(DescriptorSet &set_state, const Validati
             case AccelerationStructure: {
                 if (mutable_src.is_khr()) {
                     acc_ = mutable_src.GetAccelerationStructureKHR();
-                    ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_KHR>(acc_),
+                    ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<vvl::AccelerationStructureKHR>(acc_),
                                     is_bindless);
                 } else {
                     acc_nv_ = mutable_src.GetAccelerationStructureNV();
-                    ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<ACCELERATION_STRUCTURE_STATE_NV>(acc_nv_),
+                    ReplaceStatePtr(set_state, acc_state_nv_, dev_data.GetConstCastShared<vvl::AccelerationStructureNV>(acc_nv_),
                                     is_bindless);
                 }
 

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -41,9 +41,9 @@ class ValidationStateTracker;
 class CMD_BUFFER_STATE;
 class UPDATE_TEMPLATE_STATE;
 struct DeviceExtensions;
-class SAMPLER_STATE;
 
 namespace vvl {
+class Sampler;
 class DescriptorSet;
 struct AllocateDescriptorSetsData;
 
@@ -380,15 +380,15 @@ class SamplerDescriptor : public Descriptor {
     virtual bool IsImmutableSampler() const override { return immutable_; };
     VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->sampler() : VK_NULL_HANDLE; }
 
-    void SetSamplerState(std::shared_ptr<SAMPLER_STATE> &&state) {
+    void SetSamplerState(std::shared_ptr<vvl::Sampler> &&state) {
         sampler_state_ = std::move(state);
         // currently this method is only used to initialize immutable samplers during DescriptorSet creation
         immutable_ = true;
     }
 
-    const SAMPLER_STATE *GetSamplerState() const { return sampler_state_.get(); }
-    SAMPLER_STATE *GetSamplerState() { return sampler_state_.get(); }
-    std::shared_ptr<SAMPLER_STATE> GetSharedSamplerState() const { return sampler_state_; }
+    const vvl::Sampler *GetSamplerState() const { return sampler_state_.get(); }
+    vvl::Sampler *GetSamplerState() { return sampler_state_.get(); }
+    std::shared_ptr<vvl::Sampler> GetSharedSamplerState() const { return sampler_state_; }
 
     bool AddParent(BASE_NODE *base_node) override {
         bool result = false;
@@ -406,7 +406,7 @@ class SamplerDescriptor : public Descriptor {
 
   private:
     bool immutable_{false};
-    std::shared_ptr<SAMPLER_STATE> sampler_state_;
+    std::shared_ptr<vvl::Sampler> sampler_state_;
 };
 
 class ImageDescriptor : public Descriptor {
@@ -471,15 +471,15 @@ class ImageSamplerDescriptor : public ImageDescriptor {
     virtual bool IsImmutableSampler() const override { return immutable_; };
     VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->sampler() : VK_NULL_HANDLE; }
 
-    void SetSamplerState(std::shared_ptr<SAMPLER_STATE> &&state) {
+    void SetSamplerState(std::shared_ptr<vvl::Sampler> &&state) {
         sampler_state_ = std::move(state);
         // currently this method is only used to initialize immutable samplers during DescriptorSet creation
         immutable_ = true;
     }
 
-    const SAMPLER_STATE *GetSamplerState() const { return sampler_state_.get(); }
-    SAMPLER_STATE *GetSamplerState() { return sampler_state_.get(); }
-    std::shared_ptr<SAMPLER_STATE> GetSharedSamplerState() const { return sampler_state_; }
+    const vvl::Sampler *GetSamplerState() const { return sampler_state_.get(); }
+    vvl::Sampler *GetSamplerState() { return sampler_state_.get(); }
+    std::shared_ptr<vvl::Sampler> GetSharedSamplerState() const { return sampler_state_; }
 
     bool AddParent(BASE_NODE *base_node) override {
         bool result = ImageDescriptor::AddParent(base_node);
@@ -498,7 +498,7 @@ class ImageSamplerDescriptor : public ImageDescriptor {
     bool Invalid() const override { return ImageDescriptor::Invalid() || !sampler_state_ || sampler_state_->Invalid(); }
 
   private:
-    std::shared_ptr<SAMPLER_STATE> sampler_state_;
+    std::shared_ptr<vvl::Sampler> sampler_state_;
     bool immutable_{false};
 };
 
@@ -669,7 +669,7 @@ class MutableDescriptor : public Descriptor {
     }
     VkDeviceSize GetBufferSize() const { return buffer_size_; }
 
-    std::shared_ptr<SAMPLER_STATE> GetSharedSamplerState() const { return sampler_state_; }
+    std::shared_ptr<vvl::Sampler> GetSharedSamplerState() const { return sampler_state_; }
     std::shared_ptr<IMAGE_VIEW_STATE> GetSharedImageViewState() const { return image_view_state_; }
     VkImageLayout GetImageLayout() const { return image_layout_; }
     std::shared_ptr<vvl::Buffer> GetSharedBufferState() const { return buffer_state_; }
@@ -707,7 +707,7 @@ class MutableDescriptor : public Descriptor {
 
     // Sampler and ImageSampler Descriptor
     bool immutable_{false};
-    std::shared_ptr<SAMPLER_STATE> sampler_state_;
+    std::shared_ptr<vvl::Sampler> sampler_state_;
     // Image Descriptor
     std::shared_ptr<IMAGE_VIEW_STATE> image_view_state_;
     VkImageLayout image_layout_{VK_IMAGE_LAYOUT_UNDEFINED};

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -511,9 +511,9 @@ class TexelDescriptor : public Descriptor {
     void CopyUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data, const Descriptor &, bool is_bindless,
                     VkDescriptorType type) override;
     VkBufferView GetBufferView() const { return buffer_view_state_ ? buffer_view_state_->buffer_view() : VK_NULL_HANDLE; }
-    const BUFFER_VIEW_STATE *GetBufferViewState() const { return buffer_view_state_.get(); }
-    BUFFER_VIEW_STATE *GetBufferViewState() { return buffer_view_state_.get(); }
-    std::shared_ptr<BUFFER_VIEW_STATE> GetSharedBufferViewState() const { return buffer_view_state_; }
+    const vvl::BufferView *GetBufferViewState() const { return buffer_view_state_.get(); }
+    vvl::BufferView *GetBufferViewState() { return buffer_view_state_.get(); }
+    std::shared_ptr<vvl::BufferView> GetSharedBufferViewState() const { return buffer_view_state_; }
 
     bool AddParent(BASE_NODE *base_node) override {
         bool result = false;
@@ -531,7 +531,7 @@ class TexelDescriptor : public Descriptor {
     bool Invalid() const override { return !buffer_view_state_ || buffer_view_state_->Invalid(); }
 
   private:
-    std::shared_ptr<BUFFER_VIEW_STATE> buffer_view_state_;
+    std::shared_ptr<vvl::BufferView> buffer_view_state_;
 };
 
 class BufferDescriptor : public Descriptor {
@@ -675,7 +675,7 @@ class MutableDescriptor : public Descriptor {
     std::shared_ptr<vvl::Buffer> GetSharedBufferState() const { return buffer_state_; }
     VkDeviceSize GetOffset() const { return offset_; }
     VkDeviceSize GetRange() const { return range_; }
-    std::shared_ptr<BUFFER_VIEW_STATE> GetSharedBufferViewState() const { return buffer_view_state_; }
+    std::shared_ptr<vvl::BufferView> GetSharedBufferViewState() const { return buffer_view_state_; }
     VkAccelerationStructureKHR GetAccelerationStructureKHR() const { return acc_; }
     const ACCELERATION_STRUCTURE_STATE_KHR *GetAccelerationStructureStateKHR() const { return acc_state_.get(); }
     ACCELERATION_STRUCTURE_STATE_KHR *GetAccelerationStructureStateKHR() { return acc_state_.get(); }
@@ -712,7 +712,7 @@ class MutableDescriptor : public Descriptor {
     std::shared_ptr<IMAGE_VIEW_STATE> image_view_state_;
     VkImageLayout image_layout_{VK_IMAGE_LAYOUT_UNDEFINED};
     // Texel Descriptor
-    std::shared_ptr<BUFFER_VIEW_STATE> buffer_view_state_;
+    std::shared_ptr<vvl::BufferView> buffer_view_state_;
     // Buffer Descriptor
     VkDeviceSize offset_{0};
     VkDeviceSize range_{0};

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -586,11 +586,11 @@ class AccelerationStructureDescriptor : public Descriptor {
     void WriteUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data, const VkWriteDescriptorSet &, const uint32_t,
                      bool is_bindless) override;
     VkAccelerationStructureKHR GetAccelerationStructure() const { return acc_; }
-    const ACCELERATION_STRUCTURE_STATE_KHR *GetAccelerationStructureStateKHR() const { return acc_state_.get(); }
-    ACCELERATION_STRUCTURE_STATE_KHR *GetAccelerationStructureStateKHR() { return acc_state_.get(); }
+    const vvl::AccelerationStructureKHR *GetAccelerationStructureStateKHR() const { return acc_state_.get(); }
+    vvl::AccelerationStructureKHR *GetAccelerationStructureStateKHR() { return acc_state_.get(); }
     VkAccelerationStructureNV GetAccelerationStructureNV() const { return acc_nv_; }
-    const ACCELERATION_STRUCTURE_STATE_NV *GetAccelerationStructureStateNV() const { return acc_state_nv_.get(); }
-    ACCELERATION_STRUCTURE_STATE_NV *GetAccelerationStructureStateNV() { return acc_state_nv_.get(); }
+    const vvl::AccelerationStructureNV *GetAccelerationStructureStateNV() const { return acc_state_nv_.get(); }
+    vvl::AccelerationStructureNV *GetAccelerationStructureStateNV() { return acc_state_nv_.get(); }
     void CopyUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data, const Descriptor &, bool is_bindless,
                     VkDescriptorType type) override;
     bool is_khr() const { return is_khr_; }
@@ -624,9 +624,9 @@ class AccelerationStructureDescriptor : public Descriptor {
   private:
     bool is_khr_{false};
     VkAccelerationStructureKHR acc_{VK_NULL_HANDLE};
-    std::shared_ptr<ACCELERATION_STRUCTURE_STATE_KHR> acc_state_;
+    std::shared_ptr<vvl::AccelerationStructureKHR> acc_state_;
     VkAccelerationStructureNV acc_nv_{VK_NULL_HANDLE};
-    std::shared_ptr<ACCELERATION_STRUCTURE_STATE_NV> acc_state_nv_;
+    std::shared_ptr<vvl::AccelerationStructureNV> acc_state_nv_;
 };
 
 class MutableDescriptor : public Descriptor {
@@ -677,11 +677,11 @@ class MutableDescriptor : public Descriptor {
     VkDeviceSize GetRange() const { return range_; }
     std::shared_ptr<vvl::BufferView> GetSharedBufferViewState() const { return buffer_view_state_; }
     VkAccelerationStructureKHR GetAccelerationStructureKHR() const { return acc_; }
-    const ACCELERATION_STRUCTURE_STATE_KHR *GetAccelerationStructureStateKHR() const { return acc_state_.get(); }
-    ACCELERATION_STRUCTURE_STATE_KHR *GetAccelerationStructureStateKHR() { return acc_state_.get(); }
+    const vvl::AccelerationStructureKHR *GetAccelerationStructureStateKHR() const { return acc_state_.get(); }
+    vvl::AccelerationStructureKHR *GetAccelerationStructureStateKHR() { return acc_state_.get(); }
     VkAccelerationStructureNV GetAccelerationStructureNV() const { return acc_nv_; }
-    const ACCELERATION_STRUCTURE_STATE_NV *GetAccelerationStructureStateNV() const { return acc_state_nv_.get(); }
-    ACCELERATION_STRUCTURE_STATE_NV *GetAccelerationStructureStateNV() { return acc_state_nv_.get(); }
+    const vvl::AccelerationStructureNV *GetAccelerationStructureStateNV() const { return acc_state_nv_.get(); }
+    vvl::AccelerationStructureNV *GetAccelerationStructureStateNV() { return acc_state_nv_.get(); }
     // Returns true if there is a stored KHR acceleration structure and false if there is a stored NV acceleration structure.
     // Asserts that there is only one of the two.
     bool IsAccelerationStructureKHR() const {
@@ -720,9 +720,9 @@ class MutableDescriptor : public Descriptor {
     // Acceleration Structure Descriptor
     bool is_khr_{false};
     VkAccelerationStructureKHR acc_{VK_NULL_HANDLE};
-    std::shared_ptr<ACCELERATION_STRUCTURE_STATE_KHR> acc_state_;
+    std::shared_ptr<vvl::AccelerationStructureKHR> acc_state_;
     VkAccelerationStructureNV acc_nv_{VK_NULL_HANDLE};
-    std::shared_ptr<ACCELERATION_STRUCTURE_STATE_NV> acc_state_nv_;
+    std::shared_ptr<vvl::AccelerationStructureNV> acc_state_nv_;
 };
 
 // Structs to contain common elements that need to be shared between Validate* and Perform* calls below

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -64,12 +64,16 @@ class PHYSICAL_DEVICE_STATE : public BASE_NODE {
     }
 };
 
-class DISPLAY_MODE_STATE : public BASE_NODE {
+namespace vvl {
+
+class DisplayMode : public BASE_NODE {
   public:
     const VkPhysicalDevice physical_device;
 
-    DISPLAY_MODE_STATE(VkDisplayModeKHR dm, VkPhysicalDevice phys_dev)
+    DisplayMode(VkDisplayModeKHR dm, VkPhysicalDevice phys_dev)
         : BASE_NODE(dm, kVulkanObjectTypeDisplayModeKHR), physical_device(phys_dev) {}
 
     VkDisplayModeKHR display_mode() const { return handle_.Cast<VkDisplayModeKHR>(); }
 };
+
+}  // namespace vvl

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -34,7 +34,9 @@ class SURFACELESS_QUERY_STATE {
     safe_VkSurfaceCapabilities2KHR capabilities;
 };
 
-class PHYSICAL_DEVICE_STATE : public BASE_NODE {
+namespace vvl {
+
+class PhysicalDevice : public BASE_NODE {
   public:
     uint32_t queue_family_known_count = 1;  // spec implies one QF must always be supported
     const std::vector<VkQueueFamilyProperties> queue_family_properties;
@@ -48,7 +50,7 @@ class PHYSICAL_DEVICE_STATE : public BASE_NODE {
     // Surfaceless Query extension needs 'global' surface_state data
     SURFACELESS_QUERY_STATE surfaceless_query_state{};
 
-    PHYSICAL_DEVICE_STATE(VkPhysicalDevice phys_dev)
+    PhysicalDevice(VkPhysicalDevice phys_dev)
         : BASE_NODE(phys_dev, kVulkanObjectTypePhysicalDevice), queue_family_properties(GetQueueFamilyProps(phys_dev)) {}
 
     VkPhysicalDevice PhysDev() const { return handle_.Cast<VkPhysicalDevice>(); }
@@ -63,8 +65,6 @@ class PHYSICAL_DEVICE_STATE : public BASE_NODE {
         return result;
     }
 };
-
-namespace vvl {
 
 class DisplayMode : public BASE_NODE {
   public:

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -603,28 +603,30 @@ std::shared_ptr<const IMAGE_STATE> SWAPCHAIN_NODE::GetSwapChainImageShared(uint3
     return std::shared_ptr<const IMAGE_STATE>();
 }
 
-void SURFACE_STATE::Destroy() {
+namespace vvl {
+
+void Surface::Destroy() {
     if (swapchain) {
         swapchain = nullptr;
     }
     BASE_NODE::Destroy();
 }
 
-void SURFACE_STATE::RemoveParent(BASE_NODE *parent_node) {
+void Surface::RemoveParent(BASE_NODE *parent_node) {
     if (swapchain == parent_node) {
         swapchain = nullptr;
     }
     BASE_NODE::RemoveParent(parent_node);
 }
 
-void SURFACE_STATE::SetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi, bool supported) {
+void Surface::SetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi, bool supported) {
     auto guard = Lock();
     assert(phys_dev);
     GpuQueue key{phys_dev, qfi};
     gpu_queue_support_[key] = supported;
 }
 
-bool SURFACE_STATE::GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) const {
+bool Surface::GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) const {
     auto guard = Lock();
     assert(phys_dev);
     GpuQueue key{phys_dev, qfi};
@@ -639,7 +641,7 @@ bool SURFACE_STATE::GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) con
 }
 
 // Save data from vkGetPhysicalDeviceSurfacePresentModes
-void SURFACE_STATE::SetPresentModes(VkPhysicalDevice phys_dev, vvl::span<const VkPresentModeKHR> modes) {
+void Surface::SetPresentModes(VkPhysicalDevice phys_dev, vvl::span<const VkPresentModeKHR> modes) {
     auto guard = Lock();
     assert(phys_dev);
     for (auto new_present_mode : modes) {
@@ -651,8 +653,8 @@ void SURFACE_STATE::SetPresentModes(VkPhysicalDevice phys_dev, vvl::span<const V
 }
 
 // Helper for data obtained from vkGetPhysicalDeviceSurfacePresentModesKHR
-std::vector<VkPresentModeKHR> SURFACE_STATE::GetPresentModes(VkPhysicalDevice phys_dev, const Location &loc,
-                                                             const ValidationObject *validation_obj) const {
+std::vector<VkPresentModeKHR> Surface::GetPresentModes(VkPhysicalDevice phys_dev, const Location &loc,
+                                                       const ValidationObject *validation_obj) const {
     auto guard = Lock();
     assert(phys_dev);
     std::vector<VkPresentModeKHR> result;
@@ -685,15 +687,15 @@ std::vector<VkPresentModeKHR> SURFACE_STATE::GetPresentModes(VkPhysicalDevice ph
     return result;
 }
 
-void SURFACE_STATE::SetFormats(VkPhysicalDevice phys_dev, std::vector<safe_VkSurfaceFormat2KHR> &&fmts) {
+void Surface::SetFormats(VkPhysicalDevice phys_dev, std::vector<safe_VkSurfaceFormat2KHR> &&fmts) {
     auto guard = Lock();
     assert(phys_dev);
     formats_[phys_dev] = std::move(fmts);
 }
 
-vvl::span<const safe_VkSurfaceFormat2KHR> SURFACE_STATE::GetFormats(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                                    const void *surface_info2_pnext, const Location &loc,
-                                                                    const ValidationObject *validation_obj) const {
+vvl::span<const safe_VkSurfaceFormat2KHR> Surface::GetFormats(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
+                                                              const void *surface_info2_pnext, const Location &loc,
+                                                              const ValidationObject *validation_obj) const {
     auto guard = Lock();
     assert(phys_dev);
 
@@ -764,15 +766,15 @@ vvl::span<const safe_VkSurfaceFormat2KHR> SURFACE_STATE::GetFormats(bool get_sur
     return vvl::span<const safe_VkSurfaceFormat2KHR>(formats_[phys_dev]);
 }
 
-void SURFACE_STATE::SetCapabilities(VkPhysicalDevice phys_dev, const safe_VkSurfaceCapabilities2KHR &caps) {
+void Surface::SetCapabilities(VkPhysicalDevice phys_dev, const safe_VkSurfaceCapabilities2KHR &caps) {
     auto guard = Lock();
     assert(phys_dev);
     capabilities_[phys_dev] = caps;
 }
 
-safe_VkSurfaceCapabilities2KHR SURFACE_STATE::GetCapabilities(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                              const void *surface_info2_pnext, const Location &loc,
-                                                              const ValidationObject *validation_obj) const {
+safe_VkSurfaceCapabilities2KHR Surface::GetCapabilities(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
+                                                        const void *surface_info2_pnext, const Location &loc,
+                                                        const ValidationObject *validation_obj) const {
     auto guard = Lock();
     assert(phys_dev);
 
@@ -806,8 +808,8 @@ safe_VkSurfaceCapabilities2KHR SURFACE_STATE::GetCapabilities(bool get_surface_c
     return safe_surface_caps2;
 }
 
-void SURFACE_STATE::SetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
-                                       vvl::span<const VkPresentModeKHR> compatible_modes) {
+void Surface::SetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
+                                 vvl::span<const VkPresentModeKHR> compatible_modes) {
     auto guard = Lock();
     assert(phys_dev);
 
@@ -826,8 +828,7 @@ void SURFACE_STATE::SetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresen
     }
 }
 
-std::vector<VkPresentModeKHR> SURFACE_STATE::GetCompatibleModes(VkPhysicalDevice phys_dev,
-                                                                const VkPresentModeKHR present_mode) const {
+std::vector<VkPresentModeKHR> Surface::GetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode) const {
     auto guard = Lock();
     assert(phys_dev);
     auto iter = present_modes_data_.find(phys_dev);
@@ -858,9 +859,9 @@ std::vector<VkPresentModeKHR> SURFACE_STATE::GetCompatibleModes(VkPhysicalDevice
 }
 
 // Set the surface and scaling caps for this present mode
-void SURFACE_STATE::SetPresentModeCapabilities(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
-                                               const VkSurfaceCapabilitiesKHR &caps,
-                                               const VkSurfacePresentScalingCapabilitiesEXT &scaling_caps) {
+void Surface::SetPresentModeCapabilities(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
+                                         const VkSurfaceCapabilitiesKHR &caps,
+                                         const VkSurfacePresentScalingCapabilitiesEXT &scaling_caps) {
     auto guard = Lock();
     assert(phys_dev);
     if (!present_modes_data_[phys_dev][present_mode].has_value()) {
@@ -872,8 +873,8 @@ void SURFACE_STATE::SetPresentModeCapabilities(VkPhysicalDevice phys_dev, const 
 }
 
 // Get the surface caps this particular present mode
-VkSurfaceCapabilitiesKHR SURFACE_STATE::GetPresentModeSurfaceCapabilities(VkPhysicalDevice phys_dev,
-                                                                          const VkPresentModeKHR present_mode) const {
+VkSurfaceCapabilitiesKHR Surface::GetPresentModeSurfaceCapabilities(VkPhysicalDevice phys_dev,
+                                                                    const VkPresentModeKHR present_mode) const {
     auto iter = present_modes_data_.find(phys_dev);
     if ((iter != present_modes_data_.end()) && (iter->second.find(present_mode) != iter->second.end())) {
         auto const caps = (iter->second)[present_mode];
@@ -895,8 +896,8 @@ VkSurfaceCapabilitiesKHR SURFACE_STATE::GetPresentModeSurfaceCapabilities(VkPhys
 }
 
 // Get the scaling capabilities for this particular present mode
-VkSurfacePresentScalingCapabilitiesEXT SURFACE_STATE::GetPresentModeScalingCapabilities(VkPhysicalDevice phys_dev,
-                                                                                        const VkPresentModeKHR present_mode) const {
+VkSurfacePresentScalingCapabilitiesEXT Surface::GetPresentModeScalingCapabilities(VkPhysicalDevice phys_dev,
+                                                                                  const VkPresentModeKHR present_mode) const {
     auto iter = present_modes_data_.find(phys_dev);
     if ((iter != present_modes_data_.end()) && (iter->second.find(present_mode) != iter->second.end())) {
         auto const &caps = (iter->second)[present_mode];
@@ -918,6 +919,8 @@ VkSurfacePresentScalingCapabilitiesEXT SURFACE_STATE::GetPresentModeScalingCapab
     DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_capabilities);
     return scaling_caps;
 }
+
+}  // namespace vvl
 
 bool GlobalImageLayoutRangeMap::AnyInRange(RangeGenerator &gen,
                                            std::function<bool(const key_type &range, const mapped_type &state)> &&func) const {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -31,11 +31,11 @@
 namespace vvl {
 class Fence;
 class Semaphore;
+class Surface;
 } // namespace vvl
 
 class ValidationStateTracker;
 class VideoProfileDesc;
-class SURFACE_STATE;
 class SWAPCHAIN_NODE;
 
 static inline bool operator==(const VkImageSubresource &lhs, const VkImageSubresource &rhs) {
@@ -329,7 +329,7 @@ struct SWAPCHAIN_IMAGE {
 
 // State for VkSwapchainKHR objects.
 // Parent -> child relationships in the object usage tree:
-//    SWAPCHAIN_NODE [N] -> [1] SURFACE_STATE
+//    SWAPCHAIN_NODE [N] -> [1] vvl::Surface
 //    However, only 1 swapchain for each surface can be !retired.
 class SWAPCHAIN_NODE : public BASE_NODE {
   public:
@@ -343,7 +343,7 @@ class SWAPCHAIN_NODE : public BASE_NODE {
     uint64_t max_present_id = 0;
     const safe_VkImageCreateInfo image_create_info;
 
-    std::shared_ptr<SURFACE_STATE> surface;
+    std::shared_ptr<vvl::Surface> surface;
     ValidationStateTracker *dev_data;
     uint32_t acquired_images = 0;
 
@@ -399,13 +399,15 @@ struct PresentModeState {
     std::vector<VkPresentModeKHR> compatible_present_modes_;
 };
 
-// Parent -> child relationships in the object usage tree:
-//    SURFACE_STATE -> nothing
-class SURFACE_STATE : public BASE_NODE {
-  public:
-    SURFACE_STATE(VkSurfaceKHR s) : BASE_NODE(s, kVulkanObjectTypeSurfaceKHR) {}
+namespace vvl {
 
-    ~SURFACE_STATE() {
+// Parent -> child relationships in the object usage tree:
+//    vvl::Surface -> nothing
+class Surface : public BASE_NODE {
+  public:
+    Surface(VkSurfaceKHR s) : BASE_NODE(s, kVulkanObjectTypeSurfaceKHR) {}
+
+    ~Surface() {
         if (!Destroyed()) {
             Destroy();
         }
@@ -462,3 +464,5 @@ class SURFACE_STATE : public BASE_NODE {
                                       vvl::unordered_map<VkPresentModeKHR, std::optional<std::shared_ptr<PresentModeState>>>>
         present_modes_data_;
 };
+
+}  // namespace vvl

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -449,7 +449,7 @@ std::shared_ptr<VertexInputState> PIPELINE_STATE::CreateVertexInputState(const P
 // static
 std::shared_ptr<PreRasterState> PIPELINE_STATE::CreatePreRasterState(const PIPELINE_STATE &p, const ValidationStateTracker &state,
                                                                      const safe_VkGraphicsPipelineCreateInfo &create_info,
-                                                                     const std::shared_ptr<const RENDER_PASS_STATE> &rp) {
+                                                                     const std::shared_ptr<const vvl::RenderPass> &rp) {
     const auto lib_type = GetGraphicsLibType(create_info);
     if (lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT) {  // Pre-raster graphics library
         return std::make_shared<PreRasterState>(p, state, create_info, rp);
@@ -473,7 +473,7 @@ std::shared_ptr<PreRasterState> PIPELINE_STATE::CreatePreRasterState(const PIPEL
 // static
 std::shared_ptr<FragmentShaderState> PIPELINE_STATE::CreateFragmentShaderState(
     const PIPELINE_STATE &p, const ValidationStateTracker &state, const VkGraphicsPipelineCreateInfo &create_info,
-    const safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const RENDER_PASS_STATE> &rp) {
+    const safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const vvl::RenderPass> &rp) {
     const auto lib_type = GetGraphicsLibType(create_info);
 
     if (lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT) {  // Fragment shader graphics library
@@ -504,7 +504,7 @@ std::shared_ptr<FragmentShaderState> PIPELINE_STATE::CreateFragmentShaderState(
 // create_info.
 std::shared_ptr<FragmentOutputState> PIPELINE_STATE::CreateFragmentOutputState(
     const PIPELINE_STATE &p, const ValidationStateTracker &state, const VkGraphicsPipelineCreateInfo &create_info,
-    const safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const RENDER_PASS_STATE> &rp) {
+    const safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const vvl::RenderPass> &rp) {
     // If this pipeline is being created a non-executable (i.e., does not contain complete state) pipeline with FO state, then
     // unconditionally set this pipeline's FO state.
     const auto lib_type = GetGraphicsLibType(create_info);
@@ -598,7 +598,7 @@ std::shared_ptr<const SHADER_MODULE_STATE> PIPELINE_STATE::GetSubStateShader(VkS
 }
 
 PIPELINE_STATE::PIPELINE_STATE(const ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
-                               std::shared_ptr<const RENDER_PASS_STATE> &&rpstate,
+                               std::shared_ptr<const vvl::RenderPass> &&rpstate,
                                std::shared_ptr<const PIPELINE_LAYOUT_STATE> &&layout, CreateShaderModuleStates *csm_states)
     : BASE_NODE(static_cast<VkPipeline>(VK_NULL_HANDLE), kVulkanObjectTypePipeline),
       rp_state(rpstate),

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -34,12 +34,11 @@ class DescriptorSetLayoutDef;
 class DescriptorSetLayout;
 class DescriptorSet;
 class Descriptor;
-
+class RenderPass;
 }  // namespace vvl
 
 class ValidationStateTracker;
 class CMD_BUFFER_STATE;
-class RENDER_PASS_STATE;
 struct SHADER_MODULE_STATE;
 class PIPELINE_STATE;
 
@@ -70,7 +69,7 @@ class PIPELINE_STATE : public BASE_NODE {
         template <typename CI>
         struct Traits {};
 
-        CreateInfo(const VkGraphicsPipelineCreateInfo &ci, std::shared_ptr<const RENDER_PASS_STATE> rpstate,
+        CreateInfo(const VkGraphicsPipelineCreateInfo &ci, std::shared_ptr<const vvl::RenderPass> rpstate,
                    const ValidationStateTracker *state_data)
             : graphics() {
             bool use_color = false;
@@ -125,7 +124,7 @@ class PIPELINE_STATE : public BASE_NODE {
     // NOTE: The style guide suggests private data appear at the end, but we need this populated first, so placing it here
 
     // Render pass state for dynamic rendering, etc.
-    std::shared_ptr<const RENDER_PASS_STATE> rp_state;
+    std::shared_ptr<const vvl::RenderPass> rp_state;
 
     const CreateInfo create_info;
 
@@ -180,7 +179,7 @@ class PIPELINE_STATE : public BASE_NODE {
 
     // Executable or legacy pipeline
     PIPELINE_STATE(const ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
-                   std::shared_ptr<const RENDER_PASS_STATE> &&rpstate, std::shared_ptr<const PIPELINE_LAYOUT_STATE> &&layout,
+                   std::shared_ptr<const vvl::RenderPass> &&rpstate, std::shared_ptr<const PIPELINE_LAYOUT_STATE> &&layout,
                    CreateShaderModuleStates *csm_states = nullptr);
 
     // Compute pipeline
@@ -253,7 +252,7 @@ class PIPELINE_STATE : public BASE_NODE {
     // Important as some pipeline checks need pipeline state that won't be there if the substate is from linking
     bool OwnsSubState(const std::shared_ptr<PipelineSubState> sub_state) const { return sub_state && (&sub_state->parent == this); }
 
-    const std::shared_ptr<const RENDER_PASS_STATE> RenderPassState() const {
+    const std::shared_ptr<const vvl::RenderPass> RenderPassState() const {
         // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
         if (fragment_output_state && fragment_output_state->rp_state) {
             return fragment_output_state->rp_state;
@@ -562,17 +561,17 @@ class PIPELINE_STATE : public BASE_NODE {
                                                                     const safe_VkGraphicsPipelineCreateInfo &create_info);
     static std::shared_ptr<PreRasterState> CreatePreRasterState(const PIPELINE_STATE &p, const ValidationStateTracker &state,
                                                                 const safe_VkGraphicsPipelineCreateInfo &create_info,
-                                                                const std::shared_ptr<const RENDER_PASS_STATE> &rp);
+                                                                const std::shared_ptr<const vvl::RenderPass> &rp);
     static std::shared_ptr<FragmentShaderState> CreateFragmentShaderState(const PIPELINE_STATE &p,
                                                                           const ValidationStateTracker &state,
                                                                           const VkGraphicsPipelineCreateInfo &create_info,
                                                                           const safe_VkGraphicsPipelineCreateInfo &safe_create_info,
-                                                                          const std::shared_ptr<const RENDER_PASS_STATE> &rp);
+                                                                          const std::shared_ptr<const vvl::RenderPass> &rp);
     static std::shared_ptr<FragmentOutputState> CreateFragmentOutputState(const PIPELINE_STATE &p,
                                                                           const ValidationStateTracker &state,
                                                                           const VkGraphicsPipelineCreateInfo &create_info,
                                                                           const safe_VkGraphicsPipelineCreateInfo &safe_create_info,
-                                                                          const std::shared_ptr<const RENDER_PASS_STATE> &rp);
+                                                                          const std::shared_ptr<const vvl::RenderPass> &rp);
 
     template <typename CreateInfo>
     static bool EnablesRasterizationStates(const CreateInfo &create_info) {

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -42,15 +42,17 @@ class CMD_BUFFER_STATE;
 struct SHADER_MODULE_STATE;
 class PIPELINE_STATE;
 
-class PIPELINE_CACHE_STATE : public BASE_NODE {
+namespace vvl {
+class PipelineCache : public BASE_NODE {
   public:
-    PIPELINE_CACHE_STATE(VkPipelineCache pipeline_cache, const VkPipelineCacheCreateInfo *pCreateInfo)
+    PipelineCache(VkPipelineCache pipeline_cache, const VkPipelineCacheCreateInfo *pCreateInfo)
         : BASE_NODE(pipeline_cache, kVulkanObjectTypePipelineCache), create_info(pCreateInfo) {}
 
     VkPipelineCache pipelineCache() const { return handle_.Cast<VkPipelineCache>(); }
 
     const safe_VkPipelineCacheCreateInfo create_info;
 };
+}  // namespace vvl
 
 struct StageCreateInfo {
     const PIPELINE_STATE *pipeline;

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -57,13 +57,13 @@ VertexInputState::VertexInputState(const PIPELINE_STATE &p, const safe_VkGraphic
 }
 
 PreRasterState::PreRasterState(const PIPELINE_STATE &p, const ValidationStateTracker &state_data,
-                               const safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const RENDER_PASS_STATE> rp)
+                               const safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp)
     : PipelineSubState(p), rp_state(rp), subpass(create_info.subpass) {
     pipeline_layout = state_data.Get<PIPELINE_LAYOUT_STATE>(create_info.layout);
 
     viewport_state = create_info.pViewportState;
 
-    rp_state = state_data.Get<RENDER_PASS_STATE>(create_info.renderPass);
+    rp_state = state_data.Get<vvl::RenderPass>(create_info.renderPass);
 
     raster_state = create_info.pRasterizationState;
 
@@ -235,10 +235,10 @@ void FragmentShaderState::SetFragmentShaderInfo(FragmentShaderState &fs_state, c
 }
 
 FragmentShaderState::FragmentShaderState(const PIPELINE_STATE &p, const ValidationStateTracker &dev_data,
-                                         std::shared_ptr<const RENDER_PASS_STATE> rp, uint32_t subp, VkPipelineLayout layout)
+                                         std::shared_ptr<const vvl::RenderPass> rp, uint32_t subp, VkPipelineLayout layout)
     : PipelineSubState(p), rp_state(rp), subpass(subp), pipeline_layout(dev_data.Get<PIPELINE_LAYOUT_STATE>(layout)) {}
 
-FragmentOutputState::FragmentOutputState(const PIPELINE_STATE &p, std::shared_ptr<const RENDER_PASS_STATE> rp, uint32_t sp)
+FragmentOutputState::FragmentOutputState(const PIPELINE_STATE &p, std::shared_ptr<const vvl::RenderPass> rp, uint32_t sp)
     : PipelineSubState(p), rp_state(rp), subpass(sp) {}
 
 // static

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -22,9 +22,12 @@
 
 // Graphics pipeline sub-state as defined by VK_KHR_graphics_pipeline_library
 //
-class RENDER_PASS_STATE;
 struct SHADER_MODULE_STATE;
 struct EntryPoint;
+
+namespace vvl {
+class RenderPass;
+}  // namespace vvl
 
 template <typename CreateInfoType>
 static inline VkGraphicsPipelineLibraryFlagsEXT GetGraphicsLibType(const CreateInfoType &create_info) {
@@ -67,7 +70,7 @@ struct VertexInputState : public PipelineSubState {
 
 struct PreRasterState : public PipelineSubState {
     PreRasterState(const PIPELINE_STATE &p, const ValidationStateTracker &dev_data,
-                   const safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const RENDER_PASS_STATE> rp);
+                   const safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp);
 
     static inline VkShaderStageFlags ValidShaderStages() {
         return VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT |
@@ -79,7 +82,7 @@ struct PreRasterState : public PipelineSubState {
 
     safe_VkPipelineRasterizationStateCreateInfo *raster_state = nullptr;
 
-    std::shared_ptr<const RENDER_PASS_STATE> rp_state;
+    std::shared_ptr<const vvl::RenderPass> rp_state;
     uint32_t subpass = 0;
 
     VkShaderStageFlagBits last_stage = VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM;
@@ -109,12 +112,12 @@ std::unique_ptr<const safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(cons
 std::unique_ptr<const safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(const VkPipelineShaderStageCreateInfo &cbs);
 
 struct FragmentShaderState : public PipelineSubState {
-    FragmentShaderState(const PIPELINE_STATE &p, const ValidationStateTracker &dev_data,
-                        std::shared_ptr<const RENDER_PASS_STATE> rp, uint32_t subpass, VkPipelineLayout layout);
+    FragmentShaderState(const PIPELINE_STATE &p, const ValidationStateTracker &dev_data, std::shared_ptr<const vvl::RenderPass> rp,
+                        uint32_t subpass, VkPipelineLayout layout);
 
     template <typename CreateInfo>
     FragmentShaderState(const PIPELINE_STATE &p, const ValidationStateTracker &dev_data, const CreateInfo &create_info,
-                        std::shared_ptr<const RENDER_PASS_STATE> rp)
+                        std::shared_ptr<const vvl::RenderPass> rp)
         : FragmentShaderState(p, dev_data, rp, create_info.subpass, create_info.layout) {
         if (create_info.pMultisampleState) {
             ms_state = ToSafeMultisampleState(*create_info.pMultisampleState);
@@ -127,7 +130,7 @@ struct FragmentShaderState : public PipelineSubState {
 
     static inline VkShaderStageFlags ValidShaderStages() { return VK_SHADER_STAGE_FRAGMENT_BIT; }
 
-    std::shared_ptr<const RENDER_PASS_STATE> rp_state;
+    std::shared_ptr<const vvl::RenderPass> rp_state;
     uint32_t subpass = 0;
 
     std::shared_ptr<const PIPELINE_LAYOUT_STATE> pipeline_layout;
@@ -162,12 +165,12 @@ static bool IsSampleLocationEnabled(const CreateInfo &create_info) {
 struct FragmentOutputState : public PipelineSubState {
     using AttachmentVector = std::vector<VkPipelineColorBlendAttachmentState>;
 
-    FragmentOutputState(const PIPELINE_STATE &p, std::shared_ptr<const RENDER_PASS_STATE> rp, uint32_t sp);
+    FragmentOutputState(const PIPELINE_STATE &p, std::shared_ptr<const vvl::RenderPass> rp, uint32_t sp);
     // For a graphics library, a "non-safe" create info must be passed in in order for pColorBlendState and pMultisampleState to not
     // get stripped out. If this is a "normal" pipeline, then we want to keep the logic from safe_VkGraphicsPipelineCreateInfo that
     // strips out pointers that should be ignored.
     template <typename CreateInfo>
-    FragmentOutputState(const PIPELINE_STATE &p, const CreateInfo &create_info, std::shared_ptr<const RENDER_PASS_STATE> rp)
+    FragmentOutputState(const PIPELINE_STATE &p, const CreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp)
         : FragmentOutputState(p, rp, create_info.subpass) {
         if (create_info.pColorBlendState) {
             const auto &cbci = *create_info.pColorBlendState;
@@ -195,7 +198,7 @@ struct FragmentOutputState : public PipelineSubState {
     static bool IsBlendConstantsEnabled(const AttachmentVector &attachments);
     static bool GetDualSourceBlending(const safe_VkPipelineColorBlendStateCreateInfo *color_blend_state);
 
-    std::shared_ptr<const RENDER_PASS_STATE> rp_state;
+    std::shared_ptr<const vvl::RenderPass> rp_state;
     uint32_t subpass = 0;
 
     std::unique_ptr<const safe_VkPipelineColorBlendStateCreateInfo> color_blend_state;

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -21,9 +21,11 @@
 #include "state_tracker/buffer_state.h"
 #include "generated/layer_chassis_dispatch.h"
 
-class ACCELERATION_STRUCTURE_STATE_NV : public BINDABLE {
+namespace vvl {
+
+class AccelerationStructureNV : public BINDABLE {
   public:
-    ACCELERATION_STRUCTURE_STATE_NV(VkDevice device, VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV *ci)
+    AccelerationStructureNV(VkDevice device, VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV *ci)
         : BINDABLE(as, kVulkanObjectTypeAccelerationStructureNV, false, false, 0),
           create_infoNV(ci),
           memory_requirements(GetMemReqs(device, as, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV)),
@@ -34,7 +36,7 @@ class ACCELERATION_STRUCTURE_STATE_NV : public BINDABLE {
           tracker_(&memory_requirements) {
         BINDABLE::SetMemoryTracker(&tracker_);
     }
-    ACCELERATION_STRUCTURE_STATE_NV(const ACCELERATION_STRUCTURE_STATE_NV &rh_obj) = delete;
+    AccelerationStructureNV(const AccelerationStructureNV &rh_obj) = delete;
 
     VkAccelerationStructureNV acceleration_structure() const { return handle_.Cast<VkAccelerationStructureNV>(); }
 
@@ -67,12 +69,12 @@ class ACCELERATION_STRUCTURE_STATE_NV : public BINDABLE {
     BindableLinearMemoryTracker tracker_;
 };
 
-class ACCELERATION_STRUCTURE_STATE_KHR : public BASE_NODE {
+class AccelerationStructureKHR : public BASE_NODE {
   public:
-    ACCELERATION_STRUCTURE_STATE_KHR(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci,
-                                     std::shared_ptr<vvl::Buffer> &&buf_state, VkDeviceAddress address)
+    AccelerationStructureKHR(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci,
+                             std::shared_ptr<vvl::Buffer> &&buf_state, VkDeviceAddress address)
         : BASE_NODE(as, kVulkanObjectTypeAccelerationStructureKHR), create_infoKHR(ci), buffer_state(buf_state), address(address) {}
-    ACCELERATION_STRUCTURE_STATE_KHR(const ACCELERATION_STRUCTURE_STATE_KHR &rh_obj) = delete;
+    AccelerationStructureKHR(const AccelerationStructureKHR &rh_obj) = delete;
 
     VkAccelerationStructureKHR acceleration_structure() const { return handle_.Cast<VkAccelerationStructureKHR>(); }
 
@@ -89,7 +91,7 @@ class ACCELERATION_STRUCTURE_STATE_KHR : public BASE_NODE {
         BASE_NODE::Destroy();
     }
 
-    virtual ~ACCELERATION_STRUCTURE_STATE_KHR() {
+    virtual ~AccelerationStructureKHR() {
         if (!Destroyed()) {
             Destroy();
         }
@@ -108,6 +110,8 @@ class ACCELERATION_STRUCTURE_STATE_KHR : public BASE_NODE {
     std::shared_ptr<vvl::Buffer> buffer_state;
     VkDeviceAddress address;
 };
+
+}  // namespace vvl
 
 // Safe struct that spans NV and KHR VkRayTracingPipelineCreateInfo structures.
 // It is a safe_VkRayTracingPipelineCreateInfoKHR and supports construction from

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -398,25 +398,28 @@ RENDER_PASS_STATE::RENDER_PASS_STATE(VkCommandBufferInheritanceRenderingInfo con
       has_multiview_enabled(false),
       inheritance_rendering_info(pInheritanceRenderingInfo) {}
 
-FRAMEBUFFER_STATE::FRAMEBUFFER_STATE(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo,
-                                     std::shared_ptr<RENDER_PASS_STATE> &&rpstate,
-                                     std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> &&attachments)
+namespace vvl {
+
+Framebuffer::Framebuffer(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RENDER_PASS_STATE> &&rpstate,
+                         std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> &&attachments)
     : BASE_NODE(fb, kVulkanObjectTypeFramebuffer),
       createInfo(pCreateInfo),
       rp_state(rpstate),
       attachments_view_state(std::move(attachments)) {}
 
-void FRAMEBUFFER_STATE::LinkChildNodes() {
+void Framebuffer::LinkChildNodes() {
     // Connect child node(s), which cannot safely be done in the constructor.
     for (auto &a : attachments_view_state) {
         a->AddParent(this);
     }
 }
 
-void FRAMEBUFFER_STATE::Destroy() {
+void Framebuffer::Destroy() {
     for (auto &view : attachments_view_state) {
         view->RemoveParent(this);
     }
     attachments_view_state.clear();
     BASE_NODE::Destroy();
 }
+
+}  // namespace vvl

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -54,14 +54,14 @@ static VkSubpassDependency2 ImplicitDependencyToExternal(uint32_t subpass) {
                                         0};
     return to_external;
 }
-// NOTE: The functions below are only called from the RENDER_PASS_STATE constructor, and use const_cast<> to set up
+// NOTE: The functions below are only called from the vvl::RenderPass constructor, and use const_cast<> to set up
 // members that never change after construction is finished.
-static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, RENDER_PASS_STATE *render_pass) {
-    auto &subpass_to_node = const_cast<RENDER_PASS_STATE::DAGNodeVec &>(render_pass->subpass_to_node);
+static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl::RenderPass *render_pass) {
+    auto &subpass_to_node = const_cast<vvl::RenderPass::DAGNodeVec &>(render_pass->subpass_to_node);
     subpass_to_node.resize(pCreateInfo->subpassCount);
-    auto &self_dependencies = const_cast<RENDER_PASS_STATE::SelfDepVec &>(render_pass->self_dependencies);
+    auto &self_dependencies = const_cast<vvl::RenderPass::SelfDepVec &>(render_pass->self_dependencies);
     self_dependencies.resize(pCreateInfo->subpassCount);
-    auto &subpass_dependencies = const_cast<RENDER_PASS_STATE::SubpassGraphVec &>(render_pass->subpass_dependencies);
+    auto &subpass_dependencies = const_cast<vvl::RenderPass::SubpassGraphVec &>(render_pass->subpass_dependencies);
     subpass_dependencies.resize(pCreateInfo->subpassCount);
 
     for (uint32_t i = 0; i < pCreateInfo->subpassCount; ++i) {
@@ -136,22 +136,22 @@ static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, REND
 }
 
 struct AttachmentTracker {  // This is really only of local interest, but a bit big for a lambda
-    RENDER_PASS_STATE *const rp;
-    RENDER_PASS_STATE::SubpassVec &first;
-    RENDER_PASS_STATE::FirstIsTransitionVec &first_is_transition;
-    RENDER_PASS_STATE::SubpassVec &last;
-    RENDER_PASS_STATE::TransitionVec &subpass_transitions;
-    RENDER_PASS_STATE::FirstReadMap &first_read;
+    vvl::RenderPass *const rp;
+    vvl::RenderPass::SubpassVec &first;
+    vvl::RenderPass::FirstIsTransitionVec &first_is_transition;
+    vvl::RenderPass::SubpassVec &last;
+    vvl::RenderPass::TransitionVec &subpass_transitions;
+    vvl::RenderPass::FirstReadMap &first_read;
     const uint32_t attachment_count;
     std::vector<VkImageLayout> attachment_layout;
     std::vector<std::vector<VkImageLayout>> subpass_attachment_layout;
-    explicit AttachmentTracker(RENDER_PASS_STATE *render_pass)
+    explicit AttachmentTracker(vvl::RenderPass *render_pass)
         : rp(render_pass),
-          first(const_cast<RENDER_PASS_STATE::SubpassVec &>(rp->attachment_first_subpass)),
-          first_is_transition(const_cast<RENDER_PASS_STATE::FirstIsTransitionVec &>(rp->attachment_first_is_transition)),
-          last(const_cast<RENDER_PASS_STATE::SubpassVec &>(rp->attachment_last_subpass)),
-          subpass_transitions(const_cast<RENDER_PASS_STATE::TransitionVec &>(rp->subpass_transitions)),
-          first_read(const_cast<RENDER_PASS_STATE::FirstReadMap &>(rp->attachment_first_read)),
+          first(const_cast<vvl::RenderPass::SubpassVec &>(rp->attachment_first_subpass)),
+          first_is_transition(const_cast<vvl::RenderPass::FirstIsTransitionVec &>(rp->attachment_first_is_transition)),
+          last(const_cast<vvl::RenderPass::SubpassVec &>(rp->attachment_last_subpass)),
+          subpass_transitions(const_cast<vvl::RenderPass::TransitionVec &>(rp->subpass_transitions)),
+          first_read(const_cast<vvl::RenderPass::FirstReadMap &>(rp->attachment_first_read)),
           attachment_count(rp->createInfo.attachmentCount),
           attachment_layout(),
           subpass_attachment_layout() {
@@ -244,7 +244,7 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
     }
 };
 
-static void InitRenderPassState(RENDER_PASS_STATE *render_pass) {
+static void InitRenderPassState(vvl::RenderPass *render_pass) {
     auto create_info = render_pass->createInfo.ptr();
 
     RecordRenderPassDAG(create_info, render_pass);
@@ -267,7 +267,9 @@ static void InitRenderPassState(RENDER_PASS_STATE *render_pass) {
     attachment_tracker.FinalTransitions();
 }
 
-RENDER_PASS_STATE::RENDER_PASS_STATE(VkRenderPass rp, VkRenderPassCreateInfo2 const *pCreateInfo)
+namespace vvl {
+
+RenderPass::RenderPass(VkRenderPass rp, VkRenderPassCreateInfo2 const *pCreateInfo)
     : BASE_NODE(rp, kVulkanObjectTypeRenderPass),
       use_dynamic_rendering(false),
       use_dynamic_rendering_inherited(false),
@@ -281,7 +283,7 @@ static safe_VkRenderPassCreateInfo2 ConvertCreateInfo(const VkRenderPassCreateIn
     return create_info_2;
 }
 
-RENDER_PASS_STATE::RENDER_PASS_STATE(VkRenderPass rp, VkRenderPassCreateInfo const *pCreateInfo)
+RenderPass::RenderPass(VkRenderPass rp, VkRenderPassCreateInfo const *pCreateInfo)
     : BASE_NODE(rp, kVulkanObjectTypeRenderPass),
       use_dynamic_rendering(false),
       use_dynamic_rendering_inherited(false),
@@ -293,7 +295,7 @@ RENDER_PASS_STATE::RENDER_PASS_STATE(VkRenderPass rp, VkRenderPassCreateInfo con
 const VkPipelineRenderingCreateInfo VkPipelineRenderingCreateInfo_default = {
     VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO, nullptr, 0, 0, nullptr, VK_FORMAT_UNDEFINED, VK_FORMAT_UNDEFINED};
 
-RENDER_PASS_STATE::RENDER_PASS_STATE(VkPipelineRenderingCreateInfo const *pPipelineRenderingCreateInfo, bool rasterization_enabled)
+RenderPass::RenderPass(VkPipelineRenderingCreateInfo const *pPipelineRenderingCreateInfo, bool rasterization_enabled)
     : BASE_NODE(static_cast<VkRenderPass>(VK_NULL_HANDLE), kVulkanObjectTypeRenderPass),
       use_dynamic_rendering(true),
       use_dynamic_rendering_inherited(false),
@@ -303,7 +305,7 @@ RENDER_PASS_STATE::RENDER_PASS_STATE(VkPipelineRenderingCreateInfo const *pPipel
                                                  ? pPipelineRenderingCreateInfo
                                                  : &VkPipelineRenderingCreateInfo_default) {}
 
-bool RENDER_PASS_STATE::UsesColorAttachment(uint32_t subpass_num) const {
+bool RenderPass::UsesColorAttachment(uint32_t subpass_num) const {
     bool result = false;
 
     if (subpass_num < createInfo.subpassCount) {
@@ -332,7 +334,7 @@ bool RENDER_PASS_STATE::UsesColorAttachment(uint32_t subpass_num) const {
     return result;
 }
 
-bool RENDER_PASS_STATE::UsesDepthStencilAttachment(uint32_t subpass_num) const {
+bool RenderPass::UsesDepthStencilAttachment(uint32_t subpass_num) const {
     bool result = false;
     if (subpass_num < createInfo.subpassCount) {
         const auto &subpass = createInfo.pSubpasses[subpass_num];
@@ -343,7 +345,7 @@ bool RENDER_PASS_STATE::UsesDepthStencilAttachment(uint32_t subpass_num) const {
     return result;
 }
 
-uint32_t RENDER_PASS_STATE::GetDynamicRenderingColorAttachmentCount() const {
+uint32_t RenderPass::GetDynamicRenderingColorAttachmentCount() const {
     if (use_dynamic_rendering_inherited) {
         return inheritance_rendering_info.colorAttachmentCount;
     } else if (use_dynamic_rendering) {
@@ -352,7 +354,7 @@ uint32_t RENDER_PASS_STATE::GetDynamicRenderingColorAttachmentCount() const {
     return 0;
 }
 
-uint32_t RENDER_PASS_STATE::GetDynamicRenderingViewMask() const {
+uint32_t RenderPass::GetDynamicRenderingViewMask() const {
     if (use_dynamic_rendering_inherited) {
         return inheritance_rendering_info.viewMask;
     } else if (use_dynamic_rendering) {
@@ -361,7 +363,7 @@ uint32_t RENDER_PASS_STATE::GetDynamicRenderingViewMask() const {
     return 0;
 }
 
-uint32_t RENDER_PASS_STATE::GetViewMaskBits(uint32_t subpass) const {
+uint32_t RenderPass::GetViewMaskBits(uint32_t subpass) const {
     if (use_dynamic_rendering_inherited) {
         return GetBitSetCount(inheritance_rendering_info.viewMask);
     } else if (use_dynamic_rendering) {
@@ -375,7 +377,7 @@ uint32_t RENDER_PASS_STATE::GetViewMaskBits(uint32_t subpass) const {
     return 0;
 }
 
-const VkMultisampledRenderToSingleSampledInfoEXT *RENDER_PASS_STATE::GetMSRTSSInfo(uint32_t subpass) const {
+const VkMultisampledRenderToSingleSampledInfoEXT *RenderPass::GetMSRTSSInfo(uint32_t subpass) const {
     if (UsesDynamicRendering()) {
         return vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(
             dynamic_rendering_begin_rendering_info.pNext);
@@ -383,7 +385,7 @@ const VkMultisampledRenderToSingleSampledInfoEXT *RENDER_PASS_STATE::GetMSRTSSIn
     return vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(createInfo.pSubpasses[subpass].pNext);
 }
 
-RENDER_PASS_STATE::RENDER_PASS_STATE(VkRenderingInfo const *pRenderingInfo, bool rasterization_enabled)
+RenderPass::RenderPass(VkRenderingInfo const *pRenderingInfo, bool rasterization_enabled)
     : BASE_NODE(static_cast<VkRenderPass>(VK_NULL_HANDLE), kVulkanObjectTypeRenderPass),
       use_dynamic_rendering(true),
       use_dynamic_rendering_inherited(false),
@@ -391,16 +393,14 @@ RENDER_PASS_STATE::RENDER_PASS_STATE(VkRenderingInfo const *pRenderingInfo, bool
       rasterization_enabled(rasterization_enabled),
       dynamic_rendering_begin_rendering_info((pRenderingInfo && rasterization_enabled) ? pRenderingInfo : nullptr) {}
 
-RENDER_PASS_STATE::RENDER_PASS_STATE(VkCommandBufferInheritanceRenderingInfo const *pInheritanceRenderingInfo)
+RenderPass::RenderPass(VkCommandBufferInheritanceRenderingInfo const *pInheritanceRenderingInfo)
     : BASE_NODE(static_cast<VkRenderPass>(VK_NULL_HANDLE), kVulkanObjectTypeRenderPass),
       use_dynamic_rendering(false),
       use_dynamic_rendering_inherited(true),
       has_multiview_enabled(false),
       inheritance_rendering_info(pInheritanceRenderingInfo) {}
 
-namespace vvl {
-
-Framebuffer::Framebuffer(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RENDER_PASS_STATE> &&rpstate,
+Framebuffer::Framebuffer(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RenderPass> &&rpstate,
                          std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> &&attachments)
     : BASE_NODE(fb, kVulkanObjectTypeFramebuffer),
       createInfo(pCreateInfo),

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -119,19 +119,23 @@ class RENDER_PASS_STATE : public BASE_NODE {
     const VkMultisampledRenderToSingleSampledInfoEXT *GetMSRTSSInfo(uint32_t subpass) const;
 };
 
-class FRAMEBUFFER_STATE : public BASE_NODE {
+namespace vvl {
+
+class Framebuffer : public BASE_NODE {
   public:
     const safe_VkFramebufferCreateInfo createInfo;
     std::shared_ptr<const RENDER_PASS_STATE> rp_state;
     std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> attachments_view_state;
 
-    FRAMEBUFFER_STATE(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RENDER_PASS_STATE> &&rpstate,
-                      std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> &&attachments);
+    Framebuffer(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RENDER_PASS_STATE> &&rpstate,
+                std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> &&attachments);
     void LinkChildNodes() override;
 
     VkFramebuffer framebuffer() const { return handle_.Cast<VkFramebuffer>(); }
 
-    virtual ~FRAMEBUFFER_STATE() { Destroy(); }
+    virtual ~Framebuffer() { Destroy(); }
 
     void Destroy() override;
 };
+
+}  // namespace vvl

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -66,7 +66,9 @@ struct SubpassLayout {
     VkImageLayout layout;
 };
 
-class RENDER_PASS_STATE : public BASE_NODE {
+namespace vvl {
+
+class RenderPass : public BASE_NODE {
   public:
     struct AttachmentTransition {
         uint32_t prev_pass;
@@ -100,12 +102,12 @@ class RENDER_PASS_STATE : public BASE_NODE {
     using TransitionVec = std::vector<std::vector<AttachmentTransition>>;
     const TransitionVec subpass_transitions;
 
-    RENDER_PASS_STATE(VkRenderPass rp, VkRenderPassCreateInfo2 const *pCreateInfo);
-    RENDER_PASS_STATE(VkRenderPass rp, VkRenderPassCreateInfo const *pCreateInfo);
+    RenderPass(VkRenderPass rp, VkRenderPassCreateInfo2 const *pCreateInfo);
+    RenderPass(VkRenderPass rp, VkRenderPassCreateInfo const *pCreateInfo);
 
-    RENDER_PASS_STATE(VkPipelineRenderingCreateInfo const *pPipelineRenderingCreateInfo, bool rasterization_enabled);
-    RENDER_PASS_STATE(VkRenderingInfo const *pRenderingInfo, bool rasterization_enabled);
-    RENDER_PASS_STATE(VkCommandBufferInheritanceRenderingInfo const *pInheritanceRenderingInfo);
+    RenderPass(VkPipelineRenderingCreateInfo const *pPipelineRenderingCreateInfo, bool rasterization_enabled);
+    RenderPass(VkRenderingInfo const *pRenderingInfo, bool rasterization_enabled);
+    RenderPass(VkCommandBufferInheritanceRenderingInfo const *pInheritanceRenderingInfo);
 
     VkRenderPass renderPass() const { return handle_.Cast<VkRenderPass>(); }
 
@@ -119,15 +121,13 @@ class RENDER_PASS_STATE : public BASE_NODE {
     const VkMultisampledRenderToSingleSampledInfoEXT *GetMSRTSSInfo(uint32_t subpass) const;
 };
 
-namespace vvl {
-
 class Framebuffer : public BASE_NODE {
   public:
     const safe_VkFramebufferCreateInfo createInfo;
-    std::shared_ptr<const RENDER_PASS_STATE> rp_state;
+    std::shared_ptr<const RenderPass> rp_state;
     std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> attachments_view_state;
 
-    Framebuffer(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RENDER_PASS_STATE> &&rpstate,
+    Framebuffer(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RenderPass> &&rpstate,
                 std::vector<std::shared_ptr<IMAGE_VIEW_STATE>> &&attachments);
     void LinkChildNodes() override;
 

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -54,13 +54,15 @@ struct hash<SamplerUsedByImage> {
 };
 }  // namespace std
 
-class SAMPLER_STATE : public BASE_NODE {
+namespace vvl {
+
+class Sampler : public BASE_NODE {
   public:
     const VkSamplerCreateInfo createInfo;
     const VkSamplerYcbcrConversion samplerConversion;
     const VkSamplerCustomBorderColorCreateInfoEXT customCreateInfo;
 
-    SAMPLER_STATE(const VkSampler s, const VkSamplerCreateInfo *pci)
+    Sampler(const VkSampler s, const VkSamplerCreateInfo *pci)
         : BASE_NODE(s, kVulkanObjectTypeSampler),
           createInfo(*pci),
           samplerConversion(GetConversion(pci)),
@@ -80,6 +82,8 @@ class SAMPLER_STATE : public BASE_NODE {
         return result;
     }
 };
+
+}  // namespace vvl
 
 class SAMPLER_YCBCR_CONVERSION_STATE : public BASE_NODE {
   public:

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -83,17 +83,15 @@ class Sampler : public BASE_NODE {
     }
 };
 
-}  // namespace vvl
-
-class SAMPLER_YCBCR_CONVERSION_STATE : public BASE_NODE {
+class SamplerYcbcrConversion : public BASE_NODE {
   public:
     const VkFormatFeatureFlags2KHR format_features;
     const VkFormat format;
     const VkFilter chromaFilter;
     const uint64_t external_format;
 
-    SAMPLER_YCBCR_CONVERSION_STATE(VkSamplerYcbcrConversion ycbcr, const VkSamplerYcbcrConversionCreateInfo *info,
-                                   VkFormatFeatureFlags2KHR features)
+    SamplerYcbcrConversion(VkSamplerYcbcrConversion ycbcr, const VkSamplerYcbcrConversionCreateInfo *info,
+                           VkFormatFeatureFlags2KHR features)
         : BASE_NODE(ycbcr, kVulkanObjectTypeSamplerYcbcrConversion),
           format_features(features),
           format(info->format),
@@ -102,3 +100,5 @@ class SAMPLER_YCBCR_CONVERSION_STATE : public BASE_NODE {
 
     VkSamplerYcbcrConversion ycbcr_conversion() const { return handle_.Cast<VkSamplerYcbcrConversion>(); }
 };
+
+}  // namespace vvl

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1741,9 +1741,9 @@ void ValidationStateTracker::PostCallRecordCreateFence(VkDevice device, const Vk
     Add(std::make_shared<vvl::Fence>(*this, *pFence, pCreateInfo));
 }
 
-std::shared_ptr<PIPELINE_CACHE_STATE> ValidationStateTracker::CreatePipelineCacheState(
+std::shared_ptr<vvl::PipelineCache> ValidationStateTracker::CreatePipelineCacheState(
     VkPipelineCache pipeline_cache, const VkPipelineCacheCreateInfo *pCreateInfo) const {
-    return std::make_shared<PIPELINE_CACHE_STATE>(pipeline_cache, pCreateInfo);
+    return std::make_shared<vvl::PipelineCache>(pipeline_cache, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo *pCreateInfo,
@@ -1756,7 +1756,7 @@ void ValidationStateTracker::PostCallRecordCreatePipelineCache(VkDevice device, 
 void ValidationStateTracker::PreCallRecordDestroyPipelineCache(VkDevice device, VkPipelineCache pipelineCache,
                                                                const VkAllocationCallbacks *pAllocator,
                                                                const RecordObject &record_obj) {
-    Destroy<PIPELINE_CACHE_STATE>(pipelineCache);
+    Destroy<vvl::PipelineCache>(pipelineCache);
 }
 
 std::shared_ptr<PIPELINE_STATE> ValidationStateTracker::CreateGraphicsPipelineState(

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -378,10 +378,10 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
     Add(std::move(buffer_state));
 }
 
-std::shared_ptr<BUFFER_VIEW_STATE> ValidationStateTracker::CreateBufferViewState(const std::shared_ptr<vvl::Buffer> &bf,
-                                                                                 VkBufferView bv, const VkBufferViewCreateInfo *ci,
-                                                                                 VkFormatFeatureFlags2KHR buf_ff) {
-    return std::make_shared<BUFFER_VIEW_STATE>(bf, bv, ci, buf_ff);
+std::shared_ptr<vvl::BufferView> ValidationStateTracker::CreateBufferViewState(const std::shared_ptr<vvl::Buffer> &bf,
+                                                                               VkBufferView bv, const VkBufferViewCreateInfo *ci,
+                                                                               VkFormatFeatureFlags2KHR buf_ff) {
+    return std::make_shared<vvl::BufferView>(bf, bv, ci, buf_ff);
 }
 
 void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
@@ -530,7 +530,7 @@ void ValidationStateTracker::PreCallRecordDestroyBuffer(VkDevice device, VkBuffe
 void ValidationStateTracker::PreCallRecordDestroyBufferView(VkDevice device, VkBufferView bufferView,
                                                             const VkAllocationCallbacks *pAllocator,
                                                             const RecordObject &record_obj) {
-    Destroy<BUFFER_VIEW_STATE>(bufferView);
+    Destroy<vvl::BufferView>(bufferView);
 }
 
 void ValidationStateTracker::PreCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -2264,9 +2264,9 @@ void ValidationStateTracker::PostCallRecordCmdSetViewportShadingRatePaletteNV(Vk
     cb_state->dynamic_state_value.shading_rate_palette_count = viewportCount;
 }
 
-std::shared_ptr<ACCELERATION_STRUCTURE_STATE_NV> ValidationStateTracker::CreateAccelerationStructureState(
+std::shared_ptr<vvl::AccelerationStructureNV> ValidationStateTracker::CreateAccelerationStructureState(
     VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV *ci) {
-    return std::make_shared<ACCELERATION_STRUCTURE_STATE_NV>(device, as, ci);
+    return std::make_shared<vvl::AccelerationStructureNV>(device, as, ci);
 }
 
 void ValidationStateTracker::PostCallRecordCreateAccelerationStructureNV(VkDevice device,
@@ -2278,10 +2278,10 @@ void ValidationStateTracker::PostCallRecordCreateAccelerationStructureNV(VkDevic
     Add(CreateAccelerationStructureState(*pAccelerationStructure, pCreateInfo));
 }
 
-std::shared_ptr<ACCELERATION_STRUCTURE_STATE_KHR> ValidationStateTracker::CreateAccelerationStructureState(
+std::shared_ptr<vvl::AccelerationStructureKHR> ValidationStateTracker::CreateAccelerationStructureState(
     VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci, std::shared_ptr<vvl::Buffer> &&buf_state,
     VkDeviceAddress address) {
-    return std::make_shared<ACCELERATION_STRUCTURE_STATE_KHR>(as, ci, std::move(buf_state), address);
+    return std::make_shared<vvl::AccelerationStructureKHR>(as, ci, std::move(buf_state), address);
 }
 
 void ValidationStateTracker::PostCallRecordCreateAccelerationStructureKHR(VkDevice device,
@@ -2302,7 +2302,7 @@ void ValidationStateTracker::PostCallRecordBuildAccelerationStructuresKHR(
     const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const RecordObject &record_obj) {
     for (uint32_t i = 0; i < infoCount; ++i) {
-        auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfos[i].dstAccelerationStructure);
+        auto dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfos[i].dstAccelerationStructure);
         if (dst_as_state != nullptr) {
             dst_as_state->Build(&pInfos[i], true, *ppBuildRangeInfos);
         }
@@ -2312,7 +2312,7 @@ void ValidationStateTracker::PostCallRecordBuildAccelerationStructuresKHR(
 // helper method for device side acceleration structure builds
 void ValidationStateTracker::RecordDeviceAccelerationStructureBuildInfo(CMD_BUFFER_STATE &cb_state,
                                                                         const VkAccelerationStructureBuildGeometryInfoKHR &info) {
-    auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(info.dstAccelerationStructure);
+    auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure);
     if (dst_as_state) {
         dst_as_state->Build(&info, false, nullptr);
     }
@@ -2322,7 +2322,7 @@ void ValidationStateTracker::RecordDeviceAccelerationStructureBuildInfo(CMD_BUFF
     if (dst_as_state) {
         cb_state.AddChild(dst_as_state);
     }
-    auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(info.srcAccelerationStructure);
+    auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure);
     if (src_as_state) {
         cb_state.AddChild(src_as_state);
     }
@@ -2367,7 +2367,7 @@ void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructuresIndirec
 void ValidationStateTracker::PostCallRecordGetAccelerationStructureMemoryRequirementsNV(
     VkDevice device, const VkAccelerationStructureMemoryRequirementsInfoNV *pInfo, VkMemoryRequirements2 *pMemoryRequirements,
     const RecordObject &record_obj) {
-    auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(pInfo->accelerationStructure);
+    auto as_state = Get<vvl::AccelerationStructureNV>(pInfo->accelerationStructure);
     if (as_state != nullptr) {
         if (pInfo->type == VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV) {
             as_state->memory_requirements_checked = true;
@@ -2386,7 +2386,7 @@ void ValidationStateTracker::PostCallRecordBindAccelerationStructureMemoryNV(
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         const VkBindAccelerationStructureMemoryInfoNV &info = pBindInfos[i];
 
-        auto as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(info.accelerationStructure);
+        auto as_state = Get<vvl::AccelerationStructureNV>(info.accelerationStructure);
         if (as_state) {
             // Track objects tied to memory
             auto mem_state = Get<DEVICE_MEMORY_STATE>(info.memory);
@@ -2413,7 +2413,7 @@ void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructureNV(
     }
     cb_state->RecordCmd(record_obj.location.function);
 
-    auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(dst);
+    auto dst_as_state = Get<vvl::AccelerationStructureNV>(dst);
     if (dst_as_state) {
         dst_as_state->Build(pInfo);
         if (!disabled[command_buffer_state]) {
@@ -2421,7 +2421,7 @@ void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructureNV(
         }
     }
     if (!disabled[command_buffer_state]) {
-        auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(src);
+        auto src_as_state = Get<vvl::AccelerationStructureNV>(src);
         if (src_as_state) {
             cb_state->AddChild(src_as_state);
         }
@@ -2466,8 +2466,8 @@ void ValidationStateTracker::PostCallRecordCmdCopyAccelerationStructureNV(VkComm
                                                                           const RecordObject &record_obj) {
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     if (cb_state) {
-        auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(src);
-        auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_NV>(dst);
+        auto src_as_state = Get<vvl::AccelerationStructureNV>(src);
+        auto dst_as_state = Get<vvl::AccelerationStructureNV>(dst);
         if (!disabled[command_buffer_state]) {
             cb_state->RecordTransferCmd(record_obj.location.function, src_as_state, dst_as_state);
         }
@@ -2482,14 +2482,14 @@ void ValidationStateTracker::PreCallRecordDestroyAccelerationStructureKHR(VkDevi
                                                                           VkAccelerationStructureKHR accelerationStructure,
                                                                           const VkAllocationCallbacks *pAllocator,
                                                                           const RecordObject &record_obj) {
-    Destroy<ACCELERATION_STRUCTURE_STATE_KHR>(accelerationStructure);
+    Destroy<vvl::AccelerationStructureKHR>(accelerationStructure);
 }
 
 void ValidationStateTracker::PreCallRecordDestroyAccelerationStructureNV(VkDevice device,
                                                                          VkAccelerationStructureNV accelerationStructure,
                                                                          const VkAllocationCallbacks *pAllocator,
                                                                          const RecordObject &record_obj) {
-    Destroy<ACCELERATION_STRUCTURE_STATE_NV>(accelerationStructure);
+    Destroy<vvl::AccelerationStructureNV>(accelerationStructure);
 }
 
 void ValidationStateTracker::PostCallRecordCmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t firstViewport,
@@ -4498,8 +4498,8 @@ void ValidationStateTracker::PostCallRecordGetSwapchainImagesKHR(VkDevice device
 void ValidationStateTracker::PostCallRecordCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                         const VkCopyAccelerationStructureInfoKHR *pInfo,
                                                                         const RecordObject &record_obj) {
-    auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->src);
-    auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->dst);
+    auto src_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->src);
+    auto dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst);
     if (dst_as_state != nullptr && src_as_state != nullptr) {
         dst_as_state->built = true;
         dst_as_state->build_info_khr = src_as_state->build_info_khr;
@@ -4512,8 +4512,8 @@ void ValidationStateTracker::PostCallRecordCmdCopyAccelerationStructureKHR(VkCom
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     if (cb_state) {
         cb_state->RecordCmd(record_obj.location.function);
-        auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->src);
-        auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->dst);
+        auto src_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->src);
+        auto dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst);
         if (dst_as_state != nullptr && src_as_state != nullptr) {
             dst_as_state->built = true;
             dst_as_state->build_info_khr = src_as_state->build_info_khr;
@@ -4530,7 +4530,7 @@ void ValidationStateTracker::PostCallRecordCmdCopyAccelerationStructureToMemoryK
     auto cb_state = GetWrite<CMD_BUFFER_STATE>(commandBuffer);
     if (cb_state) {
         cb_state->RecordCmd(record_obj.location.function);
-        auto src_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->src);
+        auto src_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->src);
         if (!disabled[command_buffer_state]) {
             cb_state->AddChild(src_as_state);
         }
@@ -4546,7 +4546,7 @@ void ValidationStateTracker::PostCallRecordCmdCopyMemoryToAccelerationStructureK
     if (cb_state) {
         cb_state->RecordCmd(record_obj.location.function);
         if (!disabled[command_buffer_state]) {
-            auto dst_as_state = Get<ACCELERATION_STRUCTURE_STATE_KHR>(pInfo->dst);
+            auto dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst);
             cb_state->AddChild(dst_as_state);
 
             // Issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6461

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3447,7 +3447,7 @@ void ValidationStateTracker::PostCallRecordCreateDisplayModeKHR(VkPhysicalDevice
                                                                 const RecordObject &record_obj) {
     if (VK_SUCCESS != record_obj.result) return;
     if (!pMode) return;
-    Add(std::make_shared<DISPLAY_MODE_STATE>(*pMode, physicalDevice));
+    Add(std::make_shared<vvl::DisplayMode>(*pMode, physicalDevice));
 }
 
 void ValidationStateTracker::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1617,7 +1617,7 @@ void ValidationStateTracker::PreCallRecordDestroyPipelineLayout(VkDevice device,
 void ValidationStateTracker::PreCallRecordDestroySampler(VkDevice device, VkSampler sampler,
                                                          const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
     if (!sampler) return;
-    auto sampler_state = Get<SAMPLER_STATE>(sampler);
+    auto sampler_state = Get<vvl::Sampler>(sampler);
     // Any bound cmd buffers are now invalid
     if (sampler_state) {
         if (sampler_state->createInfo.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
@@ -1625,7 +1625,7 @@ void ValidationStateTracker::PreCallRecordDestroySampler(VkDevice device, VkSamp
             custom_border_color_sampler_count--;
         }
     }
-    Destroy<SAMPLER_STATE>(sampler);
+    Destroy<vvl::Sampler>(sampler);
 }
 
 void ValidationStateTracker::PreCallRecordDestroyDescriptorSetLayout(VkDevice device, VkDescriptorSetLayout descriptorSetLayout,
@@ -1946,8 +1946,8 @@ void ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice
     crtpl_state->pipe_state.clear();
 }
 
-std::shared_ptr<SAMPLER_STATE> ValidationStateTracker::CreateSamplerState(VkSampler s, const VkSamplerCreateInfo *ci) {
-    return std::make_shared<SAMPLER_STATE>(s, ci);
+std::shared_ptr<vvl::Sampler> ValidationStateTracker::CreateSamplerState(VkSampler s, const VkSamplerCreateInfo *ci) {
+    return std::make_shared<vvl::Sampler>(s, ci);
 }
 
 void ValidationStateTracker::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -37,7 +37,7 @@
 // NOTE:  Beware the lifespan of the rp_begin when holding  the return.  If the rp_begin isn't a "safe" copy, "IMAGELESS"
 //        attachments won't persist past the API entry point exit.
 static std::pair<uint32_t, const VkImageView *> GetFramebufferAttachments(const VkRenderPassBeginInfo &rp_begin,
-                                                                          const FRAMEBUFFER_STATE &fb_state) {
+                                                                          const vvl::Framebuffer &fb_state) {
     const VkImageView *attachments = fb_state.createInfo.pAttachments;
     uint32_t count = fb_state.createInfo.attachmentCount;
     if (fb_state.createInfo.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
@@ -51,7 +51,7 @@ static std::pair<uint32_t, const VkImageView *> GetFramebufferAttachments(const 
 }
 
 template <typename ImageViewPointer, typename Get>
-std::vector<ImageViewPointer> GetAttachmentViewsImpl(const VkRenderPassBeginInfo &rp_begin, const FRAMEBUFFER_STATE &fb_state,
+std::vector<ImageViewPointer> GetAttachmentViewsImpl(const VkRenderPassBeginInfo &rp_begin, const vvl::Framebuffer &fb_state,
                                                      const Get &get_fn) {
     std::vector<ImageViewPointer> views;
 
@@ -68,7 +68,7 @@ std::vector<ImageViewPointer> GetAttachmentViewsImpl(const VkRenderPassBeginInfo
 }
 
 std::vector<std::shared_ptr<const IMAGE_VIEW_STATE>> ValidationStateTracker::GetAttachmentViews(
-    const VkRenderPassBeginInfo &rp_begin, const FRAMEBUFFER_STATE &fb_state) const {
+    const VkRenderPassBeginInfo &rp_begin, const vvl::Framebuffer &fb_state) const {
     auto get_fn = [this](VkImageView handle) { return this->Get<IMAGE_VIEW_STATE>(handle); };
     return GetAttachmentViewsImpl<std::shared_ptr<const IMAGE_VIEW_STATE>>(rp_begin, fb_state, get_fn);
 }
@@ -1725,7 +1725,7 @@ void ValidationStateTracker::PostCallRecordResetFences(VkDevice device, uint32_t
 void ValidationStateTracker::PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer,
                                                              const VkAllocationCallbacks *pAllocator,
                                                              const RecordObject &record_obj) {
-    Destroy<FRAMEBUFFER_STATE>(framebuffer);
+    Destroy<vvl::Framebuffer>(framebuffer);
 }
 
 void ValidationStateTracker::PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass,
@@ -2986,8 +2986,8 @@ void ValidationStateTracker::PostCallRecordCreateFramebuffer(VkDevice device, co
         }
     }
 
-    Add(std::make_shared<FRAMEBUFFER_STATE>(*pFramebuffer, pCreateInfo, Get<RENDER_PASS_STATE>(pCreateInfo->renderPass),
-                                            std::move(views)));
+    Add(std::make_shared<vvl::Framebuffer>(*pFramebuffer, pCreateInfo, Get<RENDER_PASS_STATE>(pCreateInfo->renderPass),
+                                           std::move(views)));
 }
 
 void ValidationStateTracker::PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4091,7 +4091,7 @@ void ValidationStateTracker::PostCallRecordCreateSamplerYcbcrConversion(VkDevice
         format_features = GetExternalFormatFeaturesANDROID(pCreateInfo);
     }
 
-    Add(std::make_shared<SAMPLER_YCBCR_CONVERSION_STATE>(*pYcbcrConversion, pCreateInfo, format_features));
+    Add(std::make_shared<vvl::SamplerYcbcrConversion>(*pYcbcrConversion, pCreateInfo, format_features));
 }
 
 void ValidationStateTracker::PostCallRecordCreateSamplerYcbcrConversionKHR(VkDevice device,
@@ -4105,7 +4105,7 @@ void ValidationStateTracker::PostCallRecordCreateSamplerYcbcrConversionKHR(VkDev
 void ValidationStateTracker::PostCallRecordDestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcrConversion ycbcrConversion,
                                                                          const VkAllocationCallbacks *pAllocator,
                                                                          const RecordObject &record_obj) {
-    Destroy<SAMPLER_YCBCR_CONVERSION_STATE>(ycbcrConversion);
+    Destroy<vvl::SamplerYcbcrConversion>(ycbcrConversion);
 }
 
 void ValidationStateTracker::PostCallRecordDestroySamplerYcbcrConversionKHR(VkDevice device,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -51,6 +51,7 @@ class Semaphore;
 class Buffer;
 class BufferView;
 class Sampler;
+class SamplerYcbcrConversion;
 }  // namespace vvl
 
 class CMD_BUFFER_STATE;
@@ -64,7 +65,6 @@ class IMAGE_VIEW_STATE;
 class COMMAND_POOL_STATE;
 class DISPLAY_MODE_STATE;
 class RENDER_PASS_STATE;
-class SAMPLER_YCBCR_CONVERSION_STATE;
 class EVENT_STATE;
 class SWAPCHAIN_NODE;
 class SURFACE_STATE;
@@ -310,7 +310,7 @@ VALSTATETRACK_STATE_OBJECT(VkFence, vvl::Fence)
 VALSTATETRACK_STATE_OBJECT(VkQueryPool, QUERY_POOL_STATE)
 VALSTATETRACK_STATE_OBJECT(VkSemaphore, vvl::Semaphore)
 VALSTATETRACK_STATE_OBJECT(VkEvent, EVENT_STATE)
-VALSTATETRACK_STATE_OBJECT(VkSamplerYcbcrConversion, SAMPLER_YCBCR_CONVERSION_STATE)
+VALSTATETRACK_STATE_OBJECT(VkSamplerYcbcrConversion, vvl::SamplerYcbcrConversion)
 VALSTATETRACK_STATE_OBJECT(VkVideoSessionKHR, VIDEO_SESSION_STATE)
 VALSTATETRACK_STATE_OBJECT(VkVideoSessionParametersKHR, VIDEO_SESSION_PARAMETERS_STATE)
 VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureKHR, ACCELERATION_STRUCTURE_STATE_KHR)
@@ -1929,7 +1929,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkQueryPool, QUERY_POOL_STATE, query_pool_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkSemaphore, vvl::Semaphore, semaphore_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkEvent, EVENT_STATE, event_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkSamplerYcbcrConversion, SAMPLER_YCBCR_CONVERSION_STATE, sampler_ycbcr_conversion_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkSamplerYcbcrConversion, vvl::SamplerYcbcrConversion, sampler_ycbcr_conversion_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkVideoSessionKHR, VIDEO_SESSION_STATE, video_session_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkVideoSessionParametersKHR, VIDEO_SESSION_PARAMETERS_STATE, video_session_parameters_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureKHR, ACCELERATION_STRUCTURE_STATE_KHR, acceleration_structure_khr_map_)

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -56,6 +56,7 @@ class Framebuffer;
 class RenderPass;
 class PipelineCache;
 class Surface;
+class DisplayMode;
 }  // namespace vvl
 
 class CMD_BUFFER_STATE;
@@ -65,7 +66,6 @@ class PIPELINE_LAYOUT_STATE;
 class IMAGE_STATE;
 class IMAGE_VIEW_STATE;
 class COMMAND_POOL_STATE;
-class DISPLAY_MODE_STATE;
 class EVENT_STATE;
 class SWAPCHAIN_NODE;
 struct SHADER_MODULE_STATE;
@@ -315,7 +315,7 @@ VALSTATETRACK_STATE_OBJECT(VkVideoSessionKHR, VIDEO_SESSION_STATE)
 VALSTATETRACK_STATE_OBJECT(VkVideoSessionParametersKHR, VIDEO_SESSION_PARAMETERS_STATE)
 VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureKHR, vvl::AccelerationStructureKHR)
 VALSTATETRACK_STATE_OBJECT(VkSurfaceKHR, vvl::Surface)
-VALSTATETRACK_STATE_OBJECT(VkDisplayModeKHR, DISPLAY_MODE_STATE)
+VALSTATETRACK_STATE_OBJECT(VkDisplayModeKHR, vvl::DisplayMode)
 VALSTATETRACK_STATE_OBJECT(VkPhysicalDevice, PHYSICAL_DEVICE_STATE)
 
 class ValidationStateTracker : public ValidationObject {
@@ -1934,7 +1934,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkVideoSessionParametersKHR, VIDEO_SESSION_PARAMETERS_STATE, video_session_parameters_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureKHR, vvl::AccelerationStructureKHR, acceleration_structure_khr_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, vvl::Surface, surface_map_)
-    VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkDisplayModeKHR, DISPLAY_MODE_STATE, display_mode_map_)
+    VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkDisplayModeKHR, vvl::DisplayMode, display_mode_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkPhysicalDevice, PHYSICAL_DEVICE_STATE, physical_device_map_)
 
     // Simple base address allocator allow allow VkDeviceMemory allocations to appear to exist in a common address space.

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -50,6 +50,7 @@ class Queue;
 class Semaphore;
 class Buffer;
 class BufferView;
+class Sampler;
 }  // namespace vvl
 
 class CMD_BUFFER_STATE;
@@ -63,7 +64,6 @@ class IMAGE_VIEW_STATE;
 class COMMAND_POOL_STATE;
 class DISPLAY_MODE_STATE;
 class RENDER_PASS_STATE;
-class SAMPLER_STATE;
 class SAMPLER_YCBCR_CONVERSION_STATE;
 class EVENT_STATE;
 class SWAPCHAIN_NODE;
@@ -288,7 +288,7 @@ VALSTATETRACK_STATE_OBJECT(VkQueue, vvl::Queue)
 VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE_NV)
 VALSTATETRACK_STATE_OBJECT(VkRenderPass, RENDER_PASS_STATE)
 VALSTATETRACK_STATE_OBJECT(VkDescriptorSetLayout, vvl::DescriptorSetLayout)
-VALSTATETRACK_STATE_OBJECT(VkSampler, SAMPLER_STATE)
+VALSTATETRACK_STATE_OBJECT(VkSampler, vvl::Sampler)
 VALSTATETRACK_STATE_OBJECT(VkImageView, IMAGE_VIEW_STATE)
 VALSTATETRACK_STATE_OBJECT(VkImage, IMAGE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkBufferView, vvl::BufferView)
@@ -919,7 +919,7 @@ class ValidationStateTracker : public ValidationObject {
                                                        const VkAllocationCallbacks* pAllocator,
                                                        const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<SAMPLER_STATE> CreateSamplerState(VkSampler s, const VkSamplerCreateInfo *ci);
+    virtual std::shared_ptr<vvl::Sampler> CreateSamplerState(VkSampler s, const VkSamplerCreateInfo* ci);
     void PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
                                      const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
                                      const RecordObject& record_obj) override;
@@ -1907,7 +1907,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE_NV, acceleration_structure_nv_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkRenderPass, RENDER_PASS_STATE, render_pass_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorSetLayout, vvl::DescriptorSetLayout, descriptor_set_layout_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkSampler, SAMPLER_STATE, sampler_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkSampler, vvl::Sampler, sampler_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkImageView, IMAGE_VIEW_STATE, image_view_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkImage, IMAGE_STATE, image_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkBufferView, vvl::BufferView, buffer_view_map_)

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -53,6 +53,7 @@ class BufferView;
 class Sampler;
 class SamplerYcbcrConversion;
 class Framebuffer;
+class RenderPass;
 }  // namespace vvl
 
 class CMD_BUFFER_STATE;
@@ -64,7 +65,6 @@ class IMAGE_STATE;
 class IMAGE_VIEW_STATE;
 class COMMAND_POOL_STATE;
 class DISPLAY_MODE_STATE;
-class RENDER_PASS_STATE;
 class EVENT_STATE;
 class SWAPCHAIN_NODE;
 class SURFACE_STATE;
@@ -286,7 +286,7 @@ static inline VkDeviceSize GetBufferSizeFromCopyImage(const RegionType& region, 
 
 VALSTATETRACK_STATE_OBJECT(VkQueue, vvl::Queue)
 VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE_NV)
-VALSTATETRACK_STATE_OBJECT(VkRenderPass, RENDER_PASS_STATE)
+VALSTATETRACK_STATE_OBJECT(VkRenderPass, vvl::RenderPass)
 VALSTATETRACK_STATE_OBJECT(VkDescriptorSetLayout, vvl::DescriptorSetLayout)
 VALSTATETRACK_STATE_OBJECT(VkSampler, vvl::Sampler)
 VALSTATETRACK_STATE_OBJECT(VkImageView, IMAGE_VIEW_STATE)
@@ -816,7 +816,7 @@ class ValidationStateTracker : public ValidationObject {
                                            const RecordObject& record_obj) override;
 
     virtual std::shared_ptr<PIPELINE_STATE> CreateGraphicsPipelineState(const VkGraphicsPipelineCreateInfo* pCreateInfo,
-                                                                        std::shared_ptr<const RENDER_PASS_STATE>&& render_pass,
+                                                                        std::shared_ptr<const vvl::RenderPass>&& render_pass,
                                                                         std::shared_ptr<const PIPELINE_LAYOUT_STATE>&& layout,
                                                                         CreateShaderModuleStates* csm_states) const;
     bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
@@ -1905,7 +1905,7 @@ class ValidationStateTracker : public ValidationObject {
   private:
     VALSTATETRACK_MAP_AND_TRAITS(VkQueue, vvl::Queue, queue_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE_NV, acceleration_structure_nv_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkRenderPass, RENDER_PASS_STATE, render_pass_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkRenderPass, vvl::RenderPass, render_pass_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorSetLayout, vvl::DescriptorSetLayout, descriptor_set_layout_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkSampler, vvl::Sampler, sampler_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkImageView, IMAGE_VIEW_STATE, image_view_map_)

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -52,10 +52,10 @@ class Buffer;
 class BufferView;
 class Sampler;
 class SamplerYcbcrConversion;
+class Framebuffer;
 }  // namespace vvl
 
 class CMD_BUFFER_STATE;
-class FRAMEBUFFER_STATE;
 class PIPELINE_CACHE_STATE;
 class PIPELINE_STATE;
 struct PipelineStageState;
@@ -297,7 +297,7 @@ VALSTATETRACK_STATE_OBJECT(VkPipelineCache, PIPELINE_CACHE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkPipeline, PIPELINE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkShaderEXT, SHADER_OBJECT_STATE)
 VALSTATETRACK_STATE_OBJECT(VkDeviceMemory, DEVICE_MEMORY_STATE)
-VALSTATETRACK_STATE_OBJECT(VkFramebuffer, FRAMEBUFFER_STATE)
+VALSTATETRACK_STATE_OBJECT(VkFramebuffer, vvl::Framebuffer)
 VALSTATETRACK_STATE_OBJECT(VkShaderModule, SHADER_MODULE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkDescriptorUpdateTemplate, vvl::DescriptorUpdateTemplate)
 VALSTATETRACK_STATE_OBJECT(VkSwapchainKHR, SWAPCHAIN_NODE)
@@ -1480,7 +1480,7 @@ class ValidationStateTracker : public ValidationObject {
 
     // State Utilty functions
     std::vector<std::shared_ptr<const IMAGE_VIEW_STATE>> GetAttachmentViews(const VkRenderPassBeginInfo& rp_begin,
-                                                                            const FRAMEBUFFER_STATE& fb_state) const;
+                                                                            const vvl::Framebuffer& fb_state) const;
 
     VkFormatFeatureFlags2KHR GetPotentialFormatFeatures(VkFormat format) const;
     void PerformUpdateDescriptorSetsWithTemplateKHR(VkDescriptorSet descriptorSet,
@@ -1916,7 +1916,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkPipeline, PIPELINE_STATE, pipeline_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkShaderEXT, SHADER_OBJECT_STATE, shader_object_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkDeviceMemory, DEVICE_MEMORY_STATE, mem_obj_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkFramebuffer, FRAMEBUFFER_STATE, frame_buffer_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkFramebuffer, vvl::Framebuffer, frame_buffer_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkShaderModule, SHADER_MODULE_STATE, shader_module_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorUpdateTemplate, vvl::DescriptorUpdateTemplate, desc_template_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkSwapchainKHR, SWAPCHAIN_NODE, swapchain_map_)

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -54,10 +54,10 @@ class Sampler;
 class SamplerYcbcrConversion;
 class Framebuffer;
 class RenderPass;
+class PipelineCache;
 }  // namespace vvl
 
 class CMD_BUFFER_STATE;
-class PIPELINE_CACHE_STATE;
 class PIPELINE_STATE;
 struct PipelineStageState;
 class PIPELINE_LAYOUT_STATE;
@@ -293,7 +293,7 @@ VALSTATETRACK_STATE_OBJECT(VkImageView, IMAGE_VIEW_STATE)
 VALSTATETRACK_STATE_OBJECT(VkImage, IMAGE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkBufferView, vvl::BufferView)
 VALSTATETRACK_STATE_OBJECT(VkBuffer, vvl::Buffer)
-VALSTATETRACK_STATE_OBJECT(VkPipelineCache, PIPELINE_CACHE_STATE)
+VALSTATETRACK_STATE_OBJECT(VkPipelineCache, vvl::PipelineCache)
 VALSTATETRACK_STATE_OBJECT(VkPipeline, PIPELINE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkShaderEXT, SHADER_OBJECT_STATE)
 VALSTATETRACK_STATE_OBJECT(VkDeviceMemory, DEVICE_MEMORY_STATE)
@@ -807,8 +807,8 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator,
                                          const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<PIPELINE_CACHE_STATE> CreatePipelineCacheState(VkPipelineCache pipeline_cache,
-                                                                           const VkPipelineCacheCreateInfo* pCreateInfo) const;
+    virtual std::shared_ptr<vvl::PipelineCache> CreatePipelineCacheState(VkPipelineCache pipeline_cache,
+                                                                         const VkPipelineCacheCreateInfo* pCreateInfo) const;
     void PostCallRecordCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkPipelineCache* pPipelineCache,
                                            const RecordObject& record_obj) override;
@@ -1912,7 +1912,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkImage, IMAGE_STATE, image_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkBufferView, vvl::BufferView, buffer_view_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkBuffer, vvl::Buffer, buffer_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkPipelineCache, PIPELINE_CACHE_STATE, pipeline_cache_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkPipelineCache, vvl::PipelineCache, pipeline_cache_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkPipeline, PIPELINE_STATE, pipeline_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkShaderEXT, SHADER_OBJECT_STATE, shader_object_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkDeviceMemory, DEVICE_MEMORY_STATE, mem_obj_map_)

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -49,6 +49,7 @@ class DescriptorUpdateTemplate;
 class Queue;
 class Semaphore;
 class Buffer;
+class BufferView;
 }  // namespace vvl
 
 class CMD_BUFFER_STATE;
@@ -57,7 +58,6 @@ class PIPELINE_CACHE_STATE;
 class PIPELINE_STATE;
 struct PipelineStageState;
 class PIPELINE_LAYOUT_STATE;
-class BUFFER_VIEW_STATE;
 class IMAGE_STATE;
 class IMAGE_VIEW_STATE;
 class COMMAND_POOL_STATE;
@@ -291,7 +291,7 @@ VALSTATETRACK_STATE_OBJECT(VkDescriptorSetLayout, vvl::DescriptorSetLayout)
 VALSTATETRACK_STATE_OBJECT(VkSampler, SAMPLER_STATE)
 VALSTATETRACK_STATE_OBJECT(VkImageView, IMAGE_VIEW_STATE)
 VALSTATETRACK_STATE_OBJECT(VkImage, IMAGE_STATE)
-VALSTATETRACK_STATE_OBJECT(VkBufferView, BUFFER_VIEW_STATE)
+VALSTATETRACK_STATE_OBJECT(VkBufferView, vvl::BufferView)
 VALSTATETRACK_STATE_OBJECT(VkBuffer, vvl::Buffer)
 VALSTATETRACK_STATE_OBJECT(VkPipelineCache, PIPELINE_CACHE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkPipeline, PIPELINE_STATE)
@@ -722,9 +722,9 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator,
                                     const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<BUFFER_VIEW_STATE> CreateBufferViewState(const std::shared_ptr<vvl::Buffer>& bf, VkBufferView bv,
-                                                                     const VkBufferViewCreateInfo* ci,
-                                                                     VkFormatFeatureFlags2KHR buf_ff);
+    virtual std::shared_ptr<vvl::BufferView> CreateBufferViewState(const std::shared_ptr<vvl::Buffer>& bf, VkBufferView bv,
+                                                                   const VkBufferViewCreateInfo* ci,
+                                                                   VkFormatFeatureFlags2KHR buf_ff);
     void PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
                                         const VkAllocationCallbacks* pAllocator, VkBufferView* pView,
                                         const RecordObject& record_obj) override;
@@ -1910,7 +1910,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkSampler, SAMPLER_STATE, sampler_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkImageView, IMAGE_VIEW_STATE, image_view_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkImage, IMAGE_STATE, image_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkBufferView, BUFFER_VIEW_STATE, buffer_view_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkBufferView, vvl::BufferView, buffer_view_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkBuffer, vvl::Buffer, buffer_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkPipelineCache, PIPELINE_CACHE_STATE, pipeline_cache_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkPipeline, PIPELINE_STATE, pipeline_map_)

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -285,7 +285,7 @@ static inline VkDeviceSize GetBufferSizeFromCopyImage(const RegionType& region, 
 }
 
 VALSTATETRACK_STATE_OBJECT(VkQueue, vvl::Queue)
-VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE_NV)
+VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureNV, vvl::AccelerationStructureNV)
 VALSTATETRACK_STATE_OBJECT(VkRenderPass, vvl::RenderPass)
 VALSTATETRACK_STATE_OBJECT(VkDescriptorSetLayout, vvl::DescriptorSetLayout)
 VALSTATETRACK_STATE_OBJECT(VkSampler, vvl::Sampler)
@@ -313,7 +313,7 @@ VALSTATETRACK_STATE_OBJECT(VkEvent, EVENT_STATE)
 VALSTATETRACK_STATE_OBJECT(VkSamplerYcbcrConversion, vvl::SamplerYcbcrConversion)
 VALSTATETRACK_STATE_OBJECT(VkVideoSessionKHR, VIDEO_SESSION_STATE)
 VALSTATETRACK_STATE_OBJECT(VkVideoSessionParametersKHR, VIDEO_SESSION_PARAMETERS_STATE)
-VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureKHR, ACCELERATION_STRUCTURE_STATE_KHR)
+VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureKHR, vvl::AccelerationStructureKHR)
 VALSTATETRACK_STATE_OBJECT(VkSurfaceKHR, SURFACE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkDisplayModeKHR, DISPLAY_MODE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkPhysicalDevice, PHYSICAL_DEVICE_STATE)
@@ -678,7 +678,7 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
                                     const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<ACCELERATION_STRUCTURE_STATE_NV> CreateAccelerationStructureState(
+    virtual std::shared_ptr<vvl::AccelerationStructureNV> CreateAccelerationStructureState(
         VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV* pCreateInfo);
     void PostCallRecordCreateAccelerationStructureNV(VkDevice device, const VkAccelerationStructureCreateInfoNV* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator,
@@ -688,7 +688,7 @@ class ValidationStateTracker : public ValidationObject {
                                                      const VkAllocationCallbacks* pAllocator,
                                                      const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<ACCELERATION_STRUCTURE_STATE_KHR> CreateAccelerationStructureState(
+    virtual std::shared_ptr<vvl::AccelerationStructureKHR> CreateAccelerationStructureState(
         VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
         std::shared_ptr<vvl::Buffer>&& buf_state, VkDeviceAddress address);
     void PostCallRecordCreateAccelerationStructureKHR(VkDevice device, const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
@@ -1904,7 +1904,7 @@ class ValidationStateTracker : public ValidationObject {
 
   private:
     VALSTATETRACK_MAP_AND_TRAITS(VkQueue, vvl::Queue, queue_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, ACCELERATION_STRUCTURE_STATE_NV, acceleration_structure_nv_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, vvl::AccelerationStructureNV, acceleration_structure_nv_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkRenderPass, vvl::RenderPass, render_pass_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorSetLayout, vvl::DescriptorSetLayout, descriptor_set_layout_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkSampler, vvl::Sampler, sampler_map_)
@@ -1932,7 +1932,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkSamplerYcbcrConversion, vvl::SamplerYcbcrConversion, sampler_ycbcr_conversion_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkVideoSessionKHR, VIDEO_SESSION_STATE, video_session_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkVideoSessionParametersKHR, VIDEO_SESSION_PARAMETERS_STATE, video_session_parameters_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureKHR, ACCELERATION_STRUCTURE_STATE_KHR, acceleration_structure_khr_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureKHR, vvl::AccelerationStructureKHR, acceleration_structure_khr_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, SURFACE_STATE, surface_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkDisplayModeKHR, DISPLAY_MODE_STATE, display_mode_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkPhysicalDevice, PHYSICAL_DEVICE_STATE, physical_device_map_)

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -55,6 +55,7 @@ class SamplerYcbcrConversion;
 class Framebuffer;
 class RenderPass;
 class PipelineCache;
+class Surface;
 }  // namespace vvl
 
 class CMD_BUFFER_STATE;
@@ -67,7 +68,6 @@ class COMMAND_POOL_STATE;
 class DISPLAY_MODE_STATE;
 class EVENT_STATE;
 class SWAPCHAIN_NODE;
-class SURFACE_STATE;
 struct SHADER_MODULE_STATE;
 struct SHADER_OBJECT_STATE;
 struct SPIRV_MODULE_STATE;
@@ -314,7 +314,7 @@ VALSTATETRACK_STATE_OBJECT(VkSamplerYcbcrConversion, vvl::SamplerYcbcrConversion
 VALSTATETRACK_STATE_OBJECT(VkVideoSessionKHR, VIDEO_SESSION_STATE)
 VALSTATETRACK_STATE_OBJECT(VkVideoSessionParametersKHR, VIDEO_SESSION_PARAMETERS_STATE)
 VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureKHR, vvl::AccelerationStructureKHR)
-VALSTATETRACK_STATE_OBJECT(VkSurfaceKHR, SURFACE_STATE)
+VALSTATETRACK_STATE_OBJECT(VkSurfaceKHR, vvl::Surface)
 VALSTATETRACK_STATE_OBJECT(VkDisplayModeKHR, DISPLAY_MODE_STATE)
 VALSTATETRACK_STATE_OBJECT(VkPhysicalDevice, PHYSICAL_DEVICE_STATE)
 
@@ -1490,7 +1490,7 @@ class ValidationStateTracker : public ValidationObject {
     virtual std::shared_ptr<SWAPCHAIN_NODE> CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info,
                                                                  VkSwapchainKHR swapchain);
     void RecordCreateSwapchainState(VkResult result, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR* pSwapchain,
-                                    std::shared_ptr<SURFACE_STATE>&& surface_state, SWAPCHAIN_NODE* old_swapchain_state);
+                                    std::shared_ptr<vvl::Surface>&& surface_state, SWAPCHAIN_NODE* old_swapchain_state);
     void RecordEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCounters(VkPhysicalDevice physicalDevice,
                                                                           uint32_t queueFamilyIndex, uint32_t* pCounterCount,
                                                                           VkPerformanceCounterKHR* pCounters);
@@ -1933,7 +1933,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkVideoSessionKHR, VIDEO_SESSION_STATE, video_session_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkVideoSessionParametersKHR, VIDEO_SESSION_PARAMETERS_STATE, video_session_parameters_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureKHR, vvl::AccelerationStructureKHR, acceleration_structure_khr_map_)
-    VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, SURFACE_STATE, surface_map_)
+    VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, vvl::Surface, surface_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkDisplayModeKHR, DISPLAY_MODE_STATE, display_mode_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkPhysicalDevice, PHYSICAL_DEVICE_STATE, physical_device_map_)
 

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -316,7 +316,7 @@ VALSTATETRACK_STATE_OBJECT(VkVideoSessionParametersKHR, VIDEO_SESSION_PARAMETERS
 VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureKHR, vvl::AccelerationStructureKHR)
 VALSTATETRACK_STATE_OBJECT(VkSurfaceKHR, vvl::Surface)
 VALSTATETRACK_STATE_OBJECT(VkDisplayModeKHR, vvl::DisplayMode)
-VALSTATETRACK_STATE_OBJECT(VkPhysicalDevice, PHYSICAL_DEVICE_STATE)
+VALSTATETRACK_STATE_OBJECT(VkPhysicalDevice, vvl::PhysicalDevice)
 
 class ValidationStateTracker : public ValidationObject {
     using Func = vvl::Func;
@@ -524,7 +524,7 @@ class ValidationStateTracker : public ValidationObject {
 
     // State update functions
     // Gets/Enumerations
-    virtual std::shared_ptr<PHYSICAL_DEVICE_STATE> CreatePhysicalDeviceState(VkPhysicalDevice phys_dev);
+    virtual std::shared_ptr<vvl::PhysicalDevice> CreatePhysicalDeviceState(VkPhysicalDevice phys_dev);
     void PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                       VkInstance* pInstance, const RecordObject& record_obj) override;
     void PostCallRecordEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
@@ -1772,7 +1772,7 @@ class ValidationStateTracker : public ValidationObject {
                            bool* error) const { return false; }
 
     // Link to the device's physical-device data
-    PHYSICAL_DEVICE_STATE* physical_device_state;
+    vvl::PhysicalDevice* physical_device_state;
 
     // Link for derived device objects back to their parent instance object
     ValidationStateTracker* instance_state;
@@ -1935,7 +1935,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureKHR, vvl::AccelerationStructureKHR, acceleration_structure_khr_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, vvl::Surface, surface_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkDisplayModeKHR, vvl::DisplayMode, display_mode_map_)
-    VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkPhysicalDevice, PHYSICAL_DEVICE_STATE, physical_device_map_)
+    VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkPhysicalDevice, vvl::PhysicalDevice, physical_device_map_)
 
     // Simple base address allocator allow allow VkDeviceMemory allocations to appear to exist in a common address space.
     // At 256GB allocated/sec  ( > 8GB at 30Hz), will overflow in just over 2 years

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -765,7 +765,7 @@ void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, con
 QueueId CommandBufferAccessContext::GetQueueId() const { return kQueueIdInvalid; }
 
 ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(
-    vvl::Func command, const RENDER_PASS_STATE &rp_state, const VkRect2D &render_area,
+    vvl::Func command, const vvl::RenderPass &rp_state, const VkRect2D &render_area,
     const std::vector<const syncval_state::ImageViewState *> &attachment_views) {
     // Create an access context the current renderpass.
     const auto barrier_tag = NextCommandTag(command, NamedHandle("renderpass", rp_state.Handle()),

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -274,7 +274,7 @@ class CommandBufferAccessContext : public CommandExecutionContext {
 
     RenderPassAccessContext *GetCurrentRenderPassContext() { return current_renderpass_context_; }
     const RenderPassAccessContext *GetCurrentRenderPassContext() const { return current_renderpass_context_; }
-    ResourceUsageTag RecordBeginRenderPass(vvl::Func command, const RENDER_PASS_STATE &rp_state, const VkRect2D &render_area,
+    ResourceUsageTag RecordBeginRenderPass(vvl::Func command, const vvl::RenderPass &rp_state, const VkRect2D &render_area,
                                            const std::vector<const syncval_state::ImageViewState *> &attachment_views);
 
     bool ValidateBeginRendering(const ErrorObject &error_obj, syncval_state::BeginRenderingCmdState &cmd_state) const;

--- a/layers/sync/sync_common.cpp
+++ b/layers/sync/sync_common.cpp
@@ -55,7 +55,7 @@ ResourceAccessRange MakeRange(const vvl::Buffer& buffer, VkDeviceSize offset, Vk
     return MakeRange(offset, buffer.ComputeSize(offset, size));
 }
 
-ResourceAccessRange MakeRange(const BUFFER_VIEW_STATE& buf_view_state) {
+ResourceAccessRange MakeRange(const vvl::BufferView& buf_view_state) {
     return MakeRange(*buf_view_state.buffer_state.get(), buf_view_state.create_info.offset, buf_view_state.create_info.range);
 }
 

--- a/layers/sync/sync_common.h
+++ b/layers/sync/sync_common.h
@@ -23,9 +23,9 @@
 
 namespace vvl {
 class Buffer;
+class BufferView;
 }  // namespace vvl
 
-class BUFFER_VIEW_STATE;
 struct BufferBinding;
 class HazardResult;
 class SyncValidator;
@@ -52,7 +52,7 @@ ResourceAccessRange MakeRange(const T &has_offset_and_size) {
 }
 ResourceAccessRange MakeRange(VkDeviceSize start, VkDeviceSize size);
 ResourceAccessRange MakeRange(const vvl::Buffer &buffer, VkDeviceSize offset, VkDeviceSize size);
-ResourceAccessRange MakeRange(const BUFFER_VIEW_STATE &buf_view_state);
+ResourceAccessRange MakeRange(const vvl::BufferView &buf_view_state);
 ResourceAccessRange MakeRange(VkDeviceSize offset, uint32_t first_index, uint32_t count, uint32_t stride);
 ResourceAccessRange MakeRange(const BufferBinding &binding, uint32_t first_index, const std::optional<uint32_t> &count,
                               uint32_t stride);

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1020,7 +1020,7 @@ SyncOpBeginRenderPass::SyncOpBeginRenderPass(vvl::Func command, const SyncValida
                                              const VkSubpassBeginInfo *pSubpassBeginInfo)
     : SyncOpBase(command), rp_context_(nullptr) {
     if (pRenderPassBegin) {
-        rp_state_ = sync_state.Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
+        rp_state_ = sync_state.Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
         renderpass_begin_info_ = safe_VkRenderPassBeginInfo(pRenderPassBegin);
         auto fb_state = sync_state.Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
         if (fb_state) {

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1022,7 +1022,7 @@ SyncOpBeginRenderPass::SyncOpBeginRenderPass(vvl::Func command, const SyncValida
     if (pRenderPassBegin) {
         rp_state_ = sync_state.Get<RENDER_PASS_STATE>(pRenderPassBegin->renderPass);
         renderpass_begin_info_ = safe_VkRenderPassBeginInfo(pRenderPassBegin);
-        auto fb_state = sync_state.Get<FRAMEBUFFER_STATE>(pRenderPassBegin->framebuffer);
+        auto fb_state = sync_state.Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
         if (fb_state) {
             shared_attachments_ = sync_state.GetAttachmentViews(*renderpass_begin_info_.ptr(), *fb_state);
             // TODO: Revisit this when all attachment validation is through SyncOps to see if we can discard the plain pointer copy

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -296,7 +296,7 @@ class SyncOpBeginRenderPass : public SyncOpBase {
     safe_VkSubpassBeginInfo subpass_begin_info_;
     std::vector<std::shared_ptr<const IMAGE_VIEW_STATE>> shared_attachments_;
     std::vector<const syncval_state::ImageViewState *> attachments_;
-    std::shared_ptr<const RENDER_PASS_STATE> rp_state_;
+    std::shared_ptr<const vvl::RenderPass> rp_state_;
     const RenderPassAccessContext *rp_context_;
 };
 

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -66,7 +66,7 @@ class UpdateStateResolveAction {
     const ResourceUsageTag tag_;
 };
 
-void InitSubpassContexts(VkQueueFlags queue_flags, const RENDER_PASS_STATE &rp_state, const AccessContext *external_context,
+void InitSubpassContexts(VkQueueFlags queue_flags, const vvl::RenderPass &rp_state, const AccessContext *external_context,
                          std::vector<AccessContext> &subpass_contexts) {
     const auto &create_info = rp_state.createInfo;
     // Add this for all subpasses here so that they exsist during next subpass validation
@@ -111,7 +111,7 @@ static SyncStageAccessIndex DepthStencilLoadUsage(VkAttachmentLoadOp load_op) {
 }
 
 // Caller must manage returned pointer
-static AccessContext *CreateStoreResolveProxyContext(const AccessContext &context, const RENDER_PASS_STATE &rp_state,
+static AccessContext *CreateStoreResolveProxyContext(const AccessContext &context, const vvl::RenderPass &rp_state,
                                                      uint32_t subpass, const AttachmentViewGenVector &attachment_views) {
     auto *proxy = new AccessContext(context);
     RenderPassAccessContext::UpdateAttachmentResolveAccess(rp_state, attachment_views, subpass, kInvalidTag, *proxy);
@@ -121,7 +121,7 @@ static AccessContext *CreateStoreResolveProxyContext(const AccessContext &contex
 
 // Layout transitions are handled as if the were occuring in the beginning of the next subpass
 bool RenderPassAccessContext::ValidateLayoutTransitions(const SyncValidationInfo &val_info, const AccessContext &access_context,
-                                                        const RENDER_PASS_STATE &rp_state, const VkRect2D &render_area,
+                                                        const vvl::RenderPass &rp_state, const VkRect2D &render_area,
                                                         uint32_t subpass, const AttachmentViewGenVector &attachment_views,
                                                         vvl::Func command) {
     bool skip = false;
@@ -173,9 +173,8 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const SyncValidationInfo
 }
 
 bool RenderPassAccessContext::ValidateLoadOperation(const SyncValidationInfo &val_info, const AccessContext &access_context,
-                                                    const RENDER_PASS_STATE &rp_state, const VkRect2D &render_area,
-                                                    uint32_t subpass, const AttachmentViewGenVector &attachment_views,
-                                                    vvl::Func command) {
+                                                    const vvl::RenderPass &rp_state, const VkRect2D &render_area, uint32_t subpass,
+                                                    const AttachmentViewGenVector &attachment_views, vvl::Func command) {
     bool skip = false;
     const auto *attachment_ci = rp_state.createInfo.pAttachments;
 
@@ -337,7 +336,7 @@ bool IsStencilAttachmentWriteable(const LAST_BOUND_STATE &last_bound_state, cons
 //
 // The signature for Action() reflect the needs of both uses.
 template <typename Action>
-void ResolveOperation(Action &action, const RENDER_PASS_STATE &rp_state, const AttachmentViewGenVector &attachment_views,
+void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
                       uint32_t subpass) {
     const auto &rp_ci = rp_state.createInfo;
     const auto *attachment_ci = rp_ci.pAttachments;
@@ -403,14 +402,14 @@ bool RenderPassAccessContext::ValidateResolveOperations(const SyncValidationInfo
     return validate_action.GetSkip();
 }
 
-void RenderPassAccessContext::UpdateAttachmentResolveAccess(const RENDER_PASS_STATE &rp_state,
+void RenderPassAccessContext::UpdateAttachmentResolveAccess(const vvl::RenderPass &rp_state,
                                                             const AttachmentViewGenVector &attachment_views, uint32_t subpass,
                                                             const ResourceUsageTag tag, AccessContext access_context) {
     UpdateStateResolveAction update(access_context, tag);
     ResolveOperation(update, rp_state, attachment_views, subpass);
 }
 
-void RenderPassAccessContext::UpdateAttachmentStoreAccess(const RENDER_PASS_STATE &rp_state,
+void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass &rp_state,
                                                           const AttachmentViewGenVector &attachment_views, uint32_t subpass,
                                                           const ResourceUsageTag tag, AccessContext &access_context) {
     const auto *attachment_ci = rp_state.createInfo.pAttachments;
@@ -446,7 +445,7 @@ void RenderPassAccessContext::UpdateAttachmentStoreAccess(const RENDER_PASS_STAT
     }
 }
 
-void RenderPassAccessContext::RecordLayoutTransitions(const RENDER_PASS_STATE &rp_state, uint32_t subpass,
+void RenderPassAccessContext::RecordLayoutTransitions(const vvl::RenderPass &rp_state, uint32_t subpass,
                                                       const AttachmentViewGenVector &attachment_views, const ResourceUsageTag tag,
                                                       AccessContext &access_context) {
     const auto &transitions = rp_state.subpass_transitions[subpass];
@@ -883,7 +882,7 @@ AttachmentViewGenVector RenderPassAccessContext::CreateAttachmentViewGen(
     }
     return view_gens;
 }
-RenderPassAccessContext::RenderPassAccessContext(const RENDER_PASS_STATE &rp_state, const VkRect2D &render_area,
+RenderPassAccessContext::RenderPassAccessContext(const vvl::RenderPass &rp_state, const VkRect2D &render_area,
                                                  VkQueueFlags queue_flags,
                                                  const std::vector<const syncval_state::ImageViewState *> &attachment_views,
                                                  const AccessContext *external_context)

--- a/layers/sync/sync_renderpass.h
+++ b/layers/sync/sync_renderpass.h
@@ -71,7 +71,7 @@ struct BeginRenderingCmdState {
 };
 }  // namespace syncval_state
 
-void InitSubpassContexts(VkQueueFlags queue_flags, const RENDER_PASS_STATE &rp_state, const AccessContext *external_context,
+void InitSubpassContexts(VkQueueFlags queue_flags, const vvl::RenderPass &rp_state, const AccessContext *external_context,
                          std::vector<AccessContext> &subpass_contexts);
 
 struct ClearAttachmentInfo {
@@ -103,28 +103,28 @@ class RenderPassAccessContext {
     static AttachmentViewGenVector CreateAttachmentViewGen(
         const VkRect2D &render_area, const std::vector<const syncval_state::ImageViewState *> &attachment_views);
     RenderPassAccessContext() : rp_state_(nullptr), render_area_(VkRect2D()), current_subpass_(0) {}
-    RenderPassAccessContext(const RENDER_PASS_STATE &rp_state, const VkRect2D &render_area, VkQueueFlags queue_flags,
+    RenderPassAccessContext(const vvl::RenderPass &rp_state, const VkRect2D &render_area, VkQueueFlags queue_flags,
                             const std::vector<const syncval_state::ImageViewState *> &attachment_views,
                             const AccessContext *external_context);
 
     static bool ValidateLayoutTransitions(const SyncValidationInfo &val_info, const AccessContext &access_context,
-                                          const RENDER_PASS_STATE &rp_state, const VkRect2D &render_area, uint32_t subpass,
+                                          const vvl::RenderPass &rp_state, const VkRect2D &render_area, uint32_t subpass,
                                           const AttachmentViewGenVector &attachment_views, vvl::Func command);
 
     static bool ValidateLoadOperation(const SyncValidationInfo &val_info, const AccessContext &access_context,
-                                      const RENDER_PASS_STATE &rp_state, const VkRect2D &render_area, uint32_t subpass,
+                                      const vvl::RenderPass &rp_state, const VkRect2D &render_area, uint32_t subpass,
                                       const AttachmentViewGenVector &attachment_views, vvl::Func command);
 
     bool ValidateStoreOperation(const SyncValidationInfo &val_info, vvl::Func command) const;
     bool ValidateResolveOperations(const SyncValidationInfo &val_info, vvl::Func command) const;
 
-    static void UpdateAttachmentResolveAccess(const RENDER_PASS_STATE &rp_state, const AttachmentViewGenVector &attachment_views,
+    static void UpdateAttachmentResolveAccess(const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
                                               uint32_t subpass, const ResourceUsageTag tag, AccessContext access_context);
 
-    static void UpdateAttachmentStoreAccess(const RENDER_PASS_STATE &rp_state, const AttachmentViewGenVector &attachment_views,
+    static void UpdateAttachmentStoreAccess(const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
                                             uint32_t subpass, const ResourceUsageTag tag, AccessContext &access_context);
 
-    static void RecordLayoutTransitions(const RENDER_PASS_STATE &rp_state, uint32_t subpass,
+    static void RecordLayoutTransitions(const vvl::RenderPass &rp_state, uint32_t subpass,
                                         const AttachmentViewGenVector &attachment_views, const ResourceUsageTag tag,
                                         AccessContext &access_context);
 
@@ -149,11 +149,11 @@ class RenderPassAccessContext {
     const AccessContext &CurrentContext() const { return subpass_contexts_[current_subpass_]; }
     const std::vector<AccessContext> &GetContexts() const { return subpass_contexts_; }
     uint32_t GetCurrentSubpass() const { return current_subpass_; }
-    const RENDER_PASS_STATE *GetRenderPassState() const { return rp_state_; }
+    const vvl::RenderPass *GetRenderPassState() const { return rp_state_; }
     AccessContext *CreateStoreResolveProxy() const;
 
   private:
-    const RENDER_PASS_STATE *rp_state_;
+    const vvl::RenderPass *rp_state_;
     const VkRect2D render_area_;
     uint32_t current_subpass_;
     std::vector<AccessContext> subpass_contexts_;


### PR DESCRIPTION
- `BUFFER_VIEW_STATE` to `vvl::BufferView`
- `SAMPLER_STATE` to `vvl::Sampler`
- `SAMPLER_YCBCR_CONVERSION_STATE` to `vvl::SamplerYcbcrConversion`
- `FRAMEBUFFER_STATE` to `vvl::Framebuffer`
- `RENDER_PASS_STATE` to `vvl::RenderPass`
- `vvl::AccelerationStructure`
- `vvl::PipelineCache`
- `vvl:Surface`
- `vvl:DisplayMode`
- `vvl::PhysicalDevice`


