### PR TITLE
ci: Remove MacOS from CI

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -197,40 +197,6 @@ jobs:
           working-directory: ./build
           run: ctest --output-on-failure -C Debug
 
-  macos:
-    runs-on: ${{matrix.os}}
-    strategy:
-      matrix:
-        # Dev Survey shows little to no users still use MacOS 11 or earlier
-        # iOS run uses macos-11 already also
-        os: [ macos-12 ]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - uses: lukka/get-cmake@latest
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{matrix.os}}-cache
-      - name: Configure
-        run: |
-          cmake -S . -B build/ \
-          -D BUILD_WERROR=ON \
-          -D UPDATE_DEPS=ON \
-          -D CMAKE_BUILD_TYPE=Debug
-        env:
-          CMAKE_C_COMPILER_LAUNCHER: ccache
-          CMAKE_CXX_COMPILER_LAUNCHER: ccache
-          LDFLAGS: -Wl,-fatal_warnings
-      - run: cmake --build build
-      - run: cmake --install build --prefix /tmp
-      # Helps verify install location and prints the exported symbols
-      - run: nm -gU /tmp/lib/libVkLayer_khronos_validation.dylib
-      # Helps verify useful details about the dylib (platform, minos, sdk)
-      - run: vtool -show-build /tmp/lib/libVkLayer_khronos_validation.dylib
-
   iOS:
     runs-on: macos-11
     steps:


### PR DESCRIPTION
Per team meeting the limited amount of minutes due to the free account KhronosGroup uses.