### PR TITLE
scripts: Move TSAN blacklist into C++ code instead of script

### DIFF
--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -225,34 +225,20 @@ def RunVVLTests(args):
 
     lvt_cmd = os.path.join(CI_INSTALL_DIR, 'bin', 'vk_layer_validation_tests')
 
-    # The following test(s) fail with thread sanitization enabled.
-    failing_tsan_tests = '-VkPositiveLayerTest.QueueThreading'
-    failing_tsan_tests += ':NegativeCommand.SecondaryCommandBufferRerecordedExplicitReset'
-    failing_tsan_tests += ':NegativeCommand.SecondaryCommandBufferRerecordedNoReset'
-    failing_tsan_tests += ':NegativeSyncVal.CopyOptimalImageHazards'
-    failing_tsan_tests += ':NegativeViewportInheritance.BasicUsage'
-    failing_tsan_tests += ':NegativeViewportInheritance.MultiViewport'
-    # NOTE: These test(s) fails sporadically.
-    # These need extra care to prevent a regression in the future.
-    failing_tsan_tests += ':PositiveSyncObject.WaitTimelineSemThreadRace'
-    failing_tsan_tests += ':PositiveSyncObject.WaitEventThenSet'
-    failing_tsan_tests += ':PositiveQuery.ResetQueryPoolFromDifferentCB'
-    failing_tsan_tests += ':PositiveQuery.PerformanceQueries'
-
     if args.mockAndroid:
         # TODO - only reason running this subset, is mockAndoid fails any test that does
         # a manual vkCreateDevice call and need to investigate more why
         RunShellCmd(lvt_cmd + " --gtest_filter=*AndroidHardwareBuffer.*:*AndroidExternalResolve.*", env=lvt_env)
         return
 
-    RunShellCmd(lvt_cmd + f" --gtest_filter={failing_tsan_tests}", env=lvt_env)
+    RunShellCmd(lvt_cmd, env=lvt_env)
 
     print("Re-Running syncval tests with core validation enabled")
-    RunShellCmd(lvt_cmd + f' --gtest_filter=*SyncVal*:{failing_tsan_tests} --syncval-enable-core', env=lvt_env)
+    RunShellCmd(lvt_cmd + f' --gtest_filter=*SyncVal* --syncval-enable-core', env=lvt_env)
 
     print("Re-Running multithreaded tests with VK_LAYER_FINE_GRAINED_LOCKING disabled")
     lvt_env['VK_LAYER_FINE_GRAINED_LOCKING'] = '0'
-    RunShellCmd(lvt_cmd + f' --gtest_filter=*Thread*:{failing_tsan_tests}', env=lvt_env)
+    RunShellCmd(lvt_cmd + f' --gtest_filter=*Thread*', env=lvt_env)
 
 def GetArgParser():
     configs = ['release', 'debug']

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -55,6 +55,16 @@ using std::vector;
 #define VVL_ENABLE_ASAN 1
 #endif
 
