### PR TITLE
tests: Create common Framebuffer init

### DIFF
--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1030,6 +1030,18 @@ class Framebuffer : public internal::NonDispHandle<VkFramebuffer> {
   public:
     Framebuffer() = default;
     Framebuffer(const Device &dev, const VkFramebufferCreateInfo &info) { init(dev, info); }
+    // The most common case, anything outside of this should create there own VkFramebufferCreateInfo
+    Framebuffer(const Device &dev, VkRenderPass rp, uint32_t attchment_count, const VkImageView *attchments, uint32_t width = 32,
+                uint32_t height = 32) {
+        VkFramebufferCreateInfo info = vku::InitStructHelper();
+        info.renderPass = rp;
+        info.attachmentCount = attchment_count;
+        info.pAttachments = attchments;
+        info.width = width;
+        info.height = height;
+        info.layers = 1;
+        init(dev, info);
+    }
     ~Framebuffer() noexcept;
     void destroy() noexcept;
 

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -472,15 +472,8 @@ TEST_F(NegativeAndroidExternalResolve, Framebuffer) {
     attachments[0] = color_view.handle();
     attachments[1] = resolve_view.handle();
 
-    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
-    fb_ci.width = 32;
-    fb_ci.height = 32;
-    fb_ci.layers = 1;
-    fb_ci.renderPass = render_pass.handle();
-    fb_ci.attachmentCount = 2;
-    fb_ci.pAttachments = attachments;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-pAttachments-09350");
-    vkt::Framebuffer framebuffer(*m_device, fb_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 2, attachments);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1228,14 +1221,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     attachments[0] = color_view.handle();
     attachments[1] = resolve_view.handle();
 
-    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
-    fb_ci.width = 32;
-    fb_ci.height = 32;
-    fb_ci.layers = 1;
-    fb_ci.renderPass = render_pass.handle();
-    fb_ci.attachmentCount = 2;
-    fb_ci.pAttachments = attachments;
-    vkt::Framebuffer framebuffer(*m_device, fb_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 2, attachments);
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -148,14 +148,7 @@ TEST_F(PositiveAndroidExternalResolve, RenderPassAndFramebuffer) {
     attachments[0] = color_view.handle();
     attachments[1] = resolve_view.handle();
 
-    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
-    fb_ci.width = 32;
-    fb_ci.height = 32;
-    fb_ci.layers = 1;
-    fb_ci.renderPass = render_pass.handle();
-    fb_ci.attachmentCount = 2;
-    fb_ci.pAttachments = attachments;
-    vkt::Framebuffer framebuffer(*m_device, fb_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 2, attachments);
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -1507,9 +1507,7 @@ TEST_F(VkArmBestPracticesLayerTest, BlitImageLoadOpLoad) {
     vkt::RenderPass rp(*m_device, rpci);
 
     auto imageView = images[1]->CreateView();
-    VkFramebufferCreateInfo fbci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.handle(), 1, &imageView.handle(), WIDTH, HEIGHT, 1};
-    vkt::Framebuffer fb(*m_device, fbci);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &imageView.handle(), WIDTH, HEIGHT);
 
     VkRenderPassBeginInfo rpbi =
         vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp.handle(), fb.handle(), VkRect2D{{0, 0}, {WIDTH, HEIGHT}}, 0u, nullptr);

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -678,15 +678,7 @@ TEST_F(VkBestPracticesLayerTest, AttachmentShouldNotBeTransient) {
 
     vkt::ImageView image_view(*m_device, iv_info);
 
-    VkFramebufferCreateInfo fb_info{};
-    fb_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-    fb_info.renderPass = rp.handle();
-    fb_info.layers = 1;
-    fb_info.width = 1920;
-    fb_info.height = 1080;
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &image_view.handle();
-    vkt::Framebuffer fb(*m_device, fb_info);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &image_view.handle(), 1920, 1080);
 
     m_errorMonitor->VerifyFound();
 }
@@ -1553,17 +1545,7 @@ TEST_F(VkBestPracticesLayerTest, RenderPassClearWithoutLoadOpClear) {
     rp_info.pSubpasses = &spd;
 
     vkt::RenderPass rp(*m_device, rp_info);
-
-    // Setup Framebuffer
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.width = w;
-    fb_info.height = h;
-    fb_info.layers = 1;
-    fb_info.renderPass = rp.handle();
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &image_view.handle();
-
-    vkt::Framebuffer fb(*m_device, fb_info);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &image_view.handle(), w, h);
 
     m_commandBuffer->begin();
 
@@ -1648,17 +1630,7 @@ TEST_F(VkBestPracticesLayerTest, RenderPassClearValueCountHigherThanAttachmentCo
     rp_info.pSubpasses = &spd;
 
     vkt::RenderPass rp(*m_device, rp_info);
-
-    // Setup Framebuffer
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.width = w;
-    fb_info.height = h;
-    fb_info.layers = 1;
-    fb_info.renderPass = rp.handle();
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &image_view.handle();
-
-    vkt::Framebuffer fb(*m_device, fb_info);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &image_view.handle(), w, h);
 
     m_commandBuffer->begin();
 
