### PR TITLE
apple: Add WSI support for tests on MacOS

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -185,6 +185,15 @@ target_sources(vk_layer_validation_tests PRIVATE
     vvl_utils/small_vector.cpp
     vvl_utils/pnext_chain_extraction.cpp
 )
+if (APPLE)
+    target_sources(vk_layer_validation_tests PRIVATE
+        framework/apple_wsi.h
+        framework/apple_wsi.mm
+    )
+    # QuartzCore framework is needed for minimal Metal interaction
+    target_link_libraries(vk_layer_validation_tests PRIVATE "-framework QuartzCore")
+endif()
+
 get_target_property(TEST_SOURCES vk_layer_validation_tests SOURCES)
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${TEST_SOURCES})
 

--- a/tests/framework/apple_wsi.h
+++ b/tests/framework/apple_wsi.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+namespace vkt {
+VkMetalSurfaceCreateInfoEXT CreateMetalSurfaceInfoEXT();
+}  // namespace vkt

--- a/tests/framework/apple_wsi.mm
+++ b/tests/framework/apple_wsi.mm
@@ -1,0 +1,19 @@
+#include "apple_wsi.h"
+#include <vulkan/utility/vk_struct_helper.hpp>
+
+// Needed to get the CAMetalLayer
+#import <QuartzCore/CAMetalLayer.h>
+
+namespace vkt {
+
+// This function is based off of glfw's WSI code for MoltenVK.
+// Main exception is we do link against the QuartzCore framework.
+// https://github.com/glfw/glfw/blob/3.3.8/src/cocoa_window.m#L1832
+VkMetalSurfaceCreateInfoEXT CreateMetalSurfaceInfoEXT() {
+    VkMetalSurfaceCreateInfoEXT info = vku::InitStructHelper();
+    info.pLayer = [CAMetalLayer layer];
+
+    return info;
+}
+
+}  // namespace vkt

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -529,6 +529,10 @@ void VkLayerTest::AddSurfaceExtension() {
     AddWsiExtensions(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
 #endif
 
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+    AddWsiExtensions(VK_EXT_METAL_SURFACE_EXTENSION_NAME);
+#endif
+
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     AddWsiExtensions(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME);
 #endif

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -28,6 +28,10 @@
 #include "utils/vk_layer_utils.h"
 #include "layer_validation_tests.h"
 
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+#include "apple_wsi.h"
+#endif
+
 using std::string;
 using std::strncmp;
 using std::vector;
@@ -698,6 +702,14 @@ bool VkRenderFramework::CreateSurface(SurfaceContext &surface_context, VkSurface
         surface_create_info.hinstance = window_instance;
         surface_create_info.hwnd = window;
         return VK_SUCCESS == vk::CreateWin32SurfaceKHR(surface_instance, &surface_create_info, nullptr, &surface);
+    }
+#endif
+
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+    if (IsExtensionsEnabled(VK_EXT_METAL_SURFACE_EXTENSION_NAME)) {
+        const VkMetalSurfaceCreateInfoEXT surface_create_info = vkt::CreateMetalSurfaceInfoEXT();
+        assert(surface_create_info.pLayer != nullptr);
+        return VK_SUCCESS == vk::CreateMetalSurfaceEXT(surface_instance, &surface_create_info, nullptr, &surface);
     }
 #endif
 

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -52,6 +52,10 @@ struct SurfaceContext {
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     xcb_connection_t *m_surface_xcb_conn{};
 #endif
+
+#if defined(VK_USE_PLATFORM_METAL_EXT)
+    void *caMetalLayer;
+#endif
 };
 
 struct SurfaceInformation {

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -561,8 +561,6 @@ TEST_F(VkArmBestPracticesLayerTest, PresentModeTest) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     InitState();
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
     if (!InitSurface()) {
         GTEST_SKIP() << "Cannot create surface, skipping test";
     }
@@ -604,11 +602,16 @@ TEST_F(VkArmBestPracticesLayerTest, PresentModeTest) {
         }
     }
 
-    ASSERT_EQ(VK_ERROR_VALIDATION_FAILED_EXT, vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain));
-    m_errorMonitor->VerifyFound();
+    {
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_WARNING_BIT_EXT,
+                                             "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
 
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
+        const auto err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
+
+        ASSERT_TRUE(err == VK_ERROR_VALIDATION_FAILED_EXT) << string_VkResult(err);
+        m_errorMonitor->VerifyFound();
+    }
+
     swapchain_create_info.presentMode = VK_PRESENT_MODE_FIFO_KHR;
     ASSERT_EQ(VK_SUCCESS, vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain));
 }

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -544,8 +544,12 @@ TEST_F(PositiveWsi, SwapchainImageLayout) {
     const auto swapchainImages = GetSwapchainImages(m_swapchain);
     const vkt::Fence fence(*m_device);
     uint32_t image_index = 0;
-    ASSERT_EQ(VK_SUCCESS,
-        vk::AcquireNextImageKHR(m_device->handle(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index));
+    {
+        auto result = vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
+        ASSERT_TRUE(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR);
+        fence.wait(vvl::kU32Max);
+    }
+
     VkAttachmentDescription attach[] = {
         {0, m_surface_formats[0].format, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
          VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_UNDEFINED,
@@ -889,8 +893,11 @@ TEST_F(PositiveWsi, SwapchainImageFormatProps) {
     const vkt::Fence fence(*m_device);
 
     uint32_t image_index;
-    ASSERT_EQ(VK_SUCCESS, vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index));
-    fence.wait(vvl::kU32Max);
+    {
+        auto result = vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
+        ASSERT_TRUE(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR);
+        fence.wait(vvl::kU32Max);
+    }
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = swapchain_images[image_index];


### PR DESCRIPTION
Required adding objective-c++ code into the test codebase to properly aquire the MetalLayer

closes #6412

<details>

```
Note: Google Test filter = *PositiveWsi*
[==========] Running 16 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 16 tests from PositiveWsi
[ RUN      ] PositiveWsi.UseDestroyedSwapchain
Driver Name = MoltenVK
Driver Info = 1.2.6
[       OK ] PositiveWsi.UseDestroyedSwapchain (2840 ms)
[ RUN      ] PositiveWsi.CreateWaylandSurface
/Users/juanramos/projects/vvl/tests/unit/wsi_positive.cpp:23: Skipped
test not supported on platform

[  SKIPPED ] PositiveWsi.CreateWaylandSurface (1 ms)
[ RUN      ] PositiveWsi.CreateXcbSurface
/Users/juanramos/projects/vvl/tests/unit/wsi_positive.cpp:94: Skipped
test not supported on platform

[  SKIPPED ] PositiveWsi.CreateXcbSurface (1 ms)
[ RUN      ] PositiveWsi.CreateX11Surface
/Users/juanramos/projects/vvl/tests/unit/wsi_positive.cpp:129: Skipped
test not supported on platform

[  SKIPPED ] PositiveWsi.CreateX11Surface (0 ms)
[ RUN      ] PositiveWsi.CmdCopySwapchainImage
[       OK ] PositiveWsi.CmdCopySwapchainImage (49 ms)
[ RUN      ] PositiveWsi.TransferImageToSwapchainDeviceGroup
/Users/juanramos/projects/vvl/tests/unit/wsi_positive.cpp:310: Skipped
minImageExtent is not large enough

[  SKIPPED ] PositiveWsi.TransferImageToSwapchainDeviceGroup (42 ms)
[ RUN      ] PositiveWsi.SwapchainAcquireImageAndPresent
[       OK ] PositiveWsi.SwapchainAcquireImageAndPresent (36 ms)
[ RUN      ] PositiveWsi.SwapchainAcquireImageAndWaitForFence
[       OK ] PositiveWsi.SwapchainAcquireImageAndWaitForFence (34 ms)
[ RUN      ] PositiveWsi.WaitForAcquireFenceAndIgnoreSemaphore
[       OK ] PositiveWsi.WaitForAcquireFenceAndIgnoreSemaphore (36 ms)
[ RUN      ] PositiveWsi.WaitForAcquireSemaphoreAndIgnoreFence
[       OK ] PositiveWsi.WaitForAcquireSemaphoreAndIgnoreFence (36 ms)
[ RUN      ] PositiveWsi.SwapchainImageLayout
[       OK ] PositiveWsi.SwapchainImageLayout (37 ms)
[ RUN      ] PositiveWsi.SwapchainPresentShared
/Users/juanramos/projects/vvl/tests/framework/render.cpp:349: Skipped
VK_KHR_shared_presentable_image not supported

[  SKIPPED ] PositiveWsi.SwapchainPresentShared (22 ms)
[ RUN      ] PositiveWsi.CreateSurface
[       OK ] PositiveWsi.CreateSurface (34 ms)
[ RUN      ] PositiveWsi.SwapchainImageFormatProps
[       OK ] PositiveWsi.SwapchainImageFormatProps (47 ms)
[ RUN      ] PositiveWsi.SwapchainExclusiveModeQueueFamilyPropertiesReferences
[       OK ] PositiveWsi.SwapchainExclusiveModeQueueFamilyPropertiesReferences (33 ms)
[ DISABLED ] PositiveWsi.DISABLED_ProtectedSwapchainImageColorAttachment
[ RUN      ] PositiveWsi.CreateSwapchainWithPresentModeInfo
[       OK ] PositiveWsi.CreateSwapchainWithPresentModeInfo (34 ms)
[----------] 16 tests from PositiveWsi (3289 ms total)

[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (3316 ms total)
[  PASSED  ] 11 tests.
[  SKIPPED ] 5 tests, listed below:
[  SKIPPED ] PositiveWsi.CreateWaylandSurface
[  SKIPPED ] PositiveWsi.CreateXcbSurface
[  SKIPPED ] PositiveWsi.CreateX11Surface
[  SKIPPED ] PositiveWsi.TransferImageToSwapchainDeviceGroup
[  SKIPPED ] PositiveWsi.SwapchainPresentShared

  YOU HAVE 1 DISABLED TEST
```

</details>