### PR TITLE
tests: Fix disabled VK_KHR_workgroup_memory_explicit_layout

### DIFF
--- a/layers/vulkan/generated/spirv_grammar_helper.cpp
+++ b/layers/vulkan/generated/spirv_grammar_helper.cpp
@@ -969,6 +969,8 @@ const char* string_SpvOpcode(uint32_t opcode) {
             return "OpConstantCompositeContinuedINTEL";
         case spv::OpSpecConstantCompositeContinuedINTEL:
             return "OpSpecConstantCompositeContinuedINTEL";
+        case spv::OpCompositeConstructContinuedINTEL:
+            return "OpCompositeConstructContinuedINTEL";
         case spv::OpConvertFToBF16INTEL:
             return "OpConvertFToBF16INTEL";
         case spv::OpConvertBF16ToFINTEL:
@@ -1481,6 +1483,12 @@ const char* string_SpvDecoration(uint32_t decoration) {
             return "BankBitsINTEL";
         case spv::DecorationForcePow2DepthINTEL:
             return "ForcePow2DepthINTEL";
+        case spv::DecorationStridesizeINTEL:
+            return "StridesizeINTEL";
+        case spv::DecorationWordsizeINTEL:
+            return "WordsizeINTEL";
+        case spv::DecorationTrueDualPortINTEL:
+            return "TrueDualPortINTEL";
         case spv::DecorationBurstCoalesceINTEL:
             return "BurstCoalesceINTEL";
         case spv::DecorationCacheSizeINTEL:
@@ -1517,12 +1525,8 @@ const char* string_SpvDecoration(uint32_t decoration) {
             return "VectorComputeCallableFunctionINTEL";
         case spv::DecorationMediaBlockIOINTEL:
             return "MediaBlockIOINTEL";
-        case spv::DecorationInitModeINTEL:
-            return "InitModeINTEL";
-        case spv::DecorationImplementInRegisterMapINTEL:
-            return "ImplementInRegisterMapINTEL";
-        case spv::DecorationHostAccessINTEL:
-            return "HostAccessINTEL";
+        case spv::DecorationStallFreeINTEL:
+            return "StallFreeINTEL";
         case spv::DecorationFPMaxErrorDecorationINTEL:
             return "FPMaxErrorDecorationINTEL";
         case spv::DecorationLatencyControlLabelINTEL:
@@ -1547,6 +1551,12 @@ const char* string_SpvDecoration(uint32_t decoration) {
             return "MMHostInterfaceWaitRequestINTEL";
         case spv::DecorationStableKernelArgumentINTEL:
             return "StableKernelArgumentINTEL";
+        case spv::DecorationHostAccessINTEL:
+            return "HostAccessINTEL";
+        case spv::DecorationInitModeINTEL:
+            return "InitModeINTEL";
+        case spv::DecorationImplementInRegisterMapINTEL:
+            return "ImplementInRegisterMapINTEL";
         case spv::DecorationCacheControlLoadINTEL:
             return "CacheControlLoadINTEL";
         case spv::DecorationCacheControlStoreINTEL:
@@ -2327,6 +2337,7 @@ const OperandInfo& GetOperandInfo(uint32_t opcode) {
         {spv::OpTypeStructContinuedINTEL, {{OperandKind::Id}}},
         {spv::OpConstantCompositeContinuedINTEL, {{OperandKind::Id}}},
         {spv::OpSpecConstantCompositeContinuedINTEL, {{OperandKind::Id}}},
+        {spv::OpCompositeConstructContinuedINTEL, {{OperandKind::Id}}},
         {spv::OpConvertFToBF16INTEL, {{OperandKind::Id}}},
         {spv::OpConvertBF16ToFINTEL, {{OperandKind::Id}}},
         {spv::OpControlBarrierArriveINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::Id}}},

--- a/layers/vulkan/generated/spirv_grammar_helper.h
+++ b/layers/vulkan/generated/spirv_grammar_helper.h
@@ -391,6 +391,7 @@ static constexpr bool OpcodeHasType(uint32_t opcode) {
         case spv::OpRayQueryGetIntersectionObjectToWorldKHR:
         case spv::OpRayQueryGetIntersectionWorldToObjectKHR:
         case spv::OpAtomicFAddEXT:
+        case spv::OpCompositeConstructContinuedINTEL:
         case spv::OpConvertFToBF16INTEL:
         case spv::OpConvertBF16ToFINTEL:
         case spv::OpGroupIMulKHR:
@@ -787,6 +788,7 @@ static constexpr bool OpcodeHasResult(uint32_t opcode) {
         case spv::OpRayQueryGetIntersectionWorldToObjectKHR:
         case spv::OpAtomicFAddEXT:
         case spv::OpTypeBufferSurfaceINTEL:
+        case spv::OpCompositeConstructContinuedINTEL:
         case spv::OpConvertFToBF16INTEL:
         case spv::OpConvertBF16ToFINTEL:
         case spv::OpGroupIMulKHR:

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -29,7 +29,7 @@
             "sub_dir": "SPIRV-Headers",
             "build_dir": "SPIRV-Headers/build",
             "install_dir": "SPIRV-Headers/build/install",
-            "commit": "e867c06631767a2d96424cbec530f9ee5e78180f"
+            "commit": "1c6bb2743599e6eb6f37b2969acc0aef812e32e3"
         },
         {
             "name": "SPIRV-Tools",

--- a/tests/unit/shader_compute.cpp
+++ b/tests/unit/shader_compute.cpp
@@ -463,7 +463,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantSet) {
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-x-06429");
 }
 
-TEST_F(NegativeShaderCompute, DISABLED_WorkgroupMemoryExplicitLayout) {
+TEST_F(NegativeShaderCompute, WorkgroupMemoryExplicitLayout) {
     TEST_DESCRIPTION("Test VK_KHR_workgroup_memory_explicit_layout");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 

--- a/tests/unit/shader_limits.cpp
+++ b/tests/unit/shader_limits.cpp
@@ -314,7 +314,7 @@ TEST_F(NegativeShaderLimits, DISABLED_MaxFragmentDualSrcAttachments) {
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeShaderLimits, DISABLED_OffsetMaxComputeSharedMemorySize) {
+TEST_F(NegativeShaderLimits, OffsetMaxComputeSharedMemorySize) {
     TEST_DESCRIPTION("Have an offset that is over maxComputeSharedMemorySize");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -341,6 +341,8 @@ TEST_F(NegativeShaderLimits, DISABLED_OffsetMaxComputeSharedMemorySize) {
     std::stringstream csSource;
     csSource << R"asm(
                OpCapability Shader
+               OpCapability WorkgroupMemoryExplicitLayoutKHR
+               OpExtension "SPV_KHR_workgroup_memory_explicit_layout"
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %_
                OpExecutionMode %main LocalSize 1 1 1


### PR DESCRIPTION
Fixes 2 tests @jeremyg-lunarg disabled to get the new SPIRV-Tools in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7062