@@ -1756,17 +1728,7 @@ TEST_F(VkBestPracticesLayerTest, DontCareThenLoad) {
     attachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     vkt::RenderPass rp2(*m_device, rp_info);
-
-    // Setup Framebuffer
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.width = w;
-    fb_info.height = h;
-    fb_info.layers = 1;
-    fb_info.renderPass = rp1.handle();
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &image_view.handle();
-
-    vkt::Framebuffer fb(*m_device, fb_info);
+    vkt::Framebuffer fb(*m_device, rp1.handle(), 1, &image_view.handle(), w, h);
 
     m_commandBuffer->begin();
 
@@ -1924,17 +1886,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     rp_info.pSubpasses = &spd;
 
     vkt::RenderPass rp(*m_device, rp_info);
-
-    // Setup Framebuffer
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.width = w;
-    fb_info.height = h;
-    fb_info.layers = 1;
-    fb_info.renderPass = rp.handle();
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &image_view.handle();
-
-    vkt::Framebuffer fb(*m_device, fb_info);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &image_view.handle(), w, h);
 
     vkt::CommandPool graphics_pool(*m_device, graphics_queue->get_family_index());
 

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -63,9 +63,7 @@ TEST_F(NegativeCommand, SecondaryCommandBufferBarrier) {
     VkImageObj image2(m_device);
     image2.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
 
-    VkFramebufferCreateInfo fbci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.Handle(), 1, &imageView.handle(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fbci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &imageView.handle());
 
     m_commandBuffer->begin();
 
@@ -5837,15 +5835,7 @@ TEST_F(NegativeCommand, EndConditionalRendering) {
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView imageView = image.CreateView();
 
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.renderPass = render_pass.handle();
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &imageView.handle();
-    fbci.width = 32;
-    fbci.height = 32;
-    fbci.layers = 1;
-    vkt::Framebuffer framebuffer(*m_device, fbci);
-    ASSERT_TRUE(framebuffer.initialized());
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &imageView.handle());
 
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = 32;
@@ -5970,11 +5960,7 @@ TEST_F(NegativeCommand, ExecuteCommandsSubpassIndices) {
     VkImageObj image(m_device);
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView imageView = image.CreateView();
-
-    VkFramebufferCreateInfo fbci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, render_pass.handle(), 1, &imageView.handle(), 32, 32, 1};
-    vkt::Framebuffer framebuffer(*m_device, fbci);
-    ASSERT_TRUE(framebuffer.initialized());
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &imageView.handle());
 
     vkt::CommandBuffer secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
@@ -6029,10 +6015,7 @@ TEST_F(NegativeCommand, IncompatibleRenderPassesInExecuteCommands) {
     VkImageObj image(m_device);
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView imageView = image.CreateView();
-
-    VkFramebufferCreateInfo fbci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, render_pass_1.handle(), 1, &imageView.handle(), 32, 32, 1};
-    vkt::Framebuffer framebuffer(*m_device, fbci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass_1.handle(), 1, &imageView.handle());
 
     vkt::CommandBuffer secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
@@ -6550,16 +6533,7 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
     stencil_dynamic_pipe.gp_ci_.pDepthStencilState = &stencil_state_info;
     stencil_dynamic_pipe.CreateGraphicsPipeline(false);
 
-    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
-    framebuffer_ci.width = 32;
-    framebuffer_ci.height = 32;
-    framebuffer_ci.layers = 1;
-    framebuffer_ci.renderPass = rp.Handle();
-    framebuffer_ci.attachmentCount = 1;
-    framebuffer_ci.pAttachments = &image_view.handle();
-
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_ci);
-    ASSERT_TRUE(framebuffer.initialized());
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
     VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
     render_pass_begin_info.renderPass = rp.Handle();
     render_pass_begin_info.framebuffer = framebuffer.handle();
@@ -7380,8 +7354,7 @@ TEST_F(NegativeCommand, ClearDsImageWithInvalidAspect) {
         rp.AddDepthStencilAttachment(0);
         rp.CreateRenderPass();
 
-        auto fbci = vku::InitStruct<VkFramebufferCreateInfo>(nullptr, 0, rp.Handle(), 1, &image_view.handle(), 32, 32, 1);
-        vkt::Framebuffer framebuffer(*m_device, fbci);
+        vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
 
         VkClearValue clear_value = {};
         clear_value.depthStencil = {0};

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -34,9 +34,7 @@ TEST_F(PositiveCommand, SecondaryCommandBufferBarrier) {
     image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView imageView = image.CreateView();
 
-    VkFramebufferCreateInfo fbci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.Handle(), 1, &imageView.handle(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fbci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &imageView.handle());
 
     m_commandBuffer->begin();
     VkRenderPassBeginInfo rpbi =
@@ -500,10 +498,7 @@ TEST_F(PositiveCommand, FramebufferBindingDestroyCommandPool) {
     ASSERT_TRUE(image.initialized());
 
     vkt::ImageView view = image.CreateView();
-
-    VkFramebufferCreateInfo fci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.Handle(), 1, &view.handle(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
 
     // Explicitly create a command buffer to bind the FB to so that we can then
     //  destroy the command pool in order to implicitly free command buffer

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -3078,8 +3078,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenAttachmentsAndDescript
     rp.AddDepthStencilAttachment(1);
     rp.CreateRenderPass();
 
-    const auto fbci = vku::InitStruct<VkFramebufferCreateInfo>(0, 0u, rp.Handle(), 2u, attachments, 64u, 64u, 1u);
-    vkt::Framebuffer fb(*m_device, fbci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 2u, attachments, 64, 64);
 
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_info);
@@ -3779,15 +3778,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.width = width;
-    fbci.height = height;
-    fbci.layers = 1;
-    fbci.renderPass = rp.Handle();
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &image_view_handle;
-
-    vkt::Framebuffer framebuffer(*m_device, fbci);
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle, width, height);
 
     VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer.handle();
@@ -3902,15 +3893,7 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.width = width;
-    fbci.height = height;
-    fbci.layers = 1;
-    fbci.renderPass = rp.Handle();
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &image_view_handle;
-
-    vkt::Framebuffer framebuffer(*m_device, fbci);
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle, width, height);
 
     VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer.handle();
@@ -4026,15 +4009,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.width = width;
-    fbci.height = height;
-    fbci.layers = 1;
-    fbci.renderPass = rp.Handle();
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &image_view_handle;
-
-    vkt::Framebuffer framebuffer(*m_device, fbci);
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle, width, height);
 
     VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer.handle();

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -610,15 +610,7 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.width = width;
-    fbci.height = height;
-    fbci.layers = 1;
-    fbci.renderPass = rp.Handle();
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &image_view_handle;
-
-    vkt::Framebuffer framebuffer(*m_device, fbci);
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle, width, height);
 
     VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.framebuffer = framebuffer.handle();
