### PR TITLE
syncval: Move SyncImageMemoryBarrier to sync_op module

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -486,11 +486,6 @@ HazardResult AccessContext::DetectImageBarrierHazard(const ImageState &image, Vk
     return DetectHazard(detector, image, subresource_range, false, options);
 }
 
-HazardResult AccessContext::DetectImageBarrierHazard(const SyncImageMemoryBarrier &image_barrier) const {
-    return DetectImageBarrierHazard(*image_barrier.image.get(), image_barrier.barrier.src_exec_scope.exec_scope,
-                                    image_barrier.barrier.src_access_scope, image_barrier.range, kDetectAll);
-}
-
 ResourceAccessRangeMap::iterator AccessContext::UpdateMemoryAccessStateFunctor::Infill(ResourceAccessRangeMap *accesses,
                                                                                        const Iterator &pos,
                                                                                        const ResourceAccessRange &range) const {

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -239,31 +239,6 @@ class AttachmentViewGen {
 
 using AttachmentViewGenVector = std::vector<AttachmentViewGen>;
 
-struct SyncImageMemoryBarrier {
-    using ImageState = syncval_state::ImageState;
-    using Image = std::shared_ptr<const ImageState>;
-
-    Image image;
-    uint32_t index;
-    SyncBarrier barrier;
-    VkImageLayout old_layout;
-    VkImageLayout new_layout;
-    VkImageSubresourceRange range;
-
-    bool IsLayoutTransition() const { return old_layout != new_layout; }
-    const VkImageSubresourceRange &Range() const { return range; };
-    const ImageState *GetState() const { return image.get(); }
-    SyncImageMemoryBarrier(const Image &image_, uint32_t index_, const SyncBarrier &barrier_, VkImageLayout old_layout_,
-                           VkImageLayout new_layout_, const VkImageSubresourceRange &subresource_range_)
-        : image(image_),
-          index(index_),
-          barrier(barrier_),
-          old_layout(old_layout_),
-          new_layout(new_layout_),
-          range(subresource_range_) {}
-    SyncImageMemoryBarrier() = default;
-};
-
 class AccessContext {
   public:
     using ImageState = syncval_state::ImageState;
@@ -300,7 +275,6 @@ class AccessContext {
     HazardResult DetectImageBarrierHazard(const ImageState &image, VkPipelineStageFlags2KHR src_exec_scope,
                                           const SyncStageAccessFlags &src_access_scope,
                                           const VkImageSubresourceRange &subresource_range, DetectOptions options) const;
-    HazardResult DetectImageBarrierHazard(const SyncImageMemoryBarrier &image_barrier) const;
     HazardResult DetectSubpassTransitionHazard(const TrackBack &track_back, const AttachmentViewGen &attach_view) const;
 
     HazardResult DetectFirstUseHazard(QueueId queue_id, const ResourceUsageRange &tag_range,

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -126,6 +126,31 @@ struct SyncBufferMemoryBarrier {
     SyncBufferMemoryBarrier() = default;
 };
 
+struct SyncImageMemoryBarrier {
+    using ImageState = syncval_state::ImageState;
+    using Image = std::shared_ptr<const ImageState>;
+
+    Image image;
+    uint32_t index;
+    SyncBarrier barrier;
+    VkImageLayout old_layout;
+    VkImageLayout new_layout;
+    VkImageSubresourceRange range;
+
+    bool IsLayoutTransition() const { return old_layout != new_layout; }
+    const VkImageSubresourceRange &Range() const { return range; };
+    const ImageState *GetState() const { return image.get(); }
+    SyncImageMemoryBarrier(const Image &image_, uint32_t index_, const SyncBarrier &barrier_, VkImageLayout old_layout_,
+                           VkImageLayout new_layout_, const VkImageSubresourceRange &subresource_range_)
+        : image(image_),
+          index(index_),
+          barrier(barrier_),
+          old_layout(old_layout_),
+          new_layout(new_layout_),
+          range(subresource_range_) {}
+    SyncImageMemoryBarrier() = default;
+};
+
 class SyncOpBase {
   public:
     SyncOpBase() : command_(vvl::Func::Empty) {}


### PR DESCRIPTION
`SyncImageMemoryBarrier` and `SyncBufferMemoryBarrier` were in different files. Logically they belong to a higher-level `sync_op` module, which uses them to define other structures and defines all implementation that works with those structures.