+// GCC defines __SANITIZE_THREAD__ when compiling with address sanitization
+// However, clang doesn't. Instead you have to use __has_feature to check.
+#if defined(__clang__)
+#if __has_feature(thread_sanitizer)
+#define VVL_ENABLE_TSAN 1
+#endif
+#elif defined(__SANITIZE_THREAD__)
+#define VVL_ENABLE_TSAN 1
+#endif
+
 #if defined(VVL_ENABLE_ASAN)
 #if __has_include(<sanitizer/lsan_interface.h>)
 #include <sanitizer/lsan_interface.h>

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -483,6 +483,10 @@ TEST_F(NegativeCommand, NoBeginCommandBuffer) {
 }
 
 TEST_F(NegativeCommand, SecondaryCommandBufferRerecordedExplicitReset) {
+#if defined(VVL_ENABLE_TSAN)
+    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
+#endif
+
     RETURN_IF_SKIP(Init());
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdExecuteCommands-commandBuffer-recording");
@@ -507,6 +511,10 @@ TEST_F(NegativeCommand, SecondaryCommandBufferRerecordedExplicitReset) {
 }
 
 TEST_F(NegativeCommand, SecondaryCommandBufferRerecordedNoReset) {
+#if defined(VVL_ENABLE_TSAN)
+    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
+#endif
+
     RETURN_IF_SKIP(Init());
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdExecuteCommands-commandBuffer-recording");

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -433,6 +433,10 @@ TEST_F(VkPositiveLayerTest, Vulkan12FeaturesBufferDeviceAddress) {
 }
 
 TEST_F(VkPositiveLayerTest, QueueThreading) {
+#if defined(VVL_ENABLE_TSAN)
+    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
+#endif
+
     TEST_DESCRIPTION("Test concurrent Queue access from vkGet and vkSubmit");
 
     using namespace std::chrono;

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -24,6 +24,10 @@ bool QueryTest::HasZeroTimestampValidBits() {
 }
 
 TEST_F(PositiveQuery, ResetQueryPoolFromDifferentCB) {
+#if defined(VVL_ENABLE_TSAN)
+    // NOTE: This test in particular has failed sporadically on CI when TSAN is enabled.
+    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
+#endif
     TEST_DESCRIPTION("Reset a query on one CB and use it in another.");
 
     RETURN_IF_SKIP(Init());
@@ -443,6 +447,10 @@ TEST_F(PositiveQuery, CommandBufferInheritanceFlags) {
 }
 
 TEST_F(PositiveQuery, PerformanceQueries) {
+#if defined(VVL_ENABLE_TSAN)
+    // NOTE: This test in particular has failed sporadically on CI when TSAN is enabled.
+    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
+#endif
     TEST_DESCRIPTION("Test performance queries.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1568,6 +1568,10 @@ TEST_F(PositiveSyncObject, BasicSetAndWaitEvent2) {
 }
 
 TEST_F(PositiveSyncObject, WaitEventThenSet) {
+#if defined(VVL_ENABLE_TSAN)
+    // NOTE: This test in particular has failed sporadically on CI when TSAN is enabled.
+    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
+#endif
     TEST_DESCRIPTION("Wait on a event then set it after the wait has been submitted.");
 
     RETURN_IF_SKIP(Init());
@@ -2128,6 +2132,10 @@ struct WaitTimelineSemThreadData : public SemBufferRaceData {
 };
 
 TEST_F(PositiveSyncObject, WaitTimelineSemThreadRace) {
+#if defined(VVL_ENABLE_TSAN)
+    // NOTE: This test in particular has failed sporadically on CI when TSAN is enabled.
+    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
+#endif
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
 
     RETURN_IF_SKIP(InitFramework());

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -583,6 +583,9 @@ TEST_F(NegativeSyncVal, CmdClearAttachmentsDynamicHazards) {
 }
 
 TEST_F(NegativeSyncVal, CopyOptimalImageHazards) {
+#if defined(VVL_ENABLE_TSAN)
+    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
+#endif
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState());
 

--- a/tests/unit/viewport_inheritance.cpp
+++ b/tests/unit/viewport_inheritance.cpp
@@ -401,6 +401,9 @@ class ViewportInheritanceTestData {
 };
 
 TEST_F(NegativeViewportInheritance, BasicUsage) {
+#if defined(VVL_ENABLE_TSAN)
+    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
+#endif
     TEST_DESCRIPTION("Simple correct and incorrect usage of VK_NV_inherited_viewport_scissor");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
@@ -662,6 +665,9 @@ TEST_F(NegativeViewportInheritance, MissingFeature) {
 }
 
 TEST_F(NegativeViewportInheritance, MultiViewport) {
+#if defined(VVL_ENABLE_TSAN)
+    GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";
+#endif
     TEST_DESCRIPTION("VK_NV_inherited_viewport_scissor tests with multiple viewports/scissors");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());


### PR DESCRIPTION
Currently all of these tests aren't being run at all despite only having issues with thread sanitizer.