### PR TITLE
ci: Update to macos-12 for iOS build

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -198,7 +198,7 @@ jobs:
           run: ctest --output-on-failure -C Debug
 
   iOS:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4


### PR DESCRIPTION
CMake 3.28 is having issues with the macos-11 runner.