@@ -826,15 +818,7 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
     rp.AddInputAttachment(0);
     rp.CreateRenderPass();
 
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.renderPass = rp.Handle();
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &view_input.handle();
-    fbci.width = width;
-    fbci.height = height;
-    fbci.layers = 1;
-    vkt::Framebuffer fb(*m_device, fbci);
-    ASSERT_TRUE(fb.initialized());
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view_input.handle(), width, height);
 
     char const *fsSource = R"glsl(
         #version 450
@@ -1082,15 +1066,7 @@ TEST_F(PositiveDescriptors, AttachmentFeedbackLoopLayout) {
     VkClearValue clear_value;
     clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
 
-    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
-    framebuffer_ci.width = 32u;
-    framebuffer_ci.height = 32u;
-    framebuffer_ci.layers = 1u;
-    framebuffer_ci.renderPass = rp.Handle();
-    framebuffer_ci.attachmentCount = 1;
-    framebuffer_ci.pAttachments = &image_view.handle();
-
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_ci);
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
 
     VkRenderPassBeginInfo render_pass_begin = vku::InitStructHelper();
     render_pass_begin.renderPass = rp.Handle();

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -3121,13 +3121,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
 
     vkt::RenderPass render_pass(*m_device, render_pass_ci);
 
-    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
-    framebuffer_ci.renderPass = render_pass.handle();
-    framebuffer_ci.width = 32;
-    framebuffer_ci.height = 32;
-    framebuffer_ci.layers = 1;
-
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 0, nullptr);
 
     vkt::CommandBuffer cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     VkCommandBuffer secondary_handle = cb.handle();
@@ -6130,10 +6124,7 @@ TEST_F(NegativeDynamicRendering, EndRenderingWithIncorrectlyStartedRenderpassIns
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView imageView = image.CreateView();
 
-    VkFramebufferCreateInfo fbci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.handle(), 1, &imageView.handle(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fbci);
-    ASSERT_TRUE(fb.initialized());
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &imageView.handle());
 
     m_commandBuffer->begin();
 

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -5238,17 +5238,7 @@ TEST_F(NegativeDynamicState, DynamicRasterizationSamples) {
     render_pass_ci.pSubpasses = &subpass;
 
     vkt::RenderPass render_pass(*m_device, render_pass_ci);
-
-    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
-    framebuffer_ci.flags = 0u;
-    framebuffer_ci.renderPass = render_pass.handle();
-    framebuffer_ci.attachmentCount = 0u;
-    framebuffer_ci.pAttachments = nullptr;
-    framebuffer_ci.width = 32u;
-    framebuffer_ci.height = 32u;
-    framebuffer_ci.layers = 1u;
-
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 0, nullptr);
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
@@ -5418,14 +5408,7 @@ TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
     rp.AddColorAttachment(0);
     rp.CreateRenderPass();
 
-    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
-    framebuffer_ci.renderPass = rp.Handle();
-    framebuffer_ci.attachmentCount = 1u;
-    framebuffer_ci.pAttachments = &image_view.handle();
-    framebuffer_ci.width = 32u;
-    framebuffer_ci.height = 32u;
-    framebuffer_ci.layers = 1u;
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_ci);
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
 
     VkClearValue clear_value;
     clear_value.color = {{0, 0, 0, 0}};
