### PR TITLE
tests: Remove bloat from  InitRenderTarget

### DIFF
--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -233,7 +233,7 @@ def RunVVLTests(args):
 
     RunShellCmd(lvt_cmd, env=lvt_env)
 
-    print("Re-Running syncval tests with core validation enabled")
+    print("Re-Running syncval tests with core validation enabled (--syncval-enable-core)")
     RunShellCmd(lvt_cmd + f' --gtest_filter=*SyncVal* --syncval-enable-core', env=lvt_env)
 
     print("Re-Running multithreaded tests with VK_LAYER_FINE_GRAINED_LOCKING disabled")

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1190,6 +1190,18 @@ void CommandBuffer::BeginRenderPass(const VkRenderPassBeginInfo &info, VkSubpass
     vk::CmdBeginRenderPass(handle(), &info, contents);
 }
 
+void CommandBuffer::BeginRenderPass(VkRenderPass rp, VkFramebuffer fb, uint32_t render_area_width, uint32_t render_area_height,
+                                    uint32_t clear_count, VkClearValue *clear_values) {
+    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
+    render_pass_begin_info.renderPass = rp;
+    render_pass_begin_info.framebuffer = fb;
+    render_pass_begin_info.renderArea.extent.width = render_area_width;
+    render_pass_begin_info.renderArea.extent.height = render_area_height;
+    render_pass_begin_info.clearValueCount = clear_count;
+    render_pass_begin_info.pClearValues = clear_values;
+    vk::CmdBeginRenderPass(handle(), &render_pass_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+}
+
 void CommandBuffer::NextSubpass(VkSubpassContents contents) { vk::CmdNextSubpass(handle(), contents); }
 
 void CommandBuffer::EndRenderPass() { vk::CmdEndRenderPass(handle()); }

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -979,6 +979,8 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     static VkCommandBufferAllocateInfo create_info(VkCommandPool const &pool);
 
     void BeginRenderPass(const VkRenderPassBeginInfo &info, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
+    void BeginRenderPass(VkRenderPass rp, VkFramebuffer fb, uint32_t render_area_width = 1, uint32_t render_area_height = 1,
+                         uint32_t clear_count = 0, VkClearValue *clear_values = nullptr);
     void NextSubpass(VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
     void EndRenderPass();
     void BeginRendering(const VkRenderingInfoKHR &renderingInfo);

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -73,7 +73,7 @@ class VkRenderFramework : public VkTestFramework {
     vkt::Device *DeviceObj() const { return m_device; }
     VkPhysicalDevice gpu() const;
     VkRenderPass renderPass() const { return m_renderPass; }
-    VkFramebuffer framebuffer() const { return m_framebuffer; }
+    VkFramebuffer framebuffer() const { return m_framebuffer->handle(); }
     ErrorMonitor &Monitor();
     const VkPhysicalDeviceProperties &physDevProps() const;
 
@@ -189,7 +189,6 @@ class VkRenderFramework : public VkTestFramework {
     vkt::CommandPool *m_commandPool;
     vkt::CommandBuffer *m_commandBuffer;
     VkRenderPass m_renderPass = VK_NULL_HANDLE;
-    VkFramebuffer m_framebuffer = VK_NULL_HANDLE;
 
     // WSI items
     SurfaceContext m_surface_context{};
@@ -231,6 +230,7 @@ class VkRenderFramework : public VkTestFramework {
 
   private:
     // TODO - move to own helper logic
+    vkt::Framebuffer *m_framebuffer;
     std::vector<VkAttachmentDescription> m_renderPass_attachments;
     std::vector<VkSubpassDescription> m_renderPass_subpasses;
     std::vector<VkSubpassDependency> m_renderPass_dependencies;

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -201,22 +201,14 @@ class VkRenderFramework : public VkTestFramework {
     VkPresentModeKHR m_surface_non_shared_present_mode{};
     VkCompositeAlphaFlagBitsKHR m_surface_composite_alpha{};
 
-    std::vector<VkViewport> m_viewports;
-    std::vector<VkRect2D> m_scissors;
     bool m_addRenderPassSelfDependency;
-    std::vector<VkSubpassDependency> m_additionalSubpassDependencies;
     std::vector<VkClearValue> m_renderPassClearValues;
     VkRenderPassBeginInfo m_renderPassBeginInfo;
     std::vector<std::unique_ptr<VkImageObj>> m_renderTargets;
     uint32_t m_width, m_height;
     VkFormat m_render_target_fmt;
     VkFormat m_depth_stencil_fmt;
-    VkImageLayout m_depth_stencil_layout;
-    VkImageLayout m_color_layout = VK_IMAGE_LAYOUT_UNDEFINED;
     VkClearColorValue m_clear_color;
-    bool m_load_op_clear;
-    float m_depth_clear_color;
-    uint32_t m_stencil_clear_color;
     VkImageObj *m_depthStencil;
     // first graphics queue, used must often, don't overwrite, use Device class
     VkQueue m_default_queue;

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -200,7 +200,6 @@ class VkRenderFramework : public VkTestFramework {
     VkPresentModeKHR m_surface_non_shared_present_mode{};
     VkCompositeAlphaFlagBitsKHR m_surface_composite_alpha{};
 
-    bool m_addRenderPassSelfDependency;
     std::vector<VkClearValue> m_renderPassClearValues;
     VkRenderPassBeginInfo m_renderPassBeginInfo;
     std::vector<std::unique_ptr<VkImageObj>> m_renderTargets;
@@ -231,9 +230,6 @@ class VkRenderFramework : public VkTestFramework {
   private:
     // TODO - move to own helper logic
     vkt::Framebuffer *m_framebuffer;
-    std::vector<VkAttachmentDescription> m_renderPass_attachments;
-    std::vector<VkSubpassDescription> m_renderPass_subpasses;
-    std::vector<VkSubpassDependency> m_renderPass_dependencies;
     std::vector<vkt::ImageView> m_render_target_views;   // color attachments but not depth
     std::vector<VkImageView> m_framebuffer_attachments;  // all attachments, can be consumed directly by the API
 

--- a/tests/framework/render_pass_helper.cpp
+++ b/tests/framework/render_pass_helper.cpp
@@ -82,6 +82,11 @@ void RenderPassSingleSubpass::AddDepthStencilAttachment(uint32_t index) {
     subpass_description_.pDepthStencilAttachment = &ds_attachments_;
 }
 
+void RenderPassSingleSubpass::AddSubpassDependency(VkSubpassDependency dependency) {
+    subpass_dependency_ = dependency;
+    rp_create_info_.dependencyCount = 1;
+}
+
 void RenderPassSingleSubpass::AddSubpassDependency(VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
                                                    VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask,
                                                    VkDependencyFlags dependencyFlags) {

--- a/tests/framework/render_pass_helper.h
+++ b/tests/framework/render_pass_helper.h
@@ -53,6 +53,7 @@ class RenderPassSingleSubpass {
     void AddResolveAttachment(uint32_t index);
     void AddDepthStencilAttachment(uint32_t index);
 
+    void AddSubpassDependency(VkSubpassDependency dependency);
     void AddSubpassDependency(VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                               VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                               VkAccessFlags srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -1228,9 +1228,6 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
 
-    auto rp_begin =
-        vku::InitStruct<VkRenderPassBeginInfo>(nullptr, render_pass.handle(), framebuffer.handle(), VkRect2D{{0, 0}, {32u, 32u}}, 0u, nullptr);
-
     m_commandBuffer->begin();
 
     VkImageMemoryBarrier2 barrier = vku::InitStructHelper();
@@ -1256,7 +1253,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     // Valid because outside renderpass
     vk::CmdPipelineBarrier2KHR(*m_commandBuffer, &dependency_info);
 
-    m_commandBuffer->BeginRenderPass(rp_begin);
+    m_commandBuffer->BeginRenderPass(render_pass.handle(), framebuffer.handle(), 32, 32);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdPipelineBarrier2-image-09374");
     barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -249,7 +249,7 @@ TEST_F(VkArmBestPracticesLayerTest, AttachmentNeedsReadback) {
     InitState();
 
     VkImageObj image(m_device);
-    image.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
+    image.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     auto image_view = image.CreateView();
 
     RenderPassSingleSubpass rp(*this);

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -745,7 +745,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     InitState();
 
     VkImageObj image(m_device);
-    image.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
+    image.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     auto image_view = image.CreateView();
 
     RenderPassSingleSubpass rp(*this);
@@ -802,7 +802,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-inefficient-clear");
 
     VkImageObj image(m_device);
-    image.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL);
+    image.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     auto image_view = image.CreateView();
 
     RenderPassSingleSubpass rp(*this);

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -756,13 +756,6 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     rp.CreateRenderPass();
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view.handle());
 
-    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-    render_pass_begin_info.renderPass = rp.Handle();
-    render_pass_begin_info.framebuffer = fb.handle();
-    // need full clear
-    render_pass_begin_info.renderArea.extent.width = m_width;
-    render_pass_begin_info.renderArea.extent.height = m_height;
-
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
 
     // On tiled renderers, this can also trigger a warning about LOAD_OP_LOAD causing a readback
@@ -773,7 +766,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-inefficient-clear");
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(render_pass_begin_info);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle(), m_width, m_height);
 
     VkClearAttachment color_attachment;
     color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1773,24 +1766,12 @@ TEST_F(VkBestPracticesLayerTest, DontCareThenLoad) {
     std::fill(std::begin(cv.color.float32), std::begin(cv.color.float32) + 4, 1.0f);
 
     // Begin first renderpass
-    VkRenderPassBeginInfo begin_info = vku::InitStructHelper();
-    begin_info.clearValueCount = 1;
-    begin_info.pClearValues = &cv;
-    begin_info.renderPass = rp1.handle();
-    begin_info.renderArea.extent.width = w;
-    begin_info.renderArea.extent.height = h;
-    begin_info.framebuffer = fb.handle();
-
-    m_commandBuffer->BeginRenderPass(begin_info);
+    m_commandBuffer->BeginRenderPass(rp1.handle(), fb.handle(), w, h, 1, &cv);
 
     m_commandBuffer->EndRenderPass();
 
     // Begin second renderpass
-    begin_info.clearValueCount = 0;
-    begin_info.pClearValues = nullptr;
-    begin_info.renderPass = rp2.handle();
-
-    m_commandBuffer->BeginRenderPass(begin_info);
+    m_commandBuffer->BeginRenderPass(rp2.handle(), fb.handle(), w, h, 0, nullptr);
 
     m_commandBuffer->EndRenderPass();
 

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -4473,7 +4473,7 @@ TEST_F(NegativeCommand, ExecuteDiffertQueueFlagsSecondaryCB) {
     VkCommandBufferInheritanceInfo cmdbuff_ii = vku::InitStructHelper();
     cmdbuff_ii.renderPass = m_renderPass;
     cmdbuff_ii.subpass = 0;
-    cmdbuff_ii.framebuffer = m_framebuffer;
+    cmdbuff_ii.framebuffer = framebuffer();
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     begin_info.pInheritanceInfo = &cmdbuff_ii;
@@ -4577,7 +4577,7 @@ TEST_F(NegativeCommand, RenderPassScopeSecondaryCmdBuffer) {
         nullptr,  // pNext
         m_renderPass,
         0,  // subpass
-        m_framebuffer,
+        framebuffer(),
     };
     const VkCommandBufferBeginInfo cmdbuff_bi_tmpl = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
                                                       nullptr,  // pNext
@@ -4599,9 +4599,9 @@ TEST_F(NegativeCommand, RenderPassScopeSecondaryCmdBuffer) {
     vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &sec_cmdbuff_inside_rp.handle());
     m_errorMonitor->VerifyFound();
 
-    VkRenderPassBeginInfo rp_bi =
-        vku::InitStruct<VkRenderPassBeginInfo>(nullptr, m_renderPass, m_framebuffer, VkRect2D{{0, 0}, {32u, 32u}},
-                                             static_cast<uint32_t>(m_renderPassClearValues.size()), m_renderPassClearValues.data());
+    VkRenderPassBeginInfo rp_bi = vku::InitStruct<VkRenderPassBeginInfo>(
+        nullptr, m_renderPass, framebuffer(), VkRect2D{{0, 0}, {32u, 32u}}, static_cast<uint32_t>(m_renderPassClearValues.size()),
+        m_renderPassClearValues.data());
     vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rp_bi, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdExecuteCommands-pCommandBuffers-00096");
@@ -4623,7 +4623,7 @@ TEST_F(NegativeCommand, SecondaryCommandBufferClearColorAttachmentsRenderArea) {
     vkt::CommandBuffer secondary_command_buffer(*m_device, command_buffer_allocate_info);
     VkCommandBufferInheritanceInfo command_buffer_inheritance_info = vku::InitStructHelper();
     command_buffer_inheritance_info.renderPass = m_renderPass;
-    command_buffer_inheritance_info.framebuffer = m_framebuffer;
+    command_buffer_inheritance_info.framebuffer = framebuffer();
 
     VkCommandBufferBeginInfo command_buffer_begin_info = vku::InitStructHelper();
     command_buffer_begin_info.flags =
@@ -5876,7 +5876,7 @@ TEST_F(NegativeCommand, RenderPassContentsWhenCallingCmdExecuteCommandsWithBegin
         nullptr,  // pNext
         m_renderPass,
         0,  // subpass
-        m_framebuffer,
+        framebuffer(),
     };
 
     VkCommandBufferBeginInfo cmdbuff__bi = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
@@ -5888,9 +5888,9 @@ TEST_F(NegativeCommand, RenderPassContentsWhenCallingCmdExecuteCommandsWithBegin
 
     m_commandBuffer->begin();
 
-    VkRenderPassBeginInfo rp_bi =
-        vku::InitStruct<VkRenderPassBeginInfo>(nullptr, m_renderPass, m_framebuffer, VkRect2D{{0, 0}, {32u, 32u}},
-                                             static_cast<uint32_t>(m_renderPassClearValues.size()), m_renderPassClearValues.data());
+    VkRenderPassBeginInfo rp_bi = vku::InitStruct<VkRenderPassBeginInfo>(
+        nullptr, m_renderPass, framebuffer(), VkRect2D{{0, 0}, {32u, 32u}}, static_cast<uint32_t>(m_renderPassClearValues.size()),
+        m_renderPassClearValues.data());
     m_commandBuffer->BeginRenderPass(rp_bi);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdExecuteCommands-contents-06018");

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -5886,11 +5886,8 @@ TEST_F(NegativeCommand, RenderPassContentsWhenCallingCmdExecuteCommandsWithBegin
     secondary.end();
 
     m_commandBuffer->begin();
-
-    VkRenderPassBeginInfo rp_bi = vku::InitStruct<VkRenderPassBeginInfo>(
-        nullptr, m_renderPass, framebuffer(), VkRect2D{{0, 0}, {32u, 32u}}, static_cast<uint32_t>(m_renderPassClearValues.size()),
-        m_renderPassClearValues.data());
-    m_commandBuffer->BeginRenderPass(rp_bi);
+    m_commandBuffer->BeginRenderPass(m_renderPass, framebuffer(), 32, 32, m_renderPassClearValues.size(),
+                                     m_renderPassClearValues.data());
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdExecuteCommands-contents-06018");
     vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary.handle());
@@ -6513,14 +6510,9 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
     stencil_dynamic_pipe.CreateGraphicsPipeline(false);
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
-    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-    render_pass_begin_info.renderPass = rp.Handle();
-    render_pass_begin_info.framebuffer = framebuffer.handle();
-    render_pass_begin_info.renderArea.extent.width = 32;
-    render_pass_begin_info.renderArea.extent.height = 32;
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(render_pass_begin_info);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32);
 
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, depth_pipe.pipeline_);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-06886");
@@ -7346,15 +7338,8 @@ TEST_F(NegativeCommand, ClearDsImageWithInvalidAspect) {
         clear_rect.baseArrayLayer = 0u;
         clear_rect.layerCount = 1u;
 
-        VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-        render_pass_begin_info.renderPass = rp.Handle();
-        render_pass_begin_info.framebuffer = framebuffer.handle();
-        render_pass_begin_info.renderArea = {{0, 0}, {32, 32}};
-        render_pass_begin_info.clearValueCount = 1u;
-        render_pass_begin_info.pClearValues = &clear_value;
-
         m_commandBuffer->begin();
-        m_commandBuffer->BeginRenderPass(render_pass_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+        m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, &clear_value);
         if (missing_depth) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-aspectMask-07884");
         } else {

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -4473,7 +4473,6 @@ TEST_F(NegativeCommand, ExecuteDiffertQueueFlagsSecondaryCB) {
     VkCommandBufferInheritanceInfo cmdbuff_ii = vku::InitStructHelper();
     cmdbuff_ii.renderPass = m_renderPass;
     cmdbuff_ii.subpass = 0;
-    cmdbuff_ii.framebuffer = framebuffer();
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     begin_info.pInheritanceInfo = &cmdbuff_ii;

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -94,7 +94,7 @@ TEST_F(PositiveCommand, ClearAttachmentsCalledInSecondaryCB) {
     info.pInheritanceInfo = &hinfo;
     hinfo.renderPass = renderPass();
     hinfo.subpass = 0;
-    hinfo.framebuffer = m_framebuffer;
+    hinfo.framebuffer = framebuffer();
     hinfo.occlusionQueryEnable = VK_FALSE;
     hinfo.queryFlags = 0;
     hinfo.pipelineStatistics = 0;
@@ -222,7 +222,7 @@ TEST_F(PositiveCommand, SecondaryCommandBufferClearColorAttachments) {
     VkCommandBufferBeginInfo command_buffer_begin_info = vku::InitStructHelper();
     VkCommandBufferInheritanceInfo command_buffer_inheritance_info = vku::InitStructHelper();
     command_buffer_inheritance_info.renderPass = m_renderPass;
-    command_buffer_inheritance_info.framebuffer = m_framebuffer;
+    command_buffer_inheritance_info.framebuffer = framebuffer();
 
     command_buffer_begin_info.flags =
         VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -3777,14 +3777,6 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle, width, height);
 
-    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.framebuffer = framebuffer.handle();
-    rpbi.renderPass = rp.Handle();
-    rpbi.renderArea.extent.width = width;
-    rpbi.renderArea.extent.height = height;
-    rpbi.clearValueCount = 1;
-    rpbi.pClearValues = m_renderPassClearValues.data();
-
     char const *fsSource = R"glsl(
             #version 450
             layout(location = 0) out vec4 x;
@@ -3832,7 +3824,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-06537");
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), width, height, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
@@ -3892,14 +3884,6 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle, width, height);
 
-    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.framebuffer = framebuffer.handle();
-    rpbi.renderPass = rp.Handle();
-    rpbi.renderArea.extent.width = width;
-    rpbi.renderArea.extent.height = height;
-    rpbi.clearValueCount = 1;
-    rpbi.pClearValues = m_renderPassClearValues.data();
-
     char const *fsSource = R"glsl(
             #version 450
             layout(location = 0) out vec4 color;
@@ -3946,7 +3930,7 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-09000");
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), width, height, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
@@ -4008,14 +3992,6 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle, width, height);
 
-    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.framebuffer = framebuffer.handle();
-    rpbi.renderPass = rp.Handle();
-    rpbi.renderArea.extent.width = width;
-    rpbi.renderArea.extent.height = height;
-    rpbi.clearValueCount = 1;
-    rpbi.pClearValues = m_renderPassClearValues.data();
-
     char const *fsSource = R"glsl(
             #version 450
             layout(set = 0, binding = 0, rgba8) writeonly uniform image2D image1;
@@ -4075,7 +4051,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), width, height, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set_storage_image.set_, 0, nullptr);

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -612,14 +612,6 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle, width, height);
 
-    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.framebuffer = framebuffer.handle();
-    rpbi.renderPass = rp.Handle();
-    rpbi.renderArea.extent.width = width;
-    rpbi.renderArea.extent.height = height;
-    rpbi.clearValueCount = 1;
-    rpbi.pClearValues = m_renderPassClearValues.data();
-
     char const *fsSource = R"glsl(
             #version 450
             layout(location = 0) out vec4 color;
@@ -675,7 +667,7 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
     vk::UpdateDescriptorSets(m_device->device(), 1, &descriptor_write, 0, nullptr);
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), width, height, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
@@ -1067,13 +1059,6 @@ TEST_F(PositiveDescriptors, AttachmentFeedbackLoopLayout) {
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
 
-    VkRenderPassBeginInfo render_pass_begin = vku::InitStructHelper();
-    render_pass_begin.renderPass = rp.Handle();
-    render_pass_begin.framebuffer = framebuffer.handle();
-    render_pass_begin.renderArea = {{0, 0}, {32u, 32u}};
-    render_pass_begin.clearValueCount = 1;
-    render_pass_begin.pClearValues = &clear_value;
-
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
                                            {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
@@ -1102,7 +1087,7 @@ TEST_F(PositiveDescriptors, AttachmentFeedbackLoopLayout) {
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, &clear_value);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0u, 1u,
                               &descriptor_set.set_, 0u, nullptr);

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -5979,7 +5979,7 @@ TEST_F(NegativeDynamicRendering, InSecondaryCommandBuffers) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper(&inheritanceRenderingInfo);
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = m_framebuffer;
+    cbii.framebuffer = framebuffer();
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     cbbi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -5979,7 +5979,6 @@ TEST_F(NegativeDynamicRendering, InSecondaryCommandBuffers) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper(&inheritanceRenderingInfo);
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = framebuffer();
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     cbbi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -6121,10 +6121,7 @@ TEST_F(NegativeDynamicRendering, EndRenderingWithIncorrectlyStartedRenderpassIns
 
     m_commandBuffer->begin();
 
-    VkRenderPassBeginInfo rpbi =
-        vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp.handle(), fb.handle(), VkRect2D{{0, 0}, {32u, 32u}}, 0u, nullptr);
-
-    m_commandBuffer->BeginRenderPass(rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.handle(), fb.handle(), 32, 32);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndRendering-None-06161");
     m_commandBuffer->EndRendering();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -349,15 +349,9 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesPipelineDepthWriteEnable) {
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
-    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-    render_pass_begin_info.renderPass = rp.Handle();
-    render_pass_begin_info.framebuffer = fb.handle();
-    render_pass_begin_info.renderArea.extent.width = 1;
-    render_pass_begin_info.renderArea.extent.height = 1;
-
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
-    m_commandBuffer->BeginRenderPass(render_pass_begin_info);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle());
 
     vk::CmdSetDepthTestEnableEXT(m_commandBuffer->handle(), VK_FALSE);
 
@@ -400,15 +394,9 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesDynamicDepthWriteEnable) {
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
-    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-    render_pass_begin_info.renderPass = rp.Handle();
-    render_pass_begin_info.framebuffer = fb.handle();
-    render_pass_begin_info.renderArea.extent.width = 1;
-    render_pass_begin_info.renderArea.extent.height = 1;
-
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
-    m_commandBuffer->BeginRenderPass(render_pass_begin_info);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle());
 
     vk::CmdSetDepthTestEnableEXT(m_commandBuffer->handle(), VK_FALSE);
     vk::CmdSetDepthWriteEnableEXT(m_commandBuffer->handle(), VK_TRUE);

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -978,7 +978,7 @@ TEST_F(PositiveDynamicState, ViewportInheritance) {
     auto hinfo = vku::InitStruct<VkCommandBufferInheritanceInfo>(&viewport_scissor_inheritance);
     hinfo.renderPass = m_renderPass;
     hinfo.subpass = 0;
-    hinfo.framebuffer = m_framebuffer;
+    hinfo.framebuffer = framebuffer();
 
     auto info = vku::InitStruct<VkCommandBufferBeginInfo>();
     info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -228,21 +228,13 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
     image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView imageView = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
-    VkFramebufferCreateInfo framebufferCreateInfo = vku::InitStructHelper();
-    framebufferCreateInfo.width = m_width;
-    framebufferCreateInfo.height = m_height;
-    framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = m_renderPass;
-    framebufferCreateInfo.attachmentCount = 1;
-    framebufferCreateInfo.pAttachments = &imageView.handle();
-
-    vk::CreateFramebuffer(m_device->device(), &framebufferCreateInfo, nullptr, &m_framebuffer);
+    vkt::Framebuffer fb(*m_device, m_renderPass, 1, &imageView.handle(), m_width, m_height);
 
     VkClearValue clear{};
     clear.color = m_clear_color;
     m_renderPassClearValues.emplace_back(clear);
     m_renderPassBeginInfo.renderPass = m_renderPass;
-    m_renderPassBeginInfo.framebuffer = m_framebuffer;
+    m_renderPassBeginInfo.framebuffer = fb.handle();
     m_renderPassBeginInfo.renderArea.extent.width = m_width;
     m_renderPassBeginInfo.renderArea.extent.height = m_height;
     m_renderPassBeginInfo.clearValueCount = m_renderPassClearValues.size();

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -111,13 +111,7 @@ TEST_F(NegativeMultiview, ClearColorAttachments) {
     clear_rect.rect.extent.width = 32;
     clear_rect.rect.extent.height = 32;
 
-    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-    render_pass_begin_info.renderPass = rp.Handle();
-    render_pass_begin_info.framebuffer = framebuffer.handle();
-    render_pass_begin_info.renderArea.extent.width = 32;
-    render_pass_begin_info.renderArea.extent.height = 32;
-
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &render_pass_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-baseArrayLayer-00018");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-pRects-06937");
     clear_rect.layerCount = 2;
@@ -660,19 +654,13 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle());
 
-    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-    render_pass_begin_info.renderPass = rp.Handle();
-    render_pass_begin_info.framebuffer = framebuffer.handle();
-    render_pass_begin_info.renderArea.extent.width = 32;
-    render_pass_begin_info.renderArea.extent.height = 32;
-
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(render_pass_begin_info);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginTransformFeedbackEXT-None-04128");

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -750,15 +750,9 @@ TEST_F(NegativeObjectLifetime, FramebufferImageInUseDestroyedSignaled) {
     rp.CreateRenderPass();
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle(), 256, 256);
 
-    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-    render_pass_begin_info.renderPass = rp.Handle();
-    render_pass_begin_info.framebuffer = fb.handle();
-    render_pass_begin_info.renderArea.extent.width = 1;
-    render_pass_begin_info.renderArea.extent.height = 1;
-
     // Create Null cmd buffer for submit
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(render_pass_begin_info);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle());
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
     // Submit cmd buffer to put it (and attached imageView) in-flight

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -2412,7 +2412,7 @@ TEST_F(VkLayerTest, ImageSubresourceOverlapBetweenCurrentRenderPassAndDescriptor
     VkClearValue clear_values[2] = {m_renderPassClearValues[0], m_renderPassClearValues[0]};
 
     VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.framebuffer = m_framebuffer;
+    rpbi.framebuffer = framebuffer();
     rpbi.renderPass = render_pass.handle();
     rpbi.renderArea.extent.width = width;
     rpbi.renderArea.extent.height = height;

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -2411,16 +2411,8 @@ TEST_F(VkLayerTest, ImageSubresourceOverlapBetweenCurrentRenderPassAndDescriptor
 
     VkClearValue clear_values[2] = {m_renderPassClearValues[0], m_renderPassClearValues[0]};
 
-    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.framebuffer = framebuffer();
-    rpbi.renderPass = render_pass.handle();
-    rpbi.renderArea.extent.width = width;
-    rpbi.renderArea.extent.height = height;
-    rpbi.clearValueCount = 2;
-    rpbi.pClearValues = clear_values;
-
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(render_pass.handle(), framebuffer(), width, height, 2, clear_values);
     m_commandBuffer->end();
 
     m_errorMonitor->VerifyFound();

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -501,14 +501,8 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     pipeline_2.gp_ci_.renderPass = renderpass.handle();
     pipeline_2.CreateGraphicsPipeline();
 
-    VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
-    rpbinfo.renderPass = renderpass.handle();
-    rpbinfo.framebuffer = framebuffer;
-    rpbinfo.renderArea.extent.width = fb_width;
-    rpbinfo.renderArea.extent.height = fb_height;
-
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(rpbinfo);
+    m_commandBuffer->BeginRenderPass(renderpass.handle(), framebuffer, fb_width, fb_height);
 
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_1.Handle());
 

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -858,9 +858,7 @@ TEST_F(PositivePipeline, ConditionalRendering) {
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &imageView.handle());
 
     m_commandBuffer->begin();
-    VkRenderPassBeginInfo rpbi =
-        vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp.Handle(), fb.handle(), VkRect2D{{0, 0}, {32u, 32u}}, 0u, nullptr);
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
 
     VkImageMemoryBarrier imb = vku::InitStructHelper();
     imb.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -462,18 +462,9 @@ TEST_F(VkPositiveLayerTest, TopologyAtRasterizer) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_WIDTH);
     pipe.CreateGraphicsPipeline();
 
-    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.renderPass = m_renderPass;
-    rpbi.framebuffer = framebuffer();
-    rpbi.renderArea.offset.x = 0;
-    rpbi.renderArea.offset.y = 0;
-    rpbi.renderArea.extent.width = 32;
-    rpbi.renderArea.extent.height = 32;
-    rpbi.clearValueCount = static_cast<uint32_t>(m_renderPassClearValues.size());
-    rpbi.pClearValues = m_renderPassClearValues.data();
-
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(renderPass(), framebuffer(), 32, 32, m_renderPassClearValues.size(),
+                                     m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     vk::CmdDraw(m_commandBuffer->handle(), 4, 1, 0, 0);
     m_commandBuffer->EndRenderPass();

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -464,7 +464,7 @@ TEST_F(VkPositiveLayerTest, TopologyAtRasterizer) {
 
     VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
     rpbi.renderPass = m_renderPass;
-    rpbi.framebuffer = m_framebuffer;
+    rpbi.framebuffer = framebuffer();
     rpbi.renderArea.offset.x = 0;
     rpbi.renderArea.offset.y = 0;
     rpbi.renderArea.extent.width = 32;

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -861,8 +861,6 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     image_copy.extent = {1, 1, 1};
     uint32_t update_data[4] = {0, 0, 0, 0};
     VkRect2D render_area = {{0, 0}, {8, 8}};
-    VkRenderPassBeginInfo render_pass_begin =
-        vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp.Handle(), framebuffer.handle(), render_area, 0u, nullptr);
     VkClearAttachment clear_attachments[2] = {{VK_IMAGE_ASPECT_COLOR_BIT, 0, {m_clear_color}},
                                               {VK_IMAGE_ASPECT_COLOR_BIT, 1, {m_clear_color}}};
     VkClearRect clear_rect[2] = {{render_area, 0, 1}, {render_area, 0, 1}};
@@ -960,7 +958,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
         vk::CmdUpdateBuffer(m_commandBuffer->handle(), buffer_protected.handle(), 0, 4, (void *)update_data);
         m_errorMonitor->VerifyFound();
 
-        vk::CmdBeginRenderPass(m_commandBuffer->handle(), &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+        m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), render_area.extent.width, render_area.extent.height);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-commandBuffer-02504");
         vk::CmdClearAttachments(m_commandBuffer->handle(), 2, clear_attachments, 2, clear_rect);
@@ -1031,7 +1029,8 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
         vk::CmdUpdateBuffer(protectedCommandBuffer.handle(), buffer_unprotected.handle(), 0, 4, (void *)update_data);
         m_errorMonitor->VerifyFound();
 
-        vk::CmdBeginRenderPass(protectedCommandBuffer.handle(), &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+        protectedCommandBuffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), render_area.extent.width,
+                                               render_area.extent.height);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdClearAttachments-commandBuffer-02505");
         vk::CmdClearAttachments(protectedCommandBuffer.handle(), 2, clear_attachments, 2, clear_rect);

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -2529,7 +2529,6 @@ TEST_F(NegativeQuery, CmdExecuteBeginActiveQuery) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = framebuffer();
     cbii.occlusionQueryEnable = VK_TRUE;
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -1758,13 +1758,8 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
 
     vkt::QueryPool query_pool(*m_device, qpci);
 
-    VkRenderPassBeginInfo rp_begin = vku::InitStructHelper();
-    rp_begin.renderPass = render_pass.handle();
-    rp_begin.framebuffer = framebuffer.handle();
-    rp_begin.renderArea.extent = {64, 64};
-
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(rp_begin);
+    m_commandBuffer->BeginRenderPass(render_pass.handle(), framebuffer.handle(), 64, 64);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBeginQuery-query-00808");
     vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 1, 0);
     m_errorMonitor->VerifyFound();
@@ -2215,13 +2210,8 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
 
     vkt::QueryPool query_pool(*m_device, qpci);
 
-    VkRenderPassBeginInfo rp_begin = vku::InitStructHelper();
-    rp_begin.renderPass = render_pass.handle();
-    rp_begin.framebuffer = framebuffer.handle();
-    rp_begin.renderArea.extent = {64, 64};
-
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(rp_begin);
+    m_commandBuffer->BeginRenderPass(render_pass.handle(), framebuffer.handle(), 64, 64);
 
     vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 1, 0);
 
@@ -2238,7 +2228,7 @@ TEST_F(NegativeQuery, MultiviewEndQuery) {
     if (indexed_queries) {
         m_commandBuffer->reset();
         m_commandBuffer->begin();
-        m_commandBuffer->BeginRenderPass(rp_begin);
+        m_commandBuffer->BeginRenderPass(render_pass.handle(), framebuffer.handle(), 64, 64);
         vk::CmdBeginQueryIndexedEXT(m_commandBuffer->handle(), query_pool.handle(), 1, 0, 0);
         m_commandBuffer->NextSubpass();
 

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -2061,7 +2061,7 @@ TEST_F(NegativeQuery, CommandBufferMissingOcclusion) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = m_framebuffer;
+    cbii.framebuffer = framebuffer();
     cbii.occlusionQueryEnable = VK_FALSE;  // Invalid
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
@@ -2097,7 +2097,7 @@ TEST_F(NegativeQuery, CommandBufferInheritanceFlags) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = m_framebuffer;
+    cbii.framebuffer = framebuffer();
     cbii.occlusionQueryEnable = VK_TRUE;
     cbii.queryFlags = 0;
 
@@ -2529,7 +2529,7 @@ TEST_F(NegativeQuery, CmdExecuteBeginActiveQuery) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = m_framebuffer;
+    cbii.framebuffer = framebuffer();
     cbii.occlusionQueryEnable = VK_TRUE;
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
@@ -2738,7 +2738,7 @@ TEST_F(NegativeQuery, PipelineStatisticsQueryWithSecondaryCmdBuffer) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = m_framebuffer;
+    cbii.framebuffer = framebuffer();
     cbii.pipelineStatistics = VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT;
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -421,7 +421,7 @@ TEST_F(PositiveQuery, CommandBufferInheritanceFlags) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = m_framebuffer;
+    cbii.framebuffer = framebuffer();
     cbii.occlusionQueryEnable = VK_TRUE;
     cbii.queryFlags = VK_QUERY_CONTROL_PRECISE_BIT;
 

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -1607,7 +1607,7 @@ TEST_F(NegativeRenderPass, DestroyWhileInUse) {
 
     m_commandBuffer->begin();
     VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.framebuffer = m_framebuffer;
+    rpbi.framebuffer = framebuffer();
     rpbi.renderPass = rp.Handle();
     rpbi.renderArea.extent = {1, 1};
     m_commandBuffer->BeginRenderPass(rpbi);
@@ -2374,7 +2374,7 @@ TEST_F(NegativeRenderPass, RenderArea) {
 
     VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
     rpbinfo.renderPass = m_renderPass;
-    rpbinfo.framebuffer = m_framebuffer;
+    rpbinfo.framebuffer = framebuffer();
     rpbinfo.renderArea.extent.width = m_width;
     rpbinfo.renderArea.extent.height = m_height;
     rpbinfo.renderArea.offset.x = -32;
@@ -2432,7 +2432,7 @@ TEST_F(NegativeRenderPass, DeviceGroupRenderArea) {
 
     VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper(&device_group_render_pass_begin_info);
     rpbinfo.renderPass = m_renderPass;
-    rpbinfo.framebuffer = m_framebuffer;
+    rpbinfo.framebuffer = framebuffer();
     rpbinfo.renderArea.extent.width = m_width;
     rpbinfo.renderArea.extent.height = m_height;
     rpbinfo.renderArea.offset.x = -32;

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -1417,18 +1417,8 @@ TEST_F(NegativeShaderObject, DrawWithShadersInNonDynamicRenderPass) {
     clear_value.color.float32[2] = 0.25f;
     clear_value.color.float32[3] = 0.0f;
 
-    VkRenderPassBeginInfo beginInfo = vku::InitStructHelper();
-    beginInfo.renderPass = rp.Handle();
-    beginInfo.framebuffer = framebuffer.handle();
-    beginInfo.renderArea.extent.width = 32;
-    beginInfo.renderArea.extent.height = 32;
-    beginInfo.renderArea.offset.x = 0;
-    beginInfo.renderArea.offset.y = 0;
-    beginInfo.clearValueCount = 1;
-    beginInfo.pClearValues = &clear_value;
-
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &beginInfo, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, &clear_value);
     SetDefaultDynamicStates();
     BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -60,11 +60,6 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
     vkt::ImageView image_view = image.CreateView();
     vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle());
 
-    VkRenderPassBeginInfo render_pass_begin = vku::InitStructHelper();
-    render_pass_begin.renderPass = render_pass;
-    render_pass_begin.framebuffer = framebuffer;
-    render_pass_begin.renderArea = VkRect2D{{0, 0}, {32, 32}};
-
     // VkImageMemoryBarrier
     VkImageMemoryBarrier barrier = vku::InitStructHelper();
     barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
@@ -90,7 +85,7 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
 
     // Test vkCmdPipelineBarrier subpass barrier
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(*m_commandBuffer, &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(render_pass, framebuffer, 32, 32);
     vk::CmdPipelineBarrier(*m_commandBuffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1,
                            &barrier);
@@ -99,7 +94,7 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
 
     // Test vkCmdPipelineBarrier2 subpass barrier
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(*m_commandBuffer, &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(render_pass, framebuffer, 32, 32);
     vk::CmdPipelineBarrier2(*m_commandBuffer, &dependency_info);
     vk::CmdEndRenderPass(*m_commandBuffer);
     m_commandBuffer->end();
@@ -147,11 +142,6 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
     vkt::ImageView image_view = image.CreateView();
     vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle());
 
-    VkRenderPassBeginInfo render_pass_begin = vku::InitStructHelper();
-    render_pass_begin.renderPass = render_pass;
-    render_pass_begin.framebuffer = framebuffer;
-    render_pass_begin.renderArea = VkRect2D{{0, 0}, {32, 32}};
-
     // VkImageMemoryBarrier
     VkImageMemoryBarrier barrier = vku::InitStructHelper();
     barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
@@ -180,7 +170,7 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
         vkt::Event event(*m_device);
         m_commandBuffer->begin();
         vk::CmdSetEvent(*m_commandBuffer, event, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
-        vk::CmdBeginRenderPass(*m_commandBuffer, &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+        m_commandBuffer->BeginRenderPass(render_pass, framebuffer, 32, 32);
         vk::CmdWaitEvents(*m_commandBuffer, 1, &event.handle(), VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, nullptr, 0, nullptr, 1, &barrier);
         vk::CmdEndRenderPass(*m_commandBuffer);
@@ -193,7 +183,7 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
         vkt::Event event2(*m_device);
         m_commandBuffer->begin();
         vk::CmdSetEvent2(*m_commandBuffer, event2, &dependency_info);
-        vk::CmdBeginRenderPass(*m_commandBuffer, &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
+        m_commandBuffer->BeginRenderPass(render_pass, framebuffer, 32, 32);
         vk::CmdWaitEvents2(*m_commandBuffer, 1, &event2.handle(), &dependency_info);
         vk::CmdEndRenderPass(*m_commandBuffer);
         m_commandBuffer->end();

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -56,10 +56,7 @@ TEST_F(NegativeSyncObject, ImageBarrierSubpassConflicts) {
     vkt::Framebuffer fb_noselfdep(*m_device, rp_noselfdep.handle(), 1, &imageView.handle());
 
     m_commandBuffer->begin();
-    VkRenderPassBeginInfo rpbi = vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp_noselfdep.handle(), fb_noselfdep.handle(),
-                                                                      VkRect2D{{0, 0}, {32u, 32u}}, 0u, nullptr);
-
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp_noselfdep.handle(), fb_noselfdep.handle(), 32, 32);
     VkMemoryBarrier mem_barrier = vku::InitStructHelper();
     mem_barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
     mem_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
@@ -69,9 +66,7 @@ TEST_F(NegativeSyncObject, ImageBarrierSubpassConflicts) {
     m_errorMonitor->VerifyFound();
     m_commandBuffer->EndRenderPass();
 
-    rpbi.renderPass = rp.handle();
-    rpbi.framebuffer = fb.handle();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.handle(), fb.handle(), 32, 32);
     VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     img_barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
@@ -312,14 +307,8 @@ TEST_F(NegativeSyncObject, Barriers) {
     conc_test.image_barrier_.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     conc_test("");
 
-    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-    render_pass_begin_info.renderPass = rp.Handle();
-    render_pass_begin_info.framebuffer = fb.handle();
-    render_pass_begin_info.renderArea.extent.width = 1;
-    render_pass_begin_info.renderArea.extent.height = 1;
-
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(render_pass_begin_info);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle());
 
     // Can't send buffer memory barrier during a render pass
     m_commandBuffer->EndRenderPass();
@@ -852,14 +841,8 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     conc_test.image_barrier_.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     conc_test("");
 
-    VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-    render_pass_begin_info.renderPass = rp.Handle();
-    render_pass_begin_info.framebuffer = fb.handle();
-    render_pass_begin_info.renderArea.extent.width = 1;
-    render_pass_begin_info.renderArea.extent.height = 1;
-
     m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderPass(render_pass_begin_info);
+    m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle());
 
     // Can't send buffer memory barrier during a render pass
     m_commandBuffer->EndRenderPass();

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -107,12 +107,6 @@ TEST_F(PositiveSyncVal, CmdClearAttachmentLayer) {
     fbci.layers = layers;
     vkt::Framebuffer framebuffer(*m_device, fbci);
 
-    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.framebuffer = framebuffer;
-    rpbi.renderPass = render_pass;
-    rpbi.renderArea.extent.width = width;
-    rpbi.renderArea.extent.height = height;
-
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.renderPass = render_pass;
     pipe.InitState();
@@ -136,7 +130,7 @@ TEST_F(PositiveSyncVal, CmdClearAttachmentLayer) {
     // Write 1: Copy to render target's layer 0
     vk::CmdCopyImage(*m_commandBuffer, image, VK_IMAGE_LAYOUT_GENERAL, rt, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
-    vk::CmdBeginRenderPass(*m_commandBuffer, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(render_pass, framebuffer, width, height);
     // Write 2: Clear render target's layer 1
     vk::CmdClearAttachments(*m_commandBuffer, 1, &clear_attachment, 1, &clear_rect);
     vk::CmdEndRenderPass(*m_commandBuffer);

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -1129,13 +1129,7 @@ TEST_F(NegativeTransformFeedback, CmdNextSubpass) {
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
-    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.renderPass = rp.handle();
-    rpbi.framebuffer = fb.handle();
-    rpbi.renderArea.offset = {0, 0};
-    rpbi.renderArea.extent = {32, 32};
-
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp.handle(), fb.handle(), 32, 32);
     vk::CmdBeginTransformFeedbackEXT(m_commandBuffer->handle(), 0, 1, nullptr, nullptr);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdNextSubpass-None-02349");
     m_commandBuffer->NextSubpass();

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -3482,12 +3482,6 @@ TEST_F(PositiveWsi, UseDestroyedSwapchain) {
     pipe.gp_ci_.renderPass = rp.handle();
     pipe.CreateGraphicsPipeline();
 
-    VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
-    rpbinfo.renderPass = rp.handle();
-    rpbinfo.framebuffer = fb.handle();
-    rpbinfo.renderArea.extent.width = 1;
-    rpbinfo.renderArea.extent.height = 1;
-
     VkSwapchainKHR oldSwapchain = m_swapchain;
     swapchain_create_info.oldSwapchain = m_swapchain;
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
@@ -3495,7 +3489,7 @@ TEST_F(PositiveWsi, UseDestroyedSwapchain) {
 
     m_commandBuffer->begin();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkRenderPassBeginInfo-framebuffer-parameter");
-    m_commandBuffer->BeginRenderPass(rpbinfo);
+    m_commandBuffer->BeginRenderPass(rp.handle(), fb.handle());
     m_errorMonitor->VerifyFound();
     m_commandBuffer->end();
 }

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -604,14 +604,10 @@ TEST_F(PositiveWsi, SwapchainImageLayout) {
     vkt::Framebuffer fb1(*m_device, rp1.handle(), 1, &view.handle(), 1, 1);
     vkt::Framebuffer fb2(*m_device, rp2.handle(), 1, &view.handle(), 1, 1);
 
-    VkRenderPassBeginInfo rpbi =
-        vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp1.handle(), fb1.handle(), VkRect2D{{0, 0}, {1u, 1u}}, 0u, nullptr);
     m_commandBuffer->begin();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp1.handle(), fb1.handle());
     m_commandBuffer->EndRenderPass();
-    rpbi.framebuffer = fb2.handle();
-    rpbi.renderPass = rp2.handle();
-    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+    m_commandBuffer->BeginRenderPass(rp2.handle(), fb2.handle());
     m_commandBuffer->EndRenderPass();
 
     const VkImageMemoryBarrier present_transition =
@@ -922,11 +918,7 @@ TEST_F(PositiveWsi, SwapchainImageFormatProps) {
 
     vkt::CommandBuffer cmdbuff(DeviceObj(), m_commandPool);
     cmdbuff.begin();
-    VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-    rpbi.renderPass = render_pass.handle();
-    rpbi.framebuffer = framebuffer.handle();
-    rpbi.renderArea = {{0, 0}, {1, 1}};
-    cmdbuff.BeginRenderPass(rpbi);
+    cmdbuff.BeginRenderPass(render_pass.handle(), framebuffer.handle());
 
     vk::CmdBindPipeline(cmdbuff.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 }

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -1142,14 +1142,8 @@ TEST_F(PositiveWsi, ProtectedSwapchainImageColorAttachment) {
     rp_info.dependencyCount = 1;
     rp_info.pDependencies = &dependency;
     ASSERT_EQ(VK_SUCCESS, vk::CreateRenderPass(device(), &rp_info, nullptr, &m_renderPass));
-    VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = m_renderPass;
-    fb_info.attachmentCount = 1;
-    fb_info.pAttachments = &image_view.handle();
-    fb_info.width = swapchain_create_info.imageExtent.width;
-    fb_info.height = swapchain_create_info.imageExtent.height;
-    fb_info.layers = 1;
-    ASSERT_EQ(VK_SUCCESS, vk::CreateFramebuffer(device(), &fb_info, nullptr, &m_framebuffer));
+    vkt::Framebuffer fb(*m_device, m_renderPass, 1, &image_view.handle(), swapchain_create_info.imageExtent.width,
+                        swapchain_create_info.imageExtent.height);
 
     // basic pipeline to allow for a valid vkCmdDraw()
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
@@ -1166,7 +1160,7 @@ TEST_F(PositiveWsi, ProtectedSwapchainImageColorAttachment) {
     protectedCommandBuffer.begin();
     VkRect2D render_area = {{0, 0}, swapchain_create_info.imageExtent};
     VkRenderPassBeginInfo render_pass_begin =
-        vku::InitStruct<VkRenderPassBeginInfo>(nullptr, m_renderPass, m_framebuffer, render_area, 0u, nullptr);
+        vku::InitStruct<VkRenderPassBeginInfo>(nullptr, m_renderPass, fb.handle(), render_area, 0u, nullptr);
     vk::CmdBeginRenderPass(protectedCommandBuffer.handle(), &render_pass_begin, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(protectedCommandBuffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
     // This should be valid since the framebuffer color attachment is a protected swapchain image


### PR DESCRIPTION
More progress towards the seemly endless cleanup of `InitRenderTarget`

instead of making the function more complex, the few tests that need one-off stuff use other helpers