### PR TITLE
layers: Report barrier buffer/image in syncval messages

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1083,7 +1083,7 @@ std::ostream &operator<<(std::ostream &out, const ResourceUsageRecord::Formatter
             out << ", subcmd: " << record.sub_command;
         }
         for (const auto &named_handle : record.handles) {
-            out << "," << named_handle.Formatter(formatter.sync_state);
+            out << ", " << named_handle.Formatter(formatter.sync_state);
         }
         out << ", reset_no: " << std::to_string(record.reset_count);
     }

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -334,6 +334,14 @@ void SyncOpBarriers::ApplyGlobalBarriers(const Barriers &barriers, const Functor
 
 ResourceUsageTag SyncOpPipelineBarrier::Record(CommandBufferAccessContext *cb_context) {
     const auto tag = cb_context->NextCommandTag(command_);
+    for (const auto &barrier_set : barriers_) {
+        for (const auto &buffer_barrier : barrier_set.buffer_memory_barriers) {
+            cb_context->AddHandle(tag, buffer_barrier.buffer->Handle());
+        }
+        for (const auto &image_barrier : barrier_set.image_memory_barriers) {
+            cb_context->AddHandle(tag, image_barrier.image->Handle());
+        }
+    }
     ReplayRecord(*cb_context, tag);
     return tag;
 }


### PR DESCRIPTION
Addresses https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7010
Adds buffer/image handles from CmdPipelineBarrier command to syncval error messages.

@jzulauf-lunarg any issues with adding handles this way? 
I also not sure if there's a reason that current formatting puts handle between `seq_no` and `reset_no`. It looks nicer if resource handles are listed after command buffer handle or at the end of the message.

Updated error message for `vkCmdPipelineBarrier2`:
> Validation Error: [ SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0x1b93f430d30, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0x5c0ec5d6 | vkQueueSubmit2():  Hazard WRITE_AFTER_WRITE for entry 0, VkCommandBuffer 0x1b94908b6c0[], Submitted access info (submitted_usage: SYNC_IMAGE_LAYOUT_TRANSITION, command: vkCmdPipelineBarrier2, seq_no: 1, **VkImage 0xf443490000000006[]**, reset_no: 1). Access info (prior_usage: SYNC_IMAGE_LAYOUT_TRANSITION, write_barriers: 0, queue: VkQueue 0x1b944629070[], submit: 0, batch: 0, batch_tag: 5, command: vkCmdPipelineBarrier2, command_buffer: VkCommandBuffer 0x1b93eebde70[], seq_no: 2, **VkImage 0xf443490000000006[]**, reset_no: 1).