@@ -5544,14 +5527,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsEnable) {
     rp.AddDepthStencilAttachment(0);
     rp.CreateRenderPass();
 
-    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
-    framebuffer_ci.renderPass = rp.Handle();
-    framebuffer_ci.attachmentCount = 1u;
-    framebuffer_ci.pAttachments = &image_view.handle();
-    framebuffer_ci.width = 32u;
-    framebuffer_ci.height = 32u;
-    framebuffer_ci.layers = 1u;
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_ci);
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
 
     VkClearValue clear_value;
     clear_value.depthStencil = {1.0f, 0u};

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -289,15 +289,7 @@ TEST_F(PositiveDynamicState, DynamicColorWriteNoColorAttachments) {
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpasses;
     vkt::RenderPass rp(*m_device, rpci);
-
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = rp.handle();
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &depth_image_view.handle();
-    fb_info.width = m_width;
-    fb_info.height = m_height;
-    fb_info.layers = 1;
-    vkt::Framebuffer fb(*m_device, fb_info);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &depth_image_view.handle(), m_width, m_height);
 
     // Enable dynamic color write enable
     pipe.gp_ci_.renderPass = rp.handle();

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -910,16 +910,10 @@ TEST_F(NegativeFragmentShadingRate, FramebufferUsage) {
     image.InitNoLayout(1, 1, 1, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView imageView = image.CreateView();
 
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = rp.handle();
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &imageView.handle();
-    fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
-    fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
-    fb_info.layers = 1;
-
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04548");
-    vkt::Framebuffer fb(*m_device, fb_info);
+    vkt::Framebuffer framebuffer(*m_device, rp.handle(), 1, &imageView.handle(),
+                                 fsr_properties.minFragmentShadingRateAttachmentTexelSize.width,
+                                 fsr_properties.minFragmentShadingRateAttachmentTexelSize.height);
     m_errorMonitor->VerifyFound();
 }
 
@@ -2038,19 +2032,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
     ASSERT_TRUE(iv6.initialized());
     iv[6] = iv6.handle();
 
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.flags = 0;
-    fbci.width = 16;
-    fbci.height = 16;
-    fbci.layers = 1;
-    fbci.renderPass = rp2[0].handle();
-    fbci.attachmentCount = 7;
-    fbci.pAttachments = iv;
-
-    vkt::Framebuffer fb1(*m_device, fbci);
-
-    fbci.renderPass = rp2[1].handle();
-    vkt::Framebuffer fb2(*m_device, fbci);
+    vkt::Framebuffer fb1(*m_device, rp2[0].handle(), 7, iv, 16, 16);
+    vkt::Framebuffer fb2(*m_device, rp2[1].handle(), 7, iv, 16, 16);
 
     // define renderpass begin info
     auto rpbi1 =

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -141,14 +141,8 @@ TEST_F(PositiveFragmentShadingRate, Attachments) {
                        0);
     vkt::ImageView imageView = image.CreateView();
 
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = rp.handle();
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &imageView.handle();
-    fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
-    fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
-    fb_info.layers = 1;
-
-    vkt::Framebuffer fb(*m_device, fb_info);
-    ASSERT_TRUE(fb.initialized());
+    vkt::Framebuffer framebuffer(*m_device, rp.handle(), 1, &imageView.handle(),
+                                 fsr_properties.minFragmentShadingRateAttachmentTexelSize.width,
+                                 fsr_properties.minFragmentShadingRateAttachmentTexelSize.height);
+    ASSERT_TRUE(framebuffer.initialized());
 }

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -1277,9 +1277,7 @@ TEST_F(VkPositiveLayerTest, ImageDescriptor3D2DSubresourceLayout) {
         for (TestType test_type : test_list) {
             VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
 
-            VkFramebufferCreateInfo fbci = {
-                VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.handle(), 1, &view->handle(), kWidth, kHeight, 1};
-            vkt::Framebuffer fb(*m_device, fbci);
+            vkt::Framebuffer fb(*m_device, rp.handle(), 1, &view->handle(), kWidth, kHeight);
 
             cmd_buf.begin();
             image_barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -94,16 +94,7 @@ TEST_F(NegativeMultiview, ClearColorAttachments) {
     image.Init(image_create_info);
     vkt::ImageView imageView = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
-    VkFramebufferCreateInfo framebufferCreateInfo = vku::InitStructHelper();
-    framebufferCreateInfo.width = 32;
-    framebufferCreateInfo.height = 32;
-    framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = rp.Handle();
-    framebufferCreateInfo.attachmentCount = 1;
-    framebufferCreateInfo.pAttachments = &imageView.handle();
-
-    vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-    ASSERT_TRUE(framebuffer.initialized());
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle());
 
     // Start no RenderPass
     m_commandBuffer->begin();
@@ -675,15 +666,7 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     const vkt::ImageView imageView(*m_device, image_view_ci);
 
-    VkFramebufferCreateInfo framebufferCreateInfo = vku::InitStructHelper();
-    framebufferCreateInfo.width = 32;
-    framebufferCreateInfo.height = 32;
-    framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = rp.Handle();
-    framebufferCreateInfo.attachmentCount = 1;
-    framebufferCreateInfo.pAttachments = &imageView.handle();
-
-    vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle());
 
     VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
     render_pass_begin_info.renderPass = rp.Handle();

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -196,15 +196,8 @@ TEST_F(NegativeParent, RenderPassFramebuffer) {
     auto features = m_device->phy().features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = m_renderPass;
-    fb_info.attachmentCount = 0;
-    fb_info.width = m_width;
-    fb_info.height = m_height;
-    fb_info.layers = 1;
-
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-commonparent");
-    vkt::Framebuffer fb(*m_second_device, fb_info);
+    vkt::Framebuffer fb(*m_second_device, m_renderPass, 0, nullptr, m_width, m_height);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -484,14 +484,10 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     ASSERT_TRUE(renderpass.initialized());
 
     auto render_target_view = m_renderTargets[0]->CreateView();
-    VkFramebufferCreateInfo framebuffer_info = vku::InitStructHelper();
-    framebuffer_info.renderPass = renderpass;
-    framebuffer_info.width = m_renderTargets[0]->width();
-    framebuffer_info.height = m_renderTargets[0]->height();
-    framebuffer_info.layers = 1;
-    framebuffer_info.attachmentCount = 1;
-    framebuffer_info.pAttachments = &render_target_view.handle();
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_info);
+
+    const uint32_t fb_width = m_renderTargets[0]->width();
+    const uint32_t fb_height = m_renderTargets[0]->height();
+    vkt::Framebuffer framebuffer(*m_device, renderpass, 1, &render_target_view.handle(), fb_width, fb_height);
 
     CreatePipelineHelper pipeline_1(*this);
     pipeline_1.InitState();
@@ -508,8 +504,8 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
     rpbinfo.renderPass = renderpass.handle();
     rpbinfo.framebuffer = framebuffer;
-    rpbinfo.renderArea.extent.width = framebuffer_info.width;
-    rpbinfo.renderArea.extent.height = framebuffer_info.height;
+    rpbinfo.renderArea.extent.width = fb_width;
+    rpbinfo.renderArea.extent.height = fb_height;
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(rpbinfo);
@@ -2436,16 +2432,7 @@ TEST_F(VkLayerTest, ValidateVariableSampleLocations) {
     image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView image_view = image.CreateView();
 
-    VkFramebufferCreateInfo framebuffer_info = vku::InitStructHelper();
-    framebuffer_info.renderPass = render_pass.handle();
-    framebuffer_info.attachmentCount = 1;
-    framebuffer_info.pAttachments = &image_view.handle();
-    framebuffer_info.width = 32;
-    framebuffer_info.height = 32;
-    framebuffer_info.layers = 1;
-
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_info);
-    ASSERT_TRUE(framebuffer.initialized());
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &image_view.handle());
 
     VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
     vk::GetPhysicalDeviceMultisamplePropertiesEXT(gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -856,9 +856,7 @@ TEST_F(PositivePipeline, ConditionalRendering) {
     image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
 
-    VkFramebufferCreateInfo fbci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.Handle(), 1, &imageView.handle(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fbci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &imageView.handle());
 
     m_commandBuffer->begin();
     VkRenderPassBeginInfo rpbi =

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -832,9 +832,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
                             VK_ACCESS_SHADER_WRITE_BIT, VK_ACCESS_SHADER_WRITE_BIT);
     rp.CreateRenderPass();
 
-    VkFramebufferCreateInfo framebuffer_create_info = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.Handle(), 2, image_views, 8, 8, 1};
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_create_info);
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, image_views, 8, 8);
 
     // Various structs used for commands
     VkImageSubresourceLayers image_subresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -1750,15 +1750,7 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
 
     VkImageView image_view_handle = image_view.handle();
 
