### PR TITLE
tests: Remove unused functions from VkImageObj

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -123,7 +123,7 @@
             "sub_dir": "Vulkan-Profiles",
             "build_dir": "Vulkan-Profiles/build",
             "install_dir": "Vulkan-Profiles/build/install",
-            "commit": "5e4b686c6072daba252836d48b13a2e4e100bd62",
+            "commit": "b8eb9bfbc4019e882b86f7a3a6b409626789f08e",
             "build_step": "skip",
             "optional": [
                 "tests"
@@ -136,7 +136,7 @@
             "sub_dir": "Vulkan-Tools",
             "build_dir": "Vulkan-Tools/build",
             "install_dir": "Vulkan-Tools/build/install",
-            "commit": "2d956672d73321bfb22b378c06033f0bd885d61c",
+            "commit": "98d168c168041bc026bb55b11c59b256f8162791",
             "build_step": "skip",
             "optional": [
                 "tests"

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -750,11 +750,6 @@ VkSubresourceLayout Image::subresource_layout(const VkImageSubresourceLayers &su
     return data;
 }
 
-bool Image::transparent() const {
-    return (create_info_.tiling == VK_IMAGE_TILING_LINEAR && create_info_.samples == VK_SAMPLE_COUNT_1_BIT &&
-            !(create_info_.usage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)));
-}
-
 VkImageAspectFlags Image::aspect_mask(VkFormat format) {
     VkImageAspectFlags image_aspect;
     if (vkuFormatIsDepthAndStencil(format)) {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -583,6 +583,8 @@ class Image : public internal::NonDispHandle<VkImage> {
     void init(const Device &dev, const VkImageCreateInfo &info) { init(dev, info, 0); }
     void init_no_mem(const Device &dev, const VkImageCreateInfo &info);
 
+    VkImage image() const { return handle(); }
+
     // get the internal memory
     const DeviceMemory &memory() const { return internal_mem_; }
     DeviceMemory &memory() { return internal_mem_; }
@@ -601,18 +603,15 @@ class Image : public internal::NonDispHandle<VkImage> {
     VkSubresourceLayout subresource_layout(const VkImageSubresource &subres) const;
     VkSubresourceLayout subresource_layout(const VkImageSubresourceLayers &subres) const;
 
-    bool transparent() const;
-    bool copyable() const { return (format_features_ & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT); }
-
     VkImageAspectFlags aspect_mask() const { return aspect_mask(create_info_.format); }
 
-    VkImageSubresourceRange subresource_range() const { return subresource_range(create_info_, aspect_mask()); }
     VkImageSubresourceRange subresource_range(VkImageAspectFlags aspect) const { return subresource_range(create_info_, aspect); }
 
     VkExtent3D extent() const { return create_info_.extent; }
+    uint32_t width() const { return create_info_.extent.width; }
+    uint32_t height() const { return create_info_.extent.height; }
     VkFormat format() const { return create_info_.format; }
     VkImageUsageFlags usage() const { return create_info_.usage; }
-    VkSharingMode sharing_mode() const { return create_info_.sharingMode; }
     VkImageMemoryBarrier image_memory_barrier(VkFlags output_mask, VkFlags input_mask, VkImageLayout old_layout,
                                               VkImageLayout new_layout, const VkImageSubresourceRange &range,
                                               uint32_t srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -295,29 +295,13 @@ class VkImageObj : public vkt::Image {
 
     void InitNoLayout(const VkImageCreateInfo &create_info, VkMemoryPropertyFlags reqs = 0, bool memory = true);
 
-    //    void clear( CommandBuffer*, uint32_t[4] );
-
     void Layout(VkImageLayout const layout) { m_descriptorImageInfo.imageLayout = layout; }
-
-    VkDeviceMemory Memory() const { return Image::memory().handle(); }
-
-    void *MapMemory() { return Image::memory().map(); }
-
-    void UnmapMemory() { Image::memory().unmap(); }
 
     void ImageMemoryBarrier(vkt::CommandBuffer *cmd, VkImageAspectFlags aspect, VkFlags output_mask, VkFlags input_mask,
                             VkImageLayout image_layout, VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                             VkPipelineStageFlags dest_stages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                             uint32_t srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
                             uint32_t dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED);
-
-    VkResult CopyImage(VkImageObj &src_image);
-
-    VkResult CopyImageOut(VkImageObj &dst_image);
-
-    std::array<std::array<uint32_t, 16>, 16> Read();
-
-    VkImage image() const { return handle(); }
 
     VkImageViewCreateInfo BasicViewCreatInfo(VkImageAspectFlags aspect_mask = VK_IMAGE_ASPECT_COLOR_BIT) const {
         VkImageViewCreateInfo ci = vku::InitStructHelper();
@@ -353,14 +337,9 @@ class VkImageObj : public vkt::Image {
     void SetLayout(VkImageLayout image_layout) { SetLayout(aspect_mask(), image_layout); };
 
     VkImageLayout Layout() const { return m_descriptorImageInfo.imageLayout; }
-    uint32_t width() const { return extent().width; }
-    uint32_t height() const { return extent().height; }
     vkt::Device *device() const { return m_device; }
 
   protected:
     vkt::Device *m_device = nullptr;
-    VkFormat m_format = VK_FORMAT_UNDEFINED;
-    uint32_t m_mipLevels = 0;
-    uint32_t m_arrayLayers = 0;
     VkDescriptorImageInfo m_descriptorImageInfo = {VK_NULL_HANDLE, VK_NULL_HANDLE, VK_IMAGE_LAYOUT_GENERAL};
 };


### PR DESCRIPTION
`VkImageObj` is the last remaining object we have both in binding.cpp and render.cpp and it is a mess currently

This is a first step of cleaning it up by removing things that are not being used anymore to make the migration process a bit nicer