### PR TITLE
tests: Add RenderPassSingleSubpass

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,8 @@ target_sources(vk_layer_validation_tests PRIVATE
     framework/thread_timeout_helper.h
     framework/thread_timeout_helper.cpp
     framework/gpu_av_helper.h
+    framework/render_pass_helper.h
+    framework/render_pass_helper.cpp
     unit/amd_best_practices.cpp
     unit/android_hardware_buffer.cpp
     unit/android_hardware_buffer_positive.cpp
@@ -132,7 +134,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/ray_tracing_pipeline_positive_nv.cpp
     unit/ray_tracing_positive.cpp
     unit/render_pass_positive.cpp
-    unit/renderpass.cpp
+    unit/render_pass.cpp
     unit/robustness.cpp
     unit/robustness_positive.cpp
     unit/sampler.cpp

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -38,10 +38,10 @@ typename C::iterator RemoveIf(C &container, F &&fn) {
 }
 
 VkRenderFramework::VkRenderFramework()
-    : instance_(NULL),
-      m_device(NULL),
+    : instance_(nullptr),
+      m_device(nullptr),
       m_commandPool(VK_NULL_HANDLE),
-      m_commandBuffer(NULL),
+      m_commandBuffer(nullptr),
       m_renderPass(VK_NULL_HANDLE),
       m_framebuffer(VK_NULL_HANDLE),
       m_addRenderPassSelfDependency(false),
@@ -53,7 +53,7 @@ VkRenderFramework::VkRenderFramework()
       m_load_op_clear(true),
       m_depth_clear_color(1.0),
       m_stencil_clear_color(0),
-      m_depthStencil(NULL) {
+      m_depthStencil(nullptr) {
     m_renderPassBeginInfo = vku::InitStructHelper();
 
     // clear the back buffer to dark grey

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -185,8 +185,7 @@ class VkRenderFramework : public VkTestFramework {
     vkt::CommandPool *m_commandPool;
     vkt::CommandBuffer *m_commandBuffer;
     VkRenderPass m_renderPass = VK_NULL_HANDLE;
-
-    VkFramebuffer m_framebuffer;
+    VkFramebuffer m_framebuffer = VK_NULL_HANDLE;
 
     // WSI items
     SurfaceContext m_surface_context{};

--- a/tests/framework/render_pass_helper.cpp
+++ b/tests/framework/render_pass_helper.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "render_pass_helper.h"
+
+RenderPassSingleSubpass::RenderPassSingleSubpass(VkLayerTest& test, vkt::Device* device) : layer_test_(test) {
+    // default VkDevice, can be overwritten if multi-device tests
+    device_ = (device) ? device : layer_test_.DeviceObj();
+
+    rp_create_info_ = vku::InitStructHelper();
+
+    rp_create_info_.dependencyCount = 0;  // default to not having one
+    rp_create_info_.pDependencies = &subpass_dependency_;
+
+    subpass_description_.flags = 0;
+    subpass_description_.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_description_.inputAttachmentCount = 0;
+    subpass_description_.pInputAttachments = nullptr;
+    subpass_description_.colorAttachmentCount = 0;
+    subpass_description_.pColorAttachments = nullptr;
+    subpass_description_.pResolveAttachments = nullptr;
+    subpass_description_.pDepthStencilAttachment = nullptr;
+    subpass_description_.preserveAttachmentCount = 0;
+    subpass_description_.pPreserveAttachments = nullptr;
+    rp_create_info_.subpassCount = 1;
+    rp_create_info_.pSubpasses = &subpass_description_;
+}
+
+RenderPassSingleSubpass::~RenderPassSingleSubpass() { Destroy(); }
+
+VkRenderPassCreateInfo RenderPassSingleSubpass::GetCreateInfo() {
+    rp_create_info_.attachmentCount = attachment_descriptions_.size();
+    rp_create_info_.pAttachments = attachment_descriptions_.data();
+    return rp_create_info_;
+}
+
+void RenderPassSingleSubpass::AddAttachmentDescription(VkFormat format, VkImageLayout initialLayout, VkImageLayout finalLayout,
+                                                       VkAttachmentLoadOp loadOp, VkAttachmentStoreOp storeOp) {
+    attachment_descriptions_.push_back({0, format, VK_SAMPLE_COUNT_1_BIT, loadOp, storeOp, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                        VK_ATTACHMENT_STORE_OP_DONT_CARE, initialLayout, finalLayout});
+}
+
+void RenderPassSingleSubpass::AddAttachmentDescription(VkFormat format, VkSampleCountFlagBits samples, VkImageLayout initialLayout,
+                                                       VkImageLayout finalLayout) {
+    attachment_descriptions_.push_back({0, format, samples, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                        VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, initialLayout,
+                                        finalLayout});
+}
+
+void RenderPassSingleSubpass::AddAttachmentReference(VkAttachmentReference reference) {
+    attachments_references_.push_back(reference);
+}
+
+void RenderPassSingleSubpass::AddInputAttachment(uint32_t index) {
+    input_attachments_.push_back(attachments_references_[index]);
+    subpass_description_.inputAttachmentCount = input_attachments_.size();
+    subpass_description_.pInputAttachments = input_attachments_.data();
+}
+
+void RenderPassSingleSubpass::AddColorAttachment(uint32_t index) {
+    color_attachments_.push_back(attachments_references_[index]);
+    subpass_description_.colorAttachmentCount = color_attachments_.size();
+    subpass_description_.pColorAttachments = color_attachments_.data();
+}
+
+void RenderPassSingleSubpass::AddResolveAttachment(uint32_t index) {
+    resolve_attachments_ = attachments_references_[index];
+    subpass_description_.pResolveAttachments = &resolve_attachments_;
+}
+
+void RenderPassSingleSubpass::AddDepthStencilAttachment(uint32_t index) {
+    ds_attachments_ = attachments_references_[index];
+    subpass_description_.pDepthStencilAttachment = &ds_attachments_;
+}
+
+void RenderPassSingleSubpass::AddSubpassDependency(VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
+                                                   VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask,
+                                                   VkDependencyFlags dependencyFlags) {
+    subpass_dependency_.srcSubpass = 0;
+    subpass_dependency_.dstSubpass = 0;
+    subpass_dependency_.srcStageMask = srcStageMask;
+    subpass_dependency_.srcStageMask = srcStageMask;
+    subpass_dependency_.dstStageMask = dstStageMask;
+    subpass_dependency_.srcAccessMask = srcAccessMask;
+    subpass_dependency_.dstAccessMask = dstAccessMask;
+    subpass_dependency_.dependencyFlags = dependencyFlags;
+    rp_create_info_.dependencyCount = 1;
+}
+
+void RenderPassSingleSubpass::CreateRenderPass(void* pNext) {
+    VkRenderPassCreateInfo rp_create_info = GetCreateInfo();
+    rp_create_info.pNext = pNext;
+    render_pass_.init(*device_, rp_create_info);
+}

--- a/tests/framework/render_pass_helper.h
+++ b/tests/framework/render_pass_helper.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include "layer_validation_tests.h"
+#include <vector>
+
+// Helper designed to quickly make a renderPass/framebuffer that only has a single Subpass.
+// The goal is to keep the class simple as possible.
+//
+// Common usage:
+//   RenderPassSingleSubpass rp(*this);
+//   rp.AddAttachmentDescription(input_format); // sets description[0]
+//   rp.AddAttachmentDescription(color_format); // sets description[1]
+//   rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});                  // sets reference[0]
+//   rp.AddAttachmentReference({1, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL}); // sets reference[1]
+//   rp.AddInputAttachment(0); // index maps to reference[0]
+//   rp.AddColorAttachment(1); // index maps to reference[1]
+//   rp.CreateRenderPass();
+class RenderPassSingleSubpass {
+  public:
+    RenderPassSingleSubpass(VkLayerTest &test, vkt::Device *device = nullptr);
+    ~RenderPassSingleSubpass();
+
+    VkRenderPassCreateInfo GetCreateInfo();
+    VkRenderPass Handle() { return render_pass_; }
+
+    // Ordered from most likely to be custom vs will use defauly
+    void AddAttachmentDescription(VkFormat format, VkImageLayout initialLayout = VK_IMAGE_LAYOUT_GENERAL,
+                                  VkImageLayout finalLayout = VK_IMAGE_LAYOUT_GENERAL,
+                                  VkAttachmentLoadOp loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                  VkAttachmentStoreOp storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE);
+    // Overload for setting sampler count
+    void AddAttachmentDescription(VkFormat format, VkSampleCountFlagBits samples,
+                                  VkImageLayout initialLayout = VK_IMAGE_LAYOUT_GENERAL,
+                                  VkImageLayout finalLayout = VK_IMAGE_LAYOUT_GENERAL);
+
+    void AddAttachmentReference(VkAttachmentReference reference);
+
+    // Pass in index to VkAttachmentReference
+    void AddInputAttachment(uint32_t index);
+    void AddColorAttachment(uint32_t index);
+    void AddResolveAttachment(uint32_t index);
+    void AddDepthStencilAttachment(uint32_t index);
+
+    void AddSubpassDependency(VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                              VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                              VkAccessFlags srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                              VkAccessFlags dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                              VkDependencyFlags dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT);
+
+    void CreateRenderPass(void *pNext = nullptr);
+
+    // Explicit destroy for those tests that need to test render pass lifetime
+    void Destroy() { render_pass_.destroy(); };
+
+  private:
+    VkLayerTest &layer_test_;
+    vkt::Device *device_;
+
+    vkt::RenderPass render_pass_;
+    VkRenderPassCreateInfo rp_create_info_;
+
+    std::vector<VkAttachmentDescription> attachment_descriptions_;
+
+    std::vector<VkAttachmentReference> attachments_references_;  // global pool
+    std::vector<VkAttachmentReference> input_attachments_;
+    std::vector<VkAttachmentReference> color_attachments_;
+    VkAttachmentReference resolve_attachments_;
+    VkAttachmentReference ds_attachments_;
+
+    VkSubpassDescription subpass_description_;
+    VkSubpassDependency subpass_dependency_;
+};

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -13,6 +13,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include "../framework/render_pass_helper.h"
 #include "generated/vk_extension_helper.h"
 
 void DynamicRenderingTest::InitBasicDynamicRendering(void* pNextFeatures) {
@@ -391,32 +392,17 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipeline) {
     rendering_info.colorAttachmentCount = 1;
     rendering_info.pColorAttachmentFormats = &color_format;
 
-    VkAttachmentReference attachment = {};
-    attachment.layout = VK_IMAGE_LAYOUT_GENERAL;
-    attachment.attachment = 0;
-
-    VkAttachmentDescription attach_desc = {};
-    attach_desc.format = VK_FORMAT_B8G8R8A8_UNORM;
-    attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkSubpassDescription subpass = {};
-    subpass.inputAttachmentCount = 1;
-    subpass.pInputAttachments = &attachment;
-    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper();
-    render_pass_ci.subpassCount = 1;
-    render_pass_ci.pSubpasses = &subpass;
-    render_pass_ci.attachmentCount = 1;
-    render_pass_ci.pAttachments = &attach_desc;
-
-    vkt::RenderPass render_pass(*m_device, render_pass_ci);
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_PREINITIALIZED);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddInputAttachment(0);
+    rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
-    pipe.gp_ci_.renderPass = render_pass.handle();
+    pipe.gp_ci_.renderPass = rp.Handle();
     pipe.gp_ci_.pNext = &rendering_info;
     pipe.CreateGraphicsPipeline();
 }
@@ -439,32 +425,17 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipelineNoInfo) {
     const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    VkAttachmentReference attachment = {};
-    attachment.layout = VK_IMAGE_LAYOUT_GENERAL;
-    attachment.attachment = 0;
-
-    VkAttachmentDescription attach_desc = {};
-    attach_desc.format = VK_FORMAT_B8G8R8A8_UNORM;
-    attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkSubpassDescription subpass = {};
-    subpass.inputAttachmentCount = 1;
-    subpass.pInputAttachments = &attachment;
-    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper();
-    render_pass_ci.subpassCount = 1;
-    render_pass_ci.pSubpasses = &subpass;
-    render_pass_ci.attachmentCount = 1;
-    render_pass_ci.pAttachments = &attach_desc;
-
-    vkt::RenderPass render_pass(*m_device, render_pass_ci);
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_LAYOUT_PREINITIALIZED);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddInputAttachment(0);
+    rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
-    pipe.gp_ci_.renderPass = render_pass.handle();
+    pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 }
 

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "../framework/layer_validation_tests.h"
+#include "../framework/render_pass_helper.h"
 
 TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     TEST_DESCRIPTION(
@@ -34,23 +35,11 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     VkFormat framebufferAttachmentFormats[3] = {VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_B8G8R8A8_UNORM};
 
     // Create a renderPass with a single attachment
-    VkAttachmentDescription attachmentDescription = {};
-    attachmentDescription.format = attachmentFormats[0];
-    attachmentDescription.samples = VK_SAMPLE_COUNT_1_BIT;
-    attachmentDescription.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescription.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    VkAttachmentReference attachmentReference = {};
-    attachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    VkSubpassDescription subpassDescription = {};
-    subpassDescription.colorAttachmentCount = 1;
-    subpassDescription.pColorAttachments = &attachmentReference;
-    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
-    rpci.subpassCount = 1;
-    rpci.pSubpasses = &subpassDescription;
-    rpci.attachmentCount = 1;
-    rpci.pAttachments = &attachmentDescription;
-    vkt::RenderPass rp(*m_device, rpci);
-    ASSERT_TRUE(rp.initialized());
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(attachmentFormats[0]);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.CreateRenderPass();
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfo = vku::InitStructHelper();
     framebufferAttachmentImageInfo.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
@@ -70,7 +59,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     framebufferCreateInfo.layers = 1;
     framebufferCreateInfo.attachmentCount = 1;
     framebufferCreateInfo.pAttachments = nullptr;
-    framebufferCreateInfo.renderPass = rp.handle();
+    framebufferCreateInfo.renderPass = rp.Handle();
 
     VkImageFormatListCreateInfoKHR imageFormatListCreateInfo = vku::InitStructHelper();
     imageFormatListCreateInfo.viewFormatCount = 2;
@@ -116,7 +105,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     renderPassAttachmentBeginInfo.attachmentCount = 1;
     renderPassAttachmentBeginInfo.pAttachments = image_views;
     VkRenderPassBeginInfo renderPassBeginInfo = vku::InitStructHelper(&renderPassAttachmentBeginInfo);
-    renderPassBeginInfo.renderPass = rp.handle();
+    renderPassBeginInfo.renderPass = rp.Handle();
     renderPassBeginInfo.renderArea.extent.width = attachmentWidth;
     renderPassBeginInfo.renderArea.extent.height = attachmentHeight;
 
@@ -360,22 +349,11 @@ TEST_F(NegativeImagelessFramebuffer, FeatureEnable) {
     VkFormat attachmentFormat = VK_FORMAT_R8G8B8A8_UNORM;
 
     // Create a renderPass with a single attachment
-    VkAttachmentDescription attachmentDescription = {};
-    attachmentDescription.format = attachmentFormat;
-    attachmentDescription.samples = VK_SAMPLE_COUNT_1_BIT;
-    attachmentDescription.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescription.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    VkAttachmentReference attachmentReference = {};
-    attachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    VkSubpassDescription subpassDescription = {};
-    subpassDescription.colorAttachmentCount = 1;
-    subpassDescription.pColorAttachments = &attachmentReference;
-    VkRenderPassCreateInfo renderPassCreateInfo = vku::InitStructHelper();
-    renderPassCreateInfo.subpassCount = 1;
-    renderPassCreateInfo.pSubpasses = &subpassDescription;
-    renderPassCreateInfo.attachmentCount = 1;
-    renderPassCreateInfo.pAttachments = &attachmentDescription;
-    vkt::RenderPass render_pass(*m_device, renderPassCreateInfo);
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(attachmentFormat);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.CreateRenderPass();
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfo = vku::InitStructHelper();
     framebufferAttachmentImageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -392,7 +370,7 @@ TEST_F(NegativeImagelessFramebuffer, FeatureEnable) {
     framebufferCreateInfo.width = attachmentWidth;
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = render_pass.handle();
+    framebufferCreateInfo.renderPass = rp.Handle();
     framebufferCreateInfo.attachmentCount = 1;
 
     // Imageless framebuffer creation bit not present
@@ -424,22 +402,11 @@ TEST_F(NegativeImagelessFramebuffer, BasicUsage) {
     VkFormat attachmentFormat = VK_FORMAT_R8G8B8A8_UNORM;
 
     // Create a renderPass with a single attachment
-    VkAttachmentDescription attachmentDescription = {};
-    attachmentDescription.format = attachmentFormat;
-    attachmentDescription.samples = VK_SAMPLE_COUNT_1_BIT;
-    attachmentDescription.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescription.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    VkAttachmentReference attachmentReference = {};
-    attachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    VkSubpassDescription subpassDescription = {};
-    subpassDescription.colorAttachmentCount = 1;
-    subpassDescription.pColorAttachments = &attachmentReference;
-    VkRenderPassCreateInfo renderPassCreateInfo = vku::InitStructHelper();
-    renderPassCreateInfo.subpassCount = 1;
-    renderPassCreateInfo.pSubpasses = &subpassDescription;
-    renderPassCreateInfo.attachmentCount = 1;
-    renderPassCreateInfo.pAttachments = &attachmentDescription;
-    vkt::RenderPass render_pass(*m_device, renderPassCreateInfo);
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(attachmentFormat);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.CreateRenderPass();
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfo = vku::InitStructHelper();
     framebufferAttachmentImageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -456,7 +423,7 @@ TEST_F(NegativeImagelessFramebuffer, BasicUsage) {
     framebufferCreateInfo.width = attachmentWidth;
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = render_pass.handle();
+    framebufferCreateInfo.renderPass = rp.Handle();
     framebufferCreateInfo.attachmentCount = 1;
     VkFramebuffer framebuffer = VK_NULL_HANDLE;
 
@@ -532,55 +499,20 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImageUsageMismatch) {
     VkFormat colorAndInputAttachmentFormat = VK_FORMAT_R8G8B8A8_UNORM;
     VkFormat depthStencilAttachmentFormat = VK_FORMAT_D32_SFLOAT_S8_UINT;
 
-    VkAttachmentDescription attachmentDescriptions[4] = {};
-    // Color attachment
-    attachmentDescriptions[0].format = colorAndInputAttachmentFormat;
-    attachmentDescriptions[0].samples = VK_SAMPLE_COUNT_4_BIT;
-    attachmentDescriptions[0].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[0].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    // Color resolve attachment
-    attachmentDescriptions[1].format = colorAndInputAttachmentFormat;
-    attachmentDescriptions[1].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachmentDescriptions[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[1].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    // Depth stencil attachment
-    attachmentDescriptions[2].format = depthStencilAttachmentFormat;
-    attachmentDescriptions[2].samples = VK_SAMPLE_COUNT_4_BIT;
-    attachmentDescriptions[2].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[2].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[2].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    // Input attachment
-    attachmentDescriptions[3].format = colorAndInputAttachmentFormat;
-    attachmentDescriptions[3].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachmentDescriptions[3].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[3].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkAttachmentReference colorAttachmentReference = {};
-    colorAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    colorAttachmentReference.attachment = 0;
-    VkAttachmentReference colorResolveAttachmentReference = {};
-    colorResolveAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    colorResolveAttachmentReference.attachment = 1;
-    VkAttachmentReference depthStencilAttachmentReference = {};
-    depthStencilAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    depthStencilAttachmentReference.attachment = 2;
-    VkAttachmentReference inputAttachmentReference = {};
-    inputAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    inputAttachmentReference.attachment = 3;
-    VkSubpassDescription subpassDescription = {};
-    subpassDescription.colorAttachmentCount = 1;
-    subpassDescription.pColorAttachments = &colorAttachmentReference;
-    subpassDescription.pResolveAttachments = &colorResolveAttachmentReference;
-    subpassDescription.pDepthStencilAttachment = &depthStencilAttachmentReference;
-    subpassDescription.inputAttachmentCount = 1;
-    subpassDescription.pInputAttachments = &inputAttachmentReference;
-
-    VkRenderPassCreateInfo renderPassCreateInfo = vku::InitStructHelper();
-    renderPassCreateInfo.attachmentCount = 4;
-    renderPassCreateInfo.subpassCount = 1;
-    renderPassCreateInfo.pSubpasses = &subpassDescription;
-    renderPassCreateInfo.pAttachments = attachmentDescriptions;
-    vkt::RenderPass render_pass(*m_device, renderPassCreateInfo);
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(colorAndInputAttachmentFormat, VK_SAMPLE_COUNT_4_BIT);  // Color attachment
+    rp.AddAttachmentDescription(colorAndInputAttachmentFormat);                         // Color resolve attachment
+    rp.AddAttachmentDescription(depthStencilAttachmentFormat, VK_SAMPLE_COUNT_4_BIT);   // Depth stencil attachment
+    rp.AddAttachmentDescription(colorAndInputAttachmentFormat);                         // Input attachment
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddAttachmentReference({1, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddAttachmentReference({2, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddAttachmentReference({3, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.AddResolveAttachment(1);
+    rp.AddDepthStencilAttachment(2);
+    rp.AddInputAttachment(3);
+    rp.CreateRenderPass();
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfos[4] = {};
     // Color attachment
@@ -623,7 +555,7 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImageUsageMismatch) {
     framebufferCreateInfo.width = attachmentWidth;
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = render_pass.handle();
+    framebufferCreateInfo.renderPass = rp.Handle();
     framebufferCreateInfo.attachmentCount = 4;
     VkFramebuffer framebuffer = VK_NULL_HANDLE;
 
@@ -675,59 +607,25 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentMultiviewImageLayerCountMismatch)
     VkFormat colorAndInputAttachmentFormat = VK_FORMAT_R8G8B8A8_UNORM;
     VkFormat depthStencilAttachmentFormat = VK_FORMAT_D32_SFLOAT_S8_UINT;
 
-    VkAttachmentDescription attachmentDescriptions[4] = {};
-    // Color attachment
-    attachmentDescriptions[0].format = colorAndInputAttachmentFormat;
-    attachmentDescriptions[0].samples = VK_SAMPLE_COUNT_4_BIT;
-    attachmentDescriptions[0].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[0].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    // Color resolve attachment
-    attachmentDescriptions[1].format = colorAndInputAttachmentFormat;
-    attachmentDescriptions[1].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachmentDescriptions[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[1].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    // Depth stencil attachment
-    attachmentDescriptions[2].format = depthStencilAttachmentFormat;
-    attachmentDescriptions[2].samples = VK_SAMPLE_COUNT_4_BIT;
-    attachmentDescriptions[2].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[2].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[2].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    // Input attachment
-    attachmentDescriptions[3].format = colorAndInputAttachmentFormat;
-    attachmentDescriptions[3].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachmentDescriptions[3].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[3].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkAttachmentReference colorAttachmentReference = {};
-    colorAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    colorAttachmentReference.attachment = 0;
-    VkAttachmentReference colorResolveAttachmentReference = {};
-    colorResolveAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    colorResolveAttachmentReference.attachment = 1;
-    VkAttachmentReference depthStencilAttachmentReference = {};
-    depthStencilAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    depthStencilAttachmentReference.attachment = 2;
-    VkAttachmentReference inputAttachmentReference = {};
-    inputAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    inputAttachmentReference.attachment = 3;
-    VkSubpassDescription subpassDescription = {};
-    subpassDescription.colorAttachmentCount = 1;
-    subpassDescription.pColorAttachments = &colorAttachmentReference;
-    subpassDescription.pResolveAttachments = &colorResolveAttachmentReference;
-    subpassDescription.pDepthStencilAttachment = &depthStencilAttachmentReference;
-    subpassDescription.inputAttachmentCount = 1;
-    subpassDescription.pInputAttachments = &inputAttachmentReference;
-
     uint32_t viewMask = 0x3u;
     VkRenderPassMultiviewCreateInfo renderPassMultiviewCreateInfo = vku::InitStructHelper();
     renderPassMultiviewCreateInfo.subpassCount = 1;
     renderPassMultiviewCreateInfo.pViewMasks = &viewMask;
-    VkRenderPassCreateInfo renderPassCreateInfo = vku::InitStructHelper(&renderPassMultiviewCreateInfo);
-    renderPassCreateInfo.attachmentCount = 4;
-    renderPassCreateInfo.subpassCount = 1;
-    renderPassCreateInfo.pSubpasses = &subpassDescription;
-    renderPassCreateInfo.pAttachments = attachmentDescriptions;
-    vkt::RenderPass render_pass(*m_device, renderPassCreateInfo);
+
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(colorAndInputAttachmentFormat, VK_SAMPLE_COUNT_4_BIT);  // Color attachment
+    rp.AddAttachmentDescription(colorAndInputAttachmentFormat);                         // Color resolve attachment
+    rp.AddAttachmentDescription(depthStencilAttachmentFormat, VK_SAMPLE_COUNT_4_BIT);   // Depth stencil attachment
+    rp.AddAttachmentDescription(colorAndInputAttachmentFormat);                         // Input attachment
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddAttachmentReference({1, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddAttachmentReference({2, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddAttachmentReference({3, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.AddResolveAttachment(1);
+    rp.AddDepthStencilAttachment(2);
+    rp.AddInputAttachment(3);
+    rp.CreateRenderPass(&renderPassMultiviewCreateInfo);
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfos[4] = {};
     // Color attachment
@@ -770,7 +668,7 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentMultiviewImageLayerCountMismatch)
     framebufferCreateInfo.width = attachmentWidth;
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = render_pass.handle();
+    framebufferCreateInfo.renderPass = rp.Handle();
     framebufferCreateInfo.attachmentCount = 4;
     VkFramebuffer framebuffer = VK_NULL_HANDLE;
 
@@ -1116,23 +1014,11 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     VkFormat framebufferAttachmentFormats[1] = {VK_FORMAT_R8G8B8A8_UNORM};
 
     // Create a renderPass with a single attachment
-    VkAttachmentDescription attachmentDescription = {};
-    attachmentDescription.format = attachmentFormats[0];
-    attachmentDescription.samples = VK_SAMPLE_COUNT_1_BIT;
-    attachmentDescription.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescription.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    VkAttachmentReference attachmentReference = {};
-    attachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    VkSubpassDescription subpassDescription = {};
-    subpassDescription.colorAttachmentCount = 1;
-    subpassDescription.pColorAttachments = &attachmentReference;
-    VkRenderPassCreateInfo renderPassCreateInfo = vku::InitStructHelper();
-    renderPassCreateInfo.subpassCount = 1;
-    renderPassCreateInfo.pSubpasses = &subpassDescription;
-    renderPassCreateInfo.attachmentCount = 1;
-    renderPassCreateInfo.pAttachments = &attachmentDescription;
-    vkt::RenderPass renderPass(*m_device, renderPassCreateInfo);
-    ASSERT_TRUE(renderPass.initialized());
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(attachmentFormats[0], VK_IMAGE_LAYOUT_UNDEFINED);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.CreateRenderPass();
 
     // Create Attachments
     VkImageCreateInfo imageCreateInfo = vku::InitStructHelper();
@@ -1178,7 +1064,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
     framebufferCreateInfo.attachmentCount = 1;
-    framebufferCreateInfo.renderPass = renderPass.handle();
+    framebufferCreateInfo.renderPass = rp.Handle();
 
     // Try to use 3D Image View without imageless flag
     {
@@ -1200,7 +1086,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     renderPassAttachmentBeginInfo.attachmentCount = 1;
     renderPassAttachmentBeginInfo.pAttachments = &imageView3D.handle();
     VkRenderPassBeginInfo renderPassBeginInfo = vku::InitStructHelper(&renderPassAttachmentBeginInfo);
-    renderPassBeginInfo.renderPass = renderPass.handle();
+    renderPassBeginInfo.renderPass = rp.Handle();
     renderPassBeginInfo.renderArea.extent.width = attachmentWidth;
     renderPassBeginInfo.renderArea.extent.height = attachmentHeight;
     renderPassBeginInfo.framebuffer = framebuffer.handle();

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "../framework/layer_validation_tests.h"
+#include "../framework/render_pass_helper.h"
 
 TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
     TEST_DESCRIPTION("Create an imageless framebuffer");
@@ -27,22 +28,11 @@ TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
 
     // Create a renderPass with a single attachment
-    VkAttachmentDescription attachment_description = {};
-    attachment_description.format = format;
-    attachment_description.samples = VK_SAMPLE_COUNT_1_BIT;
-    attachment_description.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachment_description.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    VkAttachmentReference attachment_reference = {};
-    attachment_reference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    VkSubpassDescription subpass = {};
-    subpass.colorAttachmentCount = 1;
-    subpass.pColorAttachments = &attachment_reference;
-    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper();
-    rp_ci.subpassCount = 1;
-    rp_ci.pSubpasses = &subpass;
-    rp_ci.attachmentCount = 1;
-    rp_ci.pAttachments = &attachment_description;
-    vkt::RenderPass render_pass(*m_device, rp_ci);
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(format);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.CreateRenderPass();
 
     VkFramebufferAttachmentImageInfoKHR fb_attachment_image_info = vku::InitStructHelper();
     fb_attachment_image_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -59,7 +49,7 @@ TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
     fb_ci.width = attachment_width;
     fb_ci.height = attachment_height;
     fb_ci.layers = 1;
-    fb_ci.renderPass = render_pass.handle();
+    fb_ci.renderPass = rp.Handle();
     fb_ci.attachmentCount = 1;
 
     fb_ci.pAttachments  = nullptr;
@@ -84,28 +74,12 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled - requires imageView2DOn3DImage to be VK_TRUE.\n";
     }
 
-    VkSubpassDescription subpass = {};
-
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-
-    VkAttachmentDescription attachment = {};
-    attachment.format = format;
-    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
-    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    attachment.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
-    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkRenderPassCreateInfo rp_ci = vku::InitStructHelper();
-    rp_ci.subpassCount = 1;
-    rp_ci.pSubpasses = &subpass;
-    rp_ci.attachmentCount = 1;
-    rp_ci.pAttachments = &attachment;
-
-    vkt::RenderPass render_pass;
-    render_pass.init(*m_device, rp_ci);
+    RenderPassSingleSubpass rp(*this);
+    rp.AddAttachmentDescription(format);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL});
+    rp.AddColorAttachment(0);
+    rp.CreateRenderPass();
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
@@ -139,7 +113,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
 
     VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper(&framebuffer_attachments);
     framebuffer_ci.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
-    framebuffer_ci.renderPass = render_pass.handle();
+    framebuffer_ci.renderPass = rp.Handle();
     framebuffer_ci.attachmentCount = 1;
     framebuffer_ci.pAttachments = &imageView.handle();
     framebuffer_ci.width = 32;
@@ -156,7 +130,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     render_pass_attachment_bi.pAttachments = &imageView.handle();
 
     VkRenderPassBeginInfo render_pass_bi = vku::InitStructHelper(&render_pass_attachment_bi);
-    render_pass_bi.renderPass = render_pass.handle();
+    render_pass_bi.renderPass = rp.Handle();
     render_pass_bi.framebuffer = framebuffer.handle();
     render_pass_bi.renderArea.extent = {1, 1};
     render_pass_bi.clearValueCount = 1;

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -14,6 +14,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include "../framework/render_pass_helper.h"
 
 struct icd_spv_header {
     uint32_t magic = 0x07230203;
@@ -1762,28 +1763,11 @@ TEST_F(NegativeShaderSpirv, ShaderImageFootprintEnabled) {
     vs.InitFromGLSLTry(false, &test_device);
     fs.InitFromGLSLTry(false, &test_device);
 
-    VkAttachmentReference attach = {};
-    attach.layout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkSubpassDescription subpass = {};
-    subpass.pColorAttachments = &attach;
-    subpass.colorAttachmentCount = 1;
-
-    VkAttachmentDescription attach_desc = {};
-    attach_desc.format = VK_FORMAT_B8G8R8A8_UNORM;
-    attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attach_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-
-    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
-    rpci.subpassCount = 1;
-    rpci.pSubpasses = &subpass;
-    rpci.attachmentCount = 1;
-    rpci.pAttachments = &attach_desc;
-
-    vkt::RenderPass render_pass(test_device, rpci);
+    RenderPassSingleSubpass rp(*this, &test_device);
+    rp.AddAttachmentDescription(VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
     pipe.device_ = &test_device;
@@ -1799,7 +1783,7 @@ TEST_F(NegativeShaderSpirv, ShaderImageFootprintEnabled) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-pCode-08740");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-pCode-08742");
     pipe.gp_ci_.layout = pipeline_layout.handle();
-    pipe.gp_ci_.renderPass = render_pass.handle();
+    pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -1832,28 +1816,12 @@ TEST_F(NegativeShaderSpirv, FragmentShaderBarycentricEnabled) {
     vs.InitFromGLSLTry(false, &test_device);
     fs.InitFromGLSLTry(false, &test_device);
 
-    VkAttachmentReference attach = {};
-    attach.layout = VK_IMAGE_LAYOUT_GENERAL;
+    RenderPassSingleSubpass rp(*this, &test_device);
+    rp.AddAttachmentDescription(VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.CreateRenderPass();
 
-    VkSubpassDescription subpass = {};
-    subpass.pColorAttachments = &attach;
-    subpass.colorAttachmentCount = 1;
-
-    VkAttachmentDescription attach_desc = {};
-    attach_desc.format = VK_FORMAT_B8G8R8A8_UNORM;
-    attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attach_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-
-    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
-    rpci.subpassCount = 1;
-    rpci.pSubpasses = &subpass;
-    rpci.attachmentCount = 1;
-    rpci.pAttachments = &attach_desc;
-
-    vkt::RenderPass render_pass(test_device, rpci);
     const vkt::PipelineLayout pipeline_layout(test_device);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-pCode-08740");
@@ -1862,7 +1830,7 @@ TEST_F(NegativeShaderSpirv, FragmentShaderBarycentricEnabled) {
     pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
-    pipe.gp_ci_.renderPass = render_pass.handle();
+    pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -1959,28 +1927,12 @@ TEST_F(NegativeShaderSpirv, FragmentShaderInterlockEnabled) {
     vs.InitFromGLSLTry(false, &test_device);
     fs.InitFromGLSLTry(false, &test_device);
 
-    VkAttachmentReference attach = {};
-    attach.layout = VK_IMAGE_LAYOUT_GENERAL;
+    RenderPassSingleSubpass rp(*this, &test_device);
+    rp.AddAttachmentDescription(VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.CreateRenderPass();
 
-    VkSubpassDescription subpass = {};
-    subpass.pColorAttachments = &attach;
-    subpass.colorAttachmentCount = 1;
-
-    VkAttachmentDescription attach_desc = {};
-    attach_desc.format = VK_FORMAT_B8G8R8A8_UNORM;
-    attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attach_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-
-    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
-    rpci.subpassCount = 1;
-    rpci.pSubpasses = &subpass;
-    rpci.attachmentCount = 1;
-    rpci.pAttachments = &attach_desc;
-
-    vkt::RenderPass render_pass(test_device, rpci);
     const vkt::PipelineLayout pipeline_layout(test_device);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-pCode-08740");
@@ -1990,7 +1942,7 @@ TEST_F(NegativeShaderSpirv, FragmentShaderInterlockEnabled) {
     pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
-    pipe.gp_ci_.renderPass = render_pass.handle();
+    pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -2022,28 +1974,12 @@ TEST_F(NegativeShaderSpirv, DemoteToHelperInvocation) {
     vs.InitFromGLSLTry(false, &test_device);
     fs.InitFromGLSLTry(false, &test_device);
 
-    VkAttachmentReference attach = {};
-    attach.layout = VK_IMAGE_LAYOUT_GENERAL;
+    RenderPassSingleSubpass rp(*this, &test_device);
+    rp.AddAttachmentDescription(VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED);
+    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    rp.AddColorAttachment(0);
+    rp.CreateRenderPass();
 
-    VkSubpassDescription subpass = {};
-    subpass.pColorAttachments = &attach;
-    subpass.colorAttachmentCount = 1;
-
-    VkAttachmentDescription attach_desc = {};
-    attach_desc.format = VK_FORMAT_B8G8R8A8_UNORM;
-    attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attach_desc.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-
-    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
-    rpci.subpassCount = 1;
-    rpci.pSubpasses = &subpass;
-    rpci.attachmentCount = 1;
-    rpci.pAttachments = &attach_desc;
-
-    vkt::RenderPass render_pass(test_device, rpci);
     const vkt::PipelineLayout pipeline_layout(test_device);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-pCode-08740");
@@ -2052,7 +1988,7 @@ TEST_F(NegativeShaderSpirv, DemoteToHelperInvocation) {
     pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
-    pipe.gp_ci_.renderPass = render_pass.handle();
+    pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
Adds the first RenderPass helper `RenderPassSingleSubpass`

The goal is to make creating a basic `VkRenderPass` for most tests much easier. I wanted to fix the few tests that do crazy stuff inside `InitRenderTarget`, but in order to do that, we need a better way to create a simple RenderPass

It is not aimed to work with RenderPass2 or multi-subpasses... I figured those can be added as needed, potentially in a second class object

Final note, I plan to add this to more tests, but wanted to get "something" up for now