-    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
-    fb_ci.renderPass = render_pass.handle();
-    fb_ci.attachmentCount = 1;
-    fb_ci.pAttachments = &image_view_handle;
-    fb_ci.width = 64;
-    fb_ci.height = 64;
-    fb_ci.layers = 1;
-
-    vkt::Framebuffer framebuffer(*m_device, fb_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &image_view_handle, 64, 64);
 
     VkQueryPoolCreateInfo qpci = vku::InitStructHelper();
     qpci.queryType = VK_QUERY_TYPE_OCCLUSION;
@@ -2215,15 +2207,7 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
 
     VkImageView image_view_handle = image_view.handle();
 
-    VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
-    fb_ci.renderPass = render_pass.handle();
-    fb_ci.attachmentCount = 1;
-    fb_ci.pAttachments = &image_view_handle;
-    fb_ci.width = 64;
-    fb_ci.height = 64;
-    fb_ci.layers = 1;
-
-    vkt::Framebuffer framebuffer(*m_device, fb_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &image_view_handle, 64, 64);
 
     VkQueryPoolCreateInfo qpci = vku::InitStructHelper();
     qpci.queryType = VK_QUERY_TYPE_OCCLUSION;

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -61,10 +61,7 @@ TEST_F(PositiveRenderPass, InitialLayoutUndefined) {
     };
 
     vkt::ImageView view(*m_device, ivci);
