### PR TITLE
tests: Cleanup of RenderPass/Framebuffer helper

### DIFF
--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -69,7 +69,6 @@ class VkRenderFramework : public VkTestFramework {
     vkt::Device *DeviceObj() const { return m_device; }
     VkPhysicalDevice gpu() const;
     VkRenderPass renderPass() const { return m_renderPass; }
-    const VkRenderPassCreateInfo &RenderPassInfo() const { return m_renderPass_info; };
     VkFramebuffer framebuffer() const { return m_framebuffer; }
     ErrorMonitor &Monitor();
     const VkPhysicalDeviceProperties &physDevProps() const;
@@ -112,8 +111,6 @@ class VkRenderFramework : public VkTestFramework {
     // default to CommandPool Reset flag to allow recording multiple command buffers simpler
     void InitState(VkPhysicalDeviceFeatures *features = nullptr, void *create_device_pnext = nullptr,
                    const VkCommandPoolCreateFlags flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-
-    const VkRenderPassBeginInfo &renderPassBeginInfo() const { return m_renderPassBeginInfo; }
 
     bool DeviceExtensionSupported(const char *extension_name, uint32_t spec_version = 0) const;
     bool DeviceExtensionSupported(VkPhysicalDevice, const char *, const char *name,
@@ -188,15 +185,8 @@ class VkRenderFramework : public VkTestFramework {
     vkt::CommandPool *m_commandPool;
     vkt::CommandBuffer *m_commandBuffer;
     VkRenderPass m_renderPass = VK_NULL_HANDLE;
-    VkRenderPassCreateInfo m_renderPass_info = {};
-    std::vector<VkAttachmentDescription> m_renderPass_attachments;
-    std::vector<VkSubpassDescription> m_renderPass_subpasses;
-    std::vector<VkSubpassDependency> m_renderPass_dependencies;
 
     VkFramebuffer m_framebuffer;
-    VkFramebufferCreateInfo m_framebuffer_info;
-    std::vector<vkt::ImageView> m_render_target_views;   // color attachments but not depth
-    std::vector<VkImageView> m_framebuffer_attachments;  // all attachments, can be consumed directly by the API
 
     // WSI items
     SurfaceContext m_surface_context{};
@@ -245,6 +235,13 @@ class VkRenderFramework : public VkTestFramework {
     VkValidationFeatureDisableEXT validation_disable_all = VK_VALIDATION_FEATURE_DISABLE_ALL_EXT;
 
   private:
+    // TODO - move to own helper logic
+    std::vector<VkAttachmentDescription> m_renderPass_attachments;
+    std::vector<VkSubpassDescription> m_renderPass_subpasses;
+    std::vector<VkSubpassDependency> m_renderPass_dependencies;
+    std::vector<vkt::ImageView> m_render_target_views;   // color attachments but not depth
+    std::vector<VkImageView> m_framebuffer_attachments;  // all attachments, can be consumed directly by the API
+
     // Add ext_name, the names of all instance extensions required by ext_name, and return true if ext_name is supported. If the
     // extension is not supported, no extension names are added for instance creation. `ext_name` can refer to a device or instance
     // extension.

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -218,7 +218,6 @@ TEST_F(VkArmBestPracticesLayerTest, MultisampledBlending) {
     rp_info.pSubpasses = &subpass;
 
     vk::CreateRenderPass(m_device->device(), &rp_info, nullptr, &m_renderPass);
-    m_renderPass_info = rp_info;
 
     VkPipelineMultisampleStateCreateInfo pipe_ms_state_ci = {};
     pipe_ms_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -649,7 +649,7 @@ TEST_F(NegativeCommand, ClearColorAttachmentsZeroLayercount) {
     InitRenderTarget();
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment color_attachment;
     color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -671,7 +671,7 @@ TEST_F(NegativeCommand, ClearColorAttachmentsZeroExtent) {
     InitRenderTarget();
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment color_attachment;
     color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -703,7 +703,7 @@ TEST_F(NegativeCommand, ClearAttachmentsAspectMasks) {
     InitRenderTarget();
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment attachment;
     attachment.clearValue.color.float32[0] = 0;
@@ -745,7 +745,7 @@ TEST_F(NegativeCommand, ClearAttachmentsImplicitCheck) {
     InitRenderTarget();
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment color_attachment;
     color_attachment.clearValue.color.float32[0] = 0;
@@ -785,7 +785,7 @@ TEST_F(NegativeCommand, ClearAttachmentsDepth) {
     InitRenderTarget(&depth_image_view.handle());
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment attachment;
     attachment.colorAttachment = 0;
@@ -816,7 +816,7 @@ TEST_F(NegativeCommand, ClearAttachmentsStencil) {
     InitRenderTarget(&depth_image_view.handle());
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment attachment;
     attachment.colorAttachment = 0;
@@ -908,7 +908,7 @@ TEST_F(NegativeCommand, ExecuteCommandsPrimaryCB) {
     cb.end();
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     VkCommandBuffer handle = cb.handle();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdExecuteCommands-pCommandBuffers-00088");
@@ -7098,10 +7098,13 @@ TEST_F(NegativeCommand, CmdClearAttachmentTests) {
     ivci.components.b = VK_COMPONENT_SWIZZLE_B;
     ivci.components.a = VK_COMPONENT_SWIZZLE_A;
     vkt::ImageView render_target_view(*m_device, ivci);
-    VkFramebufferCreateInfo fb_info = m_framebuffer_info;
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
+    fb_info.renderPass = renderPass();
     fb_info.layers = 2;
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = &render_target_view.handle();
+    fb_info.width = m_width;
+    fb_info.height = m_height;
     vkt::Framebuffer framebuffer(*m_device, fb_info);
     m_renderPassBeginInfo.framebuffer = framebuffer.handle();
 
@@ -7134,7 +7137,7 @@ TEST_F(NegativeCommand, CmdClearAttachmentTests) {
     auto clear_cmds = [this, &color_attachment](VkCommandBuffer cmd_buffer, VkClearRect clear_rect) {
         // extent too wide
         VkClearRect clear_rect_too_large = clear_rect;
-        clear_rect_too_large.rect.extent.width = renderPassBeginInfo().renderArea.extent.width + 4;
+        clear_rect_too_large.rect.extent.width = m_renderPassBeginInfo.renderArea.extent.width + 4;
         clear_rect_too_large.rect.extent.height = clear_rect_too_large.rect.extent.height / 2;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-pRects-00016");
         vk::CmdClearAttachments(cmd_buffer, 1, &color_attachment, 1, &clear_rect_too_large);

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -751,7 +751,7 @@ TEST_F(PositiveCommand, ClearAttachmentsDepthStencil) {
     InitRenderTarget();
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment attachment;
     attachment.colorAttachment = 0;

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -24,7 +24,6 @@ TEST_F(NegativeDescriptors, DescriptorPoolConsistency) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkFreeDescriptorSets-pDescriptorSets-parent");
 
     RETURN_IF_SKIP(Init());
-    InitRenderTarget();
 
     VkDescriptorPoolSize ds_type_count = {};
     ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
@@ -52,7 +51,6 @@ TEST_F(NegativeDescriptors, AllocDescriptorFromEmptyPool) {
     SetTargetApiVersion(VK_API_VERSION_1_0);
 
     RETURN_IF_SKIP(Init());
-    InitRenderTarget();
 
     // This test is valid for Vulkan 1.0 only -- skip if device has an API version greater than 1.0.
     if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
@@ -114,7 +112,6 @@ TEST_F(NegativeDescriptors, AllocDescriptorFromEmptyPool) {
 
 TEST_F(NegativeDescriptors, FreeDescriptorFromOneShotPool) {
     RETURN_IF_SKIP(Init());
-    InitRenderTarget();
 
     VkDescriptorPoolSize ds_type_count = {};
     ds_type_count.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -345,7 +345,7 @@ TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
     auto clear_cmds = [this, &color_attachment](VkCommandBuffer cmd_buffer, VkClearRect clear_rect) {
         // extent too wide
         VkClearRect clear_rect_too_large = clear_rect;
-        clear_rect_too_large.rect.extent.width = renderPassBeginInfo().renderArea.extent.width + 4;
+        clear_rect_too_large.rect.extent.width = m_renderPassBeginInfo.renderArea.extent.width + 4;
         clear_rect_too_large.rect.extent.height = clear_rect_too_large.rect.extent.height / 2;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-pRects-00016");
         vk::CmdClearAttachments(cmd_buffer, 1, &color_attachment, 1, &clear_rect_too_large);

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -181,7 +181,6 @@ TEST_F(NegativeDynamicState, DepthBoundsNotBound) {
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthWriteEnable = VK_TRUE;
     pipe.ds_ci_.depthBoundsTestEnable = VK_TRUE;
-    pipe.gp_ci_.renderPass = renderPass();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -211,7 +210,6 @@ TEST_F(NegativeDynamicState, StencilReadNotBound) {
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthWriteEnable = VK_TRUE;
     pipe.ds_ci_.stencilTestEnable = VK_TRUE;
-    pipe.gp_ci_.renderPass = renderPass();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -241,7 +239,6 @@ TEST_F(NegativeDynamicState, StencilWriteNotBound) {
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthWriteEnable = VK_TRUE;
     pipe.ds_ci_.stencilTestEnable = VK_TRUE;
-    pipe.gp_ci_.renderPass = renderPass();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -271,7 +268,6 @@ TEST_F(NegativeDynamicState, StencilRefNotBound) {
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthWriteEnable = VK_TRUE;
     pipe.ds_ci_.stencilTestEnable = VK_TRUE;
-    pipe.gp_ci_.renderPass = renderPass();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -3025,24 +3021,21 @@ TEST_F(NegativeDynamicState, SampleLocations) {
         {0, depth_format, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
          VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_UNDEFINED,
          VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL}};
-    m_renderPass_attachments.push_back(descriptions[0]);
-    m_renderPass_attachments.push_back(descriptions[1]);
     VkAttachmentReference color_ref = {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
     VkAttachmentReference depth_stencil_ref = {1, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL};
     VkSubpassDescription subpass = {
         0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, &color_ref, nullptr, &depth_stencil_ref, 0, nullptr};
-    m_renderPass_subpasses.push_back(subpass);
-    m_renderPass_info = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, 2u, descriptions, 1u, &subpass, 0u, nullptr);
-    vk::CreateRenderPass(m_device->device(), &m_renderPass_info, NULL, &m_renderPass);
+    auto rp_info = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, 2u, descriptions, 1u, &subpass, 0u, nullptr);
+    vk::CreateRenderPass(m_device->device(), &rp_info, NULL, &m_renderPass);
 
     // Create a framebuffer
     vkt::ImageView color_view = color_image.CreateView();
     vkt::ImageView depth_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
     const std::array<VkImageView, 2> attachments = {color_view, depth_view};
 
-    m_framebuffer_info = vku::InitStruct<VkFramebufferCreateInfo>(
-        nullptr, 0u, m_renderPass, static_cast<uint32_t>(attachments.size()), attachments.data(), 128u, 128u, 1u);
-    vk::CreateFramebuffer(m_device->handle(), &m_framebuffer_info, nullptr, &m_framebuffer);
+    auto fb_info = vku::InitStruct<VkFramebufferCreateInfo>(nullptr, 0u, m_renderPass, static_cast<uint32_t>(attachments.size()),
+                                                            attachments.data(), 128u, 128u, 1u);
+    vk::CreateFramebuffer(m_device->handle(), &fb_info, nullptr, &m_framebuffer);
 
     VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
     vk::GetPhysicalDeviceMultisamplePropertiesEXT(gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -290,11 +290,14 @@ TEST_F(PositiveDynamicState, DynamicColorWriteNoColorAttachments) {
     rpci.pSubpasses = &subpasses;
     vkt::RenderPass rp(*m_device, rpci);
 
-    VkFramebufferCreateInfo &fbci = m_framebuffer_info;
-    fbci.renderPass = rp.handle();
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &depth_image_view.handle();
-    vkt::Framebuffer fb(*m_device, fbci);
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
+    fb_info.renderPass = rp.handle();
+    fb_info.attachmentCount = 1;
+    fb_info.pAttachments = &depth_image_view.handle();
+    fb_info.width = m_width;
+    fb_info.height = m_height;
+    fb_info.layers = 1;
+    vkt::Framebuffer fb(*m_device, fb_info);
 
     // Enable dynamic color write enable
     pipe.gp_ci_.renderPass = rp.handle();

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -1215,14 +1215,19 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImagePNext) {
     TEST_DESCRIPTION("Begin render pass with missing framebuffer attachment");
     AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
 
-    RETURN_IF_SKIP(InitFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
+
+    VkImageObj image(m_device);
+    image.Init(256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM,
+               VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+               VK_IMAGE_TILING_OPTIMAL);
+    vkt::ImageView imageView = image.CreateView();
 
     // random invalid struct for a framebuffer pNext change
     VkCommandPoolCreateInfo invalid_struct = vku::InitStructHelper();
 
-    VkFormat attachment_format = VK_FORMAT_R8G8B8A8_UNORM;
+    VkFormat attachment_format = VK_FORMAT_B8G8R8A8_UNORM;
     VkFramebufferAttachmentImageInfo fb_fdm = vku::InitStructHelper(&invalid_struct);
     fb_fdm.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     fb_fdm.width = 64;
@@ -1240,8 +1245,8 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImagePNext) {
     framebufferCreateInfo.height = 64;
     framebufferCreateInfo.layers = 1;
     framebufferCreateInfo.renderPass = m_renderPass;
-    framebufferCreateInfo.attachmentCount = static_cast<uint32_t>(m_framebuffer_attachments.size());
-    framebufferCreateInfo.pAttachments = m_framebuffer_attachments.data();
+    framebufferCreateInfo.attachmentCount = 1;
+    framebufferCreateInfo.pAttachments = &imageView.handle();
 
     // VkFramebufferCreateInfo -pNext-> VkFramebufferAttachmentsCreateInfo
     //                                             |-> VkFramebufferAttachmentImageInfo -pNext-> INVALID

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -936,7 +936,7 @@ TEST_F(NegativeMesh, DrawCmds) {
     pipe1.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(renderPassBeginInfo());
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     uint32_t max_group_count_X = mesh_shader_properties.maxTaskWorkGroupCount[0];
@@ -1082,7 +1082,7 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(renderPassBeginInfo());
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-07088");
@@ -1194,7 +1194,7 @@ TEST_F(NegativeMesh, DrawCmdsNV) {
     pipe1.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(renderPassBeginInfo());
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawMeshTasksIndirectNV-drawCount-02156");

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -553,7 +553,6 @@ TEST_F(PositivePipeline, ViewportArray2NV) {
         pipe.InitState();
         pipe.ia_ci_.topology =
             (stage != TestStage::VERTEX) ? VK_PRIMITIVE_TOPOLOGY_PATCH_LIST : VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
-        pipe.gp_ci_.renderPass = renderPass();
         pipe.shader_stages_.clear();
 
         std::stringstream vs_src, tes_src, geom_src;

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -362,7 +362,6 @@ TEST_F(NegativePortabilitySubset, RasterizationState) {
     rp_info.pSubpasses = &subpass;
 
     vk::CreateRenderPass(device(), &rp_info, nullptr, &m_renderPass);
-    m_renderPass_info = rp_info;
 
     CreatePipelineHelper pipe(*this);
     pipe.rs_state_ci_.polygonMode = VK_POLYGON_MODE_POINT;

--- a/tests/unit/renderpass.cpp
+++ b/tests/unit/renderpass.cpp
@@ -2483,8 +2483,8 @@ TEST_F(NegativeRenderPass, RenderArea) {
     VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
     rpbinfo.renderPass = m_renderPass;
     rpbinfo.framebuffer = m_framebuffer;
-    rpbinfo.renderArea.extent.width = m_framebuffer_info.width;
-    rpbinfo.renderArea.extent.height = m_framebuffer_info.height;
+    rpbinfo.renderArea.extent.width = m_width;
+    rpbinfo.renderArea.extent.height = m_height;
     rpbinfo.renderArea.offset.x = -32;
     rpbinfo.renderArea.offset.y = 0;
     rpbinfo.clearValueCount = 1;
@@ -2503,14 +2503,14 @@ TEST_F(NegativeRenderPass, RenderArea) {
     m_errorMonitor->VerifyFound();
 
     rpbinfo.renderArea.offset.y = 0;
-    rpbinfo.renderArea.extent.width = m_framebuffer_info.width + 128;
+    rpbinfo.renderArea.extent.width = m_width + 128;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassBeginInfo-pNext-02852");
     m_commandBuffer->BeginRenderPass(rpbinfo);
     m_errorMonitor->VerifyFound();
 
-    rpbinfo.renderArea.extent.width = m_framebuffer_info.width;
-    rpbinfo.renderArea.extent.height = m_framebuffer_info.height + 1;
+    rpbinfo.renderArea.extent.width = m_width;
+    rpbinfo.renderArea.extent.height = m_height + 1;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassBeginInfo-pNext-02853");
     m_commandBuffer->BeginRenderPass(rpbinfo);
@@ -2524,9 +2524,7 @@ TEST_F(NegativeRenderPass, DeviceGroupRenderArea) {
 
     AddRequiredExtensions(VK_KHR_DEVICE_GROUP_CREATION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework());
-
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
     VkRect2D renderArea = {};
@@ -2543,8 +2541,8 @@ TEST_F(NegativeRenderPass, DeviceGroupRenderArea) {
     VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper(&device_group_render_pass_begin_info);
     rpbinfo.renderPass = m_renderPass;
     rpbinfo.framebuffer = m_framebuffer;
-    rpbinfo.renderArea.extent.width = m_framebuffer_info.width;
-    rpbinfo.renderArea.extent.height = m_framebuffer_info.height;
+    rpbinfo.renderArea.extent.width = m_width;
+    rpbinfo.renderArea.extent.height = m_height;
     rpbinfo.renderArea.offset.x = -32;
     rpbinfo.renderArea.offset.y = 0;
     rpbinfo.clearValueCount = 1;
@@ -2559,8 +2557,8 @@ TEST_F(NegativeRenderPass, DeviceGroupRenderArea) {
 
     renderArea.offset.x = 0;
     renderArea.offset.y = 1;
-    renderArea.extent.width = m_framebuffer_info.width + 1;
-    renderArea.extent.height = m_framebuffer_info.height;
+    renderArea.extent.width = m_width + 1;
+    renderArea.extent.height = m_height;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassBeginInfo-pNext-02856");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassBeginInfo-pNext-02857");

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -80,7 +80,7 @@ TEST_F(NegativeTransformFeedback, FeatureEnabled) {
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
     {
@@ -118,7 +118,7 @@ TEST_F(NegativeTransformFeedback, NoBoundPipeline) {
     InitRenderTarget();
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginTransformFeedbackEXT-None-06233");
     vk::CmdBeginTransformFeedbackEXT(m_commandBuffer->handle(), 0, 1, nullptr, nullptr);
     m_errorMonitor->VerifyFound();
@@ -139,7 +139,7 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
     {
@@ -290,7 +290,7 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackEXT) {
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
     {
@@ -377,7 +377,7 @@ TEST_F(NegativeTransformFeedback, CmdEndTransformFeedbackEXT) {
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
     {
@@ -469,7 +469,7 @@ TEST_F(NegativeTransformFeedback, ExecuteSecondaryCommandBuffers) {
     VkCommandBufferInheritanceInfo hinfo = vku::InitStructHelper();
     info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     info.pInheritanceInfo = &hinfo;
-    hinfo.renderPass = renderPassBeginInfo().renderPass;
+    hinfo.renderPass = m_renderPassBeginInfo.renderPass;
     hinfo.subpass = 0;
     hinfo.framebuffer = VK_NULL_HANDLE;
     hinfo.occlusionQueryEnable = VK_FALSE;
@@ -485,7 +485,7 @@ TEST_F(NegativeTransformFeedback, ExecuteSecondaryCommandBuffers) {
 
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
-    m_commandBuffer->BeginRenderPass(renderPassBeginInfo(), VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginTransformFeedbackEXT-commandBuffer-recording");
     vk::CmdBeginTransformFeedbackEXT(m_commandBuffer->handle(), 0, 1, nullptr, nullptr);
     m_errorMonitor->VerifyFound();
@@ -537,7 +537,7 @@ TEST_F(NegativeTransformFeedback, EndRenderPass) {
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(renderPassBeginInfo(), VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     vk::CmdBeginTransformFeedbackEXT(m_commandBuffer->handle(), 0, 1, nullptr, nullptr);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndRenderPass-None-02351");

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -1122,18 +1122,22 @@ TEST_F(PositiveWsi, ProtectedSwapchainImageColorAttachment) {
                                       VK_ACCESS_SHADER_WRITE_BIT,
                                       VK_DEPENDENCY_BY_REGION_BIT};
     // Use framework render pass and framebuffer so pipeline helper uses it
-    m_renderPass_info = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 1, attachments, 1, &subpass, 1, &dependency};
-    ASSERT_EQ(VK_SUCCESS, vk::CreateRenderPass(device(), &m_renderPass_info, nullptr, &m_renderPass));
-    m_framebuffer_info = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
-                          nullptr,
-                          0,
-                          m_renderPass,
-                          1,
-                          &image_view.handle(),
-                          swapchain_create_info.imageExtent.width,
-                          swapchain_create_info.imageExtent.height,
-                          1};
-    ASSERT_EQ(VK_SUCCESS, vk::CreateFramebuffer(device(), &m_framebuffer_info, nullptr, &m_framebuffer));
+    VkRenderPassCreateInfo rp_info = vku::InitStructHelper();
+    rp_info.attachmentCount = 1;
+    rp_info.pAttachments = attachments;
+    rp_info.subpassCount = 1;
+    rp_info.pSubpasses = &subpass;
+    rp_info.dependencyCount = 1;
+    rp_info.pDependencies = &dependency;
+    ASSERT_EQ(VK_SUCCESS, vk::CreateRenderPass(device(), &rp_info, nullptr, &m_renderPass));
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
+    fb_info.renderPass = m_renderPass;
+    fb_info.attachmentCount = 1;
+    fb_info.pAttachments = &image_view.handle();
+    fb_info.width = swapchain_create_info.imageExtent.width;
+    fb_info.height = swapchain_create_info.imageExtent.height;
+    fb_info.layers = 1;
+    ASSERT_EQ(VK_SUCCESS, vk::CreateFramebuffer(device(), &fb_info, nullptr, &m_framebuffer));
 
     // basic pipeline to allow for a valid vkCmdDraw()
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);


### PR DESCRIPTION
My goal is to improve the way we do Renderpass/Framebuffer so things are just magically done in the `InitRenderTarget` with hidden options

This tries to cleanup some of the member variables and soon move them behind a proper "render pass helper" object