### PR TITLE
scripts: Remove sType workaround

### DIFF
--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -7273,8 +7273,7 @@ bool StatelessValidation::PreCallValidateCreateInstance(const VkInstanceCreateIn
                                                                      VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT,
                                                                      VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT,
                                                                      VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT,
-                                                                     VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT,
-                                                                     VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT};
+                                                                     VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT};
 
         skip |= ValidateStructPnext(pCreateInfo_loc, pCreateInfo->pNext, allowed_structs_VkInstanceCreateInfo.size(),
                                     allowed_structs_VkInstanceCreateInfo.data(), GeneratedVulkanHeaderVersion,

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -837,9 +837,8 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
                             extStructVar = f'allowed_structs_{structTypeName}'
                             extStructCount = f'{extStructVar}.size()'
                             extStructData = f'{extStructVar}.data()'
-                            extraStype = ', VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT' if structTypeName == 'VkInstanceCreateInfo' else ''
                             extendedBy = ", ".join([self.vk.structs[x].sType for x in struct.extendedBy])
-                            usedLines.append(f'constexpr std::array {extStructVar} = {{ {extendedBy}{extraStype} }};\n')
+                            usedLines.append(f'constexpr std::array {extStructVar} = {{ {extendedBy} }};\n')
                         usedLines.append(f'skip |= ValidateStructPnext({errorLoc}, {valuePrefix}{member.name}, {extStructCount}, {extStructData}, GeneratedVulkanHeaderVersion, {pNextVuid}, {sTypeVuid});\n')
                     else:
                         usedLines += self.makePointerCheck(valuePrefix, member, lengthMember, errorLoc, valueRequired, lenValueRequired, lenPtrRequired, funcName, structTypeName)


### PR DESCRIPTION
Now that VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT is an official sType we no longer need this workaround in the codegen.