-
-    VkFramebufferCreateInfo fci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.Handle(), 1, &view.handle(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
 
     // Record a single command buffer which uses this renderpass twice. The
     // bug is triggered at the beginning of the second renderpass, when the
@@ -136,10 +133,7 @@ TEST_F(PositiveRenderPass, BeginSubpassZeroTransitionsApplied) {
     ASSERT_TRUE(image.initialized());
 
     vkt::ImageView view = image.CreateView();
-
-    VkFramebufferCreateInfo fci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.Handle(), 1, &view.handle(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
 
     // Record a single command buffer which issues a pipeline barrier w/
     // image memory barrier for the attachment. This detects the previously
@@ -173,8 +167,7 @@ TEST_F(PositiveRenderPass, BeginTransitionsAttachmentUnused) {
     vkt::RenderPass rp(*m_device, rpci);
 
     // A compatible framebuffer.
-    VkFramebufferCreateInfo fci = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.handle(), 0, nullptr, 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fci);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 0, nullptr);
 
     // Record a command buffer which just begins and ends the renderpass. The
     // bug manifests in BeginRenderPass.
@@ -212,14 +205,7 @@ TEST_F(PositiveRenderPass, BeginStencilLoadOp) {
     clear.depthStencil.stencil = 0;
 
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = rp.Handle();
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &depth_image_view.handle();
-    fb_info.width = 100;
-    fb_info.height = 100;
-    fb_info.layers = 1;
-    vkt::Framebuffer fb(*m_device, fb_info);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &depth_image_view.handle(), 100, 100);
 
     VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
     rpbinfo.clearValueCount = 1;
@@ -346,10 +332,7 @@ TEST_F(PositiveRenderPass, BeginDepthStencilLayoutTransitionFromUndefined) {
         {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1},
     };
     vkt::ImageView view(*m_device, ivci);
-
-    VkFramebufferCreateInfo fci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.Handle(), 1, &view.handle(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
 
     VkRenderPassBeginInfo rpbi =
         vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp.Handle(), fb.handle(), VkRect2D{{0, 0}, {32u, 32u}}, 0u, nullptr);
@@ -591,8 +574,7 @@ TEST_F(PositiveRenderPass, SingleMipTransition) {
 
     VkImageView fullViews[] = {fullView0.handle(), fullView1.handle()};
 
-    VkFramebufferCreateInfo fci = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.Handle(), 2, baseViews, 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 2, baseViews);
 
     // Create shader modules
 
@@ -753,15 +735,7 @@ TEST_F(PositiveRenderPass, BeginWithViewMasks) {
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
     vkt::ImageView view(*m_device, ivci);
-
-    VkFramebufferCreateInfo fci = vku::InitStructHelper();
-    fci.renderPass = render_pass.handle();
-    fci.attachmentCount = 1;
-    fci.pAttachments = &view.handle();
-    fci.width = 32;
-    fci.height = 32;
-    fci.layers = 1;
-    vkt::Framebuffer fb(*m_device, fci);
+    vkt::Framebuffer fb(*m_device, render_pass.handle(), 1, &view.handle());
 
     VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.renderPass = render_pass.handle();
@@ -955,14 +929,7 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
     vkt::ImageView view(*m_device, ivci);
     VkImageView image_view_handle = view.handle();
 
-    VkFramebufferCreateInfo fci = vku::InitStructHelper();
-    fci.renderPass = rp.Handle();
-    fci.attachmentCount = 1;
-    fci.pAttachments = &image_view_handle;
-    fci.width = 32;
-    fci.height = 32;
-    fci.layers = 1;
-    vkt::Framebuffer fb(*m_device, fci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view_handle);
 
     vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
@@ -1042,10 +1009,7 @@ TEST_F(PositiveRenderPass, FramebufferCreateDepthStencilLayoutTransitionForDepth
     image.SetLayout(0x6, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 
     vkt::ImageView view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
-
-    VkFramebufferCreateInfo fci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.Handle(), 1, &view.handle(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fci);
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
 
     m_commandBuffer->begin();
 
@@ -1141,16 +1105,8 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
     rp_info.pAttachments = attach_desc;
 
     vkt::RenderPass renderpass(*m_device, rp_info);
-
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = renderpass.handle();
-    fb_info.attachmentCount = depth_count;
-    fb_info.pAttachments = views;
-    fb_info.width = image_info.extent.width;
-    fb_info.height = image_info.extent.height;
-    fb_info.layers = 1;
-
-    vkt::Framebuffer framebuffer(*m_device, fb_info);
+    vkt::Framebuffer framebuffer(*m_device, renderpass.handle(), depth_count, views, image_info.extent.width,
+                                 image_info.extent.height);
 
     VkRenderPassBeginInfo rp_begin_info = vku::InitStructHelper();
     rp_begin_info.renderPass = renderpass.handle();
@@ -1227,14 +1183,7 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     rp_1.AddInputAttachment(0);
     rp_1.CreateRenderPass();
 
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = rp_1.Handle();
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &views[0];
-    fb_info.width = image_info.extent.width;
-    fb_info.height = image_info.extent.height;
-    fb_info.layers = 1;
-    vkt::Framebuffer framebuffer_1(*m_device, fb_info);
+    vkt::Framebuffer framebuffer_1(*m_device, rp_1.Handle(), 1, &views[0], image_info.extent.width, image_info.extent.height);
 
     VkRenderPassBeginInfo rp_begin_info_1 = vku::InitStructHelper();
     rp_begin_info_1.renderPass = rp_1.Handle();
@@ -1253,14 +1202,7 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     rp_2.AddColorAttachment(0);
     rp_2.CreateRenderPass();
 
-    VkFramebufferCreateInfo fb_info_2 = vku::InitStructHelper();
-    fb_info_2.renderPass = rp_2.Handle();
-    fb_info_2.attachmentCount = 1;
-    fb_info_2.pAttachments = &views[1];
-    fb_info_2.width = image_info.extent.width;
-    fb_info_2.height = image_info.extent.height;
-    fb_info_2.layers = 1;
-    vkt::Framebuffer framebuffer_2(*m_device, fb_info_2);
+    vkt::Framebuffer framebuffer_2(*m_device, rp_2.Handle(), 1, &views[1], image_info.extent.width, image_info.extent.height);
 
     VkRenderPassBeginInfo rp_begin_info_2 = vku::InitStructHelper();
     rp_begin_info_2.renderPass = rp_2.Handle();
@@ -1325,9 +1267,7 @@ TEST_F(PositiveRenderPass, SubpassWithReadOnlyLayoutWithoutDependency) {
     vkt::ImageView view(*m_device, ivci);
     std::array<VkImageView, size> views = {{view.handle(), view.handle()}};
 
-    VkFramebufferCreateInfo fci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.handle(), size, views.data(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fci);
+    vkt::Framebuffer fb(*m_device, rp.handle(), size, views.data());
 
     VkRenderPassBeginInfo rpbi =
         vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp.handle(), fb.handle(), VkRect2D{{0, 0}, {32u, 32u}}, 0u, nullptr);
@@ -1469,17 +1409,8 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
     att.pNext = nullptr;
     vkt::RenderPass render_pass_combined(*m_device, rp2);
 
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = render_pass_separate.handle();
-    fb_info.width = 1;
-    fb_info.height = 1;
-    fb_info.layers = 1;
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &view.handle();
-    vkt::Framebuffer framebuffer_separate(*m_device, fb_info);
-
-    fb_info.renderPass = render_pass_combined.handle();
-    vkt::Framebuffer framebuffer_combined(*m_device, fb_info);
+    vkt::Framebuffer framebuffer_separate(*m_device, render_pass_separate.handle(), 1, &view.handle(), 1, 1);
+    vkt::Framebuffer framebuffer_combined(*m_device, render_pass_combined.handle(), 1, &view.handle(), 1, 1);
 
     for (auto &barrier : barriers) {
         vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
@@ -1555,14 +1486,7 @@ TEST_F(PositiveRenderPass, TestDepthStencilRenderPassTransition) {
         rp.AddDepthStencilAttachment(0);
         rp.CreateRenderPass();
 
-        VkFramebufferCreateInfo fb_ci = vku::InitStructHelper();
-        fb_ci.renderPass = rp.Handle();
-        fb_ci.attachmentCount = 1;
-        fb_ci.pAttachments = &depth_or_stencil_view.handle();
-        fb_ci.width = 32;
-        fb_ci.height = 32;
-        fb_ci.layers = 1;
-        const vkt::Framebuffer fb(*m_device, fb_ci);
+        const vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &depth_or_stencil_view.handle());
 
         VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
         rpbinfo.renderPass = rp.Handle();

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -1409,16 +1409,7 @@ TEST_F(NegativeShaderObject, DrawWithShadersInNonDynamicRenderPass) {
     VkImageObj image(m_device);
     image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView image_view = image.CreateView();
-
-    VkFramebufferCreateInfo framebuffer_info = vku::InitStructHelper();
-    framebuffer_info.renderPass = rp.Handle();
-    framebuffer_info.attachmentCount = 1;
-    framebuffer_info.pAttachments = &image_view.handle();
-    framebuffer_info.width = 32;
-    framebuffer_info.height = 32;
-    framebuffer_info.layers = 1;
-
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_info);
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
 
     VkClearValue clear_value;
     clear_value.color.float32[0] = 0.25f;

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -348,10 +348,7 @@ TEST_F(NegativeSubpass, RenderPassEndBeforeFinalSubpass) {
     auto rcpi = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, 0u, nullptr, 2u, sd, 0u, nullptr);
 
     vkt::RenderPass rp(*m_device, rcpi);
-
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>(nullptr, 0u, rp.handle(), 0u, nullptr, 16u, 16u, 1u);
-
-    vkt::Framebuffer fb(*m_device, fbci);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 0u, nullptr, 16, 16);
 
     m_commandBuffer->begin();
 
@@ -454,9 +451,7 @@ TEST_F(NegativeSubpass, DrawWithPipelineIncompatibleWithSubpass) {
     VkImageObj image(m_device);
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView imageView = image.CreateView();
-
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>(nullptr, 0u, rp.handle(), 1u, &imageView.handle(), 32u, 32u, 1u);
-    vkt::Framebuffer fb(*m_device, fbci);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1u, &imageView.handle());
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
@@ -527,9 +522,7 @@ TEST_F(NegativeSubpass, ImageBarrierSubpassConflict) {
     vkt::ImageView imageView2 = image2.CreateView();
     // re-use imageView from start of test
     VkImageView iv_array[2] = {imageView, imageView2};
-
-    auto fbci = vku::InitStruct<VkFramebufferCreateInfo>(nullptr, 0u, rp.handle(), 2u, iv_array, 32u, 32u, 1u);
-    vkt::Framebuffer fb(*m_device, fbci);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 2u, iv_array);
 
     auto rpbi = vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp.handle(), fb.handle(), VkRect2D{{0, 0}, {32u, 32u}}, 0u, nullptr);
 
@@ -600,21 +593,10 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
     const auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, size32(attachmentDescs), attachmentDescs.data(),
                                                             size32(subpasses), subpasses.data(), 0u, nullptr);
     vkt::RenderPass rp(*m_device, rpci);
-    ASSERT_TRUE(rp.initialized());
-
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.renderPass = rp.handle();
-    fbci.attachmentCount = 1u;
-    fbci.pAttachments = &view_input.handle();
-    fbci.width = 64;
-    fbci.height = 64;
-    fbci.layers = 1u;
-    vkt::Framebuffer fb(*m_device, fbci);
-    ASSERT_TRUE(fb.initialized());
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &view_input.handle(), 64, 64);
 
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     vkt::Sampler sampler(*m_device, sampler_info);
-    ASSERT_TRUE(sampler.initialized());
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
 
@@ -777,16 +759,7 @@ TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     VkImageObj image(m_device);
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView imageView = image.CreateView();
-
-    VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper();
-    framebuffer_ci.renderPass = render_pass.handle();
-    framebuffer_ci.attachmentCount = 1;
-    framebuffer_ci.pAttachments = &imageView.handle();
-    framebuffer_ci.width = 32;
-    framebuffer_ci.height = 32;
-    framebuffer_ci.layers = 1;
-
-    vkt::Framebuffer framebuffer(*m_device, framebuffer_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &imageView.handle());
 
     CreatePipelineHelper pipe1(*this);
     pipe1.gp_ci_.renderPass = render_pass.handle();

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -58,15 +58,7 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM,
                        VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
-
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.renderPass = render_pass;
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &image_view.handle();
-    fbci.width = 32;
-    fbci.height = 32;
-    fbci.layers = 1;
-    vkt::Framebuffer framebuffer(*m_device, fbci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle());
 
     VkRenderPassBeginInfo render_pass_begin = vku::InitStructHelper();
     render_pass_begin.renderPass = render_pass;
@@ -153,15 +145,7 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM,
                        VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
-
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.renderPass = render_pass;
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &image_view.handle();
-    fbci.width = 32;
-    fbci.height = 32;
-    fbci.layers = 1;
-    vkt::Framebuffer framebuffer(*m_device, fbci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle());
 
     VkRenderPassBeginInfo render_pass_begin = vku::InitStructHelper();
     render_pass_begin.renderPass = render_pass;

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -51,15 +51,8 @@ TEST_F(NegativeSyncObject, ImageBarrierSubpassConflicts) {
     VkImageObj image(m_device);
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView imageView = image.CreateView();
-
-    VkFramebufferCreateInfo fbci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, rp.handle(), 1, &imageView.handle(), 32, 32, 1};
-    vkt::Framebuffer fb(*m_device, fbci);
-    ASSERT_TRUE(fb.initialized());
-
-    fbci.renderPass = rp_noselfdep.handle();
-    vkt::Framebuffer fb_noselfdep(*m_device, fbci);
-    ASSERT_TRUE(fb_noselfdep.initialized());
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &imageView.handle());
+    vkt::Framebuffer fb_noselfdep(*m_device, rp_noselfdep.handle(), 1, &imageView.handle());
 
     m_commandBuffer->begin();
     VkRenderPassBeginInfo rpbi = vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp_noselfdep.handle(), fb_noselfdep.handle(),

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -2223,13 +2223,7 @@ TEST_F(PositiveSyncObject, SubpassBarrierWithExpandableStages) {
     rpci.dependencyCount = 1;
     rpci.pDependencies = &subpass_dependency;
     const vkt::RenderPass rp(*m_device, rpci);
-
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.renderPass = rp;
-    fbci.width = m_width;
-    fbci.height = m_height;
-    fbci.layers = 1;
-    const vkt::Framebuffer fb(*m_device, fbci);
+    const vkt::Framebuffer fb(*m_device, rp, 0, nullptr, m_width, m_height);
 
     m_renderPassBeginInfo.renderPass = rp;
     m_renderPassBeginInfo.framebuffer = fb;

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -622,11 +622,9 @@ TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
     pipeline.gp_ci_.renderPass = renderpass.handle();
     pipeline.CreateGraphicsPipeline();
 
+    vkt::Framebuffer fb(test_device, renderpass.handle(), 0, nullptr, 256, 256);
+
     m_renderPassBeginInfo.renderPass = renderpass.handle();
-    VkFramebufferCreateInfo fbci = {
-        VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, nullptr, 0, renderpass.handle(), 0, nullptr, 256, 256, 1};
-    vkt::Framebuffer fb(test_device, fbci);
-    ASSERT_TRUE(fb.initialized());
     m_renderPassBeginInfo.framebuffer = fb.handle();
     m_renderPassBeginInfo.renderPass = renderpass.handle();
     commandBuffer.begin();
@@ -1119,16 +1117,7 @@ TEST_F(NegativeTransformFeedback, CmdNextSubpass) {
     VkImageObj image(m_device);
     image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL, 0);
     vkt::ImageView imageView = image.CreateView();
-
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.renderPass = rp.handle();
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &imageView.handle();
-    fbci.width = 32;
-    fbci.height = 32;
-    fbci.layers = 1;
-
-    vkt::Framebuffer fb(*m_device, fbci);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &imageView.handle());
 
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.renderPass = rp.handle();

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -3475,15 +3475,7 @@ TEST_F(PositiveWsi, UseDestroyedSwapchain) {
 
     VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, nullptr, 0, 1, attach, 1, subpasses, 0, nullptr};
     vkt::RenderPass rp(*m_device, rpci);
-
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.renderPass = rp.handle();
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &image_view_handle;
-    fbci.width = 1u;
-    fbci.height = 1u;
-    fbci.layers = 1u;
-    vkt::Framebuffer fb(*m_device, fbci);
+    vkt::Framebuffer fb(*m_device, rp.handle(), 1, &image_view_handle, 1, 1);
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
@@ -3493,8 +3485,8 @@ TEST_F(PositiveWsi, UseDestroyedSwapchain) {
     VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
     rpbinfo.renderPass = rp.handle();
     rpbinfo.framebuffer = fb.handle();
-    rpbinfo.renderArea.extent.width = fbci.width;
-    rpbinfo.renderArea.extent.height = fbci.height;
+    rpbinfo.renderArea.extent.width = 1;
+    rpbinfo.renderArea.extent.height = 1;
 
     VkSwapchainKHR oldSwapchain = m_swapchain;
     swapchain_create_info.oldSwapchain = m_swapchain;

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -578,19 +578,10 @@ TEST_F(PositiveWsi, SwapchainImageLayout) {
                        VK_COMPONENT_SWIZZLE_IDENTITY};
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     vkt::ImageView view(*m_device, ivci);
-    ASSERT_TRUE(view.initialized());
-    VkFramebufferCreateInfo fci = vku::InitStructHelper();
-    fci.renderPass = rp1.handle();
-    fci.attachmentCount = 1;
-    fci.pAttachments = &view.handle();
-    fci.width = 1;
-    fci.height = 1;
-    fci.layers = 1;
-    vkt::Framebuffer fb1(*m_device, fci);
-    ASSERT_TRUE(fb1.initialized());
-    fci.renderPass = rp2.handle();
-    vkt::Framebuffer fb2(*m_device, fci);
-    ASSERT_TRUE(fb2.initialized());
+
+    vkt::Framebuffer fb1(*m_device, rp1.handle(), 1, &view.handle(), 1, 1);
+    vkt::Framebuffer fb2(*m_device, rp2.handle(), 1, &view.handle(), 1, 1);
+
     VkRenderPassBeginInfo rpbi =
         vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp1.handle(), fb1.handle(), VkRect2D{{0, 0}, {1u, 1u}}, 0u, nullptr);
     m_commandBuffer->begin();
@@ -905,15 +896,7 @@ TEST_F(PositiveWsi, SwapchainImageFormatProps) {
     ivci.format = format;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     vkt::ImageView image_view(*m_device, ivci);
-
-    VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.renderPass = render_pass.handle();
-    fbci.attachmentCount = 1;
-    fbci.pAttachments = &image_view.handle();
-    fbci.width = 1;
-    fbci.height = 1;
-    fbci.layers = 1;
-    vkt::Framebuffer framebuffer(*m_device, fbci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &image_view.handle(), 1, 1);
 
     vkt::CommandBuffer cmdbuff(DeviceObj(), m_commandPool);
     cmdbuff.begin();


### PR DESCRIPTION
Almost all use of `vkt::Framebuffer` in our tests use a simple way to init the framebuffer. This provides one more overload to reduce a lot of boilerplate and make it easier for places that just need a simple `VkFramebuffer`